### PR TITLE
fix-27998 - [Windows] ScrollView is not scrolling to the bottom if in grid with *,auto Width

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27998.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27998.xaml
@@ -59,7 +59,7 @@
     </ScrollView>
     
     <Border x:Name="InvisibleBorder"
-        WidthRequest="250"
+        WidthRequest="50"
         Background="Red"
         Grid.Row="1"
         Grid.Column="1">

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27998.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27998.xaml
@@ -1,0 +1,68 @@
+﻿<local:TestContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+            xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            mc:Ignorable="d"
+            xmlns:local="using:Maui.Controls.Sample.Issues"
+            x:Class="Maui.Controls.Sample.Issues.Issue27998"
+            x:Name="Test"
+            Title="Issue27998">
+
+  <Grid x:Name="rootGrid">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="Auto" />
+    </Grid.ColumnDefinitions>
+    
+    <VerticalStackLayout  x:Name="notScrollableStack"
+                          Background="Beige"
+                          Grid.ColumnSpan="2">
+      <Label FontSize="36">First line</Label>
+      <Label FontSize="30">Second line</Label>
+    </VerticalStackLayout>
+
+    <ScrollView AutomationId="ItemsId"
+                Grid.Row="1">
+      <VerticalStackLayout>
+        <Label AutomationId="FirstItemId" FontSize="28">INSIDE SCROLL 1</Label>
+        <Label FontSize="28">INSIDE SCROLL 2</Label>
+        <Label FontSize="28">INSIDE SCROLL 3</Label>
+        <Label FontSize="28">INSIDE SCROLL 4</Label>
+        <Label FontSize="28">INSIDE SCROLL 5</Label>
+        <Label FontSize="28">INSIDE SCROLL 6</Label>
+        <Label FontSize="28">INSIDE SCROLL 7</Label>
+        <Label FontSize="28">INSIDE SCROLL 8</Label>
+        <Label FontSize="28">INSIDE SCROLL 9</Label>
+        <Label FontSize="28">INSIDE SCROLL 10</Label>
+        <Label FontSize="28">INSIDE SCROLL 11</Label>
+        <Label FontSize="28">INSIDE SCROLL 12</Label>
+        <Label FontSize="28">INSIDE SCROLL 13</Label>
+        <Label FontSize="28">INSIDE SCROLL 14</Label>
+        <Label FontSize="28">INSIDE SCROLL 15</Label>
+        <Label FontSize="28">INSIDE SCROLL 16</Label>
+        <Label FontSize="28">INSIDE SCROLL 17</Label>
+        <Label FontSize="28">INSIDE SCROLL 18</Label>
+        <Label FontSize="28">INSIDE SCROLL 19</Label>
+        <Label FontSize="28">INSIDE SCROLL 20</Label>
+        <Label FontSize="28">INSIDE SCROLL 21</Label>
+        <Label FontSize="28">INSIDE SCROLL 22</Label>
+        <Label FontSize="28">INSIDE SCROLL 23</Label>
+        <Label FontSize="28">INSIDE SCROLL 24</Label>
+        <Label FontSize="28">INSIDE SCROLL 25</Label>
+        <Label FontSize="28">INSIDE SCROLL 26</Label>
+        <Label AutomationId="LastItemId" FontSize="28">INSIDE SCROLL 27</Label>
+      </VerticalStackLayout>
+    </ScrollView>
+    
+    <Border x:Name="InvisibleBorder"
+        WidthRequest="250"
+        Background="Red"
+        Grid.Row="1"
+        Grid.Column="1">
+    </Border>
+  </Grid>
+</local:TestContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27998.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27998.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using Maui.Controls.Sample.Issues;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(	IssueTracker.Github,
+		27998,
+		"[Windows] ScrollView is not scrolling to the bottom if in grid with *,auto Width",
+		PlatformAffected.UWP)]
+public partial class Issue27998 : TestContentPage
+{
+	public Issue27998()
+	{
+		InitializeComponent();
+	}
+
+	protected override void Init() { }
+
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	public class Issue27998 : _IssuesUITest
 	{
-		private const string _itemsId = "ItemsId";
-		private const string _lastItemId = "LastItemId";
-		private const string _firstItemId = "FirstItemId";
-		private const string _lastItemText = "INSIDE SCROLL 27";
+		const string ItemsId = "ItemsId";
+		const string LastItemId = "LastItemId";
+		const string FirstItemId = "FirstItemId";
+		const string LastItemText = "INSIDE SCROLL 27";
 
 		public Issue27998(TestDevice testDevice) : base(testDevice)
 		{
@@ -31,12 +31,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		private void TestWindows()
 		{
 #if WINDOWS
-			var firstItem = App.WaitForElement(_firstItemId);
-			var lastItem = App.WaitForElement(_lastItemId);
+			var firstItem = App.WaitForElement(FirstItemId);
+			var lastItem = App.WaitForElement(LastItemId);
 			Assert.That(lastItem.IsDisplayed().Equals(false));
 
-			App.ScrollDown(_itemsId);
-			App.WaitForTextToBePresentInElement(_lastItemId, _lastItemText);
+			App.ScrollDown(ItemsId);
+			App.WaitForTextToBePresentInElement(LastItemId, LastItemText);
 
 			Assert.That(lastItem.IsDisplayed().Equals(true));
 #endif
@@ -45,10 +45,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		private void TestOtherPlatforms()
 		{
 #if !WINDOWS
-			var firstItem = App.WaitForElement(_firstItemId);
+			var firstItem = App.WaitForElement(FirstItemId);
 
-			App.ScrollDown(_itemsId);
-			var lastItem = App.WaitForElement(_lastItemId);
+			App.ScrollDown(ItemsId);
+			var lastItem = App.WaitForElement(LastItemId);
 			Assert.That(lastItem.IsDisplayed().Equals(true));
 #endif
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
@@ -1,0 +1,39 @@
+﻿//#if WINDOWS
+using NUnit.Framework;
+using OpenQA.Selenium.Internal;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27998 : _IssuesUITest
+	{
+		private const string _itemsId = "ItemsId";
+		private const string _lastItemId = "LastItemId";
+		private const string _firstItemId = "FirstItemId";
+		private const string _lastItemText = "INSIDE SCROLL 27";
+
+		public Issue27998(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "[Windows] ScrollView is not scrolling to the bottom if in grid with *,auto Width";
+
+		[Test]
+		[Category(UITestCategories.Cells)]
+		[Category(UITestCategories.ScrollView)]
+		[Category(UITestCategories.Border)]
+		public void GridAutosStarsScollToEndDisplaysLastItem()
+		{
+			var firstItem = App.WaitForElement(_firstItemId);
+			var lastItem = App.WaitForElement(_lastItemId);
+			Assert.That(lastItem.IsDisplayed().Equals(false));
+
+			App.ScrollDown(_itemsId);
+			App.WaitForTextToBePresentInElement(_lastItemId, _lastItemText);
+			
+			Assert.That(lastItem.IsDisplayed().Equals(true));
+		}
+	}
+}
+//#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
@@ -1,5 +1,4 @@
-﻿//#if WINDOWS
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using OpenQA.Selenium.Internal;
 using UITest.Appium;
 using UITest.Core;
@@ -25,15 +24,33 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Border)]
 		public void GridAutosStarsScollToEndDisplaysLastItem()
 		{
+			TestWindows();
+			TestOtherPlatforms();
+		}
+
+		private void TestWindows()
+		{
+#if WINDOWS
 			var firstItem = App.WaitForElement(_firstItemId);
 			var lastItem = App.WaitForElement(_lastItemId);
 			Assert.That(lastItem.IsDisplayed().Equals(false));
 
 			App.ScrollDown(_itemsId);
 			App.WaitForTextToBePresentInElement(_lastItemId, _lastItemText);
-			
+
 			Assert.That(lastItem.IsDisplayed().Equals(true));
+#endif
+		}
+
+		private void TestOtherPlatforms()
+		{
+#if !WINDOWS
+			var firstItem = App.WaitForElement(_firstItemId);
+
+			App.ScrollDown(_itemsId);
+			var lastItem = App.WaitForElement(_lastItemId);
+			Assert.That(lastItem.IsDisplayed().Equals(true));
+#endif
 		}
 	}
 }
-//#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27998.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using OpenQA.Selenium.Internal;
 using UITest.Appium;
 using UITest.Core;
 
@@ -19,9 +18,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public override string Issue => "[Windows] ScrollView is not scrolling to the bottom if in grid with *,auto Width";
 
 		[Test]
-		[Category(UITestCategories.Cells)]
 		[Category(UITestCategories.ScrollView)]
-		[Category(UITestCategories.Border)]
 		public void GridAutosStarsScollToEndDisplaysLastItem()
 		{
 			TestWindows();

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Primitives;
 
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.Layouts
 
 			var measuredWidth = _gridStructure.MeasuredGridWidth();
 			var measuredHeight = _gridStructure.MeasuredGridHeight();
-
+			
 			return new Size(measuredWidth, measuredHeight);
 		}
 
@@ -140,6 +141,29 @@ namespace Microsoft.Maui.Layouts
 				_cells = new Cell[_childrenToLayOut.Length];
 
 				InitializeCells();
+
+				// some _childrenToLayout could have set Height/Width abosultely set, while our columns/rows are on auto or *
+				// in this case we set set the column/row size to the child's size
+				foreach (var cell in _cells)
+				{
+					var view = _childrenToLayOut[cell.ViewIndex];
+					if (view.Height > 0)
+					{
+						var row = _rows[cell.Row];
+						if (row.IsAuto)
+						{
+							row.Size = view.Height;
+						}
+					}
+					if (view.Width > 0)
+					{
+						var column = _columns[cell.Column];
+						if (column.IsAuto)
+						{
+							column.Size = view.Width;
+						}
+					}
+				}
 
 				MeasureCells();
 			}
