### PR TITLE
Remove PlatformWrapperView.java setHasShadow

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java
@@ -63,11 +63,6 @@ public abstract class PlatformWrapperView extends PlatformContentViewGroup {
         shadowInvalidated = true;
     }
 
-    @Deprecated
-    protected final void setHasShadow(boolean hasShadow) {
-        // TODO: remove this method in .NET10
-    }
-
     protected final void updateShadow(int paintType, float radius, float offsetX, float offsetY, int[] colors, float[] positions, float[] bounds) {
         this.paintType = paintType;
         this.radius = radius;

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -1859,6 +1859,7 @@ Microsoft.Maui.PlatformContentViewGroup.ViewGroupDispatchDraw(Android.Graphics.C
 Microsoft.Maui.PlatformWrapperView
 Microsoft.Maui.PlatformWrapperView.PlatformWrapperView(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformWrapperView.PlatformWrapperView(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.PlatformWrapperView.SetHasShadow(bool hasShadow) -> void
 Microsoft.Maui.PortHandlerAttribute
 Microsoft.Maui.PortHandlerAttribute.Description.get -> string?
 Microsoft.Maui.PortHandlerAttribute.Description.set -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -1859,7 +1859,6 @@ Microsoft.Maui.PlatformContentViewGroup.ViewGroupDispatchDraw(Android.Graphics.C
 Microsoft.Maui.PlatformWrapperView
 Microsoft.Maui.PlatformWrapperView.PlatformWrapperView(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformWrapperView.PlatformWrapperView(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
-Microsoft.Maui.PlatformWrapperView.SetHasShadow(bool hasShadow) -> void
 Microsoft.Maui.PortHandlerAttribute
 Microsoft.Maui.PortHandlerAttribute.Description.get -> string?
 Microsoft.Maui.PortHandlerAttribute.Description.set -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -54,6 +54,7 @@ Microsoft.Maui.Platform.MauiHybridWebViewClient.MauiHybridWebViewClient(Microsof
 Microsoft.Maui.Platform.MauiMaterialButton.MauiMaterialButton(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
 Microsoft.Maui.Platform.MauiMaterialButton.MauiMaterialButton(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
 Microsoft.Maui.Platform.MauiMaterialButton.MauiMaterialButton(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+*REMOVED*Microsoft.Maui.PlatformWrapperView.SetHasShadow(bool hasShadow) -> void
 Microsoft.Maui.TextAlignment.Justify = 3 -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.WebProcessTerminatedEventArgs
 Microsoft.Maui.WebProcessTerminatedEventArgs.RenderProcessGoneDetail.get -> Android.Webkit.RenderProcessGoneDetail?


### PR DESCRIPTION
### Description of Change

Resolves a todo in code by removing the `setHasShadow` method from `PlatformWrapperView.java`, which was already marked as deprecated.
