### PR TITLE
What if we did not use dictionaries?

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 #if __IOS__ || MACCATALYST
 using PlatformView = UIKit.UIView;
@@ -20,10 +22,170 @@ namespace Microsoft.Maui.Handlers
 	/// Handlers are also responsible for instantiating the underlying platform view, and mapping the cross-platform control API to the platform view API. </remarks>
 	public abstract partial class ViewHandler : ElementHandler, IViewHandler
 	{
+		class ViewHandlerPropertyMapper : IPropertyMapper<IView, IViewHandler>
+		{
+			static IPropertyMapper Base => ElementHandler.ElementMapper;
+
+			public void Add(string key, Action<IViewHandler, IView> action)
+			{
+				throw new NotImplementedException();
+			}
+
+			public IEnumerable<string> GetKeys()
+			{
+				// This property is a special one and needs to be set before other properties.
+				yield return nameof(IViewHandler.ContainerView);
+				yield return nameof(IView.AutomationId);
+				yield return nameof(IView.Clip);
+				yield return nameof(IView.Shadow);
+				yield return nameof(IView.Visibility);
+				yield return nameof(IView.Background);
+				yield return nameof(IView.FlowDirection);
+				yield return nameof(IView.Width);
+				yield return nameof(IView.Height);
+				yield return nameof(IView.MinimumHeight);
+				yield return nameof(IView.MaximumHeight);
+				yield return nameof(IView.MinimumWidth);
+				yield return nameof(IView.MaximumWidth);
+				yield return nameof(IView.IsEnabled);
+				yield return nameof(IView.Opacity);
+				yield return nameof(IView.Semantics);
+				yield return nameof(IView.TranslationX);
+				yield return nameof(IView.TranslationY);
+				yield return nameof(IView.Scale);
+				yield return nameof(IView.ScaleX);
+				yield return nameof(IView.ScaleY);
+				yield return nameof(IView.Rotation);
+				yield return nameof(IView.RotationX);
+				yield return nameof(IView.RotationY);
+				yield return nameof(IView.AnchorX);
+				yield return nameof(IView.AnchorY);
+#pragma warning disable CS0618 // Type or member is obsolete
+				yield return nameof(IBorder.Border);
+#pragma warning restore CS0618 // Type or member is obsolete
+#if ANDROID || WINDOWS || TIZEN
+				yield return nameof(IToolbarElement.Toolbar);
+#endif
+				yield return nameof(IView.InputTransparent);
+				yield return nameof(IToolTipElement.ToolTip);
+#if WINDOWS || MACCATALYST
+				yield return nameof(IContextFlyoutElement.ContextFlyout);
+#endif
+				
+				foreach(var key in Base.GetKeys())
+				{
+					yield return key;
+				}
+			}
+
+			public Action<IElementHandler, IElement>? GetProperty(string key)
+			{
+				throw new NotImplementedException();
+			}
+
+			public void UpdateProperties(IElementHandler elementHandler, IElement virtualView)
+			{
+				if (elementHandler is not IViewHandler viewHandler || virtualView is not IView view)
+					return;
+
+				// This property is a special one and needs to be set before other properties.
+				MapContainerView(viewHandler, view);
+				MapAutomationId(viewHandler, view);
+				MapClip(viewHandler, view);
+				MapShadow(viewHandler, view);
+				MapVisibility(viewHandler, view);
+				MapBackground(viewHandler, view);
+				MapFlowDirection(viewHandler, view);
+				MapWidth(viewHandler, view);
+				MapHeight(viewHandler, view);
+				MapMinimumHeight(viewHandler, view);
+				MapMaximumHeight(viewHandler, view);
+				MapMinimumWidth(viewHandler, view);
+				MapMaximumWidth(viewHandler, view);
+				MapIsEnabled(viewHandler, view);
+				MapOpacity(viewHandler, view);
+				MapSemantics(viewHandler, view);
+				MapTranslationX(viewHandler, view);
+				MapTranslationY(viewHandler, view);
+				MapScale(viewHandler, view);
+				MapScaleX(viewHandler, view);
+				MapScaleY(viewHandler, view);
+				MapRotation(viewHandler, view);
+				MapRotationX(viewHandler, view);
+				MapRotationY(viewHandler, view);
+				MapAnchorX(viewHandler, view);
+				MapAnchorY(viewHandler, view);
+#pragma warning disable CS0618 // Type or member is obsolete
+				MapBorderView(viewHandler, view);
+#pragma warning restore CS0618 // Type or member is obsolete
+#if ANDROID || WINDOWS || TIZEN
+				MapToolbar(viewHandler, view);
+#endif
+				MapInputTransparent(viewHandler, view);
+				MapToolTip(viewHandler, view);
+#if WINDOWS || MACCATALYST
+				MapContextFlyout(viewHandler, view);
+#endif
+
+				Base.UpdateProperties(elementHandler, virtualView);
+			}
+
+			public void UpdateProperty(IElementHandler elementHandler, IElement virtualView, string property)
+			{
+				if (elementHandler is not IViewHandler viewHandler || virtualView is not IView view)
+					return;
+
+				switch (property)
+				{
+					// This property is a special one and needs to be set before other properties.
+					case nameof(IViewHandler.ContainerView): MapContainerView(viewHandler, view); break;
+					case nameof(IView.AutomationId): MapAutomationId(viewHandler, view); break;
+					case nameof(IView.Clip): MapClip(viewHandler, view); break;
+					case nameof(IView.Shadow): MapShadow(viewHandler, view); break;
+					case nameof(IView.Visibility): MapVisibility(viewHandler, view); break;
+					case nameof(IView.Background): MapBackground(viewHandler, view); break;
+					case nameof(IView.FlowDirection): MapFlowDirection(viewHandler, view); break;
+					case nameof(IView.Width): MapWidth(viewHandler, view); break;
+					case nameof(IView.Height): MapHeight(viewHandler, view); break;
+					case nameof(IView.MinimumHeight): MapMinimumHeight(viewHandler, view); break;
+					case nameof(IView.MaximumHeight): MapMaximumHeight(viewHandler, view); break;
+					case nameof(IView.MinimumWidth): MapMinimumWidth(viewHandler, view); break;
+					case nameof(IView.MaximumWidth): MapMaximumWidth(viewHandler, view); break;
+					case nameof(IView.IsEnabled): MapIsEnabled(viewHandler, view); break;
+					case nameof(IView.Opacity): MapOpacity(viewHandler, view); break;
+					case nameof(IView.Semantics): MapSemantics(viewHandler, view); break;
+					case nameof(IView.TranslationX): MapTranslationX(viewHandler, view); break;
+					case nameof(IView.TranslationY): MapTranslationY(viewHandler, view); break;
+					case nameof(IView.Scale): MapScale(viewHandler, view); break;
+					case nameof(IView.ScaleX): MapScaleX(viewHandler, view); break;
+					case nameof(IView.ScaleY): MapScaleY(viewHandler, view); break;
+					case nameof(IView.Rotation): MapRotation(viewHandler, view); break;
+					case nameof(IView.RotationX): MapRotationX(viewHandler, view); break;
+					case nameof(IView.RotationY): MapRotationY(viewHandler, view); break;
+					case nameof(IView.AnchorX): MapAnchorX(viewHandler, view); break;
+					case nameof(IView.AnchorY): MapAnchorY(viewHandler, view); break;
+	#pragma warning disable CS0618 // Type or member is obsolete
+					case nameof(IBorder.Border): MapBorderView(viewHandler, view); break;
+	#pragma warning restore CS0618 // Type or member is obsolete
+	#if ANDROID || WINDOWS || TIZEN
+					case nameof(IToolbarElement.Toolbar): MapToolbar(viewHandler, view); break;
+	#endif
+					case nameof(IView.InputTransparent): MapInputTransparent(viewHandler, view); break;
+					case nameof(IToolTipElement.ToolTip): MapToolTip(viewHandler, view); break;
+	#if WINDOWS || MACCATALYST
+					case nameof(IContextFlyoutElement.ContextFlyout): MapContextFlyout(viewHandler, view); break;
+	#endif
+					default: Base.UpdateProperty(elementHandler, virtualView, property); break;
+				}
+			}
+		}
+
 		/// <summary>
 		/// A dictionary that maps the virtual view properties to their platform view counterparts.
 		/// </summary>
-		public static IPropertyMapper<IView, IViewHandler> ViewMapper =
+		public static IPropertyMapper<IView, IViewHandler> ViewMapper = 
+			// new ViewHandlerPropertyMapper();
+//*
 #if ANDROID
 			// Use a custom mapper for Android which knows how to batch the initial property sets
 			new AndroidBatchPropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)
