### PR TITLE
Upgrade Syncfusion Toolkit version from 1.0.3 to 1.0.4

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -85,7 +85,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
-		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.3" />
+		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.4" />
 	</ItemGroup>
 	
 <!--#endif -->


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR upgrades Syncfusion.Maui.Toolkit version from 1.0.3 to 1.0.4.

Using Syncfusion Toolkit now the sample app size is 49% smaller and the app start up time 24% faster if using NativeAOT in iOS. 

|     | Before  | After    |
|-------------|-------------|-------------|
| App Size   | 17.4 MB   | 8.54 MB   |
| Start up Time   | 484 MS  | 367 MS   |
