### PR TITLE
[NET10.0] Fix parameter name for `ScrollViewerExtensions.UpdateScrollBarVisibility`

### DIFF
--- a/src/Core/src/Platform/Windows/ScrollViewerExtensions.cs
+++ b/src/Core/src/Platform/Windows/ScrollViewerExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
-using WScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
+﻿using WScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
 
 namespace Microsoft.Maui.Platform
 {
@@ -16,10 +15,9 @@ namespace Microsoft.Maui.Platform
 			};
 		}
 
-		public static void UpdateScrollBarVisibility(this ScrollViewer scrollViewer, ScrollOrientation orientation,
-			ScrollBarVisibility horizontalScrollBarVisibility)
+		public static void UpdateScrollBarVisibility(this ScrollViewer scrollViewer, ScrollOrientation orientation, ScrollBarVisibility visibility)
 		{
-			if (horizontalScrollBarVisibility == ScrollBarVisibility.Default)
+			if (visibility == ScrollBarVisibility.Default)
 			{
 				// If the user has not explicitly set a horizontal scroll bar visibility, then the orientation will
 				// determine what the horizontal scroll bar does
@@ -38,7 +36,7 @@ namespace Microsoft.Maui.Platform
 
 			scrollViewer.HorizontalScrollBarVisibility = orientation switch
 			{
-				ScrollOrientation.Horizontal or ScrollOrientation.Both => horizontalScrollBarVisibility.ToWindowsScrollBarVisibility(),
+				ScrollOrientation.Horizontal or ScrollOrientation.Both => visibility.ToWindowsScrollBarVisibility(),
 				_ => WScrollBarVisibility.Disabled,
 			};
 
@@ -52,7 +50,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateContent(this ScrollViewer scrollViewer, IView? content, IMauiContext context)
 		{
-			scrollViewer.Content = content == null ? null : content.ToPlatform(context);
+			scrollViewer.Content = content?.ToPlatform(context);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/ScrollViewerExtensions.cs
+++ b/src/Core/src/Platform/Windows/ScrollViewerExtensions.cs
@@ -1,4 +1,5 @@
-﻿using WScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
+﻿using Microsoft.UI.Xaml.Controls;
+using WScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
 
 namespace Microsoft.Maui.Platform
 {

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -81,3 +81,5 @@ static Microsoft.Maui.Platform.DatePickerExtensions.UpdateBackground(this Micros
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateBackground(this Microsoft.UI.Xaml.Controls.TimePicker! platformTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Handlers.TimePickerHandler.MapBackground(Microsoft.Maui.Handlers.ITimePickerHandler! handler, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Platform.TextBoxExtensions.GetCursorPosition(this Microsoft.UI.Xaml.Controls.TextBox! textBox, int cursorOffset = 0) -> int
+*REMOVED*static Microsoft.Maui.Platform.ScrollViewerExtensions.UpdateScrollBarVisibility(this Microsoft.UI.Xaml.Controls.ScrollViewer! scrollViewer, Microsoft.Maui.ScrollOrientation orientation, Microsoft.Maui.ScrollBarVisibility horizontalScrollBarVisibility) -> void
+static Microsoft.Maui.Platform.ScrollViewerExtensions.UpdateScrollBarVisibility(this Microsoft.UI.Xaml.Controls.ScrollViewer! scrollViewer, Microsoft.Maui.ScrollOrientation orientation, Microsoft.Maui.ScrollBarVisibility visibility) -> void


### PR DESCRIPTION
### Description of Change

This PR is related to #27231 where `ScrollBarVisibility horizontalScrollBarVisibility` was renamed and then reverted back for API break reasons.