### PR TITLE
[Testing] Disable system animations to save test execution time

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/_IssuesUITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/_IssuesUITest.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Maui.TestCases.Tests
 				try
 				{
 					base.FixtureSetup();
+#if ANDROID || MACCATALYST
+					App.ToggleSystemAnimations(false);
+#endif
 					NavigateToIssue(Issue);
 					break;
 				}
@@ -36,6 +39,9 @@ namespace Microsoft.Maui.TestCases.Tests
 					if (retries++ < SetupMaxRetries)
 					{
 						App.Back();
+#if ANDROID || MACCATALYST
+						App.ToggleSystemAnimations(true);
+#endif
 						Reset();
 					}
 					else

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Maui.TestCases.Tests
 				}
 			}
 		}
-		
+
 #if MACUITEST
 		byte[] TakeScreenshot()
 		{
@@ -265,7 +265,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 			// The app might not be ready to take the screenshot.
 			// Wait a little bit to complete the system animation moving the App Window to FullScreen.
-			Thread.Sleep(1000);
+			Thread.Sleep(500);
 
 			byte[] screenshotPngBytes = App.Screenshot() ?? throw new InvalidOperationException("Failed to get screenshot");
 

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidSpecificActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidSpecificActions.cs
@@ -114,17 +114,17 @@ namespace UITest.Appium
 
 				if (enableSystemAnimations)
 				{
-					ShellHelper.ExecuteAdbCommand($"adb shell settings put global window_animation_scale 0");
-					ShellHelper.ExecuteAdbCommand($"adb shell settings put global transition_animation_scale 0");
-					ShellHelper.ExecuteAdbCommand($"adb shell settings put global animator_duration_scale 0");
+					ShellHelper.ExecuteShellCommand($"adb shell settings put global window_animation_scale 0");
+					ShellHelper.ExecuteShellCommand($"adb shell settings put global transition_animation_scale 0");
+					ShellHelper.ExecuteShellCommand($"adb shell settings put global animator_duration_scale 0");
 
 					return CommandResponse.SuccessEmptyResponse;
 				}
 				else
 				{
-					ShellHelper.ExecuteAdbCommand($"adb shell settings put global window_animation_scale 1");
-					ShellHelper.ExecuteAdbCommand($"adb shell settings put global transition_animation_scale 1");
-					ShellHelper.ExecuteAdbCommand($"adb shell settings put global animator_duration_scale 1");
+					ShellHelper.ExecuteShellCommand($"adb shell settings put global window_animation_scale 1");
+					ShellHelper.ExecuteShellCommand($"adb shell settings put global transition_animation_scale 1");
+					ShellHelper.ExecuteShellCommand($"adb shell settings put global animator_duration_scale 1");
 
 					return CommandResponse.SuccessEmptyResponse;
 				}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidThemeChangeAction.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumAndroidThemeChangeAction.cs
@@ -17,12 +17,12 @@ namespace UITest.Appium
 		{
 			if (commandName == SetLightTheme)
 			{
-				ShellHelper.ExecuteAdbCommand($"adb shell cmd uimode night no");
+				ShellHelper.ExecuteShellCommand($"adb shell cmd uimode night no");
 				return CommandResponse.SuccessEmptyResponse;
 			}
 			else if (commandName == SetDarkTheme)
 			{
-				ShellHelper.ExecuteAdbCommand($"adb shell cmd uimode night yes");
+				ShellHelper.ExecuteShellCommand($"adb shell cmd uimode night yes");
 				return CommandResponse.SuccessEmptyResponse;
 			}
 

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSpecificActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSpecificActions.cs
@@ -6,13 +6,15 @@ public class AppiumCatalystSpecificActions : ICommandExecutionGroup
 {
 	const string EnterFullScreenCommand = "enterFullScreen";
 	const string ExitFullScreenCommand = "exitFullScreen";
-	
+	const string ToggleSystemAnimationsCommand = "toggleSystemAnimations";
+
 	readonly AppiumApp _appiumApp;
 
 	readonly List<string> _commands = new()
 	{
 		EnterFullScreenCommand,
 		ExitFullScreenCommand,
+		ToggleSystemAnimationsCommand,
 	};
 
 	public AppiumCatalystSpecificActions(AppiumApp appiumApp)
@@ -31,6 +33,7 @@ public class AppiumCatalystSpecificActions : ICommandExecutionGroup
 		{
 			EnterFullScreenCommand => EnterFullScreen(parameters),
 			ExitFullScreenCommand => ExitFullScreen(parameters),
+			ToggleSystemAnimationsCommand => ToggleSystemAnimations(parameters),
 			_ => CommandResponse.FailedEmptyResponse,
 		};
 	}
@@ -60,6 +63,36 @@ public class AppiumCatalystSpecificActions : ICommandExecutionGroup
 			});
 
 			return CommandResponse.SuccessEmptyResponse;