@@ -369,6 +393,8 @@ namespace Microsoft.Maui.Layouts
 					ResolveStarRows(_gridHeightConstraint);
 				}
 
+				AdjustDefinitions();
+
 				SecondMeasurePass();
 
 				ResolveSpans();
@@ -428,6 +454,8 @@ namespace Microsoft.Maui.Layouts
 							TrackSpan(new Span(cell.Row, cell.RowSpan, false, measure.Height));
 						}
 					}
+
+					AdjustDefinitions();
 				}
 			}
 
@@ -499,8 +527,31 @@ namespace Microsoft.Maui.Layouts
 							_rows[cell.Row].Update(measure.Height);
 						}
 					}
+
+					AdjustDefinitions();
 				}
 			}
+
+			void AdjustDefinitions()
+			{
+				AdjustDefinitions(_rows, _gridHeightConstraint);
+				AdjustDefinitions(_columns, _gridWidthConstraint);
+			}
+
+			static void AdjustDefinitions(Definition[] definitions, double gridContrains)
+			{
+				var definitionsTempMax = definitions.Sum(d => d.Size);
+				if (definitionsTempMax > gridContrains)
+				{
+					var overflow = definitionsTempMax - gridContrains;
+					var biggestDefinition = definitions.Where(d => d.IsAuto || d.IsStar).OrderByDescending(d => d.Size).FirstOrDefault();
+					if (biggestDefinition != null)
+					{
+						biggestDefinition.Size -= overflow;
+					}
+				}
+			}
+
 
 			void TrackSpan(Span span)
 			{

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -142,8 +142,8 @@ namespace Microsoft.Maui.Layouts
 
 				InitializeCells();
 
-				// some _childrenToLayout could have set Height/Width abosultely set, while our columns/rows are on auto or *
-				// in this case we set set the column/row size to the child's size
+				// Some _childrenToLayout may have an absolute Height/Width, while our columns/rows are set to auto or *.  
+				// In this case, we adjust the column/row size to match the child's size.  
 				foreach (var cell in _cells)
 				{
 					var view = _childrenToLayOut[cell.ViewIndex];
@@ -538,12 +538,12 @@ namespace Microsoft.Maui.Layouts
 				AdjustDefinitions(_columns, _gridWidthConstraint);
 			}
 
-			static void AdjustDefinitions(Definition[] definitions, double gridContrains)
+			static void AdjustDefinitions(Definition[] definitions, double gridConstrain)
 			{
 				var definitionsTempMax = definitions.Sum(d => d.Size);
-				if (definitionsTempMax > gridContrains)
+				if (definitionsTempMax > gridConstrain)
 				{
-					var overflow = definitionsTempMax - gridContrains;
+					var overflow = definitionsTempMax - gridConstrain;
 					var biggestDefinition = definitions.Where(d => d.IsAuto || d.IsStar).OrderByDescending(d => d.Size).FirstOrDefault();
 					if (biggestDefinition != null)
 					{

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Maui.Graphics;
@@ -142,25 +143,27 @@ namespace Microsoft.Maui.Layouts
 
 				InitializeCells();
 
-				// Some _childrenToLayout may have an absolute Height/Width, while our columns/rows are set to auto or *.  
-				// In this case, we adjust the column/row size to match the child's size.  
-				foreach (var cell in _cells)
+				// Some children may have an explicit Width/Height set. Pre-seed Auto row/column sizes
+				// from those values using Update() (max semantics) so that ResolveStarColumns/Rows
+				// accounts for the Auto size before computing the star allocation.
+				for (int n = 0; n < _cells.Length; n++)
 				{
+					var cell = _cells[n];
 					var view = _childrenToLayOut[cell.ViewIndex];
-					if (view.Height > 0)
+					if (cell.RowSpan == 1 && Dimension.IsExplicitSet(view.Height))
 					{
 						var row = _rows[cell.Row];
 						if (row.IsAuto)
 						{
-							row.Size = view.Height;
+							row.Update(view.Height + view.Margin.VerticalThickness);
 						}
 					}
-					if (view.Width > 0)
+					if (cell.ColumnSpan == 1 && Dimension.IsExplicitSet(view.Width))
 					{
 						var column = _columns[cell.Column];
 						if (column.IsAuto)
 						{
-							column.Size = view.Width;
+							column.Update(view.Width + view.Margin.HorizontalThickness);
 						}
 					}
 				}
@@ -534,24 +537,38 @@ namespace Microsoft.Maui.Layouts
 
 			void AdjustDefinitions()
 			{
-				AdjustDefinitions(_rows, _gridHeightConstraint);
-				AdjustDefinitions(_columns, _gridWidthConstraint);
+				AdjustDefinitions(_rows, _gridHeightConstraint, _rowSpacing, _padding.VerticalThickness);
+				AdjustDefinitions(_columns, _gridWidthConstraint, _columnSpacing, _padding.HorizontalThickness);
 			}
 
-			static void AdjustDefinitions(Definition[] definitions, double gridConstrain)
+			static void AdjustDefinitions(Definition[] definitions, double constraint, double spacing, double paddingThickness)
 			{
-				var definitionsTempMax = definitions.Sum(d => d.Size);
-				if (definitionsTempMax > gridConstrain)
+				var total = SumDefinitions(definitions, spacing);
+				if (total <= constraint - paddingThickness)
 				{
-					var overflow = definitionsTempMax - gridConstrain;
-					var biggestDefinition = definitions.Where(d => d.IsAuto || d.IsStar).OrderByDescending(d => d.Size).FirstOrDefault();
-					if (biggestDefinition != null)
+					return;
+				}
+				
+				var overflow = total - (constraint - paddingThickness);
+				
+				// Find the largest Auto or Star definition to absorb the overflow.
+				int biggestIndex = -1;
+				double biggestSize = 0;
+				for (int n = 0; n < definitions.Length; n++)
+				{
+					var def = definitions[n];
+					if ((def.IsAuto || def.IsStar) && def.Size > biggestSize)
 					{
-						biggestDefinition.Size -= overflow;
+						biggestSize = def.Size;
+						biggestIndex = n;
 					}
 				}
+				
+				if (biggestIndex >= 0)
+				{
+					definitions[biggestIndex].Size = Math.Max(0, definitions[biggestIndex].Size - overflow);
+				}
 			}
-
 
 			void TrackSpan(Span span)
 			{

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -381,6 +381,8 @@ namespace Microsoft.Maui.Layouts
 			void MeasureCells()
 			{
 				FirstMeasurePass();
+				MeasureDeferredAutoCells();
+				FitAutoDefinitionsToConstraints();
 
 				if (!_isStarWidthPrecomputable)
 				{
@@ -396,9 +398,8 @@ namespace Microsoft.Maui.Layouts
 					ResolveStarRows(_gridHeightConstraint);
 				}
 
-				AdjustDefinitions();
-
 				SecondMeasurePass();
+				FitAutoDefinitionsToConstraints();
 
 				ResolveSpans();
 
@@ -457,8 +458,6 @@ namespace Microsoft.Maui.Layouts
 							TrackSpan(new Span(cell.Row, cell.RowSpan, false, measure.Height));
 						}
 					}
-
-					AdjustDefinitions();
 				}
 			}
 
@@ -530,43 +529,96 @@ namespace Microsoft.Maui.Layouts
 							_rows[cell.Row].Update(measure.Height);
 						}
 					}
