### PR TITLE
[net9.0] Test new runtime 9.0.4

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,6 +17,7 @@
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-pub-dotnet-runtime-f0d7e1f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-f0d7e1f5/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="local" value="LOCAL_PLACEHOLDER" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,9 +31,9 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100" Version="9.0.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100" Version="9.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>4c9d1b112c16716c2479e054e9ad4db8b5b8c70c</Sha>
+      <Sha>f0d7e1f58406583972ea640029d5a5a341a76731</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Authorization" Version="9.0.4">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>049799c39d766c58ef6388865d5f5ed273b6a75e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.1" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>c8acea22626efab11c13778c028975acdc34678f</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>f0d7e1f58406583972ea640029d5a5a341a76731</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.57">
       <Uri>https://github.com/dotnet/android</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,7 +31,7 @@
     <MicrosoftNETSdkPackageVersion>9.0.103-servicing.25065.25</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.1</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>9.0.4</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,7 +58,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100Version>9.0.1</MicrosoftNETWorkloadEmscriptenCurrentManifest90100Version>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest90100Version>9.0.4</MicrosoftNETWorkloadEmscriptenCurrentManifest90100Version>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100Version)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.6.250205002</MicrosoftWindowsAppSDKPackageVersion>


### PR DESCRIPTION
### Description of Change

Test some changes on runtime 9.0.4 related with AOT

```
➜  maui git:(net9.0) darc update-dependencies --id 260020
Looking up build with BAR id 260020
Updating 'Microsoft.NETCore.App.Ref': '9.0.1' => '9.0.4' (from build '20250312.17' of 'https://github.com/dotnet/runtime')
Checking for coherency updates...
Local dependencies updated based on build with BAR id 260020 (20250312.17 from https://github.com/dotnet/runtime@release/9.0)
```