### PR TITLE
Fix NullReferenceException in PaintExtensions.IsSolid on Android

### DIFF
--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Graphics
 
 		internal static bool IsSolid(this SolidPaint paint)
 		{
-			return paint.Color.Alpha == 1;
+			return paint?.Color != null && paint.Color.Alpha == 1;
 		}
 
 		internal static bool IsSolid(this LinearGradientPaint paint)

--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -83,17 +83,13 @@ namespace Microsoft.Maui.Graphics
 		}
 
 		internal static bool IsSolid(this SolidPaint? paint) =>
-			paint?.Color.Alpha == 1;
+			paint?.Color?.Alpha == 1;
 
-		internal static bool IsSolid(this LinearGradientPaint paint)
-		{
-			return paint.GradientStops.All(s => s.Color.Alpha == 1);
-		}
+		internal static bool IsSolid(this LinearGradientPaint? paint) =>
+			paint?.GradientStops?.All(s => s.Color?.Alpha == 1) == true;
 
-		internal static bool IsSolid(this RadialGradientPaint paint)
-		{
-			return paint.GradientStops.All(s => s.Color.Alpha == 1);
-		}
+		internal static bool IsSolid(this RadialGradientPaint? paint) =>
+			paint?.GradientStops?.All(s => s.Color?.Alpha == 1) == true;
 
 		internal static bool IsValid(this GradientPaint? gradientPaint) =>
 			gradientPaint?.GradientStops?.Length > 0;

--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Android.Content;
 using Android.Content.Res;
@@ -82,10 +82,8 @@ namespace Microsoft.Maui.Graphics
 			return color.A is 1;
 		}
 
-		internal static bool IsSolid(this SolidPaint paint)
-		{
-			return paint?.Color != null && paint.Color.Alpha == 1;
-		}
+		internal static bool IsSolid(this SolidPaint? paint) =>
+			paint?.Color.Alpha == 1;
 
 		internal static bool IsSolid(this LinearGradientPaint paint)
 		{

--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -82,14 +82,25 @@ namespace Microsoft.Maui.Graphics
 			return color.A is 1;
 		}
 
-		internal static bool IsSolid(this SolidPaint? paint) =>
-			paint?.Color?.Alpha == 1;
+		internal static bool IsSolid(this SolidPaint paint)
+		{
+			return !paint.IsNullOrEmpty() && paint.Color.Alpha == 1;
+		}
 
-		internal static bool IsSolid(this LinearGradientPaint? paint) =>
-			paint?.GradientStops?.All(s => s.Color?.Alpha == 1) == true;
+		internal static bool IsSolid(this GradientPaint paint)
+		{
+			return !paint.IsNullOrEmpty() && paint.GradientStops.All(s => s.Color?.Alpha == 1);
+		}
 
-		internal static bool IsSolid(this RadialGradientPaint? paint) =>
-			paint?.GradientStops?.All(s => s.Color?.Alpha == 1) == true;
+		internal static bool IsSolid(this LinearGradientPaint paint)
+		{
+			return IsSolid(paint as GradientPaint);
+		}
+
+		internal static bool IsSolid(this RadialGradientPaint paint)
+		{
+			return IsSolid(paint as GradientPaint);
+		}
 
 		internal static bool IsValid(this GradientPaint? gradientPaint) =>
 			gradientPaint?.GradientStops?.Length > 0;

--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -92,16 +92,6 @@ namespace Microsoft.Maui.Graphics
 			return !paint.IsNullOrEmpty() && paint.GradientStops.All(s => s.Color?.Alpha == 1);
 		}
 
-		internal static bool IsSolid(this LinearGradientPaint paint)
-		{
-			return IsSolid(paint as GradientPaint);
-		}
-
-		internal static bool IsSolid(this RadialGradientPaint paint)
-		{
-			return IsSolid(paint as GradientPaint);
-		}
-
 		internal static bool IsValid(this GradientPaint? gradientPaint) =>
 			gradientPaint?.GradientStops?.Length > 0;
 

