### PR TITLE
[iOS] Fixed a crash in CarouselViewHandler2 on iOS 15.

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			NSCollectionLayoutDimension groupWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
 			NSCollectionLayoutDimension groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
 			nfloat itemSpacing = 0;
+			NSCollectionLayoutGroup group = null;
 
 			var layout = new UICollectionViewCompositionalLayout((sectionIndex, environment) =>
 			{
@@ -78,8 +79,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				var groupSize = NSCollectionLayoutSize.Create(groupWidth, groupHeight);
 
-				var group = IsHorizontal ? NSCollectionLayoutGroup.GetHorizontalGroup(groupSize, item, 1) :
-										 NSCollectionLayoutGroup.GetVerticalGroup(groupSize, item, 1);
+				if (OperatingSystem.IsIOSVersionAtLeast(16))
+				{
+					group = IsHorizontal ? NSCollectionLayoutGroup.GetHorizontalGroup(groupSize, item, 1) :
+										   NSCollectionLayoutGroup.GetVerticalGroup(groupSize, item, 1);
+				}
+				else
+				{
+					group = IsHorizontal ? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, 1) :
+										   NSCollectionLayoutGroup.CreateVertical(groupSize, item, 1);
+				}
 
 				// Create our section layout
 				var section = NSCollectionLayoutSection.Create(group: group);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27818.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27818.cs
@@ -1,0 +1,32 @@
+﻿namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 27818, "CarouselView crashes on iOS 15.8.3 when using CarouselViewHandler2", PlatformAffected.iOS)]
+public class Issue27818 : ContentPage
+{
+    public Issue27818()
+    {
+        Content = new CarouselView2
+        {
+            AutomationId = "CarouselView",
+            ItemsSource = new List<string>
+            {
+                "Baboon",
+                "Capuchin Monkey",
+                "Blue Monkey",
+                "Squirrel Monkey",
+                "Golden Lion Tamarin",
+                "Howler Monkey",
+                "Japanese Macaque",
+                "Mandrill",
+                "Proboscis Monkey",
+                "Red-shanked Douc",
+                "Gray-shanked Douc",
+                "Golden Snub-nosed Monkey",
+                "Black Snub-nosed Monkey",
+                "Tonkin Snub-nosed Monkey",
+                "Thomas's Langur",
+                "Purple-faced Langur",
+                "Gelada"
+            }
+        };
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27818.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27818.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27818 : _IssuesUITest
+	{
+		public Issue27818(TestDevice device) : base(device) { }
+
+		public override string Issue => "CarouselView crashes on iOS 15.8.3 when using CarouselViewHandler2";
+
+		[Test]
+		[Category(UITestCategories.CarouselView)]
+		public void CarouselViewShouldNotCrash()
+		{
+			App.WaitForElement("CarouselView");
+		}
+	}
+}


### PR DESCRIPTION
### Root Cause of the issue



- The crash in `iOS 15` versions is likely due to the use of API methods that are not available in iOS 15 and earlier. The `GetHorizontalGroup` and `GetVerticalGroup` methods used in the SelectLayout override method of CarouselViewHandler2.iOS were introduced in` iOS 16.0. `



### Description of Change



- Fixed the crash by using `compatible` API methods based on the iOS version. 



### Issues Fixed



Fixes #27818



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Tested Version

| iOS Version | App Crashed |
|----------|----------|
| 15.2 | Yes|
| 15.5 | Yes  |
| 16.0  | No |
| 17.5 | No |
| 18.0 | No |
| 18.2 | No |

### Screenshot

#### iOS 15.2 and 15.5
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/7393d1fc-2ac5-4530-8883-46831d6cd21c"> | <video src="https://github.com/user-attachments/assets/435e855c-7450-4cca-b674-80c623422846"> |
| <video src="https://github.com/user-attachments/assets/ec549e09-5c56-4eec-a2b5-9fb9e2c38e36"> | <video src="https://github.com/user-attachments/assets/223055f6-b7e4-40c7-9a96-8ccf77b86d08"> |

#### iOS 16.0

https://github.com/user-attachments/assets/12651962-5c54-41a7-84a1-4443f8614838


#### iOS 17.5

https://github.com/user-attachments/assets/b8cb0814-ccf2-4909-b419-e73b301cabcb


#### iOS 18.2


https://github.com/user-attachments/assets/7366dd73-0ae3-4699-a305-0ff0288ab478

