### PR TITLE
[Testing] Implement Appium swipe action on Catalyst using the Mac Driver

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue9306.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue9306.cs
@@ -1,4 +1,4 @@
-﻿#if IOS
+﻿#if IOS || MACCATALYST
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSwipeActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSwipeActions.cs
@@ -11,27 +11,25 @@ namespace UITest.Appium
 			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
 			var size = element is not null ? element.Size : driver.Manage().Window.Size;
 
-			int y = (int)(position.X + (size.Width * swipePercentage));
-			int x = position.Y + size.Height / 2;
+			int startX = (int)(position.X + (size.Width * 0.05));
+			int startY = position.Y + size.Height / 2;
+
+			int endX = (int)(position.X + (size.Width * swipePercentage));
+			int endY = startY;
 
 			var parameters = new Dictionary<string, object>
 			{
-				{ "x" , x },
-				{ "y" , y },
-				{ "direction" , "right" },
-				{ "velocity" , swipeSpeed },
-
+				{ "startX" , startX },
+				{ "startY" , startY },
+				{ "endX" , endX },
+				{ "endY" , endY },
+				{ "duration" , swipeSpeed },
 			};
 
 			if (element is not null)
-			{
-				// The internal element identifier to swipe on.
-				// If both are set then x and y are considered as relative element coordinates.
-				// If only x and y are set then these are parsed as absolute coordinates.
-				parameters.Add("elementId", element.Id);
-			}
-
-			driver.ExecuteScript("mobile: swipe", parameters);
+				parameters.Add("sourceElementId", element.Id);
+			
+			driver.ExecuteScript("macos: clickAndDrag", parameters);
 		}
 
 		protected override void SwipeToLeft(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
@@ -39,27 +37,25 @@ namespace UITest.Appium
 			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
 			var size = element is not null ? element.Size : driver.Manage().Window.Size;
 
-			int x = (int)(position.X + (size.Width * 0.05));
-			int y = position.Y + size.Height / 2;
+			int startX = (int)(position.X + (size.Width * swipePercentage));
+			int startY = position.Y + size.Height / 2;
+
+			int endX = (int)(position.X + (size.Width * 0.05));
+			int endY = startY;
 
 			var parameters = new Dictionary<string, object>
 			{
-				{ "x" , x },
-				{ "y" , y },
-				{ "direction" , "left" },
-				{ "velocity" , swipeSpeed },
-
+				{ "startX" , startX },
+				{ "startY" , startY },
+				{ "endX" , endX },
+				{ "endY" , endY },
+				{ "duration" , swipeSpeed },
 			};
 
 			if (element is not null)
-			{
-				// The internal element identifier to swipe on.
-				// If both are set then x and y are considered as relative element coordinates.
-				// If only x and y are set then these are parsed as absolute coordinates.
-				parameters.Add("elementId", element.Id);
-			}
-
-			driver.ExecuteScript("mobile: swipe", parameters);
+				parameters.Add("sourceElementId", element.Id);
+			
+			driver.ExecuteScript("macos: pressAndDrag", parameters);
 		}
 	}
 }

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSwipeActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSwipeActions.cs
@@ -23,12 +23,9 @@ namespace UITest.Appium
 				{ "startY" , startY },
 				{ "endX" , endX },
 				{ "endY" , endY },
-				{ "duration" , swipeSpeed },
+				{ "duration" , 0.5 },
 			};
 
-			if (element is not null)
-				parameters.Add("sourceElementId", element.Id);
-			
 			driver.ExecuteScript("macos: clickAndDrag", parameters);
 		}
 
@@ -49,11 +46,8 @@ namespace UITest.Appium
 				{ "startY" , startY },
 				{ "endX" , endX },
 				{ "endY" , endY },
-				{ "duration" , swipeSpeed },
+				{ "duration" , 0.5 },
 			};
-
-			if (element is not null)
-				parameters.Add("sourceElementId", element.Id);
 			
 			driver.ExecuteScript("macos: pressAndDrag", parameters);
 		}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSwipeActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumCatalystSwipeActions.cs
@@ -1,0 +1,65 @@
+﻿using OpenQA.Selenium.Appium;
+
+namespace UITest.Appium
+{
+	public class AppiumCatalystSwipeActions : AppiumSwipeActions
+	{
+		public AppiumCatalystSwipeActions(AppiumApp appiumApp) : base(appiumApp) { }
+
+		protected override void SwipeToRight(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
+		{
+			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
+			var size = element is not null ? element.Size : driver.Manage().Window.Size;
+
+			int y = (int)(position.X + (size.Width * swipePercentage));
+			int x = position.Y + size.Height / 2;
+
+			var parameters = new Dictionary<string, object>
+			{
+				{ "x" , x },
+				{ "y" , y },
+				{ "direction" , "right" },
+				{ "velocity" , swipeSpeed },
+
+			};
+
+			if (element is not null)
+			{
+				// The internal element identifier to swipe on.
+				// If both are set then x and y are considered as relative element coordinates.
+				// If only x and y are set then these are parsed as absolute coordinates.
+				parameters.Add("elementId", element.Id);
+			}
+
+			driver.ExecuteScript("mobile: swipe", parameters);
+		}
+
+		protected override void SwipeToLeft(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
+		{
+			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
+			var size = element is not null ? element.Size : driver.Manage().Window.Size;
+
+			int x = (int)(position.X + (size.Width * 0.05));
+			int y = position.Y + size.Height / 2;
+
+			var parameters = new Dictionary<string, object>
+			{
+				{ "x" , x },
+				{ "y" , y },
+				{ "direction" , "left" },
+				{ "velocity" , swipeSpeed },
+
+			};
+
+			if (element is not null)
+			{
+				// The internal element identifier to swipe on.
+				// If both are set then x and y are considered as relative element coordinates.
+				// If only x and y are set then these are parsed as absolute coordinates.
+				parameters.Add("elementId", element.Id);
+			}
+
+			driver.ExecuteScript("mobile: swipe", parameters);
+		}
+	}
+}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumSwipeActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumSwipeActions.cs
@@ -80,7 +80,7 @@ namespace UITest.Appium
 			return null;
 		}
 
-		static void SwipeToRight(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
+		virtual protected void SwipeToRight(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
 		{
 			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
 			var size = element is not null ? element.Size : driver.Manage().Window.Size;
@@ -100,7 +100,7 @@ namespace UITest.Appium
 			driver.PerformActions([swipeSequence]);
 		}
 
-		static void SwipeToLeft(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
+		virtual protected void SwipeToLeft(AppiumDriver driver, AppiumElement? element, double swipePercentage, int swipeSpeed, bool withInertia = true)
 		{
 			var position = element is not null ? element.Location : System.Drawing.Point.Empty;
 			var size = element is not null ? element.Size : driver.Manage().Window.Size;

--- a/src/TestUtils/src/UITest.Appium/AppiumCatalystApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumCatalystApp.cs
@@ -14,6 +14,7 @@ namespace UITest.Appium
 			_commandExecutor.AddCommandGroup(new AppiumCatalystTouchActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumCatalystAlertActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumCatalystSpecificActions(this));
+			_commandExecutor.AddCommandGroup(new AppiumCatalystSwipeActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumCatalystVirtualKeyboardActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumCatalystScrollActions(this));
 		}


### PR DESCRIPTION
### Description of Change

Implement Appium swipe action on Catalyst using the Mac Driver https://github.com/appium/appium-mac2-driver?tab=readme-ov-file#macos-clickanddrag.
Using an action with a pointer of type `PointerKind.Touch` does not work on Mac.