### PR TITLE
Fix: OnIdiom Default Value Handling for ValueType Properties

### DIFF
--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -61,7 +61,18 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			var value = GetValue();
 			if (value == null && propertyType.IsValueType)
+			{
+				if(bp != null)
+				{
+					object targetObject = valueProvider.TargetObject;
+
+						if (targetObject is Setter)
+							return null;
+						else
+							return bp.GetDefaultValue(targetObject as BindableObject);
+				}
 				return Activator.CreateInstance(propertyType);
+			}
 
 			if (Converter != null)
 				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue9978.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue9978.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Controls.TestCases.HostApp.Issues.Issue9978"
+             Title="Issue9978">
+            <VerticalStackLayout>
+                <Image AutomationId="MauiImage" Source="dotnet_bot.png" HeightRequest="{OnIdiom  Tablet=100}" />
+            </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue9978.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue9978.xaml
@@ -4,6 +4,6 @@
              x:Class="Controls.TestCases.HostApp.Issues.Issue9978"
              Title="Issue9978">
             <VerticalStackLayout>
-                <Image AutomationId="MauiImage" Source="dotnet_bot.png" HeightRequest="{OnIdiom  Tablet=100}" />
+                <Image AutomationId="MauiImage" Source="groceries.png" HeightRequest="{OnIdiom  Tablet=100}" />
             </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue9978.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue9978.xaml.cs
@@ -1,0 +1,11 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 9978, "VisualElement.HeightRequest defaults to 0 instead of -1 when using OnIdiom default value",
+		PlatformAffected.All)]
+public partial class Issue9978 : ContentPage
+{
+	public Issue9978()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue9978.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue9978.cs
@@ -1,0 +1,24 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+
+public class Issue9978 : _IssuesUITest
+{
+	public Issue9978(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "VisualElement.HeightRequest defaults to 0 instead of -1 when using OnIdiom default value";
+
+    
+    [Test]
+	[Category(UITestCategories.Layout)]
+	public void Issue9978Test()
+	{
+		App.WaitForElement("MauiImage");
+		
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue9978.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue9978.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Issues.Issue9978"
+             Title="Issue9978">
+    <Button x:Name="mauiButton" Text="Sample Button" HeightRequest="{OnIdiom Tablet=50}" /> 
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue9978.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue9978.xaml.cs
@@ -1,0 +1,52 @@
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Devices;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.Issues;
+
+public partial class Issue9978 : ContentPage
+{
+	public Issue9978()
+	{
+		InitializeComponent();
+	}
+
+	public Issue9978(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	public class Tests
+	{
+		[TestCase(false)]
+		[TestCase(true)]
+		public void OnIdiomReturnsBindableDefaultIfNotSet(bool useCompiledXaml)
+		{
+			var idioms = new[]
+			{
+				DeviceIdiom.Tablet,   
+				DeviceIdiom.Phone,     
+				DeviceIdiom.Desktop,
+				DeviceIdiom.Watch,
+				DeviceIdiom.TV         
+			};
+
+			foreach (var idiom in idioms)
+			{
+				DeviceInfo.SetCurrent(new MockDeviceInfo { Idiom = idiom });
+				var page = new Issue9978(useCompiledXaml);
+
+				if (idiom == DeviceIdiom.Tablet)
+				{
+					Assert.AreEqual(50, page.mauiButton.HeightRequest, $"Expected 50 for idiom Tablet");
+				}
+				else
+				{
+					Assert.AreEqual(-1, page.mauiButton.HeightRequest, $"Expected -1 for idiom {idiom}");
+				}
+			}
+		}
+
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformTests.cs
@@ -179,27 +179,5 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			Assert.AreEqual(StackOrientation.Horizontal, layout.Orientation);
 		}
 
-		[Test]
-		public void OnIdiomReturnsBindablePropertyDefaultWhenNotSet()
-		{
-			var xaml = @"
-			<Button
-				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
-				xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-				Text=""Sample Button""
-				HeightRequest=""{OnIdiom Tablet=50}"" />";
-
-			mockDeviceInfo.Idiom = DeviceIdiom.Tablet;
-			var button = new Button().LoadFromXaml(xaml);
-			Assert.AreEqual(50, button.HeightRequest);
-
-			foreach (var idiom in new[] { DeviceIdiom.Phone, DeviceIdiom.Desktop, DeviceIdiom.TV, DeviceIdiom.Watch })
-			{
-				mockDeviceInfo.Idiom = idiom;
-				button = new Button().LoadFromXaml(xaml);
-				Assert.AreEqual(-1, button.HeightRequest, $"Expected default value -1 for idiom {idiom}");
-			}
-		}
-
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformTests.cs
@@ -178,5 +178,28 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			layout = new StackLayout().LoadFromXaml(xaml);
 			Assert.AreEqual(StackOrientation.Horizontal, layout.Orientation);
 		}
+
+		[Test]
+		public void OnIdiomReturnsBindablePropertyDefaultWhenNotSet()
+		{
+			var xaml = @"
+			<Button
+				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
+				xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+				Text=""Sample Button""
+				HeightRequest=""{OnIdiom Tablet=50}"" />";
+
+			mockDeviceInfo.Idiom = DeviceIdiom.Tablet;
+			var button = new Button().LoadFromXaml(xaml);
+			Assert.AreEqual(50, button.HeightRequest);
+
+			foreach (var idiom in new[] { DeviceIdiom.Phone, DeviceIdiom.Desktop, DeviceIdiom.TV, DeviceIdiom.Watch })
+			{
+				mockDeviceInfo.Idiom = idiom;
+				button = new Button().LoadFromXaml(xaml);
+				Assert.AreEqual(-1, button.HeightRequest, $"Expected default value -1 for idiom {idiom}");
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR fixes an issue, where `OnIdiom` without a default value incorrectly assigns 0 instead of the expected default.


### Root Cause

- OnIdiom<T> relies on `Activator.CreateInstance(propertyType)` when value  is null.
- For value types like double  `Activator.CreateInstance()` returns 0.0 , instead of the expected default value (-1) from `BindableProperty.GetDefaultValue()`.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #9978 
