### PR TITLE
Mark VerifyInitialEntryReturnTypeChange and VerifyGraphicsViewWithoutGrayLine tests as flaky

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "[Android] MAUI 8.0.3 -> 8.0.6 regression: custom handler with key listener no longer works";
 
-		[FlakyTest, Order(1)]
+		[FlakyTest("Issue to reenable this test: https://github.com/dotnet/maui/issues/27778"), Order(1)]
 		[Category(UITestCategories.Entry)]
 		public void VerifyInitialEntryReturnTypeChange()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21109.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "[Android] MAUI 8.0.3 -> 8.0.6 regression: custom handler with key listener no longer works";
 
-		[Test, Order(1)]
+		[FlakyTest, Order(1)]
 		[Category(UITestCategories.Entry)]
 		public void VerifyInitialEntryReturnTypeChange()
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25502.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25502.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "Gray Line Appears on the Right Side of GraphicsView with Decimal WidthRequest on iOS Platform";
 
-		[Test]
+		[FlakyTest("Issue to reenable this test: https://github.com/dotnet/maui/issues/27798")]
 		[Category(UITestCategories.GraphicsView)]
 		public void VerifyGraphicsViewWithoutGrayLine()
 		{


### PR DESCRIPTION
### Description of Change

These tests, added/updated in #27639 and #26368 are flaky and failing with unrelated PRs. Marking these as flaky for now to see if we can make it better. cc: @HarishKumarSF4517 @devanathan-vaithiyanathan