-
-					AdjustDefinitions();
 				}
 			}
 
-			void AdjustDefinitions()
+			void MeasureDeferredAutoCells()
 			{
-				AdjustDefinitions(_rows, _gridHeightConstraint, _rowSpacing, _padding.VerticalThickness);
-				AdjustDefinitions(_columns, _gridWidthConstraint, _columnSpacing, _padding.HorizontalThickness);
+				var fallbackWidth = double.IsInfinity(_gridWidthConstraint)
+					? double.PositiveInfinity
+					: Math.Max(0, _gridWidthConstraint - _padding.HorizontalThickness);
+				var fallbackHeight = double.IsInfinity(_gridHeightConstraint)
+					? double.PositiveInfinity
+					: Math.Max(0, _gridHeightConstraint - _padding.VerticalThickness);
+
+				for (int n = 0; n < _cells.Length; n++)
+				{
+					var cell = _cells[n];
+
+					if (!cell.NeedsSecondPass)
+					{
+						continue;
+					}
+
+					var measureWidthAsAuto = cell.ColumnSpan == 1 && TreatCellWidthAsAuto(cell);
+					var measureHeightAsAuto = cell.RowSpan == 1 && TreatCellHeightAsAuto(cell);
+
+					if (!measureWidthAsAuto && !measureHeightAsAuto)
+					{
+						continue;
+					}
+
+					var width = double.IsNaN(cell.MeasureWidth) ? fallbackWidth : cell.MeasureWidth;
+					var height = double.IsNaN(cell.MeasureHeight) ? fallbackHeight : cell.MeasureHeight;
+					var measure = MeasureCell(cell, width, height);
+
+					if (measureWidthAsAuto)
+					{
+						_columns[cell.Column].Update(measure.Width);
+					}
+
+					if (measureHeightAsAuto)
+					{
+						_rows[cell.Row].Update(measure.Height);
+					}
+				}
 			}
 
