### PR TITLE
[net10.0] Remove mobile librarybuilder net9

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -79,8 +79,7 @@
     <ItemGroup>
       <_WorkloadSource Include="$(NugetArtifactsPath)" />
       <_LocalWorkloadIds Include="maui" />
-      <!-- NOTE: temporary for .NET 9 targeting https://github.com/xamarin/xamarin-macios/pull/21848/commits/cb1340221774ba9af226ac71a5aef551d765ee21 -->
-      <_LocalWorkloadIds Include="mobile-librarybuilder-net9" />
+      
       <_LocalWorkloadIds Include="tizen" Condition=" '$(IncludeTizenTargetFrameworks)' == 'true' " />
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />


### PR DESCRIPTION
### Description of Change

Remove workaround to instal workload for building net9 iOS workloads