### PR TITLE
[HybridWebView] Bubble up exceptions in JS into .NET

### DIFF
--- a/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/scripts/HybridWebView.js
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/HybridSamplePage/scripts/HybridWebView.js
@@ -91,20 +91,49 @@
         }
     },
 
-    "__InvokeJavaScript": function __InvokeJavaScript(taskId, methodName, args) {
-        if (methodName[Symbol.toStringTag] === 'AsyncFunction') {
-            // For async methods, we need to call the method and then trigger the callback when it's done
-            const asyncPromise = methodName(...args);
-            asyncPromise
-                .then(asyncResult => {
-                    window.HybridWebView.__TriggerAsyncCallback(taskId, asyncResult);
-                })
-                .catch(error => console.error(error));
-        } else {
-            // For sync methods, we can call the method and trigger the callback immediately
-            const syncResult = methodName(...args);
-            window.HybridWebView.__TriggerAsyncCallback(taskId, syncResult);
+    "__InvokeJavaScript": async function __InvokeJavaScript(taskId, methodName, args) {
+        try {
+            var result = null;
+            if (methodName[Symbol.toStringTag] === 'AsyncFunction') {
+                result = await methodName(...args);
+            } else {
+                result = methodName(...args);
+            }
+            window.HybridWebView.__TriggerAsyncCallback(taskId, result);
+        } catch (ex) {
+            console.error(ex);
+            window.HybridWebView.__TriggerAsyncFailedCallback(taskId, ex);
         }
+    },
+
+    "__TriggerAsyncFailedCallback": function __TriggerAsyncCallback(taskId, error) {
+
+        if (!error) {
+            json = {
+                Message: "Unknown error",
+                StackTrace: Error().stack
+            };
+        } else if (error instanceof Error) {
+            json = {
+                Name: error.name,
+                Message: error.message,
+                StackTrace: error.stack
+            };
+        } else if (typeof (error) === 'string') {
+            json = {
+                Message: error,
+                StackTrace: Error().stack
+            };
+        } else {
+            json = {
+                Message: JSON.stringify(error),
+                StackTrace: Error().stack
+            };
+        }
+
+        json = JSON.stringify(json);
+
+        window.HybridWebView.__SendMessageInternal('__InvokeJavaScriptFailed', taskId + '|' + json);
     },
 
     "__TriggerAsyncCallback": function __TriggerAsyncCallback(taskId, result) {

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -189,6 +189,12 @@ public static partial class AppHostBuilderExtensions
 			handlers.AddControlsHandlers();
 		});
 
+		// NOTE: not registered under NativeAOT or TrimMode=Full scenarios
+		if (RuntimeFeature.IsHybridWebViewSupported)
+		{
+			builder.Services.AddScoped<IHybridWebViewTaskManager>(_ => new HybridWebViewTaskManager());
+		}
+
 #if WINDOWS
 		builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, MauiControlsInitializer>());
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -318,6 +318,14 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData("Async")]
 		public async Task InvokeJavaScriptMethodThatThrowsNumber(string type)
 		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
 			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 1);
 			Assert.Equal("InvokeJavaScript threw an exception: 777.777", ex.Message);
 			Assert.Equal("777.777", ex.InnerException.Message);
@@ -330,6 +338,14 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData("Async")]
 		public async Task InvokeJavaScriptMethodThatThrowsString(string type)
 		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
 			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 2);
 			Assert.Equal("InvokeJavaScript threw an exception: String: 777.777", ex.Message);
 			Assert.Equal("String: 777.777", ex.InnerException.Message);
@@ -342,6 +358,14 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData("Async")]
 		public async Task InvokeJavaScriptMethodThatThrowsError(string type)
 		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
 			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 3);
 			Assert.Equal("InvokeJavaScript threw an exception: Generic Error: 777.777", ex.Message);
 			Assert.Equal("Generic Error: 777.777", ex.InnerException.Message);
@@ -354,6 +378,14 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData("Async")]
 		public async Task InvokeJavaScriptMethodThatThrowsTypedNumber(string type)
 		{
+#if ANDROID
+			// NOTE: skip this test on older Android devices because it is not currently supported on these versions
+			if (!System.OperatingSystem.IsAndroidVersionAtLeast(24))
+			{
+				return;
+			}
+#endif
+
 			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 4);
 			Assert.Contains("undefined", ex.Message, StringComparison.OrdinalIgnoreCase);
 			Assert.Contains("undefined", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -24,6 +25,7 @@ namespace Microsoft.Maui.DeviceTests
 				});
 
 				builder.Services.AddHybridWebViewDeveloperTools();
