### PR TITLE
Improve PropertyMapper performance

### DIFF
--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -118,16 +118,6 @@ namespace Microsoft.Maui.Handlers
 		void UpdateFlyout()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-
-			// Once this issue has been taken care of
-			// https://github.com/dotnet/maui/issues/8456
-			// we can remove this code
-			if (VirtualView.Flyout.Handler?.MauiContext != null &&
-				VirtualView.Flyout.Handler.MauiContext != MauiContext)
-			{
-				VirtualView.Flyout.Handler.DisconnectHandler();
-			}
-
 			_ = VirtualView.Flyout.ToPlatform(MauiContext);
 
 			var newFlyoutView = VirtualView.Flyout.ToPlatform();

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
@@ -16,11 +16,19 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class FlyoutViewHandler : IFlyoutViewHandler
 	{
-		public static IPropertyMapper<IFlyoutView, IFlyoutViewHandler> Mapper = new PropertyMapper<IFlyoutView, IFlyoutViewHandler>(ViewHandler.ViewMapper)
+		// Like IViewHandler.ContainerView, those properties should be set with priority because other mappers depend on them (like IToolbarElement.Toolbar).
+		// So we have a separate mapper for them.
+		private static readonly IPropertyMapper<IFlyoutView, IFlyoutViewHandler> FlyoutLayoutMapper = new PropertyMapper<IFlyoutView, IFlyoutViewHandler>()
 		{
 #if ANDROID || WINDOWS || TIZEN
 			[nameof(IFlyoutView.Flyout)] = MapFlyout,
 			[nameof(IFlyoutView.Detail)] = MapDetail,
+#endif
+		};
+
+		public static IPropertyMapper<IFlyoutView, IFlyoutViewHandler> Mapper = new PropertyMapper<IFlyoutView, IFlyoutViewHandler>(ViewHandler.ViewMapper, FlyoutLayoutMapper)
+		{
+#if ANDROID || WINDOWS || TIZEN
 			[nameof(IFlyoutView.IsPresented)] = MapIsPresented,
 			[nameof(IFlyoutView.FlyoutBehavior)] = MapFlyoutBehavior,
 			[nameof(IFlyoutView.FlyoutWidth)] = MapFlyoutWidth,

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -26,11 +26,17 @@ namespace Microsoft.Maui.Handlers
 		public static IPropertyMapper<IView, IViewHandler> ViewMapper =
 #if ANDROID
 			// Use a custom mapper for Android which knows how to batch the initial property sets
-			new AndroidBatchPropertyMapper<IView, IViewHandler>(ElementMapper)
+			new AndroidBatchPropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)
 #else
 			new PropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)
 #endif
 			{
+				// This property is a special one and needs to be set before other properties.
+				[nameof(IViewHandler.ContainerView)] = MapContainerView,
+#if ANDROID
+				[AndroidBatchPropertyMapper.InitializeBatchedPropertiesKey] = MapInitializeBatchedProperties,
+#endif
+
 				[nameof(IView.AutomationId)] = MapAutomationId,
 				[nameof(IView.Clip)] = MapClip,
 				[nameof(IView.Shadow)] = MapShadow,
@@ -56,7 +62,6 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IView.RotationY)] = MapRotationY,
 				[nameof(IView.AnchorX)] = MapAnchorX,
 				[nameof(IView.AnchorY)] = MapAnchorY,
-				[nameof(IViewHandler.ContainerView)] = MapContainerView,
 #pragma warning disable CS0618 // Type or member is obsolete
 				[nameof(IBorder.Border)] = MapBorderView,
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -67,10 +72,6 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IToolTipElement.ToolTip)] = MapToolTip,
 #if WINDOWS || MACCATALYST
 				[nameof(IContextFlyoutElement.ContextFlyout)] = MapContextFlyout,
-#endif
-
-#if ANDROID
-				["_InitializeBatchedProperties"] = MapInitializeBatchedProperties
 #endif
 			};
 

