### PR TITLE
[Testing] Migration of Compatibility.Core platform-specific unit tests into device tests - 6

### DIFF
--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -219,6 +219,17 @@ namespace Microsoft.Maui.DeviceTests
 			return false;
 		}
 
+		protected void AssertTranslationMatches(Android.Views.View nativeView, double expectedTranslationX, double expectedTranslationY)
+		{
+			var context = nativeView?.Context ?? throw new InvalidOperationException("Context cannot be null.");
+			
+			var expectedXInPixels = context.ToPixels(expectedTranslationX);
+			Assert.Equal(expectedXInPixels, nativeView.TranslationX, precision: 1);
+			
+			var expectedYInPixels = context.ToPixels(expectedTranslationY);
+			Assert.Equal(expectedYInPixels, nativeView.TranslationY, precision: 1);
+		}
+
 		class WindowTestFragment : Fragment
 		{
 			TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>();

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs
@@ -144,15 +144,7 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetNativeBoxView(handler);
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var translation = nativeView.TranslationX;
-				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
-				var expectedInPixels = density * boxView.TranslationX;
-
-				Assert.Equal(expectedInPixels, translation, 1.0);
-
-				var translationY = nativeView.TranslationY;
-				var expectedYInPixels = density * boxView.TranslationY;
-				Assert.Equal(expectedYInPixels, translationY, 1.0);
+				AssertTranslationMatches(nativeView, boxView.TranslationX, boxView.TranslationY);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs
@@ -126,5 +126,34 @@ namespace Microsoft.Maui.DeviceTests
 				return nativeView.Visibility == Android.Views.ViewStates.Visible;
 			});
 		}
+        
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a BoxView should match with native Translation")]
+		public async Task BoxViewTranslationConsistent()
+		{
+			var boxView = new BoxView()
+			{
+				HeightRequest = 100,
+				WidthRequest = 200,
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<ShapeViewHandler>(boxView);
+			var nativeView = GetNativeBoxView(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var translation = nativeView.TranslationX;
+				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
+				var expectedInPixels = density * boxView.TranslationX;
+
+				Assert.Equal(expectedInPixels, translation, 1.0);
+
+				var translationY = nativeView.TranslationY;
+				var expectedYInPixels = density * boxView.TranslationY;
+				Assert.Equal(expectedYInPixels, translationY, 1.0);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
@@ -207,15 +207,7 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetPlatformButton(handler);
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var translation = nativeView.TranslationX;
-				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
-				var expectedInPixels = density * button.TranslationX;
-
-				Assert.Equal(expectedInPixels, translation, 1.0);
-
-				var translationY = nativeView.TranslationY;
-				var expectedYInPixels = density * button.TranslationY;
-				Assert.Equal(expectedYInPixels, translationY, 1.0);
+				AssertTranslationMatches(nativeView, button.TranslationX, button.TranslationY);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs
@@ -190,5 +190,33 @@ namespace Microsoft.Maui.DeviceTests
 			var platformRotation = await InvokeOnMainThreadAsync(() => platformButton.Rotation);
 			Assert.Equal(expected, platformRotation);
 		}
+
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a Button should match with native Translation")]
+		public async Task ButtonTranslationConsistent()
+		{
+			var button = new Button()
+			{
+				Text = "Button Test",
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<ButtonHandler>(button);
+			var nativeView = GetPlatformButton(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var translation = nativeView.TranslationX;
+				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
+				var expectedInPixels = density * button.TranslationX;
+
+				Assert.Equal(expectedInPixels, translation, 1.0);
+
+				var translationY = nativeView.TranslationY;
+				var expectedYInPixels = density * button.TranslationY;
+				Assert.Equal(expectedYInPixels, translationY, 1.0);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs
@@ -138,15 +138,7 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetNativeCheckBox(handler);
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var translation = nativeView.TranslationX;
-				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
-				var expectedInPixels = density * checkBox.TranslationX;
-
-				Assert.Equal(expectedInPixels, translation, 1.0);
-
-				var translationY = nativeView.TranslationY;
-				var expectedYInPixels = density * checkBox.TranslationY;
-				Assert.Equal(expectedYInPixels, translationY, 1.0);
+				AssertTranslationMatches(nativeView, checkBox.TranslationX, checkBox.TranslationY);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs
@@ -122,5 +122,32 @@ namespace Microsoft.Maui.DeviceTests
 				return nativeView.Visibility == Android.Views.ViewStates.Visible;
 			});
 		}
+        
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a CheckBox should match with native Translation")]
+		public async Task CheckBoxTranslationConsistent()
+		{
+			var checkBox = new CheckBox()
+			{
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<CheckBoxHandler>(checkBox);
+			var nativeView = GetNativeCheckBox(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var translation = nativeView.TranslationX;
+				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
+				var expectedInPixels = density * checkBox.TranslationX;
+
+				Assert.Equal(expectedInPixels, translation, 1.0);
+
+				var translationY = nativeView.TranslationY;
+				var expectedYInPixels = density * checkBox.TranslationY;
+				Assert.Equal(expectedYInPixels, translationY, 1.0);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
@@ -191,3 +191,4 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
@@ -170,5 +170,24 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(expectedValue, isEnabled);
 			});
 		}
+
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a Editor should match with native Translation")]
+		public async Task EditorTranslationConsistent()
+		{
+			var editor = new Editor()
+			{
+				Text = "Editor Test",
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<EditorHandler>(editor);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				AssertTranslationMatches(nativeView, editor.TranslationX, editor.TranslationY);
+			});
+		}
 	}