-			static void AdjustDefinitions(Definition[] definitions, double constraint, double spacing, double paddingThickness)
+			void FitAutoDefinitionsToConstraints()
 			{
-				var total = SumDefinitions(definitions, spacing);
-				if (total <= constraint - paddingThickness)
+				FitAutoDefinitionsToConstraint(_rows, _gridHeightConstraint, _rowSpacing, _padding.VerticalThickness);
+				FitAutoDefinitionsToConstraint(_columns, _gridWidthConstraint, _columnSpacing, _padding.HorizontalThickness);
+			}
+
+			static void FitAutoDefinitionsToConstraint(Definition[] definitions, double constraint, double spacing, double paddingThickness)
+			{
+				if (double.IsInfinity(constraint))
 				{
 					return;
 				}
-				
-				var overflow = total - (constraint - paddingThickness);
-				
-				// Find the largest Auto or Star definition to absorb the overflow.
-				int biggestIndex = -1;
-				double biggestSize = 0;
+
+				var target = Math.Max(0, constraint - paddingThickness);
+				var total = SumDefinitions(definitions, spacing);
+
+				if (total <= target)
+				{
+					return;
+				}
+
+				double autoTotal = 0;
 				for (int n = 0; n < definitions.Length; n++)
 				{
-					var def = definitions[n];
-					if ((def.IsAuto || def.IsStar) && def.Size > biggestSize)
+					if (definitions[n].IsAuto)
 					{
-						biggestSize = def.Size;
-						biggestIndex = n;
+						autoTotal += definitions[n].Size;
 					}
 				}
-				
-				if (biggestIndex >= 0)
+
+				if (autoTotal <= 0)
 				{
-					definitions[biggestIndex].Size = Math.Max(0, definitions[biggestIndex].Size - overflow);
+					return;
+				}
+
+				var overflow = total - target;
+				for (int n = 0; n < definitions.Length; n++)
+				{
+					var definition = definitions[n];
+
+					if (definition.IsAuto)
+					{
+						var reduction = overflow * (definition.Size / autoTotal);
+						definition.Size = Math.Max(0, definition.Size - reduction);
+					}
 				}
 			}
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2737,10 +2737,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 1, col: 0, colSpan: 1);
 
 			var measure = MeasureAndArrange(grid, widthConstraint: widthConstraint, heightConstraint: 100);
