### PR TITLE
[Android] Fixed the ScrollbarVisibility issues

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Platform
 		ScrollBarVisibility _defaultHorizontalScrollVisibility;
 		ScrollBarVisibility _defaultVerticalScrollVisibility;
 		ScrollBarVisibility _horizontalScrollVisibility;
+		ScrollBarVisibility _verticalScrollVisibility;
 
 		internal float LastX { get; set; }
 		internal float LastY { get; set; }
@@ -63,10 +64,13 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_hScrollView.HorizontalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
+			_hScrollView.ScrollbarFadingEnabled = _horizontalScrollVisibility != ScrollBarVisibility.Always;
+			_hScrollView.RequestLayout();
 		}
 
 		public void SetVerticalScrollBarVisibility(ScrollBarVisibility scrollBarVisibility)
 		{
+			_verticalScrollVisibility = scrollBarVisibility;
 			if (_defaultVerticalScrollVisibility == 0)
 				_defaultVerticalScrollVisibility = VerticalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
 
@@ -74,8 +78,8 @@ namespace Microsoft.Maui.Platform
 				scrollBarVisibility = _defaultVerticalScrollVisibility;
 
 			VerticalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
-
-			this.HandleScrollBarVisibilityChange();
+			ScrollbarFadingEnabled = _verticalScrollVisibility != ScrollBarVisibility.Always;
+			RequestLayout();
 		}
 
 		public void SetContent(View content)
@@ -428,7 +432,6 @@ namespace Microsoft.Maui.Platform
 			set
 			{
 				base.HorizontalScrollBarEnabled = value;
-				this.HandleScrollBarVisibilityChange();
 			}
 		}
 

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Platform
 
 		public void SetVerticalScrollBarVisibility(ScrollBarVisibility scrollBarVisibility)
 		{
-			ScrollBarVisibility _verticalScrollVisibility = scrollBarVisibility;
+			ScrollBarVisibility verticalScrollVisibility = scrollBarVisibility;
 
 			if (_defaultVerticalScrollVisibility == 0)
 				_defaultVerticalScrollVisibility = VerticalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Platform
 				scrollBarVisibility = _defaultVerticalScrollVisibility;
 
 			VerticalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
-			ScrollbarFadingEnabled = _verticalScrollVisibility != ScrollBarVisibility.Always;
+			ScrollbarFadingEnabled = verticalScrollVisibility != ScrollBarVisibility.Always;
 			PlatformInterop.RequestLayoutIfNeeded(this);
 		}
 

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui.Platform
 		ScrollBarVisibility _defaultHorizontalScrollVisibility;
 		ScrollBarVisibility _defaultVerticalScrollVisibility;
 		ScrollBarVisibility _horizontalScrollVisibility;
-		ScrollBarVisibility _verticalScrollVisibility;
 
 		internal float LastX { get; set; }
 		internal float LastY { get; set; }
@@ -65,12 +64,13 @@ namespace Microsoft.Maui.Platform
 
 			_hScrollView.HorizontalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
 			_hScrollView.ScrollbarFadingEnabled = _horizontalScrollVisibility != ScrollBarVisibility.Always;
-			_hScrollView.RequestLayout();
+			PlatformInterop.RequestLayoutIfNeeded(this);
 		}
 
 		public void SetVerticalScrollBarVisibility(ScrollBarVisibility scrollBarVisibility)
 		{
-			_verticalScrollVisibility = scrollBarVisibility;
+			ScrollBarVisibility _verticalScrollVisibility = scrollBarVisibility;
+
 			if (_defaultVerticalScrollVisibility == 0)
 				_defaultVerticalScrollVisibility = VerticalScrollBarEnabled ? ScrollBarVisibility.Always : ScrollBarVisibility.Never;
 
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Platform
 
 			VerticalScrollBarEnabled = scrollBarVisibility == ScrollBarVisibility.Always;
 			ScrollbarFadingEnabled = _verticalScrollVisibility != ScrollBarVisibility.Always;
-			RequestLayout();
+			PlatformInterop.RequestLayoutIfNeeded(this);
 		}
 
 		public void SetContent(View content)

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -146,6 +146,32 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, result);
 		}
 
