### PR TITLE
[ci] Publish VS workload zips

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetName>Microsoft.NET.Sdk.Maui.Workload.@VSMAN_VERSION@</TargetName>
+    <TargetName>maui.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
     <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>

--- a/src/Workload/Shared/Maestro.targets
+++ b/src/Workload/Shared/Maestro.targets
@@ -22,6 +22,8 @@
 
     <ItemGroup>
       <ItemsToPush Include="$(RootManifestOutputPath)**\*.nupkg" />
+      <WorkloadArtifacts Include="$(RootManifestOutputPath)**\*.zip" />
+      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="maui/$(PackageReferenceVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/commit/96d7858cce242c5eea76028f3f051bb9ffda793c

Adds the VS manifest zips needed by the workload versions VS insertion
pipeline to Maestro publishing.

The first update to VS that includes these changes will have to be done
manually, as the manifest names are also changing to work with the new
pipeline.