### PR TITLE
[net10.0-pre1 ONLY] Add workaround for missing blazor.modules.json file

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -176,16 +176,15 @@ stages:
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           catalyst: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           windows: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-        # Disable BlazorWebView tests until we figure why they are not working https://github.com/dotnet/maui/issues/27556  
-        # - name: blazorwebview
-        #   desc: BlazorWebView
-        #   androidApiLevelsExclude: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
-        #   androidConfiguration: 'Release'
-        #   iOSConfiguration: 'Debug'
-        #   windowsConfiguration: 'Debug'
-        #   windowsPackageId: 'Microsoft.Maui.MauiBlazorWebView.DeviceTests'
-        #   android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-        #   ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-        #   catalyst: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-        #   windows: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+        - name: blazorwebview
+          desc: BlazorWebView
+          androidApiLevelsExclude: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
+          androidConfiguration: 'Release'
+          iOSConfiguration: 'Debug'
+          windowsConfiguration: 'Debug'
+          windowsPackageId: 'Microsoft.Maui.MauiBlazorWebView.DeviceTests'
+          android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+          ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+          catalyst: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+          windows: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
 

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -121,4 +121,28 @@
     </ItemGroup>
   </Target>
 
+  <!-- 
+    Workaround the issue where the empty json file is not included. 
+    Remove for preview 2 as it is fixed in https://github.com/dotnet/aspnetcore/pull/60368
+    See: https://github.com/dotnet/maui/issues/27806
+  -->
+  <Target Name="_Maui_Before_AddBlazorWebViewAssets"
+    BeforeTargets="_AddBlazorWebViewAssets"
+    DependsOnTargets="_MauiAddEmptyBlazorModulesJson"
+    Condition="'$(_MauiSkipAddEmptyBlazorModulesJson)' == 'true'" />
+  <Target Name="_MauiAddEmptyBlazorModulesJson" Condition="'@(_ExistingBuildJSModules)' == ''">
+    <PropertyGroup>
+      <_MauiBlazorWebViewModulesJsonPath>$(IntermediateOutputPath)blazor.modules.json</_MauiBlazorWebViewModulesJsonPath>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_MauiBlazorWebViewModulesJsonPath)" Lines="[]" Overwrite="true" WriteOnlyWhenDifferent="True" />
+    <ItemGroup>
+      <FileWrites Include="$(_MauiBlazorWebViewModulesJsonPath)" />
+    </ItemGroup>
+    <ItemGroup>
+      <_WebViewAssetCandidates Include="$(_MauiBlazorWebViewModulesJsonPath)">
+        <RelativePath>_framework/blazor.modules.json</RelativePath>
+      </_WebViewAssetCandidates>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Enable Razor files to be visible in Solution Explorer because they are not Content files in .NET MAUI projects -->
   <ItemGroup>
@@ -129,7 +129,8 @@
   <Target Name="_Maui_Before_AddBlazorWebViewAssets"
     BeforeTargets="_AddBlazorWebViewAssets"
     DependsOnTargets="_MauiAddEmptyBlazorModulesJson"
-    Condition="'$(_MauiSkipAddEmptyBlazorModulesJson)' == 'true'" />
+    Condition="'$(_MauiSkipAddEmptyBlazorModulesJson)' != 'true'" />
+
   <Target Name="_MauiAddEmptyBlazorModulesJson" Condition="'@(_ExistingBuildJSModules)' == ''">
     <PropertyGroup>
       <_MauiBlazorWebViewModulesJsonPath>$(IntermediateOutputPath)blazor.modules.json</_MauiBlazorWebViewModulesJsonPath>


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2360915 
Related to https://github.com/dotnet/aspnetcore/pull/60368 

This PR is not meant to go anywhere but .NET 10 Preview 1 as there was a last minute bug detected.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/27806
Fixes https://github.com/dotnet/maui/issues/27556  

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
