### PR TITLE
[Testing] Migration of Compatibility.Core platform-specific unit tests into device tests - 4

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -60,24 +60,6 @@ namespace Microsoft.Maui.DeviceTests
 			await AssertColorAtPoint(border, expected, typeof(BorderHandler), cornerRadius, cornerRadius);
 		}
 
-		[Fact]
-		[Description("The Opacity property of a Border should match with native IsVisible")]
-		public async Task VerifyBorderOpacityProperty()
-		{
-			var border = new Border
-			{
-				Opacity = 0.35f
-			}
-			var expectedValue = border.Opacity;
-
-			var handler = await CreateHandlerAsync<BorderHandler>(border);
-			var nativeView = GetNativeBorder(handler);
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var nativeOpacityValue = nativeView.Opacity;
-				Assert.Equal(expectedValue, nativeOpacityValue);
-			});
-		}
 		ContentPanel GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.Windows.cs
@@ -60,6 +60,24 @@ namespace Microsoft.Maui.DeviceTests
 			await AssertColorAtPoint(border, expected, typeof(BorderHandler), cornerRadius, cornerRadius);
 		}
 
+		[Fact]
+		[Description("The Opacity property of a Border should match with native IsVisible")]
+		public async Task VerifyBorderOpacityProperty()
+		{
+			var border = new Border
+			{
+				Opacity = 0.35f
+			}
+			var expectedValue = border.Opacity;
+
+			var handler = await CreateHandlerAsync<BorderHandler>(border);
+			var nativeView = GetNativeBorder(handler);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = nativeView.Opacity;
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 		ContentPanel GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs
@@ -10,5 +10,14 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		MauiShapeView GetNativeBoxView(ShapeViewHandler boxViewViewHandler) =>
 			boxViewViewHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(ShapeViewHandler handler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeBoxView(handler);
+				return nativeView.Alpha;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Windows.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetNativeBoxView(handler);
-				return nativeView.Opacity;
+				return (float)nativeView.Opacity;
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Windows.cs
@@ -10,5 +10,14 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		W2DGraphicsView GetNativeBoxView(ShapeViewHandler boxViewHandler) =>
 			boxViewHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(ShapeViewHandler handler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeBoxView(handler);
+				return nativeView.Opacity;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Description("The Opacity property of a BoxView should match with native IsVisible")]
+		[Description("The Opacity property of a BoxView should match with native Opacity")]
 		public async Task VerifyBoxViewOpacityProperty()
 		{
 			var boxView = new BoxView

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
@@ -44,6 +45,24 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidateHasColor(boxView, expected, typeof(ShapeViewHandler));
+		}
+
+		[Fact]
+		[Description("The Opacity property of a BoxView should match with native IsVisible")]
+		public async Task VerifyBoxViewOpacityProperty()
+		{
+			var boxView = new BoxView
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = boxView.Opacity;
+
+			var handler = await CreateHandlerAsync<ShapeViewHandler>(boxView);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.iOS.cs
@@ -15,6 +15,15 @@ namespace Microsoft.Maui.DeviceTests
 		MauiShapeView GetNativeBoxView(ShapeViewHandler boxViewHandler) =>
 			boxViewHandler.PlatformView;
 
+		Task<float> GetPlatformOpacity(ShapeViewHandler handler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeBoxView(handler);
+				return (float)nativeView.Alpha; 
+			});
+		}
+
 		[Fact(DisplayName = "ShapeView Parts Keep Around")]
 		public async Task ShapeViewPartsKeepAround()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Maui.DeviceTests
 		Android.Text.TextUtils.TruncateAt? GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
 			GetPlatformButton(buttonHandler).Ellipsize;
 
+		Task<float> GetPlatformOpacity(ButtonHandler buttonHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformButton(buttonHandler);
+				return nativeView.Alpha;
+			});
+		}
 
 		[Theory(DisplayName = "Button Icon has Correct Position"), Category(TestCategory.Layout)]
 		[InlineData(Button.ButtonContentLayout.ImagePosition.Left)]

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Widget;
@@ -89,5 +90,22 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		[Description("The Opacity property of a Button should match with native Opacity")]
+		public async Task VerifyButtonOpacityProperty()
+		{
+			var button = new Button
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = button.Opacity;
+
+			var handler = await CreateHandlerAsync<ButtonHandler>(button);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				var nativeView = GetNativeBoxView(buttonHandler);
-				return nativeView.Opacity;
+				var nativeView = GetPlatformButton(buttonHandler);
+				return (float)nativeView.Opacity;
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -34,7 +35,7 @@ namespace Microsoft.Maui.DeviceTests
 		[Description("The Opacity property of a Button should match with native Opacity")]
 		public async Task VerifyButtonOpacityProperty()
 		{
-			var button = new Button
+			var button = new Microsoft.Maui.Controls.Button
 			{
 				Opacity = 0.35f
 			};

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -26,6 +27,24 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var nativeView = GetPlatformButton(buttonHandler);
 				return (float)nativeView.Opacity;
+			});
+		}
+
+		[Fact]
+		[Description("The Opacity property of a Button should match with native Opacity")]
+		public async Task VerifyButtonOpacityProperty()
+		{
+			var button = new Button
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = button.Opacity;
+
+			var handler = await CreateHandlerAsync<ButtonHandler>(button);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
@@ -19,5 +19,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		TextTrimming GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
 			(GetPlatformButton(buttonHandler).Content as FrameworkElement)!.GetFirstDescendant<TextBlock>()!.TextTrimming;
+
+		Task<float> GetPlatformOpacity(ButtonHandler buttonHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeBoxView(buttonHandler);
+				return nativeView.Opacity;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.cs
@@ -70,25 +70,5 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateHasColor(button, expected, typeof(ButtonHandler));
 		}
-
-		[Fact]
-		[Description("The Opacity property of a Button should match with native Opacity")]
-		public async Task VerifyButtonOpacityProperty()
-		{
-			var button = new Button
-			{
-				Opacity = 0.35f
-			};
-			var expectedValue = button.Opacity;
-
-			var handler = await CreateHandlerAsync<ButtonHandler>(button);
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var nativeOpacityValue = await GetPlatformOpacity(handler);
-				Assert.Equal(expectedValue, nativeOpacityValue);
-			});
-		}
-
-
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.cs
@@ -71,5 +71,24 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateHasColor(button, expected, typeof(ButtonHandler));
 		}
 
