### PR TITLE
[Android] [Shell] Ensure `AnimationFinished` is called when app backgrounds mid-animation

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellContentFragment.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellContentFragment.cs
@@ -167,6 +167,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void Destroy()
 		{
+			// If the user taps very quickly on back button multiple times to pop a page,
+			// the app enters background state in the middle of the animation causing the fragment to be destroyed without completing the animation.
+			// That'll cause `IAnimationListener.onAnimationEnd` to not be called, so we need to call it manually if something is still subscribed to the event
+			// to avoid the navigation `TaskCompletionSource` to be stuck forever.
+			AnimationFinished?.Invoke(this, EventArgs.Empty);
+
 			((IShellController)_shellContext.Shell).RemoveAppearanceObserver(this);
 
 			if (_shellContent != null)


### PR DESCRIPTION
### Issue

Consider this shell stack: `ShellContent` > `InnerPage`.

The user presses a button to pop the page programmatically:

```
await Shell.Current.GoToAsync("..")
DoSomethingElse();
```

`DoSomethingElse` is never being called if the user presses the android back button quickly while the animation is still in progress.

This is caused because `IAnimationListener.onAnimationEnd` is never being invoked by android as the animation was canceled.

### Description of Change

Trigger the animation complete even upon fragment `Destroy` so that if the navigation is still waiting, it can complete.

### Issues Fixed

Relates to #26617 (#27364)

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
