### PR TITLE
Revert "Fix FlyoutPage ShouldShowToolbarButton when overridden to return false, still shows button in title bar"

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -35,10 +35,6 @@ namespace Microsoft.Maui.Controls.Platform
 			platformToolbar.IsBackEnabled =
 				toolbar.BackButtonEnabled && toolbar.BackButtonVisible;
 
-			// Adjusts WinUI TogglePaneButton visibility based on DrawerToggleVisible setting.
-			if (platformToolbar.TogglePaneButton is not null)
-				platformToolbar.TogglePaneButton.Visibility = toolbar.DrawerToggleVisible ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
-
 			platformToolbar
 				.IsBackButtonVisible = (toolbar.BackButtonVisible) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS
+﻿#if TEST_FAILS_ON_WINDOWS // Fix reverted. Refer For further info - https://github.com/dotnet/maui/issues/24547
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAILS_ON_WINDOWS
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -17,3 +18,4 @@ public class Issue24547 : _IssuesUITest
 		VerifyScreenshot();
 	}
 }
+#endif


### PR DESCRIPTION
This PR reverts the changes made in PR #25857.

Fixes #28130
