### PR TITLE
[Housekeeping] Controls sample navigation crash - fix

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTabbedPageSwipePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTabbedPageSwipePage.xaml.cs
@@ -8,18 +8,9 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class AndroidTabbedPageSwipePage : Microsoft.Maui.Controls.TabbedPage
 	{
-		ICommand? _returnToPlatformSpecificsPage;
-
 		public AndroidTabbedPageSwipePage()
 		{
 			InitializeComponent();
-		}
-
-		public AndroidTabbedPageSwipePage(ICommand restore)
-		{
-			InitializeComponent();
-
-			_returnToPlatformSpecificsPage = restore;
 		}
 
 		void OnSwipePagingButtonClicked(object sender, EventArgs e)
@@ -34,7 +25,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			_returnToPlatformSpecificsPage?.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTitleViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTitleViewPage.xaml.cs
@@ -6,25 +6,14 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class AndroidTitleViewPage : ContentPage
 	{
-		readonly ICommand? _returnToPlatformSpecificsPage;
-
 		public AndroidTitleViewPage()
 		{
 			InitializeComponent();
 		}
 
-		public AndroidTitleViewPage(ICommand restore)
-		{
-			InitializeComponent();
-			_returnToPlatformSpecificsPage = restore;
-		}
-
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			if (_returnToPlatformSpecificsPage == null)
-				return;
-
-			_returnToPlatformSpecificsPage.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSLargeTitlePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSLargeTitlePage.xaml.cs
@@ -8,12 +8,9 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class iOSLargeTitlePage : ContentPage
 	{
-		ICommand _returnToPlatformSpecificsPage;
-
-		public iOSLargeTitlePage(ICommand restore)
+		public iOSLargeTitlePage()
 		{
 			InitializeComponent();
-			_returnToPlatformSpecificsPage = restore;
 		}
 
 		void OnButtonClicked(object sender, EventArgs e)
@@ -34,7 +31,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			_returnToPlatformSpecificsPage.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSScrollViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSScrollViewPage.xaml.cs
@@ -7,12 +7,9 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class iOSScrollViewPage : Microsoft.Maui.Controls.FlyoutPage
 	{
-		ICommand _returnToPlatformSpecificsPage;
-
-		public iOSScrollViewPage(ICommand restore)
+		public iOSScrollViewPage()
 		{
 			InitializeComponent();
-			_returnToPlatformSpecificsPage = restore;
 		}
 
 		void OnButtonClicked(object sender, EventArgs e)
@@ -22,7 +19,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			_returnToPlatformSpecificsPage.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTitleViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTitleViewPage.xaml.cs
@@ -6,19 +6,15 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class iOSTitleViewPage : ContentPage
 	{
-		ICommand _returnToPlatformSpecificsPage;
-
-		public iOSTitleViewPage(ICommand restore)
+		public iOSTitleViewPage()
 		{
 			InitializeComponent();
-
-			_returnToPlatformSpecificsPage = restore;
 			_searchBar.Effects.Add(Effect.Resolve("XamarinDocs.SearchBarEffect"));
 		}
 
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			_returnToPlatformSpecificsPage.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentNavigationBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentNavigationBarPage.xaml.cs
@@ -8,12 +8,9 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class iOSTranslucentNavigationBarPage : ContentPage
 	{
-		ICommand _returnToPlatformSpecificsPage;
-
-		public iOSTranslucentNavigationBarPage(ICommand restore)
+		public iOSTranslucentNavigationBarPage()
 		{
 			InitializeComponent();
-			_returnToPlatformSpecificsPage = restore;
 		}
 
 		void OnTranslucentNavigationBarButtonClicked(object sender, EventArgs e)
@@ -23,7 +20,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			_returnToPlatformSpecificsPage.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentTabbedPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentTabbedPage.xaml.cs
@@ -2,17 +2,13 @@
 using System.Windows.Input;
 using Microsoft.Maui.Controls.PlatformConfiguration;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
-
 namespace Maui.Controls.Sample.Pages
 {
 	public partial class iOSTranslucentTabbedPage : Microsoft.Maui.Controls.TabbedPage
 	{
-		ICommand returnToPlatformSpecificsPage;
-
-		public iOSTranslucentTabbedPage(ICommand restore)
+		public iOSTranslucentTabbedPage()
 		{
 			InitializeComponent();
-			returnToPlatformSpecificsPage = restore;
 		}
 
 		void OnToggleButtonClicked(object sender, EventArgs e)
@@ -33,7 +29,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnReturnButtonClicked(object sender, EventArgs e)
 		{
-			returnToPlatformSpecificsPage.Execute(null);
+			Navigation.PopAsync();
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/ViewModels/PlatformSpecificsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/PlatformSpecificsViewModel.cs
@@ -111,7 +111,7 @@ namespace Maui.Controls.Sample.ViewModels
 				new SectionModel(typeof(iOSTranslucentNavigationBarPage), "NavigationPage Translucent TabBar",
 					"This iOS platform-specific is used to set the translucency mode of the tab bar on a NavigationPage."),
 
-				new SectionModel(typeof(MainPage), "TabbedPage Translucent TabBar",
+				new SectionModel(typeof(iOSTranslucentTabbedPage), "TabbedPage Translucent TabBar",
 					"This iOS platform-specific is used to set the translucency mode of the tab bar on a TabbedPage."),
 
 #if MACCATALYST


### PR DESCRIPTION
### Description of Change

Navigation to each page without the parameters constructor crashes the app.

Here's a screenshot from VS, after I selected TabbedPage Translucent Tabbar
<img width="1385" alt="Screenshot 2025-02-27 at 02 20 01" src="https://github.com/user-attachments/assets/7cbbdc25-acec-4794-a04d-f7dd42a367a7" />
