### PR TITLE
[net10.0] [Binding SG] Removed deprecated `InterceptsLocationAttribute`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,12 +27,6 @@
     <!-- Microsoft.Build.Msix.props" cannot be imported again -->
     <!-- Found version-specific or distribution-specific runtime identifier(s)-->
     <NoWarn>$(NoWarn);MSB4011;NETSDK1206</NoWarn>
-    <!--
-      Temporarily disable warning about Roslyn interceptors
-      * https://github.com/dotnet/roslyn/pull/76312
-      * https://github.com/dotnet/roslyn/issues/72133
-    -->
-    <NoWarn>$(NoWarn);CS9270</NoWarn>
   </PropertyGroup>
 
   <!-- FIXME: various test projects have trimmer warnings, which are enabled by default on iOS/Catalyst -->

--- a/src/Controls/src/BindingSourceGen/BindingCodeWriter.cs
+++ b/src/Controls/src/BindingSourceGen/BindingCodeWriter.cs
@@ -92,19 +92,15 @@ public static class BindingCodeWriter
 			using System.CodeDom.Compiler;
 		
 			{{GeneratedCodeAttribute}}
+			[global::System.Diagnostics.Conditional("DEBUG")]
 			[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 			file sealed class InterceptsLocationAttribute : Attribute
 			{
-				public InterceptsLocationAttribute(string filePath, int line, int column)
+				public InterceptsLocationAttribute(int version, string data)
 				{
-					FilePath = filePath;
-					Line = line;
-					Column = column;
+					_ = version;
+					_ = data;
 				}
-		
-				public string FilePath { get; }
-				public int Line { get; }
-				public int Column { get; }
 			}
 		}
 
@@ -177,7 +173,7 @@ public static class BindingCodeWriter
 		public void AppendSetBindingInterceptor(uint id, BindingInvocationDescription binding)
 		{
 			AppendLine(GeneratedCodeAttribute);
-			AppendInterceptorAttribute(binding.Location);
+			AppendInterceptorAttribute(binding.InterceptableLocation);
 			AppendMethodName(binding, id);
 			if (binding.SourceType.IsGenericParameter && binding.PropertyType.IsGenericParameter)
 			{
@@ -310,9 +306,9 @@ public static class BindingCodeWriter
 			});
 		}
 
-		private void AppendInterceptorAttribute(InterceptorLocation location)
+		private void AppendInterceptorAttribute(InterceptableLocationRecord location)
 		{
-			AppendLine($"[InterceptsLocationAttribute(@\"{location.FilePath}\", {location.Line}, {location.Column})]");
+			AppendLine($"[InterceptsLocationAttribute({location.Version}, @\"{location.Data}\")]");
 		}
 
 		private void AppendSetterAction(BindingInvocationDescription binding, uint id, string sourceVariableName = "source", string valueVariableName = "value")

--- a/src/Controls/src/BindingSourceGen/BindingInvocationDescription.cs
+++ b/src/Controls/src/BindingSourceGen/BindingInvocationDescription.cs
@@ -4,13 +4,17 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.Maui.Controls.BindingSourceGen;
 
 public sealed record BindingInvocationDescription(
-	InterceptorLocation Location,
+	InterceptableLocationRecord InterceptableLocation,
+	SimpleLocation SimpleLocation,
 	TypeDescription SourceType,
 	TypeDescription PropertyType,
 	EquatableArray<IPathPart> Path,
 	SetterOptions SetterOptions,
 	bool NullableContextEnabled,
 	InterceptedMethodType MethodType);
+
+
+public sealed record InterceptableLocationRecord(int Version, string Data);
 
 public sealed record SourceCodeLocation(string FilePath, TextSpan TextSpan, LinePositionSpan LineSpan)
 {
@@ -24,13 +28,13 @@ public sealed record SourceCodeLocation(string FilePath, TextSpan TextSpan, Line
 		return Location.Create(FilePath, TextSpan, LineSpan);
 	}
 
-	public InterceptorLocation ToInterceptorLocation()
+	public SimpleLocation ToSimpleLocation()
 	{
-		return new InterceptorLocation(FilePath, LineSpan.Start.Line + 1, LineSpan.Start.Character + 1);
+		return new SimpleLocation(FilePath, LineSpan.Start.Line + 1, LineSpan.Start.Character + 1);
 	}
 }
 
