### PR TITLE
[Testing] Publish new snapshots and diffs to a specific artifacts folder

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -193,7 +193,7 @@ steps:
       name: CheckAndroidFolderExists
 
     - task: PublishBuildArtifacts@1
-      condition: eq(dependencies.CheckAndroidFolderExists.outputs['androidFolderExists'], 'true')
+      condition: eq(variables['CheckAndroidFolderExists.androidFolderExists'], 'true')
       displayName: publish Android screenshots artifacts
       inputs:
         PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
@@ -213,7 +213,7 @@ steps:
       name: CheckIosFolderExists
 
     - task: PublishBuildArtifacts@1
-      condition: eq(dependencies.CheckIosFolderExists.outputs['iosFolderExists'], 'true')
+      condition: eq(variables['CheckIosFolderExists.iosFolderExists'], 'true')
       displayName: publish iOS screenshots artifacts
       inputs:
         PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
@@ -233,7 +233,7 @@ steps:
       name: CheckWindowsFolderExists
 
     - task: PublishBuildArtifacts@1
-      condition: eq(dependencies.CheckWindowsFolderExists.outputs['windowsFolderExists'], 'true')
+      condition: eq(variables['CheckWindowsFolderExists.windowsFolderExists'], 'true')
       displayName: publish Windows screenshots artifacts
       inputs:
         PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
@@ -253,7 +253,7 @@ steps:
       name: CheckMacFolderExists
 
     - task: PublishBuildArtifacts@1
-      condition: eq(dependencies.CheckMacFolderExists.outputs['macFolderExists'], 'true')
+      condition: eq(variables['CheckMacFolderExists.macFolderExists'], 'true')
       displayName: publish Mac screenshots artifacts
       inputs:
         PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -182,14 +182,14 @@ steps:
   - ${{ if eq(parameters.platform, 'android')}}:
     - task: PowerShell@2
       inputs:
-      targetType: 'inline'
-      script: |
-        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
-        if (Test-Path $folderPath) {
-          Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]true"
-        } else {
-          Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]false"
-        }
+        targetType: 'inline'
+        script: |
+          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          if (Test-Path $folderPath) {
+            Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]true"
+          } else {
+            Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]false"
+          }
       name: CheckAndroidFolderExists
 
     - task: PublishBuildArtifacts@1
@@ -202,14 +202,14 @@ steps:
   - ${{ if eq(parameters.platform, 'ios')}}:
     - task: PowerShell@2
       inputs:
-      targetType: 'inline'
-      script: |
-        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
-        if (Test-Path $folderPath) {
-          Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]true"
-        } else {
-          Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]false"
-        }
+        targetType: 'inline'
+        script: |
+          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          if (Test-Path $folderPath) {
+            Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]true"
+          } else {
+            Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]false"
+          }
       name: CheckIosFolderExists
 
     - task: PublishBuildArtifacts@1
@@ -222,14 +222,14 @@ steps:
   - ${{ if eq(parameters.platform, 'windows')}}:
     - task: PowerShell@2
       inputs:
-      targetType: 'inline'
-      script: |
-        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
-        if (Test-Path $folderPath) {
-          Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]true"
-        } else {
-          Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]false"
-        }
+        targetType: 'inline'
+        script: |
+          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          if (Test-Path $folderPath) {
+            Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]true"
+          } else {
+            Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]false"
+          }
       name: CheckWindowsFolderExists
 
     - task: PublishBuildArtifacts@1
@@ -242,14 +242,14 @@ steps:
   - ${{ if eq(parameters.platform, 'catalyst')}}:
     - task: PowerShell@2
       inputs:
