### PR TITLE
[Windows] Fixed NRE when clearing ListView after navigating back

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -807,6 +807,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		private protected override void DisconnectHandlerCore()
 		{
+			if (Element != null)
+				((ITemplatedItemsView<Cell>)Element).TemplatedItems.CollectionChanged -= OnCollectionChanged;
 			CleanUpResources();
 			base.DisconnectHandlerCore();
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -807,8 +807,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		private protected override void DisconnectHandlerCore()
 		{
-			if (Element != null)
-				((ITemplatedItemsView<Cell>)Element).TemplatedItems.CollectionChanged -= OnCollectionChanged;
+			if (Element is ITemplatedItemsView<Cell> templatedItemsView)
+				templatedItemsView.TemplatedItems.CollectionChanged -= OnCollectionChanged;
+
 			CleanUpResources();
 			base.DisconnectHandlerCore();
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -808,7 +808,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		private protected override void DisconnectHandlerCore()
 		{
 			if (Element is ITemplatedItemsView<Cell> templatedItemsView)
+			{
 				templatedItemsView.TemplatedItems.CollectionChanged -= OnCollectionChanged;
+			}
 
 			CleanUpResources();
 			base.DisconnectHandlerCore();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26498.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26498.cs
@@ -1,0 +1,98 @@
+﻿using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using Maui.Controls.Sample.Issues;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 26498, "Null Exception on clearing collection in list view after navigation",
+		PlatformAffected.UWP)]
+	public class Issue26498 : NavigationPage
+	{
+		public Issue26498() : base(new Issue26498TestPage())
+		{
+		}
+
+		public class Issue26498TestPage() : TestContentPage
+		{
+			private Page _listviewPage = null;
+
+			protected override void Init()
+			{
+				var layout = new StackLayout();
+				var openListViewPageButton = new Button
+				{
+					Text = "Open ListView Page",
+					AutomationId = "OpenListViewPage",
+					Command = new Command(OpenListViewPage)
+				};
+				layout.Children.Add(openListViewPageButton);
+
+				Content = layout;
+			}
+
+			void OpenListViewPage()
+			{
+				_listviewPage ??= new ListViewPage();
+				Navigation.PushAsync(_listviewPage);
+			}
+		}
+
+	}
+
+	public class ListViewPage : ContentPage
+	{
+		private readonly ObservableCollection<string> _listOfStrings = new ObservableCollection<string>();
+		private ListView _stringListView = new ListView();
+		public ListViewPage()
+		{
+			var stackLayout = new StackLayout();
+
+			var ClearListButton = new Button
+			{
+				Text = "Clear list",
+				AutomationId = "ClearButton",
+
+			};
+
+			ClearListButton.Clicked += (s, e) =>
+			{
+				ClearListItems();
+			};
+
+			var BackButton = new Button
+			{
+				Text = "Back to Main Page",
+				AutomationId = "BackButton",
+			};
+
+			BackButton.Clicked += (s, e) =>
+			{
+				OpenMainPage();
+			};
+
+			stackLayout.Children.Add(ClearListButton);
+			stackLayout.Children.Add(BackButton);
+			_listOfStrings.Add("Item1");
+			_listOfStrings.Add("Item2");
+			_listOfStrings.Add("Item3");
+
+			_stringListView = new ListView
+			{
+				ItemsSource = _listOfStrings
+			};
+
+			stackLayout.Children.Add(_stringListView);
+
+			Content = stackLayout;
+		}
+		void ClearListItems()
+		{
+			_listOfStrings.Clear();
+		}
+		void OpenMainPage()
+		{
+			Navigation.PopAsync();
+		}
+	}
+
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26498.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26498.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Issues
 
 		public class Issue26498TestPage() : TestContentPage
 		{
-			private Page _listviewPage = null;
+			Page _listviewPage = null;
 
 			protected override void Init()
 			{
@@ -41,8 +41,8 @@ namespace Maui.Controls.Sample.Issues
 
 	public class ListViewPage : ContentPage
 	{
-		private readonly ObservableCollection<string> _listOfStrings = new ObservableCollection<string>();
-		private ListView _stringListView = new ListView();
+		readonly ObservableCollection<string> _listOfStrings = new ObservableCollection<string>();
+		ListView _stringListView = new ListView();
 		public ListViewPage()
 		{
 			var stackLayout = new StackLayout();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26498.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26498.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue26498 : _IssuesUITest
+	{
+		public override string Issue => "Null Exception on clearing collection in list view after navigation";
+		public Issue26498(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.ListView)]
+		public void Issue26498TestNullExeption()
+		{
+			App.WaitForElement("OpenListViewPage");
+			App.Tap("OpenListViewPage");
+			App.WaitForElement("BackButton");
+			App.Click("BackButton");
+			App.WaitForElement("OpenListViewPage");
+			App.Click("OpenListViewPage");
+			App.WaitForElement("ClearButton");
+			App.Click("ClearButton");
+			VerifyScreenshot();
+											
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26498.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26498.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.ListView)]
-		public void Issue26498TestNullExeption()
+		public void Issue26498TestNullException()
 		{
 			const string OpenListViewPage = "OpenListViewPage";
 			const string ClearButton = "ClearButton";

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26498.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26498.cs
@@ -15,16 +15,19 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.ListView)]
 		public void Issue26498TestNullExeption()
 		{
-			App.WaitForElement("OpenListViewPage");
-			App.Tap("OpenListViewPage");
-			App.WaitForElement("BackButton");
-			App.Click("BackButton");
-			App.WaitForElement("OpenListViewPage");
-			App.Click("OpenListViewPage");
-			App.WaitForElement("ClearButton");
-			App.Click("ClearButton");
-			VerifyScreenshot();
-											
+			const string OpenListViewPage = "OpenListViewPage";
+			const string ClearButton = "ClearButton";
+			const string BackButton = "BackButton";
+
+			App.WaitForElement(OpenListViewPage);
+			App.Tap(OpenListViewPage);
+			App.WaitForElement(BackButton);
+			App.Click(BackButton);
+			App.WaitForElement(OpenListViewPage);
+			App.Click(OpenListViewPage);
+			App.WaitForElement(ClearButton);
+			App.Click(ClearButton);
+			App.WaitForElement(ClearButton);
 		}
 	}
 }


### PR DESCRIPTION
### RootCause:

- The issue arises because the CollectionChanged event of the virtual view was not unwired in the DisconnectHandler method in ListViewRender. As a result, the CollectionChanged event was wired multiple times for each navigation, and it was never unwired. When we use the saved instance, the CollectionChanged event is wired for the second time, while the first one was never unwired. When we clear the item source, the CollectionChanged event is triggered for the first element. Since it was disconnected, we receive the virtual view as null.

### Description Of Change:

- I have unwired the CollectionChanged event in the DisconnectHandler method. 

**Tested the behaviour in the following platforms.**
- [x] Windows

**Issue Fixed:**
Fixes [https://github.com/dotnet/maui/issues/26498](https://github.com/dotnet/maui/issues/26498)

**Before Fix:** 

https://github.com/user-attachments/assets/df22c906-d303-499a-a24f-227c81534e73

**After Fix:**

https://github.com/user-attachments/assets/40d7e34c-a6b8-42b5-ac8c-e97cdd809de9







