### PR TITLE
[Accessibility] Add 'button' for TalkBalk on Android Tap Gesture Recognizers

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -11,8 +11,14 @@ namespace Microsoft.Maui.Controls.Platform
 			if (info == null)
 				return;
 
-			if (virtualView.TapGestureRecognizerNeedsDelegate())
+			if (virtualView.TapGestureRecognizerNeedsActionClick())
+			{
 				info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
+			}
+			if (virtualView.TapGestureRecognizerNeedsButtonAnnouncement())
+			{
+				info.ClassName = "android.widget.Button";
+			}
 		}
 
 		internal static void AddOrRemoveControlsAccessibilityDelegate(this View virtualView)

--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -13,10 +13,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (virtualView.TapGestureRecognizerNeedsActionClick())
 			{
+				// Add "double tap to activate" to the screen reader
 				info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
 			}
 			if (virtualView.TapGestureRecognizerNeedsButtonAnnouncement())
 			{
+				// Add "button" to the screen reader
 				info.ClassName = "android.widget.Button";
 			}
 		}

--- a/src/Controls/src/Core/Platform/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/SemanticExtensions.cs
@@ -6,6 +6,9 @@
 			=> virtualView.TapGestureRecognizerNeedsDelegate();
 
 		internal static bool TapGestureRecognizerNeedsDelegate(this View virtualView)
+			=> virtualView.TapGestureRecognizerNeedsButtonAnnouncement();
+
+		internal static bool TapGestureRecognizerNeedsActionClick(this View virtualView)
 		{
 			foreach (var gesture in virtualView.GestureRecognizers)
 			{
@@ -13,6 +16,18 @@
 				if (gesture is TapGestureRecognizer tgr && tgr.NumberOfTapsRequired == 1)
 				{
 					return (tgr.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary;
+				}
+			}
+			return false;
+		}
+
+		internal static bool TapGestureRecognizerNeedsButtonAnnouncement(this View virtualView)
+		{
+			foreach (var gesture in virtualView.GestureRecognizers)
+			{
+				if (gesture is TapGestureRecognizer)
+				{
+					return true;
 				}
 			}
 			return false;


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This PR allows android tap gestures to be announced as buttons by the screenreader similar to how iOS operates. This PR is related to https://github.com/dotnet/maui/pull/28388.

There was already logic to announce "double tap to activate" when a tap gesture required just one primary press. This PR keeps that logic but also adds the "button" to be announced for any tap gesture recognizer.

The Maui Controls Sample page for TapGestureRecognizers showcases this well: 

https://github.com/user-attachments/assets/3981f81e-c6e1-4240-b308-bfa0f789d81f



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Partially fixes: https://github.com/dotnet/maui/issues/26913 and https://github.com/dotnet/maui/issues/26895

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
