### PR TITLE
Fix concurrency issues and leak reliability

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	[Collection("TestsAccessingStaticHandlers")]
 	public abstract class BindingBaseUnitTests : BaseTestFixture
 	{
 		protected abstract BindingBase CreateBinding(BindingMode mode = BindingMode.Default, string stringFormat = null);

--- a/src/Controls/tests/Core.UnitTests/ControlsMapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ControlsMapperTests.cs
@@ -14,13 +14,12 @@ using Xunit.Sdk;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-	[Collection("ControlsMapperTests")]
+	[Collection("TestsAccessingStaticHandlers")]
 	public class ControlsMapperTests : BaseTestFixture
 	{
 		MauiContext SetupMauiContext()
 		{
 			var mauiApp1 = MauiApp.CreateBuilder()
-				.UseMauiApp<ApplicationStub>()
 				.ConfigureMauiHandlers(handlers => handlers.AddHandler<ButtonWithControlsMapper, ButtonWithControlsMapperHandler>())
 				.Build();
 

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -13,6 +13,7 @@ using Xunit.Sdk;
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 
+	[Collection("TestsAccessingStaticHandlers")]
 	public class HandlerLifeCycleTests : BaseTestFixture
 	{
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 
+	[Collection("TestsAccessingStaticHandlers")]
 	public class HostBuilderAppTests
 	{
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/HostBuilderHandlerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HostBuilderHandlerTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 
+	[Collection("TestsAccessingStaticHandlers")]
 	public class HostBuilderHandlerTests
 	{
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
@@ -46,11 +46,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			list.Remove(SetterSpecificity.FromBinding);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(weakReference.TryGetTarget(out _));
+			Assert.False(await weakReference.WaitForCollect());
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 
+	[Collection("TestsAccessingStaticHandlers")]
 	public class StyleTests : BaseTestFixture
 	{
 

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -24,5 +24,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			return reference.IsAlive;
 		}
+
+		public static async Task<bool> WaitForCollect<T>(this WeakReference<T> reference)
+			where T : class
+		{
+			for (int i = 0; i < 40 && reference.TryGetTarget(out _); i++)
+			{
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			return reference.TryGetTarget(out _);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -13,6 +13,7 @@ using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	[Collection("TestsAccessingStaticHandlers")]
 	public class VisualElementTests
 	{
 		[Fact("If WidthRequest has been set and is reset to -1, the Core Width should return to being Unset")]

--- a/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
@@ -22,11 +22,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				reference = new WeakReference(subscriber);
 			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(reference.IsAlive, "Subscriber should not be alive!");
+			Assert.False(await reference.WaitForCollect(), "Subscriber should not be alive!");
 		}
 
 		[Fact]


### PR DESCRIPTION
### Description of Change

- Use some GC helpers for some tests I noticed were a bit unreliable locally
- Add any tests that need to use MauiAppBuilder to a collection so they don't run in parallel. There's probably a bigger conversation here about fixing MauiApp so that the SetupDefaults code isn't re-entrant but I figure for now this band-aid for improving test reliability is acceptable. 