### PR TITLE
Fixed Unnecessary SizeChanged Event Triggering

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1762,11 +1762,15 @@ namespace Microsoft.Maui.Controls
 
 			X = bounds.X;
 			Y = bounds.Y;
+			var previousWidth = Width;
+			var previousHeight = Height;
 			Width = bounds.Width;
 			Height = bounds.Height;
-
 			SizeAllocated(Width, Height);
-			SizeChanged?.Invoke(this, EventArgs.Empty);
+			if (previousHeight != Height || previousWidth != Width)
+			{
+				SizeChanged?.Invoke(this, EventArgs.Empty);
+			}
 
 			BatchCommit();
 		}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1756,6 +1756,8 @@ namespace Microsoft.Maui.Controls
 
 		void UpdateBoundsComponents(Rect bounds)
 		{
+			if (_frame == bounds)
+				return;
 			_frame = bounds;
 
 			BatchBegin();
@@ -1766,9 +1768,9 @@ namespace Microsoft.Maui.Controls
 			var previousHeight = Height;
 			Width = bounds.Width;
 			Height = bounds.Height;
-			SizeAllocated(Width, Height);
 			if (previousHeight != Height || previousWidth != Width)
 			{
+				SizeAllocated(Width, Height);
 				SizeChanged?.Invoke(this, EventArgs.Empty);
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27223.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27223.cs
@@ -1,0 +1,79 @@
+namespace Maui.Controls.Sample.Issues
+{
+    [Issue(IssueTracker.Github, 27223, "SizeChanged event fires when size hasn't changed", PlatformAffected.UWP)]
+    public class Issue27223 : ContentPage
+    {
+        private int counter = 0;
+        private Label Counter;
+        private Editor ShowSizes;
+        private Editor ShowCoordinates;
+        private VerticalStackLayout stackLayout;
+
+        public Issue27223()
+        {
+            Grid mainGrid = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                    new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                    new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }
+                }
+            };
+
+            Grid leftGrid = new Grid
+            {
+                RowDefinitions =
+                {
+                    new RowDefinition { Height = GridLength.Auto },
+                    new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                    new RowDefinition { Height = GridLength.Auto }
+                }
+            };
+
+            Counter = new Label { AutomationId = "Label" };
+            leftGrid.Children.Add(Counter);
+            Grid.SetRow(Counter, 0);
+
+            stackLayout = new VerticalStackLayout();
+            stackLayout.SizeChanged += VerticalStackLayout_SizeChanged;
+            var button1 = new Button { Text = "button 1", AutomationId = "Button1" };
+            button1.Clicked += Button_Clicked;
+            stackLayout.Children.Add(button1);
+            stackLayout.Children.Add(new Button { Text = "button 2" });
+            stackLayout.Children.Add(new Button { Text = "button 3" });
+            leftGrid.Children.Add(stackLayout);
+            Grid.SetRow(stackLayout, 2);
+
+            ShowSizes = new Editor { BackgroundColor = Colors.SkyBlue, VerticalOptions = LayoutOptions.Fill };
+            ShowCoordinates = new Editor { BackgroundColor = Colors.DarkGoldenrod, VerticalOptions = LayoutOptions.Fill };
+
+            mainGrid.Children.Add(leftGrid);
+            Grid.SetColumn(leftGrid, 0);
+
+            mainGrid.Children.Add(ShowSizes);
+            Grid.SetColumn(ShowSizes, 1);
+
+            mainGrid.Children.Add(ShowCoordinates);
+            Grid.SetColumn(ShowCoordinates, 2);
+
+            Content = mainGrid;
+        }
+
+        private void Button_Clicked(object sender, EventArgs e)
+        {
+#if WINDOWS
+			Window.Height = 500;
+#endif
+        }
+
+        private void VerticalStackLayout_SizeChanged(object sender, EventArgs e)
+        {
+            if (sender is VerticalStackLayout ctrl)
+            {
+                counter++;
+                Counter.Text = $"resized {counter} times";
+            }
+        }
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27223.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27223.cs
@@ -1,4 +1,4 @@
-#if WINDOWS
+#if WINDOWS // mac does not respond to the window size change. so, ignored test on mac.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27223.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27223.cs
@@ -1,4 +1,4 @@
-#if WINDOWS // mac does not respond to the window size change. so, ignored test on mac.
+#if WINDOWS
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27223.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27223.cs
@@ -1,0 +1,28 @@
+#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue27223 : _IssuesUITest
+    {
+        public Issue27223(TestDevice testDevice) : base(testDevice)
+        {
+        }
+
+        public override string Issue => "SizeChanged event fires when size hasn't changed";
+
+        [Test]
+        [Category(UITestCategories.Layout)]
+        public void SizeChangedOnlyFiresWhenSizeChanges()
+        {
+            App.WaitForElement("Label");
+            var initialValue = App.FindElement("Label").GetText();
+            App.Tap("Button1");
+            var finalValue = App.FindElement("Label").GetText();
+            Assert.That(initialValue, Is.EqualTo(finalValue));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
### Issue Details:

The SizeChanged event was being triggered continuously even when the width and height of the element remained unchanged.

### Root Cause:

The existing implementation did not verify whether the width and height had actually changed before invoking the event.

### Description of Change:
A condition was added to compare the existing width and height with the new values before triggering the SizeChanged event. This ensures that the event is only fired when there is an actual change in size, preventing unnecessary event invocations.

### Tested the behavior in the following platforms

- [ ] Android
- [x] Windows
- [ ] iOS
- [x] Mac

### Issues Fixed:

Fixes #27223 

### Screenshots
| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/ea7f811d-b71c-4633-966d-607f4ba8ad1d"> |   <video src="https://github.com/user-attachments/assets/66abf5c1-9ad8-4069-8d88-3a7bf5638bb4"> |







