### PR TITLE
Fix CSS Hot Reload on iOS device

### DIFF
--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Components.WebView
 			{ (ApplicationAssemblyName, "_framework/static-content-hot-reload.js"), ("text/javascript", Encoding.UTF8.GetBytes(@"
 	export function notifyCssUpdated() {
 		const allLinkElems = Array.from(document.querySelectorAll('link[rel=stylesheet]'));
-		allLinkElems.forEach(elem => elem.href += '');
+		allLinkElems.forEach(elem => elem.href = elem.href.split('?')[0] + '?reload_version=' + Date.now());
 	}
 ")) }
 		};

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -24,14 +24,21 @@ namespace Microsoft.AspNetCore.Components.WebView
 		private static string ApplicationAssemblyName { get; } = Assembly.GetEntryAssembly()?.GetName().Name
 			?? "__application_assembly__";
 
+		private const string NotifyCssUpdatedScript =
+@"export function notifyCssUpdated(matchPathSuffix) {
+	const allLinkElems = Array.from(document.querySelectorAll('link[rel=stylesheet]'));
+	allLinkElems.forEach(elem => {
+		const url = new URL(elem.href);
+		if (url.pathname.endsWith(matchPathSuffix)) {
+			url.searchParams.set('reload_version', Date.now());
+			elem.href = url.toString();
+		}
+	});
+}";
+
 		private static readonly Dictionary<(string AssemblyName, string RelativePath), (string? ContentType, byte[] Content)> _updatedContent = new()
 		{
-			{ (ApplicationAssemblyName, "_framework/static-content-hot-reload.js"), ("text/javascript", Encoding.UTF8.GetBytes(@"
-	export function notifyCssUpdated() {
-		const allLinkElems = Array.from(document.querySelectorAll('link[rel=stylesheet]'));
-		allLinkElems.forEach(elem => elem.href = elem.href.split('?')[0] + '?reload_version=' + Date.now());
-	}
-")) }
+			{ (ApplicationAssemblyName, "_framework/static-content-hot-reload.js"), ("text/javascript", Encoding.UTF8.GetBytes(NotifyCssUpdatedScript)) }
 		};
 
 		/// <summary>
@@ -153,8 +160,18 @@ namespace Microsoft.AspNetCore.Components.WebView
 						// We could try to supply the URL of the modified file, so the JS-side logic could only update the affected
 						// stylesheet. This would reduce flicker. However, this involves hardcoding further details about URL conventions
 						// (e.g., _content/AssemblyName/Path) and accounting for configurable content roots. To reduce the chances of
-						// CSS hot reload being broken by customizations, we'll have the JS-side code refresh all stylesheets.
-						await module.InvokeVoidAsync("notifyCssUpdated");
+						// CSS hot reload being broken by customizations, we'll have the JS-side refresh stylesheets with a matching filename.
+						// Most of the time this will only reload a single stylesheet.
+
+						string matchPathSuffix = "/" + Path.GetFileName(relativePath);
+						if (matchPathSuffix.EndsWith(".bundle.scp.css"))
+						{
+							// Bundles from class libraries are imported in the <Project>.styles.css file,
+							// so match that file instead of the bundle.
+							matchPathSuffix = ".styles.css";
+						}
+
+						await module.InvokeVoidAsync("notifyCssUpdated", matchPathSuffix);
 					}
 				}
 				catch (Exception ex)


### PR DESCRIPTION
### Description of Change

This fixes a bug with:
* MAUI Blazor Hybrid apps
* Open in Visual Studio 2022
* Using Pair to Mac to debug on a Mac
* Hot reload CSS on iOS Simulator

Hot reloading CSS didn't work because the web view on iOS didn't refresh the CSS since the href didn't change. The CSS link looks like:

* `<link rel="stylesheet" href="app.css" />`

And when the CSS file changed, the href was modified by adding an empty string to it. The browser in iOS didn't detect any change in the href (since the change was a no-op) and didn't refresh the CSS. On Windows and Android the browser would still refresh CSS when the href had a no-op change.

My fix is to make a real change to the CSS link's href by appending a query string with a timestamp to it. Now all the browsers refresh the CSS since the timestamp is always unique.

### Issues Fixed

[Bug 1821555](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1821555): [XVS][MAUI] CSS Hot reload on iOS Simulator not working
