### PR TITLE
[CollectionView] Crash occurs when switching CollectionView.IsVisible right after setting ItemsSource 

### DIFF
--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Maui.Controls.Internals
 {
@@ -27,15 +28,11 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			var childList = children as IReadOnlyList<IVisualTreeElement>;
-			if (childList is not null)
+			if (children is IReadOnlyList<IVisualTreeElement> childList)
 			{
-				for (int i = 0; i < childList.Count; i++)
+				foreach (var child in childList.OfType<IPropertyPropagationController>().ToList())
 				{
-					if (childList[i] is IPropertyPropagationController view)
-					{
-						view.PropagatePropertyChanged(propertyName);
-					}
+					child.PropagatePropertyChanged(propertyName);
 				}
 			}
 		}

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			for (int i = 0; i < children.Count; i++)
+			for (int i = 0; i < children.ToList().Count; i++)
 			{
 				if (children[i] is IPropertyPropagationController view)
 				{

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -28,9 +28,12 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			foreach (var view in children.ToList().OfType<IPropertyPropagationController>())
+			foreach (var child in children.ToList())
 			{
-				view.PropagatePropertyChanged(propertyName);
+				if (child is IPropertyPropagationController view)
+				{
+					view.PropagatePropertyChanged(propertyName);
+				}
 			}
 		}
 

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -28,12 +28,9 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			for (int i = 0; i < children.ToList().Count; i++)
+			foreach (var view in children.ToList().OfType<IPropertyPropagationController>())
 			{
-				if (children[i] is IPropertyPropagationController view)
-				{
-					view.PropagatePropertyChanged(propertyName);
-				}
+				view.PropagatePropertyChanged(propertyName);
 			}
 		}
 

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PropertyPropagationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.PropertyPropagationExtensions']/Docs/*" />
 	public static class PropertyPropagationExtensions
 	{
-		internal static void PropagatePropertyChanged(string propertyName, Element element, IEnumerable children)
+		internal static void PropagatePropertyChanged(string propertyName, Element element, IReadOnlyList<IVisualTreeElement> children)
 		{
 			if (propertyName == null || propertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				SetFlowDirectionFromParent(element);
@@ -28,14 +28,11 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			if (children is IReadOnlyList<IVisualTreeElement> childList)
+			for (int i = 0; i < children.Count; i++)
 			{
-				for (int i = 0; i < childList.Count; i++)
+				if (children[i] is IPropertyPropagationController view)
 				{
-					if (childList[i] is IPropertyPropagationController view)
-					{
-						view.PropagatePropertyChanged(propertyName);
-					}
+					view.PropagatePropertyChanged(propertyName);
 				}
 			}
 		}

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System.Collections;
+using System.Linq;
 
 namespace Microsoft.Maui.Controls.Internals
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			foreach (var child in children)
+			foreach (var child in children?.Cast<object>().ToList())
 			{
 				if (child is IPropertyPropagationController view)
 					view.PropagatePropertyChanged(propertyName);

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -30,9 +30,12 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (children is IReadOnlyList<IVisualTreeElement> childList)
 			{
-				foreach (var child in childList.OfType<IPropertyPropagationController>().ToList())
+				for (int i = 0; i < childList.Count; i++)
 				{
-					child.PropagatePropertyChanged(propertyName);
+					if (childList[i] is IPropertyPropagationController view)
+					{
+						view.PropagatePropertyChanged(propertyName);
+					}
 				}
 			}
 		}

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -1,6 +1,6 @@
 #nullable disable
 using System.Collections;
-using System.Linq;
+using System.Collections.Generic;
 
 namespace Microsoft.Maui.Controls.Internals
 {
@@ -27,10 +27,16 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			foreach (var child in children?.Cast<object>().ToList())
+			var childList = children as IReadOnlyList<IVisualTreeElement>;
+			if (childList is not null)
 			{
-				if (child is IPropertyPropagationController view)
-					view.PropagatePropertyChanged(propertyName);
+				for (int i = 0; i < childList.Count; i++)
+				{
+					if (childList[i] is IPropertyPropagationController view)
+					{
+						view.PropagatePropertyChanged(propertyName);
+					}
+				}
 			}
 		}
 

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			foreach (var child in children.ToList())
+			foreach (var child in children.ToArray())
 			{
 				if (child is IPropertyPropagationController view)
 				{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28162.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28162.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue28162">
+    <VerticalStackLayout>
+        <Button Text="Toggle visibility"
+                AutomationId="button"
+                Clicked="Button_Clicked"/>
+        <CollectionView IsVisible="True"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"
+                        x:Name="CollectionView">
+            <CollectionView.Header>
+                <ContentView HeightRequest="50"
+                             BackgroundColor="Green"/>
+            </CollectionView.Header>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Border StrokeShape="RoundRectangle 10"
+                            Padding="20"
+                            Stroke="Red">
+                        <Label HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               Text="{Binding .}"/>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+            <CollectionView.Footer>
+                <ContentView HeightRequest="50"
+                             BackgroundColor="Green"/>
+            </CollectionView.Footer>
+        </CollectionView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28162.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28162.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 28162, "Crash occurs when switching CollectionView.IsVisible right after setting ItemsSource", PlatformAffected.iOS)]
+	public partial class Issue28162 : ContentPage
+	{
+		public Issue28162()
+		{
+			InitializeComponent();
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			CollectionView.ItemsSource = new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" };
+			CollectionView.IsVisible = !CollectionView.IsVisible;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28162.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28162.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28162 : _IssuesUITest
+	{
+		public Issue28162(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Crash occurs when switching CollectionView.IsVisible right after setting ItemsSource";
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void SwitchingVisibilityAndChangingItemsSourceShouldNotCrash()
+		{
+			App.WaitForElement("button");
+			App.Click("button");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

The error occurs because the children's collection is modified while iterating over it. To fix this, we should iterate over a snapshot of the collection instead of the collection itself. The crash happened only on iOS and only when ItemSource is ObservableCollection

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28162

```xaml
<VerticalStackLayout>
    <Button Text="Toggle visibility"
            Clicked="Button_Clicked"/>
    <CollectionView IsVisible="True"
                    HorizontalOptions="Center"
                    VerticalOptions="Center"
                    x:Name="CollectionView">
        <CollectionView.Header>
            <ContentView HeightRequest="50"
                            BackgroundColor="Green"/>
        </CollectionView.Header>
        <CollectionView.ItemTemplate>
            <DataTemplate>
                <Border StrokeShape="RoundRectangle 10"
                        Padding="20"
                        Stroke="Red">
                    <Label HorizontalOptions="Center"
                            VerticalOptions="Center"
                            Text="{Binding .}"/>
                </Border>
            </DataTemplate>
        </CollectionView.ItemTemplate>
        <CollectionView.Footer>
            <ContentView HeightRequest="50"
                            BackgroundColor="Green"/>
        </CollectionView.Footer>
    </CollectionView>
</VerticalStackLayout>
```

```c#
private void Button_Clicked(object sender, EventArgs e)
{
	CollectionView.IsVisible = !CollectionView.IsVisible;
	CollectionView.ItemsSource = new ObservableCollection<string> { "Item 1", "Item 2", "Item 3" };
}
```
