### PR TITLE
26598 - Fix for Tabbar disappears when navigating back from page with hidden TabBar in iOS 18

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -140,8 +140,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 
 			var tabBarVisible = Shell.GetTabBarIsVisible(Page) ? true : (Page.FindParentOfType<ShellItem>() as IShellItemController)?.ShowTabs ?? false;
-
-			ViewController.HidesBottomBarWhenPushed = !tabBarVisible;
+			// In iOS 18, the tab bar visibility is effectively managed by the TabBarHidden property in ShellItemRenderer.
+			if (!(OperatingSystemMacCatalyst18Workaround.IsMacCatalystVersionAtLeast18() || OperatingSystem.IsIOSVersionAtLeast(18)))
+			{
+				ViewController.HidesBottomBarWhenPushed = !tabBarVisible;
+			}
 		}
 
 		void OnToolbarPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			var tabBarVisible = Shell.GetTabBarIsVisible(Page) ? true : (Page.FindParentOfType<ShellItem>() as IShellItemController)?.ShowTabs ?? false;
+			var tabBarVisible = (Page.FindParentOfType<ShellItem>() as IShellItemController)?.ShowTabs ?? Shell.GetTabBarIsVisible(Page);
 			// In iOS 18, the tab bar visibility is effectively managed by the TabBarHidden property in ShellItemRenderer.
 			if (!(OperatingSystemMacCatalyst18Workaround.IsMacCatalystVersionAtLeast18() || OperatingSystem.IsIOSVersionAtLeast(18)))
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -139,8 +139,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			var tabBarVisible =
-				(Page.FindParentOfType<ShellItem>() as IShellItemController)?.ShowTabs ?? Shell.GetTabBarIsVisible(Page);
+			var tabBarVisible = Shell.GetTabBarIsVisible(Page) ? true : (Page.FindParentOfType<ShellItem>() as IShellItemController)?.ShowTabs ?? false;
 
 			ViewController.HidesBottomBarWhenPushed = !tabBarVisible;
 		}

--- a/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
@@ -157,6 +157,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(true);
 		}
 
+		[Fact]
+		public async Task PoppingModalStackFiresAppearingOnRevealedNonModalPage()
+		{
+			Shell shell = new TestShell();
+			shell.Items.Add(CreateShellItem(shellContentRoute: "MainContent"));
+
+			await shell.GoToAsync($"LifeCyclePage/ContentPage/ModalTestPage2/ModalTestPage");
+			var lifeCyclePage = shell.Descendants().OfType<ShellLifeCycleTests.LifeCyclePage>().First();
+			Assert.False(lifeCyclePage.Appearing);
+			await shell.GoToAsync($"../../..");
+			Assert.True(lifeCyclePage.Appearing);
+		}
 
 		[Fact]
 		public async Task ModalPopsWhenSwitchingShellContent()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26598.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26598.cs
@@ -10,7 +10,7 @@ public class Issue26598 : TestShell
 	ShellContent homeShellContent = new ShellContent
 	{
 		ContentTemplate = new DataTemplate(() => new Issue26598Home()),
-		Title = "Home",
+		Title = "HomeTab",
 		AutomationId = "Issue26598Home",
 		Route = nameof(Issue26598Home)
 	};
@@ -19,7 +19,7 @@ public class Issue26598 : TestShell
 	ShellContent recentShellContent = new ShellContent
 	{
 		ContentTemplate = new DataTemplate(() => new Issue26598Recent()),
-		Title = "Recent",
+		Title = "RecentTab",
 		Route = nameof(Issue26598Recent)
 	};
 
@@ -30,107 +30,106 @@ public class Issue26598 : TestShell
 		tabBar.Items.Add(homeShellContent);
 		tabBar.Items.Add(recentShellContent);
 		Items.Add(tabBar);
-		Shell.SetTabBarIsVisible(this, true);
 	}
-}
 
