### PR TITLE
Fixed SearchHandler Keyboard does not dismiss when unfocus

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -92,8 +92,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void SearchHandlerFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
 		{
-			e.Result = true;
-
 			if (e.Focus)
 			{
 				_control?.RequestFocus();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_searchHandler = searchView.SearchHandler;
 			_control = searchView.View;
 			_searchHandler.PropertyChanged += SearchHandlerPropertyChanged;
+			_searchHandler.FocusChangeRequested += SearchHandlerFocusChangeRequested;
 			_editText = (_control as ViewGroup).GetChildrenOfType<EditText>().FirstOrDefault();
 			_editText.FocusChange += EditTextFocusChange;
 			UpdateSearchBarColors();
@@ -89,6 +90,21 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_searchHandler.SetIsFocused(_editText.IsFocused);
 		}
 
+		void SearchHandlerFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
+		{
+			e.Result = true;
+
+			if (e.Focus)
+			{
+				_control?.RequestFocus();
+				_control?.ShowSoftInput();
+			}
+			else
+			{
+				_control.ClearFocus();
+				_control.HideSoftInput();
+			}
+		}
 		void UpdateSearchBarColors()
 		{
 			UpdateBackgroundColor();
@@ -227,6 +243,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_searchHandler != null)
 				{
 					_searchHandler.PropertyChanged -= SearchHandlerPropertyChanged;
+					_searchHandler.FocusChangeRequested -= SearchHandlerFocusChangeRequested;
 					_editText.FocusChange -= EditTextFocusChange;
 				}
 				_searchHandler = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -101,10 +101,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 			else
 			{
-				_control.ClearFocus();
-				_control.HideSoftInput();
+				_control?.ClearFocus();
+				_control?.HideSoftInput();
 			}
 		}
+		
 		void UpdateSearchBarColors()
 		{
 			UpdateBackgroundColor();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -74,7 +74,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		void SearchHandlerFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
 		{
 			if (e.Focus)
+			{
 				e.Result = _uiSearchBar.BecomeFirstResponder();
+			}
+			else if (!e.Focus)
+			{
+				e.Result = _uiSearchBar.ResignFirstResponder();
+			}
 		}
 
 		void SearchHandlerPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				e.Result = _uiSearchBar.BecomeFirstResponder();
 			}
-			else if (!e.Focus)
+			else
 			{
 				e.Result = _uiSearchBar.ResignFirstResponder();
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16298.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16298.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue16298">
+    <ShellContent
+        Title="Home"
+        Route="MainPage">
+        <ContentPage>
+            <Shell.SearchHandler>
+                <SearchHandler x:Name="searchHandler"
+                               Placeholder="Type a player's name to search"
+                               ShowsResults="true"
+                               Keyboard="Plain"/>
+            </Shell.SearchHandler>
+            <StackLayout>
+                <Button
+                    AutomationId="FocusBtn"
+                    Text="Focus Button"
+                    Clicked="FocusBtnClicked"/>
+                <Button
+                    AutomationId="UnFocusBtn"
+                    Text="UnFocus Button"
+                    Clicked="UnFocusBtnClicked"/>
+            </StackLayout>
+        </ContentPage>
+    </ShellContent>
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16298.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16298.xaml.cs
@@ -1,23 +1,21 @@
-namespace Maui.Controls.Sample.Issues
+namespace Maui.Controls.Sample.Issues;
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, "16298", "keyboard should dismiss on unfocused event", PlatformAffected.Android)]
+public partial class Issue16298 : Shell
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
-    [Issue(IssueTracker.Github, "16298", "keyboard should dismiss on unfocused event", PlatformAffected.Android)]
-    public partial class Issue16298 : Shell
+    public Issue16298()
     {
-        public Issue16298()
-        {
-            InitializeComponent();
-        }
-
-        private void FocusBtnClicked(object sender, EventArgs e)
-        {
-            searchHandler.Focus();
-        }
-
-        private void UnFocusBtnClicked(object sender, EventArgs e)
-        {
-            searchHandler.Unfocus();
-        }
-
+        InitializeComponent();
     }