@@ -74,6 +236,7 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IContextFlyoutElement.ContextFlyout)] = MapContextFlyout,
 #endif
 			};
+// */
 
 		/// <summary>
 		/// A dictionary that maps the virtual view commands to their platform view counterparts.

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Maui.Graphics;
 #if __IOS__ || MACCATALYST
 using PlatformView = UIKit.UIView;
@@ -22,7 +23,7 @@ namespace Microsoft.Maui.Handlers
 	/// Handlers are also responsible for instantiating the underlying platform view, and mapping the cross-platform control API to the platform view API. </remarks>
 	public abstract partial class ViewHandler : ElementHandler, IViewHandler
 	{
-		class ViewHandlerPropertyMapper : IPropertyMapper<IView, IViewHandler>
+		class ViewHandlerPropertyMapper : IPropertyMapper<IView, IViewHandler>, ICanUpdate
 		{
 			static IPropertyMapper Base => ElementHandler.ElementMapper;
 
@@ -31,57 +32,97 @@ namespace Microsoft.Maui.Handlers
 				throw new NotImplementedException();
 			}
 
-			public IEnumerable<string> GetKeys()
+			string[]? _keys;
+
+			public IEnumerable<string> GetKeys() => (_keys ??= new[]
 			{
 				// This property is a special one and needs to be set before other properties.
-				yield return nameof(IViewHandler.ContainerView);
-				yield return nameof(IView.AutomationId);
-				yield return nameof(IView.Clip);
-				yield return nameof(IView.Shadow);
-				yield return nameof(IView.Visibility);
-				yield return nameof(IView.Background);
-				yield return nameof(IView.FlowDirection);
-				yield return nameof(IView.Width);
-				yield return nameof(IView.Height);
-				yield return nameof(IView.MinimumHeight);
-				yield return nameof(IView.MaximumHeight);
-				yield return nameof(IView.MinimumWidth);
-				yield return nameof(IView.MaximumWidth);
-				yield return nameof(IView.IsEnabled);
-				yield return nameof(IView.Opacity);
-				yield return nameof(IView.Semantics);
-				yield return nameof(IView.TranslationX);
-				yield return nameof(IView.TranslationY);
-				yield return nameof(IView.Scale);
-				yield return nameof(IView.ScaleX);
-				yield return nameof(IView.ScaleY);
-				yield return nameof(IView.Rotation);
-				yield return nameof(IView.RotationX);
-				yield return nameof(IView.RotationY);
-				yield return nameof(IView.AnchorX);
-				yield return nameof(IView.AnchorY);
+				nameof(IViewHandler.ContainerView),
+				nameof(IView.AutomationId),
+				nameof(IView.Clip),
+				nameof(IView.Shadow),
+				nameof(IView.Visibility),
+				nameof(IView.Background),
+				nameof(IView.FlowDirection),
+				nameof(IView.Width),
+				nameof(IView.Height),
+				nameof(IView.MinimumHeight),
+				nameof(IView.MaximumHeight),
+				nameof(IView.MinimumWidth),
+				nameof(IView.MaximumWidth),
+				nameof(IView.IsEnabled),
+				nameof(IView.Opacity),
+				nameof(IView.Semantics),
+				nameof(IView.TranslationX),
+				nameof(IView.TranslationY),
+				nameof(IView.Scale),
+				nameof(IView.ScaleX),
+				nameof(IView.ScaleY),
+				nameof(IView.Rotation),
+				nameof(IView.RotationX),
+				nameof(IView.RotationY),
+				nameof(IView.AnchorX),
+				nameof(IView.AnchorY),
 #pragma warning disable CS0618 // Type or member is obsolete
-				yield return nameof(IBorder.Border);
+				nameof(IBorder.Border),
 #pragma warning restore CS0618 // Type or member is obsolete
 #if ANDROID || WINDOWS || TIZEN
-				yield return nameof(IToolbarElement.Toolbar);
+				nameof(IToolbarElement.Toolbar),
 #endif
-				yield return nameof(IView.InputTransparent);
-				yield return nameof(IToolTipElement.ToolTip);
+				nameof(IView.InputTransparent),
+				nameof(IToolTipElement.ToolTip),
 #if WINDOWS || MACCATALYST
-				yield return nameof(IContextFlyoutElement.ContextFlyout);
+				nameof(IContextFlyoutElement.ContextFlyout)
 #endif
-				
-				foreach(var key in Base.GetKeys())
-				{
-					yield return key;
-				}
-			}
+			}).Union(Base.GetKeys());
 
