### PR TITLE
[nuget-msi-convert] Enable improved VS component IDs

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -4,7 +4,7 @@
     <TargetName>maui.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
     <EnableSideBySideManifests>true</EnableSideBySideManifests>
-    <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>
+    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>
   </PropertyGroup>
   <ItemGroup>
     <!-- Shorten package names to avoid long path caching issues in Visual Studio -->


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/a5b3f6847abbd6b557f3f2201e314c7ee6d312bb
Context: https://github.com/dotnet/maui/commit/ce01c154f737bfbbf09c4fce2044de246ba199a7
Context: https://github.com/dotnet/arcade/commit/b2d3a3a35526b529490e8f7e410b3777b3f20bd6
Context: https://github.com/xamarin/yaml-templates/commit/fbaa7e47097a3b320502310e81b4166ef057e3e3

The VS insertion manifest generation has been updated to use new VS
component IDs required for .NET 10+.