### PR TITLE
Add test run message to device tests logs

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 						: runInfos.FirstOrDefault()?.TestCases.FirstOrDefault()?.DisplayName;
 				}
 
-				_logger.LogTestStart(message);
+				_logger.LogTestsStart(message);
 
 				try
 				{
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 				}
 				finally
 				{
-					_logger.LogTestComplete();
+					_logger.LogTestsComplete();
 				}
 			}
 		}
@@ -284,7 +284,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 			var diagSink = new DiagnosticMessageSink(d => context.Post(_ => OnDiagnosticMessage?.Invoke(d), null), runInfo.AssemblyFileName, executionOptions.GetDiagnosticMessagesOrDefault());
 
-			var deviceExecSink = new DeviceExecutionSink(xunitTestCases, this, context);
+			var deviceExecSink = new DeviceExecutionSink(xunitTestCases, this, _logger, context);
 
 			IExecutionSink resultsSink = new ExecutionSink(deviceExecSink, new ExecutionSinkOptions
 			{

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DeviceExecutionSink.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DeviceExecutionSink.cs
@@ -13,20 +13,29 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 	{
 		readonly SynchronizationContext _context;
 		readonly ITestListener _listener;
+		readonly TestRunLogger _logger;
 		readonly Dictionary<ITestCase, TestCaseViewModel> _testCases;
 
 		public DeviceExecutionSink(
 			Dictionary<ITestCase, TestCaseViewModel> testCases,
 			ITestListener listener,
+			TestRunLogger logger,
 			SynchronizationContext context)
 		{
 			_testCases = testCases ?? throw new ArgumentNullException(nameof(testCases));
 			_listener = listener ?? throw new ArgumentNullException(nameof(listener));
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
 			_context = context ?? throw new ArgumentNullException(nameof(context));
 
 			Execution.TestFailedEvent += HandleTestFailed;
 			Execution.TestPassedEvent += HandleTestPassed;
 			Execution.TestSkippedEvent += HandleTestSkipped;
+			Execution.TestStartingEvent += HandleTestStarting;
+		}
+
+		void HandleTestStarting(MessageHandlerArgs<ITestStarting> args)
+		{
+			LogSingleTestStarting(args.Message);
 		}
 
 		void HandleTestFailed(MessageHandlerArgs<ITestFailed> args)
@@ -42,6 +51,18 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 		void HandleTestSkipped(MessageHandlerArgs<ITestSkipped> args)
 		{
 			MakeTestResultViewModel(args.Message, TestState.Skipped);
+		}
+
+		void LogSingleTestStarting(ITestStarting test)
+		{
+			var displayName = test.TestCase.DisplayName;
+
+			if (test.TestCase.Traits.TryGetValue("Category", out var categories) && categories.Count > 0)
+			{
+				displayName = $"[{categories[0]}] {displayName}";
+			}
+
+			_logger.LogTestStart(displayName);
 		}
 
 		async void MakeTestResultViewModel(ITestResultMessage testResult, TestState outcome)

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/TestRunLogger.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/TestRunLogger.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			}
 		}
 
-		public void LogTestStart(string? message = null)
+		public void LogTestsStart(string? message = null)
 		{
 			lock (_locker)
 			{
@@ -87,7 +87,15 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			}
 		}
 
-		public void LogTestComplete()
+		public void LogTestStart(string displayName)
+		{
+			lock (_locker)
+			{
+				_logger.LogInformation("\t[RUN] {0}", displayName);
+			}
+		}
+
+		public void LogTestsComplete()
 		{
 			lock (_locker)
 			{


### PR DESCRIPTION
### Description of Change

Sometimes device tests gets stuck or maybe the application crashes and we have no clue on where the problem was.
Logging a test's display name when it's about to start gives us the required information when looking at logs.

Sample output:
```
2025-02-24 08:49:29.514926+0100 Microsoft.Maui.Controls.DeviceTests[47875:6602729] info: TestRun[0]
      	[RUN] [Button] LineBreakMode Initializes Correctly(lineBreakMode: NoWrap)
2025-02-24 08:49:29.654033+0100 Microsoft.Maui.Controls.DeviceTests[47875:6602729] info: TestRun[0]
      	[PASS] [Button] LineBreakMode Initializes Correctly(lineBreakMode: NoWrap)
```