+		[Fact]
+		[Description("The Opacity property of a Button should match with native Opacity")]
+		public async Task VerifyButtonOpacityProperty()
+		{
+			var button = new Button
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = button.Opacity;
+
+			var handler = await CreateHandlerAsync<ButtonHandler>(button);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
+
+
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -19,6 +19,15 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() => GetPlatformButton(buttonHandler).CurrentTitle);
 		}
 
+		Task<float> GetPlatformOpacity(ButtonHandler buttonHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformButton(buttonHandler);
+				return (float)nativeView.Alpha; 
+			});
+		}
+		
 		UILineBreakMode GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
 			GetPlatformButton(buttonHandler).TitleLabel.LineBreakMode;
 

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -19,15 +19,6 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() => GetPlatformButton(buttonHandler).CurrentTitle);
 		}
 
-		Task<float> GetPlatformOpacity(ButtonHandler buttonHandler)
-		{
-			return InvokeOnMainThreadAsync(() =>
-			{
-				var nativeView = GetPlatformButton(buttonHandler);
-				return (float)nativeView.Alpha; 
-			});
-		}
-		
 		UILineBreakMode GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
 			GetPlatformButton(buttonHandler).TitleLabel.LineBreakMode;
 

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs
@@ -13,5 +13,14 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		AppCompatCheckBox GetNativeCheckBox(CheckBoxHandler checkBoxHandler) =>
 			checkBoxHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(CheckBoxHandler CheckBoxHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeCheckBox(CheckBoxHandler);
+				return nativeView.Alpha;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Windows.cs
@@ -10,5 +10,14 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		CheckBox GetNativeCheckBox(CheckBoxHandler checkBoxHandler) =>
 			checkBoxHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(CheckBoxHandler checkBoxHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeCheckBox(checkBoxHandler);
+				return nativeView.Opacity;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Windows.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetNativeCheckBox(checkBoxHandler);
-				return nativeView.Opacity;
+				return (float)nativeView.Opacity;
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -42,6 +43,24 @@ namespace Microsoft.Maui.DeviceTests
 			checkBox.BackgroundColor = color;
 
 			await ValidateHasColor<CheckBoxHandler>(checkBox, color);
+		}
+
+		[Fact]
+		[Description("The Opacity property of a Checkbox should match with native Opacity")]
+		public async Task VerifyCheckBoxOpacityProperty()
+		{
+			var checkBox = new CheckBox
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = checkBox.Opacity;
+
+			var handler = await CreateHandlerAsync<CheckBoxHandler>(checkBox);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Description("The Opacity property of a Checkbox should match with native Opacity")]
+		[Description("The Opacity property of a CheckBox should match with native Opacity")]
 		public async Task VerifyCheckBoxOpacityProperty()
 		{
 			var checkBox = new CheckBox

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.iOS.cs
@@ -12,5 +12,14 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		MauiCheckBox GetNativeCheckBox(CheckBoxHandler checkBoxHandler) =>
 			checkBoxHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(CheckBoxHandler checkBoxHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetNativeCheckBox(checkBoxHandler);
+				return (float)nativeView.Alpha;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
@@ -40,6 +40,15 @@ namespace Microsoft.Maui.DeviceTests
 			return -1;
 		}
 
+		Task<float> GetPlatformOpacity(EditorHandler editorHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(editorHandler);
+				return nativeView.Alpha;
+			});
+		}
+
 		[Fact]
 		public async Task CursorPositionPreservedWhenTextTransformPresent()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs
