### PR TITLE
[Testing] Fix for flaky UITests in CI that occasionally fail - 4

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -30,8 +30,9 @@ public class Issue16910 : _IssuesUITest
 	[Test]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{
-		_ = App.WaitForElement("CollectionView");
-		App.ScrollUp("CollectionView", ScrollStrategy.Gesture, 0.7, 500);
+		var collectionViewRect = App.WaitForElement("CollectionView").GetRect();
+		//In CI, using App.ScrollDown sometimes fails to trigger the refresh command, so here use DragCoordinates instead of the ScrollDown action in Appium.
+		App.DragCoordinates(collectionViewRect.CenterX(), collectionViewRect.Y + 50, collectionViewRect.CenterX(), collectionViewRect.Y + collectionViewRect.Height - 50);
 		App.WaitForElement("IsRefreshing");
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("collectionView");
 			App.ScrollDown("collectionView", ScrollStrategy.Gesture, 0.99);
-			// In CI, the CommandFired text does not update when Using ScrollDown action from Appium. To ensure the command is triggered, first scroll up and then attempt to scrolling down again.
+			// In CI, the CommandFired text does not update when using the ScrollDown action. To reliably trigger the command, first scroll up and then scroll down again.
             App.ScrollUp("collectionView", ScrollStrategy.Gesture, swipePercentage:0.99);
 			App.WaitForElement("collectionView");
 			App.ScrollDown("collectionView", ScrollStrategy.Gesture, 0.99);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("collectionView");
 			App.ScrollDown("collectionView", ScrollStrategy.Gesture, 0.99);
-
+			// In CI, the CommandFired text does not update when Using ScrollDown action from Appium. To ensure the command is triggered, first scroll up and then attempt to scrolling down again.
+            App.ScrollUp("collectionView", ScrollStrategy.Gesture, swipePercentage:0.99);
 			App.WaitForElement("collectionView");
 			App.ScrollDown("collectionView", ScrollStrategy.Gesture, 0.99);
 


### PR DESCRIPTION
### Description of Change
This pull request includes updates to the test cases in the `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues` directory to improve the reliability of UI interactions during automated testing. The most important changes involve replacing certain Appium actions with more reliable alternatives and adding comments to explain these changes.

* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs`](diffhunk://#diff-468406c5ba9f1991e6dddcc77b918874a2a674506f0adacd03f911b4a9e6b1d5L33-R35): Replaced `App.ScrollUp` with `App.DragCoordinates` in the `BindingUpdatesFromInteractiveRefresh` method to ensure the refresh command is triggered consistently in CI environments.
* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25889.cs`](diffhunk://#diff-46edda2b08924d4700db8c5586b555b339d343c458b0ed4ea4629fc202b26c99L21-R22): Added a step to scroll up before scrolling down in the `RemainingItemsThresholdReachedCommandFired` method to ensure the command is triggered reliably in CI environments.

### TestCases

- Issue16910
- Issue25889

Fixes https://github.com/dotnet/maui/issues/28178
