### PR TITLE
[Test] Compile test projects in release mode

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -4,7 +4,7 @@
 
 var ext = IsRunningOnWindows() ? ".exe" : "";
 var dotnetPath = $"./.dotnet/dotnet{ext}";
-string configuration = GetBuildVariable("configuration", GetBuildVariable("BUILD_CONFIGURATION", "DEBUG"));
+string configuration = GetBuildVariable("configuration", GetBuildVariable("BUILD_CONFIGURATION", "RELEASE"));
 var localDotnet = GetBuildVariable("workloads", "local") == "local";
 var vsVersion = GetBuildVariable("VS", "");
 string MSBuildExe = Argument("msbuild", EnvironmentVariable("MSBUILD_EXE", ""));

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -24,7 +24,7 @@ var DEVICETEST_APP = Argument("devicetestapp", EnvironmentVariable("WINDOWS_DEVI
 FilePath TEST_APP_PROJECT = Argument("appproject", EnvironmentVariable("WINDOWS_TEST_APP_PROJECT") ?? (!string.IsNullOrEmpty(DEFAULT_APP_PROJECT) ? DEFAULT_APP_PROJECT : PROJECT));
 FilePath DEVICETEST_APP_PROJECT = Argument("appproject", EnvironmentVariable("WINDOWS_DEVICETEST_APP_PROJECT") ?? PROJECT);
 var TEST_RESULTS = Argument("results", EnvironmentVariable("WINDOWS_TEST_RESULTS") ?? "");
-string CONFIGURATION = Argument("configuration", "Debug");
+string CONFIGURATION = Argument("configuration", "Release");
 
 var windowsVersion = Argument("apiversion", EnvironmentVariable("WINDOWS_PLATFORM_VERSION") ?? defaultVersion);
 

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -13,7 +13,7 @@ parameters:
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)
-  androidConfiguration: 'debug' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
+  androidConfiguration: 'release'
   useArtifacts: false
   targetFrameworkVersion:
     tfm: ''


### PR DESCRIPTION
### Description of Change

Compile test projects in release mode to speed up execution time.

_NOTE: I've reviewed history and perhaps I've missed some context to determine why now we compile test projects etc in Debug mode._