-}

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -164,5 +164,33 @@ namespace Microsoft.Maui.DeviceTests
 			var platformRotation = await InvokeOnMainThreadAsync(() => platformEntry.Rotation);
 			Assert.Equal(expected, platformRotation);
 		}
+
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a Entry should match with native Translation")]
+		public async Task EntryTranslationConsistent()
+		{
+			var entry = new Entry()
+			{
+				Text = "Entry Test",
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var translation = nativeView.TranslationX;
+				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
+				var expectedInPixels = density * entry.TranslationX;
+
+				Assert.Equal(expectedInPixels, translation, 1.0);
+
+				var translationY = nativeView.TranslationY;
+				var expectedYInPixels = density * entry.TranslationY;
+				Assert.Equal(expectedYInPixels, translationY, 1.0);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -181,15 +181,7 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetPlatformControl(handler);
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var translation = nativeView.TranslationX;
-				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
-				var expectedInPixels = density * entry.TranslationX;
-
-				Assert.Equal(expectedInPixels, translation, 1.0);
-
-				var translationY = nativeView.TranslationY;
-				var expectedYInPixels = density * entry.TranslationY;
-				Assert.Equal(expectedYInPixels, translationY, 1.0);
+				AssertTranslationMatches(nativeView, entry.TranslationX, entry.TranslationY);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
@@ -182,6 +182,26 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a Label should match with native Translation")]
+		public async Task LabelTranslationConsistent()
+		{
+			var label = new Label()
+			{
+				Text = "Label Test",
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<LabelHandler>(label);
+			var nativeView = GetPlatformLabel(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				AssertTranslationMatches(nativeView, label.TranslationX, label.TranslationY);
+			});
+		}
+
 		TextView GetPlatformLabel(LabelHandler labelHandler) =>
 			labelHandler.PlatformView;
 

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Platform;
 using Xunit;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
+
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarTests
@@ -143,6 +144,34 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var nativeView = GetPlatformControl(searchBarHandler);
 				return nativeView.Visibility == Android.Views.ViewStates.Visible;
+			});
+		}
+
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
+		[Fact]
+		[Description("The Translation property of a SearchBar should match with native Translation")]
+		public async Task SearchBarTranslationConsistent()
+		{
+			var searchBar = new SearchBar()
+			{
+				Text = "SearchBar Test",
+				TranslationX = 50,
+				TranslationY = -20
+			};
+
+			var handler = await CreateHandlerAsync<SearchBarHandler>(searchBar);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var translation = nativeView.TranslationX;
+				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
+				var expectedInPixels = density * searchBar.TranslationX;
+
+				Assert.Equal(expectedInPixels, translation, 1.0);
+
+				var translationY = nativeView.TranslationY;
+				var expectedYInPixels = density * searchBar.TranslationY;
+				Assert.Equal(expectedYInPixels, translationY, 1.0);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
@@ -8,7 +8,6 @@ using Microsoft.Maui.Platform;
 using Xunit;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
-
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarTests

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs
@@ -163,15 +163,7 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetPlatformControl(handler);
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var translation = nativeView.TranslationX;
-				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
-				var expectedInPixels = density * searchBar.TranslationX;
-
-				Assert.Equal(expectedInPixels, translation, 1.0);
-
-				var translationY = nativeView.TranslationY;
-				var expectedYInPixels = density * searchBar.TranslationY;
-				Assert.Equal(expectedYInPixels, translationY, 1.0);
+				AssertTranslationMatches(nativeView, searchBar.TranslationX, searchBar.TranslationY);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -171,6 +171,25 @@ namespace Microsoft.Maui.DeviceTests
 			   });
 		}
 
