### PR TITLE
[android] move `IsDispatchRequiredImplementation()` to Java

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDispatcher.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDispatcher.java
@@ -19,6 +19,6 @@ public class PlatformDispatcher extends Handler {
     }
 
     public boolean isDispatchRequired() {
-        return Looper.getMainLooper() != getLooper();
+        return Looper.myLooper() != getLooper();
     }
 }

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDispatcher.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformDispatcher.java
@@ -1,0 +1,24 @@
+package com.microsoft.maui;
+
+import android.os.Handler;
+import android.os.Looper;
+
+/**
+ * Java-side support for Dispatcher.Android.cs
+ */
+public class PlatformDispatcher extends Handler {
+    private PlatformDispatcher(Looper looper) {
+        super(looper);
+    }
+
+    public static PlatformDispatcher create() {
+        Looper looper = Looper.myLooper();
+        if (looper == null || looper != Looper.getMainLooper())
+            return null;
+        return new PlatformDispatcher(looper);
+    }
+
+    public boolean isDispatchRequired() {
+        return Looper.getMainLooper() != getLooper();
+    }
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/8919
Context: https://github.com/jonathanpeppers/MAUI_CollectionView/tree/net9.0

Profiling the above sample, I saw a lot of time in:

    46.21ms (0.89%)	0.00ns (<0.01%)	Microsoft!Microsoft.Maui.Dispatching.Dispatcher.IsDispatchRequiredImplementation()

`Microsoft.Maui.Dispatching.Dispatcher.IsDispatchRequired` looks like it is called *a lot* by .NET MAUI, so it's likely worth improving here.

Almost all of the time is spent on the check:

    _looper != Looper.MyLooper();

`MyLooper()` does interop to Java, and then bookkeeping to create a C# instance of the `Looper`.

You can see this time spent inside `IsDispatchRequiredImplementation()` as:

    20.18ms (44%) Mono.Android!Java.Lang.Object.GetObject(intptr,Android.Runtime.JniHandleOwnership)

If we instead move the call to Java, C# can instead call a new `PlatformDispatcher` type that extends `Handler`:

    _dispatcher.IsDispatchRequired;

So now C# calls a Java method that simply returns a `bool`, and no C# `Looper` instance has to be created or managed. This completely removes the ~20ms or so we see spent in `Java.Lang.Object.GetObject()`.

This will also help performance tiny amount at startup, as we don't call `MyLooper()` or `MainLooper` any longer in C#, when creating the `Dispatcher`.