### PR TITLE
[tests] Disable CollectionView related flaky failing tests

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22417.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22417.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		[FailsOnMacWhenRunningOnXamarinUITest("VerifyScreenshot method not implemented on macOS")]
-		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows")]
+		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows https://github.com/dotnet/maui/issues/27059")]
 		public async Task AddItemsToCarouselViewWorks()
 		{
 			App.WaitForElement("WaitForStubControl");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22417.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22417.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.CarouselView)]
 		[FailsOnMacWhenRunningOnXamarinUITest("VerifyScreenshot method not implemented on macOS")]
+		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows")]
 		public async Task AddItemsToCarouselViewWorks()
 		{
 			App.WaitForElement("WaitForStubControl");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.CollectionView)]
+		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows")]
 		public void AppShouldNotCrashAfterLoadingGroupedCollectionView()
 		{
 			App.WaitForElement("button");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.CollectionView)]
-		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows")]
+		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows https://github.com/dotnet/maui/issues/27059")]
 		public void AppShouldNotCrashAfterLoadingGroupedCollectionView()
 		{
 			App.WaitForElement("button");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if !MACCATALYST
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -23,3 +24,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif


### PR DESCRIPTION
### Description of Change

Disable more CollectionView flacky tests on Windows and Catalyst 