### PR TITLE
Add ISO information to Locale API documentation

### DIFF
--- a/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
@@ -194,14 +194,24 @@ namespace Microsoft.Maui.Media
 		/// <summary>
 		/// Gets the language name or code.
 		/// </summary>
-		/// <remarks>This value may vary between platforms.</remarks>
+		/// <remarks>
+		/// <para>This value may vary between platforms.</para>
+		/// <para>
+		/// For Android this used the ISO 639 alpha-2 or alpha-3 language code, or registered language subtags up to 8 alpha letters (for future enhancements).
+		/// When a language has both an alpha-2 code and an alpha-3 code, the alpha-2 code must be used.
+		/// </para>
+		/// <para>For iOS and Windows this uses the BCP-47 language code.</para>
+		/// </remarks>
 		public string Language { get; }
 
 		/// <summary>
 		/// Gets the country name or code.
 		/// </summary>
-		/// <remarks>This value may vary between platforms.</remarks>
-
+		/// <remarks>
+		/// <para>This value may vary between platforms.</para>
+		/// <para>For Android this used the ISO 3166 alpha-2 country code or UN M.49 numeric-3 area code.</para>
+		/// <para>For iOS and Windows this field is not used and <see langword="null"/> .</para>
+		/// </remarks>
 		public string Country { get; }
 
 		/// <summary>


### PR DESCRIPTION
### Description of Change

Adds the ISO information in the API documentation so people know which standards are being used for the TTS Locale per platform.

### Issues Fixed

Fixes https://github.com/dotnet/dotnet-maui-api-docs/issues/114