@@ -15,6 +15,15 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() => GetPlatformControl(handler).Text);
 		}
 
+		Task<float> GetPlatformOpacity(EditorHandler editorHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(editorHandler);
+				return nativeView.Opacity;
+			});
+		}
+
 		static void SetPlatformText(EditorHandler editorHandler, string text) =>
 			GetPlatformControl(editorHandler).Text = text;
 

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetPlatformControl(editorHandler);
-				return nativeView.Opacity;
+				return (float)nativeView.Opacity;
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -291,6 +291,24 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+		[Fact]
+		[Description("The Opacity property of a Editor should match with native Opacity")]
+		public async Task VerifyEditorOpacityProperty()
+		{
+			var editor = new Editor
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = editor.Opacity;
+
+			var handler = await CreateHandlerAsync<EditorHandler>(editor);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
+
 		[Category(TestCategory.Editor)]
 		[Category(TestCategory.TextInput)]
 		[Collection(RunInNewWindowCollection)]

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
@@ -43,6 +43,15 @@ namespace Microsoft.Maui.DeviceTests
 			return -1;
 		}
 
+		Task<float> GetPlatformOpacity(EditorHandler editorHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(editorHandler);
+				return (float)nativeView.Alpha; 
+			});
+		}
+
 		[Category(TestCategory.Editor)]
 		public class PlaceholderTests : ControlsHandlerTestBase
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -39,6 +39,15 @@ namespace Microsoft.Maui.DeviceTests
 			return -1;
 		}
 
+		Task<float> GetPlatformOpacity(EntryHandler entryHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(entryHandler);
+				return nativeView.Alpha;
+			});
+		}
+
 		[Fact]
 		public async Task CursorPositionPreservedWhenTextTransformPresent()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetPlatformControl(entryHandler);
-				return nativeView.Opacity;
+				return (float)nativeView.Opacity;
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
@@ -15,6 +15,15 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() => GetPlatformControl(handler).Text);
 		}
 
+		Task<float> GetPlatformOpacity(EntryHandler entryHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(entryHandler);
+				return nativeView.Opacity;
+			});
+		}
+
 		static void SetPlatformText(EntryHandler entryHandler, string text) =>
 			GetPlatformControl(entryHandler).Text = text;
 

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -204,6 +204,24 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateHasColor(entry, expected, typeof(EntryHandler));
 		}
 
