### PR TITLE
Adds very basic CSS support for Border

### DIFF
--- a/src/Controls/src/Build.Tasks/CompiledConverters/StrokeShapeTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/StrokeShapeTypeConverter.cs
@@ -190,6 +190,26 @@ class StrokeShapeTypeConverter : ICompiledTypeConverter
 				yield return Instruction.Create(OpCodes.Call, module.ImportPropertySetterReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Shapes", "RoundRectangle"), "CornerRadius"));
 				yield break;
 			}
+
+			if (double.TryParse(value, out double radius))
+			{
+				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Shapes", "Rectangle"), parameterTypes: null));
+				yield return Instruction.Create(OpCodes.Dup);
+
+				yield return Instruction.Create(OpCodes.Ldc_R8, radius);
+				yield return Instruction.Create(OpCodes.Ldc_R8, radius);
+				yield return Instruction.Create(OpCodes.Ldc_R8, radius);
+				yield return Instruction.Create(OpCodes.Ldc_R8, radius);
+
+				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(context.Cache, ("Microsoft.Maui", "Microsoft.Maui", "CornerRadius"), parameterTypes: new[] {
+					("mscorlib", "System", "Double"),
+					("mscorlib", "System", "Double"),
+					("mscorlib", "System", "Double"),
+					("mscorlib", "System", "Double")}));
+
+				yield return Instruction.Create(OpCodes.Call, module.ImportPropertySetterReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Shapes", "RoundRectangle"), "CornerRadius"));
+				yield break;
+			}
 		}
 		throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(IShape));
 	}

--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -85,13 +85,16 @@ using Compatibility = Microsoft.Maui.Controls.Compatibility;
 [assembly: StyleProperty("background", typeof(VisualElement), nameof(VisualElement.BackgroundProperty))]
 [assembly: StyleProperty("background-image", typeof(Page), nameof(Page.BackgroundImageSourceProperty))]
 [assembly: StyleProperty("border-color", typeof(IBorderElement), nameof(BorderElement.BorderColorProperty))]
+[assembly: StyleProperty("border-color", typeof(IBorderView), nameof(Border.StrokeProperty))]
 [assembly: StyleProperty("border-radius", typeof(ICornerElement), nameof(CornerElement.CornerRadiusProperty))]
 [assembly: StyleProperty("border-radius", typeof(Button), nameof(Button.CornerRadiusProperty))]
 #pragma warning disable CS0618 // Type or member is obsolete
 [assembly: StyleProperty("border-radius", typeof(Frame), nameof(Frame.CornerRadiusProperty))]
 #pragma warning restore CS0618 // Type or member is obsolete
+[assembly: StyleProperty("border-radius", typeof(IBorderView), nameof(Border.StrokeShapeProperty))]
 [assembly: StyleProperty("border-radius", typeof(ImageButton), nameof(BorderElement.CornerRadiusProperty))]
 [assembly: StyleProperty("border-width", typeof(IBorderElement), nameof(BorderElement.BorderWidthProperty))]
+[assembly: StyleProperty("border-width", typeof(IBorderView), nameof(Border.StrokeThicknessProperty))]
 [assembly: StyleProperty("color", typeof(IColorElement), nameof(ColorElement.ColorProperty), Inherited = true)]
 [assembly: StyleProperty("color", typeof(ITextElement), nameof(TextElement.TextColorProperty), Inherited = true)]
 [assembly: StyleProperty("text-transform", typeof(ITextElement), nameof(TextElement.TextTransformProperty), Inherited = true)]

--- a/src/Controls/src/Core/Shapes/StrokeShapeTypeConverter.cs
+++ b/src/Controls/src/Core/Shapes/StrokeShapeTypeConverter.cs
@@ -123,6 +123,12 @@ namespace Microsoft.Maui.Controls.Shapes
 
 					return new RoundRectangle { CornerRadius = cornerRadius };
 				}
+
+				// Support for providing a double. This handles Border CSS support.
+				if (double.TryParse(strValue, out double radius))
+				{
+					return new RoundRectangle { CornerRadius = new CornerRadius(radius) };
+				}
 			}
 
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(Shape)}");

--- a/src/Controls/tests/Core.UnitTests/StrokeShapeTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StrokeShapeTests.cs
@@ -127,5 +127,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.NotNull(ellipse);
 		}
+
+		[Theory]
+		[InlineData("20")]
+		public void TestRoundRectangleSingleValue(string value)
+		{
+			RoundRectangle roundRectangle = _strokeShapeTypeConverter.ConvertFromInvariantString(value) as RoundRectangle;
+
+			Assert.NotNull(roundRectangle);
+			Assert.NotEqual(0, roundRectangle.CornerRadius.TopLeft);
+			Assert.NotEqual(0, roundRectangle.CornerRadius.TopRight);
+			Assert.NotEqual(0, roundRectangle.CornerRadius.BottomLeft);
+			Assert.NotEqual(0, roundRectangle.CornerRadius.BottomRight);
+		}
 	}
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Added basic support for CSS properties that work on the `Border` control. The following properties are now supported:

```css
.myNicePurpleBorder
{
   border-color: #512BD4; /* Also supports linear-gradient, radial-gradient, named colors etc. */
   border-radius: 10; /* Always maps to RoundRectangle [Radius] internally */
   border-width: 4;
}
```

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Partially fixes #27296 to get basic support going, making it become on par with existing support for `Frame`, `Button` and `ImageButton`. It could definitely be expanded upon in the future for `Border` explicitly, but a discussion is to be had on how that would translate to missing features on the other controls that support borders.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
