### PR TITLE
Fix for Shell does not always raise Navigating event on Windows

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -171,10 +171,11 @@ namespace Microsoft.Maui.Controls.Handlers
 			}
 			else if (selectedItem.Data is ShellContent shellContent && VirtualView.Parent is Shell parentShell)
 			{
+				// We need to invoke ProposeSection for TabBar items navigation for ShellContent
 				var currentItem = parentShell.CurrentItem?.CurrentItem;
 				if (currentItem?.Title != shellContent.Title && currentItem != shellContent.Parent)
 				{
-					((IShellItemController)parentShell.CurrentItem!).ProposeSection(shellContent);
+					((IShellItemController)parentShell.CurrentItem).ProposeSection(shellContent);
 				}
 				parentShell.CurrentItem = shellContent;
 			}

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				var currentItem = parentShell.CurrentItem?.CurrentItem;
 				if (currentItem?.Title != shellContent.Title && currentItem != shellContent.Parent)
 				{
-					((IShellItemController)parentShell.CurrentItem).ProposeSection(shellContent);
+					(parentShell.CurrentItem as IShellItemController)?.ProposeSection(shellContent);
 				}
 				parentShell.CurrentItem = shellContent;
 			}

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -169,9 +169,14 @@ namespace Microsoft.Maui.Controls.Handlers
 
 				((Shell)VirtualView.Parent).CurrentItem = shellSection;
 			}
-			else if (selectedItem.Data is ShellContent shellContent)
+			else if (selectedItem.Data is ShellContent shellContent && VirtualView.Parent is Shell parentShell)
 			{
-				((Shell)VirtualView.Parent).CurrentItem = shellContent;
+				var currentItem = parentShell.CurrentItem?.CurrentItem;
+				if (currentItem?.Title != shellContent.Title && currentItem != shellContent.Parent)
+				{
+					((IShellItemController)parentShell.CurrentItem!).ProposeSection(shellContent);
+				}
+				parentShell.CurrentItem = shellContent;
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12500.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12500.cs
@@ -1,0 +1,117 @@
+using Maui.Controls.Sample.Issues;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace Controls.TestCases.Issues;
+
+[Issue(IssueTracker.Github, 12500, "Shell does not always raise Navigating event on Windows", PlatformAffected.UWP)]
+public class Issue12500 : Shell
+{
+	public Issue12500()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Disabled;
+		// Create TabBar
+		var tabBar = new TabBar();
+
+		// Add ShellContent for MainPage
+		tabBar.Items.Add(new ShellContent
+		{
+			Title = "Hello, World!",
+			Route = "12500",
+			ContentTemplate = new DataTemplate(typeof(Issue12500Main))
+		});
+
+		// Add ShellContent for EventsPage
+		tabBar.Items.Add(new ShellContent
+		{
+			Title = "Events",
+			Route = "12500EventPage",
+			ContentTemplate = new DataTemplate(typeof(Issue12500EventPage))
+		});
+
+		// Add ShellContent for DummyPage
+		tabBar.Items.Add(new ShellContent
+		{
+			Title = "Sample",
+			Route = "12500SamplePage",
+			ContentTemplate = new DataTemplate(typeof(Issue12500Sample))
+		});
+
+		// Add TabBar to Shell
+		this.Items.Add(tabBar);
+	}
+	protected async override void OnNavigating(ShellNavigatingEventArgs args)
+	{
+		base.OnNavigating(args);
+		await DisplayAlert("Navigating", "Navigating to " + args.Target.Location.OriginalString, "OK");
+
+	}
+}
+public class Issue12500EventPage : ContentPage
+{
+	public Issue12500EventPage()
+	{
+		Title = "Issue12500 Event Page";
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+				{
+					new Label
+					{
+						Text = "This is Issue12500 Event Page.",
+						AutomationId = "Issue12500EventPage",
+						FontSize = 24,
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center
+					}
+				}
+		};
+	}
+}
+
+public class Issue12500Sample : ContentPage
+{
+	public Issue12500Sample()
+	{
+		Title = "Issue12500 Sample Page";
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+				{
+					new Label
+					{
+						Text = "This is Issue12500 Sample Page.",
+						AutomationId="Issue12500SamplePage",
+						FontSize = 24,
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center
+					}
+				}
+		};
+	}
+}
+
+public class Issue12500Main : ContentPage
+{
+	public Issue12500Main()
+	{
+		Title = "Issue12500 Main Page";
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+				{
+					new Label
+					{
+						Text = "This is Issue12500 Main Page.",
+						AutomationId="Issue12500MainPage",
+						FontSize = 24,
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center
+					}
+				}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12500.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12500.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue12500 : _IssuesUITest
+{
+	public override string Issue => "Shell does not always raise Navigating event on Windows";
+
+#if MACCATALYST
+		const string actionButton = "action-button--999";
+#else
+	const string actionButton = "OK";
+#endif
+	public Issue12500(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void ShellNavigatingShouldTrigger()
+	{
+		App.WaitForElement("Issue12500MainPage");
+		App.WaitForElement("Events");
+		App.Tap("Events");
+		App.WaitForElement(actionButton);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12500.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12500.cs
@@ -8,11 +8,6 @@ public class Issue12500 : _IssuesUITest
 {
 	public override string Issue => "Shell does not always raise Navigating event on Windows";
 
-#if MACCATALYST
-		const string actionButton = "action-button--999";
-#else
-	const string actionButton = "OK";
-#endif
 	public Issue12500(TestDevice device) : base(device)
 	{
 	}
@@ -24,6 +19,7 @@ public class Issue12500 : _IssuesUITest
 		App.WaitForElement("Issue12500MainPage");
 		App.WaitForElement("Events");
 		App.Tap("Events");
-		App.WaitForElement(actionButton);
+		var result = App.WaitForElement("Issue12500EventPage").GetText();
+		Assert.That(result, Is.EqualTo("Navigating to //EventPage"));
 	}
 }


### PR DESCRIPTION
### Issue Details :
With TabBar and ShellContent, switching between the tabs does not raise the Navigating event on Windows.

### Root Cause:
ShellContent is defined directly inside the TabBar. As a result, in `ShellItemHandler.windows.cs`, the `OnNavigationTabChanged` method triggers the Navigating event for `ShellSection`. However, since ShellContent is used directly, the Navigating event is not triggered because `ShellContent` is directly set as the CurrentItem.
 
On iOS and Android platforms, the Navigating event is directly invoked regardless of whether ShellSection or ShellContent is used. 
 
### Description of Fix:
The fix ensures that `ProposeSection` is invoked, which updates the `Navigating` event. This is done while considering that the CurrentItem is not the same as `ShellContent`, ensuring proper event triggering and navigation handling.

### Issues Fixed
Fixes #12500 

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="1000" height="500" alt="Before Fix video" src="https://github.com/user-attachments/assets/08183a81-fcd8-48f2-9ab9-ebc3215db8d2">|<video width="1000" height="500" alt="After Fix video"  src="https://github.com/user-attachments/assets/c0d6bc71-c6e9-4c80-873f-a1abe8a21669" >|