### PR TITLE
Make HybridWebViewHandler throw JS exceptions in C# by default

### DIFF
--- a/src/Controls/tests/DeviceTests/MauiProgram.cs
+++ b/src/Controls/tests/DeviceTests/MauiProgram.cs
@@ -10,11 +10,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public static class MauiProgram
 	{
-		static MauiProgram()
-		{
-			AppContext.SetSwitch("HybridWebView.InvokeJavaScriptThrowsExceptions", isEnabled: true);
-		}
-
 #if ANDROID
 		public static Android.Content.Context CurrentContext => MauiProgramDefaults.DefaultContext;
 #elif WINDOWS

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -95,9 +95,8 @@ namespace Microsoft.Maui.Handlers
 
 		private const string InvokeJavaScriptThrowsExceptionsSwitch = "HybridWebView.InvokeJavaScriptThrowsExceptions";
 
-		// TODO: .NET 10 flip the default to true for .NET 10
 		private static bool IsInvokeJavaScriptThrowsExceptionsEnabled =>
-			AppContext.TryGetSwitch(InvokeJavaScriptThrowsExceptionsSwitch, out var enabled) && enabled;
+			!AppContext.TryGetSwitch(InvokeJavaScriptThrowsExceptionsSwitch, out var enabled) || enabled;
 
 		void MessageReceived(string rawMessage)
 		{


### PR DESCRIPTION
### Description of Change

We could not make exceptions by default in .NET 9 as that would be breaking, but it really is the most sensible.

If there is an exception in .NET 9, then the method never returns. 