### PR TITLE
remove Dispose call on ShellItemRenderer

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		IShellBottomNavViewAppearanceTracker _appearanceTracker;
 		BottomNavigationViewTracker _bottomNavigationTracker;
 		BottomSheetDialog _bottomSheetDialog;
-		bool _disposed;
 		bool _menuSetup;
 		ShellAppearance _shellAppearance;
 		bool _appearanceSet;
@@ -124,18 +123,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_appearanceTracker = null;
 			_outerLayout = null;
 
-		}
-
-		protected override void Dispose(bool disposing)
-		{
-			if (_disposed)
-				return;
-
-			_disposed = true;
-			if (disposing)
-				Destroy();
-
-			base.Dispose(disposing);
 		}
 
 		// Use OnDestory become OnDestroyView may fire before events are completed.

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		IShellObservableFragment _currentFragment;
 		ShellSection _shellSection;
 		Page _displayedPage;
-		bool _disposed;
 
 		protected ShellItemRendererBase(IShellContext shellContext)
 		{
@@ -112,19 +111,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			base.OnDestroy();
 			Destroy();
-		}
-
-		protected override void Dispose(bool disposing)
-		{
-			if (_disposed)
-				return;
-
-			_disposed = true;
-
-			if (disposing)
-				Destroy();
-
-			base.Dispose(disposing);
 		}
 
 		protected abstract ViewGroup GetNavigationTarget();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -235,8 +235,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			// Don't force the commit if this is our first load 
 			if (previousView == null)
 			{
-				transaction
-					.SetReorderingAllowedEx(true);
+				transaction.SetReorderingAllowedEx(true);
 			}
 
 			transaction.CommitAllowingStateLossEx();
@@ -245,7 +244,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				previousView.Destroyed -= OnDestroyed;
 
-				previousView.Dispose();
 				previousView = null;
 			}
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -7648,10 +7648,8 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedCont
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedContentRenderer.HeaderContainer.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedContentRenderer.HeaderContainer.OnLayout(bool changed, int l, int t, int r, int b) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedContentRenderer.HeaderContainer.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.OnDestroy() -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.OnShellSectionChanged() -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRendererBase.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRendererBase.OnDestroy() -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellSearchView.Dispose(bool disposing) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellSearchView.OnAttachedToWindow() -> void


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
Remove the `Dispose` call that happens during `OnDestroy` lifecycle. If user has added a `FragmentManager.FragmentLifecycleCallbacks` the `Fragment`, that represents the `ShellItem` will be disposed too earlier causing in an app crash. Removing the `Dipose` call will make sure that the `Fragment` lives long enough to pass to all lifecycle methods.


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #27889

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