-
-			// view1 should make column 0 at least `determinantViewWidth` units wide
-			// So view0 should be getting measured at _at least_ that value; if the widthConstraint is larger
-			// than that, the * should bump the measure value up to match the widthConstraint
+			// measured should not exceed constraint
 			var expectedMeasureWidth = Math.Min(determinantViewWidth, widthConstraint);
 
 			view0.Received().Measure(Arg.Is<double>(expectedMeasureWidth), Arg.Any<double>());
@@ -2758,10 +2755,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 0, col: 1, rowSpan: 1);
 
 			var measure = MeasureAndArrange(grid, widthConstraint: 100, heightConstraint: heightConstraint);
-
-			// view1 should make row 0 at least `determinantViewHeight` units tall
-			// So view0 should be getting measured at _at least_ that value; if the heightConstraint is larger
-			// than that, the * should bump the measure value up to match the heightConstraint
+			// measured should not exceed constraint
 			var expectedMeasureHeight = Math.Min(determinantViewHeight, heightConstraint);
 
 			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedMeasureHeight));
@@ -2796,7 +2790,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var expectedeView1Width = widthConstraint - view2Width;
 			var expectedView1Height = heightConstraint - view0Height;
 			view1.Received().Measure(Arg.Is<double>(expectedeView1Width), Arg.Is<double>(expectedView1Height));
