### PR TITLE
[code style] Prefer file-scope namespaces 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -67,6 +67,10 @@ csharp_style_var_for_built_in_types = true:none
 csharp_style_var_when_type_is_apparent = true:none
 csharp_style_var_elsewhere = false:none
 
+# Namespace preference (prefer file-scoped namespaces)
+csharp_style_namespace_declarations = file_scoped
+dotnet_diagnostic.IDE0161.severity = suggestion
+
 # use language keywords instead of BCL types
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion


### PR DESCRIPTION
### Description of Change

This PR adds a suggestion to use [file-scoped namespaces](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces) (if possible) using [IDE0161](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0160-ide0161) analyzer. 

The documentation page mentions:

> This option [i.e. `csharp_style_namespace_declarations`] is used by Visual Studio to determine how namespaces are declared when new code files are added to projects. Visual Studio honors the option value even if both IDE0160 and IDE0161 are disabled.

This PR was created because when file-scoped namespaces are used, then there is bigger chance that two files can be worked on one display which leads to improved productivity. 


### What are file-scoped namespaces?

C# originally allowed only block-scoped namespaces:

```cs
using System;

namespace Microsoft.Maui
{
	internal static class ArrayExtensions
	{
	}
}
```

Modern C# versions support:

```cs
using System;

namespace Microsoft.Maui;

internal static class ArrayExtensions
{
}
```

as it saves one level of indentation, so more code fits on your screen.