### PR TITLE
[iOS/MacCatalyst] Use newer API in FilePicker

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Maui.Storage
 			using var documentPicker = new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Open);
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CA1416 // Constructor UIDocumentPickerViewController  has [UnsupportedOSPlatform("ios14.0")]
-			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
-				documentPicker.AllowsMultipleSelection = allowMultiple;
+			documentPicker.AllowsMultipleSelection = allowMultiple;
 			documentPicker.Delegate = new PickerDelegate
 			{
 				PickHandler = urls => GetFileResults(urls, tcs)

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Storage
 #pragma warning restore CA1416 // Constructor UIDocumentPickerViewController  has [UnsupportedOSPlatform("ios14.0")]
 			documentPicker.AllowsMultipleSelection = allowMultiple;
 			
-			if (OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+			if (!OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
 			{
 				documentPicker.DidPickDocumentAtUrls += (_, e) => GetFileResults(e.Urls, tcs);
 			}

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Storage
 				};
 
 #if !MACCATALYST
-				if (documentPicker.PresentationController != null)
+				if (documentPicker.PresentationController != null && !(OperatingSystem.IsIOSVersionAtLeast(14, 0) && NSProcessInfo.ProcessInfo.IsiOSApplicationOnMac))
 				{
 					documentPicker.PresentationController.Delegate =
 						new UIPresentationControllerDelegate(() => GetFileResults(null, tcs));

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -93,35 +93,35 @@ namespace Microsoft.Maui.Storage
 #pragma warning disable CA1416 // TODO: UTType has [UnsupportedOSPlatform("ios14.0")]
 #pragma warning disable CA1422 // Validate platform compatibility
 		static FilePickerFileType PlatformImageFileType() =>
-			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
 				{ DevicePlatform.iOS, new[] { (string)UTType.Image } },
 				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.Image } }
 			});
 
 		static FilePickerFileType PlatformPngFileType() =>
-			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
 				{ DevicePlatform.iOS, new[] { (string)UTType.PNG } },
 				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.PNG } }
 			});
 
 		static FilePickerFileType PlatformJpegFileType() =>
-			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
 				{ DevicePlatform.iOS, new[] { (string)UTType.JPEG } },
 				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.JPEG } }
 			});
 
 		static FilePickerFileType PlatformVideoFileType() =>
-			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
 				{ DevicePlatform.iOS, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } },
 				{ DevicePlatform.MacCatalyst, new string[] { UTType.MPEG4, UTType.Video, UTType.AVIMovie, UTType.AppleProtectedMPEG4Video, "mp4", "m4v", "mpg", "mpeg", "mp2", "mov", "avi", "mkv", "flv", "gifv", "qt" } }
 			});
 
 		static FilePickerFileType PlatformPdfFileType() =>
-			new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+			new(new Dictionary<DevicePlatform, IEnumerable<string>>
 			{
 				{ DevicePlatform.iOS, new[] { (string)UTType.PDF } },
 				{ DevicePlatform.MacCatalyst, new[] { (string)UTType.PDF } }

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Storage
 #pragma warning restore CA1416 // Constructor UIDocumentPickerViewController  has [UnsupportedOSPlatform("ios14.0")]
 			documentPicker.AllowsMultipleSelection = allowMultiple;
 			
-			if (!OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
+			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
 			{
 				documentPicker.DidPickDocumentAtUrls += (_, e) => GetFileResults(e.Urls, tcs);
 			}


### PR DESCRIPTION
### Description of Change

This is an attempt to use [this API](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/documentpicker(_:didpickdocumentsat:)) in `FilePicker` on iOS and Mac Catalyst.

Credits to @datvm and @Khongchai

FTR: I have not been able to reproduce the original issue yet.

### Issues Fixed

Fixes #15126
Fixes #25661

### Resources

* https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/documentpicker(_:didpickdocumentsat:)
* https://github.com/datvm/LukeMauiFilePicker/blob/master/LukeMauiFilePicker/FilePickerService.MaciOS.cs#L40
* https://github.com/dotnet/maui/issues/15126#issuecomment-2045342313
* https://developer.apple.com/documentation/foundation/processinfo/3608556-isiosapponmac