### PR TITLE
Fix/workaround iOS stuck device tests

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -268,7 +268,8 @@ namespace Microsoft.Maui.DeviceTests
 			border.Stroke = Colors.Blue;
 			border.StrokeThickness = borderThickness;
 
-			var bitmap = await GetRawBitmap(border, typeof(BorderHandler));
+			// This is randomly failing on iOS, so let's add a timeout to avoid device tests running for hours
+			var bitmap = await GetRawBitmap(border, typeof(BorderHandler)).WaitAsync(TimeSpan.FromSeconds(5));
 			Assert.Equal(200, bitmap.Width, 2d);
 			Assert.Equal(100, bitmap.Height, 2d);
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -52,23 +52,26 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			SetupBuilder();
 
-			var flyoutPage = CreateFlyoutPage(
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var flyoutPage = CreateFlyoutPage(
 					flyoutPageType,
 					new NavigationPage(new ContentPage() { Content = new Border(), Title = "Detail" }),
 					new ContentPage() { Title = "Flyout" });
 
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(flyoutPage), async (handler) =>
-			{
-				var currentDetailPage = flyoutPage.Detail;
+				await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(flyoutPage), async (handler) =>
+				{
+					var currentDetailPage = flyoutPage.Detail;
 
-				// Set with new page
-				var navPage = new NavigationPage(new ContentPage()) { Title = "App Page" };
-				flyoutPage.Detail = navPage;
-				await OnNavigatedToAsync(navPage);
+					// Set with new page
+					var navPage = new NavigationPage(new ContentPage()) { Title = "App Page" };
+					flyoutPage.Detail = navPage;
+					await OnNavigatedToAsync(navPage);
 
-				// Set back to previous page
-				flyoutPage.Detail = currentDetailPage;
-				await OnNavigatedToAsync(currentDetailPage);
+					// Set back to previous page
+					flyoutPage.Detail = currentDetailPage;
+					await OnNavigatedToAsync(currentDetailPage);
+				});
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -506,28 +506,22 @@ namespace Microsoft.Maui.DeviceTests
 
 			SetupBuilder();
 
-			await InvokeOnMainThreadAsync(async () =>
+			var hybridWebView = new HybridWebView
 			{
-				var hybridWebView = new HybridWebView()
-				{
-					WidthRequest = 100,
-					HeightRequest = 100,
+				WidthRequest = 100,
+				HeightRequest = 100,
 
-					HybridRoot = "HybridTestRoot",
-					DefaultFile = defaultFile ?? "index.html",
-				};
+				HybridRoot = "HybridTestRoot",
+				DefaultFile = defaultFile ?? "index.html",
+			};
 
-				var handler = CreateHandler(hybridWebView);
+			// Set up the view to be displayed/parented and run our tests on it
+			await AttachAndRun(hybridWebView, async handler =>
+			{
+				await WebViewHelpers.WaitForHybridWebViewLoaded(hybridWebView);
 
-				var platformView = handler.PlatformView;
-
-				// Set up the view to be displayed/parented and run our tests on it
-				await AttachAndRun(hybridWebView, async (handler) =>
-				{
-					await WebViewHelpers.WaitForHybridWebViewLoaded(hybridWebView);
-
-					await test(hybridWebView);
-				});
+				// This is randomly failing on iOS, so let's add a timeout to avoid device tests running for hours
+				await test(hybridWebView).WaitAsync(TimeSpan.FromSeconds(5));
 			});
 		}
 
@@ -686,7 +680,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static partial class WebViewHelpers
 		{
-			const int MaxWaitTimes = 60;
+			const int MaxWaitTimes = 100;
 			const int WaitTimeInMS = 250;
 
 			private static async Task Retry(Func<Task<bool>> tryAction, Func<int, Task<Exception>> createExceptionWithTimeoutMS)
@@ -695,8 +689,10 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					if (await tryAction())
 					{
+						await Task.Delay(WaitTimeInMS);
 						return;
 					}
+
 					await Task.Delay(WaitTimeInMS);
 				}
 

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -667,16 +667,12 @@ namespace Microsoft.Maui.DeviceTests
 			});
 
 #else
