### PR TITLE
[Windows] Fix for SearchHandler.Focused and Unfocused event never fires

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -84,7 +84,14 @@ namespace Microsoft.Maui.Controls.Handlers
 			base.DisconnectHandler(platformView);
 
 			if (platformView is MauiNavigationView mnv)
+			{
 				mnv.SelectionChanged -= OnNavigationTabChanged;
+				if (mnv.AutoSuggestBox is not null)
+				{
+					mnv.AutoSuggestBox.GotFocus -= OnSearchBoxGotFocus;
+					mnv.AutoSuggestBox.LostFocus -= OnSearchBoxLostFocus;
+				}
+			}
 
 			platformView.Loaded -= OnNavigationViewLoaded;
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -86,13 +86,13 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (platformView is MauiNavigationView mnv)
 			{
 				mnv.SelectionChanged -= OnNavigationTabChanged;
-				if (mnv.AutoSuggestBox is not null)
+				if (mnv.AutoSuggestBox is { } autoSuggestBox)
 				{
-					mnv.AutoSuggestBox.TextChanged -= OnSearchBoxTextChanged;
-					mnv.AutoSuggestBox.QuerySubmitted -= OnSearchBoxQuerySubmitted;
-					mnv.AutoSuggestBox.SuggestionChosen -= OnSearchBoxSuggestionChosen;
-					mnv.AutoSuggestBox.GotFocus -= OnSearchBoxGotFocus;
-					mnv.AutoSuggestBox.LostFocus -= OnSearchBoxLostFocus;
+					autoSuggestBox.TextChanged -= OnSearchBoxTextChanged;
+					autoSuggestBox.QuerySubmitted -= OnSearchBoxQuerySubmitted;
+					autoSuggestBox.SuggestionChosen -= OnSearchBoxSuggestionChosen;
+					autoSuggestBox.GotFocus -= OnSearchBoxGotFocus;
+					autoSuggestBox.LostFocus -= OnSearchBoxLostFocus;
 				}
 			}
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -88,6 +88,9 @@ namespace Microsoft.Maui.Controls.Handlers
 				mnv.SelectionChanged -= OnNavigationTabChanged;
 				if (mnv.AutoSuggestBox is not null)
 				{
+					mnv.AutoSuggestBox.TextChanged -= OnSearchBoxTextChanged;
+					mnv.AutoSuggestBox.QuerySubmitted -= OnSearchBoxQuerySubmitted;
+					mnv.AutoSuggestBox.SuggestionChosen -= OnSearchBoxSuggestionChosen;
 					mnv.AutoSuggestBox.GotFocus -= OnSearchBoxGotFocus;
 					mnv.AutoSuggestBox.LostFocus -= OnSearchBoxLostFocus;
 				}

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -275,6 +275,8 @@ namespace Microsoft.Maui.Controls.Handlers
 						autoSuggestBox.TextChanged += OnSearchBoxTextChanged;
 						autoSuggestBox.QuerySubmitted += OnSearchBoxQuerySubmitted;
 						autoSuggestBox.SuggestionChosen += OnSearchBoxSuggestionChosen;
+						autoSuggestBox.GotFocus += OnSearchBoxGotFocus;
+						autoSuggestBox.LostFocus += OnSearchBoxLostFocus;
 						mauiNavView.AutoSuggestBox = autoSuggestBox;
 					}
 
@@ -308,6 +310,16 @@ namespace Microsoft.Maui.Controls.Handlers
 					autoSuggestBox.Visibility = UI.Xaml.Visibility.Collapsed;
 				}
 			}
+		}
+
+		void OnSearchBoxGotFocus(object sender, RoutedEventArgs e)
+		{
+			_currentSearchHandler?.SetIsFocused(true);
+		}
+
+		void OnSearchBoxLostFocus(object sender, RoutedEventArgs e)
+		{
+			_currentSearchHandler?.SetIsFocused(false);
 		}
 
 		void OnSearchBoxTextChanged(Microsoft.UI.Xaml.Controls.AutoSuggestBox sender, Microsoft.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs args)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24670.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24670.cs
@@ -1,5 +1,4 @@
-﻿#if ANDROID
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -32,4 +31,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
-#endif


### PR DESCRIPTION
### Root cause

The root cause of the issue is that the GotFocus and LostFocus events for the AutoSuggestBox control were not previously integrated with the SearchHandler's SetIsFocused method. As a result, the Focused and Unfocused events for the Shell.SearchHandler were not being triggered when the search handler gained or lost focus, leading to incorrect focus management behavior.

### Description of Issue Fix

The fix involves connecting the GotFocus and LostFocus events of the AutoSuggestBox control to the SearchHandler's focus management. This is done by adding event handlers for these events in the UpdateSearchHandler method, which will call the SetIsFocused method when the AutoSuggestBox gains or loses focus. This ensures that the Focused and Unfocused events are triggered properly, allowing the search handler to respond when focus changes.

Tested the behavior in the following platforms.
 
- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/27551

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/8874893a-5022-40cf-a02a-e4d67eb61cab"> | <video width="270" height="600"  src="https://github.com/user-attachments/assets/857e592b-acd6-4ce2-a4e5-3da661c2b029"> |