+				builder.Services.AddScoped<IHybridWebViewTaskManager, HybridWebViewTaskManager>();
 			});
 		}
 
@@ -311,6 +313,74 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(methodName, invokeJavaScriptTarget.LastMethodCalled);
 			});
 
+		[Theory]
+		[InlineData("")]
+		[InlineData("Async")]
+		public async Task InvokeJavaScriptMethodThatThrowsNumber(string type)
+		{
+			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 1);
+			Assert.Equal("InvokeJavaScript threw an exception: 777.777", ex.Message);
+			Assert.Equal("777.777", ex.InnerException.Message);
+			Assert.Null(ex.InnerException.Data["JavaScriptErrorName"]);
+			Assert.NotNull(ex.InnerException.StackTrace);
+		}
+
+		[Theory]
+		[InlineData("")]
+		[InlineData("Async")]
+		public async Task InvokeJavaScriptMethodThatThrowsString(string type)
+		{
+			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 2);
+			Assert.Equal("InvokeJavaScript threw an exception: String: 777.777", ex.Message);
+			Assert.Equal("String: 777.777", ex.InnerException.Message);
+			Assert.Null(ex.InnerException.Data["JavaScriptErrorName"]);
+			Assert.NotNull(ex.InnerException.StackTrace);
+		}
+
+		[Theory]
+		[InlineData("")]
+		[InlineData("Async")]
+		public async Task InvokeJavaScriptMethodThatThrowsError(string type)
+		{
+			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 3);
+			Assert.Equal("InvokeJavaScript threw an exception: Generic Error: 777.777", ex.Message);
+			Assert.Equal("Generic Error: 777.777", ex.InnerException.Message);
+			Assert.Equal("Error", ex.InnerException.Data["JavaScriptErrorName"]);
+			Assert.NotNull(ex.InnerException.StackTrace);
+		}
+
+		[Theory]
+		[InlineData("")]
+		[InlineData("Async")]
+		public async Task InvokeJavaScriptMethodThatThrowsTypedNumber(string type)
+		{
+			var ex = await RunExceptionTest("EvaluateMeWithParamsThatThrows" + type, 4);
+			Assert.Contains("undefined", ex.Message, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("undefined", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+			Assert.Equal("TypeError", ex.InnerException.Data["JavaScriptErrorName"]);
+			Assert.NotNull(ex.InnerException.StackTrace);
+		}
+
+		async Task<Exception> RunExceptionTest(string method, int errorType)
+		{
+			Exception exception = null;
+
+			await RunTest(async (hybridWebView) =>
+			{
+				var x = 123.456m;
+				var y = 654.321m;
+
+				exception = await Assert.ThrowsAnyAsync<Exception>(() =>
+					hybridWebView.InvokeJavaScriptAsync<decimal>(
+						method,
+						HybridWebViewTestContext.Default.Decimal,
+						[x, y, errorType],
+						[HybridWebViewTestContext.Default.Decimal, HybridWebViewTestContext.Default.Decimal, HybridWebViewTestContext.Default.Int32]));
+			});
+
+			return exception;
+		}
+
 		Task RunTest(Func<HybridWebView, Task> test) =>
 			RunTest(null, test);
 
@@ -460,6 +530,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		[JsonSourceGenerationOptions(WriteIndented = true)]
 		[JsonSerializable(typeof(ComputationResult))]
+		[JsonSerializable(typeof(int))]
 		[JsonSerializable(typeof(decimal))]
 		[JsonSerializable(typeof(bool))]
 		[JsonSerializable(typeof(int))]

--- a/src/Controls/tests/DeviceTests/MauiProgram.cs
+++ b/src/Controls/tests/DeviceTests/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Hosting;
@@ -9,6 +10,11 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public static class MauiProgram
 	{
+		static MauiProgram()
+		{
+			AppContext.SetSwitch("HybridWebView.InvokeJavaScriptThrowsExceptions", isEnabled: true);
+		}
+
 #if ANDROID
 		public static Android.Content.Context CurrentContext => MauiProgramDefaults.DefaultContext;
 #elif WINDOWS

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/index.html
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/index.html
@@ -6,7 +6,19 @@
     <title></title>
     <link rel="icon" href="data:,">
     <script src="scripts/HybridWebView.js"></script>
+
+    <!-- test helper functions-->
     <script>
+
+        // an async delay helper function
+        function delay(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+    </script>
+
+    <script>
+
         window.addEventListener(
             "HybridWebViewMessageReceived",
             function (e) {
@@ -19,6 +31,11 @@
         function EchoParameter(value) {
             return value;
         }
+
+    </script>
+
+    <!-- test cases -->
+    <script>
 
         // test method invoke with simple parameters and simple return value
         // test evaluate javascript to invoke
@@ -59,6 +76,36 @@
             var jsonData = await response.json();
             jsonData[s1] = s2;
             return jsonData;
+        }
+
+        function ThrowAnError(value, errorType) {
+            if (errorType === 1) {                  // throw number
+                throw value;
+            } else if (errorType === 2) {           // throw string
+                throw `String: ${value}`;
+            } else if (errorType === 3) {           // throw Error
+                throw new Error(`Generic Error: ${value}`);
+            } else if (errorType === 4) {           // throw runtime Error
+                undefined.toString();
+            }
+
+            // there was an error throwing an error :-{
+            throw new Error(`Unknown error type: ${errorType}`);
+        }
+
+        // test method invoke with parameters that throws instead of returning correctly
+        function EvaluateMeWithParamsThatThrows(a, b, errorType) {
+            let sum = a + b;
+            ThrowAnError(sum, errorType);
+        }
+
+        // test async method invoke with parameters that throws instead of returning correctly
+        async function EvaluateMeWithParamsThatThrowsAsync(a, b, errorType) {
+            // actually do something sync
+            await delay(10);
+
+            let sum = a + b;
+            ThrowAnError(sum, errorType);
         }
 
         // test evaluate arbitrary javascript

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/scripts/HybridWebView.js
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/scripts/HybridWebView.js
@@ -91,20 +91,48 @@
         }
     },
 
-    "__InvokeJavaScript": function __InvokeJavaScript(taskId, methodName, args) {
-        if (methodName[Symbol.toStringTag] === 'AsyncFunction') {
-            // For async methods, we need to call the method and then trigger the callback when it's done
-            const asyncPromise = methodName(...args);
-            asyncPromise
-                .then(asyncResult => {
-                    window.HybridWebView.__TriggerAsyncCallback(taskId, asyncResult);
-                })
-                .catch(error => console.error(error));
-        } else {
-            // For sync methods, we can call the method and trigger the callback immediately
-            const syncResult = methodName(...args);
-            window.HybridWebView.__TriggerAsyncCallback(taskId, syncResult);
+    "__InvokeJavaScript": async function __InvokeJavaScript(taskId, methodName, args) {
+        try {
+            var result = null;
+            if (methodName[Symbol.toStringTag] === 'AsyncFunction') {
+                result = await methodName(...args);
+            } else {
+                result = methodName(...args);
+            }
+            window.HybridWebView.__TriggerAsyncCallback(taskId, result);
+        } catch (ex) {
+            window.HybridWebView.__TriggerAsyncFailedCallback(taskId, ex);
         }
+    },
+
+    "__TriggerAsyncFailedCallback": function __TriggerAsyncCallback(taskId, error) {
+
+        if (!error) {
+            json = {
+                Message: "Unknown error",
+                StackTrace: Error().stack
+            };
+        } else if (error instanceof Error) {
+            json = {
+                Name: error.name,
+                Message: error.message,
+                StackTrace: error.stack
+            };
+        } else if (typeof (error) === 'string') {
+            json = {
+                Message: error,
+                StackTrace: Error().stack
+            };
+        } else {
+            json = {
+                Message: JSON.stringify(error),
+                StackTrace: Error().stack
+            };
+        }
+
+        json = JSON.stringify(json);
+
+        window.HybridWebView.__SendMessageInternal('__InvokeJavaScriptFailed', taskId + '|' + json);
     },
 
     "__TriggerAsyncCallback": function __TriggerAsyncCallback(taskId, result) {

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/scripts/HybridWebView.js
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/scripts/HybridWebView.js
@@ -101,6 +101,7 @@
             }
             window.HybridWebView.__TriggerAsyncCallback(taskId, result);
         } catch (ex) {
+            console.error(ex);
             window.HybridWebView.__TriggerAsyncFailedCallback(taskId, ex);
         }
     },

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -30,7 +30,6 @@ using Microsoft.Maui.Hosting;
 using System.Collections.Specialized;
 using System.Text.Json.Serialization;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.AccessControl;
 
 namespace Microsoft.Maui.Handlers
 {

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewInvokeJavaScriptException.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewInvokeJavaScriptException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Microsoft.Maui.Handlers;
+
+internal class HybridWebViewInvokeJavaScriptException : Exception
+{
+	private readonly string? _stackTrace;
+
+	public HybridWebViewInvokeJavaScriptException()
+		: base()
+	{
+	}
+
+	public HybridWebViewInvokeJavaScriptException(string? message)
+		: base(message)
+	{
+	}
+
+	public HybridWebViewInvokeJavaScriptException(string? message, Exception? innerException)
+		: base(message, innerException)
+	{
+	}
+
+	public HybridWebViewInvokeJavaScriptException(string? message, string? name, string? stackTrace)
+		: base(message)
+	{
+		if (!string.IsNullOrWhiteSpace(name))
+		{
+			Data["JavaScriptErrorName"] = name;
+		}
+
+		_stackTrace = stackTrace;
+	}
+
+	public override string? StackTrace => _stackTrace ?? base.StackTrace;
+}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewTask.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewTask.cs
@@ -1,0 +1,5 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Handlers;
+
+internal record struct HybridWebViewTask(string TaskId, TaskCompletionSource<string?> TaskCompletionSource);

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewTaskManager.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewTaskManager.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Handlers;
+
+internal class HybridWebViewTaskManager : IHybridWebViewTaskManager
+{
+	private int _lastTaskId;
+	private readonly ConcurrentDictionary<string, TaskCompletionSource<string?>> _asyncTaskCallbacks = new();
+
+	public HybridWebViewTask CreateTask()
+	{
+		var taskId = Interlocked.Increment(ref _lastTaskId);
+		var taskIdString = taskId.ToString("0", CultureInfo.InvariantCulture);
+
+		var tcs = new TaskCompletionSource<string?>();
+
+		if (!_asyncTaskCallbacks.TryAdd(taskIdString, tcs))
+		{
+			throw new InvalidOperationException($"Unable to add a new task with new ID {taskIdString} to the task manager.");
+		}
+
+		return new(taskIdString, tcs);
+	}
+
+	public void SetTaskCompleted(string taskId, string result)
+	{
+		if (_asyncTaskCallbacks.TryRemove(taskId, out var callback))
+		{
+			callback.SetResult(result);
+		}
+	}
+
+	public void SetTaskFailed(string taskId, Exception exception)
+	{
+		if (_asyncTaskCallbacks.TryRemove(taskId, out var callback))
+		{
+			callback.SetException(exception);
+		}
+	}
+}

--- a/src/Core/src/Handlers/HybridWebView/IHybridWebViewTaskManager.cs
+++ b/src/Core/src/Handlers/HybridWebView/IHybridWebViewTaskManager.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Concurrent;
-using System.Threading.Tasks;
+﻿using System;
 
-namespace Microsoft.Maui.Handlers
+namespace Microsoft.Maui.Handlers;
+
+internal interface IHybridWebViewTaskManager
 {
-	internal interface IHybridWebViewTaskManager
-	{
-		int GetNextInvokeTaskId();
-		ConcurrentDictionary<string, TaskCompletionSource<string>> AsyncTaskCallbacks { get; }
-	}
+	HybridWebViewTask CreateTask();
+
+	void SetTaskCompleted(string taskId, string result);
+
+	void SetTaskFailed(string taskId, Exception exception);
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Previously an exception in JS would just fail to return to .NET, leaving the tasks unfinished.

This PR makes sure to catch the exception in JS and then send it back to .NET where it is re-thrown as a .NET exception.

There is additional work to remove the task manager from the handler definition and move the logic into a new service that is registered. This will allow for better testing and/or a new handler that does not need to also use the internal interface.

By default there is no behavior change, but you can enable this [AppContext Switch](https://learn.microsoft.com/dotnet/api/system.appcontext.trygetswitch?view=net-8.0) with one line of code in your app's MauiProgram.cs:

```cs
AppContext.SetSwitch("HybridWebView.InvokeJavaScriptThrowsExceptions", isEnabled: true);
```


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #27097

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
