### PR TITLE
[ci] Remove macios workaround to build net9

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -79,8 +79,6 @@
     <ItemGroup>
       <_WorkloadSource Include="$(NugetArtifactsPath)" />
       <_LocalWorkloadIds Include="maui" />
-      <!-- NOTE: temporary for .NET 9 targeting https://github.com/xamarin/xamarin-macios/pull/21848/commits/cb1340221774ba9af226ac71a5aef551d765ee21 -->
-      <_LocalWorkloadIds Include="mobile-librarybuilder-net9" />
       <_LocalWorkloadIds Include="tizen" Condition=" '$(IncludeTizenTargetFrameworks)' == 'true' " />
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
@@ -168,8 +166,6 @@
     <_WorkloadIds Include="macos" />
     <_WorkloadIds Include="ios" />
     <_WorkloadIds Include="tvos" />
-    <!-- NOTE: temporary for .NET 9 targeting https://github.com/xamarin/xamarin-macios/pull/21848/commits/cb1340221774ba9af226ac71a5aef551d765ee21 -->
-    <_WorkloadIds Include="mobile-librarybuilder-net9" />
     <_WorkloadIds Include="tizen" Condition=" '$(IncludeTizenTargetFrameworks)' == 'true' " />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

Remove the workaround where we installed the net9 workloads to build iOS net9 apps. 