### PR TITLE
[Testing] Mark BlankScreenOnNavigationBack as flaky on Android

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28098.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28098.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_ANDROID // Flaky Test. More information: https://github.com/dotnet/maui/issues/28376
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -5,19 +6,20 @@ using UITest.Core;
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 public class Issue28098 : _IssuesUITest
 {
-    public override string Issue => "Returning back from navigation to MainPage would result in a blank screen";
-    public Issue28098(TestDevice device) : base(device)
-    {
-    }
+	public override string Issue => "Returning back from navigation to MainPage would result in a blank screen";
+	public Issue28098(TestDevice device) : base(device)
+	{
+	}
 
-    [Test]
-    [Category(UITestCategories.Picker)]
-    public void BlankScreenOnNavigationBack()
-    {
-        App.WaitForElement("Button");
-        App.Tap("Button");
-        App.WaitForElement("BackButton");
-        App.Tap("BackButton");
-        VerifyScreenshot();
-    }
+	[Test]
+	[Category(UITestCategories.Picker)]
+	public void BlankScreenOnNavigationBack()
+	{
+		App.WaitForElement("Button");
+		App.Tap("Button");
+		App.WaitForElement("BackButton");
+		App.Tap("BackButton");
+		VerifyScreenshot();
+	}
 }
+#endif


### PR DESCRIPTION
### Description of Change

Avoid to run **BlankScreenOnNavigationBack** test on Android, marked as flaky. Created an issue to re-enable it: https://github.com/dotnet/maui/issues/28376
