### PR TITLE
[net10.0] Make CV2 default for net10

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.Maui.Controls.Compatibility.Platform.UWP;
 #elif IOS || MACCATALYST
 using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Handlers.Items2;
 #elif TIZEN
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
@@ -61,8 +62,13 @@ public static partial class AppHostBuilderExtensions
 
 	internal static IMauiHandlersCollection AddControlsHandlers(this IMauiHandlersCollection handlersCollection)
 	{
+#if IOS || MACCATALYST
+		handlersCollection.AddHandler<CollectionView, CollectionViewHandler2>();
+		handlersCollection.AddHandler<CarouselView, CarouselViewHandler2>();
+#else
 		handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
 		handlersCollection.AddHandler<CarouselView, CarouselViewHandler>();
+#endif
 		handlersCollection.AddHandler<Application, ApplicationHandler>();
 		handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
 		handlersCollection.AddHandler<BoxView, BoxViewHandler>();

--- a/src/Templates/src/templates/maui-mobile/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiProgram.cs
@@ -18,14 +18,7 @@ public static class MauiProgram
 #if (IncludeSampleContent)
 			.UseMauiCommunityToolkit()
 			.ConfigureSyncfusionToolkit()
-			.ConfigureMauiHandlers(handlers =>
-			{
-//-:cnd:noEmit
-#if IOS || MACCATALYST
-				handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();
-#endif
-//+:cnd:noEmit
-			})
+			.ConfigureMauiHandlers()
 #endif
 			.ConfigureFonts(fonts =>
 			{

--- a/src/Templates/src/templates/maui-mobile/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiProgram.cs
@@ -18,7 +18,6 @@ public static class MauiProgram
 #if (IncludeSampleContent)
 			.UseMauiCommunityToolkit()
 			.ConfigureSyncfusionToolkit()
-			.ConfigureMauiHandlers()
 #endif
 			.ConfigureFonts(fonts =>
 			{

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -333,32 +333,4 @@ public class SimpleTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.Build(projectFile, config, properties: buildProps, msbuildWarningsAsErrors: true),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 	}
-
-	// This test is super temporary and is just for the interim
-	// while we productize the CollectionViewHandler2. Once we
-	// ship it as the default, this test will fail and can be deleted.
-	[Test]
-	[TestCase("maui", DotNetCurrent, "", false)]
-	[TestCase("maui", DotNetCurrent, "--sample-content", true)]
-	public void SampleShouldHaveHandler2Registered(string id, string framework, string additionalDotNetNewParams, bool shouldHaveHandler2)
-	{
-		var projectDir = TestDirectory;
-		var programFile = Path.Combine(projectDir, "MauiProgram.cs");
-
-		Assert.IsTrue(DotnetInternal.New(id, projectDir, framework, additionalDotNetNewParams),
-			$"Unable to create template {id}. Check test output for errors.");
-
-		var programContents = File.ReadAllText(programFile);
-
-		if (shouldHaveHandler2)
-		{
-			AssertContains("#if IOS || MACCATALYST", programContents);
-			AssertContains("handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();", programContents);
-		}
-		else
-		{
-			AssertDoesNotContain("#if IOS || MACCATALYST", programContents);
-			AssertDoesNotContain("handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();", programContents);
-		}
-	}
 }


### PR DESCRIPTION
### Description of Change

The default handlers on net10 for CollectionView and CarouselView should be CV2 on iOS