### PR TITLE
Fixed Stepper allows incrementing beyond the maximum value

### DIFF
--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="Minimum"/>.</summary>
 		public static readonly BindableProperty MinimumProperty = BindableProperty.Create(nameof(Minimum), typeof(double), typeof(Stepper), 0.0,
-			validateValue: (bindable, value) => (double)value < ((Stepper)bindable).Maximum,
+			validateValue: (bindable, value) => (double)value <= ((Stepper)bindable).Maximum,
 			coerceValue: (bindable, value) =>
 			{
 				var stepper = (Stepper)bindable;

--- a/src/Controls/src/Core/Stepper/Stepper.cs
+++ b/src/Controls/src/Core/Stepper/Stepper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	{
 		/// <summary>Bindable property for <see cref="Maximum"/>.</summary>
 		public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(Stepper), 100.0,
-			validateValue: (bindable, value) => (double)value > ((Stepper)bindable).Minimum,
+			validateValue: (bindable, value) => (double)value >= ((Stepper)bindable).Minimum,
 			coerceValue: (bindable, value) =>
 			{
 				var stepper = (Stepper)bindable;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28330.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28330.cs
@@ -6,9 +6,9 @@ public class Issue28330 : TestContentPage
     {
         var layout = new StackLayout { };
 
-        Stepper stepper = new Stepper
+        Stepper Incrementstepper = new Stepper
         {
-            AutomationId = "stepper",
+            AutomationId = "Incrementstepper",
             HorizontalOptions = LayoutOptions.Center,
             Increment = 1,
             Minimum = 1,
@@ -16,16 +16,36 @@ public class Issue28330 : TestContentPage
             Value = 1
         };
 
-        Label label = new Label
+        Label Incrementlabel = new Label
         {
-            AutomationId = "label",
+            AutomationId = "Incrementlabel",
             HorizontalOptions = LayoutOptions.Center,
             FontSize = 32
         };
-        label.SetBinding(Label.TextProperty, new Binding("Value", source: stepper));
+        Incrementlabel.SetBinding(Label.TextProperty, new Binding("Value", source: Incrementstepper));
 
-        layout.Children.Add(stepper);
-        layout.Children.Add(label);
+        Stepper Decrementstepper = new Stepper
+        {
+            AutomationId = "Decrementstepper",
+            HorizontalOptions = LayoutOptions.Center,
+            Increment = 1,
+            Maximum = 1,
+            Minimum = 1,
+            Value = 1
+        };
+
+        Label Decrementlabel = new Label
+        {
+            AutomationId = "Decrementlabel",
+            HorizontalOptions = LayoutOptions.Center,
+            FontSize = 32
+        };
+        Decrementlabel.SetBinding(Label.TextProperty, new Binding("Value", source: Decrementstepper));
+
+        layout.Children.Add(Incrementstepper);
+        layout.Children.Add(Incrementlabel);
+        layout.Children.Add(Decrementstepper);
+        layout.Children.Add(Decrementlabel);
 
         Content = layout;
     }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28330.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28330.cs
@@ -2,14 +2,11 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 28330, "Stepper allows to increment when value equals to maximum", PlatformAffected.All)]
 public class Issue28330 : TestContentPage
 {
-    private Stepper stepper;
-    private Label stepperValue;
-
     protected override void Init()
     {
         var layout = new StackLayout { };
 
-        stepper = new Stepper
+        Stepper stepper = new Stepper
         {
             AutomationId = "stepper",
             HorizontalOptions = LayoutOptions.Center,
@@ -19,16 +16,16 @@ public class Issue28330 : TestContentPage
             Value = 1
         };
 
-        stepperValue = new Label
+        Label label = new Label
         {
-            AutomationId = "stepperValue",
+            AutomationId = "label",
             HorizontalOptions = LayoutOptions.Center,
             FontSize = 32
         };
-        stepperValue.SetBinding(Label.TextProperty, new Binding("Value", source: stepper));
+        label.SetBinding(Label.TextProperty, new Binding("Value", source: stepper));
 
         layout.Children.Add(stepper);
-        layout.Children.Add(stepperValue);
+        layout.Children.Add(label);
 
         Content = layout;
     }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28330.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28330.cs
@@ -1,0 +1,35 @@
+namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 28330, "Stepper allows to increment when value equals to maximum", PlatformAffected.All)]
+public class Issue28330 : TestContentPage
+{
+    private Stepper stepper;
+    private Label stepperValue;
+
+    protected override void Init()
+    {
+        var layout = new StackLayout { };
+
+        stepper = new Stepper
+        {
+            AutomationId = "stepper",
+            HorizontalOptions = LayoutOptions.Center,
+            Increment = 1,
+            Minimum = 1,
+            Maximum = 1,
+            Value = 1
+        };
+
+        stepperValue = new Label
+        {
+            AutomationId = "stepperValue",
+            HorizontalOptions = LayoutOptions.Center,
+            FontSize = 32
+        };
+        stepperValue.SetBinding(Label.TextProperty, new Binding("Value", source: stepper));
+
+        layout.Children.Add(stepper);
+        layout.Children.Add(stepperValue);
+
+        Content = layout;
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28330.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28330.cs
@@ -15,8 +15,10 @@ public class Issue28330 : _IssuesUITest
     [Category(UITestCategories.Stepper)]
     public void Issue28330StepperIncrementShouldBeDisabled()
     {
-        App.WaitForElement("label");
-        App.IncreaseStepper("stepper");
-        Assert.That(App.FindElement("label").GetText(), Is.EqualTo("1"));
+        App.WaitForElement("Incrementlabel");
+        App.IncreaseStepper("Incrementstepper");
+        Assert.That(App.FindElement("Incrementlabel").GetText(), Is.EqualTo("1"));
+        App.DecreaseStepper("Decrementstepper");
+        Assert.That(App.FindElement("Decrementlabel").GetText(), Is.EqualTo("1"));
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28330.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28330.cs
@@ -15,8 +15,8 @@ public class Issue28330 : _IssuesUITest
     [Category(UITestCategories.Stepper)]
     public void Issue28330StepperIncrementShouldBeDisabled()
     {
-        App.WaitForElement("stepperValue");
+        App.WaitForElement("label");
         App.IncreaseStepper("stepper");
-        Assert.That(App.FindElement("stepperValue").GetText(), Is.EqualTo("1"));
+        Assert.That(App.FindElement("label").GetText(), Is.EqualTo("1"));
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28330.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28330.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue28330 : _IssuesUITest
+{
+    public Issue28330(TestDevice device) : base(device)
+    {
+    }
+
+    public override string Issue => "Stepper allows to increment when value equals to maximum";
+
+    [Test]
+    [Category(UITestCategories.Stepper)]
+    public void Issue28330StepperIncrementShouldBeDisabled()
+    {
+        App.WaitForElement("stepperValue");
+        App.IncreaseStepper("stepper");
+        Assert.That(App.FindElement("stepperValue").GetText(), Is.EqualTo("1"));
+    }
+}


### PR DESCRIPTION
### Root cause: 

- The maximum value of the stepper is set when the maximum value is greater than the minimum value. Since the minimum and maximum values are equal, the default value of 100 is applied, which results in the increment button being enabled.
- The minimum value of the stepper is set when the minimum value is lesser than the maximum value. Since the maximum and minimum values are equal, the default value of 0 is applied, which results in the decrement button being enabled.

### Description of Change:

- I have changed the maximum value to be set by checking that the maximum value is greater than or equal to the minimum value of the stepper. 
-  Similarly, for minimum value I have changed it by checking that the maximum value is lesser than or equal to the maximum value of the stepper. 
- I have checked the behavior in the native iOS UIStepper and observed that the increment and decrement buttons are disabled.

<img src="https://github.com/user-attachments/assets/c69083e6-f490-4a56-b22f-fad6c9a4a90c"> 

### Tested the behaviour in the following platforms
- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac
### Issue Fixed:
Fixes: #28330 
### Output
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/728cb0d7-b088-4953-9fa8-400e4449f69e"> | <video src="https://github.com/user-attachments/assets/d4bb6144-2e2d-4ec4-aa05-0ee84bebed94"> |