### PR TITLE
[iOS][Shell][More Tab] Tabbar icon color wrong on IOS (extended tabbar) - proposal

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 	{
 		readonly static UITableViewCell[] EmptyUITableViewCellArray = Array.Empty<UITableViewCell>();
 
+		ShellAppearance _shellAppearance;
+
 		#region IShellItemRenderer
 
 		public ShellItem ShellItem
@@ -82,7 +84,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					MoreNavigationController.WeakDelegate = this;
 				}
 
-				UpdateMoreCellsEnabled();
+				UpdateMoreCells();
 			}
 		}
 
@@ -96,7 +98,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				ShellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, renderer.ShellSection);
 				CurrentRenderer = renderer;
 			}
-			UpdateMoreCellsEnabled();
+			UpdateMoreCells();
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -262,6 +264,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void UpdateShellAppearance(ShellAppearance appearance)
 		{
+			_shellAppearance = appearance;
 			if (appearance == null)
 			{
 				_appearanceTracker.ResetAppearance(this);
@@ -307,13 +310,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			// Make sure we are at the right item
 			GoTo(ShellItem.CurrentItem);
-			UpdateMoreCellsEnabled();
+			UpdateMoreCells();
 		}
 
-		void UpdateMoreCellsEnabled()
+		void UpdateMoreCells()
 		{
 			var moreNavigationCells = GetMoreNavigationCells();
 			var viewControllersLength = ViewControllers.Length;
+#pragma warning disable CA1416, CA1422 // TODO: 'UITableViewCell.TextLabel' is unsupported on: 'ios' 14.0 and later
+			foreach (var cell in moreNavigationCells)
+			{
+				cell.TextLabel.TextColor = _shellAppearance?.TabBarTitleColor?.ToPlatform() ?? _shellAppearance?.TabBarUnselectedColor?.ToPlatform();
+			}
+
 			// now that they are applied we can set the enabled state of the TabBar items
 			for (int i = 4; i < viewControllersLength; i++)
 			{
@@ -325,7 +334,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				var renderer = RendererForViewController(ViewControllers[i]);
 				var cell = moreNavigationCells[i - 4];
 
-#pragma warning disable CA1416, CA1422 // TODO: 'UITableViewCell.TextLabel' is unsupported on: 'ios' 14.0 and later
 				if (!renderer.ShellSection.IsEnabled)
 				{
 					cell.UserInteractionEnabled = false;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -18,6 +19,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		#region IShellContentRenderer
 
 		public bool IsInMoreTab { get; set; }
+
+		private ShellAppearance _shellAppearance;
 
 		public ShellSection ShellSection
 		{
@@ -44,10 +47,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
+			_shellAppearance = appearance;
+
 			if (appearance == null)
 				_appearanceTracker.ResetAppearance(this);
 			else
 				_appearanceTracker.SetAppearance(this, appearance);
+
+			UpdateTabBarItem();
 		}
 
 		#endregion IAppearanceObserver
@@ -509,7 +516,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			ShellSection.Icon.LoadImage(ShellSection.FindMauiContext(), icon =>
 			{
-				TabBarItem = new UITabBarItem(ShellSection.Title, icon?.Value, null);
+				if (IsInMoreTab && _shellAppearance?.TabBarUnselectedColor is Graphics.Color tabBarUnselectedColor)
+				{
+					var uIImage = icon?.Value.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal).ApplyTintColor(tabBarUnselectedColor.ToPlatform());
+					TabBarItem = new UITabBarItem(ShellSection.Title, uIImage, null);
+				}
+				else
+				{
+					TabBarItem = new UITabBarItem(ShellSection.Title, icon?.Value, null);
+				}
 				TabBarItem.AccessibilityIdentifier = ShellSection.AutomationId ?? ShellSection.Title;
 			});
 		}


### PR DESCRIPTION
### Description of Change

I created this draft to show that we can customize the cells in the 'More' tab. While this proves that customization is possible, I'm uncertain whether we should proceed with it or rely on Apple's API for handling the default styling.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/27781

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/b5323011-db85-419b-b8aa-6e34c0f74f62" width="300px"/>|<img src="https://github.com/user-attachments/assets/fafc146a-e793-4bc9-a5f0-b2d818a49a73" width="300px"/>|

```xaml
<TabBar Shell.TabBarForegroundColor="Green"
        Shell.TabBarUnselectedColor="Red">
    <ShellContent
        Title="Tab 1"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
    <ShellContent
        Title="Tab 2"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
    <ShellContent
        Title="Tab 3"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
    <ShellContent
        Title="Tab 4"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
    <ShellContent
        Title="Tab 5"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
    <ShellContent
        Title="Tab 6"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
    <ShellContent
        Title="Tab 7"
        Icon="user.png"
        Route="MainPage">
        <ContentPage/>
    </ShellContent>
</TabBar>
```