### PR TITLE
Patch in a temporary location

### DIFF
--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -72,10 +72,15 @@
       <_CopyItems Include="@(_ResizetizerFiles)" />
     </ItemGroup>
     <Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(_MauiBuildTasksLocation)%(RecursiveDir)%(_CopyItems.Arch)" ContinueOnError="true" Retries="0" />
+    <MakeDir Directories="$(IntermediateOutputPath)adjustments" />
     <AdjustReferencedAssemblyVersion
       Assembly="$(_AdjustmentsAssembly)"
       ReferencedAssembly="$(_AdjustmentsReferencedAssembly)"
-      OutputAssembly="$(_MauiBuildTasksLocation)Svg.Skia.dll" />
+      OutputAssembly="$(IntermediateOutputPath)adjustments\Svg.Skia.dll" />
+    <Copy SourceFiles="$(IntermediateOutputPath)adjustments\Svg.Skia.dll" DestinationFiles="$(_MauiBuildTasksLocation)Svg.Skia.dll" ContinueOnError="true" Retries="0" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)adjustments\Svg.Skia.dll" />
+    </ItemGroup>
   </Target>
 
   <Import Project="$(MauiSrcDirectory)Workload\Shared\LibraryPacks.targets" />


### PR DESCRIPTION
### Description of Change

I think in the multitargeted projects, the TFMs run in parallel. This causes some tasks to also run in parallel. This PR makes sure to adjust the dlls in a temporary location and then copy - first/last one wins.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #28275

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