-      targetType: 'inline'
-      script: |
-        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
-        if (Test-Path $folderPath) {
-          Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]true"
-        } else {
-          Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]false"
-        }
+        targetType: 'inline'
+        script: |
+          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          if (Test-Path $folderPath) {
+            Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]true"
+          } else {
+            Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]false"
+          }
       name: CheckMacFolderExists
 
     - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -184,7 +184,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          $folderPath = "${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff"
           if (Test-Path $folderPath) {
             Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]true"
           } else {
@@ -204,7 +204,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          $folderPath = "${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff"
           if (Test-Path $folderPath) {
             Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]true"
           } else {
@@ -224,7 +224,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          $folderPath = "${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff"
           if (Test-Path $folderPath) {
             Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]true"
           } else {
@@ -244,7 +244,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+          $folderPath = "${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff"
           if (Test-Path $folderPath) {
             Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]true"
           } else {

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -256,5 +256,5 @@ steps:
       condition: eq(dependencies.CheckMacFolderExists.outputs['macFolderExists'], 'true')
       displayName: publish Mac screenshots artifacts
       inputs:
-        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.WinUI.Tests/snapshots-diff
+        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.Mac.Tests/snapshots-diff
         ArtifactName: uitest-snapshot-results-mac

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -12,6 +12,7 @@ parameters:
   testFilter: ''
   testConfigurationArgs: ''
   skipProvisioning: true
+  checkoutDirectory: $(System.DefaultWorkingDirectory)
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -177,3 +178,83 @@ steps:
     displayName: 'Enable Notification Center'
     continueOnError: true
     timeoutInMinutes: 60
+    
+  - ${{ if eq(parameters.platform, 'android')}}:
+    - task: PowerShell@2
+      inputs:
+      targetType: 'inline'
+      script: |
+        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+        if (Test-Path $folderPath) {
+          Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]true"
+        } else {
+          Write-Host "##vso[task.setvariable variable=androidFolderExists;isOutput=true]false"
+        }
+      name: CheckAndroidFolderExists
+
+    - task: PublishBuildArtifacts@1
+      condition: eq(dependencies.CheckAndroidFolderExists.outputs['androidFolderExists'], 'true')
+      displayName: publish Android screenshots artifacts
+      inputs:
+        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.Android.Tests/snapshots-diff
+        ArtifactName: uitest-snapshot-results-android
+
+  - ${{ if eq(parameters.platform, 'ios')}}:
+    - task: PowerShell@2
+      inputs:
+      targetType: 'inline'
+      script: |
+        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+        if (Test-Path $folderPath) {
+          Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]true"
+        } else {
+          Write-Host "##vso[task.setvariable variable=iosFolderExists;isOutput=true]false"
+        }
+      name: CheckIosFolderExists
+
+    - task: PublishBuildArtifacts@1
+      condition: eq(dependencies.CheckIosFolderExists.outputs['iosFolderExists'], 'true')
+      displayName: publish iOS screenshots artifacts
+      inputs:
+        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.iOS.Tests/snapshots-diff
+        ArtifactName: uitest-snapshot-results-ios
+
+  - ${{ if eq(parameters.platform, 'windows')}}:
+    - task: PowerShell@2
+      inputs:
+      targetType: 'inline'
+      script: |
+        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+        if (Test-Path $folderPath) {
+          Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]true"
+        } else {
+          Write-Host "##vso[task.setvariable variable=windowsFolderExists;isOutput=true]false"
+        }
+      name: CheckWindowsFolderExists
+
+    - task: PublishBuildArtifacts@1
+      condition: eq(dependencies.CheckWindowsFolderExists.outputs['windowsFolderExists'], 'true')
+      displayName: publish Windows screenshots artifacts
+      inputs:
+        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.WinUI.Tests/snapshots-diff
+        ArtifactName: uitest-snapshot-results-windows
+
+  - ${{ if eq(parameters.platform, 'catalyst')}}:
+    - task: PowerShell@2
+      inputs:
+      targetType: 'inline'
+      script: |
+        $folderPath = ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
+        if (Test-Path $folderPath) {
+          Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]true"
+        } else {
+          Write-Host "##vso[task.setvariable variable=macFolderExists;isOutput=true]false"
+        }
+      name: CheckMacFolderExists
+
+    - task: PublishBuildArtifacts@1
+      condition: eq(dependencies.CheckMacFolderExists.outputs['macFolderExists'], 'true')
+      displayName: publish Mac screenshots artifacts
+      inputs:
+        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.WinUI.Tests/snapshots-diff
+        ArtifactName: uitest-snapshot-results-mac

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -196,7 +196,7 @@ steps:
       condition: eq(dependencies.CheckAndroidFolderExists.outputs['androidFolderExists'], 'true')
       displayName: publish Android screenshots artifacts
       inputs:
-        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.Android.Tests/snapshots-diff
+        PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Android.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
         ArtifactName: uitest-snapshot-results-android
 
   - ${{ if eq(parameters.platform, 'ios')}}:
@@ -216,7 +216,7 @@ steps:
       condition: eq(dependencies.CheckIosFolderExists.outputs['iosFolderExists'], 'true')
       displayName: publish iOS screenshots artifacts
       inputs:
-        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.iOS.Tests/snapshots-diff
+        PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.iOS.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
         ArtifactName: uitest-snapshot-results-ios
 
   - ${{ if eq(parameters.platform, 'windows')}}:
@@ -236,7 +236,7 @@ steps:
       condition: eq(dependencies.CheckWindowsFolderExists.outputs['windowsFolderExists'], 'true')
       displayName: publish Windows screenshots artifacts
       inputs:
-        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.WinUI.Tests/snapshots-diff
+        PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.WinUI.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
         ArtifactName: uitest-snapshot-results-windows
 
   - ${{ if eq(parameters.platform, 'catalyst')}}:
@@ -256,5 +256,5 @@ steps:
       condition: eq(dependencies.CheckMacFolderExists.outputs['macFolderExists'], 'true')
       displayName: publish Mac screenshots artifacts
       inputs:
-        PathToPublish: ${{ parameters.checkoutDirectory }}/src/Controls/tests/TestCases.Mac.Tests/snapshots-diff
+        PathToPublish: ${{ parameters.checkoutDirectory }}/artifacts/bin/Controls.TestCases.Mac.Tests/${{ parameters.configuration }}/net9.0/snapshots-diff
         ArtifactName: uitest-snapshot-results-mac

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4879.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4879.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("TestReady");
 			App.Screenshot("I am at Issue 4879. All buttons or images should be the same size.");
+			VerifyScreenshot();
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4879.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue4879.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("TestReady");
 			App.Screenshot("I am at Issue 4879. All buttons or images should be the same size.");
-			VerifyScreenshot();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Currently, we publish the snapshots diffs (or new ones, those that don't exist) under the drop folder. For those contributing, can access to the artifacts and download the entire drop folder but it's almost 2GB of data between libraries, logs, images and more. 

![image](https://github.com/user-attachments/assets/6321f9e0-2ca4-4a38-9e94-b7b27a5b6e2b)

This PR adds changes to create folders directly in the root of the artifacts if necessary:
- uitest-snapshot-results-ios
- uitest-snapshot-results-android
- uitest-snapshot-results-windows
- uitest-snapshot-results-mac

This way, can download only the necessary images from the desired platform.