-public class Issue26598Home : ContentPage
-{
-	VerticalStackLayout stackLayout;
-	Button button;
-	public Issue26598Home()
+	public class Issue26598Home : ContentPage
 	{
-		Title = "Home";
-		HeightRequest = 200;
-		stackLayout = new VerticalStackLayout();
-		button = new Button()
+		VerticalStackLayout stackLayout;
+		Button button;
+		public Issue26598Home()
 		{
-			Text = "Navigate to InnerTab",
-			AutomationId = "NavigateToInnerTab",
-			VerticalOptions = LayoutOptions.Center,
-			HorizontalOptions = LayoutOptions.Center,
-		};
-		button.Clicked += Button_OnClicked;
-		stackLayout.Add(button);
-		Shell.SetTabBarIsVisible(this, true);
-		this.Content = stackLayout;
-	}
+			Title = "Home";
+			HeightRequest = 200;
+			stackLayout = new VerticalStackLayout();
+			button = new Button()
+			{
+				Text = "Navigate to InnerTab",
+				AutomationId = "NavigateToInnerTab",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+			};
+			button.Clicked += Button_OnClicked;
+			stackLayout.Add(button);
+			Shell.SetTabBarIsVisible(this, false);
+			this.Content = stackLayout;
+		}
 
-	private void Button_OnClicked(object sender, EventArgs e)
-	{
-		Shell.Current.GoToAsync(nameof(Issue26598Inner));
-	}
-
-}
-
-public class Issue26598Inner : ContentPage
-{
-	VerticalStackLayout stackLayout;
-	Button button;
-	public Issue26598Inner()
-	{
-		Title = "InnerTab";
-		stackLayout = new VerticalStackLayout();
-		button = new Button()
+		private void Button_OnClicked(object sender, EventArgs e)
 		{
-			Text = "Navigate to TabBarPage",
-			AutomationId = "NavigateToTabBarPage",
-			VerticalOptions = LayoutOptions.Center,
-			HorizontalOptions = LayoutOptions.Center,
-		};
-		button.Clicked += Button_OnClicked;
-		stackLayout.Add(button);
-		Shell.SetTabBarIsVisible(this, true);
-		this.Content = stackLayout;
+			Shell.Current.GoToAsync(nameof(Issue26598Inner));
+		}
+
 	}
 
-	private void Button_OnClicked(object sender, EventArgs e)
+	public class Issue26598Inner : ContentPage
 	{
-		Shell.Current.GoToAsync(nameof(Issue26589NonTab));
-	}
-
-}
-
-public class Issue26598Recent : ContentPage
-{
-	VerticalStackLayout stackLayout;
-	Label label;
-	public Issue26598Recent()
-	{
-		Title = "Recent";
-		HeightRequest = 200;
-
-		stackLayout = new VerticalStackLayout();
-		label = new Label()
+		VerticalStackLayout stackLayout;
+		Button button;
+		public Issue26598Inner()
 		{
-			Text = "Page Loaded in Recent Tab",
-			VerticalOptions = LayoutOptions.Center,
-			HorizontalOptions = LayoutOptions.Center,
+			Title = "InnerTab";
+			stackLayout = new VerticalStackLayout();
+			button = new Button()
+			{
+				Text = "Navigate to TabBarPage",
+				AutomationId = "NavigateToTabBarPage",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+			};
+			button.Clicked += Button_OnClicked;
+			stackLayout.Add(button);
+			Shell.SetTabBarIsVisible(this, true);
+			this.Content = stackLayout;
+		}
 
-		};
-		stackLayout.Add(label);
-		Shell.SetTabBarIsVisible(this, true);
-		this.Content = stackLayout;
-	}
-}
-public class Issue26589NonTab : ContentPage
-{
-	VerticalStackLayout stackLayout;
-	Label label1;
-	public Issue26589NonTab()
-	{
-		Title = "NoTabBarPage";
-		stackLayout = new VerticalStackLayout();
-		label1 = new Label()
+		private void Button_OnClicked(object sender, EventArgs e)
 		{
-			Text = "This is Non TabBarPage",
-			AutomationId = "Issue26589NonTab",
-			VerticalOptions = LayoutOptions.Center,
-			HorizontalOptions = LayoutOptions.Center,
-		};
-		stackLayout.Add(label1);
-		Shell.SetTabBarIsVisible(this, false);
-		this.Content = stackLayout;
+			Shell.Current.GoToAsync(nameof(Issue26589NonTab));
+		}
+
 	}
 
