### PR TITLE
[tests] Run tests on x64 again

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -68,6 +68,7 @@ parameters:
       vmImage: $(androidTestsVmImage)
       demands:
         - macOS.Name -equals Sonoma
+        - macOS.Architecture -equals x64
 
   - name: iosPool
     type: object


### PR DESCRIPTION
### Description of Change

Reveting some changes made [here](https://github.com/dotnet/maui/pull/27560) where we removed the x64 demand. 
Seems we have some Android device tests that fail when running on arm, the idea was to be able to make these run in both arm and x64 so we can pick any available image

