### PR TITLE
Bring back iOS SetNeedsLayout propagation via inheritance

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/VisualElementRenderer.cs
@@ -99,7 +99,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_invalidateParentWhenMovedToWindow = true;
 		}
 
-		void IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating) => SetNeedsLayout();
+		public override void SetNeedsLayout()
+		{
+			base.SetNeedsLayout();
+
+			if (IPlatformMeasureInvalidationController.IsInvalidating)
+			{
+				this.InvalidateParentMeasure();
+			}
+		}
 
 		public override void MovedToWindow()
 		{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewCell.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected ItemsViewCell(CGRect frame) : base(frame)
 		{
 			ContentView.BackgroundColor = UIColor.Clear;
+			ContentView.Tag = IPlatformMeasureInvalidationController.PropagationProxyTag;
 
 			var selectedBackgroundView = new UIView
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -25,11 +25,13 @@ internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents, IP
 		_invalidateParentWhenMovedToWindow = true;
 	}
 
-	void IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
+	public override void SetNeedsLayout()
 	{
-		if (!isPropagating)
+		base.SetNeedsLayout();
+
+		if (IPlatformMeasureInvalidationController.IsInvalidatingSelf)
 		{
-			SetNeedsLayout();
+			this.InvalidateParentMeasure();
 		}
 	}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewCell2.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		protected ItemsViewCell2(CGRect frame) : base(frame)
 		{
 			ContentView.BackgroundColor = UIColor.Clear;
+			ContentView.Tag = IPlatformMeasureInvalidationController.PropagationProxyTag;
 
 			var selectedBackgroundView = new UIView
 			{

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
+override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.SetNeedsLayout() -> void
 override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~abstract Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.CreateController(TItemsView newElement, UIKit.UICollectionViewLayout layout) -> Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>
 ~abstract Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.SelectLayout() -> UIKit.UICollectionViewLayout

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
+override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.SetNeedsLayout() -> void
 override Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~abstract Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.CreateController(TItemsView newElement, UIKit.UICollectionViewLayout layout) -> Microsoft.Maui.Controls.Handlers.Items2.ItemsViewController2<TItemsView>
 ~abstract Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.SelectLayout() -> UIKit.UICollectionViewLayout

--- a/src/Core/src/Handlers/Page/PageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.iOS.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Maui.Handlers
 			throw new InvalidOperationException($"PageViewController.View must be a {nameof(ContentView)}");
 		}
 
-		public override void SetVirtualView(IView view)
-		{
-			base.SetVirtualView(view);
-
-			// Ensure we tag the ContentView as a Page so that InvalidateAncestorsMeasures can stop propagation here
-			PlatformView.IsPage = true;
-		}
-
 		public static void MapBackground(IPageHandler handler, IContentView page)
 		{
 			if (handler is IPlatformViewHandler platformViewHandler && platformViewHandler.ViewController is not null)

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Maui.Platform
 		// verify we're using the correct subview for masking (and any other purposes)
 		internal const nint ContentTag = 0x63D2A0;
 
-		internal bool IsPage { get; set; }
-
 		public ContentView()
 		{
 			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))

--- a/src/Core/src/Platform/iOS/IPlatformMeasureInvalidationController.cs
+++ b/src/Core/src/Platform/iOS/IPlatformMeasureInvalidationController.cs
@@ -1,7 +1,41 @@
+using UIKit;
+
 namespace Microsoft.Maui.Platform;
 
 internal interface IPlatformMeasureInvalidationController
 {
+	/// <summary>
+	/// Marks a UIView with this tag when it's not possible to use inheritance to override SetNeedsLayout.
+	/// When this tag is found, the invalidation is automatically propagated to the parent.
+	/// </summary>
+	const nint PropagationProxyTag = 0x845fff;
+
+	static int _invalidationDepth;
+
+	/// <summary>
+	/// Gets whether we're currently running an invalidation pass.
+	/// </summary>
+	public static bool IsInvalidating => _invalidationDepth > 0;
+
+	/// <summary>
+	/// Gets whether the current invalidation pass is invalidating the view which triggered the invalidation.
+	/// </summary>
+	public static bool IsInvalidatingSelf => _invalidationDepth == 1;
+
+	/// <summary>
+	/// Gets whether the current invalidation pass is invalidating the ancestors of the view which triggered the invalidation.
+	/// </summary>
+	public static bool IsPropagatingInvalidation => _invalidationDepth > 1;
+
+	public static void BeginInvalidation() => _invalidationDepth = 0;
+	public static void BeginAncestorsInvalidation() => _invalidationDepth = 1;
+	public static void EndInvalidation() => _invalidationDepth = 0;
+
+	public static void SetNeedsLayout(UIView view)
+	{
+		++_invalidationDepth;
+		view.SetNeedsLayout();
+	}
+
 	void InvalidateAncestorsMeasuresWhenMovedToWindow();
-	void InvalidateMeasure(bool isPropagating = false);
 }

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -87,10 +87,19 @@ namespace Microsoft.Maui.Platform
 			_invalidateParentWhenMovedToWindow = true;
 		}
 
-		void IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
+		public override void SetNeedsLayout()
 		{
-			SetNeedsLayout();
-			InvalidateConstraintsCache();
+			base.SetNeedsLayout();
+
+			if (IPlatformMeasureInvalidationController.IsInvalidating)
+			{
+				InvalidateConstraintsCache();
+			}
+
+			if (IPlatformMeasureInvalidationController.IsInvalidatingSelf)
+			{
+				this.InvalidateParentMeasure();
+			}
 		}
 
 		bool IsMeasureValid(double widthConstraint, double heightConstraint)

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -163,10 +163,15 @@ namespace Microsoft.Maui.Platform
 			_invalidateParentWhenMovedToWindow = true;
 		}
 
