### PR TITLE
[HybridWebView] Properly managed response streams

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests.cs
@@ -59,6 +59,21 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(passed, $"Waited for raw message response but it never arrived or didn't match (last message: {lastRawMessage})");
 			});
 
+		[Theory]
+		[InlineData("/asyncdata.txt", 200)]
+		[InlineData("/missingfile.txt", 404)]
+		public Task RequestFileFromJS(string url, int expectedStatus) =>
+			RunTest(async (hybridWebView) =>
+			{
+				var result = await hybridWebView.InvokeJavaScriptAsync<int>(
+					"RequestFileFromJS",
+					HybridWebViewTestContext.Default.Int32,
+					[url],
+					[HybridWebViewTestContext.Default.String]);
+
+				Assert.Equal(expectedStatus, result);
+			});
+
 		[Fact]
 		public Task InvokeJavaScriptMethodWithParametersAndNullsAndComplexResult() =>
 			RunTest(async (hybridWebView) =>

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/index.html
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/index.html
@@ -88,6 +88,11 @@
             return jsonData;
         }
 
+        async function RequestFileFromJS(url) {
+            const response = await fetch(url);
+            return response.status;
+        }
+
         function ThrowAnError(value, errorType) {
             if (errorType === 1) {                  // throw number
                 throw value;


### PR DESCRIPTION
### Description of Change

The main issue that this PR fixes is the case where we write to a stream using a StreamWriter, which is then disposed causing the stream to be disposed as well.

Instead of just leaving the stream open, I refactored the writing code to not copy so many times. Before we would copy from the source stream into a MemoryStream and then into a InMemoryRandomAccessStream. I now use the extension method to wrap the InMemoryRandomAccessStream in a Stream and write directly.

I also cache the 404 message and write the bytes directly instead of first converting/copying to a stream.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #27953

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
