### PR TITLE
[testing] Disable CheckEntitlementsForMauiBlazorOnMacCatalyst

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MacTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MacTemplateTest.cs
@@ -36,9 +36,9 @@ public class MacTemplateTest : BaseTemplateTests
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 	}
 
-	[Test]
-	[TestCase("maui-blazor", "Debug", DotNetCurrent, true)]
-	[TestCase("maui-blazor", "Release", DotNetCurrent, true)]
+	//[Test]
+	//[TestCase("maui-blazor", "Debug", DotNetCurrent, true)]
+	//[TestCase("maui-blazor", "Release", DotNetCurrent, true)]
 	public void CheckEntitlementsForMauiBlazorOnMacCatalyst(string id, string config, string framework, bool sign)
 	{
 		if (TestEnvironment.IsWindows)


### PR DESCRIPTION
### Description of Change

These tests for CheckEntitlementsForMauiBlazorOnMacCatalyst need to be signed and for some reason the build is failing, this making the MAUI main build fail. 

I created a issue to follow up and reenable them again https://github.com/dotnet/maui/issues/28408

Disabling for now while we investigate the causes. Seems the build of the project just fails midway

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11192392&view=ms.vss-test-web.build-test-results-tab&runId=124590073&resultId=100011&paneView=debug

```
Running: '/Users/builder/azdo/_work/2/s/.dotnet/dotnet' with 'new'
Args list: maui-blazor -o "/Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186" -f net9.0 
[ToolRunner] Running: /Users/builder/azdo/_work/2/s/.dotnet/dotnet new maui-blazor -o "/Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186" -f net9.0 
[ToolRunner] Process 'dotnet' exited with code: 0
The template ".NET MAUI Blazor Hybrid App" was created successfully.

Running: '/Users/builder/azdo/_work/2/s/.dotnet/dotnet' with 'build'
Args list: "/Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186/CheckEntitlemen1210376186.csproj" -c Debug -f:net9.0-maccatalyst -p:RestoreNoCache=true -p:RestorePackagesPath=/Users/builder/azdo/_work/_temp/test-dir/packages -p:RestoreConfigFile=/Users/builder/azdo/_work/_temp/test-dir/NuGet.config -p:CustomBeforeMicrosoftCSharpTargets=/Users/builder/azdo/_work/2/s/src/Templates/TemplateTestExtraTargets.targets -p:DisableTransitiveFrameworkReferenceDownloads=true -p:TreatWarningsAsErrors=true -p:EnableCodeSigning=True -bl:"/Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186/build-133863914078189180.binlog" -warnaserror -p:nowarn="NETSDK1201%3BCS1591"
[ToolRunner] Running: /Users/builder/azdo/_work/2/s/.dotnet/dotnet build "/Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186/CheckEntitlemen1210376186.csproj" -c Debug -f:net9.0-maccatalyst -p:RestoreNoCache=true -p:RestorePackagesPath=/Users/builder/azdo/_work/_temp/test-dir/packages -p:RestoreConfigFile=/Users/builder/azdo/_work/_temp/test-dir/NuGet.config -p:CustomBeforeMicrosoftCSharpTargets=/Users/builder/azdo/_work/2/s/src/Templates/TemplateTestExtraTargets.targets -p:DisableTransitiveFrameworkReferenceDownloads=true -p:TreatWarningsAsErrors=true -p:EnableCodeSigning=True -bl:"/Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186/build-133863914078189180.binlog" -warnaserror -p:nowarn="NETSDK1201%3BCS1591"
Process exit code: -1
-------- Process output start --------
  Determining projects to restore...
  Restored /Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186/CheckEntitlemen1210376186.csproj (in 399 ms).
  Detected signing identity:
          
    Code Signing Key: "Mac Developer: Luis Aguilera (PKTN6CD57Y)" (694902C9E78FBDFAFF5B9D5E86E9E287564E6A8D)
    Bundle Id: com.companyname.checkentitlemen1210376186
    App Id: com.companyname.checkentitlemen1210376186
  CheckEntitlemen1210376186 -> /Users/builder/azdo/_work/_temp/test-dir/CheckEntitlemen1210376186/bin/Debug/net9.0-maccatalyst/maccatalyst-arm64/CheckEntitlemen1210376186.dll
  Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  Optimizing assemblies for size. This process might take a while.

-------- Process output end --------
```


