### PR TITLE
Fix Android device tests on .NET 10

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
@@ -118,14 +118,15 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 				finalPath = Path.Combine(root, relative, name);
 			}
 
-			if (OperatingSystem.IsAndroidVersionAtLeast(21))
-			{
-				bundle.PutCharSequence("return-code", finalPath);
-			}
-			else
-			{
+			// TODO: reinstate this when .NET for Android have a fix on their side (https://github.com/dotnet/maui/issues/28007)
+			//if (OperatingSystem.IsAndroidVersionAtLeast(21))
+			//{
+			//	bundle.PutCharSequence("return-code", finalPath);
+			//}
+			//else
+			//{
 				bundle.PutString("return-code", finalPath);
-			}
+			//}
 		}
 
 		Task<Bundle> RunTestsAsync()

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
@@ -118,15 +118,14 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 				finalPath = Path.Combine(root, relative, name);
 			}
 
-			// TODO: reinstate this when .NET for Android have a fix on their side (https://github.com/dotnet/maui/issues/28007)
-			//if (OperatingSystem.IsAndroidVersionAtLeast(21))
-			//{
-			//	bundle.PutCharSequence("return-code", finalPath);
-			//}
-			//else
-			//{
-				bundle.PutString("return-code", finalPath);
-			//}
+			if (OperatingSystem.IsAndroidVersionAtLeast(21))
+			{
+				bundle.PutCharSequence("test-results-path", finalPath);
+			}
+			else
+			{
+				bundle.PutString("test-results-path", finalPath);
+			}
 		}
 
 		Task<Bundle> RunTestsAsync()

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
@@ -35,14 +35,15 @@ namespace mauitemplate
             var currentActivity = WaitForMonitor(monitor);
             var resultCode = currentActivity is not null ? Result.Ok : Result.Canceled;
 
-			if (OperatingSystem.IsAndroidVersionAtLeast(21))
-			{
-				results.PutCharSequence("return-code", resultCode.ToString("D"));
-			}
-			else
-			{
+            // TODO: reinstate this when .NET for Android have a fix on their side (https://github.com/dotnet/maui/issues/28007)
+			//if (OperatingSystem.IsAndroidVersionAtLeast(21))
+			//{
+			//	results.PutCharSequence("return-code", resultCode.ToString("D"));
+			//}
+			//else
+			//{
 				results.PutString("return-code", resultCode.ToString("D"));		
-			}
+			//}
 			
             Finish(resultCode, results);
         }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/TestResources/TemplateLaunchInstrumentation.cs
@@ -35,15 +35,14 @@ namespace mauitemplate
             var currentActivity = WaitForMonitor(monitor);
             var resultCode = currentActivity is not null ? Result.Ok : Result.Canceled;
 
-            // TODO: reinstate this when .NET for Android have a fix on their side (https://github.com/dotnet/maui/issues/28007)
-			//if (OperatingSystem.IsAndroidVersionAtLeast(21))
-			//{
-			//	results.PutCharSequence("return-code", resultCode.ToString("D"));
-			//}
-			//else
-			//{
+			if (OperatingSystem.IsAndroidVersionAtLeast(21))
+			{
+				results.PutCharSequence("return-code", resultCode.ToString("D"));
+			}
+			else
+			{
 				results.PutString("return-code", resultCode.ToString("D"));		
-			//}
+			}
 			
             Finish(resultCode, results);
         }


### PR DESCRIPTION
### Description of Change

This change has a copy/paste error and changes the key from `test-results-path` to `return-code` causing the device tests to fail because the result could not be determined: https://github.com/dotnet/maui/commit/90fb660d105833b2f1e2b724a24172fc99979854#diff-2dc5f5728a02b5192140bce2f50236fae29d9194ed82227c0a8ee25efd865dc7L121

Opened this issue to track later work we still need to do on this: https://github.com/dotnet/maui/issues/28007
