### PR TITLE
[Windows] WebView Navigated event is still called even after cancelling the Navigation.

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28303.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28303.cs
@@ -1,0 +1,46 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28303, "[Windows] WebView Navigated event called after cancelling it", PlatformAffected.UWP)]
+public partial class Issue28303 : ContentPage
+{
+	public Issue28303()
+	{
+		var verticalStackLayout = new VerticalStackLayout();
+		verticalStackLayout.Spacing = 20;
+		var webView = new WebView()
+		{
+			HeightRequest = 300,
+			AutomationId = "webView",
+			Source = "https://learn.microsoft.com/dotnet/maui"
+		};
+
+		var label1 = new Label
+		{
+			Text = "WebView Navigating event is not triggered",
+			AutomationId = "navigatingLabel"
+		};
+
+		var label = new Label
+		{
+			Text = "WebView Navigated event is not triggered",
+			AutomationId = "navigatedLabel"
+		};
+
+		webView.Navigating += (s, e) =>
+		{
+			label1.Text = "Navigating event is triggered";
+			e.Cancel = true;
+		};
+
+		webView.Navigated += (s, e) =>
+		{
+			label.Text = "Navigated event is triggered";
+		};
+
+		verticalStackLayout.Add(label1);
+		verticalStackLayout.Add(label);
+		verticalStackLayout.Add(webView);
+
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28303.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28303.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 28303, "[Windows] WebView Navigated event called after cancelling it", PlatformAffected.UWP)]
+[Issue(IssueTracker.Github, 28303, "[Windows] WebView Navigated event called after cancelling it", PlatformAffected.UWP, isInternetRequired: true)]
 public partial class Issue28303 : ContentPage
 {
 	public Issue28303()
@@ -10,6 +10,7 @@ public partial class Issue28303 : ContentPage
 		var webView = new WebView()
 		{
 			HeightRequest = 300,
+			WidthRequest = 400,
 			AutomationId = "webView",
 			Source = "https://learn.microsoft.com/dotnet/maui"
 		};

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28303.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28303.cs
@@ -16,9 +16,7 @@ public class Issue28303 : _IssuesUITest
 	public void VerifyWebViewNavigatedEventTriggered()
 	{
 		VerifyInternetConnectivity();
-		var navigatingLabel = App.WaitForElement("navigatingLabel");
 		var navigatedLabel = App.WaitForElement("navigatedLabel");
-
 		Assert.That(navigatedLabel.GetText(), Is.EqualTo("WebView Navigated event is not triggered"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28303.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28303.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue28303 : _IssuesUITest
+{
+	public override string Issue => "[Windows] WebView Navigated event called after cancelling it";
+
+	public Issue28303(TestDevice device)
+	: base(device)
+	{ }
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void VerifyWebViewNavigatedEventTriggered()
+	{
+		VerifyInternetConnectivity();
+		var navigatingLabel = App.WaitForElement("navigatingLabel");
+		var navigatedLabel = App.WaitForElement("navigatedLabel");
+
+		Assert.That(navigatedLabel.GetText(), Is.EqualTo("WebView Navigated event is not triggered"));
+	}
+}

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			_proxy.Connect(this, platformView);
 			base.ConnectHandler(platformView);
+			_navigationResult = WebNavigationResult.Success;
 
 			if (platformView.IsLoaded)
 				OnLoaded();
@@ -44,7 +45,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			var window = MauiContext!.GetPlatformWindow();
 			_proxy.Connect(window);
-			_navigationResult = WebNavigationResult.Success;
 		}
 
 		void Disconnect(WebView2 platformView)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Maui.Handlers
 
 			void OnNavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
 			{
-				if (Handler is WebViewHandler handler && handler._navigationResult != WebNavigationResult.Cancel)
+				if (Handler is WebViewHandler handler && handler._navigationResult is not WebNavigationResult.Cancel)
 				{
 					if (args.IsSuccess)
 						handler.NavigationSucceeded(sender, args);

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class WebViewHandler : ViewHandler<IWebView, WebView2>
 	{
+		WebNavigationResult _navigationResult;
 		WebNavigationEvent _eventState;
 		readonly WebView2Proxy _proxy = new();
 		readonly HashSet<string> _loadedCookies = new();
 
 		protected override WebView2 CreatePlatformView() => new MauiWebView(this);
-		WebNavigationResult _navigationResult;
 
 		internal WebNavigationEvent CurrentNavigationEvent
 		{

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Handlers
 		readonly HashSet<string> _loadedCookies = new();
 
 		protected override WebView2 CreatePlatformView() => new MauiWebView(this);
+		WebNavigationResult _navigationResult;
 
 		internal WebNavigationEvent CurrentNavigationEvent
 		{
@@ -43,6 +44,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			var window = MauiContext!.GetPlatformWindow();
 			_proxy.Connect(window);
+			_navigationResult = WebNavigationResult.Success;
 		}
 
 		void Disconnect(WebView2 platformView)
@@ -71,7 +73,14 @@ namespace Microsoft.Maui.Handlers
 
 				// Reset in this case because this is the last event we will get
 				if (cancel)
+				{
 					_eventState = WebNavigationEvent.NewPage;
+					_navigationResult = WebNavigationResult.Cancel;
+				}
+				else
+				{
+					_navigationResult = WebNavigationResult.Success;
+				}
 			}
 		}
 
@@ -388,7 +397,7 @@ namespace Microsoft.Maui.Handlers
 
 			void OnNavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
 			{
-				if (Handler is WebViewHandler handler)
+				if (Handler is WebViewHandler handler && handler._navigationResult != WebNavigationResult.Cancel)
 				{
 					if (args.IsSuccess)
 						handler.NavigationSucceeded(sender, args);


### PR DESCRIPTION
### Root Cause of the issue 

- On Windows platforms, the Navigated event is not being restricted like on other platforms. Since the NavigationCompleted event is still triggered from the platform's view, it is considered a failed event based on the IsSuccess boolean property, causing the Navigated event to be called with failure event details.
 
### Description of Change

- The issue has been addressed by restricting the Navigated event using the WebNavigationResult enum. The event is now triggered only when it is not in a Cancel state. This change resolves the issue and ensures consistency with how other platforms behave.

### Issues Fixed

Fixes #28303

### Tested the behaviour in the following platforms

- [x] iOS
- [x] Android
- [x] Windows
- [x] Mac

### Screenshot

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video  src="https://github.com/user-attachments/assets/51d71f85-ec04-4acd-9b9d-e0ba0ccbed6a"> | <video  src="https://github.com/user-attachments/assets/a9c209cb-d51b-41e5-b4f3-e5a356ce0553"> |


