### PR TITLE
[Android] Image is not loading in RadioButton - fix

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButton.Android.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.Android.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Maui.Controls
 
 				return;
 			}
+			else if (radioButton.Content is IView view)
+			{
+				radioButton.ControlTemplate = DefaultTemplate;
+				MapContent(handler, radioButton);
+				return;
+			}
 
 			RadioButtonHandler.MapContent(handler, radioButton);
 		}
@@ -32,7 +38,7 @@ namespace Microsoft.Maui.Controls
 			if (radioButton.VirtualView is not RadioButton rb)
 				return null;
 
-			if (rb.ResolveControlTemplate() == null)
+			if (rb.ResolveControlTemplate() == null && rb.Content is not IView)
 			{
 				return null;
 			}

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -451,9 +451,9 @@ namespace Microsoft.Maui.Controls
 			border.SetBinding(HorizontalOptionsProperty, static (RadioButton rb) => rb.HorizontalOptions, source: RelativeBindingSource.TemplatedParent);
 			border.SetBinding(VerticalOptionsProperty, static (RadioButton rb) => rb.VerticalOptions, source: RelativeBindingSource.TemplatedParent);
 
-			border.SetBinding(Border.StrokeProperty, static (RadioButton rb) => rb.BorderColor, source: RelativeBindingSource.TemplatedParent);
+			border.SetBinding(Border.StrokeProperty, static (RadioButton rb) => rb.BorderColor, source: RelativeBindingSource.TemplatedParent, targetNullValue: SolidColorBrush.Transparent);
 			border.SetBinding(Border.StrokeShapeProperty, static (RadioButton rb) => rb.CornerRadius, source: RelativeBindingSource.TemplatedParent, converter: new CornerRadiusToShape());
-			border.SetBinding(Border.StrokeThicknessProperty, static (RadioButton rb) => rb.BorderWidth, source: RelativeBindingSource.TemplatedParent);
+			border.SetBinding(Border.StrokeThicknessProperty, static (RadioButton rb) => rb.BorderWidth, source: RelativeBindingSource.TemplatedParent, targetNullValue: 0);
 
 			var grid = new Grid
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28253.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28253.xaml
@@ -5,6 +5,7 @@
              Title="Issue28253">
     <ScrollView>
         <StackLayout Margin="15,30">
+            <Label Text="RadioButton with Image and Label" AutomationId="label"/>
             <RadioButton Value="Elephant">
                 <RadioButton.Content>
                     <Image Source="dotnet_bot.png"/>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28253.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28253.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue28253"
+             Title="Issue28253">
+    <ScrollView>
+        <StackLayout Margin="15,30">
+            <RadioButton Value="Elephant">
+                <RadioButton.Content>
+                    <Image Source="dotnet_bot.png"/>
+                </RadioButton.Content>
+            </RadioButton>
+            <RadioButton Value="Monkey">
+                <RadioButton.Content>
+                    <HorizontalStackLayout>
+                        <Label VerticalTextAlignment="Center"
+                               Text="Horizontal stack layout"/>
+                        <Image AutomationId="coffeeImage"
+                               Source="coffee.png"/>
+                    </HorizontalStackLayout>
+                </RadioButton.Content>
+            </RadioButton>
+            <RadioButton
+                Value="Tiger"
+                Content="Tiger"/>
+        </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28253.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28253.xaml.cs
@@ -1,0 +1,10 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28253, "Image is not loading in RadioButton (RadioButton.Content)", PlatformAffected.Android)]
+public partial class Issue28253 : ContentPage
+{
+	public Issue28253()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28253.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28253.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28253 : _IssuesUITest
+{
+	public Issue28253(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Image is not loading in RadioButton (RadioButton.Content)";
+
+	[Test]
+	[Category(UITestCategories.RadioButton)]
+	public void RadioButtonsShouldHaveImages()
+	{
+		App.WaitForElement("coffeeImage");
+		VerifyScreenshot();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28253.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28253.cs
@@ -16,7 +16,7 @@ public class Issue28253 : _IssuesUITest
 	[Category(UITestCategories.RadioButton)]
 	public void RadioButtonsShouldHaveImages()
 	{
-		App.WaitForElement("coffeeImage");
+		App.WaitForElement("label");
 		VerifyScreenshot();
 	}
 }


### PR DESCRIPTION
### Description

This change aligns Android's behavior with iOS, ensuring consistency across platforms. Previously, the only way to customize a RadioButton's content on Android was by setting a ControlTemplate, which was unintuitive and could lead to confusion. https://github.com/dotnet/maui/issues/6614#issuecomment-1412509470

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28253
Fixes https://github.com/dotnet/maui/issues/6614

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/f005012b-ae1e-4938-aa8d-3023d3d6611a" width="300px"/>|<img src="https://github.com/user-attachments/assets/424a6bfe-e8db-4f28-8f5d-f89c58bf6354" width="300px"/>|
