### PR TITLE
[iOS] Improvements for LayoutOptions of CV1

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/HorizontalCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/HorizontalCell.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var measure = PlatformHandler.VirtualView.Measure(double.PositiveInfinity, ConstrainedDimension);
 
+			IntrinsicCellSize = new CGSize(measure.Width, measure.Height);
 			return new CGSize(measure.Width, ConstrainedDimension);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/HorizontalDefaultCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/HorizontalDefaultCell.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override CGSize Measure()
 		{
+			IntrinsicCellSize = new CGSize(Label.IntrinsicContentSize.Width, Label.IntrinsicContentSize.Height);
 			return new CGSize(Label.IntrinsicContentSize.Width, Constraint.Constant);
 		}
 	}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewCell.cs
@@ -54,5 +54,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public abstract void ConstrainTo(nfloat constant);
 		public abstract void ConstrainTo(CGSize constraint);
 		public abstract CGSize Measure();
+		internal CGSize IntrinsicCellSize { get; set; }
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -346,7 +346,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return _emptyUIView.Frame.Size.ToSize();
 			}
 
-			return CollectionView.CollectionViewLayout.CollectionViewContentSize.ToSize();
+			var fullSize = CollectionView.CollectionViewLayout.CollectionViewContentSize.ToSize();
+			double width = fullSize.Width;
+			double height = fullSize.Height;
+
+			if (ItemsView.VerticalOptions != LayoutOptions.Fill &&
+				ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+			{
+				height = ItemsViewLayout.AutoMeasuredHeight;
+			}
+
+			if (ItemsView.HorizontalOptions != LayoutOptions.Fill &&
+				ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Vertical)
+			{
+				width = ItemsViewLayout.AutoMeasuredWidth;
+			}
+
+			return new Size(width, height);
 		}
 
 		void ConstrainItemsToBounds()
@@ -665,11 +681,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// Is view set on the ItemsView?
 			if (view is null && (viewTemplate is null || viewTemplate is DataTemplateSelector))
 			{
-				if (formsElement != null)
-				{
-					//Platform.GetRenderer(formsElement)?.DisposeRendererAndChildren();
-				}
-
 				uiView?.Dispose();
 				uiView = null;
 				formsElement?.Handler?.DisconnectHandler();

--- a/src/Controls/src/Core/Handlers/Items/iOS/VerticalCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/VerticalCell.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var measure = PlatformHandler.VirtualView.Measure(ConstrainedDimension, double.PositiveInfinity);
 
+			IntrinsicCellSize = new CGSize(measure.Width, measure.Height);
 			return new CGSize(ConstrainedDimension, measure.Height);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/VerticalDefaultCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/VerticalDefaultCell.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override CGSize Measure()
 		{
+			IntrinsicCellSize = new CGSize(Label.IntrinsicContentSize.Width, Label.IntrinsicContentSize.Height);
 			return new CGSize(Constraint.Constant, Label.IntrinsicContentSize.Height);
 		}
 	}


### PR DESCRIPTION
### Description of Change

Currently `CollectionView` on iOS always expands to the full available width when it has vertical direction, and to full available height when it has horizontal direction.

 it doesn't respect `HorizontalOptions="Start|Center|End"` for
```
<CollectionView.ItemsLayout>
    <LinearItemsLayout Orientation="Vertical" />
</CollectionView.ItemsLayout>
```
It doesn't respect `VerticalOptions="Start|Center|End"` for
```
<CollectionView.ItemsLayout>
    <LinearItemsLayout Orientation="Horizontal" />
</CollectionView.ItemsLayout>  
```
The only way we can constraint the width/size is by explicitly setting WidthRequest/HeightRequest.
It is also not consistent with Android which respects all the LayoutOptions

The changes here would let fix this bug: https://github.com/dotnet/maui/issues/27150 by setting `VerticalOptions="Start|Center|End"` on the Horizontal Collection View inside a header. (Maybe if this Pr makes sense, we might want to default VerticalOptions="Start" for cv in header, to align with android's behavior?)

 The following xaml code:
```
 <CollectionView VerticalOptions="Center" Background="Red">
    <CollectionView.ItemsSource>
        <x:Array Type="{x:Type x:String}">
            <x:String>First</x:String>
            <x:String>Second</x:String>
            <x:String>Third</x:String>
        </x:Array>
    </CollectionView.ItemsSource>

    <CollectionView.ItemsLayout>
        <LinearItemsLayout Orientation="Horizontal"/>
    </CollectionView.ItemsLayout>

    <CollectionView.ItemTemplate>
        <DataTemplate>
            <Label Text="{Binding .}"/>
        </DataTemplate>
    </CollectionView.ItemTemplate>
</CollectionView>
```
would produces the following view: 
|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/0fcfb34c-e0e1-4607-905c-71dc90c9a65e" width="300px"/>|<img src="https://github.com/user-attachments/assets/05ec41d9-a336-4fd1-a75f-179e4cf52437" width="300px"/>|

 The following xaml code:
```
<CollectionView HorizontalOptions="Center" Background="Red">
    <CollectionView.ItemsSource>
        <x:Array Type="{x:Type x:String}">
            <x:String>First</x:String>
            <x:String>Second</x:String>
            <x:String>Third</x:String>
        </x:Array>
    </CollectionView.ItemsSource>

    <CollectionView.ItemsLayout>
        <LinearItemsLayout Orientation="Vertical"/>
    </CollectionView.ItemsLayout>

    <CollectionView.ItemTemplate>
        <DataTemplate>
            <Label Text="{Binding .}"/>
        </DataTemplate>
    </CollectionView.ItemTemplate>
</CollectionView>
```
would produces the following view: 
|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/2b30a34b-6297-4d0e-81f4-6b0cb97158fe" width="300px"/>|<img src="https://github.com/user-attachments/assets/4bc00367-d619-4afc-8dbe-30322d2fa695" width="300px"/>|

I've made these changes only to CV1 so far. I might figure out something similar for CV2 if this is the way we want to go.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/27150