### PR TITLE
[tests] Run tests on x64 only for devices controls

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -376,6 +376,7 @@ AndroidEmulatorToolSettings AdjustEmulatorSettingsForCI(AndroidEmulatorToolSetti
 
 void DetermineDeviceCharacteristics(string deviceDescriptor, int defaultApiLevel)
 {
+	var isArm64 = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64;
 	var working = deviceDescriptor.Trim().ToLower();
 	var emulator = true;
 	var api = defaultApiLevel;
@@ -407,7 +408,7 @@ void DetermineDeviceCharacteristics(string deviceDescriptor, int defaultApiLevel
 	}
 	else if (parts[2] == "64")
 	{
-		if (System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
+		if (isArm64)
 			deviceArch = "arm64-v8a";
 		else if (emulator)
 			deviceArch = "x86_64";
@@ -417,6 +418,8 @@ void DetermineDeviceCharacteristics(string deviceDescriptor, int defaultApiLevel
 	var sdk = api >= 27 ? "google_apis_playstore" : "google_apis";
 	if (api == 27 && deviceArch == "x86_64")
 		sdk = "default";
+	if (api == 27 && deviceArch == "arm64-v8a")
+		sdk = "google_apis";
 
 	androidAvdImage = $"system-images;android-{api};{sdk};{deviceArch}";
 

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -26,20 +26,18 @@ steps:
       timeoutInMinutes: 60
   - template: provision.yml
     parameters:
-      ${{ if eq(parameters.platform, 'windows')}}:
+      ${{ if eq(parameters.platform, 'windows') }}:
         platform: windows
-      ${{ if or(eq(parameters.platform, 'ios'), eq(parameters.platform, 'catalyst'), eq(parameters.platform, 'android'))}}:
+      ${{ if or(eq(parameters.platform, 'ios'), eq(parameters.platform, 'catalyst'), eq(parameters.platform, 'android')) }}:
         platform: macos
       skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
       skipAndroidImages : ${{ or(eq(parameters.platform, 'ios'), eq(parameters.platform, 'catalyst')) }}
       skipAndroidSdks: ${{ or(eq(parameters.platform, 'ios'), eq(parameters.platform, 'catalyst'))  }}
       installDefaultAndroidApi: ${{ or(eq(parameters.platform, 'ios'), eq(parameters.platform, 'catalyst'))  }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-      ${{ if not(parameters.skipProvisioning) }}:
+      ${{ if eq(parameters.skipProvisioning, false) }}:
         skipProvisionator : false
         gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      ${{ else }}:  
-        skipProvisionator: true
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
     displayName: 'Install .NET'

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -1,5 +1,6 @@
 parameters:
   androidPool: { }
+  androidPoolX64: { }
   iosPool: { }
   catalystPool: { }
   windowsPool: { }
@@ -34,48 +35,44 @@ stages:
     ${{ else }}:
       dependsOn: []
     jobs:
-    - job: android_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
-      workspace:
-        clean: all
-      displayName: "Android"
-      pool: ${{ parameters.androidPool }}
-      timeoutInMinutes: 60
-      strategy:
-        matrix:
-          # create all the variables used for the matrix
-          ${{ each project in parameters.projects }}:
-            ${{ if ne(project.android, '') }}:
-              ${{ each api in parameters.androidApiLevels }}:
-                ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
-                  ${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_API_${{ api }}:
-                    REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
-                    PROJECT_PATH: ${{ project.android }}
-                    ANDROID_CONFIGURATION: ${{ project.androidConfiguration }}
-                    TARGET_FRAMEWORK_VERSION: ${{ parameters.targetFrameworkVersion.tfm }}
-                    ${{ if eq(api, 27) }}:
-                      DEVICE: android-emulator-32_${{ api }}
-                      APIVERSION: ${{ api }}
-                    ${{ if not(eq(api, 27)) }}:
-                      DEVICE: android-emulator-64_${{ api }}
-                      APIVERSION: ${{ api }}
-      steps:
-        - template: device-tests-steps.yml
-          parameters:
-            platform: android
-            path: $(PROJECT_PATH) 
-            device: $(DEVICE)
-            apiVersion: $(APIVERSION)
-            windowsPackageId: android # Only needed for Windows, will be ignored
-            provisionatorChannel: ${{ parameters.provisionatorChannel }}
-            agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-            artifactName: ${{ parameters.artifactName }}
-            artifactItemPattern: ${{ parameters.artifactItemPattern }}
-            checkoutDirectory: ${{ parameters.checkoutDirectory }}
-            useArtifacts: ${{ parameters.useArtifacts }}
-            poolName: ${{ parameters.androidPool.name }}
-            deviceTestConfiguration: $(ANDROID_CONFIGURATION)
-            skipProvisioning: ${{ parameters.skipProvisioning }}
-
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.android, '') }}:
+          - ${{ each api in parameters.androidApiLevels }}:
+            - ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
+              - job: android_device_tests_${{ project.name }}_${{ api }}
+                timeoutInMinutes: 60
+                workspace:
+                  clean: all
+                displayName: android_${{ replace(coalesce(project.desc, project.name), ' ', '_') }}_API_${{ api }}
+                ${{ if eq(coalesce(project.desc, project.name), 'Controls') }}:
+                  pool: ${{ parameters.androidPoolX64 }}
+                ${{ else }}:
+                  pool: ${{ parameters.androidPool }}
+                variables:
+                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+                  PROJECT_PATH: ${{ project.android }}
+                  ANDROID_CONFIGURATION: ${{ project.androidConfiguration }}
+                  TARGET_FRAMEWORK_VERSION: ${{ parameters.targetFrameworkVersion.tfm }}
+                  DEVICE: android-emulator-64_${{ api }}
+                  APIVERSION: ${{ api }}                  
+                steps:
+                  - template: device-tests-steps.yml
+                    parameters:
+                      platform: android
+                      path: $(PROJECT_PATH) 
+                      device: $(DEVICE)
+                      apiVersion: $(APIVERSION)
+                      windowsPackageId: android # Only needed for Windows, will be ignored
+                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+                      artifactName: ${{ parameters.artifactName }}
+                      artifactItemPattern: ${{ parameters.artifactItemPattern }}
+                      checkoutDirectory: ${{ parameters.checkoutDirectory }}
+                      useArtifacts: ${{ parameters.useArtifacts }}
+                      poolName: ${{ parameters.androidPool.name }}
+                      deviceTestConfiguration: $(ANDROID_CONFIGURATION)
+                      skipProvisioning: ${{ parameters.skipProvisioning }}
+  
   - stage: ios_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
     displayName: ${{ parameters.targetFrameworkVersion.tfm }} iOS Device Tests
     ${{ if ne(parameters.targetFrameworkVersion.dependsOn, '') }}:
@@ -173,7 +170,6 @@ stages:
             poolName: 'Azure Pipelines'
             skipProvisioning: ${{ parameters.skipProvisioning }}
             deviceTestConfiguration: $(IOS_CONFIGURATION)
-
 
   - stage: windows_device_tests_${{ replace(parameters.targetFrameworkVersion.tfm, '.', '') }}
     displayName: ${{ parameters.targetFrameworkVersion.tfm }} Windows Device Tests

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -69,6 +69,15 @@ parameters:
       demands:
         - macOS.Name -equals Sonoma
 
+  - name: androidPoolX64
+    type: object
+    default:
+      name: $(androidTestsVmPool)
+      vmImage: $(androidTestsVmImage)
+      demands:
+        - macOS.Name -equals Sonoma
+        - macOS.Architecture -equals x64
+
   - name: iosPool
     type: object
     default:
@@ -109,6 +118,7 @@ stages:
   - template: common/device-tests.yml
     parameters:
       androidPool: ${{ parameters.androidPool }}
+      androidPoolX64: ${{ parameters.androidPoolX64 }}
       iosPool: ${{ parameters.iosPool }}
       catalystPool: ${{ parameters.catalystPool }}
       windowsPool: ${{ parameters.windowsPool }}


### PR DESCRIPTION
### Description of Change

- added a pool for x64 android 
- Make sure to run Controls device tests on X64 machines