+		[Fact]
+		[Description("The Opacity property of a Entry should match with native Opacity")]
+		public async Task VerifyEntryOpacityProperty()
+		{
+			var entry = new Entry
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = entry.Opacity;
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
+
 		[Category(TestCategory.Entry)]
 		[Category(TestCategory.TextInput)]
 		[Collection(RunInNewWindowCollection)]

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Description("The Opacity property of a Entry should match with native Opacity")]
+		[Description("The Opacity property of an Entry should match with native Opacity")]
 		public async Task VerifyEntryOpacityProperty()
 		{
 			var entry = new Entry

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -44,6 +44,15 @@ namespace Microsoft.Maui.DeviceTests
 
 			return -1;
 		}
+		
+		Task<float> GetPlatformOpacity(EntryHandler entryHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(entryHandler);
+				return (float)nativeView.Alpha; 
+			});
+		}
 
 		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 		public class ScrollTests : ControlsHandlerTestBase

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;
+using Android.Widget;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -68,6 +69,18 @@ namespace Microsoft.Maui.DeviceTests
 				});
 			});
 		}
+
+		ImageView GetPlatformImage(ImageHandler imageHandler) =>
+            imageHandler.PlatformView;
+    
+        Task<float> GetPlatformOpacity(ImageHandler imageHandler)
+        {
+            return InvokeOnMainThreadAsync(() =>
+            {
+                var nativeView = GetPlatformImage(imageHandler);
+                return (float)nativeView.Alpha;
+            });
+        }
 	}
 
 	// This subclass of memory stream is deliberately set up to trick Glide into using the cached image

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -70,6 +71,23 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		[Description("The Opacity property of a image should match with native Opacity")]
+		public async Task VerifyImageOpacityProperty()
+		{
+			var image = new Image
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = image.Opacity;
+
+			var handler = await CreateHandlerAsync<ImageHandler>(image);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 		ImageView GetPlatformImage(ImageHandler imageHandler) =>
 			imageHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs
@@ -71,16 +71,16 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		ImageView GetPlatformImage(ImageHandler imageHandler) =>
-            imageHandler.PlatformView;
-    
-        Task<float> GetPlatformOpacity(ImageHandler imageHandler)
-        {
-            return InvokeOnMainThreadAsync(() =>
-            {
-                var nativeView = GetPlatformImage(imageHandler);
-                return (float)nativeView.Alpha;
-            });
-        }
+			imageHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(ImageHandler imageHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformImage(imageHandler);
+				return (float)nativeView.Alpha;
+			});
+		}
 	}
 
 	// This subclass of memory stream is deliberately set up to trick Glide into using the cached image

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -92,6 +92,22 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateHasColor(image, expected, typeof(ImageHandler));
 		}
 
-
+		[Fact]
+        [Description("The Opacity property of a image should match with native Opacity")]
+        public async Task VerifyImageOpacityProperty()
+        {
+            var image = new Image
+            {
+                Opacity = 0.35f
+            };
+            var expectedValue = image.Opacity;
+        
+            var handler = await CreateHandlerAsync<ImageHandler>(image);
+            await InvokeOnMainThreadAsync(async () =>
+            {
+                var nativeOpacityValue = await GetPlatformOpacity(handler);
+                Assert.Equal(expectedValue, nativeOpacityValue);
+            });
+        }
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -93,21 +93,21 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-        [Description("The Opacity property of a image should match with native Opacity")]
-        public async Task VerifyImageOpacityProperty()
-        {
-            var image = new Image
-            {
-                Opacity = 0.35f
-            };
-            var expectedValue = image.Opacity;
-        
-            var handler = await CreateHandlerAsync<ImageHandler>(image);
-            await InvokeOnMainThreadAsync(async () =>
-            {
-                var nativeOpacityValue = await GetPlatformOpacity(handler);
-                Assert.Equal(expectedValue, nativeOpacityValue);
-            });
-        }
+		[Description("The Opacity property of a image should match with native Opacity")]
+		public async Task VerifyImageOpacityProperty()
+		{
+			var image = new Image
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = image.Opacity;
+
+			var handler = await CreateHandlerAsync<ImageHandler>(image);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -90,24 +90,6 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidateHasColor(image, expected, typeof(ImageHandler));
-		}
-
-		[Fact]
-		[Description("The Opacity property of a image should match with native Opacity")]
-		public async Task VerifyImageOpacityProperty()
-		{
-			var image = new Image
-			{
-				Opacity = 0.35f
-			};
-			var expectedValue = image.Opacity;
-
-			var handler = await CreateHandlerAsync<ImageHandler>(image);
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var nativeOpacityValue = await GetPlatformOpacity(handler);
-				Assert.Equal(expectedValue, nativeOpacityValue);
-			});
-		}
+		}		
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -153,6 +154,23 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(200, image.Width);
 		}
 