+		[Fact]
+		[Description("The IsVisible property of a SwipeView should match with native IsVisible")]		
+		public async Task VerifySwipeViewIsVisibleProperty()
+		{
+			var swipeView = new SwipeView
+			{
+				IsVisible = false
+			};
+			var expectedValue = swipeView.IsVisible;
+
+			var handler = await CreateHandlerAsync<SwipeViewHandler>(swipeView);
+			var nativeView = GetPlatformControl(handler);
+			await InvokeOnMainThreadAsync(() =>
+   			{
+				var isVisible = nativeView.Visibility == Android.Views.ViewStates.Visible;
+				Assert.Equal(expectedValue, isVisible);
+			});	
+		}
+
 		//src/Compatibility/Core/tests/Android/TranslationTests.cs
 		[Fact]
 		[Description("The Translation property of a SwipeView should match with native Translation")]

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Description("The IsVisible property of a SwipeView should match with native IsVisible")]		
+		[Description("The IsVisible property of a SwipeView should match with native IsVisible")]
 		public async Task VerifySwipeViewIsVisibleProperty()
 		{
 			var swipeView = new SwipeView
@@ -185,9 +185,9 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetPlatformControl(handler);
 			await InvokeOnMainThreadAsync(() =>
    			{
-				var isVisible = nativeView.Visibility == Android.Views.ViewStates.Visible;
-				Assert.Equal(expectedValue, isVisible);
-			});	
+				   var isVisible = nativeView.Visibility == Android.Views.ViewStates.Visible;
+				   Assert.Equal(expectedValue, isVisible);
+			   });
 		}
 
 		//src/Compatibility/Core/tests/Android/TranslationTests.cs

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -171,23 +171,31 @@ namespace Microsoft.Maui.DeviceTests
 			   });
 		}
 
+		//src/Compatibility/Core/tests/Android/TranslationTests.cs
 		[Fact]
-		[Description("The IsVisible property of a SwipeView should match with native IsVisible")]
-		public async Task VerifySwipeViewIsVisibleProperty()
+		[Description("The Translation property of a SwipeView should match with native Translation")]
+		public async Task SwipeViewTranslationConsistent()
 		{
-			var swipeView = new SwipeView
+			var swipeView = new SwipeView()
 			{
-				IsVisible = false
+				TranslationX = 50,
+				TranslationY = -20
 			};
-			var expectedValue = swipeView.IsVisible;
 
 			var handler = await CreateHandlerAsync<SwipeViewHandler>(swipeView);
 			var nativeView = GetPlatformControl(handler);
 			await InvokeOnMainThreadAsync(() =>
-   			{
-				   var isVisible = nativeView.Visibility == Android.Views.ViewStates.Visible;
-				   Assert.Equal(expectedValue, isVisible);
-			   });
+			{
+				var translation = nativeView.TranslationX;
+				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
+				var expectedInPixels = density * swipeView.TranslationX;
+
+				Assert.Equal(expectedInPixels, translation, 1.0);
+
+				var translationY = nativeView.TranslationY;
+				var expectedYInPixels = density * swipeView.TranslationY;
+				Assert.Equal(expectedYInPixels, translationY, 1.0);
+			});
 		}
 
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs
@@ -186,15 +186,7 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeView = GetPlatformControl(handler);
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var translation = nativeView.TranslationX;
-				var density = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Density;
-				var expectedInPixels = density * swipeView.TranslationX;
-
-				Assert.Equal(expectedInPixels, translation, 1.0);
-
-				var translationY = nativeView.TranslationY;
-				var expectedYInPixels = density * swipeView.TranslationY;
-				Assert.Equal(expectedYInPixels, translationY, 1.0);
+				AssertTranslationMatches(nativeView, swipeView.TranslationX, swipeView.TranslationY);
 			});
 		}
 


### PR DESCRIPTION
**Description of Change**
Migration of Compatibility.Core platform-specific unit tests to device tests. Here the migrated cases which ensuring that the Translation consistency of different elements matches their native counterparts. We are going to migrate tests in blocks in different PRs. This is the 6th group.

**There are unit tests under:**

- src\Compatibility\Core\tests\Android
- src\Compatibility\Core\tests\iOS
- src\Compatibility\Core\tests\WinUI

That are not running right now. these cases from Xamarin.Forms where they could run as unit tests, but now with .NET MAUI this is not possible. So here I migrated the following cases in device tests.

- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/Android/TranslationTests.cs

This pull request introduces several new tests to ensure the consistency of the `Translation` property across various UI elements in the Android platform. The changes include adding new test cases and necessary imports for testing the `Translation` property.

### New Tests for Translation Property Consistency:

**BoxView:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/BoxView/BoxViewTests.Android.cs : Added a test to verify that the `Translation` property of a `BoxView` matches the native `Translation`.

**Button:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Android.cs : Added a test to ensure the `Translation` property of a `Button` is consistent with the native `Translation`.

**CheckBox:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/CheckBox/CheckBoxTests.Android.cs :  Added a test to check that the `Translation` property of a `CheckBox` aligns with the native `Translation`.

**Editor:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs :  Added a test to confirm that the `Translation` property of an `Editor` corresponds with the native `Translation`.

**Entry:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs :  Added a test to validate that the `Translation` property of an `Entry` matches the native `Translation`.

**Label:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs :  Added a test to validate that the `Translation` property of an `Label` matches the native `Translation`.

**SearchBar:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.Android.cs:  Added a test to validate that the `Translation` property of an `SearchBar` matches the native `Translation`.

**SwipeView:**
  - https://github.com/dotnet/maui/blob/main/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.Android.cs :  Added a test to validate that the `Translation` property of an `SwipeView` matches the native `Translation`.
  
These changes ensure that the `Translation` properties of different UI elements are accurately tested against their native counterparts, improving the reliability of the UI framework.

Issues Fixed
Fixes https://github.com/dotnet/maui/issues/27303
