### PR TITLE
Make IShape in MauiCALayer a WeakReference

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Border/BorderTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.DeviceTests.ImageAnalysis;
 using Microsoft.Maui.Graphics;
@@ -254,6 +255,35 @@ namespace Microsoft.Maui.DeviceTests
 				var handler = CreateHandler<LayoutHandler>(layout);
 				handlerReference = new WeakReference(label.Handler);
 				platformViewReference = new WeakReference(label.Handler.PlatformView);
+			});
+
+			await AssertionExtensions.WaitForGC(handlerReference, platformViewReference);
+		}
+		
+		[Fact(DisplayName = "Border With Stroke Shape And Name Does Not Leak")]
+		public async Task DoesNotLeakWithStrokeShape()
+		{
+			SetupBuilder();
+			WeakReference platformViewReference = null;
+			WeakReference handlerReference = null;
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var layout = new Grid();
+				var border = new Border();
+				var rect = new RoundRectangle();
+				border.StrokeShape = rect;
+				layout.Add(border);
+
+				var nameScope = new NameScope();
+				((INameScope)nameScope).RegisterName("Border", border);
+				layout.transientNamescope = nameScope;
+				border.transientNamescope = nameScope;
+				rect.transientNamescope = nameScope;
+
+				var handler = CreateHandler<LayoutHandler>(layout);
+				handlerReference = new WeakReference(border.Handler);
+				platformViewReference = new WeakReference(border.Handler.PlatformView);
 			});
 
 			await AssertionExtensions.WaitForGC(handlerReference, platformViewReference);

--- a/src/Core/src/Platform/iOS/MauiCALayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCALayer.cs
@@ -12,8 +12,7 @@ namespace Microsoft.Maui.Platform
 	public class MauiCALayer : CALayer, IAutoSizableCALayer
 	{
 		CGRect _bounds;
-		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "IShape is a non-NSObject in MAUI.")]
-		IShape? _shape;
+		WeakReference<IShape?> _shape;
 
 		UIColor? _backgroundColor;
 		Paint? _background;
@@ -36,6 +35,7 @@ namespace Microsoft.Maui.Platform
 		public MauiCALayer()
 		{
 			_bounds = new CGRect();
+			_shape = new WeakReference<IShape?>(null);
 			ContentsScale = UIScreen.MainScreen.Scale;
 		}
 
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Platform
 
 		public void SetBorderShape(IShape? shape)
 		{
-			_shape = shape;
+			_shape = new WeakReference<IShape?>(shape);
 
 			SetNeedsDisplay();
 		}
@@ -306,10 +306,10 @@ namespace Microsoft.Maui.Platform
 
 		CGPath? GetClipPath()
 		{
-			if (_shape != null)
+			if (_shape.TryGetTarget(out var shape))
 			{
 				var bounds = _bounds.ToRectangle();
-				var path = _shape.PathForBounds(bounds);
+				var path = shape.PathForBounds(bounds);
 				return path?.AsCGPath();
 			}
 


### PR DESCRIPTION
### Description of Change

Fixes a memory leak in `MauiCALayer` by making it's `IShape? _shape` field a weak reference, as proposed in the attached Issue.
The leak happens from the fact that most `IShape`s are also `View`s and thereby have access to the UI's `NameScope` and `x:Name`ed elements, which causes a ref-count cycle.

### Issues Fixed

Fixes #26169
App to reproduce the memory leak / Test the fix: https://github.com/MarcelStommel/LayerLeak