+		[Theory]
+		[InlineData(ScrollBarVisibility.Always, false)]
+		[InlineData(ScrollBarVisibility.Default, true)]
+		[InlineData(ScrollBarVisibility.Never, true)]
+		public async Task VerticalandHorizontalScrollbarFadingInitializesCorrectlyOnBothOrientation(ScrollBarVisibility visibility, bool expected)
+		{
+			bool result = await InvokeOnMainThreadAsync(() =>
+			{
+				var scrollView = new ScrollViewStub()
+				{
+					Orientation = ScrollOrientation.Both,
+					HorizontalScrollBarVisibility = visibility,
+					VerticalScrollBarVisibility = visibility
+				};
+
+				var scrollViewHandler = CreateHandler(scrollView);
+
+				var horizontalScrollView = (MauiHorizontalScrollView)scrollViewHandler.PlatformView.GetChildAt(0);
+				var verticalScrollView = (MauiScrollView)scrollViewHandler.PlatformView;
+
+				return horizontalScrollView.ScrollbarFadingEnabled && verticalScrollView.ScrollbarFadingEnabled;
+			});
+
+			Assert.Equal(expected, result);
+		}
+
 		[Fact]
 		public async Task MauiScrollViewGetsFullHeightInHorizontalOrientation()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -102,6 +102,50 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, result);
 		}
 
+		[Theory]
+		[InlineData(ScrollBarVisibility.Always, false)]
+		[InlineData(ScrollBarVisibility.Default, true)]
+		[InlineData(ScrollBarVisibility.Never, true)]
+		public async Task VerticalScrollbarFadingInitializesCorrectly(ScrollBarVisibility visibility, bool expected)
+		{
+			bool result = await InvokeOnMainThreadAsync(() =>
+			{
+				var scrollView = new ScrollViewStub()
+				{
+					Orientation = ScrollOrientation.Vertical,
+					VerticalScrollBarVisibility = visibility
+				};
+
+				var scrollViewHandler = CreateHandler(scrollView);
+
+				return ((MauiScrollView)scrollViewHandler.PlatformView).ScrollbarFadingEnabled;
+			});
+
+			Assert.Equal(expected, result);
+		}
+
+		[Theory]
+		[InlineData(ScrollBarVisibility.Always, false)]
+		[InlineData(ScrollBarVisibility.Default, true)]
+		[InlineData(ScrollBarVisibility.Never, true)]
+		public async Task HorizontalScrollbarFadingInitializesCorrectly(ScrollBarVisibility visibility, bool expected)
+		{
+			bool result = await InvokeOnMainThreadAsync(() =>
+			{
+				var scrollView = new ScrollViewStub()
+				{
+					Orientation = ScrollOrientation.Horizontal,
+					HorizontalScrollBarVisibility = visibility
+				};
+
+				var scrollViewHandler = CreateHandler(scrollView);
+
+				return ((MauiHorizontalScrollView)scrollViewHandler.PlatformView.GetChildAt(0)).ScrollbarFadingEnabled;
+			});
+
+			Assert.Equal(expected, result);
+		}
+
 		[Fact]
 		public async Task MauiScrollViewGetsFullHeightInHorizontalOrientation()
 		{


### PR DESCRIPTION
### Root Cause of the issue



#### Initial Case: 

- The `ScrollBarFadingEnabled` property is always set to true even when `ScrollBarVisibility` is set to `Always`. As a result, the scrollbar remains hidden in the Always visibility mode. 

#### Dynamic Case: 

- After fixing the initial issue, it was observed that when the visibility mode changes dynamically from `Default` to `Always`, the scrollbar does not display correctly. Although `ScrollBarFadingEnabled` is updated properly, the scrollbar remains hidden because the HandleScrollBarVisibilityChange method processes both its true and false states, and RequestLayout is not called.

- In the native Android itself, dynamic changes to `ScrollbarFadingEnabled` are not properly reflected in the UI until the view is scrolled. Calling `RequestLayout` when dynamic changes occur ensures that the native UI updates correctly. 



### Description of Change


#### Initial Case: 

- Setting `ScrollBarFadingEnabled` based on ScrollBarVisibility resolves the issue. 

#### Dynamic Case: 

- Removing the HandleScrollBarVisibilityChange method which was responsible for awakening the scrollbars and adding a call to `RequestLayoutIfNeeded ` efficiently resolves the dynamic issues and ensures that the UI updates properly. With RequestLayoutIfNeeded, calling AwakenScrollBars may no longer be necessary. 



### Issues Fixed



Fixes #24894
Fixes #12760



### Tested the behaviour in the following platforms



- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac



### Screenshot


#### VerticalScrollbarVisibility
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/3e0e8ec8-371d-418a-a23a-146333f5ec2e"> | <video src="https://github.com/user-attachments/assets/73c8ab36-cd15-4767-8a12-96576eca9f0d"> |


#### HorizontalScrollbarVisibility
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/58148373-732f-47c1-bb16-fadcc1e90432"> | <video src="https://github.com/user-attachments/assets/8be4d47a-5191-45c7-bae3-c3fa56e6178b"> |




