### PR TITLE
[iOS] RefreshView Loader Appears Frozen When Used with Shell TabBar - fix

### DIFF
--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -34,18 +34,18 @@ namespace Microsoft.Maui.Platform
 			base.MovedToWindow();
 			if (IsRefreshing)
 			{
-				if (Window is not null)
+				CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
 				{
-					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+					if (Window is not null)
 					{
 						_refreshControl.BeginRefreshing();
 						TryOffsetRefresh(this, true);
-					});
-				}
-				else if (Window is null)
-				{
-					_refreshControl.EndRefreshing();
-				}
+					}
+					else if (Window is null)
+					{
+						_refreshControl.EndRefreshing();
+					}
+				});
 			}
 		}
 
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.Platform
 
 		bool TryInsertRefresh(UIView view, int index = 0)
 		{
-			if(!_refreshControl.Enabled)
+			if (!_refreshControl.Enabled)
 			{
 				return false;
 			}

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -29,6 +29,26 @@ namespace Microsoft.Maui.Platform
 			_refreshControlParent = this;
 		}
 
+		public override void MovedToWindow()
+		{
+			base.MovedToWindow();
+			if (IsRefreshing)
+			{
+				if (Window is not null)
+				{
+					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+					{
+						_refreshControl.BeginRefreshing();
+						TryOffsetRefresh(this, true);
+					});
+				}
+				else if (Window is null)
+				{
+					_refreshControl.EndRefreshing();
+				}
+			}
+		}
+
 		public bool IsRefreshing
 		{
 			get { return _isRefreshing; }

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -53,6 +53,7 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+override Microsoft.Maui.Platform.MauiRefreshView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiScrollView.LayoutSubviews() -> void
 override Microsoft.Maui.Platform.MauiScrollView.SizeThatFits(CoreGraphics.CGSize size) -> CoreGraphics.CGSize
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -54,6 +54,7 @@ Microsoft.Maui.WebProcessTerminatedEventArgs.Sender.get -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+override Microsoft.Maui.Platform.MauiRefreshView.MovedToWindow() -> void
 override Microsoft.Maui.Platform.MauiScrollView.LayoutSubviews() -> void
 override Microsoft.Maui.Platform.MauiScrollView.SizeThatFits(CoreGraphics.CGSize size) -> CoreGraphics.CGSize
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size


### PR DESCRIPTION
### Description of Change

If `UIRefreshControl` is animating during screen transition, it will stay visible but will not be animating.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/27104
Fixes https://github.com/dotnet/maui/pull/27348

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/5a30f11d-997b-402c-9679-7bb90acc3fd4" width="300px"/>|<video src="https://github.com/user-attachments/assets/99bfdc59-534b-4b6d-a330-4834a55c0498" width="300px"/>







