### PR TITLE
[Windows] Optimize formatted labels

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Maui.Controls.Platform
 			Color? defaultColor = null,
 			TextTransform defaultTextTransform = TextTransform.Default)
 		{
-			textBlock.Inlines.Clear();
+			var textBlockInlines = textBlock.Inlines;
+			textBlockInlines.Clear();
 
 			// Have to implement a measure here, otherwise inline.ContentStart and ContentEnd will be null, when used in RecalculatePositions
 			textBlock.Measure(new global::Windows.Foundation.Size(double.MaxValue, double.MaxValue));
@@ -68,7 +69,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				SetMeasuredLineHeight(run, lineHeights[i]);
 
-				textBlock.Inlines.Add(run);
+				textBlockInlines.Add(run);
 
 				if (background is not null || textColor is not null)
 				{
@@ -152,11 +153,13 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			// Span count is larger than 0, so we can always assign as the variable will be always used.
+			var controlInlines = control.Inlines;
+
 			for (int i = 0; i < spans.Count; i++)
 			{
 				var span = spans[i];
-
-				var inline = control.Inlines.ElementAt(i);
+				var inline = controlInlines.ElementAt(i);
 
 				var startRect = inline.ContentStart.GetCharacterRect(LogicalDirection.Forward);
 				var endRect = inline.ContentEnd.GetCharacterRect(LogicalDirection.Forward);


### PR DESCRIPTION
### Description of Change

Optimizes formatted texts on Windows. Sample:

```xaml
<Label>
  <Label.FormattedText>
    <FormattedString>
      <Span Text=" A " />
      <Span Text=" B " />
      <Span Text=" C " />
    </FormattedString>
  </Label.FormattedText>
</Label>
```

### Performance impact

![image](https://github.com/user-attachments/assets/cdf451cc-88fe-4839-845b-e8aadcdc3693)

Speedscopes:

* MAIN: [maui.sandbox.2025-02-27_11-08-19.main.speedscope.json](https://github.com/user-attachments/files/19007263/maui.sandbox.2025-02-27_11-08-19.main.speedscope.json)
* PR: [maui.sandbox.2025-02-27_11-03-20.PR.speedscope.json](https://github.com/user-attachments/files/19007281/maui.sandbox.2025-02-27_11-03-20.PR.speedscope.json)

-> Improvement of ~56%