### PR TITLE
[NET10.0] [Windows] Customization of TitleBar buttons

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsTileBarPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsTileBarPage.xaml
@@ -86,6 +86,16 @@
                     Text="Show TitleBar"
                     VerticalOptions="Center"/>
             </HorizontalStackLayout>
+
+            <HorizontalStackLayout>
+                <CheckBox IsChecked="{Binding CanMinimize, Mode=TwoWay}"/>
+                <Label Text="Can Minimize Window" VerticalOptions="Center"/>
+            </HorizontalStackLayout>
+
+          <HorizontalStackLayout>
+                <CheckBox IsChecked="{Binding CanMaximize, Mode=TwoWay}"/>
+                <Label Text="Can Maximize Window" VerticalOptions="Center"/>
+            </HorizontalStackLayout>
         </VerticalStackLayout>
   
         <VerticalStackLayout

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsTileBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsTileBarPage.xaml.cs
@@ -24,7 +24,9 @@ namespace Maui.Controls.Sample.Pages
 					xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 					Title="{Binding Title}"
 					Subtitle="{Binding Subtitle}"
-					IsVisible="{Binding ShowTitleBar}"/>
+					IsVisible="{Binding ShowTitleBar}"
+					CanMinimize="{Binding CanMinimize}"
+					CanMaximize="{Binding CanMaximize}"/>
 				""";
 
 			_customTitleBar = new TitleBar().LoadFromXaml(titleBarXaml);

--- a/src/Controls/samples/Controls.Sample/ViewModels/TitleBarSampleViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/TitleBarSampleViewModel.cs
@@ -41,5 +41,27 @@ namespace Maui.Controls.Sample.ViewModels
 				OnPropertyChanged();
 			}
 		}
+
+		private bool _canMinimize = true;
+		public bool CanMinimize
+		{
+			get { return _canMinimize; }
+			set
+			{
+				_canMinimize = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private bool _canMaximize = true;
+		public bool CanMaximize
+		{
+			get { return _canMaximize; }
+			set
+			{
+				_canMaximize = value;
+				OnPropertyChanged();
+			}
+		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -349,3 +349,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -548,3 +548,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -548,3 +548,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -340,3 +340,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -348,3 +348,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -339,3 +339,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -338,3 +338,9 @@ const Microsoft.Maui.Controls.BrushTypeConverter.Rgba = "rgba" -> string!
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushParser(Microsoft.Maui.Graphics.Converters.ColorTypeConverter? colorConverter = null) -> void
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
+Microsoft.Maui.Controls.TitleBar.CanMinimize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMinimize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMinimizeProperty -> Microsoft.Maui.Controls.BindableProperty!
+Microsoft.Maui.Controls.TitleBar.CanMaximize.get -> bool
+Microsoft.Maui.Controls.TitleBar.CanMaximize.set -> void
+static readonly Microsoft.Maui.Controls.TitleBar.CanMaximizeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/TitleBar/TitleBar.cs
+++ b/src/Controls/src/Core/TitleBar/TitleBar.cs
@@ -71,84 +71,131 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty ForegroundColorProperty = BindableProperty.Create(nameof(ForegroundColor),
 			typeof(Color), typeof(TitleBar));
 
+		/// <summary>Bindable property for <see cref="CanMinimize"/>.</summary>
+		public static readonly BindableProperty CanMinimizeProperty = BindableProperty.Create(nameof(CanMinimize),
+			typeof(bool), typeof(TitleBar), defaultValue: true, propertyChanged: OnCanMinimizeChanged);
+
+		/// <summary>Bindable property for <see cref="CanMaximize"/>.</summary>
+		public static readonly BindableProperty CanMaximizeProperty = BindableProperty.Create(nameof(CanMaximize),
+			typeof(bool), typeof(TitleBar), defaultValue: true, propertyChanged: OnCanMaximizeChanged);
+
 		static void OnLeadingChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			var titlebar = (TitleBar)bindable;
+			var titleBar = (TitleBar)bindable;
 			if (newValue is null)
 			{
-				titlebar.ApplyVisibleState(LeadingHiddenState);
+				titleBar.ApplyVisibleState(LeadingHiddenState);
 			}
 			else
 			{
-				titlebar.ApplyVisibleState(LeadingVisibleState);
+				titleBar.ApplyVisibleState(LeadingVisibleState);
 				(newValue as Layout)?.IgnoreLayoutSafeArea();
 			}
 		}
 
 		static void OnIconChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			var titlebar = (TitleBar)bindable;
+			var titleBar = (TitleBar)bindable;
 			var imageSource = newValue as ImageSource;
 			if (imageSource is null || imageSource.IsEmpty)
 			{
-				titlebar.ApplyVisibleState(IconHiddenState);
+				titleBar.ApplyVisibleState(IconHiddenState);
 			}
 			else
 			{
-				titlebar.ApplyVisibleState(IconVisibleState);
+				titleBar.ApplyVisibleState(IconVisibleState);
 			}
 		}
 
 		static void OnTitleChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			var titlebar = (TitleBar)bindable;
+			var titleBar = (TitleBar)bindable;
 			if (newValue is null)
 			{
-				titlebar.ApplyVisibleState(TitleHiddenState);
+				titleBar.ApplyVisibleState(TitleHiddenState);
 			}
 			else
 			{
-				titlebar.ApplyVisibleState(TitleVisibleState);
+				titleBar.ApplyVisibleState(TitleVisibleState);
 			}
 		}
 
 		static void OnSubtitleChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			var titlebar = (TitleBar)bindable;
+			var titleBar = (TitleBar)bindable;
 			if (newValue is null)
 			{
-				titlebar.ApplyVisibleState(SubtitleHiddenState);
+				titleBar.ApplyVisibleState(SubtitleHiddenState);
 			}
 			else
 			{
-				titlebar.ApplyVisibleState(SubtitleVisibleState);
+				titleBar.ApplyVisibleState(SubtitleVisibleState);
+			}
+		}
+
+		static void OnCanMinimizeChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var titleBar = (TitleBar)bindable;
+			if (newValue is bool canMinimize)
+			{
+#if WINDOWS
+				if (titleBar.Window?.Handler?.PlatformView is UI.Xaml.Window platformWindow)
+				{
+					var appWindow = platformWindow.GetAppWindow();
+
+					if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+					{
+						presenter.IsMinimizable = canMinimize;
+					}
+				}
+#endif
+			}
+		}
+
+		static void OnCanMaximizeChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var titleBar = (TitleBar)bindable;
+			if (newValue is bool canMaximize)
+			{
+#if WINDOWS
+				if (titleBar.Window?.Handler?.PlatformView is UI.Xaml.Window platformWindow)
+				{
+					var appWindow = platformWindow.GetAppWindow();
+
+					if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+					{
+						presenter.IsMaximizable = canMaximize;
+						presenter.IsResizable = !canMaximize;
+					}
+				}
+#endif
 			}
 		}
 
 		static void OnContentChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			var titlebar = (TitleBar)bindable;
+			var titleBar = (TitleBar)bindable;
 			if (newValue is null)
 			{
-				titlebar.ApplyVisibleState(ContentHiddenState);
+				titleBar.ApplyVisibleState(ContentHiddenState);
 			}
 			else
 			{
-				titlebar.ApplyVisibleState(ContentVisibleState);
+				titleBar.ApplyVisibleState(ContentVisibleState);
 				(newValue as Layout)?.IgnoreLayoutSafeArea();
 			}
 		}
 
 		static void OnTrailingContentChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			var titlebar = (TitleBar)bindable;
+			var titleBar = (TitleBar)bindable;
 			if (newValue is null)
 			{
-				titlebar.ApplyVisibleState(TrailingHiddenState);
+				titleBar.ApplyVisibleState(TrailingHiddenState);
 			}
 			else
 			{
-				titlebar.ApplyVisibleState(TrailingVisibleState);
+				titleBar.ApplyVisibleState(TrailingVisibleState);
 				(newValue as Layout)?.IgnoreLayoutSafeArea();
 			}
 		}
@@ -234,6 +281,20 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (Color)GetValue(ForegroundColorProperty); }
 			set { SetValue(ForegroundColorProperty, value); }
+		}
+
+		/// <summary>Gets or sets if the minimize button of the window is visible or not.</summary>
+		public bool CanMinimize
+		{
+			get { return (bool)GetValue(CanMinimizeProperty); }
+			set { SetValue(CanMinimizeProperty, value); }
+		}
+
+		/// <summary>Gets or sets if the maximize button of the window is visible or not.</summary>
+		public bool CanMaximize
+		{
+			get { return (bool)GetValue(CanMaximizeProperty); }
+			set { SetValue(CanMaximizeProperty, value); }
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### Description of Change

This PR allows to disable the minimization and maximization buttons of a window. Adding the same for disabling minimization should be mostly copy&paste. At this point, I'm mostly interested if the PR would be accepted and if the approach is OK or not.

The PR modifies public API so it targets NET 10.

### Current behavior

Run the `Maui.Controls.Sample` project. Navigate to `Platform Specifics` -> `TitleBar`:

![animation](https://github.com/user-attachments/assets/4bab502f-82e7-4235-833d-73731de3a8c6)

### Questions

Q1) Does the new code belong to `TitleBar` class? It means that unless the `TitleBar` is on ([see doc](https://learn.microsoft.com/en-gb/dotnet/maui/user-interface/controls/titlebar?view=net-maui-9.0)), this feature would not be available. An alternative would be to modify the `IWindow` interface.

### Issues Fixed

Contributes to #10297

### Resources

* https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.overlappedpresenter?view=windows-app-sdk-1.6
* https://learn.microsoft.com/en-us/dotnet/api/system.windows.window.resizemode?view=windowsdesktop-9.0

### Follow-up ideas

* Implement the same feature for Mac Catalyst
  * https://stackoverflow.com/questions/59749105/how-to-disabled-fullscreen-button-on-maccatalyst 
  * https://stackoverflow.com/questions/77525693/disable-close-button-and-miniaturize-window-in-maui-maccatalyst-application
