### PR TITLE
Fix NullReferenceException in PaintExtensions.IsSolid on Android (#28116)

### DIFF
--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Android.Content;
 using Android.Content.Res;
@@ -84,17 +84,12 @@ namespace Microsoft.Maui.Graphics
 
 		internal static bool IsSolid(this SolidPaint paint)
 		{
-			return paint.Color.Alpha == 1;
+			return !paint.IsNullOrEmpty() && paint.Color.Alpha == 1;
 		}
 
-		internal static bool IsSolid(this LinearGradientPaint paint)
+		internal static bool IsSolid(this GradientPaint paint)
 		{
-			return paint.GradientStops.All(s => s.Color.Alpha == 1);
-		}
-
-		internal static bool IsSolid(this RadialGradientPaint paint)
-		{
-			return paint.GradientStops.All(s => s.Color.Alpha == 1);
+			return !paint.IsNullOrEmpty() && paint.GradientStops.All(s => s.Color?.Alpha == 1);
 		}
 
 		internal static bool IsValid(this GradientPaint? gradientPaint) =>

--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
@@ -154,6 +154,19 @@ public partial class GraphicsTests : TestBase
 		Assert.True(solidPaint.IsSolid());
 	}
 
+	[Fact]
+	public void NullSolidPaintTest()
+	{
+		Color nullColor = null;
+		var solidPaintNullColor = new SolidPaint(nullColor);
+
+		Assert.False(solidPaintNullColor.IsSolid());
+
+		SolidPaint nullSolidPaint = null;
+
+		Assert.False(nullSolidPaint.IsSolid());
+	}
+
 	[Theory]
 	[InlineData("#FF0000", "#00FF00")]
 	[InlineData("#00FF00", "#0000FF")]
@@ -167,6 +180,14 @@ public partial class GraphicsTests : TestBase
 		Assert.True(linearGradientPaint.IsSolid());
 	}
 
+	[Fact]
+	public void NullLinearGradientPaintTest()
+	{
+		LinearGradientPaintStub nullLinearGradientPaint = null;
+
+		Assert.False(nullLinearGradientPaint.IsSolid());
+	}
+
 	[Theory]
 	[InlineData("#FF0000", "#00FF00")]
 	[InlineData("#00FF00", "#0000FF")]
@@ -178,5 +199,13 @@ public partial class GraphicsTests : TestBase
 		var radialGradientPaint = new RadialGradientPaintStub(startColor, endColor);
 
 		Assert.True(radialGradientPaint.IsSolid());
+	}
+
+	[Fact]
+	public void NullRadialGradientPaintTest()
+	{
+		RadialGradientPaintStub nullRadialGradientPaint = null;
+		
+		Assert.False(nullRadialGradientPaint.IsSolid());
 	}
 }


### PR DESCRIPTION
### Description

Backport https://github.com/dotnet/maui/pull/28116