### PR TITLE
Don't suppress exit codes Appium driver install

### DIFF
--- a/eng/pipelines/common/setup-jdk.yml
+++ b/eng/pipelines/common/setup-jdk.yml
@@ -24,8 +24,8 @@ steps:
       $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-${{ parameters.jdkMajorVersion }}.*\bin\java.exe) | Select-Object -First 1
       if ($path -and (Test-Path $path)) {
         $env:JAVA_HOME = $path.Directory.Parent.FullName
+      }
     }
-    
     if ($env:JAVA_HOME) {
       echo "##vso[task.setvariable variable=JAVA_HOME]$env:JAVA_HOME"
       echo "JAVA_HOME set to '$env:JAVA_HOME'"

--- a/eng/pipelines/common/setup-jdk.yml
+++ b/eng/pipelines/common/setup-jdk.yml
@@ -1,4 +1,5 @@
 parameters:
+  jdkFolder: '$(JAVA_HOME_17_X64)'
   jdkMajorVersion: 17
 
 steps:
@@ -17,9 +18,12 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - pwsh: |
-    $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-${{ parameters.jdkMajorVersion }}.*\bin\java.exe) | Select-Object -First 1
-    if ($path -and (Test-Path $path)) {
-      $env:JAVA_HOME = $path.Directory.Parent.FullName
+    if ('${{ parameters.jdkFolder }}') {
+      $env:JAVA_HOME = '${{ parameters.jdkFolder }}'
+    } else {
+      $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-${{ parameters.jdkMajorVersion }}.*\bin\java.exe) | Select-Object -First 1
+      if ($path -and (Test-Path $path)) {
+        $env:JAVA_HOME = $path.Directory.Parent.FullName
     }
     
     if ($env:JAVA_HOME) {

--- a/eng/pipelines/common/setup-jdk.yml
+++ b/eng/pipelines/common/setup-jdk.yml
@@ -1,24 +1,27 @@
 parameters:
-  jdkFolder: $(JAVA_HOME_17_X64)
   jdkMajorVersion: 17
 
 steps:
 # Setup JDK Paths (gradle needs it)
 - bash: |
-    echo "##vso[task.setvariable variable=JI_JAVA_HOME]${{ parameters.jdkFolder }}"
-    echo "##vso[task.setvariable variable=JAVA_HOME]${{ parameters.jdkFolder }}"
+    jdkPath=$(/usr/libexec/java_home -V 2>&1 | grep -E "${{ parameters.jdkMajorVersion }}.jdk" | head -n 1 | awk '{print $NF}')
+    if [ -n "$jdkPath" ]; then
+      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$jdkPath"
+      echo "##vso[task.setvariable variable=JAVA_HOME]$jdkPath"
+      echo "JAVA_HOME set to '$jdkPath'"
+    else
+      echo "Unable to find JDK ${{ parameters.jdkMajorVersion }}"
+      exit 1
+    fi
   displayName: Setup JDK ${{ parameters.jdkMajorVersion }} Paths
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - pwsh: |
-    if ('${{ parameters.jdkFolder }}') {
-      $env:JAVA_HOME = '${{ parameters.jdkFolder }}'
-    } else {
-      $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-${{ parameters.jdkMajorVersion }}.*\bin\java.exe) | Select-Object -First 1
-      if ($path -and (Test-Path $path)) {
-        $env:JAVA_HOME = $path.Directory.Parent.FullName
-      }
+    $path = (Get-ChildItem $env:ProgramFiles\Microsoft\jdk-${{ parameters.jdkMajorVersion }}.*\bin\java.exe) | Select-Object -First 1
+    if ($path -and (Test-Path $path)) {
+      $env:JAVA_HOME = $path.Directory.Parent.FullName
     }
+    
     if ($env:JAVA_HOME) {
       echo "##vso[task.setvariable variable=JAVA_HOME]$env:JAVA_HOME"
       echo "JAVA_HOME set to '$env:JAVA_HOME'"

--- a/eng/pipelines/common/setup-jdk.yml
+++ b/eng/pipelines/common/setup-jdk.yml
@@ -5,15 +5,21 @@ parameters:
 steps:
 # Setup JDK Paths (gradle needs it)
 - bash: |
-    jdkPath=$(/usr/libexec/java_home -V 2>&1 | grep -E "${{ parameters.jdkMajorVersion }}.jdk" | head -n 1 | awk '{print $NF}')
-    if [ -n "$jdkPath" ]; then
-      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$jdkPath"
-      echo "##vso[task.setvariable variable=JAVA_HOME]$jdkPath"
-      echo "JAVA_HOME set to '$jdkPath'"
+    if [ -n "${{ parameters.jdkFolder }}" ]; then
+      jdkPath="${{ parameters.jdkFolder }}"
+      echo "Using provided JDK folder: $jdkPath"
     else
-      echo "Unable to find JDK ${{ parameters.jdkMajorVersion }}"
-      exit 1
+      jdkPath=$(/usr/libexec/java_home -V 2>&1 | grep -E "${{ parameters.jdkMajorVersion }}.jdk" | head -n 1 | awk '{print $NF}')
+      if [ -n "$jdkPath" ]; then
+        echo "Found JDK path: $jdkPath"
+      else
+        echo "Unable to find JDK ${{ parameters.jdkMajorVersion }}"
+        exit 1
+      fi
     fi
+    echo "##vso[task.setvariable variable=JI_JAVA_HOME]$jdkPath"
+    echo "##vso[task.setvariable variable=JAVA_HOME]$jdkPath"
+    echo "JAVA_HOME set to '$jdkPath'"
   displayName: Setup JDK ${{ parameters.jdkMajorVersion }} Paths
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
@@ -31,6 +37,7 @@ steps:
       echo "JAVA_HOME set to '$env:JAVA_HOME'"
     } else {
       echo "Unable to set JAVA_HOME"
+      exit 1
     }
   displayName: Setup JDK ${{ parameters.jdkMajorVersion }} Paths
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -199,12 +199,13 @@ Write-Output "List of installed drivers after cleaup $drivers"
 Write-Output  "Check everything is installed correctly with appium doctor"
 
 if ($IsWindows) {
-    appium driver doctor windows || & { "ignore failure"; $global:LASTEXITCODE = 0 }
+    appium driver doctor windows
 }
 if ($IsMacOS) {
-    # appium driver doctor xcuitest || & { "ignore failure"; $global:LASTEXITCODE = 0 }
-    # appium driver doctor mac2 || & { "ignore failure"; $global:LASTEXITCODE = 0 }
+    appium driver doctor xcuitest
+    appium driver doctor mac2
 }
-appium driver doctor uiautomator2 || & { "ignore failure"; $global:LASTEXITCODE = 0 }
+
+appium driver doctor uiautomator2
 
 Write-Output  "Done, thanks!"


### PR DESCRIPTION
### Description of Change

For some reason the exit codes were reset on the `appium driver doctor` calls. If the drivers are not installed correctly, the tests will fail so we want to fail early and not let the whole pipeline go through when this happens.

This PR removes the suppressing of the exit codes for these calls so that the pipeline should fail whenever the one of the drivers fails to install.

Additionally, this PR makes changes in how the JAVA_HOME variable is set. For macOS, this step always seemed to fail as can be seen [here](https://dev.azure.com/xamarin/public/_build/results?buildId=131854&view=logs&jobId=88e1cf3c-a854-5a04-3e0c-4e528bc51a87&j=88e1cf3c-a854-5a04-3e0c-4e528bc51a87&t=5d081afd-370c-5b4d-f62b-3abe920f9830)

![image](https://github.com/user-attachments/assets/e427162c-0619-4824-9508-8d9b9654ed1c)

This needed to be fixed so that the `appium driver doctor` calls do not report the unset JAVA_HOME variable as an error.

### Issues Fixed

Fixes #27013
