### PR TITLE
[Testing] Implement methods to manage alerts from UITests on Windows

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Concepts/AlertsGalleryTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Concepts/AlertsGalleryTests.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.NavigateToGallery("Alerts Gallery");
 		}
 
-		// TODO: UI testing alert code is not yet implemented on Windows.
-#if !WINDOWS
 		[Test]
 		[Category(UITestCategories.DisplayAlert)]
 		public void AlertCancel()
@@ -147,6 +145,5 @@ namespace Microsoft.Maui.TestCases.Tests
 			var textAfterClick = remote.GetEventLabel().GetText();
 			ClassicAssert.AreEqual($"Event: {test} (SUCCESS 1)", textAfterClick);
 		}
-#endif
 	}
 }

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsAlertActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumWindowsAlertActions.cs
@@ -1,0 +1,98 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using UITest.Core;
+
+namespace UITest.Appium;
+
+public class AppiumWindowsAlertActions : ICommandExecutionGroup
+{
+	const string GetAlertsCommand = "getAlerts";
+	const string GetAlertButtonsCommand = "getAlertButtons";
+	const string GetAlertTextCommand = "getAlertText";
+
+	readonly List<string> _commands = new()
+	{
+		GetAlertsCommand,
+		GetAlertButtonsCommand,
+		GetAlertTextCommand,
+	};
+	readonly AppiumApp _appiumApp;
+
+	public AppiumWindowsAlertActions(AppiumApp appiumApp)
+	{
+		_appiumApp = appiumApp;
+	}
+
+	public bool IsCommandSupported(string commandName)
+	{
+		return _commands.Contains(commandName, StringComparer.OrdinalIgnoreCase);
+	}
+
+	public CommandResponse Execute(string commandName, IDictionary<string, object> parameters)
+	{
+		return commandName switch
+		{
+			GetAlertsCommand => GetAlerts(parameters),
+			GetAlertButtonsCommand => GetAlertButtons(parameters),
+			GetAlertTextCommand => GetAlertText(parameters),
+			_ => CommandResponse.FailedEmptyResponse,
+		};
+	}
+
+	CommandResponse GetAlerts(IDictionary<string, object> parameters)
+	{
+		var result = _appiumApp.Driver.FindElements(By.XPath("//Window[@ClassName=\"Popup\"][@IsModal=\"True\"]"));
+	
+		if (result is null || result.Count == 0)
+			return CommandResponse.FailedEmptyResponse;
+		
+		var alerts = result.Select(e => new AppiumDriverElement(e, _appiumApp)).ToList();
+
+		return new CommandResponse(alerts, CommandResponseResult.Success);
+	}
+
+	CommandResponse GetAlertButtons(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var items = AppiumQuery.ByClass("ListView")
+			.FindElements(alert, _appiumApp)
+			.FirstOrDefault()
+			?.ByClass("TextBlock");
+
+		var buttons = AppiumQuery.ByClass("Button")
+			.FindElements(alert, _appiumApp);
+
+		var all = new List<IUIElement>();
+		if (items is not null)
+			all.AddRange(items);
+		all.AddRange(buttons);
+
+		return new CommandResponse(all, CommandResponseResult.Success);
+	}
+
+	CommandResponse GetAlertText(IDictionary<string, object> parameters)
+	{
+		var alert = GetAppiumElement(parameters["element"]);
+
+		if (alert is null)
+			return CommandResponse.FailedEmptyResponse;
+
+		var text = AppiumQuery.ByClass("TextBlock")
+			.FindElements(alert, _appiumApp);
+
+		var strings = text.Select(t => t.GetText()).ToList();
+
+		return new CommandResponse(strings, CommandResponseResult.Success);
+	}
+
+	static AppiumElement? GetAppiumElement(object element) =>
+		element switch
+		{
+			AppiumElement appiumElement => appiumElement,
+			AppiumDriverElement driverElement => driverElement.AppiumElement,
+			_ => null
+		};
+}

--- a/src/TestUtils/src/UITest.Appium/AppiumWindowsApp.cs
+++ b/src/TestUtils/src/UITest.Appium/AppiumWindowsApp.cs
@@ -10,6 +10,7 @@ namespace UITest.Appium
 		public AppiumWindowsApp(Uri remoteAddress, IConfig config)
 			: base(new WindowsDriver(remoteAddress, GetOptions(config)), config)
 		{
+			_commandExecutor.AddCommandGroup(new AppiumWindowsAlertActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumWindowsContextMenuActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumWindowsStepperActions(this));
 			_commandExecutor.AddCommandGroup(new AppiumWindowsThemeChangeAction());


### PR DESCRIPTION
### Description of Change

Implement methods to manage alerts from UITests on Windows.
![image](https://github.com/user-attachments/assets/de69166d-2b45-4230-839b-80c385ce2203)

- GetAlert
- GetAlertText
- GetAlertButtons