### PR TITLE
[Windows] Flyout Menu Icon disappears from Window Title Bar after Navigation

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
@@ -180,7 +180,11 @@ namespace Microsoft.Maui.Controls
 
 			// Set this before BackButtonVisible triggers an update to the handler
 			// This way all useful information is present
-			if (Parent is FlyoutPage flyout && flyout.ShouldShowToolbarButton() && !anyPagesPushed.Value)
+			if (Parent is FlyoutPage flyout && flyout.ShouldShowToolbarButton()
+#if !WINDOWS
+				&& !anyPagesPushed.Value
+#endif
+				)
 				_drawerToggleVisible = true;
 			else
 				_drawerToggleVisible = false;

--- a/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Maui.Controls
 			// Set this before BackButtonVisible triggers an update to the handler
 			// This way all useful information is present
 			if (Parent is FlyoutPage flyout && flyout.ShouldShowToolbarButton()
-#if !WINDOWS
+#if !WINDOWS // TODO NET 10 : Move this logic to ShouldShowToolbarButton
 				&& !anyPagesPushed.Value
 #endif
 				)

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -87,9 +87,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 		private static void UpdateBackButtonVisibility(MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			platformToolbar.IsBackButtonVisible = 
-				toolbar.BackButtonVisible 
-					? NavigationViewBackButtonVisible.Visible 
+			platformToolbar.IsBackButtonVisible =
+				toolbar.BackButtonVisible
+					? NavigationViewBackButtonVisible.Visible
 					: NavigationViewBackButtonVisible.Collapsed;
 		}
 	}

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -91,7 +91,11 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var flyoutBehavior = (_shell as IFlyoutView).FlyoutBehavior;
+#if WINDOWS
+			_drawerToggleVisible = flyoutBehavior is FlyoutBehavior.Flyout;
+#else
 			_drawerToggleVisible = stack.Count <= 1 && flyoutBehavior is FlyoutBehavior.Flyout;
+#endif
 			BackButtonVisible = backButtonVisible && stack.Count > 1;
 			BackButtonEnabled = _backButtonBehavior?.IsEnabled ?? true;
 			ToolbarItems = _toolbarTracker.ToolbarItems;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28130_flyout.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28130_flyout.cs
@@ -1,0 +1,57 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 28130, "[Windows] Flyout Menu Icon disappears from Window Title Bar after Navigation", PlatformAffected.UWP)]
+	public class Issue28130_Flyout : TestFlyoutPage
+	{
+		NavigationPage _navigationPage;
+		string pageTitle = "Issue28130";
+		protected override void Init()
+		{
+			Flyout = CreateFlyoutContent();
+			FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover;
+			Detail = _navigationPage = new NavigationPage(new Issue28130_DetailPage(pageTitle) { AutomationId = pageTitle});
+		}
+
+		ContentPage CreateFlyoutContent()
+		{
+			var flyoutContent = new ContentPage() { Title = "Menu"};
+			var layout = new VerticalStackLayout();
+			var navigateButton = new Button() { Text = "Navigate to Page 2", AutomationId = "NavigateButton"};
+			navigateButton.Clicked += (s, e) => _navigationPage.PushAsync(new Issue28130_Page1());
+			layout.Add(navigateButton);
+			flyoutContent.Content = layout;
+			return flyoutContent;
+		}
+	}
+
+	public class Issue28130_Page1 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new VerticalStackLayout()
+			{
+				new Label()
+				{
+					Text = "Tap flyout",
+					AutomationId="newPageLabel"
+				}
+			};
+		}
+	}
+
+	public class Issue28130_DetailPage : ContentPage
+	{
+		public Issue28130_DetailPage(string title)
+		{
+			Title = title;
+			Content = new VerticalStackLayout()
+			{
+				new Label()
+				{
+					Text = "Once Loaded, Tap the flyout",
+					AutomationId = "detailLabel"
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28130_shell.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28130_shell.cs
@@ -1,0 +1,30 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.None,28130, "[Windows] Shell Flyout Menu Icon disappears from Window Title Bar after Navigation", PlatformAffected.UWP)]
+	public class Issue28130_Shell : TestShell
+	{
+		
+		protected override void Init()
+		{
+			Routing.RegisterRoute(nameof(Issue28130_Page1), typeof(Issue28130_Page1));
+			FlyoutBehavior = FlyoutBehavior.Flyout;
+			FlyoutWidth = 300;
+			ItemTemplate = new DataTemplate(() => CreateShellItemTemplate());
+			ShellItem shellItem = new ShellItem() { Title = "Issue28130" };
+			shellItem.Items.Add(new ShellContent() { Content = new Issue28130_DetailPage("Issue28130") });
+			Items.Add(shellItem);
+		}
+
+		Button CreateShellItemTemplate()
+		{
+			var navigateButton = new Button() { Text = "Navigate to Page 2" ,AutomationId = "NavigateButton"};
+			navigateButton.Clicked += NavigateButton_Clicked;
+			return navigateButton;
+		}
+
+		private void NavigateButton_Clicked(object sender, EventArgs e)
+		{
+			GoToAsync(nameof(Issue28130_Page1));
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24547.cs
@@ -1,5 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS // Fix reverted. Refer For further info - https://github.com/dotnet/maui/issues/24547
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -18,4 +17,3 @@ public class Issue24547 : _IssuesUITest
 		VerifyScreenshot();
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28130_flyout.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28130_flyout.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if WINDOWS
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -23,3 +24,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28130_flyout.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28130_flyout.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28130_Flyout : _IssuesUITest
+	{
+		public Issue28130_Flyout(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "[Windows] Flyout Menu Icon disappears from Window Title Bar after Navigation";
+
+		[Test]
+		[Category(UITestCategories.FlyoutPage)]
+		public void FlyoutMenuShouldNotDisappearAfterNavigation_FlyoutPage()
+		{
+			App.WaitForElement("detailLabel");
+			App.TapInFlyoutPageFlyout("NavigateButton");
+			App.WaitForElement("newPageLabel");
+			App.TapFlyoutPageIcon();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28130_shell.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28130_shell.cs
@@ -1,0 +1,28 @@
+﻿#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28130_Shell : _IssuesUITest
+	{
+		public Issue28130_Shell(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "[Windows] Shell Flyout Menu Icon disappears from Window Title Bar after Navigation";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void FlyoutMenuShouldNotDisappearAfterNavigation_Shell()
+		{
+			App.WaitForElement("detailLabel");
+			App.TapShellFlyoutIcon();
+			App.Tap("Navigate to Page 2");
+			App.WaitForElement("newPageLabel");
+			App.TapShellFlyoutIcon();
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Issue Details:
The Menu icon disappear after navigating to the second page from flyout.

### Root Cause:
The anyPagesPushed function returned true, which caused the *drawerToggleVisible variable to be set to false. The visibility of the TogglePaneButton is determined by *drawerToggleVisible. As a result, the TogglePaneButton is not visible after navigation.

### Description of Change:
Restricted the anyPagesPushed to non windows platforms.

Validated the behaviour in the following platforms

- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

### Issues Fixed

Fixes #28130

### Output

**FlyoutPage**
| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/6698d83b-fcea-49c5-bfed-c9ad7d46df31">|<video src="https://github.com/user-attachments/assets/149791a1-b892-43e6-a2ef-0958a53431d9">|

**Shell**

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/9b3b6f2b-7a4a-4c0e-ab5b-9d0d744f880a">|<video src="https://github.com/user-attachments/assets/db4380fc-6331-40b3-add0-592a649dbb9c">|

