### PR TITLE
[Testing] Mark PushingNavigationPageModallyWithShellShowsToolbarCorrectly as flaky

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -162,7 +162,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		[Fact(
 #if WINDOWS
-		Skip = "Fails on Windows"
+			Skip = "Fails on Windows"
+#elif IOS || MACCATALYST
+			Skip = "Flaky Test. More information: https://github.com/dotnet/maui/issues/28271"
 #endif
 		)]
 		public async Task PushingNavigationPageModallyWithShellShowsToolbarCorrectly()


### PR DESCRIPTION
### Description of Change

Mark **PushingNavigationPageModallyWithShellShowsToolbarCorrectly** as flaky. Created issue to investigate and re-enable it.