### PR TITLE
[Android] Fixed the SoftInputMode issues with modal pages

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -256,6 +256,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 				dialog.Window.SetBackgroundDrawable(TransparentColorDrawable);
 
+				var attributes = Context?.GetActivity()?.Window?.Attributes;
+
+				if (attributes is not null)
+				{
+					dialog.Window.SetSoftInputMode(attributes.SoftInputMode);
+				}
+
 				return dialog;
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27242.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27242.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;
+using Button = Microsoft.Maui.Controls.Button;
+using Entry = Microsoft.Maui.Controls.Entry;
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 27242, "[Android] WindowSoftInputModeAdjust is not working for modal pages", PlatformAffected.Android)]
+public class Issue27242 : ContentPage
+{
+    public Issue27242()
+    {
+        var layout = new VerticalStackLayout() { Padding = new Thickness(20) };
+        var button1 = new Button { Text = "Go to ResizeModalPage" };
+        button1.AutomationId = "Button1";
+        button1.Clicked += async (s, e) => await Navigation.PushModalAsync(new Issue27242Page1());
+        layout.Add(button1);
+
+        var button2 = new Button { Text = "Go to PanModalPage" };
+        button2.AutomationId = "Button2";
+        button2.Clicked += async (s, e) => await Navigation.PushModalAsync(new Issue27242Page2());
+        layout.Add(button2);
+        Content = layout;
+    }
+}
+
+public class Issue27242Page1 : ContentPage
+{
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        App.Current!.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
+    }
+    public Issue27242Page1()
+    {
+        var grid = new Grid
+        {
+            Padding = 20,
+            RowSpacing = 20,
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(50) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            }
+        };
+
+        var button = new Button { Text = "Back to Home Page" };
+        button.AutomationId = "BackButton";
+        button.Clicked += async (s, e) => await Navigation.PopModalAsync();
+        grid.Add(button, 0, 0);
+
+        var entry = new Entry();
+        entry.AutomationId = "Page1Entry";
+        grid.Add(entry, 0, 1);
+
+        var greenBox = new BoxView { BackgroundColor = Colors.Green };
+        grid.Add(greenBox, 0, 2);
+
+        Content = grid;
+    }
+}
+
+public class Issue27242Page2 : ContentPage
+{
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        //default mode 
+        App.Current!.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Pan);
+    }
+    public Issue27242Page2()
+    {
+        var grid = new Grid
+        {
+            Padding = 20,
+            RowSpacing = 20,
+            RowDefinitions =
+    {
+        new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+        new RowDefinition { Height = new GridLength(75) },
+        new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+    }
+        };
+
+        var redBox = new BoxView { BackgroundColor = Colors.Red };
+        grid.Add(redBox, 0, 0);
+
+        var entry = new Entry();
+        entry.AutomationId = "Page2Entry";
+        grid.Add(entry, 0, 1);
+
+        var greenBox = new BoxView { BackgroundColor = Colors.Green };
+        //scrollview
+        var scrollView = new ScrollView { Content = greenBox };
+        grid.Add(scrollView, 0, 2);
+        Content = grid;
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27242.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27242.cs
@@ -1,0 +1,47 @@
+﻿#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27242 : _IssuesUITest
+	{
+		const string Button1 = "Button1";
+		const string Page1Entry = "Page1Entry";
+		const string Button2 = "Button2";
+		const string Page2Entry = "Page2Entry";
+
+		public Issue27242(TestDevice device) : base(device) { }
+
+		public override string Issue => "[Android] WindowSoftInputModeAdjust is not working for modal pages";
+
+		[Test, Order(1)]
+		[Category(UITestCategories.Page)]
+		public void WindowSoftInputModeAdjustSetToResizeForModalPage()
+		{
+			App.WaitForElement(Button1);
+			App.Tap(Button1);
+			App.WaitForElement(Page1Entry);
+			var beforeEntryRectY = App.WaitForElement(Page1Entry).GetRect().Y;
+			App.Tap(Page1Entry);
+			var afterEntryRectY = App.WaitForElement(Page1Entry).GetRect().Y;
+			Assert.That(beforeEntryRectY, Is.Not.EqualTo(afterEntryRectY));
+			App.Tap("BackButton");
+		}
+
+		[Test, Order(2)]
+		[Category(UITestCategories.Page)]
+		public void WindowSoftInputModeAdjustSetToPanForModalpage()
+		{
+			App.WaitForElement(Button2);
+			App.Tap(Button2);
+			App.WaitForElement(Page2Entry);
+			var beforeEntryRectY = App.WaitForElement(Page2Entry).GetRect().Y;
+			App.Tap(Page2Entry);
+			var afterEntryRectY = App.WaitForElement(Page2Entry).GetRect().Y;
+			Assert.That(beforeEntryRectY, Is.EqualTo(afterEntryRectY));
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Root Cause of the issue



In the OnCreateDialog method, `CustomComponentDialog` is used to create the dialog, and its SoftInputMode defaults to `AdjustUnspecified`. As a result, the behavior varies based on the layout: 

- If a ScrollView is present, the window appears to resize. 

- Otherwise, it behaves as a pan. 

Additionally, setting `SoftInputMode` at the sample level does not apply to the dialog. 



### Description of Change


- Retrieve the `SoftInputMode` from the Context and apply it to the `dialog`. This ensures consistent behavior and proper functionality, even when SoftInputMode is set at the sample level.


### Regressed PR
- #22869 -- Initially, `DecorView` was used for modal pages, but it has now been replaced by `DialogFragment` for improvements.


### Issues Fixed




- Fixes #27242
- Fixes #27240



### Tested the behaviour in the following platforms



- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/6e9e94e0-46eb-483f-97fa-00bf81894d57"> | <video src="https://github.com/user-attachments/assets/2ba4e4e2-50e0-4b9a-b406-bd881337263f"> |
