### PR TITLE
 [Android] Fix Cursor Not Closing in File Picker to Prevent Log Spam.

### DIFF
--- a/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
@@ -344,7 +344,8 @@ namespace Microsoft.Maui.Storage
 				if (columnIndex != -1)
 					text = cursor.GetString(columnIndex);
 			}
-			if(cursor != null && !cursor.IsClosed)
+
+			if (cursor is not null && !cursor.IsClosed)
 			   cursor.Close();
 
 			return text;

--- a/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.android.cs
@@ -344,6 +344,8 @@ namespace Microsoft.Maui.Storage
 				if (columnIndex != -1)
 					text = cursor.GetString(columnIndex);
 			}
+			if(cursor != null && !cursor.IsClosed)
+			   cursor.Close();
 
 			return text;
 		}


### PR DESCRIPTION
### Description of Change
When using the File Picker API (FilePicker.PickAsync()) on Android , following warnings are being spammed on debug console:
<img width="818" alt="Screenshot 2025-02-11 at 11 30 46 PM" src="https://github.com/user-attachments/assets/8cd12015-ee87-4525-bced-838cc1f9e162" />
This issue occurs because  cursor  does not being immediately closed.Even though the cursor is inside a using statement, Android system still logs these warnings.To ensure immediate cleanup, this PR explicitly calls `cursor.Close();`preventing log spam and potential resource leaks.

### Issues Fixed
Fixes #27716 