-			public Action<IElementHandler, IElement>? GetProperty(string key)
-			{
-				throw new NotImplementedException();
-			}
+			public Action<IElementHandler, IElement>? GetProperty(string key) => throw new NotImplementedException();
+	// 		{
+	// 			Action<IViewHandler, IView>? property = key switch
+	// 			{
+					
+	// 				// This property is a special one and needs to be set before other properties.
+	// 				nameof(IViewHandler.ContainerView) => MapContainerView,
+	// 				nameof(IView.AutomationId) => MapAutomationId,
+	// 				nameof(IView.Clip) => MapClip,
+	// 				nameof(IView.Shadow) => MapShadow,
+	// 				nameof(IView.Visibility) => MapVisibility,
+	// 				nameof(IView.Background) => MapBackground,
+	// 				nameof(IView.FlowDirection) => MapFlowDirection,
+	// 				nameof(IView.Width) => MapWidth,
+	// 				nameof(IView.Height) => MapHeight,
+	// 				nameof(IView.MinimumHeight) => MapMinimumHeight,
+	// 				nameof(IView.MaximumHeight) => MapMaximumHeight,
+	// 				nameof(IView.MinimumWidth) => MapMinimumWidth,
+	// 				nameof(IView.MaximumWidth) => MapMaximumWidth,
+	// 				nameof(IView.IsEnabled) => MapIsEnabled,
+	// 				nameof(IView.Opacity) => MapOpacity,
+	// 				nameof(IView.Semantics) => MapSemantics,
+	// 				nameof(IView.TranslationX) => MapTranslationX,
+	// 				nameof(IView.TranslationY) => MapTranslationY,
+	// 				nameof(IView.Scale) => MapScale,
+	// 				nameof(IView.ScaleX) => MapScaleX,
+	// 				nameof(IView.ScaleY) => MapScaleY,
+	// 				nameof(IView.Rotation) => MapRotation,
+	// 				nameof(IView.RotationX) => MapRotationX,
+	// 				nameof(IView.RotationY) => MapRotationY,
+	// 				nameof(IView.AnchorX) => MapAnchorX,
+	// 				nameof(IView.AnchorY) => MapAnchorY,
+	// #pragma warning disable CS0618 // Type or member is obsolete
+	// 				nameof(IBorder.Border) => MapBorderView,
+	// #pragma warning restore CS0618 // Type or member is obsolete
+	// #if ANDROID || WINDOWS || TIZEN
+	// 				nameof(IToolbarElement.Toolbar) => MapToolbar,
+	// #endif
+	// 				nameof(IView.InputTransparent) => MapInputTransparent,
+	// 				nameof(IToolTipElement.ToolTip) => MapToolTip,
+	// #if WINDOWS || MACCATALYST
+	// 				nameof(IContextFlyoutElement.ContextFlyout) => MapContextFlyout,
+	// #endif
+	// 				_ => null
+	// 			};
+	// 			return property is null ? null : new((a, b) => property((IViewHandler)a, (IView)b));
+	// 		}
 
 			public void UpdateProperties(IElementHandler elementHandler, IElement virtualView)
 			{
@@ -132,51 +173,69 @@ namespace Microsoft.Maui.Handlers
 
 			public void UpdateProperty(IElementHandler elementHandler, IElement virtualView, string property)
 			{
-				if (elementHandler is not IViewHandler viewHandler || virtualView is not IView view)
-					return;
+				TryUpdateProperty(elementHandler, virtualView, property);
+			}
 
-				switch (property)
+			public bool TryUpdateProperty(IElementHandler elementHandler, IElement virtualView, string property)
+			{
+				if (elementHandler is IViewHandler viewHandler && virtualView is IView view)
 				{
-					// This property is a special one and needs to be set before other properties.
-					case nameof(IViewHandler.ContainerView): MapContainerView(viewHandler, view); break;
-					case nameof(IView.AutomationId): MapAutomationId(viewHandler, view); break;
-					case nameof(IView.Clip): MapClip(viewHandler, view); break;
-					case nameof(IView.Shadow): MapShadow(viewHandler, view); break;
-					case nameof(IView.Visibility): MapVisibility(viewHandler, view); break;
-					case nameof(IView.Background): MapBackground(viewHandler, view); break;
-					case nameof(IView.FlowDirection): MapFlowDirection(viewHandler, view); break;
-					case nameof(IView.Width): MapWidth(viewHandler, view); break;
-					case nameof(IView.Height): MapHeight(viewHandler, view); break;
-					case nameof(IView.MinimumHeight): MapMinimumHeight(viewHandler, view); break;
-					case nameof(IView.MaximumHeight): MapMaximumHeight(viewHandler, view); break;
-					case nameof(IView.MinimumWidth): MapMinimumWidth(viewHandler, view); break;
-					case nameof(IView.MaximumWidth): MapMaximumWidth(viewHandler, view); break;
-					case nameof(IView.IsEnabled): MapIsEnabled(viewHandler, view); break;
-					case nameof(IView.Opacity): MapOpacity(viewHandler, view); break;
-					case nameof(IView.Semantics): MapSemantics(viewHandler, view); break;
-					case nameof(IView.TranslationX): MapTranslationX(viewHandler, view); break;
-					case nameof(IView.TranslationY): MapTranslationY(viewHandler, view); break;
-					case nameof(IView.Scale): MapScale(viewHandler, view); break;
-					case nameof(IView.ScaleX): MapScaleX(viewHandler, view); break;
-					case nameof(IView.ScaleY): MapScaleY(viewHandler, view); break;
-					case nameof(IView.Rotation): MapRotation(viewHandler, view); break;
-					case nameof(IView.RotationX): MapRotationX(viewHandler, view); break;
-					case nameof(IView.RotationY): MapRotationY(viewHandler, view); break;
-					case nameof(IView.AnchorX): MapAnchorX(viewHandler, view); break;
-					case nameof(IView.AnchorY): MapAnchorY(viewHandler, view); break;
-	#pragma warning disable CS0618 // Type or member is obsolete
-					case nameof(IBorder.Border): MapBorderView(viewHandler, view); break;
-	#pragma warning restore CS0618 // Type or member is obsolete
-	#if ANDROID || WINDOWS || TIZEN
-					case nameof(IToolbarElement.Toolbar): MapToolbar(viewHandler, view); break;
-	#endif
-					case nameof(IView.InputTransparent): MapInputTransparent(viewHandler, view); break;
-					case nameof(IToolTipElement.ToolTip): MapToolTip(viewHandler, view); break;
-	#if WINDOWS || MACCATALYST
-					case nameof(IContextFlyoutElement.ContextFlyout): MapContextFlyout(viewHandler, view); break;
-	#endif
-					default: Base.UpdateProperty(elementHandler, virtualView, property); break;
+					switch (property)
+					{
+						// This property is a special one and needs to be set before other properties.
+						case nameof(IViewHandler.ContainerView): MapContainerView(viewHandler, view); return true;
+						case nameof(IView.AutomationId): MapAutomationId(viewHandler, view); return true;
+						case nameof(IView.Clip): MapClip(viewHandler, view); return true;
+						case nameof(IView.Shadow): MapShadow(viewHandler, view); return true;
+						case nameof(IView.Visibility): MapVisibility(viewHandler, view); return true;
+						case nameof(IView.Background): MapBackground(viewHandler, view); return true;
+						case nameof(IView.FlowDirection): MapFlowDirection(viewHandler, view); return true;
+						case nameof(IView.Width): MapWidth(viewHandler, view); return true;
+						case nameof(IView.Height): MapHeight(viewHandler, view); return true;
+						case nameof(IView.MinimumHeight): MapMinimumHeight(viewHandler, view); return true;
+						case nameof(IView.MaximumHeight): MapMaximumHeight(viewHandler, view); return true;
+						case nameof(IView.MinimumWidth): MapMinimumWidth(viewHandler, view); return true;
+						case nameof(IView.MaximumWidth): MapMaximumWidth(viewHandler, view); return true;
+						case nameof(IView.IsEnabled): MapIsEnabled(viewHandler, view); return true;
+						case nameof(IView.Opacity): MapOpacity(viewHandler, view); return true;
+						case nameof(IView.Semantics): MapSemantics(viewHandler, view); return true;
+						case nameof(IView.TranslationX): MapTranslationX(viewHandler, view); return true;
+						case nameof(IView.TranslationY): MapTranslationY(viewHandler, view); return true;
+						case nameof(IView.Scale): MapScale(viewHandler, view); return true;
+						case nameof(IView.ScaleX): MapScaleX(viewHandler, view); return true;
+						case nameof(IView.ScaleY): MapScaleY(viewHandler, view); return true;
+						case nameof(IView.Rotation): MapRotation(viewHandler, view); return true;
+						case nameof(IView.RotationX): MapRotationX(viewHandler, view); return true;
+						case nameof(IView.RotationY): MapRotationY(viewHandler, view); return true;
+						case nameof(IView.AnchorX): MapAnchorX(viewHandler, view); return true;
+						case nameof(IView.AnchorY): MapAnchorY(viewHandler, view); return true;
+		#pragma warning disable CS0618 // Type or member is obsolete
+						case nameof(IBorder.Border): MapBorderView(viewHandler, view); return true;
+		#pragma warning restore CS0618 // Type or member is obsolete
+		#if ANDROID || WINDOWS || TIZEN
+						case nameof(IToolbarElement.Toolbar): MapToolbar(viewHandler, view); return true;
+		#endif
+						case nameof(IView.InputTransparent): MapInputTransparent(viewHandler, view); return true;
+						case nameof(IToolTipElement.ToolTip): MapToolTip(viewHandler, view); return true;
+		#if WINDOWS || MACCATALYST
+						case nameof(IContextFlyoutElement.ContextFlyout): MapContextFlyout(viewHandler, view); return true;
+		#endif
+						default: break;
+					}
 				}
+
+				if (Base is ICanUpdate can)
+				{
+					return can.TryUpdateProperty(elementHandler, virtualView, property);
+				}
+
+				if (Base.GetProperty(property) is {} prop)
+				{
+					prop.Invoke(elementHandler, virtualView);
+					return true;
+				}
+
+				return false;
 			}
 		}
 
