### PR TITLE
[iOS & Android] Fix: Close keyboard on Search button press in SearchBar control

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28110.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28110.xaml
@@ -4,6 +4,6 @@
              x:Class="Controls.TestCases.HostApp.Issues.Issue28110"
              Title="Issue28110">
      <VerticalStackLayout>
-              <SearchBar AutomationId="MauiSearchBar" />
+              <SearchBar Text="Text" AutomationId="MauiSearchBar" />
              </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28110.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28110.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Controls.TestCases.HostApp.Issues.Issue28110"
+             Title="Issue28110">
+     <VerticalStackLayout>
+              <SearchBar AutomationId="MauiSearchBar" />
+             </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28110.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28110.xaml.cs
@@ -1,0 +1,10 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 28110, "Keyboard Does Not Close on Search Button Press in SearchBar Control", PlatformAffected.Android | PlatformAffected.iOS)]
+public partial class Issue28110 : ContentPage
+{
+	public Issue28110()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28110.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28110.cs
@@ -1,0 +1,28 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+
+public class Issue28110 : _IssuesUITest
+{
+	public Issue28110(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Keyboard Does Not Close on Search Button Press in SearchBar Control";
+
+    [Test]
+	[Category(UITestCategories.SearchBar)]
+	public void CarouselViewShouldNotCrash()
+	{
+		App.WaitForElement("MauiSearchBar");
+
+        App.Tap("MauiSearchBar");
+
+        App.DismissKeyboard();
+
+        Assert.That(App.IsKeyboardShown(),Is.EqualTo(false));
+	}
+}

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Handlers
 		void OnQueryTextSubmit(object? sender, QueryTextSubmitEventArgs e)
 		{
 			VirtualView.SearchButtonPressed();
-			e.Handled = true;
+		    e.Handled = false;
 		}
 
 		void OnQueryTextChange(object? sender, QueryTextChangeEventArgs e)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -214,6 +214,10 @@ namespace Microsoft.Maui.Handlers
 			void OnSearchButtonClicked(object? sender, EventArgs e)
 			{
 				VirtualView?.SearchButtonPressed();
+				if(sender is UISearchBar platformView) 
+				{
+					platformView.ResignFirstResponder();
+				}
 			}
 
 			void OnTextPropertySet(object? sender, UISearchBarTextChangedEventArgs a)


### PR DESCRIPTION




### Description of Change

This PR fixes an issue where the keyboard is not dismissed when clicking the search button in the `SearchBar` control on Android and iOS.

This issue was previously discussed in #14061 and was marked as "By Design" with the recommendation to use manual APIs to close the keyboard.

However, in many mobile applications, the expected behavior is for the keyboard to automatically close when the user presses the Search button. Since this is a common UX expectation,  it would be beneficial for this to be the default behavior in .NET MAUI as well.

In fact this is the default behaviour of  `SearchView` in `Android`

**After fix**

https://github.com/user-attachments/assets/23f873e6-3fc7-4cca-93ba-e56791fee6a9


https://github.com/user-attachments/assets/fd730f23-9886-470e-9b08-143798e40da4


### Issues Fixed

Fixes #28110

