### PR TITLE
[A11y] Add SemanticProperties.Description to the Toolbar Icon

### DIFF
--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -107,7 +107,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+			// If there is an icon and text on the UIBarItem, the platforms will behave as follows:
+			//     On Windows both will be displayed and the text will be read by screenreaders.
+			//     On Android only the icon will be displayed but the text will be read by screenreaders.
+			//     On MacCatalyst and iOS only the icon will be displayed but the text will NOT be read by screenreaders.
+			// As a result, we will add the text value to the Accessibility Label to ensure that the text is read by screenreaders on all the platforms.
+			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel ?? (Element as ToolbarItem)?.Text;
 #pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityLabel;

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			}
 			else if (!string.IsNullOrEmpty((Element as ToolbarItem)?.Text))
 			{
+				// If there is an icon and text on the UIBarItem, the platforms will behave as follows:
+				//     On Windows both will be displayed and the text will be read by screenreaders.
+				//     On Android only the icon will be displayed but the text will be read by screenreaders.
+				//     On MacCatalyst and iOS only the icon will be displayed but the text will NOT be read by screenreaders.
+				// As a result, we will add the text value to the Accessibility Label to ensure that the text is read by screenreaders on all the platforms.
 				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, new Semantics() { Description = (Element as ToolbarItem)?.Text });
 				return String.Empty;
 			}
@@ -112,11 +117,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-			// If there is an icon and text on the UIBarItem, the platforms will behave as follows:
-			//     On Windows both will be displayed and the text will be read by screenreaders.
-			//     On Android only the icon will be displayed but the text will be read by screenreaders.
-			//     On MacCatalyst and iOS only the icon will be displayed but the text will NOT be read by screenreaders.
-			// As a result, we will add the text value to the Accessibility Label to ensure that the text is read by screenreaders on all the platforms.
 			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		// TODO OBSOLETE FOR NET10
 		public static string SetAccessibilityLabel(this UIBarItem Control, Element Element, string _defaultAccessibilityLabel = null)
