### PR TITLE
Enable generation of API docs in CI for .NET 10

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -357,12 +357,12 @@ Task("dotnet-pack-docs")
                 if (filename.StartsWith("Microsoft.AspNetCore.Components.WebView.Wpf")
                     || filename.StartsWith("Microsoft.AspNetCore.Components.WebView.WindowsForms"))
                 {
-                    CopyFiles($"{d}/lib/**/net?.?-windows?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
+                    CopyFiles($"{d}/lib/**/net??.?-windows?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
 
                     continue;
                 }
 
-                CopyFiles($"{d}/lib/**/net?.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
+                CopyFiles($"{d}/lib/**/net??.?/**/*.{{dll,xml,pdb}}", $"{destDir}");
             }
         }
 


### PR DESCRIPTION
### Description of Change

Enables the generation of the XML API docs for .NET 10. Took me a minute to figure out why it wasn't working 😬 
Not changing this logic to be more robust, we have until .NET 100 before this will break again. My greatgreatgreatgrandkids can look into it then.