### PR TITLE
CollectionView2 Items display issue when Header/Footer is resized on iOS

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public const int HeaderTag = 111;
 		public const int FooterTag = 222;
 
+		View _headerView;
+		View _footerView;
+		EventHandler _footerMeasureInvalidated;
+		EventHandler _headerMeasureInvalidated;
+
 		bool _disposed;
 
 		public StructuredItemsViewController2(TItemsView structuredItemsView, UICollectionViewLayout layout)
@@ -40,7 +45,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (disposing)
 			{
+				if (_headerView != null)
+					_headerView.MeasureInvalidated -= _headerMeasureInvalidated;
 
+				if (_footerView != null)
+					_footerView.MeasureInvalidated -= _footerMeasureInvalidated;
 			}
 
 			base.Dispose(disposing);
@@ -115,26 +124,54 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (isHeader)
 			{
+				if (_headerView != null)
+					_headerView.MeasureInvalidated -= _headerMeasureInvalidated;
+
 				if (ItemsView.Header is View headerView)
 				{
+					_headerView = headerView;
 					cell.Bind(headerView, ItemsView);
 				}
 				else if (ItemsView.HeaderTemplate is not null)
 				{
+					_headerView = (View)ItemsView.HeaderTemplate.CreateContent();
 					cell.Bind(ItemsView.HeaderTemplate, ItemsView.Header, ItemsView);
 				}
+
+				_headerMeasureInvalidated = (s, e) =>
+				{
+					var indexPath = CollectionView.GetIndexPathForSupplementaryView(cell);
+					if (indexPath != null)
+						CollectionView.ReloadItems([indexPath]);
+				};
+
+				_headerView.MeasureInvalidated += _headerMeasureInvalidated;
 				cell.Tag = HeaderTag;
 			}
 			else
 			{
+				if (_footerView != null)
+					_footerView.MeasureInvalidated -= _footerMeasureInvalidated;
+
 				if (ItemsView.Footer is View footerView)
 				{
+					_footerView = footerView;
 					cell.Bind(footerView, ItemsView);
 				}
 				else if (ItemsView.FooterTemplate is not null)
 				{
+					_footerView = (View)ItemsView.FooterTemplate.CreateContent();
 					cell.Bind(ItemsView.FooterTemplate, ItemsView.Footer, ItemsView);
 				}
+
+				_footerMeasureInvalidated = (s, e) =>
+				{
+					var indexPath = CollectionView.GetIndexPathForSupplementaryView(cell);
+					if (indexPath != null)
+						CollectionView.ReloadItems([indexPath]);
+				};
+
+				_footerView.MeasureInvalidated += _footerMeasureInvalidated;
 				cell.Tag = FooterTag;
 			}
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25362.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25362.cs
@@ -13,8 +13,6 @@ public class Issue25362 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]
-	[FailsOnIOSWhenRunningOnXamarinUITest("This is not working for CV2 yet")]
-	[FailsOnMacWhenRunningOnXamarinUITest("This is not working for CV2 yet")]
 	public void HeaderShouldNotCollapseWithItems()
 	{
 		App.WaitForElement("button");


### PR DESCRIPTION
## Description

This is a proposal for the CV2. A fix for the CV1, which is also not working, is here: https://github.com/dotnet/maui/pull/21812

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/20538
Fixes https://github.com/dotnet/maui/issues/12429

|Before|After|
|--|--|
|<video src="https://github.com/dotnet/maui/assets/42434498/44facc31-dc07-42ee-a834-c1dd9f603254" width="300px"/>|<video src="https://github.com/dotnet/maui/assets/42434498/566be397-8460-401a-81b3-b0435f3ba263" width="300px"/>|