+		[Fact]
+		[Description("The Opacity property of a image should match with native Opacity")]
+		public async Task VerifyImageOpacityProperty()
+		{
+			var image = new Image
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = image.Opacity;
+
+			var handler = await CreateHandlerAsync<ImageHandler>(image);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 		UIImageView GetPlatformImage(ImageHandler imageHandler) =>
 			imageHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
@@ -154,16 +154,16 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		UIImageView GetPlatformImage(ImageHandler imageHandler) =>
-            imageHandler.PlatformView;
-    
-        Task<float> GetPlatformOpacity(ImageHandler imageHandler)
-        {
-            return InvokeOnMainThreadAsync(() =>
-            {
-                var nativeView = GetPlatformImage(imageHandler);
-                return (float)nativeView.Alpha;
-            });
-        }
+			imageHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(ImageHandler imageHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformImage(imageHandler);
+				return (float)nativeView.Alpha;
+			});
+		}
 
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.iOS.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -151,5 +152,18 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(100, image.Height);
 			Assert.Equal(200, image.Width);
 		}
+
+		UIImageView GetPlatformImage(ImageHandler imageHandler) =>
+            imageHandler.PlatformView;
+    
+        Task<float> GetPlatformOpacity(ImageHandler imageHandler)
+        {
+            return InvokeOnMainThreadAsync(() =>
+            {
+                var nativeView = GetPlatformImage(imageHandler);
+                return (float)nativeView.Alpha;
+            });
+        }
+
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetPlatformLabel(labelHandler);
-				return nativeView.Alpha;
+				return (float)nativeView.Alpha;
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
@@ -96,5 +96,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		int GetPlatformMaxLines(LabelHandler labelHandler) =>
 			GetPlatformLabel(labelHandler).MaxLines;
