### PR TITLE
[Windows] - Handle Dynamic Updates for CanDrag and AllowDrop in Drag and Drop Gesture

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -410,9 +410,13 @@ namespace Microsoft.Maui.Controls.Platform
 				if (Element is View && ElementGestureRecognizers is { } gestureRecognizers)
 				{
 					if (gestureRecognizers.FirstGestureOrDefault<DragGestureRecognizer>() is { } dragGesture)
+					{
 						dragGesture.PropertyChanged -= HandleDragAndDropGesturePropertyChanged;
+					}
 					if (gestureRecognizers.FirstGestureOrDefault<DropGestureRecognizer>() is { } dropGesture)
+					{
 						dropGesture.PropertyChanged -= HandleDragAndDropGesturePropertyChanged;
+					}
 				}
 			}
 		}
@@ -432,7 +436,6 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			ClearContainerEventHandlers();
-
 
 			if (_element is View && ElementGestureRecognizers is { } gestureRecognizers)
 			{

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.Controls.Platform
 		VisualElement? _element;
 		TappedEventHandler? _tappedEventHandler;
 		DoubleTappedEventHandler? _doubleTappedEventHandler;
+
 		SubscriptionFlags _subscriptionFlags = SubscriptionFlags.None;
 
 		bool _isDisposed;
@@ -433,7 +434,7 @@ namespace Microsoft.Maui.Controls.Platform
 			ClearContainerEventHandlers();
 
 
-			if (_element is View && ElementGestureRecognizers is {} gestureRecognizers)
+			if (_element is View && ElementGestureRecognizers is { } gestureRecognizers)
 			{
 				gestureRecognizers.CollectionChanged -= _collectionChangedHandler;
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12726.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12726.cs
@@ -1,0 +1,60 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+
+	[Issue(IssueTracker.Github, 12726, "Drag and Drop Gesture Fails on Runtime Changes of CanDrag and AllowDrop in Windows",
+		PlatformAffected.UWP)]
+	public class Issue12726 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Label dragResult = new Label();
+			Label dropResult = new Label();
+
+			DragGestureRecognizer dragGestureRecognizer = new DragGestureRecognizer { CanDrag = false };
+			Label dragBox = new Label
+			{
+				HeightRequest = 200,
+				WidthRequest = 200,
+				BackgroundColor = Colors.Purple,
+				GestureRecognizers = { dragGestureRecognizer },
+				AutomationId = "DragElement"
+			};
+			dragGestureRecognizer.DragStarting += (_, __) => dragResult.Text = "DragEventTriggered";
+
+			DropGestureRecognizer dropGestureRecognizer = new DropGestureRecognizer { AllowDrop = false };
+			Label dropBox = new Label
+			{
+				HeightRequest = 200,
+				WidthRequest = 200,
+				BackgroundColor = Colors.Pink,
+				GestureRecognizers = { dropGestureRecognizer },
+				AutomationId = "DropTarget"
+			};
+			dropGestureRecognizer.Drop += (_, __) => dropResult.Text = "DropEventTriggered";
+
+			Button button = new Button
+			{
+				Text = "Enable Drag and Drop",
+				AutomationId = "EnableDragAndDrop"
+			};
+			button.Clicked += (_, __) =>
+			{
+				dragGestureRecognizer.CanDrag = true;
+				dropGestureRecognizer.AllowDrop = true;
+			};
+
+			Content = new StackLayout
+			{
+				Spacing = 5,
+				Children =
+					{
+						dragBox,
+						dropBox,
+						button,
+						dragResult,
+						dropResult
+					}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12726.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12726.cs
@@ -8,6 +8,7 @@
 		protected override void Init()
 		{
 			Label dragResult = new Label();
+			Label dropResult = new Label();
 
 			DragGestureRecognizer dragGestureRecognizer = new DragGestureRecognizer { CanDrag = false };
 			Label dragBox = new Label
@@ -20,13 +21,16 @@
 			};
 			dragGestureRecognizer.DragStarting += (_, __) => dragResult.Text = "DragEventTriggered";
 
+			DropGestureRecognizer dropGestureRecognizer = new DropGestureRecognizer { AllowDrop = false };
 			Label dropBox = new Label
 			{
 				HeightRequest = 200,
 				WidthRequest = 200,
 				BackgroundColor = Colors.Pink,
+				GestureRecognizers = { dropGestureRecognizer },
 				AutomationId = "DropTarget"
 			};
+			dropGestureRecognizer.Drop += (_, __) => dropResult.Text = "DropEventTriggered";
 
 			Button button = new Button
 			{
@@ -37,6 +41,7 @@
 			button.Clicked += (_, __) =>
 			{
 				dragGestureRecognizer.CanDrag = true;
+				dropGestureRecognizer.AllowDrop = true;
 			};
 
 			Content = new StackLayout
@@ -48,6 +53,7 @@
 					dropBox,
 					button,
 					dragResult,
+					dropResult
 				}
 			};
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12726.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12726.cs
@@ -8,7 +8,6 @@
 		protected override void Init()
 		{
 			Label dragResult = new Label();
-			Label dropResult = new Label();
 
 			DragGestureRecognizer dragGestureRecognizer = new DragGestureRecognizer { CanDrag = false };
 			Label dragBox = new Label
@@ -21,39 +20,35 @@
 			};
 			dragGestureRecognizer.DragStarting += (_, __) => dragResult.Text = "DragEventTriggered";
 
-			DropGestureRecognizer dropGestureRecognizer = new DropGestureRecognizer { AllowDrop = false };
 			Label dropBox = new Label
 			{
 				HeightRequest = 200,
 				WidthRequest = 200,
 				BackgroundColor = Colors.Pink,
-				GestureRecognizers = { dropGestureRecognizer },
 				AutomationId = "DropTarget"
 			};
-			dropGestureRecognizer.Drop += (_, __) => dropResult.Text = "DropEventTriggered";
 
 			Button button = new Button
 			{
 				Text = "Enable Drag and Drop",
 				AutomationId = "EnableDragAndDrop"
 			};
+
 			button.Clicked += (_, __) =>
 			{
 				dragGestureRecognizer.CanDrag = true;
-				dropGestureRecognizer.AllowDrop = true;
 			};
 
 			Content = new StackLayout
 			{
 				Spacing = 5,
 				Children =
-					{
-						dragBox,
-						dropBox,
-						button,
-						dragResult,
-						dropResult
-					}
+				{
+					dragBox,
+					dropBox,
+					button,
+					dragResult,
+				}
 			};
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12726.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12726.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.Tap("EnableDragAndDrop");
 			App.DragAndDrop("DragElement", "DropTarget");
 			App.WaitForElement("DragEventTriggered");
-			App.WaitForElement("DropEventTriggered");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12726.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12726.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue12726 : _IssuesUITest
+	{
+		public Issue12726(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Drag and Drop Gesture Fails on Runtime Changes of CanDrag and AllowDrop in Windows";
+
+		[Test]
+		[Category(UITestCategories.DragAndDrop)]
+		public void DragAndDropShouldWorkRunTime()
+		{
+			App.WaitForElement("EnableDragAndDrop");
+			App.Tap("EnableDragAndDrop");
+			App.DragAndDrop("DragElement", "DropTarget");
+			App.WaitForElement("DragEventTriggered");
+			App.WaitForElement("DropEventTriggered");
+		}
+	}
+}


### PR DESCRIPTION
### Issue Details

Dynamically changing the `CanDrag` or `AllowDrop` property does not enable the expected drag-and-drop functionality when initially set to `false`. As a result, components cannot be made draggable or droppable by updating these properties at runtime.

### Root Cause

Event subscriptions were only set up during initialization. Changing `CanDrag` or `AllowDrop` dynamically did not trigger a re-subscription, preventing the component from responding to both drag and drop events.

### Description of Change

Added `PropertyChanged` event handling for `DragGestureRecognizer` and `DropGestureRecognizer` to ensure that drag-and-drop event subscriptions are updated dynamically when the properties change.

### Issues Fixed

Fixes #12726 

**Validated the behaviour in the following platforms**
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/ab77541f-6b65-4362-9500-276ea5d08f0e">|<video src="https://github.com/user-attachments/assets/32b25484-499a-42e4-937d-19dcf3877a9c">|