### PR TITLE
Timeout Android emulator start

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -459,11 +459,12 @@ async Task HandleVirtualDevice(AndroidEmulatorToolSettings emuSettings, AndroidA
 				emulatorProcess = AndroidEmulatorStart(avdName, emuSettings);
 			}
 
-			if (IsCIBuild())
+			if (IsCIBuild() && emulatorProcess is not null)
 			{
 				Information("Setting Logcat Values");
 				AdbLogcat(new AdbLogcatOptions() { Clear = true });
 				AdbShell("logcat -G 16M");
+				Information("Finished Setting Logcat Values");
 			}
 		}).WaitAsync(TimeSpan.FromMinutes(2));
 	}

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -61,17 +61,6 @@ AndroidEmulatorProcess emulatorProcess = null;
 
 var dotnetToolPath = GetDotnetToolPath();
 
-Setup(context =>
-{
-	LogSetupInfo(dotnetToolPath);
-
-	PerformCleanupIfNeeded(deviceCleanupEnabled);
-
-	DetermineDeviceCharacteristics(testDevice, DefaultApiLevel);
-
-	HandleVirtualDevice(emuSettings, avdSettings, androidAvd, androidAvdImage, deviceSkin, deviceBoot);
-});
-
 Teardown(context =>
 {
 	// For the uitest-prepare target, just leave the virtual device running
@@ -82,9 +71,24 @@ Teardown(context =>
 
 });
 
-Task("boot");
+Task("Setup")
+	.Does(async () =>
+	{
+		LogSetupInfo(dotnetToolPath);
+
+		PerformCleanupIfNeeded(deviceCleanupEnabled);
+
+		DetermineDeviceCharacteristics(testDevice, DefaultApiLevel);
+
+		// The Emulator Start command seems to hang sometimes so let's only give it two minutes to complete
+		await HandleVirtualDevice(emuSettings, avdSettings, androidAvd, androidAvdImage, deviceSkin, deviceBoot);
+	});
+
+Task("boot")
+	.IsDependentOn("Setup");
 
 Task("build")
+	.IsDependentOn("Setup")
 	.WithCriteria(!string.IsNullOrEmpty(projectPath))
 	.Does(() =>
 	{
@@ -99,6 +103,7 @@ Task("test")
 	});
 
 Task("uitest-build")
+	.IsDependentOn("Setup")
 	.IsDependentOn("dotnet-buildtasks")
 	.Does(() =>
 	{
@@ -106,6 +111,7 @@ Task("uitest-build")
 	});
 
 Task("uitest-prepare")
+	.IsDependentOn("Setup")
 	.Does(() =>
 	{
 		ExecutePrepareUITests(projectPath, testAppProjectPath, testAppPackageName, testDevice, testResultsPath, binlogDirectory, configuration, targetFramework, "", androidVersion, dotnetToolPath, testAppInstrumentation);
@@ -119,6 +125,7 @@ Task("uitest")
 	});
 
 Task("logcat")
+	.IsDependentOn("Setup")
 	.Does(() =>
 {
 	WriteLogCat();
@@ -425,32 +432,45 @@ void DetermineDeviceCharacteristics(string deviceDescriptor, int defaultApiLevel
 	}
 }
 
-void HandleVirtualDevice(AndroidEmulatorToolSettings emuSettings, AndroidAvdManagerToolSettings avdSettings, string avdName, string avdImage, string avdSkin, bool boot)
+async Task HandleVirtualDevice(AndroidEmulatorToolSettings emuSettings, AndroidAvdManagerToolSettings avdSettings, string avdName, string avdImage, string avdSkin, bool boot)
 {
-	Information("Test Device ID: {0}", avdImage);
-
-	if (boot)
+	try
 	{
-		Information("Trying to boot the emulator...");
+		// The Emulator Start command seems to hang sometimes so let's only give it two minutes to complete
+		await System.Threading.Tasks.Task.Run(() =>
+		{
+			Information("Test Device ID: {0}", avdImage);
 
-		// delete the AVD first, if it exists
-		Information("Deleting AVD if exists: {0}...", avdName);
-		try { AndroidAvdDelete(avdName, avdSettings); }
-		catch { }
+			if (boot)
+			{
+				Information("Trying to boot the emulator...");
 
-		// create the new AVD
-		Information("Creating AVD: {0} ({1})...", avdName, avdImage);
-		AndroidAvdCreate(avdName, avdImage, avdSkin, force: true, settings: avdSettings);
+				// delete the AVD first, if it exists
+				Information("Deleting AVD if exists: {0}...", avdName);
+				try { AndroidAvdDelete(avdName, avdSettings); }
+				catch { }
 
-		// start the emulator
-		Information("Starting Emulator: {0}...", avdName);
-		emulatorProcess = AndroidEmulatorStart(avdName, emuSettings);
+				// create the new AVD
+				Information("Creating AVD: {0} ({1})...", avdName, avdImage);
+				AndroidAvdCreate(avdName, avdImage, avdSkin, force: true, settings: avdSettings);
+
+				// start the emulator
+				Information("Starting Emulator: {0}...", avdName);
+				emulatorProcess = AndroidEmulatorStart(avdName, emuSettings);
+			}
+
+			if (IsCIBuild())
+			{
+				Information("Setting Logcat Values");
+				AdbLogcat(new AdbLogcatOptions() { Clear = true });
+				AdbShell("logcat -G 16M");
+			}
+		}).WaitAsync(TimeSpan.FromMinutes(2));
 	}
-
-	if (IsCIBuild())
+	catch(TimeoutException)
 	{
-		AdbLogcat(new AdbLogcatOptions() { Clear = true });
-		AdbShell("logcat -G 16M");
+		Error("Failed to start the Android Emulator.");
+		throw;
 	}
 }
 


### PR DESCRIPTION
### Description of Change
Occasionally the android emulator fails to start and then the process just hangs until CI just times out the pipeline

This adds code that will just fail the cake script after 2 minutes