### PR TITLE
Fix bug in sample data template TextValidationBehavior flag

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -20,8 +20,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 <!--#if (IncludeSampleContent) -->
-		<!-- https://github.com/CommunityToolkit/Maui/issues/2205 -->
-		<NoWarn>XC0103</NoWarn>
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 <!--#endif -->
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -82,7 +82,7 @@
 <!--#if (IncludeSampleContent) -->
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.3" />

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -61,7 +61,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>


### PR DESCRIPTION
### Description of Change

In the sample data template we use the TextValidationBehavior, and set the Flags property to influence when the behavior should kick in.

But the value is supposed to be ValidateOnUnfocused, not ValidateOnUnfocusing. See: https://github.com/CommunityToolkit/Maui/blob/0a4dd43e14c07c4df6ed2241ac600d5f972f90f9/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs#L19

Looks like it was renamed in this PR: https://github.com/CommunityToolkit/Maui/pull/2215

_Edit:_ looks like it wasn't a problem in this template yet, I updated the .NET MAUI Community Toolkit reference locally it seems and thats why I hit this. So as a part of this PR now the Community Toolkit reference is also updated.
