### PR TITLE
[Testing] Fix flaky UITests 8

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -11,6 +10,7 @@ public class Issue16910 : _IssuesUITest
 	public override string Issue => "IsRefreshing binding works";
 
 	protected override bool ResetAfterEachTest => true;
+
 	public Issue16910(TestDevice device)
 		: base(device)
 	{
@@ -26,16 +26,17 @@ public class Issue16910 : _IssuesUITest
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");
 	}
-#if TEST_FAILS_ON_CATALYST //Scroll actions cannot be performed on the macOS test server
+
 	[Test]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{
+		const int offset = 50;
+
 		var collectionViewRect = App.WaitForElement("CollectionView").GetRect();
 		//In CI, using App.ScrollDown sometimes fails to trigger the refresh command, so here use DragCoordinates instead of the ScrollDown action in Appium.
-		App.DragCoordinates(collectionViewRect.CenterX(), collectionViewRect.Y + 50, collectionViewRect.CenterX(), collectionViewRect.Y + collectionViewRect.Height - 50);
+		App.DragCoordinates(collectionViewRect.CenterX(), collectionViewRect.Y + offset, collectionViewRect.CenterX(), collectionViewRect.Y + collectionViewRect.Height - offset);
 		App.WaitForElement("IsRefreshing");
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");
 	}
-#endif
 }

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumTouchActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumTouchActions.cs
@@ -400,7 +400,7 @@ namespace UITest.Appium
 		{
 			OpenQA.Selenium.Appium.Interactions.PointerInputDevice touchDevice = new OpenQA.Selenium.Appium.Interactions.PointerInputDevice(PointerKind.Touch);
 			var dragSequence = new ActionSequence(touchDevice, 0);
-			dragSequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)fromX, (int)fromY, TimeSpan.Zero));
+			dragSequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)fromX, (int)fromY, TimeSpan.FromMilliseconds(2)));
 			dragSequence.AddAction(touchDevice.CreatePointerDown(PointerButton.TouchContact));
 			dragSequence.AddAction(touchDevice.CreatePointerMove(CoordinateOrigin.Viewport, (int)toX, (int)toY, TimeSpan.FromMilliseconds(250)));
 			dragSequence.AddAction(touchDevice.CreatePointerUp(PointerButton.TouchContact));


### PR DESCRIPTION
### Description of Change

- Fix `BindingUpdatesFromInteractiveRefresh` test on Windows. Example of failing build: https://dev.azure.com/xamarin/public/_build/results?buildId=137458&view=ms.vss-test-web.build-test-results-tab&runId=3881724&resultId=100011&paneView=debug
- Fix `CarouselItemsShouldRenderProperly`. Example of failing build: https://dev.azure.com/xamarin/public/_build/results?buildId=137334&view=ms.vss-test-web.build-test-results-tab&runId=3875913&resultId=100014&paneView=attachments