--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
@@ -155,7 +155,7 @@ public partial class GraphicsTests : TestBase
 	}
 
 	[Fact]
-	public void NullSolidPaintTest(string hexColor)
+	public void NullSolidPaintTest()
 	{
 		Color nullColor = null;
 		var solidPaintNullColor = new SolidPaint(nullColor);

--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
@@ -183,12 +183,6 @@ public partial class GraphicsTests : TestBase
 	[Fact]
 	public void NullLinearGradientPaintTest()
 	{
-		Color nullStartColor = null;
-		Color nullEndColor = null;
-		var linearGradientPaintNullColors = new LinearGradientPaintStub(nullStartColor, nullEndColor);
-
-		Assert.False(linearGradientPaintNullColors.IsSolid());
-
 		LinearGradientPaintStub nullLinearGradientPaint = null;
 
 		Assert.False(nullLinearGradientPaint.IsSolid());
@@ -210,14 +204,8 @@ public partial class GraphicsTests : TestBase
 	[Fact]
 	public void NullRadialGradientPaintTest()
 	{
-		Color nullStartColor = null;
-		Color nullEndColor = null;
-		var radialGradientPaintNullColors = new RadialGradientPaintStub(nullStartColor, nullEndColor);
-
-		Assert.False(radialGradientPaintNullColors.IsSolid());
-
 		RadialGradientPaintStub nullRadialGradientPaint = null;
-
+		
 		Assert.False(nullRadialGradientPaint.IsSolid());
 	}
 }

--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
@@ -154,6 +154,19 @@ public partial class GraphicsTests : TestBase
 		Assert.True(solidPaint.IsSolid());
 	}
 
+	[Fact]
+	public void NullSolidPaintTest(string hexColor)
+	{
+		Color nullColor = null;
+		var solidPaintNullColor = new SolidPaint(nullColor);
+
+		Assert.False(solidPaintNullColor.IsSolid());
+
+		SolidPaint nullSolidPaint = null;
+
+		Assert.False(nullSolidPaint.IsSolid());
+	}
+
 	[Theory]
 	[InlineData("#FF0000", "#00FF00")]
 	[InlineData("#00FF00", "#0000FF")]
@@ -167,6 +180,20 @@ public partial class GraphicsTests : TestBase
 		Assert.True(linearGradientPaint.IsSolid());
 	}
 
+	[Fact]
+	public void NullLinearGradientPaintTest()
+	{
+		Color nullStartColor = null;
+		Color nullEndColor = null;
+		var linearGradientPaintNullColors = new LinearGradientPaintStub(nullStartColor, nullEndColor);
+
+		Assert.False(linearGradientPaintNullColors.IsSolid());
+
+		LinearGradientPaintStub nullLinearGradientPaint = null;
+
+		Assert.False(nullLinearGradientPaint.IsSolid());
+	}
+
 	[Theory]
 	[InlineData("#FF0000", "#00FF00")]
 	[InlineData("#00FF00", "#0000FF")]
@@ -178,5 +205,19 @@ public partial class GraphicsTests : TestBase
 		var radialGradientPaint = new RadialGradientPaintStub(startColor, endColor);
 
 		Assert.True(radialGradientPaint.IsSolid());
+	}
+
+	[Fact]
+	public void NullRadialGradientPaintTest()
+	{
+		Color nullStartColor = null;
+		Color nullEndColor = null;
+		var radialGradientPaintNullColors = new RadialGradientPaintStub(nullStartColor, nullEndColor);
+
+		Assert.False(radialGradientPaintNullColors.IsSolid());
+
+		RadialGradientPaintStub nullRadialGradientPaint = null;
+
+		Assert.False(nullRadialGradientPaint.IsSolid());
 	}
 }


### PR DESCRIPTION
### Description of Change

Added null check to prevent crash when SolidPaint is null, addressing issue seen in Border rendering on Android.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

[#27844](https://github.com/dotnet/maui/issues/27844)
