### PR TITLE
[Windows] Fixed the OneWayBinding issue with MultiBindingConverter on Slider and Stepper Value

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28208.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28208.xaml
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+  x:Class="Maui.Controls.Sample.Issues.Issue28208">
+
+  <ContentPage.Resources>
+    <local:Issue28208OneWayMultiBindingValueConverter x:Key="ValueConverter"/>
+  </ContentPage.Resources>
+
+  <ScrollView>
+    <VerticalStackLayout
+      Padding="30,0"
+      Spacing="25">
+
+      <Slider x:Name="slider"
+              IsEnabled="False"
+              Maximum="100">
+        <Slider.Value>
+          <MultiBinding Converter="{StaticResource ValueConverter}"
+                        Mode="OneWay">
+            <Binding  Path="Price"/>
+          </MultiBinding>
+        </Slider.Value>
+      </Slider>
+
+      <HorizontalStackLayout>
+        <Label Text="Slider Value : "/>
+        <Label AutomationId="Sliderlabel"
+               Text="{Binding Source={x:Reference slider},Path=Value}"/>
+      </HorizontalStackLayout>
+
+      <Stepper x:Name="stepper"
+               IsEnabled="False">
+        <Stepper.Value>
+          <MultiBinding Converter="{StaticResource ValueConverter}"
+                        Mode="OneWay">
+            <Binding  Path="Price"/>
+          </MultiBinding>
+        </Stepper.Value>
+      </Stepper>
+
+      <HorizontalStackLayout>
+        <Label Text="Stepper Value : "/>
+        <Label AutomationId="StepperLabel"
+               Text="{Binding Source={x:Reference stepper},Path=Value}"/>
+      </HorizontalStackLayout>
+
+      <Button
+        Text="Increase ViewModel Price Value"
+        AutomationId="Button"
+        Clicked="OnCounterClicked"
+        HorizontalOptions="Fill"/>
+    </VerticalStackLayout>
+  </ScrollView>
+
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28208.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28208.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 28208, "[Windows] The Slider and Stepper control does not work in One-Way binding mode with a MultiBinding Converter", PlatformAffected.UWP)]
+	public partial class Issue28208 : ContentPage
+	{
+		Issue28208ViewModel _vm;
+		public Issue28208()
+		{
+			InitializeComponent();
+			this.BindingContext = _vm = new Issue28208ViewModel();
+		}
+
+		private void OnCounterClicked(object sender, EventArgs e)
+		{
+			if (_vm is not null)
+			{
+				_vm.Price++;
+			}
+		}
+	}
+
+	public class Issue28208ViewModel : INotifyPropertyChanged
+	{
+		private double _price = 2;
+
+		public double Price
+		{
+			get => _price;
+			set
+			{
+				_price = value;
+				OnPropertyChanged(nameof(Price));
+			}
+		}
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		private void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+
+	public class Issue28208OneWayMultiBindingValueConverter : IMultiValueConverter
+	{
+		public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (values[0] is double price)
+			{
+				return price;
+			}
+
+			return 0.0;
+		}
+		public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28208.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28208.xaml.cs
@@ -1,62 +1,60 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
 
-namespace Maui.Controls.Sample.Issues
+namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 28208, "[Windows] The Slider and Stepper control does not work in One-Way binding mode with a MultiBinding Converter", PlatformAffected.UWP)]
+public partial class Issue28208 : ContentPage
 {
-	[Issue(IssueTracker.Github, 28208, "[Windows] The Slider and Stepper control does not work in One-Way binding mode with a MultiBinding Converter", PlatformAffected.UWP)]
-	public partial class Issue28208 : ContentPage
+	Issue28208ViewModel _vm;
+	public Issue28208()
 	{
-		Issue28208ViewModel _vm;
-		public Issue28208()
-		{
-			InitializeComponent();
-			this.BindingContext = _vm = new Issue28208ViewModel();
-		}
-
-		private void OnCounterClicked(object sender, EventArgs e)
-		{
-			if (_vm is not null)
-			{
-				_vm.Price++;
-			}
-		}
+		InitializeComponent();
+		this.BindingContext = _vm = new Issue28208ViewModel();
 	}
 
-	public class Issue28208ViewModel : INotifyPropertyChanged
+	private void OnCounterClicked(object sender, EventArgs e)
 	{
-		private double _price = 2;
-
-		public double Price
+		if (_vm is not null)
 		{
-			get => _price;
-			set
-			{
-				_price = value;
-				OnPropertyChanged(nameof(Price));
-			}
-		}
-		public event PropertyChangedEventHandler PropertyChanged;
-
-		private void OnPropertyChanged(string propertyName)
-		{
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			_vm.Price++;
 		}
 	}
+}
 
