### PR TITLE
Fix CSS Hot Reload - Handle fingerprint when hot reloading scoped CSS bundles

### DIFF
--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -86,10 +86,20 @@ namespace Microsoft.AspNetCore.Components.WebView
 			var requestPath = new Uri(requestAbsoluteUri).AbsolutePath.Substring(1);
 			if (ContentUrlRegex.Match(requestPath) is { Success: true } match)
 			{
+				var assemblyName = match.Groups["AssemblyName"].Value;
+				var relativePath = match.Groups["RelativePath"].Value;
+
+				// Remove the fingerprint from scoped CSS bundles, since CSS hot reload will send new content without the fingerprint.
+				// LibraryName.<fingerprint>.bundle.scp.css -> LibraryName.bundle.scp.css
+				if (relativePath.StartsWith($"{assemblyName}.", StringComparison.Ordinal) && relativePath.EndsWith(".bundle.scp.css", StringComparison.Ordinal))
+				{
+					relativePath = $"{assemblyName}.bundle.scp.css";
+				}
+
 				// For RCLs (i.e., URLs of the form _content/assembly/path), we assume the content root within the
 				// RCL to be "wwwroot" since we have no other information. If this is not the case, content within
 				// that RCL will not be hot-reloadable.
-				return (match.Groups["AssemblyName"].Value, $"wwwroot/{match.Groups["RelativePath"].Value}");
+				return (assemblyName, $"wwwroot/{relativePath}");
 			}
 			else if (requestPath.StartsWith("_framework/", StringComparison.Ordinal))
 			{

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -90,7 +90,8 @@ namespace Microsoft.AspNetCore.Components.WebView
 				var relativePath = match.Groups["RelativePath"].Value;
 
 				// Remove the fingerprint from scoped CSS bundles, since CSS hot reload will send new content without the fingerprint.
-				// LibraryName.<fingerprint>.bundle.scp.css -> LibraryName.bundle.scp.css
+				// The relative path for *.bundle.scp.css is just the file name, since they are always directly in the assembly's content directory.
+				// Example: LibraryName.<fingerprint>.bundle.scp.css -> LibraryName.bundle.scp.css
 				if (relativePath.StartsWith($"{assemblyName}.", StringComparison.Ordinal) && relativePath.EndsWith(".bundle.scp.css", StringComparison.Ordinal))
 				{
 					relativePath = $"{assemblyName}.bundle.scp.css";


### PR DESCRIPTION
### Description of Change

This is for MAUI Blazor Hybrid apps. CSS Hot Reload from Visual Studio wasn't working for scoped CSS files that come from Razor Class Libraries.

During the build, the scoped CSS files get built into a bundle called:
* `LibraryName.<fingerprint>.bundle.scp.css`

At runtime, CSS Hot Reload will trigger a scoped CSS build, which outputs:
* `LibraryName.bundle.scp.css`

Fingerprints are not included during that part of the build. This fix will match the original fingerprinted name to the newly built name and allows CSS hot reload to work.

This was the PR that introduced fingerprinting:
* https://github.com/dotnet/sdk/pull/41244

### Issues Fixed

* [Bug 2272902](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2272902): [MAUI][Hot Reload] The web page doesn't apply the changes in RazorClassLibrary\xx.razor.css file after referencing RazorClassLibrary App from MAUI Blazor App
