### PR TITLE
Update the version of SkiaSharp used by SVG

### DIFF
--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -31,6 +31,27 @@
 
   <Import Project="ResizetizerPackages.projitems" />
 
+  <!-- A small task to make sure everything depends on the same version of SkiaSharp -->
+  <ItemGroup>
+    <PackageReference Include="Mono.ApiTools.MSBuildTasks" Version="0.3.0" PrivateAssets="all" />
+  </ItemGroup>
+  <PropertyGroup>
+    <_AdjustmentsAssembly>$(PkgSvg_Skia)\lib\netstandard2.0\Svg.Skia.dll</_AdjustmentsAssembly>
+    <_AdjustmentsReferencedAssembly>$(PkgSkiaSharp)\lib\net462\SkiaSharp.dll</_AdjustmentsReferencedAssembly>
+  </PropertyGroup>
+  <Target Name="_AdjustSkiaSharpVersion" BeforeTargets="Build;AssignTargetPaths"
+          Inputs="$(MSBuildProjectFile);$(_AdjustmentsAssembly);$(_AdjustmentsReferencedAssembly)" Outputs="$(IntermediateOutputPath)adjustments\Svg.Skia.dll">
+    <MakeDir Directories="$(IntermediateOutputPath)adjustments" />
+    <AdjustReferencedAssemblyVersion
+      Assembly="$(_AdjustmentsAssembly)"
+      ReferencedAssembly="$(_AdjustmentsReferencedAssembly)"
+      OutputAssembly="$(IntermediateOutputPath)adjustments\Svg.Skia.dll" />
+    <ItemGroup>
+      <None Include="$(IntermediateOutputPath)adjustments\Svg.Skia.dll" Visible="false" Pack="true" PackagePath="buildTransitive" />
+      <FileWrites Include="$(IntermediateOutputPath)adjustments\Svg.Skia.dll" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(MauiRootDirectory)eng\ILRepack.targets" />
   <Target Name="AfterILRepack">
     <ItemGroup>
@@ -51,6 +72,10 @@
       <_CopyItems Include="@(_ResizetizerFiles)" />
     </ItemGroup>
     <Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(_MauiBuildTasksLocation)%(RecursiveDir)%(_CopyItems.Arch)" ContinueOnError="true" Retries="0" />
+    <AdjustReferencedAssemblyVersion
+      Assembly="$(_AdjustmentsAssembly)"
+      ReferencedAssembly="$(_AdjustmentsReferencedAssembly)"
+      OutputAssembly="$(_MauiBuildTasksLocation)Svg.Skia.dll" />
   </Target>
 
   <Import Project="$(MauiSrcDirectory)Workload\Shared\LibraryPacks.targets" />

--- a/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
+++ b/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
@@ -40,7 +40,7 @@
     <_ResizetizerFiles Include="$(PkgSvg_Custom)\lib\netstandard2.0\Svg.Custom.dll" />
     <_ResizetizerFiles Include="$(PkgSvg_Model)\lib\netstandard2.0\Svg.Model.dll" />
     <_ResizetizerFiles Include="$(PkgShimSkiaSharp)\lib\netstandard2.0\ShimSkiaSharp.dll" />
-    <_ResizetizerFiles Include="$(PkgSvg_Skia)\lib\netstandard2.0\Svg.Skia.dll" />
+    <!-- <_ResizetizerFiles Include="$(PkgSvg_Skia)\lib\netstandard2.0\Svg.Skia.dll" /> -->
     <_ResizetizerFiles Include="$(PkgFizzler)\lib\netstandard2.0\Fizzler.dll" />
     <_ResizetizerFiles Include="$(PkgExCSS)\lib\netstandard2.0\ExCSS.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_IO_UnmanagedMemoryStream)\lib\netstandard1.3\System.IO.UnmanagedMemoryStream.dll" />


### PR DESCRIPTION
### Description of Change

All the assemblies are strong named, so when we update SkiaSharp it will fail. We could use a config file to allow this, but VS does not work like that. So, the easiest things is to just update the version in the references.

We did this during the transition from 2.80 to 2.88. We now do it for 3.x.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #28207

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
