### PR TITLE
Enable nullability annotations for `ShadowTypeConverter`

### DIFF
--- a/src/Controls/src/Core/ShadowTypeConverter.cs
+++ b/src/Controls/src/Core/ShadowTypeConverter.cs
@@ -1,9 +1,6 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Converters;
@@ -15,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	/// </summary>
 	internal class ShadowTypeConverter : TypeConverter
 	{
-		readonly ColorTypeConverter _colorTypeConverter = new ColorTypeConverter();
+		readonly ColorTypeConverter _colorTypeConverter = new();
 
 		/// <summary>
 		/// Checks whether the given <paramref name="sourceType" /> is a string.
@@ -23,7 +20,7 @@ namespace Microsoft.Maui.Controls
 		/// <param name="context">The context to use for conversion.</param>
 		/// <param name="sourceType">The type to convert from.</param>
 		/// <returns></returns>
-		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type? sourceType)
 			=> sourceType == typeof(string);
 
 		/// <summary>
@@ -32,7 +29,7 @@ namespace Microsoft.Maui.Controls
 		/// <param name="context">The context to use for conversion.</param>
 		/// <param name="destinationType">The type to convert to.</param>
 		/// <returns></returns>
-		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+		public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
 			=> destinationType == typeof(Shadow);
 
 		/// <summary>
@@ -44,11 +41,11 @@ namespace Microsoft.Maui.Controls
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="value" /> is null.</exception>
 		/// <exception cref="InvalidOperationException">Thrown when <paramref name="value" /> is not a valid Shadow.</exception>
-		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+		public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
 		{
 			var strValue = value?.ToString();
 
-			if (strValue == null)
+			if (strValue is null)
 			{
 				throw new ArgumentNullException(nameof(strValue));
 			}
@@ -140,7 +137,7 @@ namespace Microsoft.Maui.Controls
 		/// <returns>A string representation of the Shadow.</returns>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="value" /> is null.</exception>
 		/// <exception cref="InvalidOperationException">Thrown when <paramref name="value" /> is not a Shadow or the Brush is not a SolidColorBrush.</exception>
-		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type? destinationType)
 		{
 			if (value is null)
 			{
@@ -155,7 +152,7 @@ namespace Microsoft.Maui.Controls
 				var color = (shadow.Brush as SolidColorBrush)?.Color.ToHex();
 				var opacity = shadow.Opacity.ToString(CultureInfo.InvariantCulture);
 
-				if (color == null)
+				if (color is null)
 				{
 					throw new InvalidOperationException("Cannot convert Shadow to string: Brush is not a valid SolidColorBrush or has no Color.");
 				}


### PR DESCRIPTION
### Description of Change

This PR contributes to #27737 without making the type actually `public` as this PR targets .NET 9.

There are actually many converters with `#nullable disable`, I think that it would be great to modify them to use `#nullable enable` in this PR or in a follow-up one.