### PR TITLE
CollectionView display is broken when setting IsVisible after items are added - Fix

### DIFF
--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -591,18 +591,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 			}
 		}
 
-		internal override void OnIsVisibleChanged(bool oldValue, bool newValue)
-		{
-			base.OnIsVisibleChanged(oldValue, newValue);
-			if (newValue)
-			{
-				if (_lastLayoutSize != new Size(Width, Height))
-				{
-					UpdateChildrenLayout();
-				}
-			}
-		}
-
 		static int GetElementDepth(Element view)
 		{
 			var result = 0;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28415.cs
@@ -4,10 +4,11 @@ using Microsoft.Maui.Controls.Shapes;
 namespace Maui.Controls.Sample.Issues
 {
 
-	[Issue(IssueTracker.Github, 28415, "CollectionView display is broken when setting IsVisible after items are added ", PlatformAffected.Android)]
+	[Issue(IssueTracker.Github, 28415, "CollectionView display is broken when setting IsVisible after items are added", PlatformAffected.Android)]
 	public class Issue28415 : ContentPage
 	{
 		CollectionView _collectionView;
+
 		public Issue28415()
 		{
 			_collectionView = new CollectionView
@@ -36,15 +37,22 @@ namespace Maui.Controls.Sample.Issues
 				})
 			};
 
-			Content = new VerticalStackLayout
+			Button button = new Button
 			{
-				Children = { _collectionView }
+				Text = "Load List",
+				AutomationId = "LoadListButton",
+				Command = new Command(() => LoadList())
+			};
+
+			Content = new StackLayout
+			{
+				Children = { button, _collectionView }
 			};
 		}
 
-		protected override async void OnAppearing()
+		async void LoadList()
 		{
-			_collectionView.ItemsSource = new ObservableCollection<string>(Enumerable.Range(0, 1000).Select(i => $"Item{i}"));
+			_collectionView.ItemsSource = new ObservableCollection<string>(Enumerable.Range(0, 40).Select(i => $"Item{i}"));
 			await Task.Delay(1000);
 			_collectionView.IsVisible = true;
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28415.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28415.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues
+{
+
+	[Issue(IssueTracker.Github, 28415, "CollectionView display is broken when setting IsVisible after items are added ", PlatformAffected.Android)]
+	public class Issue28415 : ContentPage
+	{
+		CollectionView _collectionView;
+		public Issue28415()
+		{
+			_collectionView = new CollectionView
+			{
+				IsVisible = false,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var contentView = new ContentView();
+
+					var border = new Border
+					{
+						Margin = new Thickness(5, 0),
+						StrokeShape = new RoundRectangle { CornerRadius = 10 }
+					};
+
+					var grid = new Grid { Margin = new Thickness(15) };
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, ".");
+					label.SetBinding(Label.AutomationIdProperty, ".");
+
+					grid.Add(label);
+					border.Content = grid;
+					contentView.Content = border;
+
+					return contentView;
+				})
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Children = { _collectionView }
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			_collectionView.ItemsSource = new ObservableCollection<string>(Enumerable.Range(0, 1000).Select(i => $"Item{i}"));
+			await Task.Delay(1000);
+			_collectionView.IsVisible = true;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28415.cs
@@ -10,13 +10,15 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 		}
 
-		public override string Issue => "CollectionView display is broken when setting IsVisible after items are added ";
+		public override string Issue => "CollectionView display is broken when setting IsVisible after items are added";
 
 		[Test]
 		[Category(UITestCategories.IsVisible)]
 		[Category(UITestCategories.CollectionView)]
 		public void CollectionViewItemsShouldBeVisible()
 		{
+			App.WaitForElement("LoadListButton");
+			App.Click("LoadListButton");
 			App.WaitForElement("Item1");
 		}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28415.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28415.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28415 : _IssuesUITest
+	{
+		public Issue28415(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "CollectionView display is broken when setting IsVisible after items are added ";
+
+		[Test]
+		[Category(UITestCategories.IsVisible)]
+		[Category(UITestCategories.CollectionView)]
+		public void CollectionViewItemsShouldBeVisible()
+		{
+			App.WaitForElement("Item1");
+		}
+
+	}
+}


### PR DESCRIPTION
### Description of Change

I think that because of this PR https://github.com/dotnet/maui/pull/20154 this override of `OnIsVisibleChanged` can be removed, which would improve the performance of `Compatibility.Layout`

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28415