-		{	
+		{
 			if (Element == null || Control == null)
 				return _defaultAccessibilityLabel;
 			
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-			Control.AccessibilityLabel = SemanticProperties.GetDescription(Element) ?? (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
 #pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityLabel;

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -1,15 +1,10 @@
 #nullable disable
-#if __MOBILE__
+using System;
 using ObjCRuntime;
 using UIKit;
 using NativeView = UIKit.UIView;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
-#else
-using NativeView = AppKit.NSView;
-
-namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
-#endif
 {
 	public static class AccessibilityExtensions
 	{
@@ -25,31 +20,41 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			SetAccessibilityElementsHidden(nativeViewElement, element);
 		}
 
+		// TODO OBSOLETE FOR NET10
 		public static string SetAccessibilityHint(this NativeView Control, Element Element, string _defaultAccessibilityHint = null)
 		{
 			if (Element == null || Control == null)
 				return _defaultAccessibilityHint;
-#if __MOBILE__
+
+			var semantics = SemanticProperties.UpdateSemantics(Element, null);
+			if (semantics is not null)
+			{
+				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, semantics);
+				return String.Empty;
+			}
+
 			if (_defaultAccessibilityHint == null)
 				_defaultAccessibilityHint = Control.AccessibilityHint;
 
 #pragma warning disable CS0618 // Type or member is obsolete
 			Control.AccessibilityHint = (string)Element.GetValue(AutomationProperties.HelpTextProperty) ?? _defaultAccessibilityHint;
 #pragma warning restore CS0618 // Type or member is obsolete
-#else
-			if (_defaultAccessibilityHint == null)
-				_defaultAccessibilityHint = Control.AccessibilityTitle;
-
-			Control.AccessibilityTitle = (string)Element.GetValue(AutomationProperties.HelpTextProperty) ?? _defaultAccessibilityHint;
-#endif
 
 			return _defaultAccessibilityHint;
 		}
 
+		// TODO OBSOLETE FOR NET10
 		public static string SetAccessibilityLabel(this NativeView Control, Element Element, string _defaultAccessibilityLabel = null)
 		{
 			if (Element == null || Control == null)
 				return _defaultAccessibilityLabel;
+
+			var semantics = SemanticProperties.UpdateSemantics(Element, null);
+			if (semantics is not null)
+			{
+				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, semantics);
+				return String.Empty;
+			}
 
 			if (_defaultAccessibilityLabel == null)
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
@@ -61,11 +66,18 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			return _defaultAccessibilityLabel;
 		}
 
-#if __MOBILE__
+		// TODO OBSOLETE FOR NET10
 		public static string SetAccessibilityHint(this UIBarItem Control, Element Element, string _defaultAccessibilityHint = null)
 		{
 			if (Element == null || Control == null)
 				return _defaultAccessibilityHint;
+			
+			var semantics = SemanticProperties.UpdateSemantics(Element, null);
+			if (semantics is not null)
+			{
+				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, semantics);
+				return String.Empty;
+			}
 
 			if (_defaultAccessibilityHint == null)
 				_defaultAccessibilityHint = Control.AccessibilityHint;
@@ -78,10 +90,18 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 		}
 
+		// TODO OBSOLETE FOR NET10
 		public static string SetAccessibilityLabel(this UIBarItem Control, Element Element, string _defaultAccessibilityLabel = null)
-		{
+		{	
 			if (Element == null || Control == null)
 				return _defaultAccessibilityLabel;
+			
+			var semantics = SemanticProperties.UpdateSemantics(Element, null);
+			if (semantics is not null)
+			{
+				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, semantics);
+				return String.Empty;
+			}
 
 			if (_defaultAccessibilityLabel == null)
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
@@ -92,7 +112,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 			return _defaultAccessibilityLabel;
 		}
-#endif
 
 		public static bool? SetIsAccessibilityElement(this NativeView Control, Element Element, bool? _defaultIsAccessibilityElement = null)
 		{
@@ -103,7 +122,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			if (!Element.IsSet(AutomationProperties.IsInAccessibleTreeProperty))
 				return null;
 
-#if __MOBILE__
 			if (!_defaultIsAccessibilityElement.HasValue)
 			{
 				// iOS sets the default value for IsAccessibilityElement late in the layout cycle
@@ -119,12 +137,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			}
 
 			Control.IsAccessibilityElement = (bool)((bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultIsAccessibilityElement);
-#else
-			if (!_defaultIsAccessibilityElement.HasValue)
-				_defaultIsAccessibilityElement = Control.AccessibilityElement;
-
-			Control.AccessibilityElement = (bool)((bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultIsAccessibilityElement);
-#endif
 
 			return _defaultIsAccessibilityElement;
 		}
@@ -137,19 +149,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			if (!Element.IsSet(AutomationProperties.ExcludedWithChildrenProperty))
 				return null;
 
-#if __MOBILE__
 			if (!_defaultAccessibilityElementsHidden.HasValue)
 			{
 				_defaultAccessibilityElementsHidden = Control.AccessibilityElementsHidden || Control is UIControl;
 			}
 
 			Control.AccessibilityElementsHidden = (bool)((bool?)Element.GetValue(AutomationProperties.ExcludedWithChildrenProperty) ?? _defaultAccessibilityElementsHidden);
-#else
-			if (!_defaultAccessibilityElementsHidden.HasValue)
-				_defaultAccessibilityElementsHidden = Control.AccessibilityElementsHidden;
-
-			Control.AccessibilityElementsHidden = (bool)((bool?)Element.GetValue(AutomationProperties.ExcludedWithChildrenProperty) ?? _defaultAccessibilityElementsHidden);
-#endif
 
 			return _defaultAccessibilityElementsHidden;
 		}

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+			Control.AccessibilityLabel = SemanticProperties.GetDescription(Element) ?? (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
 #pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityLabel;

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			var semantics = SemanticProperties.UpdateSemantics(Element, null);
 			if (semantics is not null)
 			{
+				semantics.Description = semantics.Description ?? (Element as ToolbarItem)?.Text;
 				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, semantics);
 				return String.Empty;
 			}

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, semantics);
 				return String.Empty;
 			}
+			else if (!string.IsNullOrEmpty((Element as ToolbarItem)?.Text))
+			{
+				Microsoft.Maui.Platform.SemanticExtensions.UpdateSemantics(Control, new Semantics() { Description = (Element as ToolbarItem)?.Text });
+				return String.Empty;
+			}
 
 			if (_defaultAccessibilityLabel == null)
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
@@ -112,7 +117,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			//     On Android only the icon will be displayed but the text will be read by screenreaders.
 			//     On MacCatalyst and iOS only the icon will be displayed but the text will NOT be read by screenreaders.
 			// As a result, we will add the text value to the Accessibility Label to ensure that the text is read by screenreaders on all the platforms.
-			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel ?? (Element as ToolbarItem)?.Text;
+			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
 #pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityLabel;

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -89,5 +89,22 @@ namespace Microsoft.Maui.Controls
 					dest.SetValue(bp, source.GetValue(bp));
 			}
 		}
