### PR TITLE
Detect Appium driver installation failures

### DIFF
--- a/eng/scripts/appium-install.ps1
+++ b/eng/scripts/appium-install.ps1
@@ -149,14 +149,27 @@ npm cache clean --force
 $existingDrivers = appium driver list --installed --json  | ConvertFrom-Json
 Write-Output "List of installed drivers $existingDrivers"
 
+$exitCode = 0
+
+function Check-ExitCode {
+    param (
+        [int]$code
+    )
+    if ($code -ne 0 -and $exitCode -eq 0) {
+        $exitCode = $code
+    }
+}
+
 if ($IsWindows) {
     if ($existingDrivers.windows) {
         Write-Output  "Updating appium driver windows"
         appium driver update windows
+        Check-ExitCode $LASTEXITCODE
         Write-Output  "Updated appium driver windows"
     } else {
         Write-Output  "Installing appium driver windows"
         appium driver install --source=npm appium-windows-driver@$windowsDriverVersion
+        Check-ExitCode $LASTEXITCODE
         Write-Output  "Installed appium driver windows"
     }
 }
@@ -166,19 +179,23 @@ if ($IsMacOS) {
     if ($existingDrivers.xcuitest) {
         Write-Output  "Updating appium driver xcuitest"
         appium driver update xcuitest
+        Check-ExitCode $LASTEXITCODE
         Write-Output  "Updated appium driver xcuitest"
     } else {
         Write-Output  "Installing appium driver xcuitest"
         appium driver install xcuitest@$iOSDriverVersion
+        Check-ExitCode $LASTEXITCODE
         Write-Output  "Installed appium driver xcuitest"
     }
     if ($existingDrivers.mac2) {
         Write-Output  "Updating appium driver mac2"
         appium driver update mac2
+        Check-ExitCode $LASTEXITCODE
         Write-Output  "Updated appium driver mac2"
     } else {
         Write-Output  "Installing appium driver mac2"
         appium driver install mac2@$macDriverVersion
+        Check-ExitCode $LASTEXITCODE
         Write-Output  "Installed appium driver mac2"
     }
 }
@@ -186,10 +203,12 @@ if ($IsMacOS) {
 if ($existingDrivers.uiautomator2) {
     Write-Output  "Updating appium driver uiautomator2"
     appium driver update uiautomator2
+    Check-ExitCode $LASTEXITCODE
     Write-Output  "Updated appium driver uiautomator2"
 } else {
     Write-Output  "Installing appium driver uiautomator2"
     appium driver install uiautomator2@$androidDriverVersion
+    Check-ExitCode $LASTEXITCODE
     Write-Output  "Installed appium driver uiautomator2"
 }
 
@@ -207,5 +226,9 @@ if ($IsMacOS) {
 }
 
 appium driver doctor uiautomator2
+
+if ($exitCode -ne 0) {
+    throw "One or more Appium driver installations failed. Please check the logs for more information."
+}
 
 Write-Output  "Done, thanks!"


### PR DESCRIPTION
### Description of Change

I noticed during a test run that because of a hiccup the Appium driver wasn't installed, but the lane still proceeded to run the UI tests. This change adds a check for the exit code after each step and throws an exception if one of them was non-zero (so not a success). This way we should short circuit a lane when driver install fails, because when that happens the tests will fail anyway and that will just be a waste of time.
