### PR TITLE
Update MauiPreviousDotNetReleasedVersion to 9.0.50

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
-    <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.14</MicrosoftMauiPreviousDotNetReleasedVersion>
+    <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.50</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
     <MicrosoftNETSdkPackageVersion>10.0.100-preview.3.25162.35</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>


### PR DESCRIPTION
Changes: http://github.com/dotnet/maui/compare/85f2a06ecd11e4ba5a9e567d86f9d2fb49a2c5ca...9705d5c5bf0b75c77c46ecbf3c14af3bc2b4f2b3

Updates $(MicrosoftMauiPreviousDotNetReleasedVersion) to .NET 9 SR5.