### PR TITLE
[iOS] Fixed a crash issue with CollectionView when configured with CollectionViewHandler2 on iOS 15 and iOS 16.

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -265,6 +265,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		public override nint NumberOfSections(UICollectionView collectionView)
 		{
+			// https://github.com/dotnet/maui/issues/26997
+			// On iOS versions 15 and 16, this method is called immediately after the base LoadView method is invoked.
+			// At this point, ItemsSource was not set, which caused a crash when accessed.
+			// To handle this scenario, we check if ItemsSource is null before proceeding.
+			// In iOS 17 and later versions, this behavior works properly, as the method is no longer called prematurely.
+			// To ensure compatibility with older iOS versions, we include this null check and return 0 if ItemsSource is null.
+			if (ItemsSource == null)
+			{
+				return 0;
+			}
+
 			CheckForEmptySource();
 			return ItemsSource.GroupCount;
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26997.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26997.xaml
@@ -2,16 +2,17 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Maui.Controls.Sample.Issues.Issue26997"
+			 xmlns:local="clr-namespace:Maui.Controls.Sample"
 			 xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
 	<Grid>
-		<CollectionView ItemsSource="{Binding ImagesToDisplay}"
-						AutomationId="collectionView"
-						x:DataType="ns:Issue26997">
+		<local:CollectionView2 ItemsSource="{Binding ImagesToDisplay}"
+							   AutomationId="collectionView"
+							   x:DataType="ns:Issue26997">
 			<CollectionView.ItemTemplate>
 				<DataTemplate x:DataType="x:String">
 					<Image Source="{Binding .}"/>
 				</DataTemplate>
 			</CollectionView.ItemTemplate>
-		</CollectionView>
+		</local:CollectionView2>
 	</Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26997.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26997.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Maui.Controls.Sample.Issues.Issue26997"
+			 xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues">
+	<Grid>
+		<CollectionView ItemsSource="{Binding ImagesToDisplay}"
+						AutomationId="collectionView"
+						x:DataType="ns:Issue26997">
+			<CollectionView.ItemTemplate>
+				<DataTemplate x:DataType="x:String">
+					<Image Source="{Binding .}"/>
+				</DataTemplate>
+			</CollectionView.ItemTemplate>
+		</CollectionView>
+	</Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26997.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26997.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 26997, "CollectionView should not crash on iOS 15 and 16", PlatformAffected.iOS)]
+public partial class Issue26997 : ContentPage
+{
+	public ObservableCollection<string> ImagesToDisplay { get; } = new();
+
+	public Issue26997()
+	{
+		InitializeComponent();
+		BindingContext = this;
+		AddData();
+	}
+
+	void AddData()
+	{
+		ImagesToDisplay.Add("dotnet_bot.png");
+		ImagesToDisplay.Add("dotnet_bot.png");
+		ImagesToDisplay.Add("dotnet_bot.png");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26997.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26997.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue26997 : _IssuesUITest
+	{
+		public override string Issue => "CollectionView should not crash on iOS 15 and 16";
+
+		public Issue26997(TestDevice device)
+		: base(device)
+		{ }
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewShouldNotCrash()
+		{
+			App.WaitForElement("collectionView");
+		}
+	}
+}


### PR DESCRIPTION
### Root Cause of the issue 

- On iOS versions 15 and 16, the NumberOfSections method is called immediately after the base.LoadView method is invoked. At this point, ItemsSource was not set, which caused a crash when accessing the details from ItemsSource.

### Description of Change

- To address this issue, I added a check to verify if ItemsSource is null before proceeding. On iOS 17 and later, this behavior works correctly as the method is no longer called prematurely. For compatibility with older iOS versions, the null check ensures the method returns 0 if ItemsSource is null, resolving the issue with CV2 on iOS 15 and 16
 
### Issues Fixed

Fixes #26997

### Tested the behaviour in the following platforms

- [x] iOS
- [ ] Android
- [ ] Windows
- [ ] Mac

### Tested Versions

| iOS Version | Did the App crash?| 
|----------|----------|
| iOS 15.2 |  ✅  |
| iOS 15.5 |  ✅  |
| iOS 16.4 |  ✅  |
| iOS 17.5 | ❌ |
| iOS 18.0 | ❌ |
| iOS 18.1 | ❌ |

### Screenshots

**Note**: The video attached below shows that this issue occurs only on iOS 15+ and 16+ versions.

| iOS version | Before Issue Fix | After Issue Fix |
|------------|----------|----------|
| iOS 15.2 | <video src="https://github.com/user-attachments/assets/55f538c5-f3b8-4e74-927c-1a175abcd050"> | <video src="https://github.com/user-attachments/assets/8487598d-4295-4fde-90df-241a7b2bd967"> |
| iOS 15.5 | <video src="https://github.com/user-attachments/assets/4fbc708a-bdb1-406e-a05e-e6c24ec45f6a"> | <video src="https://github.com/user-attachments/assets/b5468acd-3e92-4949-9a3c-ff6995f482ef"> |
| iOS 16.4 | <video src="https://github.com/user-attachments/assets/0f04ea49-e89d-485f-bcc0-29efe3d6ecea"> | <video src="https://github.com/user-attachments/assets/cf405552-f45c-4982-9206-36bd0d29c715"> |
| iOS 17.5 | <video src="https://github.com/user-attachments/assets/a7ab687a-f2a2-4e87-be6f-04f393fa3fd4"> | <video src="https://github.com/user-attachments/assets/0a0c9c52-cf08-41d6-869e-bf46545a6fd6"> |
| iOS 18.1 | <video src="https://github.com/user-attachments/assets/ec078549-4d68-47c3-8504-b18e6a1bbc74"> | <video src="https://github.com/user-attachments/assets/5213f906-1395-4fb6-aff5-62dc3c1416e5"> |
