### PR TITLE
Fix Crashing issue with keyboard scrolling iOS

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -184,7 +184,7 @@ public static class KeyboardAutoManagerScroll
 	{
 		notification.UserInfo?.SetAnimationDuration();
 
-		if (LastScrollView is not null)
+		if (LastScrollView?.Window is not null)
 		{
 			UIView.Animate(AnimationDuration, 0, UIViewAnimationOptions.CurveEaseOut, AnimateHidingKeyboard, () => { });
 		}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -767,7 +767,7 @@ namespace Microsoft.Maui.Platform
 			{
 				// We check for Window to avoid scenarios where an invalidate might propagate up the tree
 				// To a SuperView that's been disposed which will cause a crash when trying to access it
-				if (view.Window is null)
+				if (nextResponder is UIView uiview && uiview.Window is null)
 				{
 					return null;
 				}
@@ -787,7 +787,7 @@ namespace Microsoft.Maui.Platform
 			{
 				// We check for Window to avoid scenarios where an invalidate might propagate up the tree
 				// To a SuperView that's been disposed which will cause a crash when trying to access it
-				if (controller.View?.Window is null)
+				if (nextResponder is UIView uiview && uiview.Window is null)
 				{
 					return null;
 				}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -765,6 +765,13 @@ namespace Microsoft.Maui.Platform
 			var nextResponder = view as UIResponder;
 			while (nextResponder is not null)
 			{
+				// We check for Window to avoid scenarios where an invalidate might propagate up the tree
+				// To a SuperView that's been disposed which will cause a crash when trying to access it
+				if (view.Window is null)
+				{
+					return null;
+				}
+
 				nextResponder = nextResponder.NextResponder;
 
 				if (nextResponder is T responder)
@@ -778,6 +785,13 @@ namespace Microsoft.Maui.Platform
 			var nextResponder = controller.View as UIResponder;
 			while (nextResponder is not null)
 			{
+				// We check for Window to avoid scenarios where an invalidate might propagate up the tree
+				// To a SuperView that's been disposed which will cause a crash when trying to access it
+				if (controller.View?.Window is null)
+				{
+					return null;
+				}
+
 				nextResponder = nextResponder.NextResponder;
 
 				if (nextResponder is T responder && responder != controller)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Description of Change

This PR adds some checks so that we don't crash when the an editor/entry is unfocused and the keyboard goes away, but that editor/entry's Window is null. This one is pretty tricky to test so we may just add this now and keep trying on the test.


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/28140

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
