### PR TITLE
[net10.0] Fix iOS Label html tests 

### DIFF
--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Platform
 			};
 
 			NSError? nsError = new();
-			platformLabel.AttributedText = NSAttributedString.Create(new NSUrl(text), attr, out nsError);
+			platformLabel.AttributedText = NSAttributedString.Create(text, attr, out nsError);
 		}
 
 		internal static void UpdateTextPlainText(this UILabel platformLabel, IText label)


### PR DESCRIPTION
### Description of Change

When moving to net10 we moved to a new api usage of attributed string that was wrong . 

### Issues Fixed

Should fix device tests 

```
TextTypeAfterFontStuffIsCorrect
FontStuffAfterTextTypeIsCorrect
FontStuffAppliesEvenInHtmlMode
```