### PR TITLE
[Testing] Revert change verifying snapshots on Catalyst

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 			// The app might not be ready to take the screenshot.
 			// Wait a little bit to complete the system animation moving the App Window to FullScreen.
-			Thread.Sleep(500);
+			Thread.Sleep(1000);
 
 			byte[] screenshotPngBytes = App.Screenshot() ?? throw new InvalidOperationException("Failed to get screenshot");
 


### PR DESCRIPTION
### Description of Change

Recently, among various changes and proposals to speed up UITests, we have merged this PR: https://github.com/dotnet/maui/pull/27370 where we have disabled system animations on Android and some on Mac. On Mac we also made changes capturing and verifying snapshots. This change is sometimes causing problems.

This PR reverts the value of waiting to have App in Full Screen to the original value, before capturing the screenshot.