### PR TITLE
Fixed content update issue when changing the ControlTemplate at runtime for a ContentPage

### DIFF
--- a/src/Controls/src/Core/TemplatedPage.cs
+++ b/src/Controls/src/Core/TemplatedPage.cs
@@ -59,6 +59,11 @@ namespace Microsoft.Maui.Controls
 
 		protected virtual void OnApplyTemplate()
 		{
+			OnApplyTemplateImpl();
+		}
+		void OnApplyTemplateImpl()
+		{
+			Handler?.UpdateValue(nameof(IContentView.Content));
 		}
 
 		protected override void OnChildRemoved(Element child, int oldLogicalIndex)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Controls.TestCases.HostApp.Issues.Issue15649"
+             xmlns:local="clr-namespace:Controls.TestCases.HostApp.Issues"
+             x:Name="HomePage"
+             Title="Issue15649">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ControlTemplate x:Key="Page1">
+                <StackLayout BackgroundColor="Red">
+                    <Button Text="Sheik"
+                            AutomationId="Button"
+                            Clicked="Button_Clicked"/>
+                    <Label Text="First Page"
+                            AutomationId="Page1Label"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"></Label>
+
+                </StackLayout>
+            </ControlTemplate>
+            <ControlTemplate x:Key="Page2">
+                <StackLayout BackgroundColor="Blue">
+                    <Label Text="Second Page"
+                            AutomationId="Page2Label"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"></Label>
+                </StackLayout>
+
+            </ControlTemplate>
+        </ResourceDictionary>
+
+    </ContentPage.Resources>
+    <ContentPage.Triggers>
+        <DataTrigger TargetType="ContentPage"
+                     Binding="{Binding PositionSelected, Source={x:Reference HomePage},x:DataType=local:Issue15649}"
+                     Value="1">
+            <Setter Property="ControlTemplate"
+                    Value="{DynamicResource Page1}"/>
+        </DataTrigger>
+        <DataTrigger TargetType="ContentPage"
+                     Binding="{Binding PositionSelected, Source={x:Reference HomePage},x:DataType=local:Issue15649}"
+                     Value="2">
+            <Setter Property="ControlTemplate"
+                    Value="{DynamicResource Page2}"/>
+        </DataTrigger>
+    </ContentPage.Triggers>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml
@@ -9,7 +9,7 @@
         <ResourceDictionary>
             <ControlTemplate x:Key="Page1">
                 <StackLayout BackgroundColor="Red">
-                    <Button Text="Sheik"
+                    <Button Text="Change Value"
                             AutomationId="Button"
                             Clicked="Button_Clicked"/>
                     <Label Text="First Page"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml.cs
@@ -1,0 +1,32 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 15649, "Updating a ControlTemplate at runtime for a Content Page is not working.", PlatformAffected.All)]
+public partial class Issue15649 : ContentPage
+{
+	public int _positionSelected = 1;
+
+		public int PositionSelected
+		{
+			set
+			{
+				if (_positionSelected != value)
+				{
+					_positionSelected = value;
+
+					OnPropertyChanged();
+				}
+			}
+			get => _positionSelected;
+		}
+
+	public Issue15649()
+	{
+		InitializeComponent();
+		this.BindingContext = this;
+	}
+	private void Button_Clicked(object sender, EventArgs e)
+	{
+		PositionSelected = 2;
+	}
+
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15649.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue15649(TestDevice testDevice) : _IssuesUITest(testDevice)
+{
+    public override string Issue => "Updating a ControlTemplate at runtime for a Content Page is not working.";
+
+    [Test]
+    [Category(UITestCategories.Page)]
+    public void DynamicallyUpdatingContentPage()
+    {
+        App.WaitForElement("Page1Label");
+        App.Tap("Button");
+        App.WaitForElement("Page2Label");
+    }
+}


### PR DESCRIPTION

### Description of Change

Implementation for dynamically updating the ControlTemplate was not added for TemplatedPage, whereas it was already supported for TemplatedView (ContentView). The support has now been added for TemplatedPage based on the TemplatedView implementation

### Issues Fixed

Fixes #15649

