### PR TITLE
[Mac] TitleBar not always initally set

### DIFF
--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -93,7 +93,7 @@ internal class WindowViewController : UIViewController
 			_contentWrapperView.Subviews[0].Frame = frame;
 		}
 	}
-	
+
 	/// <summary>
 	/// Sets up the TitleBar in the ViewController.
 	/// </summary>
@@ -108,8 +108,9 @@ internal class WindowViewController : UIViewController
 			return;
 		}
 
-		var newTitleBar = window.TitleBar?.ToPlatform(mauiContext);
-		HasCustomTitleBar = newTitleBar is not null;
+		var newTitleBar = window.TitleBar;
+		var newPlatTitleBar = newTitleBar?.ToPlatform(mauiContext);
+		HasCustomTitleBar = newPlatTitleBar is not null;
 
 		IView? iTitleBar = null;
 		_iTitleBarRef?.TryGetTarget(out iTitleBar);
@@ -120,13 +121,13 @@ internal class WindowViewController : UIViewController
 			iTitleBar?.DisconnectHandlers();
 			iTitleBar = null;
 
-			if (newTitleBar is not null)
+			if (newPlatTitleBar is not null)
 			{
-				iTitleBar = window.TitleBar;
-				View.AddSubview(newTitleBar);
+				iTitleBar = newTitleBar;
+				View.AddSubview(newPlatTitleBar);
 			}
 
-			_titleBar = newTitleBar;
+			_titleBar = newPlatTitleBar;
 			_iTitleBarRef = new WeakReference<IView?>(iTitleBar);
 		}
 		


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
When the TitleBar on MacCatalyst is set, on the initial page, it would not always display properly. The size and color would show up, but the page would not shift its content below the TitleBar and no elements would show inside the TitleBar. In a simple shell page, this behavior was not observed. However, it was observed inside a NavigationPage. In the NavigationPage example, if I pushed another ContentPage with the TitleBar set there, the titleBar would then display correctly.

The issue lied in the `SetUpTitleBar` method in the `WindowViewController.cs` file when comparing `if (newTitleBar != iTitleBar)`. In the NavigationPage scenario, the initial `window.TitleBar?.ToPlatform(mauiContext);` was not null. Then when the MapTitleBar called SetUpTitleBar again, there would be a second comparison of two different types which would then null out our original TitleBar and remove the handler. When the handler was removed, everything would be reset leading to our elements in the titlebar not being displayed and the window content not shifting.



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #27413

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
