### PR TITLE
Fix for shell overflow item surroundings click

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23803.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23803.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue23803"
+    xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+    x:Name="shell"
+    Shell.FlyoutBehavior="Disabled">
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23803.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23803.xaml.cs
@@ -1,0 +1,51 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 23803, "FlyoutItem in overlow menu not fully interactable", PlatformAffected.UWP)]
+	public partial class Issue23803 : Shell
+	{
+		public Issue23803()
+		{
+			InitializeComponent();
+			CreateTabContent();
+		}
+		private void CreateTabContent()
+		{
+			// Create the TabBar
+			var tabBar = new TabBar
+			{
+				Title = "Header",
+				AutomationId = "TabBar"
+			};
+
+			// Loop to create ShellContent with different content for each tab
+			for (int i = 1; i <= 20; i++)
+			{
+				// Create a new ContentPage dynamically
+				var contentPage = new ContentPage
+				{
+					Content = new Button
+					{
+						Text = $"Button_{i}",
+						AutomationId = $"Button{i}",
+						FontSize = 24,
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center
+					}
+				};
+
+				// Create a new ShellContent and set the dynamically created ContentPage as content
+				var shellContent = new ShellContent
+				{
+					Title = $"Tab{i}",
+					Content = contentPage // Set the dynamic ContentPage as content
+				};
+
+				// Add the ShellContent to the TabBar
+				tabBar.Items.Add(shellContent);
+			}
+
+			// Add the TabBar to the Shell
+			this.Items.Add(tabBar);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23803.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23803.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue23803 : _IssuesUITest
+	{
+		public override string Issue => "FlyoutItem in overlow menu not fully interactable";
+
+		public Issue23803(TestDevice device)
+		: base(device)
+		{ }
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void ClickAroundOverflowMenuItems()
+		{
+			App.Tap("More");
+			App.WaitForElement("Tab18");
+			var rect = App.WaitForElement("Tab18").GetRect();
+			App.TapCoordinates(rect.X + 80, rect.Y + 15);
+			App.WaitForElement("Button18");
+			App.Tap("Button18");
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WIconElement = Microsoft.UI.Xaml.Controls.IconElement;
 
@@ -110,7 +111,7 @@ namespace Microsoft.Maui.Platform
 
 		public WBrush? Background
 		{
-			get => IsSelected ? SelectedBackground : UnselectedBackground;
+			get => (IsSelected ? SelectedBackground : UnselectedBackground) ?? new SolidColorBrush(Microsoft.UI.Colors.Transparent);
 		}
 
 		public object? Data


### PR DESCRIPTION
### **Root cause:** 

- The issue arises because the NavigationViewItemViewModel does not set a valid background color for the overflow menu items. Instead, it assigns a null value to the background, which causes the space around the items to be unclickable and prevents the hover shadow effect from appearing. This results in a poor user experience when interacting with the overflow menu.

### **Description of change:**

- I updated the Background of the NavigationViewItemViewModel to ensure it always defaults to Transparent when no specific background value (either SelectedBackground or UnselectedBackground) is set. This prevents the Background from being null, which could cause hit-testing and rendering issues in the overflow menu.

**Tested the behavior in the following platforms.**

- [x] Windows

### **Issues Fixed**
Fixes

### **Output**

### **Before**

https://github.com/user-attachments/assets/506e851e-df33-4579-8a7e-e09bbff4954a


### **After**

https://github.com/user-attachments/assets/fa9b9bc1-3107-441e-a1ac-281ea0a3ed76

