### PR TITLE
Disable some flaky UI tests

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2354.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2354.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public override string Issue => "ListView, ImageCell and disabled source cache and same image url";
 
 		[Test]
-		[Ignore("This test is very flaky and needs to be fixed.")]
+		[Ignore("This test is very flaky and needs to be fixed. See https://github.com/dotnet/maui/issues/27272")]
 		[Category(UITestCategories.ListView)]
 		public void TestDoesntCrashWithCachingDisable()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2354.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2354.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public override string Issue => "ListView, ImageCell and disabled source cache and same image url";
 
 		[Test]
+		[Ignore("This test is very flaky and needs to be fixed.")]
 		[Category(UITestCategories.ListView)]
 		public void TestDoesntCrashWithCachingDisable()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.CollectionView)]
+		[Ignore("This test is very flaky and needs to be fixed.")]
 		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows https://github.com/dotnet/maui/issues/27059")]
 		public void AppShouldNotCrashAfterLoadingGroupedCollectionView()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25514.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.CollectionView)]
-		[Ignore("This test is very flaky and needs to be fixed.")]
+		[Ignore("This test is very flaky and needs to be fixed. See https://github.com/dotnet/maui/issues/27272")]
 		[FailsOnWindowsWhenRunningOnXamarinUITest("Flaky test on Windows https://github.com/dotnet/maui/issues/27059")]
 		public void AppShouldNotCrashAfterLoadingGroupedCollectionView()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7393.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7393.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[FailsOnMacWhenRunningOnXamarinUITest]
 		[FailsOnWindowsWhenRunningOnXamarinUITest]
 		[Ignore("This test is very flaky and needs to be fixed.")]
-
 		public void AddingItemsToGroupedCollectionViewShouldNotCrash()
 		{
 			App.WaitForElement(Success, timeout: TimeSpan.FromSeconds(30));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7393.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7393.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[FailsOnAndroidWhenRunningOnXamarinUITest]
 		[FailsOnMacWhenRunningOnXamarinUITest]
 		[FailsOnWindowsWhenRunningOnXamarinUITest]
-		[Ignore("This test is very flaky and needs to be fixed.")]
+		[Ignore("This test is very flaky and needs to be fixed. See https://github.com/dotnet/maui/issues/27272")]
 		public void AddingItemsToGroupedCollectionViewShouldNotCrash()
 		{
 			App.WaitForElement(Success, timeout: TimeSpan.FromSeconds(30));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7393.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue7393.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[FailsOnAndroidWhenRunningOnXamarinUITest]
 		[FailsOnMacWhenRunningOnXamarinUITest]
 		[FailsOnWindowsWhenRunningOnXamarinUITest]
+		[Ignore("This test is very flaky and needs to be fixed.")]
+
 		public void AddingItemsToGroupedCollectionViewShouldNotCrash()
 		{
 			App.WaitForElement(Success, timeout: TimeSpan.FromSeconds(30));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue8761.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue8761.cs
@@ -15,6 +15,7 @@ public class Issue8761 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]
+	[Ignore("This test is very flaky and needs to be fixed.")]
 	public void CollectionViewHeaderTemplateAndFooterTemplateDontWork()
 	{
 		for (int i = 0; i < 4; i++)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue8761.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue8761.cs
@@ -15,7 +15,7 @@ public class Issue8761 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]
-	[Ignore("This test is very flaky and needs to be fixed.")]
+	[Ignore("This test is very flaky and needs to be fixed. See https://github.com/dotnet/maui/issues/27272")]
 	public void CollectionViewHeaderTemplateAndFooterTemplateDontWork()
 	{
 		for (int i = 0; i < 4; i++)


### PR DESCRIPTION
### Description of Change

The tests in this PR have a low pass rate so we should probably look into those to make them better. Lets disable them for now to have more reliable pipelines.

Verifying this PR is a bit hard, just check that the runs on Azure DevOps don't have a ton of retries and we'll have a look at the dashboard of test runs and see the names of these tests disappear as failing tests.
