### PR TITLE
[Templates] Added some a11y properties in the ManageMetaPage

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -71,9 +71,8 @@
                                 SemanticProperties.HeadingLevel="None" />
 
                             <Button 
-                                ImageSource="{StaticResource IconDelete}"
-                                SemanticProperties.Hint="Tap to delete the category"                            
-                                SemanticProperties.Description="Delete"
+                                ImageSource="{StaticResource IconDelete}"                        
+                                SemanticProperties.Description="Delete Category"
                                 Background="Transparent"
                                 Command="{Binding DeleteCategoryCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
                                 Grid.Column="3" />
@@ -115,8 +114,7 @@
         
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
-                                SemanticProperties.Hint="Tap to delete the tag"
-                                SemanticProperties.Description="Delete"
+                                SemanticProperties.Description="Delete Tag"
                                 Background="Transparent"
                                 Command="{Binding DeleteTagCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
                                 Grid.Column="3"/>

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -54,7 +54,7 @@
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="models:Category">
                         <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="4*,3*,30,Auto">
-                            <Entry Text="{Binding Title}" SemanticProperties.Description="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
+                            <Entry Text="{Binding Title}" SemanticProperties.Description="{Binding Title}" Grid.Column="0" />
                             <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry"
                                 SemanticProperties.Description="Color"
                                 SemanticProperties.Hint="Category color in HEX format">
@@ -97,7 +97,7 @@
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="models:Tag">
                         <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="4*,3*,30,Auto">
-                            <Entry Text="{Binding Title}" SemanticProperties.Description="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
+                            <Entry Text="{Binding Title}" SemanticProperties.Description="{Binding Title}" Grid.Column="0" />
                             <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry"
                                 SemanticProperties.Description="Color"
                                 SemanticProperties.Hint="Tag color in HEX format">

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -54,7 +54,7 @@
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="models:Category">
                         <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="4*,3*,30,Auto">
-                            <Entry Text="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
+                            <Entry Text="{Binding Title}" SemanticProperties.Description="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
                             <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry"
                                 SemanticProperties.Description="Color"
                                 SemanticProperties.Hint="Category color in HEX format">
@@ -72,6 +72,7 @@
 
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
+                                SemanticProperties.Hint="Tap to delete the category"
                                 Background="Transparent"
                                 Command="{Binding DeleteCategoryCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
                                 Grid.Column="3"
@@ -96,7 +97,7 @@
                 <BindableLayout.ItemTemplate>
                     <DataTemplate x:DataType="models:Tag">
                         <Grid ColumnSpacing="{StaticResource LayoutSpacing}" ColumnDefinitions="4*,3*,30,Auto">
-                            <Entry Text="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
+                            <Entry Text="{Binding Title}" SemanticProperties.Description="{Binding Title}" Grid.Column="0" SemanticProperties.Description="Title" />
                             <Entry Text="{Binding Color}" Grid.Column="1" x:Name="ColorEntry"
                                 SemanticProperties.Description="Color"
                                 SemanticProperties.Hint="Tag color in HEX format">
@@ -114,6 +115,7 @@
         
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
+                                SemanticProperties.Hint="Tap to delete the tag"
                                 Background="Transparent"
                                 Command="{Binding DeleteTagCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
                                 Grid.Column="3"/>

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -72,11 +72,11 @@
 
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
-                                SemanticProperties.Hint="Tap to delete the category"
+                                SemanticProperties.Hint="Tap to delete the category"                            
+                                SemanticProperties.Description="Delete"
                                 Background="Transparent"
                                 Command="{Binding DeleteCategoryCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
-                                Grid.Column="3"
-                                SemanticProperties.Description="Delete" />
+                                Grid.Column="3" />
                         </Grid>
                     </DataTemplate>
                 </BindableLayout.ItemTemplate>
@@ -116,6 +116,7 @@
                             <Button 
                                 ImageSource="{StaticResource IconDelete}"
                                 SemanticProperties.Hint="Tap to delete the tag"
+                                SemanticProperties.Description="Delete"
                                 Background="Transparent"
                                 Command="{Binding DeleteTagCommand, Source={RelativeSource AncestorType={x:Type pageModels:ManageMetaPageModel}}, x:DataType=pageModels:ManageMetaPageModel}" CommandParameter="{Binding .}"
                                 Grid.Column="3"/>


### PR DESCRIPTION
### Description of Change

Added some a11y properties in the ManageMetaPage.

Before
<img width="1658" alt="fix-26233-before" src="https://github.com/user-attachments/assets/fe4cfea1-4f23-465b-af4d-c873bc17df50" />

After
<img width="1815" alt="fix-26233-after" src="https://github.com/user-attachments/assets/3115b3b7-d3fc-4f05-bceb-a6030cf5b7b6" />

### Issues Fixed

Fixes #26233 
