### PR TITLE
[ci] Publish workload VS insertion zips

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,6 +2,7 @@
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>
       <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+      <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishBlobItems</PublishDependsOnTargets>
    </PropertyGroup>
 
    <ItemGroup>


### PR DESCRIPTION
The `_PublishBlobItems` target in `eng/Publishing.props` needs to hook
into the publishing targets, and it looks like `PublishDependsOnTargets`
can be used to accomplish this.