-			await InvokeOnMainThreadAsync(async () =>
+			await AttachAndRun(layout, (handler) =>
 			{
-				var contentViewHandler = CreateHandler<LayoutHandler>(layout);
-				await contentViewHandler.PlatformView.AttachAndRun(() =>
-				{
-					Assert.Equal(double.Round(labelStart.Width, 5), double.Round(layout.Width, 5));
-					Assert.Equal(double.Round(labelCenter.Width, 5), double.Round(layout.Width, 5));
-					Assert.Equal(double.Round(labelEnd.Width, 5), double.Round(layout.Width, 5));
-					Assert.Equal(double.Round(labelFill.Width, 5), double.Round(layout.Width, 5));
-				});
+				Assert.Equal(double.Round(labelStart.Width, 5), double.Round(layout.Width, 5));
+				Assert.Equal(double.Round(labelCenter.Width, 5), double.Round(layout.Width, 5));
+				Assert.Equal(double.Round(labelEnd.Width, 5), double.Round(layout.Width, 5));
+				Assert.Equal(double.Round(labelFill.Width, 5), double.Round(layout.Width, 5));
 			});
 #endif
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -243,41 +243,49 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task GridCellsHonorMaxWidth()
 		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Label), typeof(LabelHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+				});
+			});
+
 			var grid = new Grid() { MaximumWidthRequest = 50 };
 			var label = new Label() { Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sodales eros nec massa facilisis venenatis", LineBreakMode = LineBreakMode.WordWrap };
 
 			grid.Add(label);
 
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				await CreateHandlerAsync<LabelHandler>(label);
-				await CreateHandlerAsync<LayoutHandler>(grid);
+			await AttachAndRun(grid, (handler) => { });
 
-				await AttachAndRun(grid, (handler) => { });
-			});
-
-			Assert.True(label.Width <= grid.MaximumWidthRequest);
-			Assert.True(grid.Width <= grid.MaximumWidthRequest);
+			// TODO: Check why Android returns a `Width = 20.xxx`
+			Assert.True((int)label.Width <= grid.MaximumWidthRequest);
+			Assert.True((int)grid.Width <= grid.MaximumWidthRequest);
 		}
 
 		[Fact]
 		public async Task GridCellsHonorMaxHeight()
 		{
+			EnsureHandlerCreated((builder) =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler(typeof(Label), typeof(LabelHandler));
+					handler.AddHandler(typeof(Layout), typeof(LayoutHandler));
+				});
+			});
+
 			var grid = new Grid() { MaximumHeightRequest = 20 };
 			var label = new Label() { Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sodales eros nec massa facilisis venenatis", LineBreakMode = LineBreakMode.WordWrap };
 
 			grid.Add(label);
 
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				await CreateHandlerAsync<LabelHandler>(label);
-				await CreateHandlerAsync<LayoutHandler>(grid);
+			await AttachAndRun(grid, (handler) => { });
 
-				await AttachAndRun(grid, (handler) => { });
-			});
-
-			Assert.True(label.Height <= grid.MaximumHeightRequest);
-			Assert.True(grid.Height <= grid.MaximumHeightRequest);
+			// TODO: Check why Android returns a `Height = 20.xxx`
+			Assert.True((int)label.Height <= grid.MaximumHeightRequest);
+			Assert.True((int)grid.Height <= grid.MaximumHeightRequest);
 		}
 
 		[Fact]
@@ -519,20 +527,17 @@ namespace Microsoft.Maui.DeviceTests
 
 			var grid = new Grid { button };
 
-			await InvokeOnMainThreadAsync(async () =>
+			await AttachAndRun(grid, async _ =>
 			{
-				await AttachAndRun(grid, async _ =>
-				{
-					// The size should be the minimum requested size, since that will easily hold the "X" text
-					Assert.Equal(300, button.Width, 0.5);
-					Assert.Equal(200, button.Height, 0.5);
+				// The size should be the minimum requested size, since that will easily hold the "X" text
+				Assert.Equal(300, button.Width, 0.5);
+				Assert.Equal(200, button.Height, 0.5);
 
-					button.ClearValue(VisualElement.MinimumWidthRequestProperty);
-					button.ClearValue(VisualElement.MinimumHeightRequestProperty);
+				button.ClearValue(VisualElement.MinimumWidthRequestProperty);
+				button.ClearValue(VisualElement.MinimumHeightRequestProperty);
 
-					// The new size should just be enough to hold the "X" text
-					await AssertionExtensions.AssertEventually(() => button.Width < 100 && button.Height < 100);
-				});
+				// The new size should just be enough to hold the "X" text
+				await AssertionExtensions.AssertEventually(() => button.Width < 100 && button.Height < 100);
 			});
 		}
 