-		void IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
+		public override void SetNeedsLayout()
 		{
-			InvalidateConstraintsCache();
-			SetNeedsLayout();
+			base.SetNeedsLayout();
+
+			if (IPlatformMeasureInvalidationController.IsInvalidating)
+			{
+				InvalidateConstraintsCache();
+				this.InvalidateParentMeasure();
+			}
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -319,10 +319,15 @@ namespace Microsoft.Maui.Platform
 			_invalidateParentWhenMovedToWindow = true;
 		}
 
-		void IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
+		public override void SetNeedsLayout()
 		{
-			InvalidateConstraintsCache();
-			SetNeedsLayout();
+			base.SetNeedsLayout();
+
+			if (IPlatformMeasureInvalidationController.IsInvalidating)
+			{
+				InvalidateConstraintsCache();
+				this.InvalidateParentMeasure();
+			}
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -54,6 +54,7 @@ override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(WebKit.WKWe
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.Maui.Platform.MauiScrollView.LayoutSubviews() -> void
+override Microsoft.Maui.Platform.MauiScrollView.SetNeedsLayout() -> void
 override Microsoft.Maui.Platform.MauiScrollView.SizeThatFits(CoreGraphics.CGSize size) -> CoreGraphics.CGSize
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
@@ -87,6 +88,3 @@ override Microsoft.Maui.Handlers.EditorHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.WindowHandler.DisconnectHandler(UIKit.UIWindow! platformView) -> void
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ImageButtonHandler.SetupContainer() -> void
-override Microsoft.Maui.Handlers.PageHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
-*REMOVED*override Microsoft.Maui.Platform.WrapperView.SetNeedsLayout() -> void
-*REMOVED*override Microsoft.Maui.Platform.MauiView.SetNeedsLayout() -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -55,6 +55,7 @@ override Microsoft.Maui.Handlers.HybridWebViewHandler.ConnectHandler(WebKit.WKWe
 override Microsoft.Maui.Handlers.HybridWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.Maui.Handlers.HybridWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.Maui.Platform.MauiScrollView.LayoutSubviews() -> void
+override Microsoft.Maui.Platform.MauiScrollView.SetNeedsLayout() -> void
 override Microsoft.Maui.Platform.MauiScrollView.SizeThatFits(CoreGraphics.CGSize size) -> CoreGraphics.CGSize
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
@@ -88,6 +89,3 @@ override Microsoft.Maui.Handlers.EditorHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.WindowHandler.DisconnectHandler(UIKit.UIWindow! platformView) -> void
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.ImageButtonHandler.SetupContainer() -> void
-override Microsoft.Maui.Handlers.PageHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
-*REMOVED*override Microsoft.Maui.Platform.WrapperView.SetNeedsLayout() -> void
-*REMOVED*override Microsoft.Maui.Platform.MauiView.SetNeedsLayout() -> void


### PR DESCRIPTION
### Description of Change

#26629 removed `SetNeedsLayout` propagation via inheritance, this was needed to fix #24996.
Unfortunately, this also removed the ability to intercept and stop propagation as needed.

A good option here would be to make `IPlatformMeasureInvalidationController` public and change `void InvalidateMeasure(bool isPropagating = false);` return type to `bool`, so that anyone could stop propagation in case of need.
This seems to me the best and clean option, but unless MAUI team makes an exception, we cannot touch PublicAPI in a Service Release.

For such reason, this PR brings back `SetNeedsLayout` propagation, but it also includes a way to tell if the `SetNeedsLayout` is being triggered by MAUI so we can avoid the issue described in #24996.

### Issues Fixed

Fixes #28410

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
