### PR TITLE
Updating MAUI projects to support Windows Universal authentication

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -18,6 +18,7 @@
     <ProjectCapability Include="Msix" />
     <ProjectCapability Include="MauiSingleProject" />
     <ProjectCapability Include="LaunchProfiles" />
+    <ProjectCapability Include="SupportUniversalAuthentication" />
     <!-- If VS is older than Dev17 -->
     <ProjectCapability Include="XamarinStaticLaunchProfiles" Condition=" '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &lt; '17.0' " />
     <!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

I'm adding a project capability that will allow MAUI projects to support Windows Universal authentication.  Right now, if you create a MAUI app, enable MSIX packaging for Windows, then attempt to edit/create a debug profile, you'll only see the following two authentication options:

![image](https://github.com/user-attachments/assets/c3f994ec-5d8c-4ef9-a43d-4855216fb33e)

With this change, you'll also see "Universal":

![image](https://github.com/user-attachments/assets/92fd3252-6c3f-4349-805e-57556bdbc66f)

Universal authentication is more useful, as it doesn't require manually installing and starting remote debugger on remote Windows machines when using them for deployment and debugging.  For more information on the differences between Windows and Universal authentication see here: https://learn.microsoft.com/en-us/windows/uwp/debug-test-perf/deploying-and-debugging-uwp-apps#authentication-modes

### Issues Fixed

Fixes VS internal bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1730421

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