-			var expectedView2Height = expectedView1Height; // expresses equality of view1 and view2 width
+			var expectedView2Height = expectedView1Height; // expresses equality of view1 and view2 height
 			view2.Received().Measure(Arg.Is<double>(double.PositiveInfinity), Arg.Is<double>(expectedView2Height));
 
 		}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2685,7 +2685,6 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 		[Theory]
 		[InlineData(20, 100)]
-		[InlineData(200, 100)]
 		public void AutoStarColumnSpanMeasureIsSumOfAutoAndStar(double determinantViewWidth, double widthConstraint)
 		{
 			var grid = CreateGridLayout(columns: "Auto, *", rows: "Auto, Auto");
@@ -2707,7 +2706,6 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 		[Theory]
 		[InlineData(20, 100)]
-		[InlineData(200, 100)]
 		public void AutoStarRowSpanMeasureIsSumOfAutoAndStar(double determinantViewHeight, double heightConstraint)
 		{
 			var grid = CreateGridLayout(columns: "Auto, Auto", rows: "Auto, *");
@@ -2725,6 +2723,82 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var expectedMeasureHeight = Math.Max(determinantViewHeight, heightConstraint);
 
 			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedMeasureHeight));
+		}
+
+		[Theory]
+		[InlineData(200, 100)]
+		public void AutoStarColumnSpanMeasureDoesNotExceedConstraint(double determinantViewWidth, double widthConstraint)
+		{
+			var grid = CreateGridLayout(columns: "Auto, *", rows: "Auto, Auto");
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(determinantViewWidth, 20));
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0, row: 0, col: 0, colSpan: 2);
+			SetLocation(grid, view1, row: 1, col: 0, colSpan: 1);
+
+			var measure = MeasureAndArrange(grid, widthConstraint: widthConstraint, heightConstraint: 100);
+
+			// view1 should make column 0 at least `determinantViewWidth` units wide
+			// So view0 should be getting measured at _at least_ that value; if the widthConstraint is larger
+			// than that, the * should bump the measure value up to match the widthConstraint
+			var expectedMeasureWidth = Math.Min(determinantViewWidth, widthConstraint);
+
+			view0.Received().Measure(Arg.Is<double>(expectedMeasureWidth), Arg.Any<double>());
+		}
+
+		[Theory]
+		[InlineData(200, 100)]
+		public void AutoStarRowSpanMeasureDoesNotExceedConstraint(double determinantViewHeight, double heightConstraint)
+		{
+			var grid = CreateGridLayout(columns: "Auto, Auto", rows: "Auto, *");
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(20, determinantViewHeight));
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0, row: 0, col: 0, rowSpan: 2);
+			SetLocation(grid, view1, row: 0, col: 1, rowSpan: 1);
+
+			var measure = MeasureAndArrange(grid, widthConstraint: 100, heightConstraint: heightConstraint);
+
+			// view1 should make row 0 at least `determinantViewHeight` units tall
+			// So view0 should be getting measured at _at least_ that value; if the heightConstraint is larger
+			// than that, the * should bump the measure value up to match the heightConstraint
+			var expectedMeasureHeight = Math.Min(determinantViewHeight, heightConstraint);
+
+			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedMeasureHeight));
+		}
+
+		[Theory]
+		[InlineData(1000, 500)]
+		[InlineData(500, 400)]
+		public void AutoStarCellsMeasureOverflowingAutoCellIsAdjusted(double widthConstraint, double heightConstraint)
+		{
+			// test for fix 27998
+			// |	 view0	   |
+			// | view1 | view2 |
+			var view0Height = 100;
+			var view2Width = 250;
+			var grid = CreateGridLayout(rows: "Auto, *", columns: "*, Auto");
+			var view0 = CreateTestView(new Size(widthConstraint, view0Height));
+			var view1 = CreateTestView(new Size(widthConstraint, heightConstraint)); // width overflow is 250 because: view1.Width + view2.Width = 1250 and constraint is 1000. similar for height
+			var view2 = CreateTestView(new Size(view2Width, heightConstraint));      // height overflow is 100 because: view0.Height + view1.Height = 100 + 500 = 600 and constraint is 500. similar for width
+			view2.Width.Returns(view2Width); // represents a border with absulute set width
+			SubstituteChildren(grid, view0, view1, view2);
+			SetLocation(grid, view0, row: 0, col: 0, colSpan: 2);
+			SetLocation(grid, view1, row: 1, col: 0);
+			SetLocation(grid, view2, row: 1, col: 1);
+
+			var measure = MeasureAndArrange(grid, widthConstraint: widthConstraint, heightConstraint: heightConstraint);
+
+			Assert.Equal(widthConstraint, measure.Width);
+			Assert.Equal(heightConstraint, measure.Height);
+
+			view0.Received().Measure(Arg.Is<double>(widthConstraint), Arg.Is<double>(double.PositiveInfinity));
+			var expectedeView1Width = widthConstraint - view2Width;
+			var expectedView1Height = heightConstraint - view0Height;
+			view1.Received().Measure(Arg.Is<double>(expectedeView1Width), Arg.Is<double>(expectedView1Height));
+			var expectedView2Height = expectedView1Height; // expresses equality of view1 and view2 width
+			view2.Received().Measure(Arg.Is<double>(double.PositiveInfinity), Arg.Is<double>(expectedView2Height));
+
 		}
 
 		[Theory, Category(GridStarSizing)]


### PR DESCRIPTION
fixes: https://github.com/dotnet/maui/issues/27998

**Problems:**
|---cell0---|
|cell1|cell2|

**Problem1:**
All row and column defs are either set to auto or *.
Cell2 has an absolute width set to 250.
After initialization of the cells this absolute value can be considered for the row and column defs.
**Solution1:**
We consider the abolsute values set for the children which have to be layouted in the column and row defs.

**Problem2:**
Whenever we measured we have to reconsider that the row and column defs should be adjusted.
**Solution2:**
Whenver we measured (which is currently after `FirstMeasurePass()` and `SecoondMeasurePass()`) we adjust the row and column defs and consider possible overflows.

