### PR TITLE
[Android] Properly Resolve File Paths in FilePicker When MANAGE_EXTERNAL_STORAGE is Granted

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.android.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.android.cs
@@ -33,10 +33,13 @@ namespace Microsoft.Maui.Storage
 					// The uri returned is only temporary and only lives as long as the Activity that requested it,
 					// so this means that it will always be cleaned up by the time we need it because we are using
 					// an intermediate activity.
+					#pragma warning disable CA1416 // Validate platform compatibility
+					 bool requireExtendedAccess = !(Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.R && Android.OS.Environment.IsExternalStorageManager);
+					 #pragma warning restore CA1416 // Validate platform compatibility
 
 					if (intent.ClipData == null)
 					{
-						var path = FileSystemUtils.EnsurePhysicalPath(intent.Data);
+						var path = FileSystemUtils.EnsurePhysicalPath(intent.Data,requireExtendedAccess);
 						resultList.Add(new FileResult(path));
 					}
 					else
@@ -44,7 +47,7 @@ namespace Microsoft.Maui.Storage
 						for (var i = 0; i < intent.ClipData.ItemCount; i++)
 						{
 							var uri = intent.ClipData.GetItemAt(i).Uri;
-							var path = FileSystemUtils.EnsurePhysicalPath(uri);
+							var path = FileSystemUtils.EnsurePhysicalPath(uri,requireExtendedAccess);
 							resultList.Add(new FileResult(path));
 						}
 					}

--- a/src/Essentials/src/FilePicker/FilePicker.android.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.android.cs
@@ -33,9 +33,7 @@ namespace Microsoft.Maui.Storage
 					// The uri returned is only temporary and only lives as long as the Activity that requested it,
 					// so this means that it will always be cleaned up by the time we need it because we are using
 					// an intermediate activity.
-					#pragma warning disable CA1416 // Validate platform compatibility
-					 bool requireExtendedAccess = !(Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.R && Android.OS.Environment.IsExternalStorageManager);
-					 #pragma warning restore CA1416 // Validate platform compatibility
+				    bool requireExtendedAccess = !(OperatingSystem.IsAndroidVersionAtLeast(30) && Android.OS.Environment.IsExternalStorageManager);
 
 					if (intent.ClipData == null)
 					{


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Summary

The `FilePicker API` for Android currently does not properly handle file access when `MANAGE_EXTERNAL_STORAGE` is granted. This leads to an incorrect behavior where the absolute file path is not resolved, and instead, the FilePicker returns a cached copy.

### Root Cause

- The issue occurs because `EnsurePhysicalPath` always forces `requireExtendedAccess = true` , which prevents `ResolveDocumentPath` from executing when Scoped Storage is enforced on Android 10+ (API 29+).
- Currently, we do not consider if `MANAGE_EXTERNAL_STORAGE` is granted, meaning it doesn't attempt to resolve the path even when the permission is granted.


### Fix

- Pass `requireExtendedAccess = false` when `MANAGE_EXTERNAL_STORAGE` is granted to allow `ResolveDocumentPath` to execute.
- If the path still cannot be resolved, it will automatically fall back to caching the file as we currently do.

<!-- Enter description of the fix in this section -->

**Current Behaviour:**

https://github.com/user-attachments/assets/d0ddda9f-692b-4817-be57-74a45661a874

**After Fix**

https://github.com/user-attachments/assets/66fbd829-5078-48bf-a1f7-45f3eaa0dbb3




### Issues Fixed
 
<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6015 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