--- a/src/Core/src/Platform/iOS/ContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/ContainerViewController.cs
@@ -68,7 +68,10 @@ namespace Microsoft.Maui.Platform
 
 		void LoadPlatformView(IElement view)
 		{
-			currentPlatformView = _pendingLoadedView ?? CreatePlatformView(view);
+			var platformView = _pendingLoadedView ?? CreatePlatformView(view);
+			platformView = platformView.Superview as WrapperView ?? platformView;
+
+			currentPlatformView = platformView;
 			_pendingLoadedView = null;
 
 			View!.AddSubview(currentPlatformView);

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 #if IOS || MACCATALYST
 using PlatformView = UIKit.UIView;
@@ -15,13 +16,17 @@ namespace Microsoft.Maui
 {
 	public abstract class PropertyMapper : IPropertyMapper
 	{
+		// TODO: Make this private in .NET10
 		protected readonly Dictionary<string, Action<IElementHandler, IElement>> _mapper = new(StringComparer.Ordinal);
-
 		IPropertyMapper[]? _chained;
 
-		// Keep a distinct list of the keys so we don't run any duplicate (overridden) updates more than once
-		// when we call UpdateProperties
-		HashSet<string>? _updateKeys;
+		List<string>? _updatePropertiesKeys;
+		List<Action<IElementHandler, IElement>>? _updatePropertiesMappers;
+		Dictionary<string, Action<IElementHandler, IElement>?>? _cachedMappers;
+
+		List<string> UpdatePropertiesKeys => _updatePropertiesKeys ?? SnapshotMappers().UpdatePropertiesKeys;
+		List<Action<IElementHandler, IElement>> UpdatePropertiesMappers => _updatePropertiesMappers ?? SnapshotMappers().UpdatePropertiesMappers;
+		Dictionary<string, Action<IElementHandler, IElement>?> CachedMappers => _cachedMappers ?? SnapshotMappers().CachedMappers;
 
 		public PropertyMapper()
 		{
@@ -35,29 +40,65 @@ namespace Microsoft.Maui
 		protected virtual void SetPropertyCore(string key, Action<IElementHandler, IElement> action)
 		{
 			_mapper[key] = action;
+
 			ClearKeyCache();
 		}
 
 		protected virtual void UpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
 		{
 			if (!viewHandler.CanInvokeMappers())
+			{
 				return;
+			}
 
-			var action = GetProperty(key);
-			action?.Invoke(viewHandler, virtualView);
+			TryUpdatePropertyCore(key, viewHandler, virtualView);
+		}
+
+		internal bool TryUpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
+		{
+			var cachedMappers = CachedMappers;
+			if (cachedMappers.TryGetValue(key, out var action))
+			{
+				if (action is not null)
+				{
+					action(viewHandler, virtualView);
+					return true;
+				}
+
+				return false;
+			}
+
+			// CachedMappers initially contains only the UpdateProperties keys which may not contain the key we are looking for.
+			// See AndroidBatchPropertyMapper for an example.
+			var mapper = GetProperty(key);
+			cachedMappers[key] = mapper;
+
+			if (mapper is not null)
+			{
+				mapper(viewHandler, virtualView);
+				return true;
+			}
+
+			return false;
 		}
 
 		public virtual Action<IElementHandler, IElement>? GetProperty(string key)
 		{
 			if (_mapper.TryGetValue(key, out var action))
-				return action;
-			else if (Chained is not null)
 			{
-				foreach (var ch in Chained)
+				return action;
+			}
+
+			var chainedPropertyMappers = Chained;
+			if (chainedPropertyMappers is not null)
+			{
+				foreach (var ch in chainedPropertyMappers)
 				{
 					var returnValue = ch.GetProperty(key);
 					if (returnValue != null)
+					{
 						return returnValue;
+					}
 				}
 			}
 
@@ -66,20 +107,24 @@ namespace Microsoft.Maui
 
 		public void UpdateProperty(IElementHandler viewHandler, IElement? virtualView, string property)
 		{
-			if (virtualView == null)
+			if (virtualView == null || !viewHandler.CanInvokeMappers())
+			{
 				return;
+			}
 
-			UpdatePropertyCore(property, viewHandler, virtualView);
+			TryUpdatePropertyCore(property, viewHandler, virtualView);
 		}
 
 		public void UpdateProperties(IElementHandler viewHandler, IElement? virtualView)
 		{
-			if (virtualView == null)
-				return;
-
-			foreach (var key in UpdateKeys)
+			if (virtualView == null || !viewHandler.CanInvokeMappers())
 			{
-				UpdatePropertyCore(key, viewHandler, virtualView);
+				return;
+			}
+
+			foreach (var mapper in UpdatePropertiesMappers)
+			{
+				mapper(viewHandler, virtualView);
 			}
 		}
 
@@ -93,34 +138,65 @@ namespace Microsoft.Maui
 			}
 		}
 
-		private HashSet<string> PopulateKeys()
-		{
-			var keys = new HashSet<string>(StringComparer.Ordinal);
-			foreach (var key in GetKeys())
-			{
-				keys.Add(key);
-			}
-			return keys;
-		}
-
+		// TODO: Make private in .NET10 with a new name: ClearMergedMappers
 		protected virtual void ClearKeyCache()
 		{
-			_updateKeys = null;
+			_updatePropertiesMappers = null;
+			_updatePropertiesKeys = null;
+			_cachedMappers = null;
 		}
 
-		public virtual IReadOnlyCollection<string> UpdateKeys => _updateKeys ??= PopulateKeys();
+		// TODO: Remove in .NET10
+		public virtual IReadOnlyCollection<string> UpdateKeys => UpdatePropertiesKeys;
 
 		public virtual IEnumerable<string> GetKeys()
 		{
-			foreach (var key in _mapper.Keys)
-				yield return key;
-
-			if (Chained is not null)
+			// We want to retain the initial order of the keys to avoid race conditions
+			// when a property mapping is overridden by a new instance of property mapper.
+			// As an example, the container view mapper should always run first.
+			// Siblings mapper should not have keys intersection.
+			var chainedPropertyMappers = Chained;
+			if (chainedPropertyMappers is not null)
 			{
-				foreach (var chain in Chained)
-					foreach (var key in chain.GetKeys())
+				for (int i = chainedPropertyMappers.Length - 1; i >= 0; i--)
+				{
+					foreach (var key in chainedPropertyMappers[i].GetKeys())
+					{
 						yield return key;
+					}
+				}
 			}
+
+			// Enqueue keys from this mapper.
+			foreach (var mapper in _mapper)
+			{
+				yield return mapper.Key;
+			}
+		}
+
+		private (List<string> UpdatePropertiesKeys, List<Action<IElementHandler, IElement>> UpdatePropertiesMappers, Dictionary<string, Action<IElementHandler, IElement>?> CachedMappers) SnapshotMappers()
+		{
+			var updatePropertiesKeys = GetKeys().Distinct().ToList();
+			var updatePropertiesMappers = new List<Action<IElementHandler, IElement>>(updatePropertiesKeys.Count);
+#if ANDROID
+			var cacheSize = updatePropertiesKeys.Count + AndroidBatchPropertyMapper.SkipList.Count;
+#else
+			var cacheSize = updatePropertiesKeys.Count;
+#endif
+			var cachedMappers = new Dictionary<string, Action<IElementHandler, IElement>?>(cacheSize);
+
+			foreach (var key in updatePropertiesKeys)
+			{
+				var mapper = GetProperty(key)!;
+				updatePropertiesMappers.Add(mapper);
+				cachedMappers[key] = mapper;
+			}
+
+			_updatePropertiesKeys = updatePropertiesKeys;
+			_updatePropertiesMappers = updatePropertiesMappers;
+			_cachedMappers = cachedMappers;
+
+			return (updatePropertiesKeys, updatePropertiesMappers, cachedMappers);
 		}
 	}
 
@@ -169,12 +245,22 @@ namespace Microsoft.Maui
 			SetPropertyCore(key, (h, v) =>
 			{
 				if (v is TVirtualView vv)
+				{
 					action?.Invoke((TViewHandler)h, vv);
+				}
 				else if (Chained != null)
 				{
 					foreach (var chain in Chained)
 					{
-						if (chain.GetProperty(key) != null)
+						// Try to leverage our internal method which uses merged mappers
+						if (chain is PropertyMapper propertyMapper)
+						{
+							if (propertyMapper.TryUpdatePropertyCore(key, h, v))
+							{
+								break;
+							}
+						}
+						else if (chain.GetProperty(key) != null)
 						{
 							chain.UpdateProperty(h, v, key);
 							break;

--- a/src/Core/tests/Benchmarks/Benchmarks/PropertyMapperBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/PropertyMapperBenchmarker.cs
@@ -1,0 +1,52 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Handlers.Benchmarks;
+
+[MemoryDiagnoser]
+public class PropertyMapperBenchmarker
+{
+	class TestButtonHandler : ButtonHandler
+	{
+		protected override object CreatePlatformView()
+		{
+			return new object();
+		}
+	}
+
+	readonly Registrar<IView, IViewHandler> _registrar;
+	readonly IViewHandler _handler;
+	readonly Button _button;
+
+	public PropertyMapperBenchmarker()
+	{
+		_button = new Button();
+
+		_registrar = new Registrar<IView, IViewHandler>();
+		_registrar.Register<IButton, TestButtonHandler>();
+
+		_handler = _registrar.GetHandler<IButton>();
+		_handler.SetVirtualView(new Button());
+	}
+
+	[Benchmark]
+	public void BenchmarkUpdateProperties()
+	{
+		var button = new Button();
+
+		for (int i = 0; i < 100_000; i++)
+		{
+			var handler = _registrar.GetHandler<IButton>();
+			handler.SetVirtualView(button);
+		}
+	}
+
+	[Benchmark]
+	public void BenchmarkUpdateProperty()
+	{
+		for (int i = 0; i < 1_000_000; i++)
+		{
+			_handler.UpdateValue(nameof(IView.Opacity));
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/PropertyMapperTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
@@ -9,6 +12,106 @@ namespace Microsoft.Maui.UnitTests
 	[Category(TestCategory.Core, TestCategory.PropertyMapping)]
 	public class PropertyMapperTests
 	{
+		[Fact]
+		public void MapperRetainsInsertionOrder()
+		{
+			// This test ensures the internal Dictionary implementation is not changed.
+
+			// Thanks to the way Dictionary is internally implemented,
+			// when looping through the dictionary entries, and considering _mapper is an append-only dictionary,
+			// the order is guaranteed to be the same as the order mappers were added.
+
+			var mapper = new PropertyMapper<IElement>();
+			var letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+			var insertedProperties = new List<string>();
+			var updatedProperties = new List<string>();
+			for (int i = 0; i < 1000; i++)
+			{
+				var randomPropertyName = string.Join(string.Empty, Enumerable.Range(0, Random.Shared.Next(8, 60))
+					.Select(chars => string.Join(string.Empty,
+						Enumerable.Range(0, chars).Select(_ => letters[Random.Shared.Next(0, letters.Length)]))));
+
+				insertedProperties.Add(randomPropertyName);
+				mapper.Add(randomPropertyName, (h, v) => updatedProperties.Add(randomPropertyName));
+			}
+
+			var keys = mapper.GetKeys().ToList();
+			mapper.UpdateProperties(null!, new Button());
+			Assert.Equal(insertedProperties, keys);
+			Assert.Equal(insertedProperties, updatedProperties);
+		}
+
+		[Fact]
+		public void MapperExecutesChainedKeysFirst()
+		{
+			int counter = 0;
+
+			int background3 = 0;
+			int scale1 = 0;
+			int scale3 = 0;
+			int zindex2 = 0;
+			int zindex3 = 0;
+
+			var mapper1 = new PropertyMapper<IView>
+			{
+				[nameof(IView.Scale)] = (r, v) => scale1 = ++counter
+			};
+
+			var mapper2 = new PropertyMapper<IView>
+			{
+				[nameof(IView.ZIndex)] = (r, v) => zindex2 = ++counter
+			};
+
+			var mapper3 = new PropertyMapper<IButton>(mapper2, mapper1)
+			{
+				[nameof(IView.Background)] = (r, v) => background3 = ++counter,
+				[nameof(IView.Scale)] = (r, v) => scale3 = ++counter,
+				[nameof(IView.ZIndex)] = (r, v) => zindex3 = ++counter,
+			};
+
+			mapper3.UpdateProperties(null!, new Button());
+
+			Assert.Equal(0, scale1);
+			Assert.Equal(0, zindex2);
+			Assert.Equal(1, scale3);
+			Assert.Equal(2, zindex3);
+			Assert.Equal(3, background3);
+		}
+
+		[Fact]
+		public void MapperCanExecuteSkippedMappers()
+		{
+			int counter = 0;
+
+			int scale1 = 0;
+			int scale2 = 0;
+			int zindex1 = 0;
+
+			var mapper1 = new SkippingPropertyMapper<IView>()
+			{
+				[nameof(IView.Scale)] = (r, v) => scale1 = ++counter,
+				[nameof(IView.ZIndex)] = (r, v) => zindex1 = ++counter
+			};
+
+			var mapper2 = new PropertyMapper<IButton>(mapper1)
+			{
+				[nameof(IView.Scale)] = (r, v) => scale2 = ++counter,
+			};
+
+			mapper2.UpdateProperties(null!, new Button());
+
+			// ZIndex is skipped, so it should not be updated
+			Assert.Equal(0, zindex1);
+			// Scale is skipped in the first mapper, but not in the second
+			Assert.Equal(0, scale1);
+			Assert.Equal(1, scale2);
+
+			mapper2.UpdateProperty(null!, new Button(), nameof(IView.ZIndex));
+
+			// When updating a single property, the skipped mapper should be executed
+			Assert.Equal(2, zindex1);
+		}
+
 		[Fact]
 		public void ChainingMappersOverrideBase()
 		{
@@ -142,6 +245,15 @@ namespace Microsoft.Maui.UnitTests
 
 			Assert.True(wasMapper1Called);
 			Assert.True(wasMapper2Called);
+		}
+
+		class SkippingPropertyMapper<T> : PropertyMapper<T>
+			where T : IElement
+		{
+			public override IEnumerable<string> GetKeys()
+			{
+				return Enumerable.Empty<string>();
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

- Improve `PropertyMapper` performance by caching mappers (same thing is currently done on mapper's keys)
  - Moves `viewHandler.CanInvokeMappers()` check to `UpdateProperties` level considering that on Android this method method uses the Java object
- Ensures properties are executed in the order they're defined (this will help with future perf developments #27259)
  - Brings to light race conditions now present on a few mappers (like `MapToolbar` depends on `MapFlyout`) and formally solves them by setting the right order of execution

### Benchmarks

> BenchmarkDotNet v0.13.10, macOS 15.3.1 (24D70) [Darwin 24.3.0]
> Apple M3 Pro, 1 CPU, 11 logical and 11 physical cores
> .NET SDK 9.0.102

**Before**

| Method                    | Mean      | Error    | StdDev   | Gen0      | Allocated  |
|-------------------------- |----------:|---------:|---------:|----------:|-----------:|
| BenchmarkUpdateProperties | 167.67 ms | 0.584 ms | 0.547 ms | 3333.3333 | 29604261 B |
| BenchmarkUpdateProperty   |  31.65 ms | 0.079 ms | 0.070 ms |         - |       46 B |

**After**

| Method                    | Mean     | Error    | StdDev   | Gen0      | Allocated  |
|-------------------------- |---------:|---------:|---------:|----------:|-----------:|
| BenchmarkUpdateProperties | 59.04 ms | 0.294 ms | 0.275 ms | 3666.6667 | 31204122 B |
| BenchmarkUpdateProperty   | 12.39 ms | 0.026 ms | 0.020 ms |         - |       12 B |


