### PR TITLE
Fix Modal Test using correct Page

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -187,7 +187,8 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(window,
 				async (_) =>
 				{
-					await windowPage.Navigation.PushAsync(new ContentPage() { Title = "Second Page on PushingNavigationPageModallyWithShellShowsToolbarCorrectly" });
+					var secondPage = new ContentPage() { Title = "Second Page on PushingNavigationPageModallyWithShellShowsToolbarCorrectly" };
+					await windowPage.Navigation.PushAsync(secondPage);
 					await windowPage.Navigation.PushModalAsync(modalPage);
 
 					// Navigation Bar is visible
@@ -203,8 +204,8 @@ namespace Microsoft.Maui.DeviceTests
 					// Remove the modal page and validate the root window pages toolbar is still setup correctly
 					await modalPage.Navigation.PopModalAsync();
 
-					await AssertEventually(() => IsNavigationBarVisible(windowPage.Handler));
-					await AssertEventually(() => IsBackButtonVisible(windowPage.Handler));
+					await AssertEventually(() => IsNavigationBarVisible(secondPage.Handler));
+					await AssertEventually(() => IsBackButtonVisible(secondPage.Handler));
 				});
 		}
 


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
After this [PR](https://github.com/dotnet/maui/pull/28148), the Controls.DeviceTest `PushingNavigationPageModallyWithShellShowsToolbarCorrectly` is failing because `FindResponder` is being called on the page that is not currently showing. That page's window is null and the test fails because it cannot continue. The fix is to call FindResponder on the page that is showing instead since that window is not null.


<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
