### PR TITLE
[release/9.0.1xx-sr4] Revert "Fix FlyoutPage ShouldShowToolbarButton when overridden to return false, still shows button in title bar" 

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -35,10 +35,6 @@ namespace Microsoft.Maui.Controls.Platform
 			platformToolbar.IsBackEnabled =
 				toolbar.BackButtonEnabled && toolbar.BackButtonVisible;
 
-			// Adjusts WinUI TogglePaneButton visibility based on DrawerToggleVisible setting.
-			if (platformToolbar.TogglePaneButton is not null)
-				platformToolbar.TogglePaneButton.Visibility = toolbar.DrawerToggleVisible ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
-
 			platformToolbar
 				.IsBackButtonVisible = (toolbar.BackButtonVisible) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
@@ -1,4 +1,4 @@
-﻿#if !MACCATALYST
+#if !MACCATALYST || TEST_FAILS_ON_WINDOWS // Fix reverted. Refer For further info - https://github.com/dotnet/maui/issues/24547
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
Backport of #28189  to release/9.0.1xx-sr4
