### PR TITLE
[Windows] - Fixed Window Title Not Shown When Reverting from TitleBar to Default State

### DIFF
--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Maui.Platform
 		{
 			// Ensure the default Window Title template is reapplied when switching from a TitleBar.
 			// The ContentTemplateSelector is reset to the default when ContentTemplate is null, restoring proper title display.
-			if (AppTitleBarContentControl.ContentTemplateSelector is null)
+			if (AppTitleBarContentControl is not null && AppTitleBarContentControl.ContentTemplateSelector is null)
 			{
 				AppTitleBarContentControl.ContentTemplateSelector =
 				(DataTemplateSelector)Application.Current.Resources["MauiAppTitleBarTemplateSelector"];

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -448,6 +448,7 @@ namespace Microsoft.Maui.Platform
 				if (AppTitleBarContentControl is not null)
 				{
 					AppTitleBarContentControl.Content = null;
+					UpdateAppTitleBarTemplate();
 				}
 				return;
 			}
@@ -558,6 +559,17 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 			PassthroughTitlebarElements = passthroughElements;
+		}
+
+		void UpdateAppTitleBarTemplate()
+		{
+			// Ensure the default Window Title template is reapplied when switching from a TitleBar.
+			// The ContentTemplateSelector is reset to the default when ContentTemplate is null, restoring proper title display.
+			if (AppTitleBarContentControl.ContentTemplateSelector is null)
+			{
+				AppTitleBarContentControl.ContentTemplateSelector =
+				(DataTemplateSelector)Application.Current.Resources["MauiAppTitleBarTemplateSelector"];
+			}
 		}
 
 		static void OnAppTitleBarTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
### Issue Details

When transitioning between the TitleBar and the Window Title, the window title fails to display correctly.

### RootCause 

During transitions between the TitleBar and the default Window Title, the ContentTemplate becomes null because the TitleBar sets Content directly without a template. This prevents the default template from being reapplied when reverting to the default Window Title, causing the title to not display.

### Description of Change

When clearing the TitleBar (title bar is null), the method now checks if the ContentTemplate is null and reapplies the default template if necessary, ensuring the Window Title is restored properly during state changes.

### Issues Fixed

Fixes #27022 

**Tested the behaviour in the following platforms**

- [x]  Windows
- [ ] Android
- [ ]  iOS
- [ ] Mac

### Output

| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/52e182a0-7e3d-47d0-b21c-8fb03452d1d4"> |   <video src="https://github.com/user-attachments/assets/74fe16d0-79a4-4548-b0ab-f1201e31a9b2">  |

### Test Case 

Unable to add a test case for this scenario because the CI does not capture the window with the title bar. Additionally, creating a unit test is not feasible since the Window Title property updates correctly, but the changes are not reflected in the view.
