### PR TITLE
Add category names in CI test runs

### DIFF
--- a/eng/pipelines/common/setup-jdk.yml
+++ b/eng/pipelines/common/setup-jdk.yml
@@ -9,6 +9,8 @@ steps:
       jdkPath="${{ parameters.jdkFolder }}"
       echo "Using provided JDK folder: $jdkPath"
     else
+      echo "Installed JDKs:"
+      /usr/libexec/java_home -V
       jdkPath=$(/usr/libexec/java_home -V 2>&1 | grep -E "${{ parameters.jdkMajorVersion }}.jdk" | head -n 1 | awk '{print $NF}')
       if [ -n "$jdkPath" ]; then
         echo "Found JDK path: $jdkPath"

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -148,7 +148,7 @@ steps:
     inputs:
       testResultsFormat: VSTest
       testResultsFiles: '$(TestResultsDirectory)/*.trx'
-      testRunTitle: '$(System.PhaseName)'
+      testRunTitle: '$(testFilter)_$(System.PhaseName)'
       failTaskOnFailedTests: true
 
   - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -148,7 +148,7 @@ steps:
     inputs:
       testResultsFormat: VSTest
       testResultsFiles: '$(TestResultsDirectory)/*.trx'
-      testRunTitle: '$(testFilter)_$(System.PhaseName)'
+      testRunTitle: '${{ parameters.testFilter }}_$(System.PhaseName)'
       failTaskOnFailedTests: true
 
   - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -99,7 +99,6 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
-                  name: android_ui_tests_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -138,7 +137,6 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
-                  name: ios_ui_tests_mono_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -175,7 +173,7 @@ stages:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
             - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
-              - job: ios_ui_tests_mono_cv2_${{ project.name }}_${{ replace(version, '.', '_') }}
+              - job: ios_ui_tests_mono_${{ project.name }}_${{ replace(version, '.', '_') }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -220,7 +218,6 @@ stages:
                       ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                         ${{ categoryGroup }}:
                           CATEGORYGROUP: ${{ categoryGroup }}
-                    name: ios_ui_tests_nativeaot_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                   timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                   workspace:
                     clean: all
@@ -261,7 +258,6 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
-                  name: winui_ui_tests_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -294,7 +290,6 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
-                  name: mac_ui_tests_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -99,6 +99,7 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
+                  name: android_ui_tests_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -137,6 +138,7 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
+                  name: ios_ui_tests_mono_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -173,7 +175,7 @@ stages:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
             - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
-              - job: ios_ui_tests_mono_${{ project.name }}_${{ replace(version, '.', '_') }}
+              - job: ios_ui_tests_mono_cv2_${{ project.name }}_${{ replace(version, '.', '_') }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -218,6 +220,7 @@ stages:
                       ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                         ${{ categoryGroup }}:
                           CATEGORYGROUP: ${{ categoryGroup }}
+                    name: ios_ui_tests_nativeaot_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                   timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                   workspace:
                     clean: all
@@ -258,6 +261,7 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
+                  name: winui_ui_tests_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all
@@ -290,6 +294,7 @@ stages:
                     ${{ each categoryGroup in parameters.categoryGroupsToTest }}:
                       ${{ categoryGroup }}:
                         CATEGORYGROUP: ${{ categoryGroup }}
+                  name: mac_ui_tests_${{ project.name }}_${{ api }}_${{ categoryGroup }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -173,7 +173,7 @@ stages:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
             - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
-              - job: ios_ui_tests_mono_${{ project.name }}_${{ replace(version, '.', '_') }}
+              - job: CV2_ios_ui_tests_mono_${{ project.name }}_${{ replace(version, '.', '_') }}
                 timeoutInMinutes: 240 # how long to run the job before automatically cancelling
                 workspace:
                   clean: all


### PR DESCRIPTION
### Description of Change

Adds the test filter (effectively categories) as the UI test run name so that it shows up in Azure Pipelines. That way its easier to see in which category(group) a test is failing. See an example underneath. New is that is shows "Editor,Effects,Entry" etc.

![image](https://github.com/user-attachments/assets/11dcb31c-df21-47c4-87e5-3f45496b8f3c)