+
+    private void FocusBtnClicked(object sender, EventArgs e)
+    {
+        searchHandler.Focus();
+    }
+
+    private void UnFocusBtnClicked(object sender, EventArgs e)
+    {
+        searchHandler.Unfocus();
+    }
+
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16298.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16298.xaml.cs
@@ -1,0 +1,23 @@
+namespace Maui.Controls.Sample.Issues
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    [Issue(IssueTracker.Github, "16298", "keyboard should dismiss on unfocused event", PlatformAffected.Android)]
+    public partial class Issue16298 : Shell
+    {
+        public Issue16298()
+        {
+            InitializeComponent();
+        }
+
+        private void FocusBtnClicked(object sender, EventArgs e)
+        {
+            searchHandler.Focus();
+        }
+
+        private void UnFocusBtnClicked(object sender, EventArgs e)
+        {
+            searchHandler.Unfocus();
+        }
+
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16298.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16298.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue16298 : _IssuesUITest
+	{
+		public override string Issue => "keyboard should dismiss on unfocused event";
+
+		public Issue16298(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void Issue16298KeyboardDismissonSearchHander()
+		{
+			App.WaitForElement("FocusBtn");
+			App.Click("FocusBtn");
+			bool IskeyboardVisible = App.IsKeyboardShown();
+			Assert.That(IskeyboardVisible, Is.True);
+
+			App.WaitForElement("UnFocusBtn");
+			App.Click("UnFocusBtn");
+
+			IskeyboardVisible = App.IsKeyboardShown();
+			Assert.That(IskeyboardVisible, Is.False);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16298.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16298.cs
@@ -1,31 +1,31 @@
+#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST //In windows and mac catalyst, keyboard won't visible on focus and unfocus
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue16298 : _IssuesUITest
 {
-	public class Issue16298 : _IssuesUITest
+	public override string Issue => "keyboard should dismiss on unfocused event";
+
+	public Issue16298(TestDevice testDevice) : base(testDevice)
 	{
-		public override string Issue => "keyboard should dismiss on unfocused event";
+	}
 
-		public Issue16298(TestDevice testDevice) : base(testDevice)
-		{
-		}
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void Issue16298KeyboardDismissonSearchHander()
+	{
+		App.WaitForElement("FocusBtn");
+		App.Click("FocusBtn");
+		bool IskeyboardVisible = App.IsKeyboardShown();
+		Assert.That(IskeyboardVisible, Is.True);
 
-		[Test]
-		[Category(UITestCategories.Shell)]
-		public void Issue16298KeyboardDismissonSearchHander()
-		{
-			App.WaitForElement("FocusBtn");
-			App.Click("FocusBtn");
-			bool IskeyboardVisible = App.IsKeyboardShown();
-			Assert.That(IskeyboardVisible, Is.True);
+		App.WaitForElement("UnFocusBtn");
+		App.Click("UnFocusBtn");
 
-			App.WaitForElement("UnFocusBtn");
-			App.Click("UnFocusBtn");
-
-			IskeyboardVisible = App.IsKeyboardShown();
-			Assert.That(IskeyboardVisible, Is.False);
-		}
+		IskeyboardVisible = App.IsKeyboardShown();
+		Assert.That(IskeyboardVisible, Is.False);
 	}
 }
+#endif


### PR DESCRIPTION
### Root Cause:
**Android:** The implementation of the SearchHandler FocusChangeRequested event was missing, causing the keyboard to remain open even after the focus change.

**iOS:** There is no implementation to hide the keyboard in the FocusChangeRequested event, causing the keyboard to remain visible
### Description of Change:
**Android:** I have implemented the FocusChangeRequested event for the SearchHandler.

**iOS:** I've checked the focus and dismissed the keyboard using ResignFirstResponder.
### Reference Link:
I took reference for android from Xamarin implementation. [Link from Xamarin](https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs#L35)
### Tested the behaviour in the following platforms
- [ ] Windows
- [x] Android
- [x] iOS
- [ ] Mac
### Issue Fixed
Fixes #16298 
| Before Issue Fix Android | After Issue Fix Android|
|----------|----------|
| <video src="https://github.com/user-attachments/assets/afddf683-db7e-45f3-81a1-c53ab3943dd4"> | <video src="https://github.com/user-attachments/assets/de4be214-4d27-46cf-ab80-d51ffc055fd8"> |

| Before Issue Fix iOS| After Issue Fix iOS |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/9e241c27-2aeb-40d5-bb73-a6de22b7129e"> | <video src="https://github.com/user-attachments/assets/dcf9f743-31d6-45c1-adbc-3bba7aa77c8f"> |