### PR TITLE
[Testing] Fix flaky UITests failing sometimes 1

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla59925.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla59925.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	public class Bugzilla59925 : _IssuesUITest
 	{
+		const string BiggerButton = "BiggerButton";
+		const string TestEntry = "TestEntry";
+
 		public Bugzilla59925(TestDevice testDevice) : base(testDevice)
 		{
 		}
@@ -17,8 +20,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Compatibility)]
 		public void Bugzilla59925Test()
 		{
-			App.WaitForElement("BiggerButton");
-			var intialSize = App.WaitForElement("TestEntry").GetRect().Height;
+			App.WaitForElement(BiggerButton);
+			var initialSize = App.WaitForElement(TestEntry).GetRect().Height;
 
 			// iOS/macOS Catalyst Workaround: Minimum Height Threshold
 			// Issue: Entry control has a minimum vertical height on these platforms.
@@ -26,24 +29,27 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			// Solution: Perform additional taps to ensure font size surpasses the minimum.
 			// This allows subsequent size comparisons to accurately reflect height changes.
 #if IOS || MACCATALYST
-			for (int i = 0; i < 8; i++)
+			for (int i = 0; i < 10; i++)
 			{
-				App.WaitForElement("BiggerButton");
-				App.Tap("BiggerButton");
+				App.WaitForElement(BiggerButton);
+				App.Tap(BiggerButton);
 			}
 #endif
 
-			App.Tap("BiggerButton");
-			var updatedSize = App.WaitForElement("TestEntry").GetRect().Height;
-			Assert.That(updatedSize, Is.GreaterThan(intialSize));
+			App.WaitForElement(BiggerButton);
+			App.DoubleTap(BiggerButton);
+			var updatedSize1 = App.WaitForElement(TestEntry).GetRect().Height;
+			Assert.That(updatedSize1, Is.GreaterThanOrEqualTo(initialSize));
 
-			App.Tap("BiggerButton");
-			var updatedSize1 = App.WaitForElement("TestEntry").GetRect().Height;
-			Assert.That(updatedSize1, Is.GreaterThan(updatedSize));
-			
-			App.Tap("BiggerButton");
-			var updatedSize2 = App.WaitForElement("TestEntry").GetRect().Height;
-			Assert.That(updatedSize2, Is.GreaterThan(updatedSize1));
+			App.WaitForElement(BiggerButton);
+			App.DoubleTap(BiggerButton);
+			var updatedSize2 = App.WaitForElement(TestEntry).GetRect().Height;
+			Assert.That(updatedSize2, Is.GreaterThanOrEqualTo(updatedSize1));
+
+			App.WaitForElement(BiggerButton);
+			App.DoubleTap(BiggerButton);
+			var updatedSize3 = App.WaitForElement(TestEntry).GetRect().Height;
+			Assert.That(updatedSize3, Is.GreaterThanOrEqualTo(updatedSize2));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23801.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23801.cs
@@ -19,10 +19,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			var label = App.WaitForElement("Label");
 			var location = label.GetRect();
-			var height = location.Height / 2;
-			var endOfFirstLine = location.X + location.Width - 150;
-			App.Click(endOfFirstLine, location.Y + height);
+			var middleHeight = location.Height / 2;
+			const int marginRight = 150;
+			var endOfFirstLine = location.X + location.Width - marginRight;
 			var testlabel = App.WaitForElement("TestLabel");
+			App.Click(endOfFirstLine, location.Y + middleHeight);	
 			Assert.That(testlabel.GetText(), Is.EqualTo("Label span tapped"));
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
@@ -18,7 +18,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public void RemainingItemsThresholdReachedCommandFired()
 		{
 			App.WaitForElement("collectionView");
-			App.ScrollDown("collectionView");
+			App.ScrollDown("collectionView", ScrollStrategy.Gesture);
+			
+			App.WaitForElement("collectionView");
+			App.ScrollDown("collectionView", ScrollStrategy.Gesture);
+
 			var label = App.WaitForElement("mainPageLabel");
 			Assert.That(label.GetText(), Is.EqualTo("Command Fired!"));
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue889.cs
@@ -22,11 +22,13 @@ public class Issue889 : _IssuesUITest
 		App.WaitForElement("PushedPageLabel");
 		
 #if IOS || MACCATALYST
-		App.Tap(AppiumQuery.ByName("Initial Page"));
+		var initialPageQuery = AppiumQuery.ByName("Initial Page");
+		App.WaitForElement(initialPageQuery);
+		App.Tap(initialPageQuery);
 #else
 		App.TapBackArrow();
 #endif
-
+		App.WaitForElement(Tab2Title);
 		App.TapTab(Tab2Title);
 		App.WaitForElement("SecondTabPageButton");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue889.cs
@@ -6,7 +6,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue889 : _IssuesUITest
 {
-	const string Tab2Title = "Tab 2 Title";
+	string _tab2Title = "Tab 2 Title";
+
 	public Issue889(TestDevice testDevice) : base(testDevice)
 	{
 	}
@@ -26,10 +27,14 @@ public class Issue889 : _IssuesUITest
 		App.WaitForElement(initialPageQuery);
 		App.Tap(initialPageQuery);
 #else
-		App.TapBackArrow();
+		App.Back();
 #endif
-		App.WaitForElement(Tab2Title);
-		App.TapTab(Tab2Title);
+
+#if ANDROID
+		_tab2Title = _tab2Title.ToUpperInvariant();
+#endif
+		App.WaitForElement(_tab2Title);
+		App.TapTab(_tab2Title);
 		App.WaitForElement("SecondTabPageButton");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue889.cs
@@ -21,13 +21,19 @@ public class Issue889 : _IssuesUITest
 		App.WaitForElement("PushPage");
 		App.Tap("PushPage");
 		App.WaitForElement("PushedPageLabel");
-		
+
 #if IOS || MACCATALYST
 		var initialPageQuery = AppiumQuery.ByName("Initial Page");
 		App.WaitForElement(initialPageQuery);
 		App.Tap(initialPageQuery);
 #else
+
+#if WINDOWS
+		App.TapBackArrow();
+#else
 		App.Back();
+#endif
+
 #endif
 
 #if ANDROID


### PR DESCRIPTION
### Description of Change

Fix flaky UITests failing sometimes on CI.
- Bugzilla59925Test
- VerifyLabelSpanGestureWhenWrappedOverTwoLines
- RemainingItemsThresholdReachedCommandFired
- Issue899TestsAppCrashWhenSwitchingTabs
