### PR TITLE
[HybridWebView] Always complete web requests

### DIFF
--- a/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
+++ b/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Maui.DeviceTests
 		public static MauiApp CreateMauiApp(List<Assembly> testAssemblies)
 		{
 			var appBuilder = MauiApp.CreateBuilder();
+
+#if DEBUG
+			appBuilder.Services.AddHybridWebViewDeveloperTools();
+#endif
+
 			appBuilder
 				.ConfigureLifecycleEvents(life =>
 				{


### PR DESCRIPTION
### Description of Change

Currently iOS and Mac Catalyst only complete the requests if they are successful. This PR updates the logic to make sure to always complete the requests so the app can continue. Any async fetches will now complete, allowing the JS to continue.

Windows and Android already do this and I added a test for this in #28230, however Mac Catalyst was very iffy and we merged thinking it was the CI ghosts. Turns out, CI was sending the right messages and we trusted AI too much. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #28285

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