+
+#nullable enable
+		internal static Semantics? UpdateSemantics(BindableObject bindable, Semantics? semantics)
+		{
+			if (!bindable.IsSet(HintProperty) &&
+				!bindable.IsSet(DescriptionProperty) &&
+				!bindable.IsSet(HeadingLevelProperty))
+			{
+				return null;
+			}
+
+			semantics ??= new Semantics();
+			semantics.Description = GetDescription(bindable);
+			semantics.HeadingLevel = GetHeadingLevel(bindable);
+			semantics.Hint = GetHint(bindable);
+			return semantics;
+		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1979,22 +1979,8 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc/>
 		Semantics? IView.Semantics => UpdateSemantics();
 
-		private protected virtual Semantics? UpdateSemantics()
-		{
-			if (!this.IsSet(SemanticProperties.HintProperty) &&
-				!this.IsSet(SemanticProperties.DescriptionProperty) &&
-				!this.IsSet(SemanticProperties.HeadingLevelProperty))
-			{
-				_semantics = null;
-				return _semantics;
-			}
-
-			_semantics ??= new Semantics();
-			_semantics.Description = SemanticProperties.GetDescription(this);
-			_semantics.HeadingLevel = SemanticProperties.GetHeadingLevel(this);
-			_semantics.Hint = SemanticProperties.GetHint(this);
-			return _semantics;
-		}
+		private protected virtual Semantics? UpdateSemantics() =>
+			_semantics = SemanticProperties.UpdateSemantics(this, _semantics);
 
 		static double EnsurePositive(double value)
 		{

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -4,10 +4,38 @@ namespace Microsoft.Maui.Platform
 {
 	public static partial class SemanticExtensions
 	{
-		public static void UpdateSemantics(this UIView platformView, IView view)
+		internal static void UpdateSemantics(this UIBarItem platformView, Semantics? semantics)
 		{
-			var semantics = view.Semantics;
+			if (semantics == null)
+				return;
 
+			platformView.AccessibilityLabel = semantics.Description;
+			platformView.AccessibilityHint = semantics.Hint;
+
+			var accessibilityTraits = platformView.AccessibilityTraits;
+			var hasHeader = (accessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header;
+
+			if (semantics.IsHeading)
+			{
+				if (!hasHeader)
+				{
+					platformView.AccessibilityTraits = accessibilityTraits | UIAccessibilityTrait.Header;
+				}
+			}
+			else
+			{
+				if (hasHeader)
+				{
+					platformView.AccessibilityTraits = accessibilityTraits & ~UIAccessibilityTrait.Header;
+				}
+			}
+		}
+
+		public static void UpdateSemantics(this UIView platformView, IView view) =>
+			UpdateSemantics(platformView, view?.Semantics);
+
+		internal static void UpdateSemantics(this UIView platformView, Semantics? semantics)
+		{
 			if (semantics == null)
 				return;
 
@@ -24,7 +52,7 @@ namespace Microsoft.Maui.Platform
 			platformView.AccessibilityLabel = semantics.Description;
 			platformView.AccessibilityHint = semantics.Hint;
 
-			if ((!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
+			if (!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description))
 			{
 				// Most UIControl elements automatically have IsAccessibilityElement set to true
 				if (platformView is not UIControl)

--- a/src/Core/src/SemanticExtensions.cs
+++ b/src/Core/src/SemanticExtensions.cs
@@ -17,6 +17,8 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui
 {
+	// TODO MARK THIS OBSOLETE FOR NET10 
+	// There's already one of these inside the Microsoft.Maui.Platform namespace
 	public static partial class SemanticExtensions
 	{
 		public static void SetSemanticFocus(this IView element)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
In the this issue: https://github.com/dotnet/maui/issues/26816, our A11y folks pointed out that Toolbar.Items with IconImageSource set do not properly have a "Label" in the accessibility inspector on Mac. This is important because that label allows the VoiceControl and VoiceOver to work properly for that button.

In the examples below you can see the accessibility inspector on the right with the label set on the After and not the Before.

```xaml
    <ContentPage.ToolbarItems>
        <ToolbarItem
            Command="{Binding GroceriesCommand}"
            Order="Primary"
            Priority="0"
            IconImageSource="groceries.png"
            SemanticProperties.Description="Groceries" />
    </ContentPage.ToolbarItems>
```

## Before:

<img width="1728" alt="Screenshot 2025-01-14 at 11 13 46 AM" src="https://github.com/user-attachments/assets/f0c0372e-0122-47f3-a618-bf4752e56c61" />


## After: 

<img height="500" alt="Screenshot 2025-01-13 at 5 45 37 PM" src="https://github.com/user-attachments/assets/0210ad54-c698-4163-a51e-92824010aa66" />


<!-- Enter description of the fix in this section -->

### Issues Fixed
Partially resolves: https://github.com/dotnet/maui/issues/26816


<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
