### PR TITLE
[Localization] Fix blocking typo

### DIFF
--- a/eng/automation/LocProject.json
+++ b/eng/automation/LocProject.json
@@ -43,7 +43,7 @@
               "SourceFile":  ".\\src\\Templates\\src\\templates\\maui-contentview-csharp\\.template.config\\localize\\templatestrings.json",
               "LclFile":  "loc\\{Lang}\\src\\Templates\\src\\templates\\maui-contentview-csharp\\.template.config\\localize\\templatestrings.json.lcl",
               "CopyOption":  "LangIDOnName",
-              "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-contentview-xaml\\.template.config\\localize\\"
+              "OutputPath":  ".\\src\\Templates\\src\\templates\\maui-contentview-csharp\\.template.config\\localize\\"
             },
             {
               "SourceFile":  ".\\src\\Templates\\src\\templates\\maui-contentview-xaml\\.template.config\\localize\\templatestrings.json",


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
Small typo that may be the reason we were missing some localization strings

Related to: https://github.com/dotnet/maui/pull/25620


<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