@@ -564,14 +569,11 @@ namespace Microsoft.Maui.DeviceTests
 
 			var grid = new Grid { button };
 
-			await InvokeOnMainThreadAsync(async () =>
+			await AttachAndRun(grid, _ =>
 			{
-				await AttachAndRun(grid, _ =>
-				{
-					// The size should be the minimum requested size, since that will easily hold the "X" text
-					Assert.Equal(button.MinimumWidthRequest, button.Width, 0.5);
-					Assert.Equal(button.MaximumHeightRequest, button.Height, 0.5);
-				});
+				// The size should be the minimum requested size, since that will easily hold the "X" text
+				Assert.Equal(button.MinimumWidthRequest, button.Width, 0.5);
+				Assert.Equal(button.MaximumHeightRequest, button.Height, 0.5);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ScrollView/ScrollViewTests.iOS.cs
@@ -22,18 +22,9 @@ namespace Microsoft.Maui.DeviceTests
 			var scrollView = new ScrollView();
 			var entry = new Entry() { Text = "In a ScrollView", HeightRequest = 10000 };
 			scrollView.Content = entry;
-
-			var scrollViewHandler = await InvokeOnMainThreadAsync(() =>
+			await AttachAndRun<ScrollViewHandler>(scrollView, handler =>
 			{
-				return CreateHandlerAsync<ScrollViewHandler>(scrollView);
-			});
-
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				await scrollViewHandler.PlatformView.AttachAndRun(() =>
-				{
-					Assert.Equal(10000, scrollViewHandler.PlatformView.ContentSize.Height);
-				});
+				Assert.Equal(10000, handler.PlatformView.ContentSize.Height);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -158,8 +158,13 @@ namespace Microsoft.Maui.DeviceTests
 				= new Dictionary<ControlsPageTypesTestCase, Page>();
 
 			var nextPage = GetPage(pageSet[0]);
-			var window = new Window(nextPage);
+			Window window = null!;
 
+			await InvokeOnMainThreadAsync(() =>
+			{
+				// This reads DisplayInfo, so it needs main thread
+				window = new Window(nextPage);
+			});
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
 			{

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBasement.cs
@@ -304,7 +304,8 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync<RawBitmap>(async () =>
 			{
-				var platformView = CreateHandler(view, handlerType).ToPlatform();
+				var handler = CreateHandler(view, handlerType);
+				var platformView = view.ToPlatform();
 #if WINDOWS
 				return await platformView.AttachAndRun<RawBitmap>(async (window) => await view.AsRawBitmapAsync(), MauiContext);
 #else

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -290,13 +290,16 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			{
 				CancelThunk = () => cancelled
 			});
+
 			if (longRunningSeconds > 0)
+			{
 				resultsSink = new ExecutionSink(resultsSink, new ExecutionSinkOptions
 				{
 					CancelThunk = () => cancelled,
 					DiagnosticMessageSink = diagSink,
 					LongRunningTestTime = TimeSpan.FromSeconds(longRunningSeconds)
 				});
+			}
 
 			var assm = new XunitProjectAssembly() { AssemblyFilename = runInfo.AssemblyFileName };
 			deviceExecSink.OnMessage(new TestAssemblyExecutionStarting(assm, executionOptions));

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DeviceExecutionSink.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DeviceExecutionSink.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 			if (test.TestCase.Traits.TryGetValue("Category", out var categories) && categories.Count > 0)
 			{
-				displayName = $"[{categories[0]}] {displayName}";
+				displayName = $"[{string.Join(", ", categories)}] {displayName}";
 			}
 
 			_logger.LogTestStart(displayName);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CoreAnimation;
 using CoreGraphics;
@@ -106,12 +107,27 @@ namespace Microsoft.Maui.DeviceTests
 				return true;
 			});
 
+		private static int _zindex = 1000;
+
+		private class TestWrapperView : UIView
+		{
+			private readonly TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+			
+			public Task WaitForLayoutPassAsync() => _tcs.Task;
+
+			public override void LayoutSubviews()
+			{
+				base.LayoutSubviews();
+				_tcs.TrySetResult();
+			}
+		}
+		
 		public static async Task<T> AttachAndRun<T>(this UIView view, Func<Task<T>> action)
 		{
 			var currentView = FindContentView();
 
 			// MauiView has optimization code that won't fire a remeasure of the child view
-			// Check LayoutSubviews inside Mauiveiw.cs for more details. 
+			// Check LayoutSubviews inside MauiView.cs for more details. 
 			// If the parent is a MauiView, the expectation is that the parent will call
 			// measure on all the children. But this view that we're "attaching" is unknown to MauiView
 			// so the optimization code causes the attached view to not remeasure when it actually should. 
@@ -120,19 +136,23 @@ namespace Microsoft.Maui.DeviceTests
 			// This middle view is also helpful so we can make sure the attached view isn't inside the safe area
 			// which can have some unexpected results
 			var safeAreaInsets = currentView.SafeAreaInsets;
-			var attachedView = new UIView()
+			var attachedView = new TestWrapperView
 			{
 				Frame = new CGRect(
 					safeAreaInsets.Right,
 					safeAreaInsets.Top,
 					currentView.Frame.Width - safeAreaInsets.Right,
-					currentView.Frame.Height - safeAreaInsets.Top)
+					currentView.Frame.Height - safeAreaInsets.Top),
 			};
 
-			attachedView.AddSubview(view);
+			attachedView.Layer.ZPosition = Interlocked.Increment(ref _zindex);
 			currentView.AddSubview(attachedView);
+			attachedView.AddSubview(view);
 
-			// Give the UI time to refresh
+			// Layout pass happens only after Window has been set on the view
+			await attachedView.WaitForLayoutPassAsync();
+
+			// We're not sure that the view has been successfully rendered, but give it time to settle
 			await Task.Delay(100);
 
 			T result;
@@ -153,56 +173,36 @@ namespace Microsoft.Maui.DeviceTests
 			return result;
 		}
 
-		public static UIViewController FindContentViewController()
-		{
-			if (GetKeyWindow(UIApplication.SharedApplication) is not UIWindow window)
-			{
-				throw new InvalidOperationException("Could not attach view - unable to find UIWindow");
-			}
-
-			if (window.RootViewController is not UIViewController viewController)
-			{
-				throw new InvalidOperationException("Could not attach view - unable to find RootViewController");
-			}
-
-			while (viewController.PresentedViewController is not null)
-			{
-				if (viewController is ModalWrapper || viewController.PresentedViewController is ModalWrapper)
-					throw new InvalidOperationException("Modal Window Is Still Present");
-
-				viewController = viewController.PresentedViewController;
-			}
-
-			if (viewController == null)
-			{
-				throw new InvalidOperationException("Could not attach view - unable to find presented ViewController");
-			}
-
-			if (viewController is UINavigationController nav)
-			{
-				viewController = nav.VisibleViewController;
-			}
-
-			return viewController;
-		}
-
+		private static UIView? _contentView;
+		private static readonly object _contentViewLock = new();
 		public static UIView FindContentView()
 		{
-			var currentView = FindContentViewController().View;
-
-			if (currentView == null)
+			if (_contentView is not null)
 			{
-				throw new InvalidOperationException("Could not attach view - unable to find visible view");
+				return _contentView;
 			}
 
-			var attachParent = currentView.FindDescendantView<ContentView>() as UIView;
-
-			if (attachParent == null)
+			lock (_contentViewLock)
 			{
-				attachParent = currentView.FindDescendantView<UIView>();
-			}
+				if (_contentView is not null)
+				{
+					return _contentView;
+				}
+				
+				if (GetKeyWindow(UIApplication.SharedApplication) is not UIWindow window)
+				{
+					throw new InvalidOperationException("Could not attach view - unable to find UIWindow");
+				}
 
-			return attachParent ?? currentView;
+				if (window.RootViewController is not UIViewController viewController)
+				{
+					throw new InvalidOperationException("Could not attach view - unable to find RootViewController");
+				}
+
+				var rootView = viewController.View ?? throw new InvalidOperationException("Could not attach view - root view is null");
+
+				return _contentView = rootView;
+			}
 		}
 
 		public static Task<UIImage> ToBitmap(this UIView view, IMauiContext mauiContext)


### PR DESCRIPTION
### Description of Change

This fixes all the randomly failing device tests except for  those two which keep failing randomly.

```
[Long Running Test] 'Ensures the border renders the expected size - Issue 15339', Elapsed: 00:05:36
[Long Running Test] 'InvokeJavaScriptMethodThatThrowsTypedNumber(type: "Async")', Elapsed: 00:04:17 
```

I've added a timeout there so that our device tests do not run for hours wasting our time and CI resources for nothing.