### PR TITLE
[iOS] Fixed the Application crash when ToolbarItem is created with invalid IconImageSource name

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2222.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2222.cs
@@ -1,5 +1,4 @@
-﻿#if TEST_FAILS_ON_IOS //Application crashes when ToolbarItem is created with invalid IconImageSource name.Issue Link: https://github.com/dotnet/maui/issues/27095
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -21,4 +20,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
-#endif

--- a/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.iOS.cs
+++ b/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.iOS.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui
 			{
 				Logger?.LogWarning(ex, "Unable to load image file '{File}'.", imageSource.File);
 
-				throw;
+				return FromResult(null);
 			}
 		}
 


### PR DESCRIPTION
### Root Cause of the issue



- The exception is thrown from `FileImageSourceService.iOS` when the image is null, causing the application to crash if an invalid IconImageSource is provided. 



### Description of Change



- Instead of throwing an exception, log the exception details and safely return to prevent the application from crashing when an invalid IconImageSource is provided. 


### Reference 

- I resolved the issue by referring to the following Xamarin code. The code logs the error details only 
https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.MacOS/ImageSourceHandlers.cs#L19


### Issues Fixed



Fixes #27095



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/3637b74f-8ef4-4e2d-972c-72e25c626e27"> | <video src="https://github.com/user-attachments/assets/aed43646-2b29-468b-89c8-183ca142c5d7"> |
