### PR TITLE
[Android] Fixed flickering when navigating using GoToAsync

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Shell.CurrentItemProperty.PropertyName)
-				SwitchFragment(FragmentManager, _frameLayout, Element.CurrentItem, Element._isAnimate);
+				SwitchFragment(FragmentManager, _frameLayout, Element.CurrentItem, Element.IsAnimateOnNavigation);
 
 			_elementPropertyChanged?.Invoke(sender, e);
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Shell.CurrentItemProperty.PropertyName)
-				SwitchFragment(FragmentManager, _frameLayout, Element.CurrentItem);
+				SwitchFragment(FragmentManager, _frameLayout, Element.CurrentItem, Element._iaAnimate);
 
 			_elementPropertyChanged?.Invoke(sender, e);
 		}
@@ -226,7 +226,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			FragmentTransaction transaction = manager.BeginTransactionEx();
 
 			if (animate)
-				transaction.SetTransitionEx((int)global::Android.App.FragmentTransit.FragmentOpen);
+			{
+				transaction.SetCustomAnimations(global::Android.Resource.Animation.FadeIn, global::Android.Resource.Animation.FadeOut);
+			}
 
 			transaction.ReplaceEx(_frameLayout.Id, fragment);
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Shell.CurrentItemProperty.PropertyName)
-				SwitchFragment(FragmentManager, _frameLayout, Element.CurrentItem, Element._iaAnimate);
+				SwitchFragment(FragmentManager, _frameLayout, Element.CurrentItem, Element._isAnimate);
 
 			_elementPropertyChanged?.Invoke(sender, e);
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -227,7 +227,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (animate)
 			{
-				transaction.SetCustomAnimations(global::Android.Resource.Animation.FadeIn, global::Android.Resource.Animation.FadeOut);
+				transaction.SetCustomAnimations(
+					global::Android.Resource.Animation.FadeIn,
+					global::Android.Resource.Animation.FadeOut,
+					global::Android.Resource.Animation.FadeIn,
+					global::Android.Resource.Animation.FadeOut
+				);
 			}
 
 			transaction.ReplaceEx(_frameLayout.Id, fragment);

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs/*" />
 		public Task GoToAsync(ShellNavigationState state, bool animate)
 		{
-			_isAnimate = animate;
+			IsAnimateOnNavigation = animate;
 			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
@@ -1055,7 +1055,7 @@ namespace Microsoft.Maui.Controls
 		/// <returns>A task that represents the asynchronous navigation operation.</returns>
 		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
 		{
-			_isAnimate = animate;
+			IsAnimateOnNavigation = animate;
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));
 		}
 
@@ -1079,7 +1079,7 @@ namespace Microsoft.Maui.Controls
 		/// <returns></returns>
 		public Task GoToAsync(ShellNavigationState state, bool animate, ShellNavigationQueryParameters shellNavigationQueryParameters)
 		{
-			_isAnimate = animate;
+			IsAnimateOnNavigation = animate;
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(shellNavigationQueryParameters));
 		}
 
@@ -1181,7 +1181,7 @@ namespace Microsoft.Maui.Controls
 		ShellNavigationManager _navigationManager;
 		ShellFlyoutItemsManager _flyoutManager;
 		Page _previousPage;
-		internal bool _isAnimate = true;
+		internal bool IsAnimateOnNavigation = true;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public Shell()

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1035,6 +1035,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs/*" />
 		public Task GoToAsync(ShellNavigationState state, bool animate)
 		{
+			_iaAnimate = animate;
 			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
@@ -1178,6 +1179,7 @@ namespace Microsoft.Maui.Controls
 		ShellNavigationManager _navigationManager;
 		ShellFlyoutItemsManager _flyoutManager;
 		Page _previousPage;
+		internal bool _iaAnimate = true;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public Shell()

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs/*" />
 		public Task GoToAsync(ShellNavigationState state, bool animate)
 		{
-			_iaAnimate = animate;
+			_isAnimate = animate;
 			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
@@ -1055,6 +1055,7 @@ namespace Microsoft.Maui.Controls
 		/// <returns>A task that represents the asynchronous navigation operation.</returns>
 		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
 		{
+			_isAnimate = animate;
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));
 		}
 
@@ -1078,6 +1079,7 @@ namespace Microsoft.Maui.Controls
 		/// <returns></returns>
 		public Task GoToAsync(ShellNavigationState state, bool animate, ShellNavigationQueryParameters shellNavigationQueryParameters)
 		{
+			_isAnimate = animate;
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(shellNavigationQueryParameters));
 		}
 
@@ -1179,7 +1181,7 @@ namespace Microsoft.Maui.Controls
 		ShellNavigationManager _navigationManager;
 		ShellFlyoutItemsManager _flyoutManager;
 		Page _previousPage;
-		internal bool _iaAnimate = true;
+		internal bool _isAnimate = true;
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 		public Shell()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Detail
Flickering occurs when navigating between pages using GoToAsync, and animations do not work correctly based on parameter values.
 
### Root Cause
Flickering occurs due to the default Android fragment transition (`SetTransitionEx(FragmentTransit.FragmentOpen)`) which briefly exposes a white flash between page transitions. This is especially noticeable in dark-themed applications where the white blink appears across the entire screen, including the tab bar transitioning from white to black.

The issue occurred regardless of the `animate` parameter value passed to `GoToAsync()` because the animation state wasn't properly tracked and passed through to the Android renderer.

### Description of Change

**1. Changed Animation Type (ShellRenderer.cs)**
- Replaced `SetTransitionEx(FragmentTransit.FragmentOpen)` with `SetCustomAnimations(FadeIn, FadeOut, FadeIn, FadeOut)`
- Custom fade animations provide smooth transitions without exposing underlying color changes
- The four animation parameters handle: enter, exit, popEnter, popExit scenarios

**2. Added Animation State Tracking (Shell.cs)**
- Introduced internal `IsAnimateOnNavigation` field to store animation parameter value
- Field is set in all `GoToAsync()` overload variations before calling the navigation manager
- Allows animation state to flow from API call through to platform renderer
- Default value is `true` for backward compatibility

**3. Wired Animation State to Renderer (ShellRenderer.cs)**
- Updated `SwitchFragment()` method signature to accept animation parameter
- `OnElementPropertyChanged()` now passes `Element.IsAnimateOnNavigation` to `SwitchFragment()`
- Animation parameter is properly respected during fragment transactions

### Technical Details

**Why This Fix Works:**
- Android's default `FragmentTransit.FragmentOpen` transition exposes the window background during page switch
- Custom fade animations (`FadeIn`/`FadeOut`) create smooth opacity transitions that mask color changes
- By tracking animation state in the Shell element, the parameter correctly flows to the platform layer

**Impact:**
- Changes the visual effect of Shell page transitions on Android
- No API changes or breaking behavior
- Backward compatible - animations enabled by default

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/16621

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/2058d04c-f078-4df4-99d9-82fc8749f928"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/b347f776-27ab-4556-b495-d75f691af6d8">) |