-	public class Issue28208OneWayMultiBindingValueConverter : IMultiValueConverter
+public class Issue28208ViewModel : INotifyPropertyChanged
+{
+	private double _price = 2;
+
+	public double Price
 	{
-		public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+		get => _price;
+		set
 		{
-			if (values[0] is double price)
-			{
-				return price;
-			}
+			_price = value;
+			OnPropertyChanged(nameof(Price));
+		}
+	}
+	public event PropertyChangedEventHandler PropertyChanged;
 
-			return 0.0;
-		}
-		public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+	private void OnPropertyChanged(string propertyName)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}
+
+public class Issue28208OneWayMultiBindingValueConverter : IMultiValueConverter
+{
+	public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+	{
+		if (values[0] is double price)
 		{
-			throw new NotImplementedException();
+			return price;
 		}
+
+		return 0.0;
+	}
+	public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+	{
+		throw new NotImplementedException();
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28208.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28208.cs
@@ -2,26 +2,24 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue28208 : _IssuesUITest
 {
-	public class Issue28208 : _IssuesUITest
+	public Issue28208(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows] The Slider and Stepper control does not work in One-Way binding mode with a MultiBinding Converter";
+
+	[Test]
+	[Category(UITestCategories.Slider)]
+	[Category(UITestCategories.Stepper)]
+	public void OneWayBindingWithMultiBindingConverterShouldReflecttInView()
 	{
-		public Issue28208(TestDevice device) : base(device) { }
-
-		public override string Issue => "[Windows] The Slider and Stepper control does not work in One-Way binding mode with a MultiBinding Converter";
-
-		[Test]
-		[Category(UITestCategories.Slider)]
-		[Category(UITestCategories.Stepper)]
-		public void OneWayBindingWithMultiBindingConverterShouldReflecttInView()
-		{
-			App.WaitForElement("Button");
-			App.Tap("Button");
-			App.Tap("Button");
-			var sliderLabel = App.FindElement("Sliderlabel").GetText();
-			Assert.That(sliderLabel, Is.EqualTo("4"));
-			var stepperLabel = App.FindElement("StepperLabel").GetText();
-			Assert.That(stepperLabel, Is.EqualTo("4"));
-		}
+		App.WaitForElement("Button");
+		App.Tap("Button");
+		App.Tap("Button");
+		var sliderLabel = App.FindElement("Sliderlabel").GetText();
+		Assert.That(sliderLabel, Is.EqualTo("4"));
+		var stepperLabel = App.FindElement("StepperLabel").GetText();
+		Assert.That(stepperLabel, Is.EqualTo("4"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28208.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28208.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28208 : _IssuesUITest
+	{
+		public Issue28208(TestDevice device) : base(device) { }
+
+		public override string Issue => "[Windows] The Slider and Stepper control does not work in One-Way binding mode with a MultiBinding Converter";
+
+		[Test]
+		[Category(UITestCategories.Slider)]
+		[Category(UITestCategories.Stepper)]
+		public void OneWayBindingWithMultiBindingConverterShouldReflecttInView()
+		{
+			App.WaitForElement("Button");
+			App.Tap("Button");
+			App.Tap("Button");
+			var sliderLabel = App.FindElement("Sliderlabel").GetText();
+			Assert.That(sliderLabel, Is.EqualTo("4"));
+			var stepperLabel = App.FindElement("StepperLabel").GetText();
+			Assert.That(stepperLabel, Is.EqualTo("4"));
+		}
+	}
+}

--- a/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
@@ -108,8 +108,10 @@ namespace Microsoft.Maui.Handlers
 
 		void OnPlatformValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
 		{
-			if (VirtualView != null)
+			if (VirtualView != null && VirtualView.Value != e.NewValue)
+			{
 				VirtualView.Value = e.NewValue;
+			}
 		}
 
 		void OnPointerPressed(object? sender, PointerRoutedEventArgs e)

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
@@ -52,7 +52,10 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || PlatformView == null)
 				return;
 
-			VirtualView.Value = PlatformView.Value;
+			if (VirtualView.Value != PlatformView.Value)
+			{
+				VirtualView.Value = PlatformView.Value;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Root Cause of the issue



- `VirtualView.Value` is updated unnecessarily even when it has already been updated, causing an issue with the MultiBinding Converter. 



### Description of Change



- Preventing `unnecessary` updates to `VirtualView.Value` resolved the One-Way binding issue with the MultiBinding Converter. 



### Issues Fixed



Fixes #28208



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/1003e6e1-f7de-42f9-b727-617c7aa57984"> | <video src="https://github.com/user-attachments/assets/fe39e025-99a7-4f91-8fb5-b9b63412e087"> |



