### PR TITLE
[Testing] Mark BindingUpdatesFromInteractiveRefresh as flaky

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -26,7 +26,7 @@ public class Issue16910 : _IssuesUITest
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");
 	}
-#if TEST_FAILS_ON_CATALYST || TEST_FAILS_ON_WINDOWS //Scroll actions cannot be performed on the macOS test server
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Failing on Mac and Windows. More information: https://github.com/dotnet/maui/issues/28368
 	[Test]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16910.cs
@@ -26,7 +26,7 @@ public class Issue16910 : _IssuesUITest
 		App.Tap("StopRefreshing");
 		App.WaitForElement("IsNotRefreshing");
 	}
-#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Failing on Mac and Windows. More information: https://github.com/dotnet/maui/issues/28368
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Failing on Mac and Windows. Flaky Test. More information: https://github.com/dotnet/maui/issues/28368
 	[Test]
 	public void BindingUpdatesFromInteractiveRefresh()
 	{


### PR DESCRIPTION
### Description of Change

Avoid to run the **BindingUpdatesFromInteractiveRefresh** test on CI. Requires changes to pass it always on CI.
