### PR TITLE
Improved accessibility of the ToDo Category Chart tooltip in the MAUI template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
@@ -13,10 +13,10 @@
     <shimmer:SfShimmer
         BackgroundColor="Transparent"
         VerticalOptions="FillAndExpand"
-        IsActive ="{Binding IsBusy}">
+        IsActive="{Binding IsBusy}">
         <shimmer:SfShimmer.CustomView>
             <Grid>
-                <BoxView 
+                <BoxView
                     CornerRadius="12"
                     VerticalOptions="FillAndExpand"
                     Style="{StaticResource ShimmerCustomViewStyle}"/>
@@ -27,24 +27,44 @@
                 <chart:SfCircularChart.Legend>
                     <controls:LegendExt Placement="Right">
                         <chart:ChartLegend.LabelStyle>
-                            <chart:ChartLegendLabelStyle 
+                            <chart:ChartLegendLabelStyle
                                 TextColor="{AppThemeBinding 
                                 Light={StaticResource DarkOnLightBackground},
-                                Dark={StaticResource LightOnDarkBackground}}" 
-                                Margin="5" 
-                                FontSize="18" />
+                                Dark={StaticResource LightOnDarkBackground}}"
+                                Margin="5,0,0,0"
+                                FontSize="14"/>
                         </chart:ChartLegend.LabelStyle>
                     </controls:LegendExt>
                 </chart:SfCircularChart.Legend>
-                <chart:RadialBarSeries 
+                <chart:RadialBarSeries
                     ItemsSource="{Binding TodoCategoryData}"
                     PaletteBrushes="{Binding TodoCategoryColors}"
                     XBindingPath="Title"
-                    YBindingPath="Count" 
+                    YBindingPath="Count"
                     ShowDataLabels="True"
-                    EnableTooltip="True" 
+                    EnableTooltip="True"
                     TrackFill="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
-                    CapStyle = "BothCurve"/>
+                    CapStyle="BothCurve">
+                    <chart:RadialBarSeries.TooltipTemplate>
+                        <DataTemplate x:DataType="chart:TooltipInfo">
+                            <HorizontalStackLayout>
+                                <Label Text="{Binding Item.Title}"
+                                       TextColor="{StaticResource LightBackground}"
+                                       FontSize="14"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"/>
+
+                                <Label Text="{Binding Item.Count, StringFormat='  :  \{0}'}"
+                                       TextColor="{StaticResource LightBackground}"
+                                       FontAttributes="Bold"
+                                       FontSize="14"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"/>
+
+                            </HorizontalStackLayout>
+                        </DataTemplate>
+                    </chart:RadialBarSeries.TooltipTemplate>
+                </chart:RadialBarSeries>
             </chart:SfCircularChart>
         </shimmer:SfShimmer.Content>
     </shimmer:SfShimmer>

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
@@ -2,7 +2,7 @@
 <Border xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         xmlns:chart="clr-namespace:Syncfusion.Maui.Toolkit.Charts;assembly=Syncfusion.Maui.Toolkit"
-        xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls" 
+        xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls"
         xmlns:shimmer="clr-namespace:Syncfusion.Maui.Toolkit.Shimmer;assembly=Syncfusion.Maui.Toolkit"
         xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
         xmlns:model="clr-namespace:TestSyncTemplate.Models"
@@ -48,14 +48,14 @@
                     CapStyle="BothCurve">
                     <chart:RadialBarSeries.TooltipTemplate>
                         <DataTemplate x:DataType="chart:TooltipInfo">
-                            <HorizontalStackLayout BindingContext="{Binding Item}" >
+                            <HorizontalStackLayout BindingContext="{Binding Item}">
                                 <Label Text="{Binding Title, x:DataType=model:CategoryChartData}"
                                        TextColor="{StaticResource LightBackground}"
                                        FontSize="14"
                                        HorizontalOptions="Center"
                                        VerticalOptions="Center"/>
 
-                                <Label Text="{Binding Count,x:DataType=model:CategoryChartData, StringFormat='  :  \{0}'}"
+                                <Label Text="{Binding Count, x:DataType=model:CategoryChartData, StringFormat='  :  \{0}'}"
                                        TextColor="{StaticResource LightBackground}"
                                        FontAttributes="Bold"
                                        FontSize="14"

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
@@ -5,6 +5,7 @@
         xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls" 
         xmlns:shimmer="clr-namespace:Syncfusion.Maui.Toolkit.Shimmer;assembly=Syncfusion.Maui.Toolkit"
         xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
+        xmlns:model="clr-namespace:TestSyncTemplate.Models"
         x:Class="MauiApp._1.Pages.Controls.CategoryChart"
         HeightRequest="{OnIdiom 300, Phone=200}"
         Margin="0, 12"
@@ -47,20 +48,19 @@
                     CapStyle="BothCurve">
                     <chart:RadialBarSeries.TooltipTemplate>
                         <DataTemplate x:DataType="chart:TooltipInfo">
-                            <HorizontalStackLayout>
-                                <Label Text="{Binding Item.Title}"
+                            <HorizontalStackLayout BindingContext="{Binding Item}" >
+                                <Label Text="{Binding Title, x:DataType=model:CategoryChartData}"
                                        TextColor="{StaticResource LightBackground}"
                                        FontSize="14"
                                        HorizontalOptions="Center"
                                        VerticalOptions="Center"/>
 
-                                <Label Text="{Binding Item.Count, StringFormat='  :  \{0}'}"
+                                <Label Text="{Binding Count,x:DataType=model:CategoryChartData, StringFormat='  :  \{0}'}"
                                        TextColor="{StaticResource LightBackground}"
                                        FontAttributes="Bold"
                                        FontSize="14"
                                        HorizontalOptions="Center"
                                        VerticalOptions="Center"/>
-
                             </HorizontalStackLayout>
                         </DataTemplate>
                     </chart:RadialBarSeries.TooltipTemplate>

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/AppStyles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/AppStyles.xaml
@@ -110,8 +110,6 @@
                 Value="Transparent" />
         <Setter Property="FontSize"
                 Value="17" />
-        <Setter Property="LineHeight"
-                Value="1.29" />
         <!-- 22 -->
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>


### PR DESCRIPTION
### Description of Change

Improved the accessibility of the Todo category radial chart tooltip by displaying the value alongside the category title. This enhancement helps users better understand the category value when tapping the tooltip in the chart. The improvement was implemented by adding a tooltip template for the radial chart. Also, customized the legend text style. 

Also, the legend and tooltip labels are not positioned in the center due to line height on Label in AppStyle. 

**Before:**
<img width="303" alt="image" src="https://github.com/user-attachments/assets/580434cc-4e24-49d1-8dff-a6f9ac160434" />

**After:**
<img width="303" alt="image" src="https://github.com/user-attachments/assets/39d40003-19d6-4624-810d-ae0d1b84da63" />
 

### Issues Fixed

Related to #26260 & #26800 

### Output 

Android:
![Image](https://github.com/user-attachments/assets/a4852a9d-0fcf-408c-9439-e179cb4b8318)

iOS:
![image](https://github.com/user-attachments/assets/73a9d3cc-d5cc-4b68-b48a-bdae824307f9)


Mac: 
<img width="871" alt="image" src="https://github.com/user-attachments/assets/17d3c3b5-0b00-49ed-a0ee-26a5f199cedf" />


