### PR TITLE
Disable test recently re-enabled BindingUpdatesFromInteractiveRefresh

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -26,7 +26,7 @@ public class Issue16910 : _IssuesUITest
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");
 	}
-#if TEST_FAILS_ON_CATALYST //Scroll actions cannot be performed on the macOS test server
+#if TEST_FAILS_ON_CATALYST || TEST_FAILS_ON_WINDOWS //Scroll actions cannot be performed on the macOS test server
 	[Test]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/28137 re-enabled this test a couple of weeks ago and it's still not 100 percent. This test doesn't represent a change/break in behavior