### PR TITLE
Fix the bounce in iOS Keyboard Scrolling with Editors

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -41,6 +41,7 @@ public static class KeyboardAutoManagerScroll
 	internal static bool ShouldDisconnectLifecycle;
 	internal static bool ShouldIgnoreSafeAreaAdjustment;
 	internal static bool ShouldScrollAgain;
+	internal static bool IgnoreContentInsetAdjustment;
 
 	/// <summary>
 	/// Enables automatic scrolling with keyboard interactions on iOS devices.
@@ -785,6 +786,12 @@ public static class KeyboardAutoManagerScroll
 	static void ApplyContentInset(UIScrollView? scrolledView, UIScrollView? lastScrollView, bool didMove, bool isInnerEditor)
 	{
 		if (scrolledView is null || lastScrollView is null || ContainerView is null)
+		{
+			return;
+		}
+
+		// if the editor has VerticalTextAlignment as Center or End, we won't want to adjust the contentInset or there will be a bounce when focusing the editor
+		if (scrolledView is UITextView editor && IgnoreContentInsetAdjustment)
 		{
 			return;
 		}

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Maui.Platform
 
 		void ShouldCenterVertically()
 		{
+			KeyboardAutoManagerScroll.IgnoreContentInsetAdjustment = false;
 			var contentHeight = ContentSize.Height;
 			var availableSpace = Bounds.Height - contentHeight * ZoomScale;
 			if (availableSpace <= 0)
@@ -172,6 +173,11 @@ namespace Microsoft.Maui.Platform
 				Maui.TextAlignment.End => new CGPoint(0, -Math.Max(1, availableSpace)),
 				_ => ContentOffset,
 			};
+
+			if (VerticalTextAlignment == Maui.TextAlignment.Center || VerticalTextAlignment == Maui.TextAlignment.End)
+			{
+				KeyboardAutoManagerScroll.IgnoreContentInsetAdjustment = true;
+			}
 		}
 
 		void UpdatePlaceholderFont(UIFont? value)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

There was a bounce introduced into iOS Keyboard Scrolling when an editor with VerticalTextAlignment set to Center or End is focused due to ContentInset shifting. This PR short-circuits the ContentInset adjustment in these cases.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes part of this issue: https://github.com/dotnet/maui/issues/24977#issuecomment-2417147599

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
