### PR TITLE
[Testing] Enabling some UITests from Issues folder in Appium-7

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CollectionViewUITests.CollectionViewBindingErrors.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CollectionViewUITests.CollectionViewBindingErrors.cs
@@ -16,12 +16,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		// CollectionViewBindingErrorsShouldBeZero (src\Compatibility\ControlGallery\src\Issues.Shared\CollectionViewBindingErrors.xaml.cs)
 		[Test]
 		[Category(UITestCategories.CollectionView)]
-		[FailsOnMacWhenRunningOnXamarinUITest("This test is failing, likely due to product issue")]
-		[FailsOnWindowsWhenRunningOnXamarinUITest("This test is failing, likely due to product issue")]
 		public void NoBindingErrors()
 		{
-			App.WaitForElement("WaitForStubControl");
-			App.WaitForNoElement("Binding Errors: 0");
+			Assert.That(App.WaitForElement("WaitForStubControl").GetText(), Is.EqualTo("Binding Errors: 0"));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2674.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2674.cs
@@ -14,12 +14,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Picker)]
-		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
-		[FailsOnMacWhenRunningOnXamarinUITest]
 		public void Issue2674Test()
 		{
-			App.Screenshot("I am at Issue2674");
 			App.WaitForElement("picker");
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2680ScrollView.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2680ScrollView.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST // In iOS and Catalyst, WaitForNoElement throws a timeout exception eventhough the text is not visible on the screen by scrolling.
+//In Windows, The ScrollView remains scrollable even when ScrollOrientation.Neither is set. Issue Link: https://github.com/dotnet/maui/issues/27140
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -18,8 +20,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.ScrollView)]
-		[Category(UITestCategories.Compatibility)]
-		[FailsOnAndroidWhenRunningOnXamarinUITest]
 		[FailsOnIOSWhenRunningOnXamarinUITest]
 		[FailsOnMacWhenRunningOnXamarinUITest]
 		public void Issue2680Test_ScrollDisabled()
@@ -48,3 +48,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6705.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6705.cs
@@ -14,17 +14,13 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Button)]
-		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
-		[FailsOnMacWhenRunningOnXamarinUITest]
-		[FailsOnWindowsWhenRunningOnXamarinUITest]
 		public void Issue6705Test()
 		{
 			for (var i = 1; i < 6; i++)
 			{
 				App.WaitForElement($"Button{i}");
 				App.Tap($"Button{i}");
-				App.WaitForNoElement($"{i}");
+				App.WaitForElement($"{i}");
 			}
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6945.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6945.cs
@@ -1,4 +1,4 @@
-﻿#if IOS
+﻿#if TEST_FAILS_ON_WINDOWS // //BoxView automation ID isn't working on the Windows platform, causing a TimeoutException.
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
@@ -19,16 +19,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Layout)]
-		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
 		public void WrongTranslationBehaviorWhenChangingHeightRequestAndSettingAnchor()
 		{
 			var rect = App.WaitForElement(BoxViewId).GetRect();
 			App.Tap(ClickMeId);
 			var rect2 = App.WaitForElement(BoxViewId).GetRect();
 
-			ClassicAssert.AreEqual(rect.X, rect2.X);
-			ClassicAssert.AreEqual(rect.Y, rect2.Y);
+			Assert.That(rect.X, Is.EqualTo(rect2.X));
+			Assert.That(rect.Y, Is.EqualTo(rect2.Y));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6945.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6945.cs
@@ -1,4 +1,5 @@
-﻿#if TEST_FAILS_ON_WINDOWS // //BoxView automation ID isn't working on the Windows platform, causing a TimeoutException.
+﻿#if TEST_FAILS_ON_WINDOWS //BoxView automation ID isn't working on the Windows platform, causing a TimeoutException.
+//Issue Link: https://github.com/dotnet/maui/issues/27195
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6994.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6994.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAILS_ON_WINDOWS //Application crash while load the listview, for more information: https://github.com/dotnet/maui/issues/27174
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -18,7 +19,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("Click me");
 			App.Tap("Click me");
-			App.WaitForElement("Success", timeout: TimeSpan.FromSeconds(3));
+			App.WaitForElementTillPageNavigationSettled("Success");
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6994.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6994.cs
@@ -14,13 +14,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Button)]
-		[Category(UITestCategories.Compatibility)]
-		[FailsOnAllPlatformsWhenRunningOnXamarinUITest]
 		public void NullPointerExceptionOnFastLabelTextColorChange()
 		{
 			App.WaitForElement("Click me");
 			App.Tap("Click me");
-			App.WaitForElement("Success");
+			App.WaitForElement("Success", timeout: TimeSpan.FromSeconds(3));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7313.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7313.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.ListView)]
-		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
 		public void RefreshControlTurnsOffSuccessfully()
 		{
-			App.WaitForNoElement("If you see the refresh circle this test has failed");
+			App.WaitForElement("If you see the refresh circle this test has failed");
 
 			App.WaitForNoElement("RefreshControl");
 		}


### PR DESCRIPTION
### Description of Change

This PR focuses on enabling and updating 7 testcases in Appium. The tests, previously ignored using Fails attribute, are reviewed, and modified to ensure they are functional with the Appium framework.We are going to enable tests in blocks in different PRs. This is the 7th group of tests enabled.

**Test Cases:**

- Issue2680ScrollView
- Issue6705
- Issue6945
- Issue6994
- Issue7313
- Issue2674
- CollectionViewBindingErrorsUITests