### PR TITLE
[iOS][Windows] ScrollView: Fix ScrollToAsync hanging when already at target position

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/ScrollViewUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/ScrollViewUITests.cs
@@ -79,9 +79,6 @@ namespace Microsoft.Maui.TestCases.Tests
 		// ScrollToYTwice (src\Compatibility\ControlGallery\src\UITests.Shared\Tests\ScrollViewUITests.cs)
 		[Test]
 		[Description("ScrollTo Y = 100")]
-		[FailsOnIOSWhenRunningOnXamarinUITest("This test is failing, likely due to product issue, More Information: https://github.com/dotnet/maui/issues/27250")]
-		[FailsOnMacWhenRunningOnXamarinUITest("This test is failing, likely due to product issue, More Information: https://github.com/dotnet/maui/issues/27250")]
-		[FailsOnWindowsWhenRunningOnXamarinUITest("This test is failing, likely due to product issue, More Information: https://github.com/dotnet/maui/issues/27250")]
 		public void ScrollToYTwice()
 		{
 			App.WaitForElement("WaitForStubControl");

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -79,6 +79,10 @@ namespace Microsoft.Maui.Handlers
 			if (args is ScrollToRequest request)
 			{
 				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
+				if(request.VerticalOffset == handler.PlatformView.VerticalOffset && request.HorizontalOffset == handler.PlatformView.HorizontalOffset)
+				{
+				   handler.VirtualView.ScrollFinished();
+				}
 			}
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -78,11 +78,12 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
-				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
 				if(request.VerticalOffset == handler.PlatformView.VerticalOffset && request.HorizontalOffset == handler.PlatformView.HorizontalOffset)
 				{
 				   handler.VirtualView.ScrollFinished();
+				   return;
 				}
+				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
 			}
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -78,12 +78,16 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
-				if(request.VerticalOffset == handler.PlatformView.VerticalOffset && request.HorizontalOffset == handler.PlatformView.HorizontalOffset)
+				var targetHorizontalOffset = Math.Clamp(request.HorizontalOffset, 0, handler.PlatformView.ScrollableWidth);
+				var targetVerticalOffset = Math.Clamp(request.VerticalOffset, 0, handler.PlatformView.ScrollableHeight);
+
+				if (targetVerticalOffset == handler.PlatformView.VerticalOffset && targetHorizontalOffset == handler.PlatformView.HorizontalOffset)
 				{
 				   handler.VirtualView.ScrollFinished();
 				   return;
 				}
-				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
+
+				handler.PlatformView.ChangeView(targetHorizontalOffset, targetVerticalOffset, null, request.Instant);
 			}
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.Handlers
 				var minScrollVertical = Math.Clamp(request.VerticalOffset, 0, availableScrollHeight);
 				uiScrollView.SetContentOffset(new CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
 
-				if (request.Instant || uiScrollView.ContentOffset.Y == minScrollVertical && uiScrollView.ContentOffset.X == minScrollHorizontal)
+				if (request.Instant || (uiScrollView.ContentOffset.Y == minScrollVertical && uiScrollView.ContentOffset.X == minScrollHorizontal))
 				{
 					scrollView.ScrollFinished();
 				}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.Handlers
 				var minScrollVertical = Math.Clamp(request.VerticalOffset, 0, availableScrollHeight);
 				uiScrollView.SetContentOffset(new CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
 
-				if (request.Instant)
+				if (request.Instant || uiScrollView.ContentOffset.Y == minScrollVertical && uiScrollView.ContentOffset.X == minScrollHorizontal)
 				{
 					scrollView.ScrollFinished();
 				}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -112,9 +112,15 @@ namespace Microsoft.Maui.Handlers
 				var availableScrollWidth = Math.Max(uiScrollView.ContentSize.Width - uiScrollView.Frame.Width, 0);
 				var minScrollHorizontal = Math.Clamp(request.HorizontalOffset, 0, availableScrollWidth);
 				var minScrollVertical = Math.Clamp(request.VerticalOffset, 0, availableScrollHeight);
-				uiScrollView.SetContentOffset(new CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
+				
+				bool alreadyAtTarget = uiScrollView.ContentOffset.Y == minScrollVertical && uiScrollView.ContentOffset.X == minScrollHorizontal;
 
-				if (request.Instant || (uiScrollView.ContentOffset.Y == minScrollVertical && uiScrollView.ContentOffset.X == minScrollHorizontal))
+				if (!alreadyAtTarget)
+				{
+    				uiScrollView.SetContentOffset(new CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
+				}
+
+				if (request.Instant || alreadyAtTarget)
 				{
 					scrollView.ScrollFinished();
 				}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

When calling ScrollToAsync with the same Y value on a ScrollView that is already at the target position, the scrolling operation does not complete on iOS, Windows, and Catalyst platforms. This behavior is inconsistent with Android, where the scrolling operation completes as expected.

### Root Cause:

ScrollToAsync hangs when called with the same position the scroll view is already at. On iOS, UIScrollView.SetContentOffset does not trigger ScrollAnimationEnded when the content offset doesn't actually change, so ScrollFinished() is never called and the Task never completes. On Windows, ScrollViewer.ChangeView has the same behavior when already at the target offset.

### Description of Change:

iOS (ScrollViewHandler.iOS.cs):
Before calling SetContentOffset, check whether the clamped target position already matches the current ContentOffset. If already at the target:

Skip the SetContentOffset call (no-op scroll)
Call ScrollFinished() directly to complete the pending Task
ScrollFinished) handles all other cases unchanged.

Windows (ScrollViewHandler.Windows.cs):
Before calling ChangeView, check whether the clamped target position already matches the current VerticalOffset/HorizontalOffset. If already at the target, call ScrollFinished() and return early.

Tests (ScrollViewUITests.cs):
Removed three [FailsOn*WhenRunningOnXamarinUITest] attributes from ScrollToYTwice that were tracking this issue on iOS, Mac, and Windows.

**Platform Affected**

- iOS (.ios.cs covers both iOS and MacCatalyst)
- MacCatalyst (via ScrollViewHandler.iOS.cs)
- Windows

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac


### Reference:

N/A


### Issues Fixed:



Fixes #27250



### Screenshots

| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/5ec192ee-e9ce-4108-816b-9f35776c86aa" width="320" height="240" controls></video>   |   <video src="https://github.com/user-attachments/assets/787e2b28-c040-4f4c-b6ae-695e3db707ba" width="320" height="240" controls></video>   |