### PR TITLE
Fix the FilePicker.PickMultipleAsync() Not Returning Null When Canceled

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.shared.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.shared.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Storage
 		/// picker, the <see cref="Task"/> object that was returned from the first call is cancelled. Be sure to
 		/// also handle the <see cref="TaskCanceledException"/> in this case.
 		/// </remarks>
-		Task<IEnumerable<FileResult>> PickMultipleAsync(PickOptions? options = null);
+		Task<IEnumerable<FileResult?>> PickMultipleAsync(PickOptions? options = null);
 	}
 
 	/// <summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Storage
 		/// picker, the <see cref="Task"/> object that was returned from the first call is cancelled. Be sure to
 		/// also handle the <see cref="TaskCanceledException"/> in this case.
 		/// </remarks>
-		public static Task<IEnumerable<FileResult>> PickMultipleAsync(PickOptions? options = null) =>
+		public static Task<IEnumerable<FileResult?>> PickMultipleAsync(PickOptions? options = null) =>
 			Default.PickMultipleAsync(options);
 
 		static IFilePicker? defaultImplementation;
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Storage
 		public async Task<FileResult?> PickAsync(PickOptions? options = null) =>
 			(await PlatformPickAsync(options))?.FirstOrDefault();
 
-		public Task<IEnumerable<FileResult>> PickMultipleAsync(PickOptions? options = null) =>
+		public Task<IEnumerable<FileResult?>> PickMultipleAsync(PickOptions? options = null) =>
 			PlatformPickAsync(options ?? PickOptions.Default, true);
 	}
 

--- a/src/Essentials/src/FilePicker/FilePicker.uwp.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.uwp.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Storage
 			if (allowMultiple)
 			{
 				var fileList = await picker.PickMultipleFilesAsync();
-				if (fileList != null)
+				if (fileList != null && fileList.Any())
 					resultList.AddRange(fileList);
 			}
 			else
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Storage
 					resultList.Add(file);
 			}
 
-			return resultList.Select(storageFile => new FileResult(storageFile));
+			return resultList.Count == 0 ? null : resultList.Select(storageFile => new FileResult(storageFile));
 		}
 
 		static void SetFileTypes(PickOptions options, FileOpenPicker picker)

--- a/src/Essentials/src/FileSystem/FileSystem.ios.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.ios.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Storage
 		public static async Task<FileResult[]> EnsurePhysicalFileResultsAsync(params NSUrl[] urls)
 		{
 			if (urls == null || urls.Length == 0)
-				return Array.Empty<FileResult>();
+				return null;
 
 			var opts = NSFileCoordinatorReadingOptions.WithoutChanges;
 			var intents = urls.Select(x => NSFileAccessIntent.CreateReadingIntent(x, opts)).ToArray();

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -901,7 +901,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1263,7 +1263,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileProvider.TemporaryLocation.get -> Microsoft.Maui.Storage.FileProviderLocation
 static Microsoft.Maui.Storage.FileProvider.TemporaryLocation.set -> void
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -889,7 +889,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1257,7 +1257,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!
 static Microsoft.Maui.Storage.FileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Storage.FileSystem.CacheDirectory.get -> string!

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -889,7 +889,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1257,7 +1257,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!
 static Microsoft.Maui.Storage.FileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Storage.FileSystem.CacheDirectory.get -> string!

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -850,7 +850,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1204,7 +1204,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!
 static Microsoft.Maui.Storage.FileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Storage.FileSystem.CacheDirectory.get -> string!

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -849,7 +849,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1207,7 +1207,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!
 static Microsoft.Maui.Storage.FileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Storage.FileSystem.CacheDirectory.get -> string!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -831,7 +831,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1178,7 +1178,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!
 static Microsoft.Maui.Storage.FileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Storage.FileSystem.CacheDirectory.get -> string!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -831,7 +831,7 @@ Microsoft.Maui.Storage.FileSystemImplementation.FileSystemImplementation() -> vo
 Microsoft.Maui.Storage.FileSystemImplementation.OpenAppPackageFileAsync(string! filename) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 Microsoft.Maui.Storage.IFilePicker
 Microsoft.Maui.Storage.IFilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Storage.IFileSystem
 Microsoft.Maui.Storage.IFileSystem.AppDataDirectory.get -> string!
 Microsoft.Maui.Storage.IFileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
@@ -1178,7 +1178,7 @@ static Microsoft.Maui.Networking.Connectivity.Current.get -> Microsoft.Maui.Netw
 static Microsoft.Maui.Networking.Connectivity.NetworkAccess.get -> Microsoft.Maui.Networking.NetworkAccess
 static Microsoft.Maui.Storage.FilePicker.Default.get -> Microsoft.Maui.Storage.IFilePicker!
 static Microsoft.Maui.Storage.FilePicker.PickAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<Microsoft.Maui.Storage.FileResult?>!
-static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Storage.FileSystem.AppDataDirectory.get -> string!
 static Microsoft.Maui.Storage.FileSystem.AppPackageFileExistsAsync(string! filename) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Storage.FileSystem.CacheDirectory.get -> string!


### PR DESCRIPTION
### Issue Details
If the user cancels the file picking, the result must be null. However, FilePicker.PickMultipleAsync() does not return a null value.
 
### Root Cause
The method currently returns a file result value even when the user cancels the file pick operation.
 
### Description of Change
Modify the FilePicker.PickMultipleAsync() method to be nullable and return null when the user cancels the file pick operation.
 
Validated the behavior in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
Fixes #27710
 
### Output  ScreenShot
 | Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/c434c2ec-2f9e-45c5-a495-88f30d908d2e" width="320" height="240" controls></video>   |   <video src="https://github.com/user-attachments/assets/a12e92b2-9160-42df-b5f3-e9cfb9c8021e" width="320" height="240" controls></video>   |
