### PR TITLE
[Windows]Fixed Shell Navigating event issue when switching tabs

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -141,8 +141,22 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			var selectedItem = (NavigationViewItemViewModel)args.SelectedItem;
 
-			if (selectedItem.Data is ShellSection shellSection)
+			if (selectedItem.Data is ShellSection shellSection && VirtualView.Parent is Shell shell)
 			{
+				NavigationViewItemViewModel? currentItem = null;
+				foreach (var item in _mainLevelTabs)
+				{
+					if (shell.CurrentItem?.CurrentItem is not null && item.Data == shell.CurrentItem.CurrentItem)
+					{
+						currentItem = item;
+						break;
+					}
+				}
+				if (PlatformView is NavigationView navView && navView?.SelectedItem is not null && navView.SelectedItem != currentItem)
+				{
+					((IShellItemController)shell.CurrentItem!).ProposeSection(shellSection);
+				}
+
 				((Shell)VirtualView.Parent).CurrentItem = shellSection;
 			}
 			else if (selectedItem.Data is ShellContent shellContent)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25599.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25599.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue25599"
+       xmlns:local="clr-namespace:Maui.Controls.Sample.Issues">
+    <TabBar>
+        <Tab Title="Home" x:Name="FirstTab" AutomationId="Tab1">
+            <ShellContent
+            Title="Home" >
+            <ShellContent.ContentTemplate>
+                <DataTemplate>
+                    <ContentPage x:Name="firstPage">
+                        <StackLayout>
+                            <Button Text="Click" Clicked="Button_Clicked" AutomationId="HomePageButton"/>
+                            <Label Text="Home Page" AutomationId="HomePageLabel"/>
+                        </StackLayout>
+                    </ContentPage>
+                </DataTemplate>
+            </ShellContent.ContentTemplate>
+            </ShellContent>
+        </Tab>
+        <Tab Title="Settings" x:Name="SecondTab">
+            <ShellContent>
+            <ShellContent.ContentTemplate>
+                <DataTemplate>
+                    <ContentPage x:Name="secondPage">
+                        <StackLayout>
+                            <Label x:Name="settingsPageLabel" Text="SettingsPage" />
+                        </StackLayout>
+                    </ContentPage>
+                </DataTemplate>
+            </ShellContent.ContentTemplate>
+            </ShellContent>
+        </Tab>
+    </TabBar>
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25599.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25599.xaml.cs
@@ -1,0 +1,35 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 25599, "OnNavigating wrong target when tapping the same tab", PlatformAffected.iOS)]
+public partial class Issue25599 : Shell
+{
+	public Issue25599()
+	{
+		InitializeComponent();
+	}
+
+	private async void Button_Clicked(object sender, EventArgs e)
+	{
+		await Navigation.PushAsync(new DetailsPage());
+	}
+
+	public class DetailsPage : ContentPage
+	{
+		public DetailsPage()
+		{
+			Title = "DetailsPage";
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "Details Page",
+						AutomationId = "DetailsPageLabel"
+					}
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25599.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25599.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST || TEST_FAILS_ON_IOS // To fix the issue in ios https://github.com/dotnet/maui/pull/25749#pullrequestreview-2554186362
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS // To fix the issue in ios https://github.com/dotnet/maui/pull/25749#pullrequestreview-2554186362
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25599.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25599.cs
@@ -1,0 +1,27 @@
+﻿#if TEST_FAILS_ON_CATALYST || TEST_FAILS_ON_IOS // To fix the issue in ios https://github.com/dotnet/maui/pull/25749#pullrequestreview-2554186362
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25599 : _IssuesUITest
+	{
+		public Issue25599(TestDevice testDevice) : base(testDevice){ }
+
+		public override string Issue => "OnNavigating wrong target when tapping the same tab";
+
+		[Test]
+		[Category(UITestCategories.Navigation)]
+		public void NavigatingEventFired()
+		{
+			App.WaitForElement("HomePageButton");
+			App.Tap("HomePageButton");
+			App.WaitForElement("DetailsPageLabel");
+			App.Tap("Home"); // Tapping already selected tab using Title
+			App.WaitForElement("DetailsPageLabel");
+			App.WaitForNoElement("HomePageLabel"); // Navigation does not occur when clicking on an already selected tab
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Issue Detail

The Navigating event was not triggered when switching tabs.

### Root Cause

There was no code in place to trigger the Navigating event upon tab switches.

### Description of Change

Added logic to trigger Navigating when switching to a different tab.

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/25599

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/42e4d8cd-6c9b-4851-82d7-62da14a9de10"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/2398388d-2df2-4775-b038-2417e66558cb">) |
