### PR TITLE
Fixed FontImageSource icon color does not change in the TabbedPage when dynamically updated. 

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Page), null);
 
 		/// <summary>Bindable property for <see cref="IconImageSource"/>.</summary>
-		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(Page), default(ImageSource));
+		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(Page), default(ImageSource), propertyChanged: (b, o, n) => OnImageSourceChanged(b, o, n));
 
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;
 
@@ -79,6 +79,20 @@ namespace Microsoft.Maui.Controls
 		internal View TitleView;
 
 		List<Action> _pendingActions = new List<Action>();
+
+		static void OnImageSourceChanged(BindableObject bindable, object oldvalue, object newValue)
+		{
+			if (oldvalue is ImageSource oldImageSource)
+				oldImageSource.SourceChanged -= ((Page)bindable).OnImageSourceSourceChanged;
+
+			if (newValue is ImageSource newImageSource)
+				newImageSource.SourceChanged += ((Page)bindable).OnImageSourceSourceChanged;
+		}
+
+		void OnImageSourceSourceChanged(object sender, EventArgs e)
+		{
+			OnPropertyChanged(IconImageSourceProperty.PropertyName);
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Page"/> class.

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(Page), null);
 
 		/// <summary>Bindable property for <see cref="IconImageSource"/>.</summary>
-		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(Page), default(ImageSource), propertyChanged: (b, o, n) => OnImageSourceChanged(b, o, n));
+		public static readonly BindableProperty IconImageSourceProperty = BindableProperty.Create(nameof(IconImageSource), typeof(ImageSource), typeof(Page), default(ImageSource), propertyChanged: OnImageSourceChanged);
 
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;
 
@@ -79,20 +79,6 @@ namespace Microsoft.Maui.Controls
 		internal View TitleView;
 
 		List<Action> _pendingActions = new List<Action>();
-
-		static void OnImageSourceChanged(BindableObject bindable, object oldvalue, object newValue)
-		{
-			if (oldvalue is ImageSource oldImageSource)
-				oldImageSource.SourceChanged -= ((Page)bindable).OnImageSourceSourceChanged;
-
-			if (newValue is ImageSource newImageSource)
-				newImageSource.SourceChanged += ((Page)bindable).OnImageSourceSourceChanged;
-		}
-
-		void OnImageSourceSourceChanged(object sender, EventArgs e)
-		{
-			OnPropertyChanged(IconImageSourceProperty.PropertyName);
-		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Page"/> class.
@@ -914,6 +900,20 @@ namespace Microsoft.Maui.Controls
 					this.OnUnloaded(() => this.DisconnectHandlers());
 				}
 			}
+		}
+
+		static void OnImageSourceChanged(BindableObject bindable, object oldvalue, object newValue)
+		{
+			if (oldvalue is ImageSource oldImageSource)
+				oldImageSource.SourceChanged -= ((Page)bindable).OnImageSourceSourceChanged;
+
+			if (newValue is ImageSource newImageSource)
+				newImageSource.SourceChanged += ((Page)bindable).OnImageSourceSourceChanged;
+		}
+
+		void OnImageSourceSourceChanged(object sender, EventArgs e)
+		{
+			OnPropertyChanged(IconImageSourceProperty.PropertyName);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Issue Details

The FontImageSource Icon color of the TabbedPage is not updated at run time.

### Root Cause

The SourceChanged event is not implemented for the IconImageSource in the Page.

### Description of Change

Implementing a source changed event listener for IconImageSource in the ImageSource call back. When the ImageSource changes are detected, manually triggering PropertyChanged for IconImageSource.This propagates the change through the UI update mechanism, ensuring the TabbedPage icon reflects the new state.

Validated the behaviour in the following platforms

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes #27549

**NOTE : This PR is dependent on the following PR's .**
Android and iOS PR - https://github.com/dotnet/maui/pull/26757
Windows PR - https://github.com/dotnet/maui/pull/26888

TestCase - I will modify the testcase once the above PR's are merged.

### Output

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/8106b640-67b7-4d4d-9fcb-acead02aba10">|<video src="https://github.com/user-attachments/assets/a4364103-1925-4f6e-b265-894ad37c006b">|




