### PR TITLE
[iOS] Fix for CarouselView ItemSpacing property in ItemsLayout not working with CV2

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -41,6 +41,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			bool isHorizontal = VirtualView.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
 			var peekInsets = VirtualView.PeekAreaInsets;
+			double itemSpacing = 0;
+			if (VirtualView.ItemsLayout is LinearItemsLayout linearItemsLayout)
+			{
+				itemSpacing = linearItemsLayout.ItemSpacing;
+			}
 
 			var weakItemsView = new WeakReference<CarouselView>(ItemsView);
 			var weakController = new WeakReference<CarouselViewController2>((CarouselViewController2)Controller);
@@ -48,6 +53,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			return LayoutFactory2.CreateCarouselLayout(
 				isHorizontal,
 				peekInsets,
+				itemSpacing,
 				weakItemsView,
 				weakController);
 		}

--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -41,11 +41,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			bool isHorizontal = VirtualView.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
 			var peekInsets = VirtualView.PeekAreaInsets;
-			double itemSpacing = 0;
-			if (VirtualView.ItemsLayout is LinearItemsLayout linearItemsLayout)
-			{
-				itemSpacing = linearItemsLayout.ItemSpacing;
-			}
 
 			var weakItemsView = new WeakReference<CarouselView>(ItemsView);
 			var weakController = new WeakReference<CarouselViewController2>((CarouselViewController2)Controller);
@@ -53,7 +48,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			return LayoutFactory2.CreateCarouselLayout(
 				isHorizontal,
 				peekInsets,
-				itemSpacing,
 				weakItemsView,
 				weakController);
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -267,6 +267,7 @@ internal static class LayoutFactory2
 	public static UICollectionViewLayout CreateCarouselLayout(
 		bool isHorizontal,
 		Thickness peekAreaInsets,
+		double itemSpacing,
 		WeakReference<CarouselView> weakItemsView,
 		WeakReference<CarouselViewController2> weakController)
 	{
@@ -274,7 +275,6 @@ internal static class LayoutFactory2
 		NSCollectionLayoutDimension itemHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
 		NSCollectionLayoutDimension groupWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
 		NSCollectionLayoutDimension groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
-		nfloat itemSpacing = 0;
 		NSCollectionLayoutGroup group = null;
 
 		var layout = new UICollectionViewCompositionalLayout((sectionIndex, environment) =>
@@ -324,7 +324,7 @@ internal static class LayoutFactory2
 			}
 
 			var section = NSCollectionLayoutSection.Create(group: group);
-			section.InterGroupSpacing = itemSpacing;
+			section.InterGroupSpacing = (nfloat)itemSpacing;
 			section.OrthogonalScrollingBehavior = isHorizontal
 				? UICollectionLayoutSectionOrthogonalScrollingBehavior.GroupPagingCentered
 				: UICollectionLayoutSectionOrthogonalScrollingBehavior.None;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -267,7 +267,6 @@ internal static class LayoutFactory2
 	public static UICollectionViewLayout CreateCarouselLayout(
 		bool isHorizontal,
 		Thickness peekAreaInsets,
-		double itemSpacing,
 		WeakReference<CarouselView> weakItemsView,
 		WeakReference<CarouselViewController2> weakController)
 	{
@@ -324,7 +323,10 @@ internal static class LayoutFactory2
 			}
 
 			var section = NSCollectionLayoutSection.Create(group: group);
-			section.InterGroupSpacing = (nfloat)itemSpacing;
+			if (itemsView.ItemsLayout is LinearItemsLayout linearItemsLayout)
+			{
+				section.InterGroupSpacing = (nfloat)linearItemsLayout.ItemSpacing;
+			}
 			section.OrthogonalScrollingBehavior = isHorizontal
 				? UICollectionLayoutSectionOrthogonalScrollingBehavior.GroupPagingCentered
 				: UICollectionLayoutSectionOrthogonalScrollingBehavior.None;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
@@ -4,8 +4,6 @@
              xmlns:local="clr-namespace:Maui.Controls.Sample"
              x:Class="Maui.Controls.Sample.Issues.Issue25192">
     <Grid>
-        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/27025 -->
-        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->
         <CarouselView Margin="2,9,2,20"
                       HeightRequest="180"
                       Loop="False"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
@@ -4,28 +4,28 @@
              xmlns:local="clr-namespace:Maui.Controls.Sample"
              x:Class="Maui.Controls.Sample.Issues.Issue25192">
     <Grid>
-        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/27025 -->    
-        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->    
-        <local:CarouselView1 Margin="2,9,2,20"
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/27025 -->
+        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->
+        <CarouselView Margin="2,9,2,20"
                       HeightRequest="180"
                       Loop="False"
                       PeekAreaInsets="20"
                       VerticalOptions="End"
                       HorizontalScrollBarVisibility="Never">
-            <local:CarouselView1.ItemsSource>
+            <CarouselView.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
                     <x:String>Item1</x:String>
                     <x:String>Item2</x:String>
                     <x:String>Item3</x:String>
                 </x:Array>
-            </local:CarouselView1.ItemsSource>
-            <local:CarouselView1.ItemsLayout>
+            </CarouselView.ItemsSource>
+            <CarouselView.ItemsLayout>
                 <LinearItemsLayout ItemSpacing="5"
                                    Orientation="Horizontal"
                                    SnapPointsAlignment="Center"
                                    SnapPointsType="MandatorySingle"/>
-            </local:CarouselView1.ItemsLayout>
-            <local:CarouselView1.ItemTemplate>
+            </CarouselView.ItemsLayout>
+            <CarouselView.ItemTemplate>
                 <DataTemplate
                     x:DataType="{x:Null}">
                     <Border BackgroundColor="Red"
@@ -103,7 +103,7 @@
                         </Grid>
                     </Border>
                 </DataTemplate>
-            </local:CarouselView1.ItemTemplate>
-        </local:CarouselView1>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
     </Grid>
 </ContentPage>


### PR DESCRIPTION
### Root Cause of the issue
The itemSpacing variable is initialized to 0. As a result, itemSpacing remains 0, and no spacing is applied between the items.

### Description of Change
To resolve this, apply the correct item spacing from the LinearItemsLayout.

### Issues Fixed



Fixes #27025



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/de42360e-0306-421d-9793-88472c135dc3"> | <img src="https://github.com/user-attachments/assets/a7e40f68-85e7-4ee7-ad98-2e9beacc9b39"> |
| <img src="https://github.com/user-attachments/assets/6968fa4d-6a7c-4d3d-ad5e-b53c309a9e81"> | <img src="https://github.com/user-attachments/assets/7951a62a-0bdc-45a4-a076-0f4d8e6599c4"> |



