### PR TITLE
Add wildcard to find JDK more precisely

### DIFF
--- a/eng/pipelines/common/setup-jdk.yml
+++ b/eng/pipelines/common/setup-jdk.yml
@@ -11,7 +11,7 @@ steps:
     else
       echo "Installed JDKs:"
       /usr/libexec/java_home -V
-      jdkPath=$(/usr/libexec/java_home -V 2>&1 | grep -E "${{ parameters.jdkMajorVersion }}.jdk" | head -n 1 | awk '{print $NF}')
+      jdkPath=$(/usr/libexec/java_home -V 2>&1 | grep -E "${{ parameters.jdkMajorVersion }}.*jdk" | head -n 1 | awk '{print $NF}')
       if [ -n "$jdkPath" ]; then
         echo "Found JDK path: $jdkPath"
       else


### PR DESCRIPTION
### Description of Change

Adds a wildcard to the detection of the JDK path for CI. This makes sure that we don't only detect the major version but also the major version we want with the minor and patch number.

### Issues Fixed

Fixes #27328