+
+		Task<float> GetPlatformOpacity(LabelHandler labelHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformLabel(labelHandler);
+				return nativeView.Alpha;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Windows.cs
@@ -19,5 +19,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		int GetPlatformMaxLines(LabelHandler labelHandler) =>
 			GetPlatformLabel(labelHandler).MaxLines;
+
+		Task<float> GetPlatformOpacity(LabelHandler labelHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(labelHandler);
+				return nativeView.Opacity;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Handlers;
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -24,8 +25,8 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
-				var nativeView = GetPlatformControl(labelHandler);
-				return nativeView.Opacity;
+				var nativeView = GetPlatformLabel(labelHandler);
+				return (float)nativeView.Opacity;
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -742,6 +742,24 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateHasColor(label, expected, typeof(LabelHandler));
 		}
 
+		[Fact]
+		[Description("The Opacity property of a Label should match with native Opacity")]
+		public async Task VerifyLabelOpacityProperty()
+		{
+			var label = new Label
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = label.Opacity;
+
+			var handler = await CreateHandlerAsync<LabelHandler>(label);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
+
 		Color TextColor(LabelHandler handler)
 		{
 #if __IOS__

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -60,6 +60,14 @@ namespace Microsoft.Maui.DeviceTests
 			return textDecorations;
 		}
 
+		Task<float> GetPlatformOpacity(LabelHandler labelHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformLabel(labelHandler);
+				return (float)nativeView.Alpha; 
+			});
+		}
 		public static IEnumerable<object[]> GetCharacterSpacingWithLineHeightWithTextDecorationsWorksTestData()
 		{
 			var label1 = new Label()

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Android.Widget;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -15,6 +16,18 @@ namespace Microsoft.Maui.DeviceTests
 		protected Task<string> GetPlatformControlText(MauiPicker platformView)
 		{
 			return InvokeOnMainThreadAsync(() => platformView.Text);
+		}
+
+		MauiPicker GetPlatformPicker(PickerHandler pickerHandler) =>
+			pickerHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(PickerHandler pickerHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformPicker(pickerHandler);
+				return (float)nativeView.Alpha;
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Windows.cs
@@ -82,5 +82,17 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return platformView.VerticalAlignment;
 		}
+
+		ComboBox GetPlatformPicker(PickerHandler pickerHandler) =>
+			pickerHandler.PlatformView;
+
+		Task<float> GetPlatformOpacity(PickerHandler pickerHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformPicker(pickerHandler);
+				return (float)nativeView.Opacity;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.cs
@@ -70,5 +70,23 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateHasColor(picker, expected, typeof(PickerHandler));
 		}
+
+		[Fact]
+		[Description("The Opacity property of a Picker should match with native Opacity")]
+		public async Task VerifyPickerOpacityProperty()
+		{
+			var picker = new Picker
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = picker.Opacity;
+
+			var handler = await CreateHandlerAsync<PickerHandler>(picker);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.iOS.cs
@@ -15,5 +15,18 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() => platformView.Text);
 		}
+
+		MauiPicker GetPlatformPicker(PickerHandler pickerHandler) =>
+            pickerHandler.PlatformView;
+    
+        Task<float> GetPlatformOpacity(PickerHandler pickerHandler)
+        {
+            return InvokeOnMainThreadAsync(() =>
+            {
+                var nativeView = GetPlatformPicker(pickerHandler);
+                return (float)nativeView.Alpha;
+            });
+        }
+
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.iOS.cs
@@ -9,16 +9,16 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	public partial class PickerTests : ControlsHandlerTestBase
-	{
-		protected Task<string> GetPlatformControlText(MauiPicker platformView)
-		{
-			return InvokeOnMainThreadAsync(() => platformView.Text);
-		}
+    public partial class PickerTests : ControlsHandlerTestBase
+    {
+        protected Task<string> GetPlatformControlText(MauiPicker platformView)
+        {
+            return InvokeOnMainThreadAsync(() => platformView.Text);
+        }
 
-		MauiPicker GetPlatformPicker(PickerHandler pickerHandler) =>
+        MauiPicker GetPlatformPicker(PickerHandler pickerHandler) =>
             pickerHandler.PlatformView;
-    
+
         Task<float> GetPlatformOpacity(PickerHandler pickerHandler)
         {
             return InvokeOnMainThreadAsync(() =>
@@ -28,5 +28,5 @@ namespace Microsoft.Maui.DeviceTests
             });
         }
 
-	}
+    }
 }

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.Windows.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Maui.Handlers;
-using xUnit;
+using Xunit;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -24,10 +25,10 @@ namespace Microsoft.Maui.DeviceTests
 			var expectedValue = radioButton.Opacity;
 
 			var handler = await CreateHandlerAsync<RadioButtonHandler>(radioButton);
