### PR TITLE
[iOS] Disabled animation for NavigationBar on initial display

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (_displayedPage != null)
 			{
 				_displayedPage.PropertyChanged += OnDisplayedPagePropertyChanged;
-				UpdateNavigationBarHidden();
+				UpdateNavigationBarHidden(animated: false);
 				UpdateNavigationBarHasShadow();
 			}
 		}
@@ -689,9 +689,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			return ((IShellController)_context.Shell).ProposeNavigation(ShellNavigationSource.Pop, shellItem, shellSection, shellContent, stack, true);
 		}
 
-		void UpdateNavigationBarHidden()
+		void UpdateNavigationBarHidden(bool animated = true)
 		{
-			SetNavigationBarHidden(!Shell.GetNavBarIsVisible(_displayedPage), true);
+			SetNavigationBarHidden(!Shell.GetNavBarIsVisible(_displayedPage), animated);
 		}
 
 		void UpdateNavigationBarHasShadow()


### PR DESCRIPTION
### Description of Change

This PR disables the animation for showing or hiding the navigation bar when a page is displayed for the first time by setting `Shell.NavBarIsVisible`. Subsequent changes to `Shell.NavBarIsVisible` remain unaffected and will animate (maybe they shouldn't though? On Android, displaying or hiding the navigation bar does not involve any navigation transitions)

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26994

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/f1dc5376-89cc-4d97-9663-482437d58d76" width="300px"/>|<video src="https://github.com/user-attachments/assets/5fcc8189-e53e-4dc5-9da2-695543b9d575" width="300px"/>|