### PR TITLE
Fixed Navigation Toolbar Visibility Issue on Dynamic Flyout Reset in FlyoutPage.

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
@@ -70,6 +70,18 @@ namespace Microsoft.Maui.Controls
 			if (sender is not ContentPage cp)
 				return;
 
+			var pages = cp.GetParentPages();
+			Page previous = null;
+			foreach (var page in pages)
+			{
+				if (page is FlyoutPage fp)
+				{
+					if (fp.Flyout == cp || previous == fp.Flyout)
+						return;
+				}
+				previous = page;
+			}
+
 			_toolbarTracker.PagePropertyChanged -= OnPagePropertyChanged;
 			_currentPage = cp;
 			_currentNavigationPage = _currentPage.FindParentOfType<NavigationPage>();

--- a/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
@@ -462,6 +463,59 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, disappearing);
 			Assert.Equal(1, appearing);
+		}
+
+		[Theory]
+		[InlineData(0)]
+		[InlineData(1)]
+		[InlineData(2)]
+		[InlineData(3)]
+		public async Task VerifyToolbarButtonVisibilityWhenFlyoutReset(int depth)
+		{
+			ContentPage detailContentPage = new ContentPage();
+
+			Page flyout = new ContentPage()
+			{
+				Title = "Initial Flyout"
+			};
+
+			NavigationPage.SetHasNavigationBar(flyout, false);
+
+			var flyoutContentPage = flyout;
+
+			for (int i = 0; i < depth; i++)
+			{
+				flyout = new NavigationPage(flyout)
+				{
+					Title = "Flyout " + i
+				};
+			}
+
+			FlyoutPage flyoutPage = new FlyoutPage
+			{
+				Flyout = flyout,
+				Detail = new NavigationPage(detailContentPage)
+			};
+
+			_ = new TestWindow(flyoutPage);
+
+			Toolbar flyoutToolBar = flyoutPage.Toolbar;
+			Assert.True(flyoutToolBar.IsVisible);
+
+			if (depth >= 1)
+			{
+				var page = new ContentPage();
+				NavigationPage.SetHasNavigationBar(page, false);
+				await flyoutContentPage.Navigation.PushAsync(page);
+			}
+			else
+			{
+				var page = new ContentPage { Title = "Reborn Flyout" };
+				NavigationPage.SetHasNavigationBar(page, false);
+				flyoutPage.Flyout = new ContentPage { Title = "Reborn Flyout" };
+			}
+
+			Assert.True(flyoutToolBar.IsVisible);
 		}
 	}
 


### PR DESCRIPTION
### Issue Details

In a FlyoutPage, The Flyout section contains a ContentPage, and the Detail section is a ContentPage wrapped within a NavigationPage. The NavigationPage includes a TitleView. When the Flyout property is dynamically reset (e.g., Flyout = new ContentPage()), the navigation toolbar unexpectedly disappears in the FlyoutPage.

### Root Cause

When the refreshed Flyout page is not a child of a NavigationPage, the toolbar visibility is set to false, resulting in its disappearance from the FlyoutPage.

### Description Of Change

In a FlyoutPage, the Detail page handles navigation and determines the toolbar's visibility state. The change ensures that when the Flyout Page is CurrentPage, it returns early. When the Detail page is already managing the toolbar visibility, it prevents redundant updates and maintains the intended behavior.

**Tested the behaviour in the following platforms**

- [x] Android
- [x]  Windows
- [x]  iOS
- [x] Mac

### Issues Fixed

Fixes #21645 

### Output


| Before| After|
|--|--|
| <video src="https://github.com/user-attachments/assets/365af9c7-72d2-4fe7-9e2f-806904f3903d"> | <video src="https://github.com/user-attachments/assets/8e861d0e-545f-4535-ab80-8f22c297fe07">
| <video src="https://github.com/user-attachments/assets/a4892ca6-87ab-4a27-8d85-981d957d5790"> | <video src="https://github.com/user-attachments/assets/ff2ec100-28dd-4f4f-8246-2c3885b25c5f"> |