-public sealed record InterceptorLocation(string FilePath, int Line, int Column);
+public sealed record SimpleLocation(string FilePath, int Line, int Column);
 
 public sealed record TypeDescription(
 	string GlobalName,

--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -84,7 +84,10 @@ public class BindingSourceGenerator : IIncrementalGenerator
 			return Result<BindingInvocationDescription>.Failure(interceptedMethodTypeResult.Diagnostics);
 		}
 
+#pragma warning disable RSEXPERIMENTAL002
 		var interceptableLocation = context.SemanticModel.GetInterceptableLocation(invocation, t);
+#pragma warning restore RSEXPERIMENTAL002
+
 		var sourceCodeLocation = SourceCodeLocation.CreateFrom(method.Name.GetLocation());
 
 

--- a/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
+++ b/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Controls/tests/BindingSourceGen.UnitTests/AssertExtensions.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/AssertExtensions.cs
@@ -25,9 +25,15 @@ internal static class AssertExtensions
 		AssertNoDiagnostics(codeGeneratorResult);
 		Assert.NotNull(codeGeneratorResult.Binding);
 
-		//TODO: Change arrays to custom collections implementing IEquatable
+		// Skip interceptable location
+		Assert.Equal(expectedBinding.SimpleLocation, codeGeneratorResult.Binding.SimpleLocation);
+		Assert.Equal(expectedBinding.SourceType, codeGeneratorResult.Binding.SourceType);
+		Assert.Equal(expectedBinding.PropertyType, codeGeneratorResult.Binding.PropertyType);
 		Assert.Equal(expectedBinding.Path, codeGeneratorResult.Binding.Path);
-		Assert.Equal(expectedBinding, codeGeneratorResult.Binding);
+		Assert.Equal(expectedBinding.SetterOptions, codeGeneratorResult.Binding.SetterOptions);
+		Assert.Equal(expectedBinding.NullableContextEnabled, codeGeneratorResult.Binding.NullableContextEnabled);
+		Assert.Equal(expectedBinding.MethodType, codeGeneratorResult.Binding.MethodType);
+
 	}
 
 	private static IEnumerable<string> SplitCode(string code)