@@ -184,8 +243,8 @@ namespace Microsoft.Maui.Handlers
 		/// A dictionary that maps the virtual view properties to their platform view counterparts.
 		/// </summary>
 		public static IPropertyMapper<IView, IViewHandler> ViewMapper = 
-			// new ViewHandlerPropertyMapper();
-//*
+			new ViewHandlerPropertyMapper();
+/*
 #if ANDROID
 			// Use a custom mapper for Android which knows how to batch the initial property sets
 			new AndroidBatchPropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

What if we did not implement core handler mappers using a big dictionary? We know exactly what there will be at build time.

This has overhead:
* dictionary creation at runtime
* dictionary lookups
* delegate overheads

This PR attempts to investigate a possiblity using a giant switch statement.

Benchmarks on:

```
BenchmarkDotNet v0.13.10, macOS Sonoma 14.7.3 (23H417) [Darwin 23.6.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
```

#### BEFORE

With #28077, @albyrock87 made things are really fast:

```md
| Method                    | Mean     | Error    | StdDev   | Gen0      | Allocated  |
|-------------------------- |---------:|---------:|---------:|----------:|-----------:|
| BenchmarkUpdateProperties | 61.61 ms | 0.224 ms | 0.187 ms | 4000.0000 | 25604194 B |
| BenchmarkUpdateProperty   | 18.14 ms | 0.044 ms | 0.037 ms |         - |       23 B |

// * Hints *
Outliers
  PropertyMapperBenchmarker.BenchmarkUpdateProperties: Default -> 2 outliers were removed (62.71 ms, 63.42 ms)
  PropertyMapperBenchmarker.BenchmarkUpdateProperty: Default   -> 2 outliers were removed (18.31 ms, 18.37 ms)
```

#### AFTER

However, that PR was too good and cached all the things. However, it cached the delegates which we don't even have. So I had to revert that and add a TryUpdateProperty instead. This meant that after the revert with the base code:

```md
| Method                    | Mean      | Error    | StdDev   | Gen0      | Allocated  |
|-------------------------- |----------:|---------:|---------:|----------:|-----------:|
| BenchmarkUpdateProperties | 224.61 ms | 0.652 ms | 0.578 ms | 4666.6667 | 29604549 B |
| BenchmarkUpdateProperty   |  45.93 ms | 0.144 ms | 0.135 ms |         - |       67 B |

// * Hints *
Outliers
  PropertyMapperBenchmarker.BenchmarkUpdateProperties: Default -> 1 outlier  was  removed, 2 outliers were detected (223.49 ms, 226.00 ms)
```

Terrible, but if I then switch to the new mapper (assuming I did it right):

```md
| Method                    | Mean      | Error    | StdDev   | Gen0      | Allocated  |
|-------------------------- |----------:|---------:|---------:|----------:|-----------:|
| BenchmarkUpdateProperties | 156.64 ms | 0.778 ms | 0.728 ms | 4500.0000 | 29604434 B |
| BenchmarkUpdateProperty   |  28.28 ms | 0.102 ms | 0.090 ms |         - |       23 B |

// * Hints *
Outliers
  PropertyMapperBenchmarker.BenchmarkUpdateProperty: Default -> 1 outlier  was  removed (28.80 ms)

```

This means that there is a large improvement just by reducing the lookups. If we were to replace all our implementations with a giant switch statement, we could see a large improvement in performance overall.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