+		}
+		catch
+		{
+			return CommandResponse.FailedEmptyResponse;
+		}
+	}
+
+	CommandResponse ToggleSystemAnimations(IDictionary<string, object> parameters)
+	{
+		try
+		{
+			bool enableSystemAnimations = (bool)parameters["enableSystemAnimations"];
+
+			if (enableSystemAnimations)
+			{
+				// Disable Window Animations.
+				ShellHelper.ExecuteShellCommand($"defaults write NSGlobalDomain NSAutomaticWindowAnimationsEnabled -bool false");
+
+				// Increase the speed of OSX dialogs boxes.
+				ShellHelper.ExecuteShellCommand($"defaults write NSGlobalDomain NSWindowResizeTime .1");
+
+				return CommandResponse.SuccessEmptyResponse;
+			}
+			else
+			{
+				ShellHelper.ExecuteShellCommand($"defaults write NSGlobalDomain NSAutomaticWindowAnimationsEnabled -bool true");
+				ShellHelper.ExecuteShellCommand($"defaults write NSGlobalDomain NSWindowResizeTime .5");
+
+				return CommandResponse.SuccessEmptyResponse;
+			}
 		}
 		catch
 		{

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1834,7 +1834,7 @@ namespace UITest.Appium
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
 		/// <param name="enableSystemAnimations">Enable/disable the system animations.</param>
-		/// <exception cref="InvalidOperationException">ToggleSystemAnimations is only supported on <see cref="AppiumAndroidApp"/> nad <see cref="AppiumCatalystApp"/>.</exception>
+		/// <exception cref="InvalidOperationException">ToggleSystemAnimations is only supported on <see cref="AppiumAndroidApp"/> and <see cref="AppiumCatalystApp"/>.</exception>
 		public static void ToggleSystemAnimations(this IApp app, bool enableSystemAnimations)
 		{
 			if (app is not AppiumAndroidApp && app is not AppiumCatalystApp)

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1830,16 +1830,16 @@ namespace UITest.Appium
 		/// <summary>
 		/// Switch the System animations state.
 		/// Optimize and accelerate tests, eliminating animations entirely when Appium is executing tests, as they serve no practical purpose in this context.
-		/// Functionality that's only available on Android.
+		/// Functionality that's only available on Android and Catalyst.
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
 		/// <param name="enableSystemAnimations">Enable/disable the system animations.</param>
-		/// <exception cref="InvalidOperationException">ToggleSystemAnimations is only supported on <see cref="AppiumAndroidApp"/>.</exception>
+		/// <exception cref="InvalidOperationException">ToggleSystemAnimations is only supported on <see cref="AppiumAndroidApp"/> nad <see cref="AppiumCatalystApp"/>.</exception>
 		public static void ToggleSystemAnimations(this IApp app, bool enableSystemAnimations)
 		{
-			if (app is not AppiumAndroidApp)
+			if (app is not AppiumAndroidApp && app is not AppiumCatalystApp)
 			{
-				throw new InvalidOperationException($"ToggleSystemAnimations is only supported on AppiumAndroidApp");
+				throw new InvalidOperationException($"ToggleSystemAnimations is not supported");
 			}
 
 			app.CommandExecutor.Execute("toggleSystemAnimations", new Dictionary<string, object>()

--- a/src/TestUtils/src/UITest.Appium/ShellHelper.cs
+++ b/src/TestUtils/src/UITest.Appium/ShellHelper.cs
@@ -4,7 +4,7 @@ namespace UITest.Appium
 {
 	public static class ShellHelper
 	{
-		public static void ExecuteAdbCommand(string command)
+		public static void ExecuteShellCommand(string command)
 		{
 			var shell = GetShell();
 			var shellArgument = GetShellArgument(shell, command);


### PR DESCRIPTION
### Description of Change

Disable system animations to save test execution time.

Appium operates as a robot devoid of features like animations that consume time. The time spent waiting for them to conclude becomes entirely futile. Also, animations can introduce instability to our testing process by creating race conditions, necessitating the use of waits or other workarounds.

This PR introduce changes to disable system animations on Android and Catalyst. In Catalyst, each test verifying snapshots puts the app in full screen which involves a time-consuming animation. The goal is to reduce execution time.