### PR TITLE
Add/remove all-checks-passed label on PR check suites

### DIFF
--- a/.github/workflows/add-remove-label-check-suites.yml
+++ b/.github/workflows/add-remove-label-check-suites.yml
@@ -1,0 +1,73 @@
+# When all check suites are completed successfully, the workflow adds a label to the pull request.
+# When a new check suite is requested (or rerequested), the workflow removes the label from the pull request.
+name: Manage Label on Check Suites
+
+on:
+  check_suite:
+    types: [completed, requested, rerequested]
+
+jobs:
+  add-label:
+    if: github.event.action == 'completed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check if all check suites are successful
+        id: check_suites
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: checkSuites } = await github.checks.listSuitesForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.check_suite.head_sha,
+            });
+
+            const allSuccessful = checkSuites.check_suites.every(
+              suite => suite.conclusion === 'success' || suite.conclusion === 'skipped');
+
+            if (allSuccessful) {
+              return { success: true };
+            } else {
+              return { success: false };
+            }
+
+      - name: Add label if all check suites are successful
+        if: steps.check_suites.outputs.success == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pullRequest = context.payload.check_suite.pull_requests[0];
+            if (pullRequest) {
+              github.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: 'all-checks-passed',
+              });
+            }
+
+  remove-label:
+    if: github.event.action == 'requested' || github.event.action == 'rerequested'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Remove label when check suite is triggered or re-requested
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pullRequest = context.payload.check_suite.pull_requests[0];
+            if (pullRequest) {
+              github.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                name: 'all-checks-passed',
+              });
+            }


### PR DESCRIPTION
### Description of Change

This PR adds a GitHub Actions workflow to manage the `all-checks-passed` label on pull requests based on the status of check suites. When all check suites are completed successfully (skipped state is counted as success), the workflow adds the `all-checks-passed` label to the pull request.

When a new check suite is requested or re-requested, the workflow removes the `all-checks-passed` label from the pull request.

This will help identify PRs with completed checks and is a first step to potentially more automation around this area.

Unfortunately its hard to test this without actually merging this and see what happens on a next PR 😅 