### PR TITLE
[iOS] Spinner of a RefreshView not visible when swapping content - Fix

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28343.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28343.cs
@@ -48,6 +48,18 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.ScrollUp("CollectionView", ScrollStrategy.Gesture, swipePercentage:0.99, swipeSpeed:2500);
 			App.WaitForElement("RefreshTriggered");
 		}
+
+#if IOS
+		[Test]
+		public void ProgressSpinnerIsVisibleWhenContentWasReset()
+		{
+			App.WaitForElement("SetToEnabled").Tap();
+			App.ScrollUp("CollectionView");
+			App.Tap("ResetContent");
+			App.ScrollUp("CollectionView");
+			VerifyScreenshot("Issue28343_ProgressSpinnerVisible");
+		}
+#endif
 	}
 }
 #endif

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -64,6 +64,11 @@ namespace Microsoft.Maui.Platform
 
 			_contentView?.RemoveFromSuperview();
 
+			if(_contentView is not null)
+			{
+				_refreshControl = new UIRefreshControl();
+			}
+
 			if (content is not null && mauiContext is not null)
 			{
 				_contentView = content.ToPlatform(mauiContext);


### PR DESCRIPTION
### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28374

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/3754ceae-d5e4-453f-81bc-33d6625842e5" width="300px"/>|<video src="https://github.com/user-attachments/assets/73db5585-6a0b-45c5-8a32-c5b02b75ba04" width="300px"/>|








