### PR TITLE
Mark `BindingUpdatesFromInteractiveRefresh` UI test as flaky

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -28,6 +28,7 @@ public class Issue16910 : _IssuesUITest
 	}
 #if TEST_FAILS_ON_CATALYST //Scroll actions cannot be performed on the macOS test server
 	[Test]
+ 	[FlakyTest("Issue to reenable this test: https://github.com/dotnet/maui/issues/28178")]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{
 		_ = App.WaitForElement("CollectionView");


### PR DESCRIPTION
### Description of Change

This test was added in #27764 but proves to be not really stable in other PRs. Marking as flaky to ignore it for now and opened #28178 to reenable later

cc: @LogishaSelvarajSF4525
