### PR TITLE
Use only major JDK version to install via homebrew

### DIFF
--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -234,7 +234,7 @@
 	</Target>
 
 	<Target Name="ProvisionJdkMacOS" DependsOnTargets="DetectJdkVersion" Condition=" '$(IsMacOS)' == 'True' AND '$(_AndroidJdkRequiresProvisioning)' == 'True' ">
-		<Exec Command="brew install --cask microsoft-openjdk@$(_AndroidJdkVersion)" />
+		<Exec Command="brew install --cask microsoft-openjdk@$(_AndroidJdkMajorVersion)" />
 	</Target>
 
 	<Target Name="ProvisionJdkLinux" DependsOnTargets="DetectJdkVersion" Condition=" '$(IsLinux)' == 'True' AND '$(_AndroidJdkRequiresProvisioning)' == 'True' ">


### PR DESCRIPTION
We only want the major version in `brew install --cask microsoft-openjdk@17` instead of the full version which would incorrectly attempt `brew install --cask microsoft-openjdk@17.0.12`.

