### PR TITLE
[net10.0] fix NativeAOT support for iOS/Catalyst

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -236,6 +236,8 @@
       <MauiImplicitCastOperatorsUsageViaReflectionSupport Condition="'$(MauiImplicitCastOperatorsUsageViaReflectionSupport)' == ''">false</MauiImplicitCastOperatorsUsageViaReflectionSupport>
       <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
       <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
+      <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
+      <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AOTTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AOTTemplateTest.cs
@@ -26,9 +26,8 @@ public class AOTTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.Build(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier, binlogPath: binLogFilePath),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
-		// FIXME: NativeAOT not working yet on .NET 10
-		//var actualWarnings = BuildWarningsUtilities.ReadNativeAOTWarningsFromBinLog(binLogFilePath);
-		//actualWarnings.AssertNoWarnings();
+		var actualWarnings = BuildWarningsUtilities.ReadNativeAOTWarningsFromBinLog(binLogFilePath);
+		actualWarnings.AssertNoWarnings();
 	}
 
 	[Test]
@@ -76,9 +75,8 @@ public class AOTTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.Build(projectFile, "Release", framework: framework, properties: extendedBuildProps, runtimeIdentifier: runtimeIdentifier, binlogPath: binLogFilePath),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
-		// FIXME: NativeAOT not working yet on .NET 10
-		//var actualWarnings = BuildWarningsUtilities.ReadNativeAOTWarningsFromBinLog(binLogFilePath);
-		//actualWarnings.AssertWarnings(BuildWarningsUtilities.ExpectedNativeAOTWarnings);
+		var actualWarnings = BuildWarningsUtilities.ReadNativeAOTWarningsFromBinLog(binLogFilePath);
+		actualWarnings.AssertWarnings(BuildWarningsUtilities.ExpectedNativeAOTWarnings);
 	}
 
 	private List<string> PrepareNativeAotBuildProps()

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Maui.IntegrationTests
 		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, null)]
 		// FIXME: has trimmer warnings
 		//[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, "full")]
-		// FIXME: NativeAOT not working yet on .NET 10
-		//[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.NativeAOT, null)]
+		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.NativeAOT, null)]
 		public void RunOniOS(string id, string config, string framework, string runtimeIdentifier, RuntimeVariant runtimeVariant, string trimMode)
 		{
 			var projectDir = TestDirectory;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/issues/22065

The introduction of a new `$(MobileAggressiveAttributeTrimming)` MSBuild property in .NET 10 breaks NativeAOT builds in two ways:

* C# attributes are stripped away by ILLink, hence:

* Trimmer warnings are introduced.

* App crashes can result, with IL removed that *shouldn't* be.

Let's set `$(MobileAggressiveAttributeTrimming)` to `false` for now to avoid these issues.

In a future PR, we can address xamarin/xamarin-macios#22065 in the iOS workload.