### PR TITLE
[net10.0] Skip more memory leak tests android

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla40955.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla40955.cs
@@ -23,6 +23,9 @@ public class Bugzilla40955 : _IssuesUITest
 	public override string Issue => "Memory leak with FormsAppCompatActivity and NavigationPage";
 
 	[Test]
+#if ANDROID
+	[Ignore("Failing on net10 https://github.com/dotnet/maui/issues/27411")]
+#endif
 	[Category(UITestCategories.Performance)]
 	public void MemoryLeakInFormsAppCompatActivity()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42329.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42329.cs
@@ -19,6 +19,9 @@ public class Bugzilla42329 : _IssuesUITest
 	public override string Issue => "ListView in Frame and FormsAppCompatActivity Memory Leak";
 
 	[Test]
+#if ANDROID
+	[Ignore("Failing on net10 https://github.com/dotnet/maui/issues/27411")]
+#endif	
 	[Category(UITestCategories.ListView)]
 	public async Task MemoryLeakB42329()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla44166.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla44166.cs
@@ -14,6 +14,9 @@ public class Bugzilla44166 : _IssuesUITest
 	public override string Issue => "FlyoutPage instances do not get disposed upon GC";
 
 	[Test]
+#if ANDROID
+	[Ignore("Failing on net10 https://github.com/dotnet/maui/issues/27411")]
+#endif
 	[Category(UITestCategories.Performance)]
 	public void Bugzilla44166Test()
 	{


### PR DESCRIPTION
### Description of Change

We are skipping these tests for now, the reason for the failure is some type of leak with NavigationPage and fragments

We have create a issue to enable them again https://github.com/dotnet/maui/issues/27411