-			var nativeView = GetPlatformControl(handler);
+			var nativeView = GetNativeRadioButton(handler);
 			await InvokeOnMainThreadAsync(() =>
    			{
-				var nativeOpacityValue = (float)nativeView.Alpha;
+				var nativeOpacityValue = (float)nativeView.Opacity;
 				Assert.Equal(expectedValue, nativeOpacityValue);
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.Windows.cs
@@ -1,4 +1,7 @@
 ﻿using Microsoft.Maui.Handlers;
+using xUnit;
+using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -9,5 +12,24 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsChecked(RadioButtonHandler radioButtonHandler) =>
 			GetNativeRadioButton(radioButtonHandler).IsChecked ?? false;
+
+		[Fact]
+		[Description("The Opacity property of a RadioButton should match with native Opacity")]
+		public async Task VerifyRadioButtonOpacityProperty()
+		{
+			var radioButton = new RadioButton
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = radioButton.Opacity;
+
+			var handler = await CreateHandlerAsync<RadioButtonHandler>(radioButton);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+   			{
+				var nativeOpacityValue = (float)nativeView.Alpha;
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
@@ -30,5 +30,14 @@ namespace Microsoft.Maui.DeviceTests
 			var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
 			return editText.SelectionStart;
 		}
+
+		Task<float> GetPlatformOpacity(SearchBarHandler searchBarHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(searchBarHandler);
+				return nativeView.Alpha;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Windows.cs
@@ -43,5 +43,14 @@ namespace Microsoft.Maui.DeviceTests
 
 			return -1;
 		}
+
+		Task<float> GetPlatformOpacity(SearchBarHandler searchBarHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(searchBarHandler);
+				return nativeView.Opacity;
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Windows.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetPlatformControl(searchBarHandler);
-				return nativeView.Opacity;
+				return (float)nativeView.Opacity;
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -75,6 +76,24 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 #endif
+
+		[Fact]
+		[Description("The Opacity property of a SearchBar should match with native Opacity")]
+		public async Task VerifySearchBarOpacityProperty()
+		{
+			var searchBar = new SearchBar
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = searchBar.Opacity;
+			
+			var handler = await CreateHandlerAsync<SearchBarHandler>(searchBar);
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var nativeOpacityValue = await GetPlatformOpacity(handler);
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
+		}
 
 #if false
 		// TODO: The search bar controls are composite controls and need to be attached to the UI to run

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.iOS.cs
@@ -34,5 +34,15 @@ namespace Microsoft.Maui.DeviceTests
 			var control = searchBarHandler.QueryEditor;
 			return control.GetCursorPosition();
 		}
+
+		Task<float> GetPlatformOpacity(SearchBarHandler searchBarHandler)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeView = GetPlatformControl(searchBarHandler);
+				return (float)nativeView.Alpha;
+			});
+		}
+
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -77,6 +78,25 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(()
 				=> GetPlatformControl(handler).ChildCount != 0);
