### PR TITLE
[Templates] Make the Project Section accessible using the keyboard

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -16,12 +16,15 @@
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
     <Grid>
-      <ScrollView>
-        <VerticalStackLayout 
-            BindableLayout.ItemsSource="{Binding Projects}" 
-            Margin="{StaticResource LayoutPadding}" 
-            Spacing="{StaticResource LayoutSpacing}">
-            <BindableLayout.ItemTemplate>
+        <CollectionView 
+            ItemsSource="{Binding Projects}" 
+            Margin="{StaticResource LayoutPadding}">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout 
+                    Orientation="Vertical"
+                    ItemSpacing="{StaticResource LayoutSpacing}"/>
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:Project">
                     <Border>
                         <VerticalStackLayout Padding="10">
@@ -33,9 +36,8 @@
                         </Border.GestureRecognizers>
                     </Border>
                 </DataTemplate>
-            </BindableLayout.ItemTemplate>
-        </VerticalStackLayout>
-      </ScrollView>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
 
         <controls:AddButton 
             Command="{Binding AddProjectCommand}" />


### PR DESCRIPTION
### Description of Change

Make the Project Section accessible using the keyboard in the .NET 9 template using SyncFusion controls.

Before
![fix-26861-before](https://github.com/user-attachments/assets/1acc9494-3e25-46a8-b882-c8ac2472754f)

After
![fix-26861-after](https://github.com/user-attachments/assets/69ac7c73-e04f-4960-befc-83c2fd8dad07)

### Issues Fixed

Fixes #26861 
