### PR TITLE
[Android][iOS] WebView Navigated event not triggered when using HtmlWebViewSource

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23502.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23502.cs
@@ -1,0 +1,49 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 23502, "WebView Navigated event is not triggered", PlatformAffected.Android)]
+public partial class Issue23502 : ContentPage
+{
+	public Issue23502()
+	{
+
+		var verticalStackLayout = new VerticalStackLayout();
+		verticalStackLayout.Spacing = 20;
+		var webview = new WebView()
+		{
+			HeightRequest = 300,
+			AutomationId = "webView",
+			Source = new HtmlWebViewSource
+			{
+				Html = @"<HTML><BODY><H1>.NET MAUI</H1><P>Welcome to WebView.</P></BODY></HTML>"
+			},
+		};
+
+		var label1 = new Label
+		{
+			Text = "WebView Navigating event is not triggered",
+			AutomationId = "navigatingLabel"
+		};
+
+		var label = new Label
+		{
+			Text = "WebView Navigated event is not triggered",
+			AutomationId = "navigatedLabel"
+		};
+
+		webview.Navigating += (s, e) =>
+		{
+			label1.Text = "Navigating event is triggered";
+		};
+
+		webview.Navigated += (s, e) =>
+		{
+			label.Text = "Navigated event is triggered";
+		};
+
+		verticalStackLayout.Add(label1);
+		verticalStackLayout.Add(label);
+		verticalStackLayout.Add(webview);
+
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23502.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23502.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 23502, "WebView Navigated event is not triggered", PlatformAffected.Android)]
+[Issue(IssueTracker.Github, 23502, "WebView Navigated event is not triggered", PlatformAffected.Android, isInternetRequired: true)]
 public partial class Issue23502 : ContentPage
 {
 	public Issue23502()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23502.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23502.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue23502 : _IssuesUITest
+	{
+		public override string Issue => "WebView Navigated event is not triggered";
+
+		public Issue23502(TestDevice device)
+		: base(device)
+		{ }
+
+		[Test]
+		[Category(UITestCategories.WebView)]
+		public void VerifyWebViewNavigatedEvent()
+		{
+			VerifyInternetConnectivity();
+			var navigatingLabel = App.WaitForElement("navigatingLabel");
+			var navigatedLabel = App.WaitForElement("navigatedLabel");
+
+			Assert.That(navigatingLabel.GetText(), Is.EqualTo("Navigating event is triggered"));
+			Assert.That(navigatedLabel.GetText(), Is.EqualTo("Navigated event is triggered"));
+		}
+	}
+}

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -146,9 +146,6 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || string.IsNullOrWhiteSpace(url))
 				return true;
 
-			if (url == AssetBaseUrl)
-				return false;
-
 			SyncPlatformCookies(url);
 			bool cancel = VirtualView.Navigating(CurrentNavigationEvent, url);
 

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Platform
 
 		public override void OnPageStarted(WebView? view, string? url, Bitmap? favicon)
 		{
-			if (!_handler.TryGetTarget(out var handler) || handler.VirtualView == null || url == WebViewHandler.AssetBaseUrl)
+			if (!_handler.TryGetTarget(out var handler) || handler.VirtualView == null)
 				return;
 
 			if (!string.IsNullOrWhiteSpace(url))
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Platform
 
 		public override void OnPageFinished(WebView? view, string? url)
 		{
-			if (!_handler.TryGetTarget(out var handler) || handler.VirtualView == null || string.IsNullOrWhiteSpace(url) || url == WebViewHandler.AssetBaseUrl)
+			if (!_handler.TryGetTarget(out var handler) || handler.VirtualView == null || string.IsNullOrWhiteSpace(url))
 				return;
 
 			bool navigate = _navigationResult != WebNavigationResult.Failure || !GetValidUrl(url).Equals(_lastUrlNavigatedCancel, StringComparison.OrdinalIgnoreCase);

--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -43,9 +43,6 @@ namespace Microsoft.Maui.Platform
 
 			var url = GetCurrentUrl();
 
-			if (url == $"file://{NSBundle.MainBundle.BundlePath}/")
-				return;
-
 			virtualView.Navigated(_lastEvent, url, WebNavigationResult.Success);
 
 			// ProcessNavigatedAsync calls UpdateCanGoBackForward


### PR DESCRIPTION
### Root Cause of the issue 

- On Android and iOS, the Navigated event is not triggered when using HtmlWebViewSource without a BaseUrl. This occurs because when BaseUrl is null, a default value is assigned ([AssetBaseUrl](https://github.com/dotnet/maui/blob/85d53f6a8ba500d7a8b5552076cf58fd12cfa2f0/src/Core/src/Platform/Android/MauiWebView.cs#L23) for Android and [NSBundle.MainBundle.BundlePath](https://github.com/dotnet/maui/blob/85d53f6a8ba500d7a8b5552076cf58fd12cfa2f0/src/Core/src/Platform/iOS/MauiWKWebView.cs#L101) for iOS). In the Navigated event, execution exits early when these default values are used, preventing the event from being triggered.
 
### Description of Change

- I have removed these conditions on both Android and iOS to fix the issue. This check seems unnecessary because the default value is explicitly set while loading the HTML when BaseUrl is null, so there is no need to restrict it in the Navigated event. Additionally, on iOS, the Navigating event was called without any such condition restriction.

### Issues Fixed

Fixes #23502
Fixed #21800

### Tested the behaviour in the following platforms

- [x] iOS
- [x] Android
- [x] Windows
- [x] Mac

### Screenshot

| Platform | Before Issue Fix | After Issue Fix |
|---------|----------|----------|
| **Android** | <video  src="https://github.com/user-attachments/assets/d1a549c0-4fc7-4039-b393-344c630dc030"> | <video  src="https://github.com/user-attachments/assets/2aec1ce1-22fc-4f4a-bcc1-8a83ae741713"> |
| **iOS** | <video  src="https://github.com/user-attachments/assets/0e4d0fb9-454c-4686-87dc-c5d74cc6490f"> | <video  src="https://github.com/user-attachments/assets/bc6b14e3-d951-4dcd-884e-94e298b92a65"> |














