### PR TITLE
[iOS] CollectionView Does Not Scroll When EmptyView Exceeds Screen Size - fix

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -721,6 +721,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var frame = DetermineEmptyViewFrame();
+			RemeasureLayout(_emptyViewFormsElement);
+			frame = new CGRect(frame.X, frame.Y, frame.Width, Math.Max(frame.Height, _emptyViewFormsElement.Height));
 
 			_emptyUIView.Frame = frame;
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -721,8 +721,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var frame = DetermineEmptyViewFrame();
-			RemeasureLayout(_emptyViewFormsElement);
-			frame = new CGRect(frame.X, frame.Y, frame.Width, Math.Max(frame.Height, _emptyViewFormsElement.Height));
+			if (_emptyViewFormsElement is not null)
+			{
+				RemeasureLayout(_emptyViewFormsElement);
+				frame = new CGRect(frame.X, frame.Y, frame.Width, Math.Max(frame.Height, _emptyViewFormsElement.Height));
+			}
 
 			_emptyUIView.Frame = frame;
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
@@ -185,12 +185,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var currentInset = CollectionView.ContentInset;
 				nfloat headerHeight = ((ItemsView?.Header is View) ? _headerViewFormsElement?.ToPlatform() : _headerUIView)?.Frame.Height ?? 0f;
 				nfloat footerHeight = ((ItemsView?.Footer is View) ? _footerViewFormsElement?.ToPlatform() : _footerUIView)?.Frame.Height ?? 0f;
-				nfloat emptyHeight = emptyView?.Frame.Height ?? 0f;
-
-				if (CollectionView.ContentInset.Top != headerHeight || CollectionView.ContentInset.Bottom != footerHeight)
+				nfloat emptyHeight = ((ItemsView?.EmptyView is View _emptyViewFormsElement) ? _emptyViewFormsElement?.ToPlatform() : emptyView)?.Frame.Height ?? 0f;
+				emptyHeight = (nfloat)Math.Max(emptyHeight, emptyView?.Frame.Height ?? 0f);
+				
+				if (CollectionView.ContentInset.Top != headerHeight || CollectionView.ContentInset.Bottom != footerHeight + emptyHeight)
 				{
 					var currentOffset = CollectionView.ContentOffset;
-					CollectionView.ContentInset = new UIEdgeInsets(headerHeight, 0, footerHeight, 0);
+					CollectionView.ContentInset = new UIEdgeInsets(headerHeight, 0, footerHeight + emptyHeight, 0);
 
 					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
 					// this changes the offset of the list by however much the header size has changed


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28080

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/666bfe4a-8083-412f-9e94-71cfd6e73ac9" width="300px"/>|<video src="https://github.com/user-attachments/assets/3b5b3b10-6879-4016-af46-343e89b64631" width="300px"/>|

```xaml
<CollectionView>
                <CollectionView.Header>
                        <ContentView BackgroundColor="Red"
                                        HeightRequest="300"/>
                </CollectionView.Header>
                <CollectionView.EmptyView>
                        <Grid RowDefinitions="Auto,Auto"
                                        BackgroundColor="Pink">
                                <ContentView
                                        BackgroundColor="Green"
                                        HeightRequest="600"/>
                                <Label Text="EmptyView"
                                       HeightRequest="400"
                                       Grid.Row="1"/>
                        </Grid>
                </CollectionView.EmptyView>
 </CollectionView>
```


