### PR TITLE
[Testing] Enabling more UI Tests by removing platform specific condition - 13

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewRemoveAt.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewRemoveAt.cs
@@ -14,8 +14,8 @@ namespace Maui.Controls.Sample.Issues
 			{
 				var btn = new Button
 				{
-					AutomationId = "Close",
-					Text = "Close",
+					AutomationId = "CloseMe",
+					Text = "CloseMe",
 					TextColor = Colors.White,
 					BackgroundColor = Colors.Red,
 					VerticalOptions = LayoutOptions.End
@@ -28,7 +28,7 @@ namespace Maui.Controls.Sample.Issues
 			{
 				Navigation.PopModalAsync();
 #pragma warning disable CS0618 // Type or member is obsolete
-				MessagingCenter.Instance.Send<Page>(this, "Delete");
+				MessagingCenter.Instance.Send<Page>(this, "DeleteMe");
 #pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
@@ -83,15 +83,15 @@ namespace Maui.Controls.Sample.Issues
 
 			var btn = new Button
 			{
-				AutomationId = "Delete",
-				Text = "Delete",
+				AutomationId = "DeleteMe",
+				Text = "DeleteMe",
 				BackgroundColor = Colors.Red,
 				TextColor = Colors.White
 			};
 			var btnAdd = new Button
 			{
-				AutomationId = "Add",
-				Text = "Add",
+				AutomationId = "AddMe",
+				Text = "AddMe",
 				BackgroundColor = Colors.Red,
 				TextColor = Colors.White
 			};
@@ -108,7 +108,7 @@ namespace Maui.Controls.Sample.Issues
 			grd.Children.Add(btnAdd);
 			Content = grd;
 #pragma warning disable CS0618 // Type or member is obsolete
-			MessagingCenter.Instance.Subscribe<Page>(this, "Delete", Callback);
+			MessagingCenter.Instance.Subscribe<Page>(this, "DeleteMe", Callback);
 #pragma warning restore CS0618 // Type or member is obsolete
 		}
 
@@ -125,10 +125,10 @@ namespace Maui.Controls.Sample.Issues
 		void Callback(Page page)
 		{
 			var index = Items.IndexOf(_carousel.CurrentItem as ModelCarouselViewRemoveAt);
-			System.Diagnostics.Debug.WriteLine($"Delete {index}");
+			System.Diagnostics.Debug.WriteLine($"DeleteMe {index}");
 			Items.RemoveAt(index);
 #pragma warning disable CS0618 // Type or member is obsolete
-			MessagingCenter.Instance.Unsubscribe<Page>(this, "Delete");
+			MessagingCenter.Instance.Unsubscribe<Page>(this, "DeleteMe");
 #pragma warning restore CS0618 // Type or member is obsolete
 		}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.RemoveAt.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.RemoveAt.cs
@@ -1,5 +1,4 @@
-﻿#if IOS
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -18,12 +17,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.CarouselView)]
 		public void Issue10300Test()
 		{
-			App.Click("Add");
-			App.Click("Delete");
-			App.WaitForElement("Close");
-			App.Click("Close");
+			App.Click("AddMe");
+			App.Click("DeleteMe");
+			App.WaitForElement("CloseMe");
+			App.Click("CloseMe");
 			App.WaitForElement("2");
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.UpdatePosition.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.UpdatePosition.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("AppearButton");
 			App.Click("AppearButton");
 			App.WaitForElement("Item 4");
-			App.Screenshot("Success");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.UpdatePosition.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.UpdatePosition.cs
@@ -1,5 +1,4 @@
-﻿#if ANDROID
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -21,9 +20,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("AppearButton");
 			App.Click("AppearButton");
-			App.WaitForNoElement("Item 4");
+			App.WaitForElement("Item 4");
 			App.Screenshot("Success");
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CollectionViewUI.CollectionViewVisibility.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CollectionViewUI.CollectionViewVisibility.cs
@@ -17,15 +17,13 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public override string Issue => "iOS application suspended at UICollectionViewFlowLayout.PrepareLayout() when using IsVisible = false";
 
 		// InitiallyInvisbleCollectionViewSurvivesiOSLayoutNonsense(src\Compatibility\ControlGallery\src\Issues.Shared\Issue12714.cs)
-#if ANDROID
 		[Test]
 		[Category(UITestCategories.CollectionView)]
 		public void InitiallyInvisbleCollectionViewSurvivesiOSLayoutNonsense()
 		{
 			App.WaitForElement(Show);
 			App.Click(Show);
-			App.WaitForNoElement(Success);
+			App.WaitForElement(Success);
 		}
-#endif
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue417.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue417.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAIlS_ON_IOS && TEST_FAIlS_ON_CATALYST //For more information, see : https://github.com/dotnet/maui/issues/27897
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -15,32 +16,30 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Test]
 		[Category(UITestCategories.Navigation)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnIOSWhenRunningOnXamarinUITest]
