### PR TITLE
[Windows] Upgrade Windows App SDK from 1.6.5 to 1.6.6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.6.250205002</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.6.250228001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.2792.45</MicrosoftWindowsWebView2PackageVersion>


### PR DESCRIPTION
### Description of Change

This PR upgrades Windows App SDK from [1.6.5](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/stable-channel#version-165-16250205002) to [1.6.6](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/stable-channel#version-166-16250228001).