### PR TITLE
[net10.0] Enable trimmer warnings

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -29,30 +29,18 @@
     <NoWarn>$(NoWarn);MSB4011;NETSDK1206</NoWarn>
   </PropertyGroup>
 
-  <!-- FIXME: various test projects have trimmer warnings, which are enabled by default on iOS/Catalyst -->
-  <PropertyGroup Condition=" '$(MauiTestProject)' == 'true' or '$(SampleProject)' == 'true' ">
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
-    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
-  </PropertyGroup>
-
   <!-- platform version number information -->
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsiOS)' == 'True'">
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>13.0</TargetPlatformMinVersion>
-    <!-- Workaround: https://github.com/dotnet/roslyn-analyzers/issues/6158 -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIstvOS)' == 'True'">
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>10.0</TargetPlatformMinVersion>
-    <!-- Workaround: https://github.com/dotnet/roslyn-analyzers/issues/6158 -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsMacCatalyst)' == 'True'">
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>15.0</TargetPlatformMinVersion>
-    <!-- Workaround: https://github.com/dotnet/roslyn-analyzers/issues/6158 -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsmacOS)' == 'True'">
     <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>

--- a/src/Controls/samples/Controls.Sample.Embedding/Platforms/MacCatalyst/NewTaskSceneDelegate.cs
+++ b/src/Controls/samples/Controls.Sample.Embedding/Platforms/MacCatalyst/NewTaskSceneDelegate.cs
@@ -40,13 +40,19 @@ public class NewTaskSceneDelegate : UIWindowSceneDelegate
 
 		var toolbar = new NSToolbar();
 
-#pragma warning disable CA1422
-		toolbar.ShowsBaselineSeparator = false;
-#pragma warning restore CA1422
+		if (OperatingSystem.IsMacOSVersionAtLeast(15, 0))
+		{
+			toolbar.ShowsBaselineSeparator = false;
+		}
 
 		var titlebar = Window.WindowScene.Titlebar;
 		titlebar.Toolbar = toolbar;
-		titlebar.ToolbarStyle = UITitlebarToolbarStyle.Automatic;
+
+		if (OperatingSystem.IsMacOSVersionAtLeast(12, 0))
+		{
+			titlebar.ToolbarStyle = UITitlebarToolbarStyle.Automatic;
+		}
+
 		titlebar.TitleVisibility = UITitlebarTitleVisibility.Visible;
 	}
 }

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/Focus/FocusHandlerTests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/Focus/FocusHandlerTests.cs
@@ -1,11 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Hosting;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	public abstract partial class FocusHandlerTests<THandler, TStub, TLayoutStub> : HandlerTestBasement<THandler, TStub>
+	public abstract partial class FocusHandlerTests<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler, TStub, TLayoutStub> : HandlerTestBasement<THandler, TStub>
 		where THandler : class, IViewHandler, new()
 		where TStub : IStubBase, new()
 		where TLayoutStub : IStubBase, ILayout, new()

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -381,7 +381,9 @@ namespace Microsoft.Maui.DeviceTests
 		public void HandlersHaveAllExpectedContructors()
 		{
 			bool hasBothMappers = false;
+#pragma warning disable IL2090 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
 			var constructors = typeof(THandler).GetConstructors();
+#pragma warning restore IL2090 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
 
 			foreach (var ctor in constructors)
 			{

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -175,10 +176,10 @@ namespace Microsoft.Maui.DeviceTests
 			return handler;
 		}
 
-		protected IPlatformViewHandler CreateHandler(IElement view, Type handlerType) =>
+		protected IPlatformViewHandler CreateHandler(IElement view, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type handlerType) =>
 			CreateHandler(view, handlerType, MauiContext);
 
-		protected IPlatformViewHandler CreateHandler(IElement view, Type handlerType, IMauiContext mauiContext)
+		protected IPlatformViewHandler CreateHandler(IElement view, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type handlerType, IMauiContext mauiContext)
 		{
 			if (view.Handler is IPlatformViewHandler t)
 				return t;
@@ -192,7 +193,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected Task ValidateHasColor(
 			IView view,
 			Color color,
-			Type handlerType,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type handlerType,
 			Action action = null,
 			string updatePropertyValue = null,
 			double? tolerance = null)
@@ -278,7 +279,7 @@ namespace Microsoft.Maui.DeviceTests
 				return result;
 			});
 
