### PR TITLE
[Mac Catalyst] `NullReferenceException` in `DragAndDropDelegate` - FIX

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/DragAndDropDelegate.cs
+++ b/src/Controls/src/Core/Platform/iOS/DragAndDropDelegate.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls.Platform
 				_viewHandler.VirtualView is View view)
 			{
 				HandleDrop(view, cdi.DataPackage, session, new PlatformDropEventArgs(cdi.View.Handler.PlatformView as UIView, interaction, session));
-				HandleDropCompleted(cdi.View, new PlatformDropCompletedEventArgs(cdi.View.Handler.PlatformView as UIView, interaction, session));
+				HandleDropCompleted(cdi.View, new PlatformDropCompletedEventArgs(cdi.View.Handler?.PlatformView as UIView, interaction, session));
 			}
 			else if (_viewHandler.VirtualView is View v)
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28416.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28416.xaml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue28416">
+  <VerticalStackLayout x:Name="stackLayout" AutomationId="StackLayout">
+    <Rectangle x:Name="dragObject" AutomationId="DragObject" Stroke="Red" Fill="DarkBlue" StrokeThickness="4" HeightRequest="200" WidthRequest="200">
+      <Rectangle.GestureRecognizers>
+        <DragGestureRecognizer DropCompleted="DragGestureRecognizer_DropCompleted" />
+      </Rectangle.GestureRecognizers>
+    </Rectangle>
+
+    <Image x:Name="dragTarget" AutomationId="DragTarget" BackgroundColor="Silver" HeightRequest="300" WidthRequest="250">
+      <Image.GestureRecognizers>
+        <DropGestureRecognizer Drop="DropGestureRecognizer_Drop" />
+      </Image.GestureRecognizers>
+    </Image>
+    <Label AutomationId="InstructionsLabel" Text="Drag the blue square onto the silver element" />
+  </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28416.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28416.xaml.cs
@@ -1,0 +1,25 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28416, "Crash in drag-n-drop with dragged element destroyed before drop is completed", PlatformAffected.iOS)]
+public partial class Issue28416 : ContentPage
+{
+	public Issue28416()
+	{
+		InitializeComponent();
+	}
+
+	private void DropGestureRecognizer_Drop(object sender, DropEventArgs e)
+	{
+		stackLayout.Remove(dragObject);
+
+		// This causes the crash.
+		dragObject.Handler = null;
+
+		stackLayout.Add(new Label { AutomationId = "DropResult", Text = "Dropped!" });
+	}
+
+	private void DragGestureRecognizer_DropCompleted(object sender, DropCompletedEventArgs e)
+	{
+		stackLayout.Add(new Label { AutomationId = "DropCompletedResult", Text = "Completed!" });
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28416.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28416.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_WINDOWS // "DropCompletedResult" does not appear on Windows. Issue https://github.com/dotnet/maui/issues/28448
+#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // "DropCompletedResult" does not appear on Windows. Issues: https://github.com/dotnet/maui/issues/28448 and https://github.com/dotnet/maui/issues/17554
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28416.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28416.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+[Category(UITestCategories.DragAndDrop)]
+public class Issue28416 : _IssuesUITest
+{
+	public Issue28416(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	protected override bool ResetAfterEachTest => true;
+
+	public override string Issue => "Crash in drag-n-drop with dragged element destroyed before drop is completed";
+
+	[Test]
+	public void DragAndDropWithAnElementThatIsRemoved()
+	{
+		App.WaitForElement("InstructionsLabel");
+		App.DragAndDrop("DragObject", "DragTarget");
+		App.WaitForElement("DropResult");
+		App.WaitForElement("DropCompletedResult");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28416.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28416.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_WINDOWS // "DropCompletedResult" does not appear on Windows. Issue https://github.com/dotnet/maui/issues/28448
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -24,3 +25,4 @@ public class Issue28416 : _IssuesUITest
 		App.WaitForElement("DropCompletedResult");
 	}
 }
+#endif


### PR DESCRIPTION
### Description of Change

I'm not exactly sure if the fix is correct but I have verified that it fixes the crash for my application.

### Test

Drag the blue square on the silver element below and the blue square is "removed" in the drop event handler. Consequently, drag-completed handler cannot be called with the proper platform view.

![image](https://github.com/user-attachments/assets/3e01e949-4094-45db-b7eb-f4e83d663013)

(This is how it looks like on Windows but the bug manifests on macOS.)

### Issues Fixed

Fixes #28416