### PR TITLE
[Android] Fix: Prevent duplicate Completed event when setting ReturnType in Entry

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Controls.TestCases.HostApp.Issues.Issue27992"
+             Title="Issue27992">
+     <VerticalStackLayout Margin="10,30,10,0">
+              <Entry AutomationId="MauiEntry" Completed="Entry_Completed"
+                ReturnType="Search" />
+              <Label AutomationId="MauiLabel" x:Name="label" FontSize="30" TextColor="Black" />
+             </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml.cs
@@ -1,0 +1,16 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 27992, "Entry Completed Event Triggered Twice", PlatformAffected.Android)]
+public partial class Issue27992 : ContentPage
+{
+	public Issue27992()
+	{
+		InitializeComponent();
+	}
+	int i =0;
+	private void Entry_Completed(object sender, EventArgs e)
+	{
+		i++;
+		label.Text = $"Completed Invoked {i} times";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27992.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27992.cs
@@ -1,0 +1,30 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+
+public class Issue27992 : _IssuesUITest
+{
+	public Issue27992(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Entry Completed Event Triggered Twice";
+
+
+    [Test]
+	[Category(UITestCategories.Entry)]
+	public void EntryCompletedShouldOnlyFireOnce()
+	{
+		App.WaitForElement("MauiEntry");
+
+        App.Tap("MauiEntry");
+
+        App.PressEnter();
+
+        var text = App.WaitForElement("MauiLabel").GetText();
+        Assert.That(text,Is.EqualTo("Completed Invoked 1 times"));
+	}
+}

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -223,6 +223,7 @@ namespace Microsoft.Maui.Handlers
 				else if (evt?.KeyCode is null && (actionId == ImeAction.Done || actionId == currentInputImeFlag))
 				{
 					VirtualView?.Completed();
+					handled = true;
 				}
 			}
 

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -223,7 +223,12 @@ namespace Microsoft.Maui.Handlers
 				else if (evt?.KeyCode is null && (actionId == ImeAction.Done || actionId == currentInputImeFlag))
 				{
 					VirtualView?.Completed();
-					handled = true;
+					// In case of Search, Go, Send the EditorAction will be invoked for KeyEventActions which will cause Completed to inovke twice
+					//So for these setting handled to true
+					if (actionId == ImeAction.Search ||
+					 actionId == ImeAction.Go ||
+					  actionId == ImeAction.Send)
+						handled = true;
 				}
 			}
 


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This change fixes an issue where the `Completed` event in `Entry` **triggers twice** on Android when setting `ReturnType`.
<!-- Enter description of the fix in this section -->

**Root Cause**

-  When setting `ReturnType`, Android internally updates the **ImeOptions**, which can cause multiple events to be fired.
- Both **ImeActions (`ImeAction.Done`, `ImeAction.Search`, etc.)** and **physical keyboard Enter presses** were not consistently handled.
- The `Completed` event is invoked **once by the soft keyboard action (`ImeAction`)** and **again by the physical Enter key press (`KeyEventActions.Up`)**.
- This results in **duplicate event triggers** when pressing the return key.

#### **Fix Implementation**

- Prevent `KeyEventActions.Up` from firing unnecessarily if the event was already handled by the soft keyboard.






### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #27992 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