+		}
+
+		[Fact]
+		[Description("The Opacity property of a SwipeView should match with native Opacity")]
+		public async Task VerifySwipeViewOpacityProperty()
+		{
+			var swipeView = new SwipeView
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = swipeView.Opacity;
+			
+			var handler = await CreateHandlerAsync<SwipeViewHandler>(swipeView);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+   			{
+				var nativeOpacityValue = (float)nativeView.Alpha;
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.iOS.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -18,6 +19,25 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(()
 				=> GetPlatformControl(handler).Subviews.Length != 0);
+		}
+
+		[Fact]
+		[Description("The Opacity property of a SwipeView should match with native Opacity")]
+		public async Task VerifySwipeViewOpacityProperty()
+		{
+			var swipeView = new SwipeView
+			{
+				Opacity = 0.35f
+			};
+			var expectedValue = swipeView.Opacity;
+			
+			var handler = await CreateHandlerAsync<SwipeViewHandler>(swipeView);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+   			{
+				var nativeOpacityValue = (float)nativeView.Alpha;
+				Assert.Equal(expectedValue, nativeOpacityValue);
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change
Migration of Compatibility.Core platform-specific unit tests to device tests. Here the migrated cases which ensuring that the Opacity consistency of different elements matches their native counterparts. We are going to migrate tests in blocks in different PRs. This is the 4st group.

There are unit tests under:

- src\Compatibility\Core\tests\Android
- src\Compatibility\Core\tests\iOS
- src\Compatibility\Core\tests\WinUI

That are not running right now. these cases from Xamarin.Forms where they could run as unit tests, but now with .NET MAUI this is not possible. So here I migrated the following cases in device tests.

 
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/Android/OpacityTests.cs
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/iOS/OpacityTests.cs


This pull request introduces a series of changes across multiple test files to add functionality for verifying the opacity property of various UI elements. The most significant changes include the addition of methods to retrieve the platform-specific opacity values and new test cases to validate the opacity property consistency between the .NET MAUI controls and their native counterparts.

### Additions for Opacity Verification:

* [`src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs`](diffhunk://#diff-6ac6261aafc1f1217fb1495b28cc1d27d39a620dc3133b5c785b50dff53a6fd9R13-R21): Added `GetPlatformOpacity` method to retrieve the opacity value for BoxView on Android.
* [`src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Windows.cs`](diffhunk://#diff-f9a784293632549016da0085cf713125585158a994a14b044ec01b27dfe7bf3eR13-R21): Added `GetPlatformOpacity` method to retrieve the opacity value for BoxView on Windows.
* [`src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.cs`](diffhunk://#diff-7902c1c8215b2a3814b489fb6bddb6e3edaba9d159fef898eb7112bd70b9098eR49-R66): Added a new test `VerifyBoxViewOpacityProperty` to check the opacity property of BoxView.

### Similar Additions for Other Elements:

* [`src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs`](diffhunk://#diff-fff9a4124ad9e7d0f71763921f49db95411c06b6c151eae56ab5cd00082c9718R27-R34): Added `GetPlatformOpacity` method for Button on Android.
* [`src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs`](diffhunk://#diff-bcd0f90864b2f2d65c3e1e98333dd404202ec85bb44e95b9bf533a67f5c3cc1aR22-R30): Added `GetPlatformOpacity` method for Button on Windows.
* [`src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.cs`](diffhunk://#diff-407bfb92dd35630e82c2fea811133cd987d0accce89ed676286a77450afaba43R74-R92): Added `VerifyButtonOpacityProperty` test for Button.

* [`src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs`](diffhunk://#diff-e1c702c22c2fc91b4f87ea4d8e463c79d98f650819b1e7826c7cec94ac59e79fR16-R24): Added `GetPlatformOpacity` method for CheckBox on Android.
* [`src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Windows.cs`](diffhunk://#diff-1a986a079c2893e851bd8ac7fe6b09d2ef32467dbf36e50abd4ca95c9cf55c8bR13-R21): Added `GetPlatformOpacity` method for CheckBox on Windows.
* [`src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.cs`](diffhunk://#diff-aeacb9c0a1891ceffc215909033e24fd8e6de018463e82f595612a1ff325d4bdR47-R64): Added `VerifyCheckBoxOpacityProperty` test for CheckBox.

* [`src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs`](diffhunk://#diff-b7d7c2ebbad021298bea061a6be50db252b1c54856cd100434559fdeb3249913R43-R51): Added `GetPlatformOpacity` method for Editor on Android.
* [`src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs`](diffhunk://#diff-61dd12c8a4febadd64e1a5e6675987de1e4b8613eed7142a54840e1a6a7b3d27R18-R26): Added `GetPlatformOpacity` method for Editor on Windows.
* [`src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs`](diffhunk://#diff-7333ab7eee3ef2f21d5d27a40e3135d8c168d8656c857a5f9f133e0f39d3281eR294-R311): Added `VerifyEditorOpacityProperty` test for Editor.

* [`src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs`](diffhunk://#diff-bcd087629fa0014afc7d968e9f1f6127a7c1a9b3039a8f0478de907f415f18a3R42-R50): Added `GetPlatformOpacity` method for Entry on Android.
* [`src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs`](diffhunk://#diff-39c20900654372817b00cdc06ffff46496954fb5effadfeb405a2baa6bb7aff5R18-R26): Added `GetPlatformOpacity` method for Entry on Windows.
* [`src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs`](diffhunk://#diff-01f3a77944793fa3d2cccb83840f179c8bb2c9db2ad1c0a27afbc44597c4baa7R207-R224): Added `VerifyEntryOpacityProperty` test for Entry.

* [`src/Controls/tests/DeviceTests/Elements/Image/ImageTests.Android.cs`](diffhunk://#diff-efcb34702fdda9e71a380045c3475750f1ef100ef1314d49257ef0109a05d816R72-R83): Added `GetPlatformOpacity` method for Image on Android.

### Issues Fixed

Fixes #27303
 