### PR TITLE
[iOS] Ignore for now obsoletes on iOS

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -125,7 +125,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				);
 			}
 
+#pragma warning disable CS0672 // Member overrides obsolete member
 			public override void RunJavaScriptTextInputPanel(
+#pragma warning restore CS0672 // Member overrides obsolete member
 				WKWebView webView, string prompt, string? defaultText, WKFrameInfo frame, Action<string> completionHandler)
 			{
 				PresentAlertController(

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -486,7 +486,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			img = UIGraphics.GetImageFromCurrentImageContext();
 			UIGraphics.EndImageContext();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			_nSCache.SetObjectforKey(img, (NSString)hamburgerKey);
+#pragma warning restore CS0618 // Type or member is obsolete
 			return img;
 		}
 

--- a/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewUIDelegate.cs
@@ -59,7 +59,10 @@ namespace Microsoft.Maui.Platform
 			);
 		}
 
+
+#pragma warning disable CS0672 // Member overrides obsolete member
 		public override void RunJavaScriptTextInputPanel(
+#pragma warning restore CS0672 // Member overrides obsolete member
 			WKWebView webView, string prompt, string? defaultText, WKFrameInfo frame, Action<string> completionHandler)
 		{
 			// TODO the okAction and cancelAction were already taking null when I removed `#nullable disable`


### PR DESCRIPTION
### Description of Change

Latest iOS workload bits obsolete the override RunJavaScriptTextInputPanel , ignoring for now, created an issue to follow up on fixing it  properly.  https://github.com/dotnet/maui/issues/28135

### Issues Fixed

Fixes build
