### PR TITLE
Fix iOS ScrollView content being measured with non-infinite constraints during LayoutSubviews pass

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27169.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27169.cs
@@ -1,0 +1,21 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 27169, "Grid inside ScrollView should measure with infinite constraints", PlatformAffected.iOS)]
+public class Issue27169 : ContentPage
+{
+	public Issue27169()
+	{
+		var grid = new Grid { VerticalOptions = LayoutOptions.Start };
+		grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+		grid.RowDefinitions.Add(new RowDefinition(GridLength.Star));
+		var firstContent = new Label { MinimumHeightRequest = 200, AutomationId = "StubLabel", BackgroundColor = Colors.LightBlue };
+		firstContent.SetBinding(Label.TextProperty, new Binding(nameof(Label.Height), source: firstContent));
+		var secondContent = new Label { MinimumHeightRequest = 40, Text = "Second Content", BackgroundColor = Colors.SlateBlue };
+		
+		grid.Add(firstContent);
+		grid.Add(secondContent, 0 , 1);
+
+		var scrollView = new ScrollView { Content = grid };
+		Content = scrollView;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27169.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27169.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27169(TestDevice device) : _IssuesUITest(device)
+	{
+		public override string Issue => "Grid inside ScrollView should measure with infinite constraints";
+
+		[Test]
+		[Category(UITestCategories.ScrollView)]
+		public void ScrollViewContentLayoutMeasuresWithInfiniteConstraints()
+		{
+			var measuredHeight = App.WaitForElement("StubLabel").GetText()!;
+			ClassicAssert.AreEqual("200", measuredHeight);
+		}
+	}
+}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(platformView);
 
-			if (platformView is MauiScrollView platformScrollView)
+			if (platformView is ICrossPlatformLayoutBacking platformScrollView)
 			{
 				platformScrollView.CrossPlatformLayout = this;
 			}
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(UIScrollView platformView)
 		{
-			if (platformView is MauiScrollView platformScrollView)
+			if (platformView is ICrossPlatformLayoutBacking platformScrollView)
 			{
 				platformScrollView.CrossPlatformLayout = null;
 			}

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Platform
 				// imposed by the parent (i.e. scroll view) with the current bounds.
 				// But we _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
 				// the window); there's no guarantee that SizeThatFits has been called in that case.
-				if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not ICrossPlatformLayoutBacking)
+				if (!IsMeasureValid(widthConstraint, heightConstraint) && !this.IsFinalMeasureHandledBySuperView())
 				{
 					crossPlatformLayout.CrossPlatformMeasure(widthConstraint, heightConstraint);
 					CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -6,7 +6,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiScrollView : UIScrollView, IUIViewLifeCycleEvents
+	public class MauiScrollView : UIScrollView, IUIViewLifeCycleEvents, ICrossPlatformLayoutBacking
 	{
 		bool _invalidateParentWhenMovedToWindow;
 		double _lastMeasureHeight;
@@ -16,11 +16,13 @@ namespace Microsoft.Maui.Platform
 
 		WeakReference<ICrossPlatformLayout>? _crossPlatformLayoutReference;
 
-		internal ICrossPlatformLayout? CrossPlatformLayout
+		ICrossPlatformLayout? ICrossPlatformLayoutBacking.CrossPlatformLayout
 		{
 			get => _crossPlatformLayoutReference != null && _crossPlatformLayoutReference.TryGetTarget(out var v) ? v : null;
 			set => _crossPlatformLayoutReference = value == null ? null : new WeakReference<ICrossPlatformLayout>(value);
 		}
+
+		internal ICrossPlatformLayout? CrossPlatformLayout => ((ICrossPlatformLayoutBacking)this).CrossPlatformLayout;
 
 		public override void LayoutSubviews()
 		{
@@ -36,11 +38,13 @@ namespace Microsoft.Maui.Platform
 				_lastArrangeWidth = widthConstraint;
 				_lastArrangeHeight = heightConstraint;
 
-				// If the SuperView is a MauiView (backing a cross-platform ContentView or Layout), then measurement
-				// has already happened via SizeThatFits and doesn't need to be repeated in LayoutSubviews. But we
-				// _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
+				// If the SuperView is a cross-platform layout backed view (i.e. MauiView, MauiScrollView, LayoutView, ..),
+				// then measurement has already happened via SizeThatFits and doesn't need to be repeated in LayoutSubviews.
+				// This is especially important to avoid overriding potentially infinite measurement constraints
+				// imposed by the parent (i.e. scroll view) with the current bounds.
+				// But we _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
 				// the window); there's no guarantee that SizeThatFits has been called in that case.
-				if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not MauiView)
+				if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not ICrossPlatformLayoutBacking)
 				{
 					crossPlatformLayout.CrossPlatformMeasure(widthConstraint, heightConstraint);
 					CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -125,12 +125,13 @@ namespace Microsoft.Maui.Platform
 			var widthConstraint = bounds.Width;
 			var heightConstraint = bounds.Height;
 
-			// If the SuperView is a MauiView (backing a cross-platform ContentView or Layout), then measurement
-			// has already happened via SizeThatFits and doesn't need to be repeated in LayoutSubviews. But we
-			// _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
+			// If the SuperView is a cross-platform layout backed view (i.e. MauiView, MauiScrollView, LayoutView, ..),
+			// then measurement has already happened via SizeThatFits and doesn't need to be repeated in LayoutSubviews.
+			// This is especially important to avoid overriding potentially infinite measurement constraints
+			// imposed by the parent (i.e. scroll view) with the current bounds.
+			// But we _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
 			// the window); there's no guarantee that SizeThatFits has been called in that case.
-
-			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not MauiView)
+			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not ICrossPlatformLayoutBacking)
 			{
 				CrossPlatformMeasure(widthConstraint, heightConstraint);
 				CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Platform
 			// imposed by the parent (i.e. scroll view) with the current bounds.
 			// But we _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
 			// the window); there's no guarantee that SizeThatFits has been called in that case.
-			if (!IsMeasureValid(widthConstraint, heightConstraint) && Superview is not ICrossPlatformLayoutBacking)
+			if (!IsMeasureValid(widthConstraint, heightConstraint) && !this.IsFinalMeasureHandledBySuperView())
 			{
 				CrossPlatformMeasure(widthConstraint, heightConstraint);
 				CacheMeasureConstraints(widthConstraint, heightConstraint);

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -945,5 +945,7 @@ namespace Microsoft.Maui.Platform
 		internal static bool ShowSoftInput(this UIView inputView) => inputView.BecomeFirstResponder();
 
 		internal static bool IsSoftInputShowing(this UIView inputView) => inputView.IsFirstResponder;
+
+		internal static bool IsFinalMeasureHandledBySuperView(this UIView? view) => view?.Superview is ICrossPlatformLayoutBacking { CrossPlatformLayout: not null };
 	}
 }

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -9,15 +9,21 @@ using static Microsoft.Maui.Primitives.Dimension;
 
 namespace Microsoft.Maui.Platform
 {
-	public partial class WrapperView : UIView, IDisposable, IUIViewLifeCycleEvents
+	public partial class WrapperView : UIView, IDisposable, IUIViewLifeCycleEvents, ICrossPlatformLayoutBacking
 	{
 		bool _fireSetNeedsLayoutOnParentWhenWindowAttached;
 		WeakReference<ICrossPlatformLayout>? _crossPlatformLayoutReference;
 
-		internal ICrossPlatformLayout? CrossPlatformLayout
+		ICrossPlatformLayout? ICrossPlatformLayoutBacking.CrossPlatformLayout
 		{
 			get => _crossPlatformLayoutReference != null && _crossPlatformLayoutReference.TryGetTarget(out var v) ? v : null;
 			set => _crossPlatformLayoutReference = value == null ? null : new WeakReference<ICrossPlatformLayout>(value);
+		}
+		
+		internal ICrossPlatformLayout? CrossPlatformLayout
+		{
+			get => ((ICrossPlatformLayoutBacking)this).CrossPlatformLayout;
+			set => ((ICrossPlatformLayoutBacking)this).CrossPlatformLayout = value;
 		}
 
 		double _lastMeasureHeight = double.NaN;


### PR DESCRIPTION
### Description of Change

With https://github.com/dotnet/maui/pull/26763 we removed the middle layer (a `MauiView`) which was sitting between the `MauiScrollView` and its content.

That middle layer was important because it prevented the content to be measured with `Bounds` during the `LayoutSubviews` pass.

This PR simply excludes the cross platform measure pass when the parent is `MauiScrollView` (same thing happening with `MauiView`).

In fact, now `MauiScrollView` can be considered a cross platform layout.

The UI test covers all platforms, so this should be helpful in verifying we have the same behavior in case we refactor also other platforms.

### Issues Fixed

Fixes #27169
