### PR TITLE
[Templates] Make Project Section from MainPage accessible using the keyboard

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -37,21 +37,24 @@
                     <VerticalStackLayout Spacing="{StaticResource LayoutSpacing}" Padding="{StaticResource LayoutPadding}">
                         <controls:CategoryChart />
                         <Label Text="Projects" Style="{StaticResource Title2}"/>
-                        <ScrollView Orientation="Horizontal" Margin="-30,0">
-                            <HorizontalStackLayout 
-                                Spacing="15" Padding="30,0"
-                                BindableLayout.ItemsSource="{Binding Projects}">
-                                <BindableLayout.ItemTemplate>
-                                    <DataTemplate x:DataType="models:Project">
-                                        <controls:ProjectCardView WidthRequest="200">
-                                            <controls:ProjectCardView.GestureRecognizers>
-                                                <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
-                                            </controls:ProjectCardView.GestureRecognizers>
-                                        </controls:ProjectCardView>
-                                    </DataTemplate>
-                                </BindableLayout.ItemTemplate>
-                            </HorizontalStackLayout>
-                        </ScrollView>
+                        <CollectionView
+                            ItemsSource="{Binding Projects}"
+                            Margin="-15, 0">
+                            <CollectionView.ItemsLayout>
+                                <LinearItemsLayout                              
+                                    Orientation="Horizontal"
+                                    ItemSpacing="15" />
+                            </CollectionView.ItemsLayout>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="models:Project">
+                                    <controls:ProjectCardView WidthRequest="200">
+                                        <controls:ProjectCardView.GestureRecognizers>
+                                            <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
+                                        </controls:ProjectCardView.GestureRecognizers>
+                                    </controls:ProjectCardView>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
                         <Grid HeightRequest="44">
                             <Label Text="Tasks" Style="{StaticResource Title2}" VerticalOptions="Center"/>
                             <ImageButton 


### PR DESCRIPTION
### Description of Change

Make Project Section from MainPage accessible using the keyboard in the .NET 9 template using SyncFusion controls.

Before
![fix-26815-before](https://github.com/user-attachments/assets/cbf767de-b12c-4b9c-8e67-967acad9e425)

After
![fix-26815-after](https://github.com/user-attachments/assets/d6a3bcef-037b-46ca-bbfe-386229a4d349)

### Issues Fixed

Fixes #26815 