-		protected Task AssertColorAtPoint(IView view, Color color, Type handlerType, int x, int y)
+		protected Task AssertColorAtPoint(IView view, Color color, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type handlerType, int x, int y)
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
@@ -291,7 +292,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		protected Task AssertColorsAtPoints(IView view, Type handlerType, Color[] colors, Point[] points)
+		protected Task AssertColorsAtPoints(IView view, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type handlerType, Color[] colors, Point[] points)
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
@@ -300,7 +301,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		protected Task<ImageAnalysis.RawBitmap> GetRawBitmap(Controls.VisualElement view, Type handlerType)
+		protected Task<ImageAnalysis.RawBitmap> GetRawBitmap(Controls.VisualElement view, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type handlerType)
 		{
 			return InvokeOnMainThreadAsync<RawBitmap>(async () =>
 			{

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasementOfT.cs
@@ -215,7 +215,9 @@ namespace Microsoft.Maui.DeviceTests
 			TValue expectedSetValue,
 			TValue expectedUnsetValue)
 		{
+#pragma warning disable IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 			var propInfo = view.GetType().GetProperty(property);
+#pragma warning restore IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 
 			// set initial values
 
@@ -241,7 +243,9 @@ namespace Microsoft.Maui.DeviceTests
 			TValue expectedUnsetValue)
 		{
 			var view = handler.VirtualView;
+#pragma warning disable IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 			var propInfo = handler.VirtualView.GetType().GetProperty(property);
+#pragma warning restore IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 
 			// confirm can update
 

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/TextStyle/TextStyleHandlerTests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/TextStyle/TextStyleHandlerTests.cs
@@ -99,6 +99,8 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(slant == FontSlant.Italic, isItalic);
 		}
 #endif
+#pragma warning disable IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+
 		protected virtual void SetFont(TStub stub, Font font)
 		{
 			stub.GetType().GetProperty("Font").SetValue(stub, font);
@@ -112,5 +114,6 @@ namespace Microsoft.Maui.DeviceTests
 			else
 				stub.GetType().GetProperty("Text").SetValue(stub, text);
 		}
+#pragma warning restore IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 	}
 }

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/TextStyle/TextStyleHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/TextStyle/TextStyleHandlerTests.iOS.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Maui.DeviceTests
 			if (view is not ITextStyle)
 				return;
 
+#pragma warning disable IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 			view.GetType().GetProperty("Font").SetValue(view, Font.OfSize(family, 10));
+#pragma warning restore IL2075 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
 
 			var handler = await CreateHandlerAsync(view);
 			var nativeFont = await GetValueAsync(view, handler => GetNativeFont(handler));

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -223,13 +223,25 @@ namespace Microsoft.Maui.DeviceTests
 				}));
 			}
 
-			UIGraphics.BeginImageContext(imageRect.Size);
+			UIImage image;
 
-			var context = UIGraphics.GetCurrentContext();
-			view.Layer.RenderInContext(context);
-			var image = UIGraphics.GetImageFromCurrentImageContext();
+			if (OperatingSystem.IsIOSVersionAtLeast(17) || OperatingSystem.IsMacCatalystVersionAtLeast(17))
+			{
+				var renderer = new UIGraphicsImageRenderer(imageRect.Size);
+				image = renderer.CreateImage(c =>
+				{
+					view.Layer.RenderInContext(c.CGContext);
+				});
+			}
+			else
+			{
+				UIGraphics.BeginImageContext(imageRect.Size);
+				var context = UIGraphics.GetCurrentContext();
+				view.Layer.RenderInContext(context);
+				image = UIGraphics.GetImageFromCurrentImageContext();
+				UIGraphics.EndImageContext();
+			}
 
-			UIGraphics.EndImageContext();
 			logger?.LogDebug($"Finish: {image.Size}");
 
 			return Task.FromResult(image);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.DeviceTests
 		private class TestWrapperView : UIView
 		{
 			private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-			
+
 			public Task WaitForLayoutPassAsync() => _tcs.Task;
 
 			public override void LayoutSubviews()
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.DeviceTests
 				_tcs.TrySetResult();
 			}
 		}
-		
+
 		public static async Task<T> AttachAndRun<T>(this UIView view, Func<Task<T>> action)
 		{
 			var currentView = FindContentView();
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					return _contentView;
 				}
-				
+
 				if (GetKeyWindow(UIApplication.SharedApplication) is not UIWindow window)
 				{
 					throw new InvalidOperationException("Could not attach view - unable to find UIWindow");
@@ -223,24 +223,13 @@ namespace Microsoft.Maui.DeviceTests
 				}));
 			}
 
-			UIImage image;
-
-			if (OperatingSystem.IsIOSVersionAtLeast(17) || OperatingSystem.IsMacCatalystVersionAtLeast(17))
-			{
-				var renderer = new UIGraphicsImageRenderer(imageRect.Size);
-				image = renderer.CreateImage(c =>
-				{
-					view.Layer.RenderInContext(c.CGContext);
-				});
-			}
-			else
-			{
-				UIGraphics.BeginImageContext(imageRect.Size);
-				var context = UIGraphics.GetCurrentContext();
-				view.Layer.RenderInContext(context);
-				image = UIGraphics.GetImageFromCurrentImageContext();
-				UIGraphics.EndImageContext();
-			}
+#pragma warning disable CA1416 // Validate platform compatibility
+			UIGraphics.BeginImageContext(imageRect.Size);
+			var context = UIGraphics.GetCurrentContext();
+			view.Layer.RenderInContext(context);
+			var image = UIGraphics.GetImageFromCurrentImageContext();
+			UIGraphics.EndImageContext();
+#pragma warning restore CA1416 // Validate platform compatibility
 
 			logger?.LogDebug($"Finish: {image.Size}");
 

--- a/src/TestUtils/src/TestShared/xUnitSharedAttributes.cs
+++ b/src/TestUtils/src/TestShared/xUnitSharedAttributes.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using Xunit;
@@ -71,14 +72,26 @@ namespace Microsoft.Maui
 		/// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
 		/// </summary>
 		/// <param name="class">The class that provides the data.</param>
-		public ClassDataAttribute(Type @class)
+#if !NETSTANDARD
+
+		public ClassDataAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type @class)
 		{
 			Class = @class;
 		}
 
+#else
+		public ClassDataAttribute(Type @class)
+		{
+			Class = @class;
+		}
+#endif
+
 		/// <summary>
 		/// Gets the type of the class that provides the data.
 		/// </summary>
+#if !NETSTANDARD
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
 		public Type Class { get; private set; }
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### Description of Change

We have disable some trimmer warnings for iOS/Mac builds. We can enable them back now as this should be fixed on iOS workload

### Issues Fixed

Fixes #27316
