### PR TITLE
Change some device test TCSs to use Async Completion

### DIFF
--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -221,8 +221,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		class WindowTestFragment : Fragment
 		{
-			TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>();
-			TaskCompletionSource<bool> _finishedDestroying = new TaskCompletionSource<bool>();
+			TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+			TaskCompletionSource<bool> _finishedDestroying = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			readonly IMauiContext _mauiContext;
 			readonly IWindow _window;
 

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.DeviceTests
 
 							if (vc.Frame.Height < 0 && vc.Frame.Width < 0)
 							{
-								var batchTcs = new TaskCompletionSource();
+								var batchTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 								vc.BatchCommitted += OnBatchCommitted;
 								await batchTcs.Task.WaitAsync(timeOut.Value);
 								if (vc.Frame.Height < 0 && vc.Frame.Width < 0)
@@ -406,7 +406,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected async Task OnLoadedAsync(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			var source = new TaskCompletionSource();
+			var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			if (frameworkElement.IsLoaded && frameworkElement.IsLoadedOnPlatform())
 			{
 				await Task.Delay(50);
@@ -440,7 +440,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected async Task OnUnloadedAsync(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			var source = new TaskCompletionSource();
+			var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			if (!frameworkElement.IsLoaded && !frameworkElement.IsLoadedOnPlatform())
 			{
 				await Task.Delay(50);

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.DeviceTests
 
 							var finalEntryBox = entry.GetBoundingBox();
 
-							var taskCompletion = new TaskCompletionSource<bool>();
+							var taskCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 							uIWindow.RootViewController.DismissViewController(true, () => { taskCompletion.SetResult(true); });
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.DeviceTests
 			// Because of queued change propagation on BPs
 			// sometimes the appearing will fire a bit later than we expect.
 			// This ensures the first one fires before we move on
-			TaskCompletionSource waitForFirstAppearing = new TaskCompletionSource();
+			TaskCompletionSource waitForFirstAppearing = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			initialPage.Appearing += OnInitialPageAppearing;
 			void OnInitialPageAppearing(object sender, EventArgs e)
 			{

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		static Task<bool> WatchContentSizeChanged(ScrollView scrollView)
 		{
-			var tcs = new TaskCompletionSource<bool>();
+			var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			void handler(object sender, PropertyChangedEventArgs args)
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.DeviceTests
 				return;
 			}
 
-			var taskCompletionSource = new TaskCompletionSource<bool>();
+			var taskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			flyout.LayoutChange += OnLayoutChanged;
 
 			try

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 				var modalVC = GetModalWrapper(modalPage);
 				int navigatedFired = 0;
 				ShellNavigationSource? shellNavigationSource = null;
-				var finishedNavigation = new TaskCompletionSource<bool>();
+				var finishedNavigation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 				shell.Navigated += ShellNavigated;
 
 				modalVC.DidDismiss(null);
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.DeviceTests
 				var modalVC = GetModalWrapper(modalPage);
 				int navigatedFired = 0;
 				ShellNavigationSource? shellNavigationSource = null;
-				var finishedNavigation = new TaskCompletionSource<bool>();
+				var finishedNavigation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 				shell.Navigated += ShellNavigated;
 
 				modalVC.DidDismiss(null);
@@ -181,7 +181,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				int navigatingFired = 0;
 				int navigatedFired = 0;
-				var finishedNavigation = new TaskCompletionSource<bool>();
+				var finishedNavigation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 				ShellNavigationSource? shellNavigationSource = null;
 
 				shell.Navigating += ShellNavigating;
@@ -232,7 +232,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				shell.Navigating += ShellNavigating;
 				shell.Navigated += ShellNavigated;
-				var finishedNavigation = new TaskCompletionSource<bool>();
+				var finishedNavigation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 				sectionRenderer.SendPop();
 
 				// Give Navigated time to fire just in case

--- a/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/WebView/WebViewTests.Windows.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.DeviceTests
 				await AttachAndRun(webView, async (handler) =>
 				{
 					// Wait for the page to load
-					var tcsLoaded = new TaskCompletionSource<bool>();
+					var tcsLoaded = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 					var ctsTimeout = new CancellationTokenSource(pageLoadTimeout);
 					ctsTimeout.Token.Register(() => tcsLoaded.TrySetException(new TimeoutException($"Failed to load HTML")));
 
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.DeviceTests
 				await AttachAndRun(webView, async (handler) =>
 				{
 					// Wait for the page to load
-					var tcsLoaded = new TaskCompletionSource<bool>();
+					var tcsLoaded = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 					var ctsTimeout = new CancellationTokenSource(pageLoadTimeout);
 					ctsTimeout.Token.Register(() => tcsLoaded.TrySetException(new TimeoutException($"Failed to load HTML")));
 

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class WindowHandlerStub : ElementHandler<IWindow, UIWindow>, IWindowHandler
 	{
-		TaskCompletionSource _finishedDisconnecting = new TaskCompletionSource();
+		TaskCompletionSource _finishedDisconnecting = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 		public Task FinishedDisconnecting => _finishedDisconnecting.Task;
 		IView _currentView;
 		WorkspaceViewController _workSpace;

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 {
 	public abstract class MauiTestActivity : AppCompatActivity
 	{
-		public TaskCompletionSource<Bundle> TaskCompletionSource { get; } = new TaskCompletionSource<Bundle>();
+		public TaskCompletionSource<Bundle> TaskCompletionSource { get; } = new TaskCompletionSource<Bundle>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		protected override void OnCreate(Bundle? savedInstanceState)
 		{

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/MauiTestApplicationDelegate.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/MauiTestApplicationDelegate.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 
 		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
-			var tcs = new TaskCompletionSource();
+			var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			Window = new UIWindow(UIScreen.MainScreen.Bounds)
 			{

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 		public Task<IReadOnlyList<TestAssemblyViewModel>> DiscoverAsync()
 		{
-			var tcs = new TaskCompletionSource<IReadOnlyList<TestAssemblyViewModel>>();
+			var tcs = new TaskCompletionSource<IReadOnlyList<TestAssemblyViewModel>>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			RunAsync(() =>
 			{

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				if (!view.IsFocused)
 				{
-					TaskCompletionSource focusSource = new TaskCompletionSource();
+					TaskCompletionSource focusSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 					view.FocusChange += OnFocused;
 
 					try
@@ -111,7 +111,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			if (view.IsFocused)
 			{
-				TaskCompletionSource focusSource = new TaskCompletionSource();
+				TaskCompletionSource focusSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 				view.FocusChange += OnUnFocused;
 
 				try
@@ -225,7 +225,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static Task<bool> WaitForLayout(this AView view, int timeout = 1000)
 		{
-			var tcs = new TaskCompletionSource<bool>();
+			var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			view.LayoutChange += OnLayout;
 			var cts = new CancellationTokenSource();

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static async Task WaitForFocused(this FrameworkElement view, int timeout = 1000)
 		{
-			TaskCompletionSource focusSource = new TaskCompletionSource();
+			TaskCompletionSource focusSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			FocusManager.GotFocus += OnFocused;
 
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static async Task WaitForUnFocused(this FrameworkElement view, int timeout = 1000)
 		{
-			TaskCompletionSource focusSource = new TaskCompletionSource();
+			TaskCompletionSource focusSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			FocusManager.LostFocus += OnUnFocused;
 
@@ -202,8 +202,8 @@ namespace Microsoft.Maui.DeviceTests
 				await _attachAndRunSemaphore.WaitAsync();
 
 				// prepare to wait for element to be in the UI
-				var loadedTcs = new TaskCompletionSource();
-				var unloadedTcs = new TaskCompletionSource();
+				var loadedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+				var unloadedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 				view.Loaded += OnViewLoaded;
 

--- a/src/TestUtils/src/DeviceTests/CaptureHelper.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/CaptureHelper.Windows.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static async Task<CanvasBitmap> RenderAsync(this GraphicsCaptureItem item, CanvasDevice device)
 		{
-			var tcs = new TaskCompletionSource<CanvasBitmap>();
+			var tcs = new TaskCompletionSource<CanvasBitmap>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			using (var framePool = Direct3D11CaptureFramePool.Create(device, DirectXPixelFormat.B8G8R8A8UIntNormalized, 1, item.Size))
 			using (var session = framePool.CreateCaptureSession(item))


### PR DESCRIPTION
### Description of Change

We're occasionally hitting scenarios where iOS/Android aren't completing the device tests.

This PR is somewhat a stab in the dark to see if changing the TCS's we use to manage flow to use async completion helps the situation

