### PR TITLE
FilePicker returns null when running iOS app on macOS (not Catalyst) - FIX

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -38,13 +38,11 @@ namespace Microsoft.Maui.Storage
 				PickHandler = urls => GetFileResults(urls, tcs)
 			};
 
-#if !MACCATALYST
-			if (documentPicker.PresentationController != null)
+			if (!OperatingSystem.IsMacCatalyst() && documentPicker.PresentationController is not null)
 			{
 				documentPicker.PresentationController.Delegate =
 					new UIPresentationControllerDelegate(() => GetFileResults(null, tcs));
 			}
-#endif
 
 			var parentController = WindowStateManager.Default.GetCurrentUIViewController(true);
 


### PR DESCRIPTION
### Description of Change

This tries https://github.com/dotnet/maui/issues/25661#issuecomment-2471795017 approach to fix the issue.

The idea is to AZP this PR to let @follesoe check out if it fixes his issue.

### Issues Fixed

Fixes #25661