### PR TITLE
Move Microsoft.Maui.Graphics.slnf to subfolder (clean up repo root)

### DIFF
--- a/src/Graphics/Microsoft.Maui.Graphics.slnf
+++ b/src/Graphics/Microsoft.Maui.Graphics.slnf
@@ -1,6 +1,6 @@
 {
   "solution": {
-    "path": "Microsoft.Maui.sln",
+    "path": "..\\..\\Microsoft.Maui.sln",
     "projects": [
       "src\\Graphics\\samples\\GraphicsTester.Android\\GraphicsTester.Android.csproj",
       "src\\Graphics\\samples\\GraphicsTester.MacCatalyst\\GraphicsTester.MacCatalyst.csproj",


### PR DESCRIPTION
### Description of Change

Moves the `Microsoft.Maui.Graphics.slnf` file to a subfolder in the `src/Graphics` directory.

### Issues Fixed

Related to #26068 
