### PR TITLE
Improve debugger experience

### DIFF
--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ActivityIndicator.xml" path="Type[@FullName='Microsoft.Maui.Controls.ActivityIndicator']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class ActivityIndicator : View, IColorElement, IElementConfiguration<ActivityIndicator>, IActivityIndicator
 	{
 		/// <summary>Bindable property for <see cref="IsRunning"/>.</summary>

--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -1,10 +1,12 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ActivityIndicator.xml" path="Type[@FullName='Microsoft.Maui.Controls.ActivityIndicator']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class ActivityIndicator : View, IColorElement, IElementConfiguration<ActivityIndicator>, IActivityIndicator
 	{
 		/// <summary>Bindable property for <see cref="IsRunning"/>.</summary>
@@ -39,6 +41,11 @@ namespace Microsoft.Maui.Controls
 		public IPlatformElementConfiguration<T, ActivityIndicator> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"IsRunning = {IsRunning}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsRunning = {IsRunning}, " + base.GetDebuggerDisplay();
+			return $"IsRunning = {IsRunning}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Maui.Controls
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsRunning = {IsRunning}, " + base.GetDebbugerDisplay();
+			return $"IsRunning = {IsRunning}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.Application']/Docs/*" />
+	[DebuggerDisplay("Windows Count: {Windows.Count}, MainPage = {MainPage}")]
 	public partial class Application : Element, IResourcesProvider, IApplicationController, IElementConfiguration<Application>, IVisualTreeElement, IApplication
 	{
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();

--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -16,7 +16,6 @@ using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="Type[@FullName='Microsoft.Maui.Controls.Application']/Docs/*" />
-	[DebuggerDisplay("Windows Count: {Windows.Count}, MainPage = {MainPage}")]
 	public partial class Application : Element, IResourcesProvider, IApplicationController, IElementConfiguration<Application>, IVisualTreeElement, IApplication
 	{
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Controls
 	/// <summary>
 	/// A button <see cref="View" /> that reacts to touch events.
 	/// </summary>
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Button : View, IFontElement, ITextElement, IBorderElement, IButtonController, IElementConfiguration<Button>, IPaddingElement, IImageController, IViewController, IButtonElement, ICommandElement, IImageElement, IButton, ITextButton, IImageButton
 	{
 		const double DefaultSpacing = 10;
@@ -606,6 +607,11 @@ namespace Microsoft.Maui.Controls
 
 			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 				=> throw new NotSupportedException();
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Text = {Text}, Command = {Command}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -609,9 +609,9 @@ namespace Microsoft.Maui.Controls
 				=> throw new NotSupportedException();
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, Command = {Command}, " + base.GetDebbugerDisplay();
+			return $"Text = {Text}, Command = {Command}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -611,7 +611,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, Command = {Command}, " + base.GetDebuggerDisplay();
+			return $"Text = {Text}, Command = {Command}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 	/// <summary>
 	/// A button <see cref="View" /> that reacts to touch events.
 	/// </summary>
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Button : View, IFontElement, ITextElement, IBorderElement, IButtonController, IElementConfiguration<Button>, IPaddingElement, IImageController, IViewController, IButtonElement, ICommandElement, IImageElement, IButton, ITextButton, IImageButton
 	{
 		const double DefaultSpacing = 10;

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="Type[@FullName='Microsoft.Maui.Controls.CheckBox']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class CheckBox : View, IElementConfiguration<CheckBox>, IBorderElement, IColorElement, ICheckBox
 	{
 		readonly Lazy<PlatformConfigurationRegistry<CheckBox>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsChecked = {IsChecked}, " + base.GetDebuggerDisplay();
+			return $"IsChecked = {IsChecked}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -1,10 +1,12 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="Type[@FullName='Microsoft.Maui.Controls.CheckBox']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class CheckBox : View, IElementConfiguration<CheckBox>, IBorderElement, IColorElement, ICheckBox
 	{
 		readonly Lazy<PlatformConfigurationRegistry<CheckBox>> _platformConfigurationRegistry;
@@ -78,6 +80,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => IsChecked;
 			set => SetValue(IsCheckedProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"IsChecked = {IsChecked}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(IsCheckedProperty, value, SetterSpecificity.FromHandler);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsChecked = {IsChecked}, " + base.GetDebbugerDisplay();
+			return $"IsChecked = {IsChecked}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Maui.Controls
 			return (this as ICrossPlatformLayout).CrossPlatformMeasure(widthConstraint, heightConstraint);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
 			return $"Content = {Content}, BindingContext = {BindingContext}";
 		}

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.HotReload;
 using Microsoft.Maui.Layouts;
@@ -9,6 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ContentPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.ContentPage']/Docs/*" />
 	[ContentProperty("Content")]
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class ContentPage : TemplatedPage, IContentView, HotReload.IHotReloadableView
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
@@ -146,6 +148,11 @@ namespace Microsoft.Maui.Controls
 		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
 			return (this as ICrossPlatformLayout).CrossPlatformMeasure(widthConstraint, heightConstraint);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Content = {Content}, BindingContext = {BindingContext}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ContentPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.ContentPage']/Docs/*" />
 	[ContentProperty("Content")]
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class ContentPage : TemplatedPage, IContentView, HotReload.IHotReloadableView
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Maui.Controls
 
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, " + base.GetDebbugerDisplay();
+			return $"Content = {Content}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ContentView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ContentView']/Docs/*" />
 	[ContentProperty("Content")]
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class ContentView : TemplatedView, IContentView
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System.Diagnostics;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
@@ -6,6 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ContentView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ContentView']/Docs/*" />
 	[ContentProperty("Content")]
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class ContentView : TemplatedView, IContentView
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
@@ -46,5 +48,10 @@ namespace Microsoft.Maui.Controls
 		object IContentView.Content => Content;
 
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Content = {Content}, " + base.GetDebbugerDisplay();
+		}
 	}
 }

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, " + base.GetDebuggerDisplay();
+			return $"Content = {Content}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.DatePicker']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class DatePicker : View, IFontElement, ITextElement, IElementConfiguration<DatePicker>, IDatePicker
 	{
 		/// <summary>Bindable property for <see cref="Format"/>.</summary>

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -242,9 +242,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(FormatProperty, value, SetterSpecificity.FromHandler);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Date = {Date}, " + base.GetDebbugerDisplay();
+			return $"Date = {Date}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Date = {Date}, " + base.GetDebuggerDisplay();
+			return $"Date = {Date}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"Date = {Date}" + base.GetDebbugerDisplay();
+			return $"Date = {Date}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -1,11 +1,13 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.DatePicker']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class DatePicker : View, IFontElement, ITextElement, IElementConfiguration<DatePicker>, IDatePicker
 	{
 		/// <summary>Bindable property for <see cref="Format"/>.</summary>
@@ -238,6 +240,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => Format;
 			set => SetValue(FormatProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Date = {Date}" + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -381,5 +381,9 @@ namespace Microsoft.Maui.Controls
 #else
 		double IFlyoutView.FlyoutWidth => -1;
 #endif
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"DetailPage = {Detail}, FlyoutPage = {Flyout}, BindingContext = {BindingContext}";
+		}
 	}
 }

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -381,7 +381,7 @@ namespace Microsoft.Maui.Controls
 #else
 		double IFlyoutView.FlyoutWidth => -1;
 #endif
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
 			return $"DetailPage = {Detail}, FlyoutPage = {Flyout}, BindingContext = {BindingContext}";
 		}

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="Type[@FullName='Microsoft.Maui.Controls.Image']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Image : View, IImageController, IElementConfiguration<Image>, IViewController, IImageElement, IImage
 	{
 		/// <summary>Bindable property for <see cref="Source"/>.</summary>

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Source = {Source}, " + base.GetDebuggerDisplay();
+			return $"Source = {Source}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -1,10 +1,12 @@
 #nullable disable
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Image.xml" path="Type[@FullName='Microsoft.Maui.Controls.Image']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Image : View, IImageController, IElementConfiguration<Image>, IViewController, IImageElement, IImage
 	{
 		/// <summary>Bindable property for <see cref="Source"/>.</summary>
@@ -103,5 +105,10 @@ namespace Microsoft.Maui.Controls
 
 		void IImageSourcePart.UpdateIsLoading(bool isLoading) =>
 			IsLoading = isLoading;
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Source = {Source}" + base.GetDebbugerDisplay();
+		}
 	}
 }

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"Source = {Source}" + base.GetDebbugerDisplay();
+			return $"Source = {Source}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -106,9 +106,9 @@ namespace Microsoft.Maui.Controls
 		void IImageSourcePart.UpdateIsLoading(bool isLoading) =>
 			IsLoading = isLoading;
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Source = {Source}, " + base.GetDebbugerDisplay();
+			return $"Source = {Source}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="Type[@FullName='Microsoft.Maui.Controls.IndicatorView']/Docs/*" />
 	[ContentProperty(nameof(IndicatorLayout))]
 
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class IndicatorView : TemplatedView, ITemplatedIndicatorView
 	{
 		const int DefaultPadding = 4;

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Position = {Position}, Count = {Count}, " + base.GetDebuggerDisplay();
+			return $"Position = {Position}, Count = {Count}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"Position = {Position}, Count = {Count}" + base.GetDebbugerDisplay();
+			return $"Position = {Position}, Count = {Count}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -197,9 +197,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(PositionProperty, value, SetterSpecificity.FromHandler);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Position = {Position}, Count = {Count}, " + base.GetDebbugerDisplay();
+			return $"Position = {Position}, Count = {Count}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
@@ -10,6 +11,8 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="Type[@FullName='Microsoft.Maui.Controls.IndicatorView']/Docs/*" />
 	[ContentProperty(nameof(IndicatorLayout))]
+
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class IndicatorView : TemplatedView, ITemplatedIndicatorView
 	{
 		const int DefaultPadding = 4;
@@ -192,6 +195,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => Position;
 			set => SetValue(PositionProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Position = {Position}, Count = {Count}" + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, " + base.GetDebuggerDisplay();
+			return $"Text = {Text}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -274,9 +274,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(TextProperty, value, SetterSpecificity.FromHandler);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, " + base.GetDebbugerDisplay();
+			return $"Text = {Text}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"Text = {Text}" + base.GetDebbugerDisplay();
+			return $"Text = {Text}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="Type[@FullName='Microsoft.Maui.Controls.InputView']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class InputView : View, IPlaceholderElement, ITextElement, ITextInput, IFontElement
 	{
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -1,11 +1,13 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/InputView.xml" path="Type[@FullName='Microsoft.Maui.Controls.InputView']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class InputView : View, IPlaceholderElement, ITextElement, ITextInput, IFontElement
 	{
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
@@ -270,6 +272,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => Text;
 			set => SetValue(TextProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Text = {Text}" + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"ItemsSource = {ItemsSource}" + base.GetDebbugerDisplay();
+			return $"ItemsSource = {ItemsSource}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"ItemsSource = {ItemsSource}, " + base.GetDebuggerDisplay();
+			return $"ItemsSource = {ItemsSource}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -226,9 +226,9 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(bo, BindingContext);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"ItemsSource = {ItemsSource}, " + base.GetDebbugerDisplay();
+			return $"ItemsSource = {ItemsSource}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -225,5 +225,10 @@ namespace Microsoft.Maui.Controls
 			if (InternalItemsLayout is BindableObject bo)
 				SetInheritedBindingContext(bo, BindingContext);
 		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"ItemsSource = {ItemsSource}" + base.GetDebbugerDisplay();
+		}
 	}
 }

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, " + base.GetDebuggerDisplay();
+			return $"Text = {Text}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.Label']/Docs/*" />
 	[ContentProperty(nameof(Text))]
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>, IDecorableTextElement, IPaddingElement, ILabel
 	{
 		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -480,9 +480,9 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, " + base.GetDebbugerDisplay();
+			return $"Text = {Text}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -12,6 +13,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.Label']/Docs/*" />
 	[ContentProperty(nameof(Text))]
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>, IDecorableTextElement, IPaddingElement, ILabel
 	{
 		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>
@@ -476,6 +478,11 @@ namespace Microsoft.Maui.Controls
 
 			// The label may grow/shrink based on the constraints, so we need to invalidate.
 			return true;
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Text = {Text}" + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"Text = {Text}" + base.GetDebbugerDisplay();
+			return $"Text = {Text}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
@@ -14,6 +15,7 @@ namespace Microsoft.Maui.Controls
 	/// Base class for layouts that allow you to arrange and group UI controls in your application.
 	/// </summary>
 	[ContentProperty(nameof(Children))]
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView, IInputTransparentContainerElement
 	{
 		protected ILayoutManager _layoutManager;
@@ -382,6 +384,11 @@ namespace Microsoft.Maui.Controls
 			{
 				layout.RefreshInputTransparentProperty();
 			}
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"ChildCount = {Count}" + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 	/// Base class for layouts that allow you to arrange and group UI controls in your application.
 	/// </summary>
 	[ContentProperty(nameof(Children))]
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public abstract partial class Layout : View, Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView, IInputTransparentContainerElement
 	{
 		protected ILayoutManager _layoutManager;

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"ChildCount = {Count}, " + base.GetDebuggerDisplay();
+			return $"ChildCount = {Count},  {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -386,9 +386,9 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"ChildCount = {Count}, " + base.GetDebbugerDisplay();
+			return $"ChildCount = {Count}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"ChildCount = {Count}" + base.GetDebbugerDisplay();
+			return $"ChildCount = {Count}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -941,7 +941,7 @@ namespace Microsoft.Maui.Controls
 		public virtual Window GetParentWindow()
 			=> this.FindParentOfType<Window>();
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
 			return $"BindingContext = {BindingContext}, Title = {Title}";
 		}

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,7 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	/// <remarks><see cref = "Page" /> is primarily a base class for more useful derived types. Objects that are derived from the <see cref="Page"/> class are most prominently used as the top level UI element in .NET MAUI applications. In addition to their role as the main pages of applications, <see cref="Page"/> objects and their descendants can be used with navigation classes, such as <see cref="NavigationPage"/> or <see cref="FlyoutPage"/>, among others, to provide rich user experiences that conform to the expected behaviors on each platform.
 	/// </remarks>
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Page : VisualElement, ILayout, IPageController, IElementConfiguration<Page>, IPaddingElement, ISafeAreaView, ISafeAreaView2, IView, ITitledElement, IToolbarElement
 #if IOS
 	,IiOSPageSpecifics
@@ -938,5 +940,10 @@ namespace Microsoft.Maui.Controls
 		/// <returns>The <see cref="Window"/> instance that parents the page.</returns>
 		public virtual Window GetParentWindow()
 			=> this.FindParentOfType<Window>();
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"BindingContext = {BindingContext}, Title = {Title}";
+		}
 	}
 }

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	/// <remarks><see cref = "Page" /> is primarily a base class for more useful derived types. Objects that are derived from the <see cref="Page"/> class are most prominently used as the top level UI element in .NET MAUI applications. In addition to their role as the main pages of applications, <see cref="Page"/> objects and their descendants can be used with navigation classes, such as <see cref="NavigationPage"/> or <see cref="FlyoutPage"/>, among others, to provide rich user experiences that conform to the expected behaviors on each platform.
 	/// </remarks>
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Page : VisualElement, ILayout, IPageController, IElementConfiguration<Page>, IPaddingElement, ISafeAreaView, ISafeAreaView2, IView, ITitledElement, IToolbarElement
 #if IOS
 	,IiOSPageSpecifics

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -14,7 +14,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="Type[@FullName='Microsoft.Maui.Controls.Picker']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Picker : View, IFontElement, ITextElement, ITextAlignmentElement, IElementConfiguration<Picker>, IPicker
 	{
 		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -463,9 +463,9 @@ namespace Microsoft.Maui.Controls
 			return string.Empty;
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Items = {ItemsSource?.Count ?? 0}, SelectedItem = {SelectedItem}, " + base.GetDebbugerDisplay();
+			return $"Items = {ItemsSource?.Count ?? 0}, SelectedItem = {SelectedItem}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Items = {ItemsSource?.Count ?? 0}, SelectedItem = {SelectedItem}, " + base.GetDebuggerDisplay();
+			return $"Items = {ItemsSource?.Count ?? 0}, SelectedItem = {SelectedItem}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
@@ -13,6 +14,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="Type[@FullName='Microsoft.Maui.Controls.Picker']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Picker : View, IFontElement, ITextElement, ITextAlignmentElement, IElementConfiguration<Picker>, IPicker
 	{
 		/// <summary>Bindable property for <see cref="TextColor"/>.</summary>
@@ -459,6 +461,11 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return string.Empty;
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Items = {ItemsSource?.Count ?? 0}, SelectedItem = {SelectedItem}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/ProgressBar/ProgressBar.cs
+++ b/src/Controls/src/Core/ProgressBar/ProgressBar.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Maui.Controls
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Progress = {Progress}, " + base.GetDebbugerDisplay();
+			return $"Progress = {Progress}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/ProgressBar/ProgressBar.cs
+++ b/src/Controls/src/Core/ProgressBar/ProgressBar.cs
@@ -9,7 +9,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ProgressBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.ProgressBar']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class ProgressBar : View, IElementConfiguration<ProgressBar>, IProgress
 	{
 		/// <summary>Bindable property for <see cref="ProgressColor"/>.</summary>

--- a/src/Controls/src/Core/ProgressBar/ProgressBar.cs
+++ b/src/Controls/src/Core/ProgressBar/ProgressBar.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Progress = {Progress}, " + base.GetDebuggerDisplay();
+			return $"Progress = {Progress}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ProgressBar/ProgressBar.cs
+++ b/src/Controls/src/Core/ProgressBar/ProgressBar.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
@@ -8,6 +9,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ProgressBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.ProgressBar']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class ProgressBar : View, IElementConfiguration<ProgressBar>, IProgress
 	{
 		/// <summary>Bindable property for <see cref="ProgressColor"/>.</summary>
@@ -52,6 +54,11 @@ namespace Microsoft.Maui.Controls
 		public IPlatformElementConfiguration<T, ProgressBar> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Progress = {Progress}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
@@ -9,6 +10,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="Type[@FullName='Microsoft.Maui.Controls.RadioButton']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class RadioButton : TemplatedView, IElementConfiguration<RadioButton>, ITextElement, IFontElement, IBorderElement, IRadioButton
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='CheckedVisualState']/Docs/*" />
@@ -643,7 +645,7 @@ namespace Microsoft.Maui.Controls
 
 		Font ITextStyle.Font => this.ToFont();
 
-#if ANDROID	
+#if ANDROID
 		object IContentView.Content 
 		{
 			get
@@ -668,6 +670,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => IsChecked;
 			set => SetValue(IsCheckedProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"IsChecked = {IsChecked}, Value = {Value}, " + base.GetDebbugerDisplay();
 		}
 
 		private protected override Semantics UpdateSemantics()

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="Type[@FullName='Microsoft.Maui.Controls.RadioButton']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class RadioButton : TemplatedView, IElementConfiguration<RadioButton>, ITextElement, IFontElement, IBorderElement, IRadioButton
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='CheckedVisualState']/Docs/*" />

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -674,7 +674,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsChecked = {IsChecked}, Value = {Value}, " + base.GetDebuggerDisplay();
+			return $"IsChecked = {IsChecked}, Value = {Value}, {base.GetDebuggerDisplay()}";
 		}
 
 		private protected override Semantics UpdateSemantics()

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -672,9 +672,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(IsCheckedProperty, value, SetterSpecificity.FromHandler);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsChecked = {IsChecked}, Value = {Value}, " + base.GetDebbugerDisplay();
+			return $"IsChecked = {IsChecked}, Value = {Value}, " + base.GetDebuggerDisplay();
 		}
 
 		private protected override Semantics UpdateSemantics()

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -150,9 +150,9 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IsRefreshingProperty, value, SetterSpecificity.FromHandler); }
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Command = {Command}, IsRefreshing = {IsRefreshing}, " + base.GetDebbugerDisplay();
+			return $"Command = {Command}, IsRefreshing = {IsRefreshing}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
@@ -9,6 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="Type[@FullName='Microsoft.Maui.Controls.RefreshView']/Docs/*" />
 	[ContentProperty(nameof(Content))]
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class RefreshView : ContentView, IElementConfiguration<RefreshView>, IRefreshView, ICommandElement
 	{
 		readonly Lazy<PlatformConfigurationRegistry<RefreshView>> _platformConfigurationRegistry;
@@ -146,6 +148,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => IsRefreshing;
 			set { SetValue(IsRefreshingProperty, value, SetterSpecificity.FromHandler); }
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Command = {Command}, IsRefreshing = {IsRefreshing}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="Type[@FullName='Microsoft.Maui.Controls.RefreshView']/Docs/*" />
 	[ContentProperty(nameof(Content))]
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class RefreshView : ContentView, IElementConfiguration<RefreshView>, IRefreshView, ICommandElement
 	{
 		readonly Lazy<PlatformConfigurationRegistry<RefreshView>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Command = {Command}, IsRefreshing = {IsRefreshing}, " + base.GetDebuggerDisplay();
+			return $"Command = {Command}, IsRefreshing = {IsRefreshing}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ScrollView']/Docs/*" />
 	[ContentProperty(nameof(Content))]
 #pragma warning disable CS0618 // Type or member is obsolete
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController, IScrollView, IContentView
 #pragma warning restore CS0618 // Type or member is obsolete
 	{

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, " + base.GetDebuggerDisplay();
+			return $"Content = {Content}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -11,6 +12,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ScrollView']/Docs/*" />
 	[ContentProperty(nameof(Content))]
 #pragma warning disable CS0618 // Type or member is obsolete
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController, IScrollView, IContentView
 #pragma warning restore CS0618 // Type or member is obsolete
 	{
@@ -478,6 +480,11 @@ namespace Microsoft.Maui.Controls
 		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
 		{
 			base.InvalidateMeasureLegacy(trigger, depth, 1);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Content = {Content}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -482,9 +482,9 @@ namespace Microsoft.Maui.Controls
 			base.InvalidateMeasureLegacy(trigger, depth, 1);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, " + base.GetDebbugerDisplay();
+			return $"Content = {Content}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -9,7 +9,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.SearchBar']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class SearchBar : InputView, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>, ICommandElement, ISearchBar
 	{
 		/// <summary>Bindable property for <see cref="SearchCommand"/>.</summary>
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"SearchCommand = {SearchCommand}, " + base.GetDebbugerDisplay();
+			return $"SearchCommand = {SearchCommand}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -8,6 +9,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.SearchBar']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class SearchBar : InputView, ITextAlignmentElement, ISearchBarController, IElementConfiguration<SearchBar>, ICommandElement, ISearchBar
 	{
 		/// <summary>Bindable property for <see cref="SearchCommand"/>.</summary>
@@ -161,6 +163,11 @@ namespace Microsoft.Maui.Controls
 		void ISearchBar.SearchButtonPressed()
 		{
 			(this as ISearchBarController).OnSearchButtonPressed();
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"SarchCommand = {SearchCommand}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"SearchCommand = {SearchCommand}, " + base.GetDebuggerDisplay();
+			return $"SearchCommand = {SearchCommand}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebbugerDisplay()
 		{
-			return $"SarchCommand = {SearchCommand}, " + base.GetDebbugerDisplay();
+			return $"SearchCommand = {SearchCommand}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Controls
 			(this as ISearchBarController).OnSearchButtonPressed();
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
 			return $"SearchCommand = {SearchCommand}, " + base.GetDebbugerDisplay();
 		}

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="Type[@FullName='Microsoft.Maui.Controls.Slider']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Slider : View, ISliderController, IElementConfiguration<Slider>, ISlider
 	{
 		/// <summary>Bindable property for <see cref="Minimum"/>.</summary>

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -185,9 +185,9 @@ namespace Microsoft.Maui.Controls
 			(this as ISliderController).SendDragStarted();
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Value = {Value}, Min-Max = {Minimum} - {Maximum}, " + base.GetDebbugerDisplay();
+			return $"Value = {Value}, Min-Max = {Minimum} - {Maximum}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -1,11 +1,13 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="Type[@FullName='Microsoft.Maui.Controls.Slider']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Slider : View, ISliderController, IElementConfiguration<Slider>, ISlider
 	{
 		/// <summary>Bindable property for <see cref="Minimum"/>.</summary>
@@ -181,6 +183,11 @@ namespace Microsoft.Maui.Controls
 		void ISlider.DragStarted()
 		{
 			(this as ISliderController).SendDragStarted();
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Value = {Value}, Min-Max = {Minimum} - {Maximum}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Value = {Value}, Min-Max = {Minimum} - {Maximum}, " + base.GetDebuggerDisplay();
+			return $"Value = {Value}, Min-Max = {Minimum} - {Maximum}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -110,9 +110,9 @@ namespace Microsoft.Maui.Controls
 
 		double IStepper.Interval => Increment;
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Value = {Value}, " + base.GetDebbugerDisplay();
+			return $"Value = {Value}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Value = {Value}, " + base.GetDebuggerDisplay();
+			return $"Value = {Value}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -1,11 +1,13 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="Type[@FullName='Microsoft.Maui.Controls.Stepper']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Stepper : View, IElementConfiguration<Stepper>, IStepper
 	{
 		/// <summary>Bindable property for <see cref="Maximum"/>.</summary>
@@ -107,5 +109,10 @@ namespace Microsoft.Maui.Controls
 		public IPlatformElementConfiguration<T, Stepper> On<T>() where T : IConfigPlatform => _platformConfigurationRegistry.Value.On<T>();
 
 		double IStepper.Interval => Increment;
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Value = {Value}, " + base.GetDebbugerDisplay();
+		}
 	}
 }

--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="Type[@FullName='Microsoft.Maui.Controls.Stepper']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Stepper : View, IElementConfiguration<Stepper>, IStepper
 	{
 		/// <summary>Bindable property for <see cref="Maximum"/>.</summary>

--- a/src/Controls/src/Core/Switch/Switch.cs
+++ b/src/Controls/src/Core/Switch/Switch.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsToggled = {IsToggled}, " + base.GetDebuggerDisplay();
+			return $"IsToggled = {IsToggled}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Switch/Switch.cs
+++ b/src/Controls/src/Core/Switch/Switch.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="Type[@FullName='Microsoft.Maui.Controls.Switch']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class Switch : View, IElementConfiguration<Switch>, ISwitch
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='SwitchOnVisualState']/Docs/*" />

--- a/src/Controls/src/Core/Switch/Switch.cs
+++ b/src/Controls/src/Core/Switch/Switch.cs
@@ -110,9 +110,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(IsToggledProperty, value, SetterSpecificity.FromHandler);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsToggled = {IsToggled}, " + base.GetDebbugerDisplay();
+			return $"IsToggled = {IsToggled}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/Switch/Switch.cs
+++ b/src/Controls/src/Core/Switch/Switch.cs
@@ -1,11 +1,13 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="Type[@FullName='Microsoft.Maui.Controls.Switch']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class Switch : View, IElementConfiguration<Switch>, ISwitch
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Switch.xml" path="//Member[@MemberName='SwitchOnVisualState']/Docs/*" />
@@ -106,6 +108,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => IsToggled;
 			set => SetValue(IsToggledProperty, value, SetterSpecificity.FromHandler);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"IsToggled = {IsToggled}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/TimePicker/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.cs
@@ -169,9 +169,9 @@ namespace Microsoft.Maui.Controls
 				timePicker.TimeSelected?.Invoke(timePicker, new TimeChangedEventArgs((TimeSpan)oldValue, (TimeSpan)newValue));
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Time = {Time}, " + base.GetDebbugerDisplay();
+			return $"Time = {Time}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/TimePicker/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Time = {Time}, " + base.GetDebuggerDisplay();
+			return $"Time = {Time}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }

--- a/src/Controls/src/Core/TimePicker/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.TimePicker']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class TimePicker : View, IFontElement, ITextElement, IElementConfiguration<TimePicker>, ITimePicker
 	{
 		/// <summary>Bindable property for <see cref="Format"/>.</summary>

--- a/src/Controls/src/Core/TimePicker/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.cs
@@ -1,11 +1,13 @@
 #nullable disable
 using System;
+using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.TimePicker']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class TimePicker : View, IFontElement, ITextElement, IElementConfiguration<TimePicker>, ITimePicker
 	{
 		/// <summary>Bindable property for <see cref="Format"/>.</summary>
@@ -165,6 +167,11 @@ namespace Microsoft.Maui.Controls
 		{
 			if (bindable is TimePicker timePicker)
 				timePicker.TimeSelected?.Invoke(timePicker, new TimeChangedEventArgs((TimeSpan)oldValue, (TimeSpan)newValue));
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Time = {Time}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2403,7 +2403,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 
-		private protected virtual string GetDebbugerDisplay()
+		private protected virtual string GetDebuggerDisplay()
 		{
 			return $"BindingContext = {BindingContext}, Bounds = {Bounds}";
 		}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
@@ -18,6 +19,8 @@ namespace Microsoft.Maui.Controls
 	/// <remarks>
 	/// The base class for most .NET MAUI on-screen elements. Provides most properties, events, and methods for presenting an item on screen.
 	/// </remarks>
+	
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IView, IControlsVisualElement
 	{
 		/// <summary>Bindable property for <see cref="NavigableElement.Navigation"/>.</summary>
@@ -2397,6 +2400,12 @@ namespace Microsoft.Maui.Controls
 					throw new NotSupportedException();
 				return visibility.ToString();
 			}
+		}
+
+
+		private protected virtual string GetDebbugerDisplay()
+		{
+			return $"BindingContext = {BindingContext}, Bounds = {Bounds}";
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 	/// The base class for most .NET MAUI on-screen elements. Provides most properties, events, and methods for presenting an item on screen.
 	/// </remarks>
 	
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IView, IControlsVisualElement
 	{
 		/// <summary>Bindable property for <see cref="NavigableElement.Navigation"/>.</summary>

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -386,9 +386,9 @@ namespace Microsoft.Maui.Controls
 			ProcessTerminated?.Invoke(this, webViewProcessTerminatedEventArgs);
 		}
 
-		private protected override string GetDebbugerDisplay()
+		private protected override string GetDebuggerDisplay()
 		{
-			return $"Source = {Source}, " + base.GetDebbugerDisplay();
+			return $"Source = {Source}, " + base.GetDebuggerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using Microsoft.Maui.Devices;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="Type[@FullName='Microsoft.Maui.Controls.WebView']/Docs/*" />
+	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
 	public partial class WebView : View, IWebViewController, IElementConfiguration<WebView>, IWebView
 	{
 		/// <summary>Bindable property for <see cref="Source"/>.</summary>
@@ -382,6 +384,11 @@ namespace Microsoft.Maui.Controls
 			var webViewProcessTerminatedEventArgs = new WebViewProcessTerminatedEventArgs();
 #endif
 			ProcessTerminated?.Invoke(this, webViewProcessTerminatedEventArgs);
+		}
+
+		private protected override string GetDebbugerDisplay()
+		{
+			return $"Source = {Source}, " + base.GetDebbugerDisplay();
 		}
 	}
 }

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -12,7 +12,7 @@ using Microsoft.Maui.Devices;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/WebView.xml" path="Type[@FullName='Microsoft.Maui.Controls.WebView']/Docs/*" />
-	[DebuggerDisplay("{GetDebbugerDisplay(), nq}")]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class WebView : View, IWebViewController, IElementConfiguration<WebView>, IWebView
 	{
 		/// <summary>Bindable property for <see cref="Source"/>.</summary>

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Source = {Source}, " + base.GetDebuggerDisplay();
+			return $"Source = {Source}, {base.GetDebuggerDisplay()}";
 		}
 	}
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR adds the `DebuggerDisplay` attribute over a good amount of controls and, this is the first step into improving the debug experience of .NET MAUI
![image](https://github.com/user-attachments/assets/280073c0-7ef1-4086-8eee-4f1173552e7d)

You can find more images in the related issue

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Related to #27016

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