--- a/src/Controls/tests/BindingSourceGen.UnitTests/BindingCodeWriterTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/BindingCodeWriterTests.cs
@@ -50,7 +50,8 @@ public class BindingCodeWriterTests
 	public void BuildsWholeBinding()
 	{
 		var code = BindingCodeWriter.GenerateBinding(new BindingInvocationDescription(
-			Location: new InterceptorLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
+			InterceptableLocation: new InterceptableLocationRecord(Version: 1, Data: "serializedData"),
+			SimpleLocation: new SimpleLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
 			SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
 			PropertyType: new TypeDescription("global::MyNamespace.MyPropertyClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
 			Path: new EquatableArray<IPathPart>([
@@ -80,19 +81,15 @@ public class BindingCodeWriterTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -107,7 +104,7 @@ public class BindingCodeWriterTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 20, 30)]
+                    [InterceptsLocationAttribute(1, @"serializedData")]
                     public static void SetBinding1(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -164,8 +161,8 @@ public class BindingCodeWriterTests
 	{
 		var codeBuilder = new BindingCodeWriter.BindingInterceptorCodeBuilder();
 		codeBuilder.AppendSetBindingInterceptor(id: 1, new BindingInvocationDescription(
-			Location: new InterceptorLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
-			SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
+			InterceptableLocation: new InterceptableLocationRecord(Version: 1, Data: "serializedData"),
+			SimpleLocation: new SimpleLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30), SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
 			PropertyType: new TypeDescription("global::MyNamespace.MyPropertyClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
 			Path: new EquatableArray<IPathPart>([
 				new MemberAccess("A"),
@@ -180,7 +177,7 @@ public class BindingCodeWriterTests
 		AssertExtensions.CodeIsEqual(
 			$$"""
             {{BindingCodeWriter.GeneratedCodeAttribute}}
-            [InterceptsLocationAttribute(@"Path\To\Program.cs", 20, 30)]
+            [InterceptsLocationAttribute(1, @"serializedData")]
             public static void SetBinding1(
                 this BindableObject bindableObject,
                 BindableProperty bindableProperty,
@@ -236,8 +233,8 @@ public class BindingCodeWriterTests
 	{
 		var codeBuilder = new BindingCodeWriter.BindingInterceptorCodeBuilder();
 		codeBuilder.AppendSetBindingInterceptor(id: 1, new BindingInvocationDescription(
-			Location: new InterceptorLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
-			SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
+			InterceptableLocation: new InterceptableLocationRecord(Version: 1, Data: "serializedData"),
+			SimpleLocation: new SimpleLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30), SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
 			PropertyType: new TypeDescription("global::MyNamespace.MyPropertyClass", IsValueType: false, IsNullable: false, IsGenericParameter: false),
 			Path: new EquatableArray<IPathPart>([
 				new MemberAccess("A"),
@@ -252,7 +249,7 @@ public class BindingCodeWriterTests
 		AssertExtensions.CodeIsEqual(
 			$$"""
             {{BindingCodeWriter.GeneratedCodeAttribute}}
-            [InterceptsLocationAttribute(@"Path\To\Program.cs", 20, 30)]
+            [InterceptsLocationAttribute(1, @"serializedData")]
             public static void SetBinding1(
                 this BindableObject bindableObject,
                 BindableProperty bindableProperty,
@@ -304,8 +301,8 @@ public class BindingCodeWriterTests
 	{
 		var codeBuilder = new BindingCodeWriter.BindingInterceptorCodeBuilder();
 		codeBuilder.AppendSetBindingInterceptor(id: 1, new BindingInvocationDescription(
-			Location: new InterceptorLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
-			SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsNullable: false, IsGenericParameter: false, IsValueType: false),
+			InterceptableLocation: new InterceptableLocationRecord(Version: 1, Data: "serializedData"),
+			SimpleLocation: new SimpleLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30), SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsNullable: false, IsGenericParameter: false, IsValueType: false),
 			PropertyType: new TypeDescription("global::MyNamespace.MyPropertyClass", IsNullable: false, IsGenericParameter: false, IsValueType: false),
 			Path: new EquatableArray<IPathPart>([
 				new MemberAccess("A"),
@@ -320,7 +317,7 @@ public class BindingCodeWriterTests
 		AssertExtensions.CodeIsEqual(
 			$$"""
             {{BindingCodeWriter.GeneratedCodeAttribute}}
-            [InterceptsLocationAttribute(@"Path\To\Program.cs", 20, 30)]
+            [InterceptsLocationAttribute(1, @"serializedData")]
             public static void SetBinding1(
                 this BindableObject bindableObject,
                 BindableProperty bindableProperty,
@@ -369,8 +366,8 @@ public class BindingCodeWriterTests
 	{
 		var codeBuilder = new BindingCodeWriter.BindingInterceptorCodeBuilder();
 		codeBuilder.AppendSetBindingInterceptor(id: 1, new BindingInvocationDescription(
-			Location: new InterceptorLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
-			SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsNullable: false, IsGenericParameter: false),
+			InterceptableLocation: new InterceptableLocationRecord(Version: 1, Data: "serializedData"),
+			SimpleLocation: new SimpleLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30), SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsNullable: false, IsGenericParameter: false),
 			PropertyType: new TypeDescription("global::MyNamespace.MyPropertyClass", IsNullable: true, IsGenericParameter: false),
 			Path: new EquatableArray<IPathPart>([
 				new IndexAccess("Item", 12),
@@ -385,7 +382,7 @@ public class BindingCodeWriterTests
 		AssertExtensions.CodeIsEqual(
 			$$"""
             {{BindingCodeWriter.GeneratedCodeAttribute}}
-            [InterceptsLocationAttribute(@"Path\To\Program.cs", 20, 30)]
+            [InterceptsLocationAttribute(1, @"serializedData")]
             public static void SetBinding1(
                 this BindableObject bindableObject,
                 BindableProperty bindableProperty,
@@ -448,8 +445,8 @@ public class BindingCodeWriterTests
 	{
 		var codeBuilder = new BindingCodeWriter.BindingInterceptorCodeBuilder();
 		codeBuilder.AppendSetBindingInterceptor(id: 1, new BindingInvocationDescription(
-			Location: new InterceptorLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30),
-			SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsNullable: false, IsGenericParameter: false),
+			InterceptableLocation: new InterceptableLocationRecord(Version: 1, Data: "serializedData"),
+			SimpleLocation: new SimpleLocation(FilePath: @"Path\To\Program.cs", Line: 20, Column: 30), SourceType: new TypeDescription("global::MyNamespace.MySourceClass", IsNullable: false, IsGenericParameter: false),
 			PropertyType: new TypeDescription("global::MyNamespace.MyPropertyClass", IsNullable: false, IsGenericParameter: false),
 			Path: new EquatableArray<IPathPart>([
 				new MemberAccess("A"),
@@ -469,7 +466,7 @@ public class BindingCodeWriterTests
 		AssertExtensions.CodeIsEqual(
 			$$"""
             {{BindingCodeWriter.GeneratedCodeAttribute}}
-            [InterceptsLocationAttribute(@"Path\To\Program.cs", 20, 30)]
+            [InterceptsLocationAttribute(1, @"serializedData")]
             public static void SetBinding1(
                 this BindableObject bindableObject,
                 BindableProperty bindableProperty,

--- a/src/Controls/tests/BindingSourceGen.UnitTests/BindingRepresentationGenTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/BindingRepresentationGenTests.cs
@@ -18,7 +18,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("string"),
 				new TypeDescription("int", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -42,7 +43,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Microsoft.Maui.Controls.Button"),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -72,7 +74,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -99,7 +102,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Microsoft.Maui.Controls.Button", IsNullable: true),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -129,7 +133,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -153,7 +158,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Microsoft.Maui.Controls.Button", IsNullable: true),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -183,7 +189,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("string", IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -213,7 +220,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 4, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 4, 7),
 				new TypeDescription("global::Foo", IsNullable: true),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -249,7 +257,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 4, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 4, 7),
 				new TypeDescription("global::Foo", IsNullable: true),
 				new TypeDescription("int", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -285,7 +294,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 4, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 4, 7),
 				new TypeDescription("global::Foo", IsNullable: true),
 				new TypeDescription("int", IsNullable: true, IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -326,7 +336,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 4, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 4, 7),
 				new TypeDescription("global::Foo", IsNullable: true),
 				new TypeDescription("global::CustomLength", IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -356,7 +367,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -387,7 +399,8 @@ public class BindingRepresentationGenTests
         """;
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 4, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 4, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -421,7 +434,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 6, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 6, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("int", IsValueType: true),
 			new EquatableArray<IPathPart>([
@@ -451,7 +465,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -486,7 +501,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("int", IsValueType: true, IsNullable: true),
 			new EquatableArray<IPathPart>([
@@ -535,7 +551,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 6, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 6, 7),
 			new TypeDescription("global::MyNamespace.MySourceClass"),
 			new TypeDescription("global::MyNamespace.MyPropertyClass", IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -569,7 +586,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 6, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 6, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("char", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -600,7 +618,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 4, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 4, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("int", IsValueType: true),
 			new EquatableArray<IPathPart>([
@@ -630,7 +649,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("string", IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -660,7 +680,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("string"),
 				new EquatableArray<IPathPart>([
@@ -695,7 +716,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true, IsNullable: true),
 				new EquatableArray<IPathPart>([
@@ -731,7 +753,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -770,7 +793,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsNullable: true, IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -803,7 +827,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsNullable: true, IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -834,7 +859,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -872,7 +898,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-				new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+				new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 				new TypeDescription("global::Foo"),
 				new TypeDescription("int", IsNullable: true, IsValueType: true),
 				new EquatableArray<IPathPart>([
@@ -903,7 +930,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("char", IsValueType: true),
 			new EquatableArray<IPathPart>([
@@ -933,7 +961,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("char", IsValueType: true),
 			new EquatableArray<IPathPart>([
@@ -963,7 +992,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("string"),
 			new EquatableArray<IPathPart>([
@@ -992,7 +1022,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("string"),
 			new EquatableArray<IPathPart>([
@@ -1021,7 +1052,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			new TypeDescription("global::Foo", IsNullable: true),
 			new TypeDescription("int", IsValueType: true, IsNullable: true),
 			new EquatableArray<IPathPart>([
@@ -1056,7 +1088,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 12, 15),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 12, 15),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("int", IsValueType: true),
 			new EquatableArray<IPathPart>([
@@ -1097,7 +1130,8 @@ public class BindingRepresentationGenTests
 
 		var codeGeneratorResult = SourceGenHelpers.Run(source);
 		var expectedBinding = new BindingInvocationDescription(
-			new InterceptorLocation(@"Path\To\Program.cs", 12, 15),
+				new InterceptableLocationRecord(1, "serializedData"),
+			new SimpleLocation(@"Path\To\Program.cs", 12, 15),
 			new TypeDescription("global::Foo"),
 			new TypeDescription("int", IsValueType: true),
 			new EquatableArray<IPathPart>([

--- a/src/Controls/tests/BindingSourceGen.UnitTests/BindingTransformerTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/BindingTransformerTests.cs
@@ -9,7 +9,8 @@ public class BindingTransformerTests
 	public void WrapMemberAccessInConditionalAccessWhenSourceTypeIsReferenceType()
 	{
 		var binding = new BindingInvocationDescription(
-			Location: new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+			InterceptableLocation: new InterceptableLocationRecord(1, "serializedData"),
+			SimpleLocation: new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			SourceType: new TypeDescription("MyType", IsValueType: false),
 			PropertyType: new TypeDescription("MyType2"),
 			Path: new EquatableArray<IPathPart>([new MemberAccess("A")]),
@@ -28,7 +29,8 @@ public class BindingTransformerTests
 	public void WrapMemberAccessInConditionalAccessWhePreviousPartTypeIsReferenceType()
 	{
 		var binding = new BindingInvocationDescription(
-			Location: new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+			InterceptableLocation: new InterceptableLocationRecord(1, "serializedData"),
+			SimpleLocation: new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			SourceType: new TypeDescription("MyType", IsValueType: true),
 			PropertyType: new TypeDescription("MyType2"),
 			Path: new EquatableArray<IPathPart>(
@@ -55,7 +57,8 @@ public class BindingTransformerTests
 	public void DoNotWrapMemberAccessInConditionalAccessWhePreviousPartTypeIsValueType()
 	{
 		var binding = new BindingInvocationDescription(
-			Location: new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+			InterceptableLocation: new InterceptableLocationRecord(1, "serializedData"),
+			SimpleLocation: new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			SourceType: new TypeDescription("MyType", IsValueType: false),
 			PropertyType: new TypeDescription("MyType2"),
 			Path: new EquatableArray<IPathPart>(
@@ -82,7 +85,8 @@ public class BindingTransformerTests
 	public void WrapAccessInConditionalAccessWhenAllPartsAreReferenceTypes()
 	{
 		var binding = new BindingInvocationDescription(
-			Location: new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+			InterceptableLocation: new InterceptableLocationRecord(1, "serializedData"),
+			SimpleLocation: new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			SourceType: new TypeDescription("MyType"),
 			PropertyType: new TypeDescription("MyType2"),
 			Path: new EquatableArray<IPathPart>(
@@ -111,7 +115,8 @@ public class BindingTransformerTests
 	public void DoNotWrapAccessInConditionalAccessWhenNoPartsAreReferenceTypes()
 	{
 		var binding = new BindingInvocationDescription(
-			Location: new InterceptorLocation(@"Path\To\Program.cs", 3, 7),
+			InterceptableLocation: new InterceptableLocationRecord(1, "serializedData"),
+			SimpleLocation: new SimpleLocation(@"Path\To\Program.cs", 3, 7),
 			SourceType: new TypeDescription("MyType", IsValueType: true),
 			PropertyType: new TypeDescription("MyType2"),
 			Path: new EquatableArray<IPathPart>(

--- a/src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IncrementalGenerationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IncrementalGenerationTests.cs
@@ -103,31 +103,6 @@ public class IncrementalGenerationTests
 	}
 
 	[Fact]
-	public void DoesNotRegenerateCodeWhenNewCodeInsertedBelow()
-	{
-		var source = """
-        using Microsoft.Maui.Controls;
-        var label = new Label();
-        label.SetBinding(Label.RotationProperty, static (string s) => s.Length);
-        """;
-
-		var newSource = """
-        using Microsoft.Maui.Controls;
-        var label = new Label();
-        label.SetBinding(Label.RotationProperty, static (string s) => s.Length);
-
-        var x = 42;
-        """;
-
-		var results = RunGeneratorOnMultipleSourcesAndReturnSteps(
-			new Dictionary<string, string> { { nameof(source), source } },
-			new Dictionary<string, string> { { nameof(source), newSource } });
-
-		var outputs = results[nameof(source)].SelectMany(step => step.Outputs);
-		Assert.All(outputs, output => Assert.True(output.Reason == IncrementalStepRunReason.Unchanged || output.Reason == IncrementalStepRunReason.Cached));
-	}
-
-	[Fact]
 	public void DoesNotRegerateCodeWhenDifferentFileEdited()
 	{
 		var fileASource = """
@@ -197,7 +172,7 @@ public class IncrementalGenerationTests
 		// Sometimes the binding has more than one run of the same step associated with it. 
 		// In such cases keep the one with Modified reason for safety.
 		return bindingRunPairs
-		.GroupBy(bindingRunPair => bindingRunPair.binding.Location.FilePath)
+		.GroupBy(bindingRunPair => bindingRunPair.binding.SimpleLocation.FilePath)
 		.ToDictionary(
 			x => x.Key,
 			x => x

--- a/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/IntegrationTests.cs
@@ -16,7 +16,7 @@ public class IntegrationTests
 		var result = SourceGenHelpers.Run(source);
 		Assert.NotNull(result.Binding);
 
-		var id = Math.Abs(result.Binding.Location.GetHashCode());
+		var id = Math.Abs(result.Binding.SimpleLocation.GetHashCode());
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -37,19 +37,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -64,7 +60,7 @@ public class IntegrationTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 3, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -119,7 +115,8 @@ public class IntegrationTests
 		AssertExtensions.AssertNoDiagnostics(result);
 		Assert.NotNull(result.Binding);
 
-		var id = Math.Abs(result.Binding.Location.GetHashCode());
+		var id = Math.Abs(result.Binding.SimpleLocation.GetHashCode());
+
 		AssertExtensions.CodeIsEqual(
 			$$"""
             //------------------------------------------------------------------------------
@@ -138,19 +135,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -165,7 +158,7 @@ public class IntegrationTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 2, 27)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static BindingBase Create{{id}}(
                         Func<string, int> getter,
                         BindingMode mode = BindingMode.Default,
@@ -293,7 +286,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -313,19 +306,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -340,7 +329,7 @@ public class IntegrationTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 6, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -418,7 +407,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -438,19 +427,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -465,7 +450,7 @@ public class IntegrationTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 7, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -649,7 +634,7 @@ public class IntegrationTests
 	public void GenerateSimpleBindingWhenNullableDisabledAndPropertyNullable(string source)
 	{
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -669,19 +654,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -696,7 +677,7 @@ public class IntegrationTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 7, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -788,7 +769,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -808,19 +789,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -835,7 +812,7 @@ public class IntegrationTests
                 {
             
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 7, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -927,7 +904,7 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -948,19 +925,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -975,7 +948,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 4, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1072,7 +1045,7 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1093,19 +1066,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1120,7 +1089,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 4, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1204,7 +1173,7 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1225,19 +1194,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1251,7 +1216,7 @@ public class IntegrationTests
                 internal static partial class GeneratedBindingInterceptors
                 {
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 3, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1332,7 +1297,7 @@ public class IntegrationTests
             """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
@@ -1353,19 +1318,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1380,7 +1341,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 6, 7)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1467,7 +1428,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1487,19 +1448,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1514,7 +1471,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 17, 23)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1592,7 +1549,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1612,19 +1569,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1639,7 +1592,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 17, 23)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1720,7 +1673,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1740,19 +1693,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1767,7 +1716,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 17, 23)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,
@@ -1847,7 +1796,7 @@ public class IntegrationTests
         """;
 
 		var result = SourceGenHelpers.Run(source);
-		var id = Math.Abs(result.Binding!.Location.GetHashCode());
+		var id = Math.Abs(result.Binding!.SimpleLocation.GetHashCode());
 		AssertExtensions.AssertNoDiagnostics(result);
 		AssertExtensions.CodeIsEqual(
 			$$"""
@@ -1867,19 +1816,15 @@ public class IntegrationTests
                 using System.CodeDom.Compiler;
 
                 {{BindingCodeWriter.GeneratedCodeAttribute}}
+                [global::System.Diagnostics.Conditional("DEBUG")]
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
                 file sealed class InterceptsLocationAttribute : Attribute
                 {
-                    public InterceptsLocationAttribute(string filePath, int line, int column)
+                    public InterceptsLocationAttribute(int version, string data)
                     {
-                        FilePath = filePath;
-                        Line = line;
-                        Column = column;
+                        _ = version;
+                        _ = data;
                     }
-
-                    public string FilePath { get; }
-                    public int Line { get; }
-                    public int Column { get; }
                 }
             }
 
@@ -1894,7 +1839,7 @@ public class IntegrationTests
                 {
 
                     {{BindingCodeWriter.GeneratedCodeAttribute}}
-                    [InterceptsLocationAttribute(@"Path\To\Program.cs", 17, 23)]
+                    [InterceptsLocationAttribute({{result.Binding.InterceptableLocation.Version}}, @"{{result.Binding.InterceptableLocation.Data}}")]
                     public static void SetBinding{{id}}(
                         this BindableObject bindableObject,
                         BindableProperty bindableProperty,

--- a/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/SourceGenHelpers.cs
@@ -17,7 +17,7 @@ internal record CodeGeneratorResult(
 internal static class SourceGenHelpers
 {
 	private static readonly CSharpParseOptions ParseOptions = new CSharpParseOptions(LanguageVersion.Preview).WithFeatures(
-				[new KeyValuePair<string, string>("InterceptorsPreviewNamespaces", "Microsoft.Maui.Controls.Generated")]);
+				[new KeyValuePair<string, string>("InterceptorsNamespaces", "Microsoft.Maui.Controls.Generated")]);
 
 	internal static List<string> StepsForComparison = [TrackingNames.Bindings, TrackingNames.BindingsWithDiagnostics];
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/27315

Backport of #27145 for .NET 10.

* [Binding SG] Updated InterceptsLocationAttribute

* Added System.Diagnostics.Conditional attribute