### PR TITLE
Revert accessibility features on template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -37,24 +37,21 @@
                     <VerticalStackLayout Spacing="{StaticResource LayoutSpacing}" Padding="{StaticResource LayoutPadding}">
                         <controls:CategoryChart />
                         <Label Text="Projects" Style="{StaticResource Title2}"/>
-                        <CollectionView
-                            ItemsSource="{Binding Projects}"
-                            Margin="-15, 0">
-                            <CollectionView.ItemsLayout>
-                                <LinearItemsLayout                              
-                                    Orientation="Horizontal"
-                                    ItemSpacing="15" />
-                            </CollectionView.ItemsLayout>
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="models:Project">
-                                    <controls:ProjectCardView WidthRequest="200">
-                                        <controls:ProjectCardView.GestureRecognizers>
-                                            <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
-                                        </controls:ProjectCardView.GestureRecognizers>
-                                    </controls:ProjectCardView>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
+                        <ScrollView Orientation="Horizontal" Margin="-30,0">
+                            <HorizontalStackLayout 
+                                Spacing="15" Padding="30,0"
+                                BindableLayout.ItemsSource="{Binding Projects}">
+                                <BindableLayout.ItemTemplate>
+                                    <DataTemplate x:DataType="models:Project">
+                                        <controls:ProjectCardView WidthRequest="200">
+                                            <controls:ProjectCardView.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
+                                            </controls:ProjectCardView.GestureRecognizers>
+                                        </controls:ProjectCardView>
+                                    </DataTemplate>
+                                </BindableLayout.ItemTemplate>
+                            </HorizontalStackLayout>
+                        </ScrollView>
                         <Grid HeightRequest="44">
                             <Label Text="Tasks" Style="{StaticResource Title2}" VerticalOptions="Center"/>
                             <ImageButton 

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -16,15 +16,12 @@
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
     <Grid>
-        <CollectionView 
-            ItemsSource="{Binding Projects}" 
-            Margin="{StaticResource LayoutPadding}">
-            <CollectionView.ItemsLayout>
-                <LinearItemsLayout 
-                    Orientation="Vertical"
-                    ItemSpacing="{StaticResource LayoutSpacing}"/>
-            </CollectionView.ItemsLayout>
-            <CollectionView.ItemTemplate>
+      <ScrollView>
+        <VerticalStackLayout 
+            BindableLayout.ItemsSource="{Binding Projects}" 
+            Margin="{StaticResource LayoutPadding}" 
+            Spacing="{StaticResource LayoutSpacing}">
+            <BindableLayout.ItemTemplate>
                 <DataTemplate x:DataType="models:Project">
                     <Border>
                         <VerticalStackLayout Padding="10">
@@ -36,8 +33,9 @@
                         </Border.GestureRecognizers>
                     </Border>
                 </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
+      </ScrollView>
 
         <controls:AddButton 
             Command="{Binding AddProjectCommand}" />


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

These appears to be a [bug](https://github.com/dotnet/maui/issues/27325) with CollectionView2 when trying to use these changes in our template. For the time being, we should keep the BindableLayout and make the BindableLayout more accessible for keyboard users.

This PR reverts https://github.com/dotnet/maui/pull/27222  and  https://github.com/dotnet/maui/pull/27224

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
