### PR TITLE
[ci] Remove usage on cake script

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,7 @@
   <PropertyGroup>
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>moderate</NuGetAuditLevel>
+    <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -588,7 +588,6 @@ void UseLocalNuGetCacheFolder(bool reset = false)
 
 void StartVisualStudioCodeForDotNet()
 {
-    string workspace = "./maui.code-workspace";
     if (IsCIBuild())
     {
         Error("This target should not run on CI.");
@@ -600,7 +599,7 @@ void StartVisualStudioCodeForDotNet()
         SetDotNetEnvironmentVariables();
     }
 
-    StartProcess("code", new ProcessSettings{ Arguments = workspace, EnvironmentVariables = GetDotNetEnvironmentVariables() });
+    StartProcess("code", new ProcessSettings{ EnvironmentVariables = GetDotNetEnvironmentVariables() });
 }
 
 void StartVisualStudioForDotNet()


### PR DESCRIPTION
### Description of Change

We removed this file so we can use it.

When using .net10  we were getting this 

```
 /Users/ruimarinho/dotnet/maui/src/Graphics/src/Graphics/Graphics.csproj : error NU1510: Warning As Error: PackageReference System.Numerics.Vectors will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
 ``` 
 
 To fix it we can disable RestoreEnablePackagePruning
 
 `<RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>`

