### PR TITLE
[ci] Reduce Xcode platform installations

### DIFF
--- a/eng/pipelines/arcade/setup-test-env.yml
+++ b/eng/pipelines/arcade/setup-test-env.yml
@@ -18,7 +18,7 @@ steps:
     xcrun xcode-select --print-path
     xcodebuild -version
     sudo xcodebuild -license accept
-    sudo xcodebuild -downloadAllPlatforms
+    sudo xcodebuild -downloadPlatform iOS
     sudo xcodebuild -runFirstLaunch
   displayName: Select Xcode Version
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -60,7 +60,7 @@ steps:
         xcrun xcode-select --print-path
         xcodebuild -version
         sudo xcodebuild -license accept
-        sudo xcodebuild -downloadAllPlatforms
+        sudo xcodebuild -downloadPlatform iOS
         sudo xcodebuild -runFirstLaunch
       displayName: Select Xcode Version
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
We've been encountering various issues with ci agent disk space
availability, and can save some space/time when provisioning by cutting
unused simulators.