### PR TITLE
[Testing] Moved ImageDoesNotLeak test case from Device Test to UI Test

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -49,34 +49,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		// NOTE: this test is slightly different than MemoryTests.HandlerDoesNotLeak
-		// It sets image.Source and waits for it to load, a valid test case.
-		[Fact("Image Does Not Leak")]
-		public async Task DoesNotLeak()
-		{
-			SetupBuilder();
-			WeakReference platformViewReference = null;
-			WeakReference handlerReference = null;
-
-			await InvokeOnMainThreadAsync(async () =>
-			{
-				var layout = new VerticalStackLayout();
-				var image = new Image
-				{
-					Background = Colors.Black,
-					Source = "red.png",
-				};
-				layout.Add(image);
-
-				var handler = CreateHandler<LayoutHandler>(layout);
-				handlerReference = new WeakReference(image.Handler);
-				platformViewReference = new WeakReference(image.Handler.PlatformView);
-				await image.WaitUntilLoaded();
-			});
-
-			await AssertionExtensions.WaitForGC(handlerReference, platformViewReference);
-		}
-
 		[Fact]
 		[Description("The BackgroundColor of a Image should match with native background color")]
 		public async Task ImageBackgroundColorConsistent()

--- a/src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs
@@ -67,7 +67,7 @@ namespace Maui.Controls.Sample.Issues
 							{
 								AutomationId = "Image",
 								Source = "red.png",
-								Background = Colors.Black,
+								Background = Colors.Black
 							};
 						});
 						break;

--- a/src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs
@@ -67,6 +67,7 @@ namespace Maui.Controls.Sample.Issues
 							{
 								AutomationId = "Image",
 								Source = "red.png",
+								Background = Colors.Black,
 							};
 						});
 						break;

--- a/src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.None, 24147, "Test Handlers for Memory Leaks", PlatformAffected.All, isInternetRequired: true)]
+	[Issue(IssueTracker.None, 24147, "Test Handlers for Memory Leaks", PlatformAffected.All)]
 	public class MemoryTests : NavigationPage
 	{
 		public class MemoryTestPage : ContentPage
@@ -57,6 +57,16 @@ namespace Maui.Controls.Sample.Issues
 							{
 								HeightRequest = 500, // NOTE: non-zero size required for Windows
 								Source = new HtmlWebViewSource { Html = "<p>hi</p>" },
+							};
+						});
+						break;
+					case "Image":
+						this.Navigation.RunMemoryTest(() =>
+						{
+							return new Image
+							{
+								AutomationId = "Image",
+								Source = "red.png",
 							};
 						});
 						break;

--- a/src/Controls/tests/TestCases.HostApp/Utils/GarbageCollectionHelper.cs
+++ b/src/Controls/tests/TestCases.HostApp/Utils/GarbageCollectionHelper.cs
@@ -55,6 +55,9 @@
 			}
 		}
 
+		public static Task WaitUntilLoaded(this Image image, int timeout = 1000) =>
+					AssertEventually(() => !image.IsLoading, timeout, message: $"Timed out loading image {image}");
+
 		public static void RunMemoryTest(this INavigation navigationPage, Func<VisualElement> elementToTest)
 		{
 			ContentPage rootPage = new ContentPage { Title = "Page 1" };
@@ -82,7 +85,14 @@
 					};
 
 					await navigationPage.PushAsync(page);
-					await Task.Delay(500); // give the View time to load
+					if (element is Image image)
+                    {
+                        await image.WaitUntilLoaded();
+                    }
+                    else
+                    {
+                        await Task.Delay(500); // give the View time to load
+                    }
 
 					references.Add(new(element));
 					references.Add(new(element.Handler));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/MemoryTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/MemoryTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.DatePicker)]
 		public void DatePickerDoesNotLeak()
 		{
-			VerifyInternetConnectivity();
 			App.WaitForElement("DataTypeEntry");
 			App.EnterText("DataTypeEntry", "DatePicker");
 			App.Tap("RunMemoryTestButton");
@@ -28,9 +27,18 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.WebView)]
 		public void WebViewDoesNotLeak()
 		{
-			VerifyInternetConnectivity();
 			App.WaitForElement("DataTypeEntry");
 			App.EnterText("DataTypeEntry", "WebView");
+			App.Tap("RunMemoryTestButton");
+			App.AssertMemoryTest();
+		}
+
+		[Test]
+		[Category(UITestCategories.Image)]
+		public void ImageDoesNotLeak()
+		{
+			App.WaitForElement("DataTypeEntry");
+			App.EnterText("DataTypeEntry", "Image");
 			App.Tap("RunMemoryTestButton");
 			App.AssertMemoryTest();
 		}


### PR DESCRIPTION
This pull request aims to relocate the memory leak tests for the Image control from device tests to UI tests, as they have been failing intermittently in the device tests. Additionally, unnecessary internet checks have been removed from these test cases, since the web view only loads simple HTML code that does not require an internet connection.

### Memory Leak Tests Update:

* [`src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs`](diffhunk://#diff-ec5331f926972b934a27d39a5cd8ab22ea2f46778be2174b5cc2617dd4fd2dc4L52-L79): Removed the `DoesNotLeak` test for `Image`.

* [`src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs`](diffhunk://#diff-34964200a1ffabf30d8124b231b566fc79703d7a72030ecf1c60d087bc91b08bR63-R73): Added a new `Image` case in the `RunMemoryTest` method to test for memory leaks.

* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/MemoryTests.cs`](diffhunk://#diff-8e447e0d109e7daa89bdbe9df4b746f62f9b698011a9b7dea0f1f5903332698fL31-R44): Added a new test method `ImageDoesNotLeak` to verify that `Image` controls do not leak memory.

### Test Case Modifications:

* [`src/Controls/tests/TestCases.HostApp/Issues/MemoryTests.cs`](diffhunk://#diff-34964200a1ffabf30d8124b231b566fc79703d7a72030ecf1c60d087bc91b08bL3-R3): Removed the `isInternetRequired: true` parameter from the `MemoryTests` attribute.

* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/MemoryTests.cs`](diffhunk://#diff-8e447e0d109e7daa89bdbe9df4b746f62f9b698011a9b7dea0f1f5903332698fL20): Removed the `VerifyInternetConnectivity` calls from the `DatePickerDoesNotLeak` and `WebViewDoesNotLeak` test methods. [[1]](diffhunk://#diff-8e447e0d109e7daa89bdbe9df4b746f62f9b698011a9b7dea0f1f5903332698fL20) [[2]](diffhunk://#diff-8e447e0d109e7daa89bdbe9df4b746f62f9b698011a9b7dea0f1f5903332698fL31-R44)<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