-		[FailsOnMacWhenRunningOnXamarinUITest]
-		[FailsOnWindowsWhenRunningOnXamarinUITest]
 		public void Issue417TestsNavigateAndPopToRoot()
 		{
-			App.WaitForElement("FirstPage");
-			App.WaitForElement("NextPage");
+			App.WaitForElement("First Page");
+			App.WaitForElement("Next Page");
 			App.Screenshot("All elements present");
 
-			App.Tap("NextPage");
+			App.Tap("Next Page");
 
-			App.WaitForElement("SecondPage");
-			App.WaitForElement("NextPage2");
+			App.WaitForElement("Second Page");
+			App.WaitForElement("Next Page 2");
 			App.Screenshot("At second page");
-			App.Tap("NextPage2");
+			App.Tap("Next Page 2");
 
-			App.WaitForElement("ThirdPage");
-			App.WaitForElement("PopToRoot");
+			App.WaitForElement("Third Page");
+			App.WaitForElement("Pop to root");
 			App.Screenshot("At third page");
-			App.Tap("PopToRoot");
+			App.Tap("Pop to root");
 
-			App.WaitForElement("FirstPage");
-			App.WaitForElement("NextPage");
+			App.WaitForElement("First Page");
+			App.WaitForElement("Next Page");
 			App.Screenshot("All elements present");
 
 			App.Screenshot("Popped to root");
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue417.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue417.cs
@@ -20,25 +20,19 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("First Page");
 			App.WaitForElement("Next Page");
-			App.Screenshot("All elements present");
 
 			App.Tap("Next Page");
 
 			App.WaitForElement("Second Page");
 			App.WaitForElement("Next Page 2");
-			App.Screenshot("At second page");
 			App.Tap("Next Page 2");
 
 			App.WaitForElement("Third Page");
 			App.WaitForElement("Pop to root");
-			App.Screenshot("At third page");
 			App.Tap("Pop to root");
 
 			App.WaitForElement("First Page");
 			App.WaitForElement("Next Page");
-			App.Screenshot("All elements present");
-
-			App.Screenshot("Popped to root");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue935.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue935.cs
@@ -21,9 +21,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("TestLabel");
 			App.Tap("TestLabel");
-			App.Screenshot("Tapped Cell Once");
+			var label=App.WaitForElement("TestLabel").GetText();
+			Assert.That("I have been selected:1", Is.EqualTo(label));
 			App.Tap("TestLabel");
-			App.Screenshot("Tapped Cell Twice");
+			var label1=App.WaitForElement("TestLabel").GetText();
+			Assert.That("I have been selected:2", Is.EqualTo(label1));
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue935.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue935.cs
@@ -1,4 +1,4 @@
-﻿#if ANDROID
+﻿#if TEST_FAILS_ON_WINDOWS //For more information, see : https://github.com/dotnet/maui/issues/27899
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
## Description of Change
The tests, previously added for specific platforms alone, now we are reviewed, and enabled the tests in all applicable platforms with the Appium framework. We are going to enable tests in blocks in different PRs. This is the 13th group of tests enabled.

## Test Cases:

- Issue417
- Issue935
- CarouselViewRemoveAt
- CarouselViewUITests.UpdatePosition
- CollectionViewUI.CollectionViewVisibility

Fixes https://github.com/dotnet/maui/issues/22902