### PR TITLE
[Testing] Enabling some UITests from Issues folder in Appium-2

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue1685.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue1685.cs
@@ -6,7 +6,7 @@ using Entry = Microsoft.Maui.Controls.Entry;
 namespace Maui.Controls.Sample.Issues
 {
 
-	[Issue(IssueTracker.Github, 1685, "Entry clears when upadting text from native with one-way binding", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.WinPhone, NavigationBehavior.PushModalAsync)]
+	[Issue(IssueTracker.Github, 1685, "Entry clears when upadting text from native with one-way binding", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.WinPhone)]
 	public class Issue1685 : TestContentPage
 	{
 		const string ButtonId = "Button1685";
@@ -46,7 +46,8 @@ namespace Maui.Controls.Sample.Issues
 
 			var entry = new Entry()
 			{
-				Placeholder = "Entry"
+				Placeholder = "Entry",
+				AutomationId = Success,
 			};
 			entry.SetBinding(Entry.TextProperty, "EntryValue", BindingMode.OneWay);
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue1685.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue1685.cs
@@ -6,7 +6,7 @@ using Entry = Microsoft.Maui.Controls.Entry;
 namespace Maui.Controls.Sample.Issues
 {
 
-	[Issue(IssueTracker.Github, 1685, "Entry clears when upadting text from native with one-way binding", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.WinPhone)]
+	[Issue(IssueTracker.Github, 1685, "Entry clears when updating text from native with one-way binding", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.WinPhone)]
 	public class Issue1685 : TestContentPage
 	{
 		const string ButtonId = "Button1685";
@@ -47,7 +47,7 @@ namespace Maui.Controls.Sample.Issues
 			var entry = new Entry()
 			{
 				Placeholder = "Entry",
-				AutomationId = Success,
+				AutomationId = "TestEntry",
 			};
 			entry.SetBinding(Entry.TextProperty, "EntryValue", BindingMode.OneWay);
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue1769.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue1769.cs
@@ -43,28 +43,24 @@
 						HorizontalOptions = LayoutOptions.Center
 					};
 
-#pragma warning disable CS0618 // Type or member is obsolete
+
 					var switcher = new Switch
 					{
 						AutomationId = SwitchAutomatedId,
 						HorizontalOptions = LayoutOptions.Center,
-						VerticalOptions = LayoutOptions.CenterAndExpand
+						VerticalOptions = LayoutOptions.Center
 					};
-#pragma warning restore CS0618 // Type or member is obsolete
+
 					switcher.Toggled += switcher_Toggled;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0612 // Type or member is obsolete
 					_label = new Label
 					{
-						AutomationId = string.Format(SwitchIsNowLabelTextFormat, switcher.IsToggled),
+						AutomationId = "SwitchLabel",
 						Text = string.Format(SwitchIsNowLabelTextFormat, switcher.IsToggled),
-						FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
+						FontSize = 20,
 						HorizontalOptions = LayoutOptions.Center,
-						VerticalOptions = LayoutOptions.CenterAndExpand
+						VerticalOptions = LayoutOptions.Center
 					};
-#pragma warning restore CS0612 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 
 					// Accomodate iPhone status bar.
 					Padding = DeviceInfo.Platform == DevicePlatform.iOS ? new Thickness(10, 20, 10, 5) : new Thickness(10, 0, 10, 5);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11962.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11962.cs
@@ -15,14 +15,19 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.WebView)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnAndroidWhenRunningOnXamarinUITest]
 		public void WebViewDisposesProperly()
 		{
+			App.WaitForElement("NextButton");
 			App.Tap("NextButton");
+			App.WaitForElement("BackButton");
 			App.Tap("BackButton");
+			App.WaitForElement("NextButton");
 			App.Tap("NextButton");
+			App.WaitForElement("BackButton");
 			App.Tap("BackButton");
+			App.WaitForElement("NextButton");
 			App.Tap("NextButton");
+			App.WaitForElement("BackButton");
 			App.Tap("BackButton");
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11969.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11969.cs
@@ -1,4 +1,4 @@
-﻿#if IOS
+﻿
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -9,6 +9,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 	{
 		const string SwipeViewId = "SwipeViewId";
 		const string SwipeButtonId = "SwipeButtonId";
+		const string TestPassId = "TestPassId";
+		const string SwipeViewCheckBoxId = "SwipeViewCheckBoxId";
+		const string SwipeViewContentCheckBoxId = "SwipeViewContentCheckBoxId";
 
 		const string Failed = "SwipeView Button not tapped";
 		const string Success = "SUCCESS";
@@ -22,16 +25,30 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.SwipeView)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
 		public void SwipeDisableChildButtonTest()
 		{
-			App.WaitForNoElement(Failed);
-			App.WaitForElement(SwipeViewId);
-			App.Tap("SwipeViewCheckBoxId");
-			App.Tap("SwipeViewContentCheckBoxId");
+			App.WaitForElement(TestPassId);
+			SwipeViewElement();
+			App.WaitForElement(SwipeViewCheckBoxId);
+			App.Tap(SwipeViewCheckBoxId);
+
+			App.WaitForElement(SwipeViewContentCheckBoxId);
+			App.Tap(SwipeViewContentCheckBoxId);
+
+			App.WaitForElement(SwipeButtonId);
 			App.Tap(SwipeButtonId);
-			App.WaitForNoElement(Success);
+
+			App.WaitForElement("Ok");
+			App.Tap("Ok");
+			App.WaitForElement(TestPassId);
+		}
+		 void SwipeViewElement() 
+		{
+#if WINDOWS
+			App.WaitForElement("Item 1");
+#else
+			App.WaitForElement(SwipeViewId);
+#endif
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11969.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11969.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public void SwipeDisableChildButtonTest()
 		{
 			App.WaitForElement(TestPassId);
-			SwipeViewElement();
+			App.WaitForElement("Item 1");
 			App.WaitForElement(SwipeViewCheckBoxId);
 			App.Tap(SwipeViewCheckBoxId);
 
@@ -41,14 +41,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("Ok");
 			App.Tap("Ok");
 			App.WaitForElement(TestPassId);
-		}
-		 void SwipeViewElement() 
-		{
-#if WINDOWS
-			App.WaitForElement("Item 1");
-#else
-			App.WaitForElement(SwipeViewId);
-#endif
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1267.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1267.cs
@@ -17,11 +17,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.Layout)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
-		[FailsOnMacWhenRunningOnXamarinUITest]
 		public void StarInGridDoesNotCrash()
 		{
-			App.WaitForNoElement(Success);
+			App.WaitForElement(Success);
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1469.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1469.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.LifeCycle)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnAllPlatformsWhenRunningOnXamarinUITest]
 		public void Issue1469Test()
 		{
 			App.WaitForElement(Go);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1685.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1685.cs
@@ -1,4 +1,4 @@
-﻿#if ANDROID
+﻿
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -19,13 +19,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.Entry)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnAndroidWhenRunningOnXamarinUITest]
 		public void EntryOneWayBindingShouldUpdate()
 		{
 			App.WaitForElement(ButtonId);
 			App.Tap(ButtonId);
-			App.WaitForNoElement(Success);
+			App.WaitForElement(Success);
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1685.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1685.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "Entry clears when upadting text from native with one-way binding";
+		public override string Issue => "Entry clears when updating text from native with one-way binding";
 
 		[Test]
 		[Category(UITestCategories.Entry)]
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement(ButtonId);
 			App.Tap(ButtonId);
-			App.WaitForElement(Success);
+			Assert.That(App.FindElement("TestEntry").GetText(), Is.EqualTo(Success));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1747.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1747.cs
@@ -19,9 +19,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.Switch)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnAndroidWhenRunningOnXamarinUITest]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
-		[FailsOnMacWhenRunningOnXamarinUITest]
+
 		public void Issue1747Test()
 		{
 			App.WaitForElement(ToggleButtonAutomationId);
@@ -29,11 +27,13 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			var toggleSwitch = App.FindElement(ToggleSwitchAutomationId);
 			ClassicAssert.AreNotEqual(toggleSwitch, null);
-
+			Assert.That(toggleSwitch?.IsEnabled(), Is.False);
+			App.WaitForElement(ToggleButtonAutomationId);
 			App.Tap(ToggleButtonAutomationId);
 
 			toggleSwitch = App.FindElement(ToggleSwitchAutomationId);
 			ClassicAssert.AreNotEqual(toggleSwitch, null);
+			Assert.That(toggleSwitch?.IsEnabled(), Is.True);
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1769.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1769.cs
@@ -19,15 +19,14 @@ public class Issue1769 : _IssuesUITest
 	[Test]
 	[Category(UITestCategories.Switch)]
 	[Category(UITestCategories.Compatibility)]
-	[FailsOnAllPlatformsWhenRunningOnXamarinUITest]
 	public void Issue1769Test()
 	{
 		App.WaitForElement(GoToPageTwoButtonText);
 		App.Tap(GoToPageTwoButtonText);
 
 		App.WaitForElement(SwitchAutomatedId);
-		App.WaitForElement(string.Format(SwitchIsNowLabelTextFormat, false));
+		Assert.That(App.FindElement("SwitchLabel").GetText(), Is.EqualTo(string.Format(SwitchIsNowLabelTextFormat, false)));
 		App.Tap(SwitchAutomatedId);
-		App.WaitForElement(string.Format(SwitchIsNowLabelTextFormat, true));
-	}
+		Assert.That(App.FindElement("SwitchLabel").GetText(), Is.EqualTo(string.Format(SwitchIsNowLabelTextFormat, true)));
+}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1851.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue1851.cs
@@ -15,9 +15,7 @@ public class Issue1851 : _IssuesUITest
 	[Test]
 	[Category(UITestCategories.ListView)]
 	[Category(UITestCategories.Compatibility)]
-	[FailsOnIOSWhenRunningOnXamarinUITest]
-	[FailsOnMacWhenRunningOnXamarinUITest]
-	[FailsOnWindowsWhenRunningOnXamarinUITest]
+
 	public void Issue1851Test()
 	{
 		App.WaitForElement("btn");


### PR DESCRIPTION
## Description of Change
This PR focuses on enabling and updating 8 related testscases in Appium. The tests, previously ignored using Fails attribute, are reviewed, and modified to ensure they are functional with the Appium framework.We are going to enable tests in blocks in different PRs. This is the 2nd group of tests enabled.

## Test cases

- Issue11962
- Issue11969
- Issue1267
- Issue1469
- Issue1685
- Issue1747
- Issue1769
- Issue1851