### PR TITLE
[Android] Fix: Prevent Duplicate MapSource Invocations on setting Image's Source to Local File Paths

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.Handlers
 			// So we want to reload the image here if it's supposed to have an image
 			if (imageHandler.SourceLoader.CheckForImageLoadedOnAttached &&
 				imageHandler.PlatformView.Drawable is null &&
-				imageHandler.VirtualView.Source is not null)
+				imageHandler.VirtualView.Source is not null && !imageHandler.SourceLoader.SourceManager.IsLoading)
 			{
 				imageHandler.SourceLoader.CheckForImageLoadedOnAttached = false;
 				imageHandler.UpdateValue(nameof(IImage.Source));

--- a/src/Core/src/ImageSources/ImageSourceServiceResultManager.cs
+++ b/src/Core/src/ImageSources/ImageSourceServiceResultManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui
 		CancellationTokenSource? _sourceCancellation;
 		IDisposable? _sourceResult;
 
-		public bool IsLoading;
+		public bool IsLoading => _sourceCancellation is not null;
 		public CancellationToken Token =>
 			_sourceCancellation?.Token ?? default;
 
@@ -36,7 +36,6 @@ namespace Microsoft.Maui
 
 		public CancellationToken BeginLoad()
 		{
-			IsLoading = true;
 			_sourceResult?.Dispose();
 
 			_sourceCancellation?.Cancel();
@@ -80,7 +79,6 @@ namespace Microsoft.Maui
 
 			IsResolutionDependent = false;
 			CurrentResolution = 1.0f;
-			IsLoading = false;
 		}
 
 		public void Reset()

--- a/src/Core/src/ImageSources/ImageSourceServiceResultManager.cs
+++ b/src/Core/src/ImageSources/ImageSourceServiceResultManager.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui
 		CancellationTokenSource? _sourceCancellation;
 		IDisposable? _sourceResult;
 
+		public bool IsLoading;
 		public CancellationToken Token =>
 			_sourceCancellation?.Token ?? default;
 
@@ -35,6 +36,7 @@ namespace Microsoft.Maui
 
 		public CancellationToken BeginLoad()
 		{
+			IsLoading = true;
 			_sourceResult?.Dispose();
 
 			_sourceCancellation?.Cancel();
@@ -78,6 +80,7 @@ namespace Microsoft.Maui
 
 			IsResolutionDependent = false;
 			CurrentResolution = 1.0f;
+			IsLoading = false;
 		}
 
 		public void Reset()


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
This PR addresses an side effect introduced by  #24023 where setting the image source to a local file path triggers duplicate calls to the MapSource mapper. This behavior can lead to performance degradation—especially in image-heavy scenarios such as CollectionView or CarouselView.In such cases, multiple calls could potentially compound the load and result in a significant performance hit when images are loaded within ItemsViews.

**Problem:**
When the platform view attaches to the window, the handler checks if the image drawable is null and then calls `UpdateValue(nameof(IImage.Source))` to reload the image. With local file paths, this can happen even if the image is already in the process of loading, causing MapSource to be fired multiple times unnecessarily. 

**Fix:**
To mitigate this,  introduced an `IsLoading` flag in the ImageSourceServiceResultManager. The flag is set to true when a load begins (via `BeginLoad()`) and reset to false upon load completion (via `CompleteLoad()`). In `OnPlatformViewAttachedToWindow`, we now check this flag before triggering a reload:
<!-- Enter description of the fix in this section -->

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it.

Fixes # -->

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
