### PR TITLE
[Housekeeping] Fix build errors on main

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -382,6 +382,7 @@ namespace Microsoft.Maui.Handlers
 			else if (invokeJavaScriptRequest.ReturnTypeJsonTypeInfo is null)
 			{
 				invokeJavaScriptRequest.SetResult(null);
+				return null;
 			}
 			// if we are expecting a result, then deserialize what we have
 			else


### PR DESCRIPTION
### Description of Change

Fix build errors on main. Recently we merged https://github.com/dotnet/maui/pull/27094 and not all code paths return a value in the HybridWebViewHandler.MapInvokeJavaScriptAsyncImpl method.

`error CS0161: 'HybridWebViewHandler.MapInvokeJavaScriptAsyncImpl(IHybridWebViewHandler, IHybridWebView, HybridWebViewInvokeJavaScriptRequest)': not all code paths return a value`
