### PR TITLE
Improve debugger display XP

### DIFF
--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -1,7 +1,7 @@
 #nullable disable
 using System;
 using System.Diagnostics;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
+++ b/src/Controls/src/Core/ActivityIndicator/ActivityIndicator.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Diagnostics;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -45,7 +46,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsRunning = {IsRunning}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(IsRunning), IsRunning);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -611,7 +612,9 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, Command = {Command}, {base.GetDebuggerDisplay()}";
+			var textString = DebuggerDisplayHelpers.GetDebugText(nameof(Text), Text);
+			var commandText = DebuggerDisplayHelpers.GetDebugText(nameof(Command), Command, false);
+			return $"{base.GetDebuggerDisplay()}, {textString}, {commandText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsChecked = {IsChecked}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, IsChecked = {IsChecked}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ContentPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.ContentPage']/Docs/*" />
 	[ContentProperty("Content")]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-	[DebuggerTypeProxy(typeof(ContentPageDebuggerView))]
 	public partial class ContentPage : TemplatedPage, IContentView, HotReload.IHotReloadableView
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.HotReload;
 using Microsoft.Maui.Layouts;
@@ -11,6 +12,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ContentPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.ContentPage']/Docs/*" />
 	[ContentProperty("Content")]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+	[DebuggerTypeProxy(typeof(ContentPageDebuggerView))]
 	public partial class ContentPage : TemplatedPage, IContentView, HotReload.IHotReloadableView
 	{
 		/// <summary>Bindable property for <see cref="Content"/>.</summary>
@@ -152,7 +154,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, BindingContext = {BindingContext}";
+			var contentText = DebuggerDisplayHelpers.GetDebugText(nameof(Content), Content);
+			return $"{base.GetDebuggerDisplay()}, {contentText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.HotReload;
 using Microsoft.Maui.Layouts;

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -1,6 +1,6 @@
 #nullable disable
 using System.Diagnostics;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System.Diagnostics;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
@@ -51,7 +52,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, {base.GetDebuggerDisplay()}";
+			var contentText = DebuggerDisplayHelpers.GetDebugText(nameof(Content), Content);
+			return $"{base.GetDebuggerDisplay()}, {contentText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/DatePicker/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker/DatePicker.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Date = {Date}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, Date = {Date}";
 		}
 	}
 }

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -2,8 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 
@@ -11,6 +13,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/FlyoutPage.xml" path="Type[@FullName='Microsoft.Maui.Controls.FlyoutPage']/Docs/*" />
 	[ContentProperty(nameof(Detail))]
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class FlyoutPage : Page, IFlyoutPageController, IElementConfiguration<FlyoutPage>, IFlyoutView
 	{
 		/// <summary>Bindable property for <see cref="IsGestureEnabled"/>.</summary>
@@ -383,7 +386,8 @@ namespace Microsoft.Maui.Controls
 #endif
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"DetailPage = {Detail}, FlyoutPage = {Flyout}, BindingContext = {BindingContext}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Detail), Detail, "FlyoutPage", Flyout, nameof(BindingContext), BindingContext);
+			return $"{GetType().FullName}: {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using Microsoft.Maui.Debugger;
 
 namespace Microsoft.Maui.Controls
 {
@@ -108,7 +109,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Source = {Source}, {base.GetDebuggerDisplay()}";
+			var sourceText = DebuggerDisplayHelpers.GetDebugText(nameof(Source), Source);
+			return $"{base.GetDebuggerDisplay()}, {sourceText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Image/Image.cs
+++ b/src/Controls/src/Core/Image/Image.cs
@@ -2,7 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using Microsoft.Maui.Debugger;
+
 
 namespace Microsoft.Maui.Controls
 {

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
@@ -11,7 +12,6 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/IndicatorView.xml" path="Type[@FullName='Microsoft.Maui.Controls.IndicatorView']/Docs/*" />
 	[ContentProperty(nameof(IndicatorLayout))]
-
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class IndicatorView : TemplatedView, ITemplatedIndicatorView
 	{
@@ -199,7 +199,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Position = {Position}, Count = {Count}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Position), Position, nameof(Count), Count);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/IndicatorView/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView/IndicatorView.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -276,7 +277,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Text), Text);
+			return $"{base.GetDebuggerDisplay()}, Text = {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -3,15 +3,18 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemsView']/Docs/*" />
+	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public abstract class ItemsView : View
 	{
 
@@ -228,7 +231,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"ItemsSource = {ItemsSource}, {base.GetDebuggerDisplay()}";
+			var itemsSourceText = DebuggerDisplayHelpers.GetDebugText(nameof(ItemsSource), ItemsSource);
+			return $"{base.GetDebuggerDisplay()}, {itemsSourceText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -482,7 +483,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Text = {Text}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Text), Text);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"ChildCount = {Count},  {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, ChildCount = {Count}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -943,7 +944,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"BindingContext = {BindingContext}, Title = {Title}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(BindingContext), BindingContext, nameof(Title), Title);
+			return $"{this.GetType().FullName}: {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -465,7 +466,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Items = {ItemsSource?.Count ?? 0}, SelectedItem = {SelectedItem}, {base.GetDebuggerDisplay()}";
+			var selectedItemText = DebuggerDisplayHelpers.GetDebugText(nameof(SelectedItem), SelectedItem);
+			return $"{base.GetDebuggerDisplay()}, Items = {ItemsSource?.Count ?? 0}, {selectedItemText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/ProgressBar/ProgressBar.cs
+++ b/src/Controls/src/Core/ProgressBar/ProgressBar.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Progress = {Progress}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, Progress = {Progress}";
 		}
 	}
 }

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
 
@@ -665,7 +666,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsChecked = {IsChecked}, Value = {Value}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Value), Value, nameof(IsChecked), IsChecked);
+			return $"{base.GetDebuggerDisplay()},{debugText}";
 		}
 
 		private protected override Semantics UpdateSemantics()

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -152,7 +153,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Command = {Command}, IsRefreshing = {IsRefreshing}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Command), Command, nameof(IsRefreshing), IsRefreshing, false);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
@@ -484,7 +485,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Content = {Content}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Content), Content);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -167,7 +168,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"SearchCommand = {SearchCommand}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(SearchCommand), SearchCommand);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Slider/Slider.cs
+++ b/src/Controls/src/Core/Slider/Slider.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Value = {Value}, Min-Max = {Minimum} - {Maximum}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, Value = {Value}, Min-Max = {Minimum} - {Maximum}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Value = {Value}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, Value = {Value}";
 		}
 	}
 }

--- a/src/Controls/src/Core/Switch/Switch.cs
+++ b/src/Controls/src/Core/Switch/Switch.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"IsToggled = {IsToggled}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, IsToggled = {IsToggled}";
 		}
 	}
 }

--- a/src/Controls/src/Core/TimePicker/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Time = {Time}, {base.GetDebuggerDisplay()}";
+			return $"{base.GetDebuggerDisplay()}, Time = {Time}";
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Geometry = Microsoft.Maui.Controls.Shapes.Geometry;
@@ -19,7 +20,7 @@ namespace Microsoft.Maui.Controls
 	/// <remarks>
 	/// The base class for most .NET MAUI on-screen elements. Provides most properties, events, and methods for presenting an item on screen.
 	/// </remarks>
-	
+
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
 	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IView, IControlsVisualElement
 	{
@@ -2402,10 +2403,10 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-
 		private protected virtual string GetDebuggerDisplay()
 		{
-			return $"BindingContext = {BindingContext}, Bounds = {Bounds}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(BindingContext), BindingContext, nameof(Bounds), Bounds);
+			return $"{GetType().FullName}: {debugText}";
 		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Geometry = Microsoft.Maui.Controls.Shapes.Geometry;

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -7,7 +7,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Debugger;
+
 using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/WebView/WebView.cs
+++ b/src/Controls/src/Core/WebView/WebView.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Debugger;
 using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls
@@ -388,7 +389,8 @@ namespace Microsoft.Maui.Controls
 
 		private protected override string GetDebuggerDisplay()
 		{
-			return $"Source = {Source}, {base.GetDebuggerDisplay()}";
+			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Source), Source);
+			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
 	}
 }

--- a/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
+++ b/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft.Maui.Debugger;
+/// <summary>
+/// Inspired on https://github.com/dotnet/aspnetcore/blob/befc463e34b17edf8aee1fbf9dec44c75f13000b/src/Shared/Debugger/DebuggerHelpers.cs from Asp.NET
+/// </summary>
+static class DebuggerDisplayHelpers
+{
+	const string NullString = "(null)";
+
+	public static void Test()
+	{
+		_ = GetDebugString("batata", new LabelHandler());
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static string GetDebugString(string name, object? value)
+	{
+		var valueString = GetDebugString(value);
+		return $"{name} = {valueString}";
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static string GetDebugString(object? value)
+	{
+		var valueString = value is null ? NullString : value.ToString();
+		Debug.Assert(valueString is not null);
+		return valueString!;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static string GetDebugText(string key1, object? value1, bool includeNullValues = true)
+	{
+		return GetDebugText([Create(key1, value1)], includeNullValues);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static string GetDebugText(string key1, object? value1, string key2, object? value2, bool includeNullValues = true)
+	{
+		return GetDebugText([Create(key1, value1), Create(key2, value2)], includeNullValues);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static string GetDebugText(string key1, object? value1, string key2, object? value2, string key3, object? value3, bool includeNullValues = true)
+	{
+		return GetDebugText([Create(key1, value1), Create(key2, value2), Create(key3, value3)], includeNullValues);
+	}
+
+	public static string GetDebugText(ReadOnlySpan<KeyValuePair<string, object?>> values, bool includeNullValues = true)
+	{
+		var size = values.Length;
+		if (size is 0)
+		{
+			return string.Empty;
+		}
+
+		var sb = new StringBuilder();
+
+		var first = true;
+		for (var i = 0; i < size; i++)
+		{
+			var kvp = values[i];
+
+			if (HasValue(kvp.Value) || includeNullValues)
+			{
+				if (first)
+				{
+					first = false;
+				}
+				else
+				{
+					sb.Append(", ");
+				}
+
+				sb.Append(kvp.Key);
+				sb.Append(" = ");
+				if (kvp.Value is null)
+				{
+					sb.Append(NullString);
+				}
+				else if (kvp.Value is string s)
+				{
+					sb.Append(s);
+				}
+				else if (kvp.Value is IEnumerable enumerable)
+				{
+					var firstItem = true;
+					foreach (var item in enumerable)
+					{
+						if (firstItem)
+						{
+							firstItem = false;
+						}
+						else
+						{
+							sb.Append(',');
+						}
+						sb.Append(item);
+					}
+				}
+				else
+				{
+					sb.Append(kvp.Value);
+				}
+			}
+		}
+
+		return sb.ToString();
+	}
+
+	static bool HasValue([NotNullWhen(true)] object? value)
+	{
+		if (value is null)
+		{
+			return false;
+		}
+
+		// Empty collections don't have a value.
+		if (value is not string && value is IEnumerable enumerable && !enumerable.GetEnumerator().MoveNext())
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+
+	public static string GetDebugString(object? value, bool showIfNull)
+	{
+		if (value is null && !showIfNull)
+		{
+			return string.Empty;
+		}
+
+		return GetDebugString(value);
+	}
+
+	static KeyValuePair<string, object?> Create(string key, object? value) => new KeyValuePair<string, object?>(key, value);
+
+}

--- a/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
+++ b/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace Microsoft.Maui.Debugger;
+namespace Microsoft.Maui;
 /// <summary>
 /// Inspired on https://github.com/dotnet/aspnetcore/blob/befc463e34b17edf8aee1fbf9dec44c75f13000b/src/Shared/Debugger/DebuggerHelpers.cs from Asp.NET
 /// </summary>

--- a/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
+++ b/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
@@ -15,21 +15,6 @@ static class DebuggerDisplayHelpers
 	const string NullString = "(null)";
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static string GetDebugString(string name, object? value)
-	{
-		var valueString = GetDebugString(value);
-		return $"{name} = {valueString}";
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static string GetDebugString(object? value)
-	{
-		var valueString = value is null ? NullString : value.ToString();
-		Debug.Assert(valueString is not null);
-		return valueString!;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static string GetDebugText(string key1, object? value1, bool includeNullValues = true)
 	{
 		return GetDebugText([Create(key1, value1)], includeNullValues);
@@ -125,17 +110,5 @@ static class DebuggerDisplayHelpers
 		return true;
 	}
 
-
-	public static string GetDebugString(object? value, bool showIfNull)
-	{
-		if (value is null && !showIfNull)
-		{
-			return string.Empty;
-		}
-
-		return GetDebugString(value);
-	}
-
 	static KeyValuePair<string, object?> Create(string key, object? value) => new KeyValuePair<string, object?>(key, value);
-
 }

--- a/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
+++ b/src/Core/src/Debugger/DebuggerDisplayHelpers.cs
@@ -14,11 +14,6 @@ static class DebuggerDisplayHelpers
 {
 	const string NullString = "(null)";
 
-	public static void Test()
-	{
-		_ = GetDebugString("batata", new LabelHandler());
-	}
-
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static string GetDebugString(string name, object? value)
 	{

--- a/src/Core/src/HotReload/HotReloadHelper.cs
+++ b/src/Core/src/HotReload/HotReloadHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.HotReload
 		{
 			replacedViews.Clear();
 		}
-		public static bool IsEnabled { get; set; } = System.Diagnostics.Debugger.IsAttached;
+		public static bool IsEnabled { get; set; } = Debugger.IsAttached;
 
 		internal static bool IsSupported
 #if !NETSTANDARD

--- a/src/Core/src/HotReload/HotReloadHelper.cs
+++ b/src/Core/src/HotReload/HotReloadHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.HotReload
 		{
 			replacedViews.Clear();
 		}
-		public static bool IsEnabled { get; set; } = Debugger.IsAttached;
+		public static bool IsEnabled { get; set; } = System.Diagnostics.Debugger.IsAttached;
 
 		internal static bool IsSupported
 #if !NETSTANDARD

--- a/src/Core/src/VisualDiagnostics/DebuggerHelper.cs
+++ b/src/Core/src/VisualDiagnostics/DebuggerHelper.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Maui
 #endif
 
 		public static bool _mockDebuggerIsAttached;
-		public static bool DebuggerIsAttached => _mockDebuggerIsAttached || System.Diagnostics.Debugger.IsAttached;
+		public static bool DebuggerIsAttached => _mockDebuggerIsAttached || Debugger.IsAttached;
 	}
 }

--- a/src/Core/src/VisualDiagnostics/DebuggerHelper.cs
+++ b/src/Core/src/VisualDiagnostics/DebuggerHelper.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Maui
 #endif
 
 		public static bool _mockDebuggerIsAttached;
-		public static bool DebuggerIsAttached => _mockDebuggerIsAttached || Debugger.IsAttached;
+		public static bool DebuggerIsAttached => _mockDebuggerIsAttached || System.Diagnostics.Debugger.IsAttached;
 	}
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR improves the debugger information adding the object type and centralizing the string creation into one method.
 - Showing `null` string when the property value is null, if it's an _important_ property.
 
![image](https://github.com/user-attachments/assets/f06c6f13-a4e2-4cb1-9b08-d2efaa351a2b)

- Not showing the property if its value is null, for example on Button's Command

![image](https://github.com/user-attachments/assets/659ce797-ac5c-4c13-b187-99c4d469c0f4)

Now with I've a command attached to it
![image](https://github.com/user-attachments/assets/35e97a90-364b-456c-a2e5-0024f48400cf)



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Related to #27016 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
