### PR TITLE
[net10.0] Trimmable view handlers

### DIFF
--- a/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
@@ -4,11 +4,13 @@ using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
 {
-	public partial class CheckBox : IRemappable
+	public partial class CheckBox
 	{
-		void IRemappable.RemapForControls()
+		static CheckBox() => RemapForControls();
+
+		private new static void RemapForControls()
 		{
-			RemappingHelper.RemapIfNeeded(typeof(VisualElement), VisualElement.RemapIfNeeded);
+			VisualElement.RemapForControls();
 
 			CheckBoxHandler.Mapper.ReplaceMapping<ICheckBox, ICheckBoxHandler>(nameof(Color), MapColor);
 		}

--- a/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Text;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 
@@ -15,7 +18,7 @@ namespace Microsoft.Maui.Controls
 			CheckBoxHandler.Mapper.ReplaceMapping<ICheckBox, ICheckBoxHandler>(nameof(Color), MapColor);
 		}
 
-		internal static void MapColor(ICheckBoxHandler? handler, ICheckBox view)
+		internal static void MapColor(ICheckBoxHandler handler, ICheckBox view)
 		{
 			handler?.UpdateValue(nameof(ICheckBox.Foreground));
 		}

--- a/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
@@ -1,20 +1,19 @@
-﻿#nullable disable
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
 {
-	public partial class CheckBox
+	public partial class CheckBox : IRemappable
 	{
-		internal new static void RemapForControls()
+		void IRemappable.RemapForControls()
 		{
+			RemappingHelper.RemapIfNeeded(typeof(VisualElement), VisualElement.RemapIfNeeded);
+
 			CheckBoxHandler.Mapper.ReplaceMapping<ICheckBox, ICheckBoxHandler>(nameof(Color), MapColor);
 		}
 
-		internal static void MapColor(ICheckBoxHandler handler, ICheckBox view)
+		internal static void MapColor(ICheckBoxHandler? handler, ICheckBox view)
 		{
 			handler?.UpdateValue(nameof(ICheckBox.Foreground));
 		}

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="Type[@FullName='Microsoft.Maui.Controls.CheckBox']/Docs/*" />
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+	[ElementHandler<CheckBoxHandler>]
 	public partial class CheckBox : View, IElementConfiguration<CheckBox>, IBorderElement, IColorElement, ICheckBox
 	{
 		readonly Lazy<PlatformConfigurationRegistry<CheckBox>> _platformConfigurationRegistry;

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -117,5 +117,16 @@ namespace Microsoft.Maui.Controls
 		{
 			return $"{base.GetDebuggerDisplay()}, IsChecked = {IsChecked}";
 		}
+
+		internal override bool TrySetValue(string text)
+		{
+			if (bool.TryParse(text, out bool result))
+			{
+				IsChecked = result;
+				return true;
+			}
+
+			return false;
+		}
 	}
 }

--- a/src/Controls/src/Core/Element/Element.Mapper.cs
+++ b/src/Controls/src/Core/Element/Element.Mapper.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Element
 	{
+		internal static void RemapIfNeeded()
+		{
+			RemappingHelper.RemapIfNeeded(typeof(Element), RemapForControls);
+		}
+
 		internal static void RemapForControls()
 		{
 			ViewHandler.ViewMapper.ReplaceMapping<Maui.IElement, IElementHandler>(AutomationProperties.IsInAccessibleTreeProperty.PropertyName, MapAutomationPropertiesIsInAccessibleTree);

--- a/src/Controls/src/Core/Element/Element.Mapper.cs
+++ b/src/Controls/src/Core/Element/Element.Mapper.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Element
 	{
+		static Element() => RemapIfNeeded();
+
 		internal static void RemapIfNeeded()
 		{
 			RemappingHelper.RemapIfNeeded(typeof(Element), RemapForControls);

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -1072,6 +1072,47 @@ namespace Microsoft.Maui.Controls
 			set => HandlerProperties.SetDisconnectPolicy(this, value);
 		}
 
+		internal virtual bool TrySetValue(string text)
+		{
+			if (this is Label label)
+			{
+				label.Text = text;
+				return true;
+			}
+			else if (this is Entry entry)
+			{
+				entry.Text = text;
+				return true;
+			}
+			else if (this is Editor editor)
+			{
+				editor.Text = text;
+				return true;
+			}
+			else if (this is Switch sw && bool.TryParse(text, out bool swResult))
+			{
+				sw.IsToggled = swResult;
+				return true;
+			}
+			else if (this is RadioButton rb && bool.TryParse(text, out bool rbResult))
+			{
+				rb.IsChecked = rbResult;
+				return true;
+			}
+			else if (this is TimePicker tp && TimeSpan.TryParse(text, out TimeSpan tpResult))
+			{
+				tp.Time = tpResult;
+				return true;
+			}
+			else if (this is DatePicker dp && DateTime.TryParse(text, out DateTime dpResult))
+			{
+				dp.Date = dpResult;
+				return true;
+			}
+
+			return false;
+		}
+
 		class TemporaryWrapper : IList<Element>
 		{
 			IReadOnlyList<Element> _inner;

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -73,13 +73,11 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
 		handlersCollection.AddHandler<BoxView, BoxViewHandler>();
 		handlersCollection.AddHandler<Button, ButtonHandler>();
-		handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
 		handlersCollection.AddHandler<DatePicker, DatePickerHandler>();
 		handlersCollection.AddHandler<Editor, EditorHandler>();
 		handlersCollection.AddHandler<Entry, EntryHandler>();
 		handlersCollection.AddHandler<GraphicsView, GraphicsViewHandler>();
 		handlersCollection.AddHandler<Image, ImageHandler>();
-		handlersCollection.AddHandler<Label, LabelHandler>();
 		handlersCollection.AddHandler<Layout, LayoutHandler>();
 		handlersCollection.AddHandler<Picker, PickerHandler>();
 		handlersCollection.AddHandler<ProgressBar, ProgressBarHandler>();
@@ -263,12 +261,10 @@ public static partial class AppHostBuilderExtensions
 	internal static MauiAppBuilder RemapForControls(this MauiAppBuilder builder)
 	{
 		// Update the mappings for IView/View to work specifically for Controls
-		Element.RemapForControls();
+		Element.RemapIfNeeded();
 		Application.RemapForControls();
-		VisualElement.RemapForControls();
-		Label.RemapForControls();
+		VisualElement.RemapIfNeeded();
 		Button.RemapForControls();
-		CheckBox.RemapForControls();
 		DatePicker.RemapForControls();
 		RadioButton.RemapForControls();
 		FlyoutPage.RemapForControls();

--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -7,10 +7,12 @@ using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.Label']/Docs/*" />
-	public partial class Label
+	public partial class Label : IRemappable
 	{
-		internal static new void RemapForControls()
+		void IRemappable.RemapForControls()
 		{
+			RemappingHelper.RemapIfNeeded(typeof(VisualElement), VisualElement.RemapIfNeeded);
+
 			// Adjust the mappings to preserve Controls.Label legacy behaviors
 			// ILabel does not include the TextType property, so we map it here to handle HTML text
 			// And we map some of the other property handlers to Controls-specific versions that avoid stepping on HTML text settings

--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -7,11 +7,13 @@ using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.Label']/Docs/*" />
-	public partial class Label : IRemappable
+	public partial class Label
 	{
-		void IRemappable.RemapForControls()
+		static Label() => RemapForControls();
+
+		private new static void RemapForControls()
 		{
-			RemappingHelper.RemapIfNeeded(typeof(VisualElement), VisualElement.RemapIfNeeded);
+			VisualElement.RemapIfNeeded();
 
 			// Adjust the mappings to preserve Controls.Label legacy behaviors
 			// ILabel does not include the TextType property, so we map it here to handle HTML text

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.Label']/Docs/*" />
 	[ContentProperty(nameof(Text))]
 	[DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+	[ElementHandler<LabelHandler>]
 	public partial class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>, IDecorableTextElement, IPaddingElement, ILabel
 	{
 		/// <summary>Bindable property for <see cref="HorizontalTextAlignment"/>.</summary>

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls.Platform
 		// For now I just built this ugly matching statement
 		// to replicate our handlers where we are setting this to true
 		public bool PreventGestureBubbling =>
-			(Element.Handler as ViewHandler)?.PreventGestureBubbling ?? false;
+			(Element?.Handler as ViewHandler)?.PreventGestureBubbling ?? false;
 
 		public FrameworkElement? Control
 		{

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -88,25 +88,8 @@ namespace Microsoft.Maui.Controls.Platform
 		// Do we need to provide a hook for this in the handlers?
 		// For now I just built this ugly matching statement
 		// to replicate our handlers where we are setting this to true
-		public bool PreventGestureBubbling
-		{
-			get
-			{
-				return Element switch
-				{
-					Button => true,
-					CheckBox => true,
-					DatePicker => true,
-					Stepper => true,
-					Slider => true,
-					Switch => true,
-					TimePicker => true,
-					ImageButton => true,
-					RadioButton => true,
-					_ => false,
-				};
-			}
-		}
+		public bool PreventGestureBubbling =>
+			(Element.Handler as ViewHandler)?.PreventGestureBubbling ?? false;
 
 		public FrameworkElement? Control
 		{

--- a/src/Controls/src/Core/ViewExtensions.cs
+++ b/src/Controls/src/Core/ViewExtensions.cs
@@ -509,52 +509,6 @@ namespace Microsoft.Maui.Controls
 			return text;
 		}
 
-		internal static bool TrySetValue(this Element element, string text)
-		{
-			if (element is Label label)
-			{
-				label.Text = text;
-				return true;
-			}
-			else if (element is Entry entry)
-			{
-				entry.Text = text;
-				return true;
-			}
-			else if (element is Editor editor)
-			{
-				editor.Text = text;
-				return true;
-			}
-			else if (element is CheckBox cb && bool.TryParse(text, out bool result))
-			{
-				cb.IsChecked = result;
-				return true;
-			}
-			else if (element is Switch sw && bool.TryParse(text, out bool swResult))
-			{
-				sw.IsToggled = swResult;
-				return true;
-			}
-			else if (element is RadioButton rb && bool.TryParse(text, out bool rbResult))
-			{
-				rb.IsChecked = rbResult;
-				return true;
-			}
-			else if (element is TimePicker tp && TimeSpan.TryParse(text, out TimeSpan tpResult))
-			{
-				tp.Time = tpResult;
-				return true;
-			}
-			else if (element is DatePicker dp && DateTime.TryParse(text, out DateTime dpResult))
-			{
-				dp.Date = dpResult;
-				return true;
-			}
-
-			return false;
-		}
-
 		static internal bool RequestFocus(this VisualElement view)
 		{
 			// if there is an attached handler, we use that and we will end up in the MapFocus method below

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -8,6 +8,12 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.VisualElement']/Docs/*" />
 	public partial class VisualElement
 	{
+		internal static new void RemapIfNeeded()
+		{
+			Element.RemapIfNeeded();
+			RemappingHelper.RemapIfNeeded(typeof(VisualElement), RemapForControls);
+		}
+
 		internal static new void RemapForControls()
 		{
 			RemapForControls(ViewHandler.ViewMapper, ViewHandler.ViewCommandMapper);

--- a/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Mapper.cs
@@ -8,9 +8,10 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.VisualElement']/Docs/*" />
 	public partial class VisualElement
 	{
+		static VisualElement() => RemapIfNeeded();
+
 		internal static new void RemapIfNeeded()
 		{
-			Element.RemapIfNeeded();
 			RemappingHelper.RemapIfNeeded(typeof(VisualElement), RemapForControls);
 		}
 
@@ -23,6 +24,8 @@ namespace Microsoft.Maui.Controls
 			IPropertyMapper<IView, IViewHandler> viewMapper,
 			CommandMapper<IView, IViewHandler> commandMapper)
 		{
+			Element.RemapIfNeeded();
+
 #if WINDOWS
 			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyHorizontalOffsetProperty.PropertyName, MapAccessKeyHorizontalOffset);
 			viewMapper.ReplaceMapping<IView, IViewHandler>(PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyPlacementProperty.PropertyName, MapAccessKeyPlacement);

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Windows.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Windows.cs
@@ -76,5 +76,7 @@ namespace Microsoft.Maui.Handlers
 			if (sender is CheckBox platformView && VirtualView != null)
 				VirtualView.IsChecked = platformView.IsChecked == true;
 		}
+
+		internal override bool PreventGestureBubbling => true;
 	}
 }

--- a/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Handlers;
 
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 internal abstract class ElementHandlerAttribute : Attribute
 {
 	public abstract IElementHandler CreateHandler();

--- a/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
@@ -11,12 +11,6 @@ internal abstract class ElementHandlerAttribute : Attribute
 internal sealed class ElementHandlerAttribute<THandler> : ElementHandlerAttribute
 	where THandler : IElementHandler, new()
 {
-	public override IElementHandler CreateHandler()
-	{
-		var handler = new THandler();
-		RemappingHelper.RemapIfNeeded(typeof(THandler), handler);
-		return handler;
-	}
-	
+	public override IElementHandler CreateHandler() => new THandler();
 	public override Type HandlerType => typeof(THandler);
 }

--- a/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Handlers;
 
-[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
 internal abstract class ElementHandlerAttribute : Attribute
 {
 	public abstract IElementHandler CreateHandler();

--- a/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Microsoft.Maui.Handlers;
+
+internal abstract class ElementHandlerAttribute : Attribute
+{
+	public abstract IElementHandler CreateHandler();
+	public abstract Type HandlerType { get; }
+}
+
+internal sealed class ElementHandlerAttribute<THandler> : ElementHandlerAttribute
+	where THandler : IElementHandler, new()
+{
+	public override IElementHandler CreateHandler()
+	{
+		var handler = new THandler();
+		return handler;
+	}
+	
+	public override Type HandlerType => typeof(THandler);
+}

--- a/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerAttribute.cs
@@ -14,6 +14,7 @@ internal sealed class ElementHandlerAttribute<THandler> : ElementHandlerAttribut
 	public override IElementHandler CreateHandler()
 	{
 		var handler = new THandler();
+		RemappingHelper.RemapIfNeeded(typeof(THandler), handler);
 		return handler;
 	}
 	

--- a/src/Core/src/Handlers/Element/IRemappable.cs
+++ b/src/Core/src/Handlers/Element/IRemappable.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Maui.Handlers;
+
+internal interface IRemappable
+{
+	void RemapForControls();
+}

--- a/src/Core/src/Handlers/Element/IRemappable.cs
+++ b/src/Core/src/Handlers/Element/IRemappable.cs
@@ -1,6 +1,0 @@
-namespace Microsoft.Maui.Handlers;
-
-internal interface IRemappable
-{
-	void RemapForControls();
-}

--- a/src/Core/src/Handlers/Element/RemappingHelper.cs
+++ b/src/Core/src/Handlers/Element/RemappingHelper.cs
@@ -13,27 +13,15 @@ internal static class RemappingHelper
 	private static readonly HashSet<Type> s_remappedTypes = new();
 	private static readonly Lock s_lock = new();
 
-	public static void RemapIfNeeded(Type handlerType, IElementHandler handler)
-	{
-		if (ShouldRemap(handlerType))
-		{
-			(handler as IRemappable)?.RemapForControls();
-		}
-	}
-
 	public static void RemapIfNeeded(Type handlerType, Action remapForControls)
-	{
-		if (ShouldRemap(handlerType))
-		{
-			remapForControls();
-		}
-	}
-
-	private static bool ShouldRemap(Type handlerType)
 	{
 		lock (s_lock)
 		{
-			return s_remappedTypes.Add(handlerType);
+			if (s_remappedTypes.Add(handlerType))
+			{
+				remapForControls();
+			}
 		}
 	}
+
 }

--- a/src/Core/src/Handlers/Element/RemappingHelper.cs
+++ b/src/Core/src/Handlers/Element/RemappingHelper.cs
@@ -23,5 +23,4 @@ internal static class RemappingHelper
 			}
 		}
 	}
-
 }

--- a/src/Core/src/Handlers/Element/RemappingHelper.cs
+++ b/src/Core/src/Handlers/Element/RemappingHelper.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+#if !NET9_0_OR_GREATER
+using Lock = object;
+#endif
+
+namespace Microsoft.Maui.Handlers;
+
+internal static class RemappingHelper
+{
+	private static readonly HashSet<Type> s_remappedTypes = new();
+	private static readonly Lock s_lock = new();
+
+	public static void RemapIfNeeded(Type handlerType, IElementHandler handler)
+	{
+		if (ShouldRemap(handlerType))
+		{
+			(handler as IRemappable)?.RemapForControls();
+		}
+	}
+
+	public static void RemapIfNeeded(Type handlerType, Action remapForControls)
+	{
+		if (ShouldRemap(handlerType))
+		{
+			remapForControls();
+		}
+	}
+
+	private static bool ShouldRemap(Type handlerType)
+	{
+		lock (s_lock)
+		{
+			return s_remappedTypes.Add(handlerType);
+		}
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -169,5 +169,19 @@ namespace Microsoft.Maui.Handlers
 				virtualView.IsFocused = isFocused;
 			}
 		}
+
+		internal virtual bool PreventGestureBubbling
+			=> this switch
+			{
+				ButtonHandler => true,
+				DatePickerHandler => true,
+				StepperHandler => true,
+				SliderHandler => true,
+				SwitchHandler => true,
+				TimePickerHandler => true,
+				ImageButtonHandler => true,
+				RadioButtonHandler => true,
+				_ => false,
+			};
 	}
 }

--- a/src/Core/src/Hosting/Internal/MauiHandlersFactory.cs
+++ b/src/Core/src/Hosting/Internal/MauiHandlersFactory.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Maui.Hosting.Internal
 	sealed class MauiHandlersFactory : MauiFactory, IMauiHandlersFactory
 	{
 		readonly ConcurrentDictionary<Type, Type?> _serviceCache = new();
-		readonly ConcurrentDictionary<Type, ElementHandlerAttribute?> _elementHandlerAttributeCache = new();
 
 		readonly RegisteredHandlerServiceTypeSet _registeredHandlerServiceTypeSet;
 
@@ -63,25 +62,9 @@ namespace Microsoft.Maui.Hosting.Internal
 				=> elementHandlerAttribute.HandlerType;
 		}
 
-		private bool TryGetElementHandlerAttribute(Type viewType, [NotNullWhen(returnValue: true)] out ElementHandlerAttribute? elementHandlerAttribute)
+		private static bool TryGetElementHandlerAttribute(Type viewType, [NotNullWhen(returnValue: true)] out ElementHandlerAttribute? elementHandlerAttribute)
 		{
-			elementHandlerAttribute = _elementHandlerAttributeCache.GetOrAdd(viewType, static (viewType) =>
-			{
-				Type? type = viewType;
-				while (type is not null)
-				{
-					var elementHandlerAttribute = type.GetCustomAttribute(typeof(ElementHandlerAttribute), inherit: false) as ElementHandlerAttribute;
-					if (elementHandlerAttribute is not null)
-					{
-						return elementHandlerAttribute;
-					}
-
-					type = type.BaseType;
-				}
-
-				return null;
-			});
-
+			elementHandlerAttribute = viewType.GetCustomAttribute<ElementHandlerAttribute>();
 			return elementHandlerAttribute is not null;
 		}
 

--- a/src/Core/src/Hosting/Internal/RegisteredHandlerServiceTypeSet.cs
+++ b/src/Core/src/Hosting/Internal/RegisteredHandlerServiceTypeSet.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Hosting.Internal
 			}
 		}
 
-		public Type ResolveVirtualViewToRegisteredHandlerServiceType(Type type)
+		public Type? ResolveVirtualViewToRegisteredHandlerServiceType(Type type)
 		{
 			Debug.Assert(typeof(IElement).IsAssignableFrom(type));
 
@@ -38,8 +38,7 @@ namespace Microsoft.Maui.Hosting.Internal
 			}
 
 			return ResolveVirtualViewFromTypeSet(type, _concreteHandlerServiceTypeSet)
-				?? ResolveVirtualViewFromTypeSet(type, _interfaceHandlerServiceTypeSet)
-				?? throw new HandlerNotFoundException($"Unable to find a {nameof(IElementHandler)} corresponding to {type}. Please register a handler for {type} using `Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler` or `Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler`");
+				?? ResolveVirtualViewFromTypeSet(type, _interfaceHandlerServiceTypeSet);
 		}
 
 		private static Type? ResolveVirtualViewFromTypeSet(Type type, HashSet<Type> set)

--- a/src/Core/tests/UnitTests/Hosting/RegisteredHandlerServiceTypeSetTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/RegisteredHandlerServiceTypeSetTests.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Maui.UnitTesting.Hosting
 		}
 
 		[Fact]
-		public void ThrowsWhenNoMatchingHandlerServiceTypeIsRegistered()
+		public void ReturnsNullWhenNoMatchingHandlerServiceTypeIsRegistered()
 		{
 			var registeredTypes = new RegisteredHandlerServiceTypeSet();
 
-			Assert.Throws<HandlerNotFoundException>(() => registeredTypes.ResolveVirtualViewToRegisteredHandlerServiceType(typeof(ViewStub)));
+			var type = registeredTypes.ResolveVirtualViewToRegisteredHandlerServiceType(typeof(ViewStub));
+
+			Assert.Null(type);
 		}
 
 		[Theory]
@@ -90,7 +92,9 @@ namespace Microsoft.Maui.UnitTesting.Hosting
 			registeredTypes.Add(typeof(MyBaseViewStub));
 			registeredTypes.Add(typeof(MyDerivedViewStub));
 
-			Assert.Throws<HandlerNotFoundException>(() => registeredTypes.ResolveVirtualViewToRegisteredHandlerServiceType(typeof(ViewStub)));
+			var resolvedServiceType = registeredTypes.ResolveVirtualViewToRegisteredHandlerServiceType(typeof(ViewStub));
+
+			Assert.Null(resolvedServiceType);
 		}
 
 		[Theory]


### PR DESCRIPTION
This PR supersedes #28115 

### Description of Change
This proof of concept explores how we could get rid of the long DI setup code in AppHostBuilderExtensions:
```c#
internal static IMauiHandlersCollection AddControlsHandlers(this IMauiHandlersCollection handlersCollection)
{
    handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
    handlersCollection.AddHandler<CarouselView, CarouselViewHandler>();
    handlersCollection.AddHandler<Application, ApplicationHandler>();
    handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
    handlersCollection.AddHandler<BoxView, BoxViewHandler>();
    // ...
```

Listing all the classes this way makes it impossible for the trimmer to remove any of them.

The idea in this PR is to connect the element and the element handler using an attribute instead of looking up the handler in the DI container:

```c#
[ElementHandler<LabelHandler>]
partial class Label
{
    static Label()
    {
        RemappingHelper.RemapIfNeeded(typeof(VisualElement), VisualElement.RemapIfNeeded);

        // ...
    }
}
```

_EDIT: The `IRemappable` interface used in earlier iteration has been removed._

if the control isn't used anywhere in the app, the trimmer will remove the element type. When the type is removed, the handler type is removed as well, because the only link to the handler type is the custom class attribute.

The DI mechanism is still checked first before looking for the attribute for two reasons:

1. Backwards compatibility: if the developer registers their own handlers in their app/library through DI today, it should continue working. They will need to make changes to their code to make their controls trimmable as well.
2. Overwriting the defaults: It should be possible to change the default handlers for built in controls. I'm not sure how useful this is, but we should keep that possibility around.

#### Notes:
- I'm sharing this Draft to get early feedback. I'm still not 100% sure this is the right way to do it. I'm especially not confident in the way RemapForControls would be handled.
- This PR shows what the changes would look like for two controls: Label and CheckBox. These two are chosen because Label is in the dotnet new maui app and so we can test that the handler for that control is created correctly, and CheckBox is NOT in the sample app, so we can verify that the trimmer removes this class + the CheckBoxHandler when trim mode is set to full.

Feedback is very welcome!

### Fixes
- #8593

/cc @jonathanpeppers @PureWeen @mattleibow @ivanpovazan