### PR TITLE
[iOS] CollectionView 1's doesn't adjust its offset when resizing a footer

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
@@ -213,7 +213,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					if (CollectionView.ContentSize.Height + headerHeight <= CollectionView.Bounds.Height)
 						yOffset = -headerHeight;
 
-					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, yOffset);
+					if (currentOffset.Y.Value < headerHeight)
+					{
+						CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, yOffset);
+					}
 				}
 
 				if (_headerUIView != null && _headerUIView.Frame.Y != headerHeight)


### PR DESCRIPTION
### Description of Change

A small improvement to the mechanism of resizing the header and footer that moves the offset only when the header would be visible. Thanks to it, the CollectionView 1's properly adjust its offset when resizing a footer

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/27962

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/53825691-0f70-487f-944d-5943f48a9284" width="300px"/>|<video src="https://github.com/user-attachments/assets/3272ed06-c791-4cb0-833c-bb3130b429c0" width="300px"/>|