+	public class Issue26598Recent : ContentPage
+	{
+		VerticalStackLayout stackLayout;
+		Label label;
+		public Issue26598Recent()
+		{
+			Title = "Recent";
+			HeightRequest = 200;
+
+			stackLayout = new VerticalStackLayout();
+			label = new Label()
+			{
+				Text = "Page Loaded in Recent Tab",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+
+			};
+			stackLayout.Add(label);
+			Shell.SetTabBarIsVisible(this, true);
+			this.Content = stackLayout;
+		}
+	}
+	public class Issue26589NonTab : ContentPage
+	{
+		VerticalStackLayout stackLayout;
+		Label label1;
+		public Issue26589NonTab()
+		{
+			Title = "NoTabBarPage";
+			stackLayout = new VerticalStackLayout();
+			label1 = new Label()
+			{
+				Text = "This is Non TabBarPage",
+				AutomationId = "Issue26589NonTab",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+			};
+			stackLayout.Add(label1);
+			Shell.SetTabBarIsVisible(this, false);
+			this.Content = stackLayout;
+		}
+
+	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26598.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26598.cs
@@ -1,0 +1,136 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 26598, "Tabbar disappears when navigating back from page with hidden TabBar in iOS", PlatformAffected.iOS)]
+public class Issue26598 : TestShell
+{
+	TabBar tabBar = new TabBar();
+
+	// Create first ShellContent
+	ShellContent homeShellContent = new ShellContent
+	{
+		ContentTemplate = new DataTemplate(() => new Issue26598Home()),
+		Title = "Home",
+		AutomationId = "Issue26598Home",
+		Route = nameof(Issue26598Home)
+	};
+
+	// Create second ShellContent
+	ShellContent recentShellContent = new ShellContent
+	{
+		ContentTemplate = new DataTemplate(() => new Issue26598Recent()),
+		Title = "Recent",
+		Route = nameof(Issue26598Recent)
+	};
+
+	protected override void Init()
+	{
+		Routing.RegisterRoute("Issue26598Inner", typeof(Issue26598Inner));
+		Routing.RegisterRoute(nameof(Issue26589NonTab), typeof(Issue26589NonTab));
+		tabBar.Items.Add(homeShellContent);
+		tabBar.Items.Add(recentShellContent);
+		Items.Add(tabBar);
+		Shell.SetTabBarIsVisible(this, true);
+	}
+}
+
+public class Issue26598Home : ContentPage
+{
+	VerticalStackLayout stackLayout;
+	Button button;
+	public Issue26598Home()
+	{
+		Title = "Home";
+		HeightRequest = 200;
+		stackLayout = new VerticalStackLayout();
+		button = new Button()
+		{
+			Text = "Navigate to InnerTab",
+			AutomationId = "NavigateToInnerTab",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+		};
+		button.Clicked += Button_OnClicked;
+		stackLayout.Add(button);
+		Shell.SetTabBarIsVisible(this, true);
+		this.Content = stackLayout;
+	}
+
+	private void Button_OnClicked(object sender, EventArgs e)
+	{
+		Shell.Current.GoToAsync(nameof(Issue26598Inner));
+	}
+
+}
+
+public class Issue26598Inner : ContentPage
+{
+	VerticalStackLayout stackLayout;
+	Button button;
+	public Issue26598Inner()
+	{
+		Title = "InnerTab";
+		stackLayout = new VerticalStackLayout();
+		button = new Button()
+		{
+			Text = "Navigate to TabBarPage",
+			AutomationId = "NavigateToTabBarPage",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+		};
+		button.Clicked += Button_OnClicked;
+		stackLayout.Add(button);
+		Shell.SetTabBarIsVisible(this, true);
+		this.Content = stackLayout;
+	}
+
+	private void Button_OnClicked(object sender, EventArgs e)
+	{
+		Shell.Current.GoToAsync(nameof(Issue26589NonTab));
+	}
+
+}
+
+public class Issue26598Recent : ContentPage
+{
+	VerticalStackLayout stackLayout;
+	Label label;
+	public Issue26598Recent()
+	{
+		Title = "Recent";
+		HeightRequest = 200;
+
+		stackLayout = new VerticalStackLayout();
+		label = new Label()
+		{
+			Text = "Page Loaded in Recent Tab",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+
+		};
+		stackLayout.Add(label);
+		Shell.SetTabBarIsVisible(this, true);
+		this.Content = stackLayout;
+	}
+}
+public class Issue26589NonTab : ContentPage
+{
+	VerticalStackLayout stackLayout;
+	Label label1;
+	public Issue26589NonTab()
+	{
+		Title = "NoTabBarPage";
+		stackLayout = new VerticalStackLayout();
+		label1 = new Label()
+		{
+			Text = "This is Non TabBarPage",
+			AutomationId = "Issue26589NonTab",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+		};
+		stackLayout.Add(label1);
+		Shell.SetTabBarIsVisible(this, false);
+		this.Content = stackLayout;
+	}
+
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
@@ -33,7 +33,7 @@ public class Issue26598 : _IssuesUITest
 		App.Click("Recent");
 		App.WaitForElement("Home");
 		App.Click("Home");
-		App.WaitForElement("Home");
+		VerifyScreenshot();
 	}
 }
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
@@ -23,17 +23,25 @@ public class Issue26598 : _IssuesUITest
 	public void TabBarShouldbeVisibleNavigatingBackFromNonTabbedPage()
 	{
 		// Is a iOS issue; see https://github.com/dotnet/maui/issues/26598
+		// Initially TabBar for Issue26598Home is hidden 
 		App.WaitForElement("NavigateToInnerTab");
 		App.Click("NavigateToInnerTab");
+
+		// Case 1 - After navigating to Inner Page ,  the TabBar should be visible
+		App.WaitForElement("RecentTab");
+
+		// Case 2 - Navigate to the InnerTabPage where the TabBar is hidden
 		App.WaitForElement("NavigateToTabBarPage");
 		App.Click("NavigateToTabBarPage");
 		App.WaitForElement("Issue26589NonTab");
+
+		// Case 3 - Navigate back to the HomeTab, the TabBar should be visible
 		App.TapBackArrow(back);
-		App.WaitForElement("Recent");
-		App.Click("Recent");
-		App.WaitForElement("Home");
-		App.Click("Home");
-		VerifyScreenshot();
+		App.WaitForElement("RecentTab");
+		App.Click("RecentTab");
+		App.WaitForElement("HomeTab");
+		App.Click("HomeTab");
+		App.WaitForElement("RecentTab");
 	}
 }
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue26598 : _IssuesUITest
+{
+	public override string Issue => "Tabbar disappears when navigating back from page with hidden TabBar in iOS";
+
+#if ANDROID
+    const string back = "";
+#else
+	const string back = "InnerTab";
+#endif
+
+	public Issue26598(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void TabBarShouldbeVisibleNavigatingBackFromNonTabbedPage()
+	{
+		// Is a iOS issue; see https://github.com/dotnet/maui/issues/26598
+		App.WaitForElement("NavigateToInnerTab");
+		App.Click("NavigateToInnerTab");
+		App.WaitForElement("NavigateToTabBarPage");
+		App.Click("NavigateToTabBarPage");
+		App.WaitForElement("Issue26589NonTab");
+		App.TapBackArrow(back);
+		App.WaitForElement("Recent");
+		App.Click("Recent");
+		App.WaitForElement("Home");
+		App.Click("Home");
+		VerifyScreenshot();
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26598.cs
@@ -33,7 +33,7 @@ public class Issue26598 : _IssuesUITest
 		App.Click("Recent");
 		App.WaitForElement("Home");
 		App.Click("Home");
-		VerifyScreenshot();
+		App.WaitForElement("Home");
 	}
 }
 


### PR DESCRIPTION
### Issue Details

When `TabBarIsVisible` is set to false on an inner page, navigating back to the previous page and switching between tabs causes the tab bar visibility to not update correctly.

### Root Cause
In iOS 18, `UIViewController.HidesBottomBarWhenPushed` does not reliably update the tab bar visibility. This property must be set before the page is pushed, which leads to inconsistent behavior when toggling between tabs.

### Description of Change
For iOS 18 and later, tab bar visibility is effectively managed using the `TabBarHidden` property. Therefore, I have restricted the use of `UIViewController.HidesBottomBarWhenPushed` to iOS versions prior to 18 within the `UpdateTabBarVisible` method.


### Issues Fixed
Fixes #26598

### Tested the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [ ] Mac

### Known Issue 
`ItemsUpdatingScrollMode` is not implemented in CollectionView2 
 

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="200" height="200" alt="Before Fix video" src="https://github.com/user-attachments/assets/0b5e2f1d-ef2e-4923-8160-5ef3cf9d70e4">|<video width="200" height="200" alt="After Fix video" src="https://github.com/user-attachments/assets/1c9cda45-ac87-4673-8f16-a3adb1f98381">