### PR TITLE
[Android] White screen when changing the main page - fix

### DIFF
--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		void UpdateContent()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			AView platformView = WindowHandler.CreateRootViewFromContent(this, VirtualView);
+			AView platformView = WindowHandler.CreateRootViewFromContent(this, VirtualView).RootView;
 
 			// This is used for cases where we are testing swapping out the page set on window
 			if (PlatformViewUnderTest?.Parent is FakeActivityRootView farw)

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		void UpdateContent()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			AView platformView = WindowHandler.CreateRootViewFromContent(this, VirtualView).RootView;
+			AView platformView = WindowHandler.SetRootViewFromContent(this, VirtualView).RootView;
 
 			// This is used for cases where we are testing swapping out the page set on window
 			if (PlatformViewUnderTest?.Parent is FakeActivityRootView farw)

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -24,8 +24,9 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			var rootView = CreateRootViewFromContent(handler, window);
-			handler.PlatformView.SetContentView(rootView);
+			var rootManager = CreateRootViewFromContent(handler, window);
+			handler.PlatformView.SetContentView(rootManager.RootView);
+			rootManager.PerformPendingFragmentTransaction();
 		}
 
 		public static void MapX(IWindowHandler handler, IWindow view) =>
@@ -88,13 +89,13 @@ namespace Microsoft.Maui.Handlers
 			navigationRootManager?.Disconnect();
 		}
 
-		internal static View? CreateRootViewFromContent(IWindowHandler handler, IWindow window)
+		internal static NavigationRootManager CreateRootViewFromContent(IWindowHandler handler, IWindow window)
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var rootManager = handler.MauiContext.GetNavigationRootManager();
 			rootManager.Connect(window.Content);
-			return rootManager.RootView;
+			return rootManager;
 		}
 
 		void UpdateVirtualViewFrame(Activity activity)

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -24,9 +24,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			var rootManager = CreateRootViewFromContent(handler, window);
-			handler.PlatformView.SetContentView(rootManager.RootView);
-			rootManager.PerformPendingFragmentTransaction();
+			SetRootViewFromContent(handler, window);
 		}
 
 		public static void MapX(IWindowHandler handler, IWindow view) =>
@@ -89,12 +87,14 @@ namespace Microsoft.Maui.Handlers
 			navigationRootManager?.Disconnect();
 		}
 
-		internal static NavigationRootManager CreateRootViewFromContent(IWindowHandler handler, IWindow window)
+		internal static NavigationRootManager SetRootViewFromContent(IWindowHandler handler, IWindow window)
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var rootManager = handler.MauiContext.GetNavigationRootManager();
 			rootManager.Connect(window.Content);
+			handler.PlatformView.SetContentView(rootManager.RootView);
+			rootManager.PerformPendingFragmentTransaction();
 			return rootManager;
 		}
 

--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Maui.Platform
 		ScopedFragment? _viewFragment;
 		IToolbarElement? _toolbarElement;
 
+		FragmentTransaction? _pendingTransaction;
+
 		// TODO MAUI: temporary event to alert when rootview is ready
 		// handlers and various bits use this to start interacting with rootview
 		internal event EventHandler? RootViewChanged;
@@ -171,13 +173,17 @@ namespace Microsoft.Maui.Platform
 									_mauiContext,
 									OnWindowContentPlatformViewCreated);
 
-							fm
+							_pendingTransaction = fm
 								.BeginTransactionEx()
 								.ReplaceEx(Resource.Id.navigationlayout_content, _viewFragment)
-								.SetReorderingAllowed(true)
-								.Commit();
+								.SetReorderingAllowed(true);
 						});
 			}
+		}
+
+		internal void PerformPendingFragmentTransaction()
+		{
+			_pendingTransaction?.CommitNow();
 		}
 
 		class ElementBasedFragment : ScopedFragment


### PR DESCRIPTION
### Description of Change

The white blink occurs when setting a new page using the following code:Application.Current!.Windows[0].Page = new TestPage2()

Each time a new root page is assigned, a new layout is inflated, which contains a fragment intended to display the page. However, because Android's fragment manager requires a few milliseconds to commit the transition, a noticeable white blink can be seen during this process.

I created a similar setup in Android Studio that mimics the behavior of .NET MAUI. The same white blink issue occurs, confirming that it stems from the fragment manager’s transition delay.

https://github.com/kubaflo/Android_Blink_Bug

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/26845

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/e31ee443-f5c5-418f-b6a2-565cf87ec46a" width="300px"/>|<video src="https://github.com/user-attachments/assets/88c881e4-b50d-4396-91c9-4e517ba4ec1b" width="300px"/>|

```c#
namespace Maui.Controls.Sample;

public partial class App : Application
{
	public App() => InitializeComponent();

	protected override Window CreateWindow(IActivationState? activationState) => new Window(new Page1());
}

class Page1 : ContentPage
{
	public Page1()
	{
		BackgroundColor = Color.FromArgb("#009900");
		Content = new Button
		{
			Text = "Open page 2",
			VerticalOptions = LayoutOptions.End,
			HeightRequest = 40,
			Command = new Command(() => Application.Current!.Windows[0].Page = new Page2())
		};
	}

}

class Page2 : ContentPage
{
	public Page2()
	{
		BackgroundColor = Color.FromArgb("#990000");
		Content = new Button
		{
			Text = "Open page 1",
			VerticalOptions = LayoutOptions.End,
			HeightRequest = 40,
			Command = new Command(() => Application.Current!.Windows[0].Page = new Page1())
		};
	}
}
```