### PR TITLE
System.MissingMethodException in PropertyPropagationExtensions fix

### DIFF
--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PropertyPropagationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.PropertyPropagationExtensions']/Docs/*" />
 	public static class PropertyPropagationExtensions
 	{
-		internal static void PropagatePropertyChanged(string propertyName, Element element, IReadOnlyList<IVisualTreeElement> children)
+		internal static void PropagatePropertyChanged(string propertyName, Element element, IEnumerable children)
 		{
 			if (propertyName == null || propertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				SetFlowDirectionFromParent(element);
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			foreach (var child in children.ToArray())
+			foreach (var child in children.OfType<IVisualTreeElement>().ToArray())
 			{
 				if (child is IPropertyPropagationController view)
 				{

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -10,6 +10,14 @@ namespace Microsoft.Maui.Controls.Internals
 	{
 		internal static void PropagatePropertyChanged(string propertyName, Element element, IEnumerable children)
 		{
+			if (children == null)
+				return;
+
+			PropagatePropertyChanged(propertyName, element, children.OfType<IVisualTreeElement>().ToList());
+		}
+
+		internal static void PropagatePropertyChanged(string propertyName, Element element, IReadOnlyList<IVisualTreeElement> children)
+		{
 			if (propertyName == null || propertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				SetFlowDirectionFromParent(element);
 
@@ -28,7 +36,7 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
-			foreach (var child in children.OfType<IVisualTreeElement>().ToArray())
+			foreach (var child in children.ToArray())
 			{
 				if (child is IPropertyPropagationController view)
 				{

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,7 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PropertyPropagationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.PropertyPropagationExtensions']/Docs/*" />
 	public static class PropertyPropagationExtensions
 	{
+		[Obsolete]
 		internal static void PropagatePropertyChanged(string propertyName, Element element, IEnumerable children)
 		{
 			if (children == null)


### PR DESCRIPTION
### Description of Change

I've added an overload to PropagatePropertyChanged to avoid potential breaks for callers such as the MCT  and to maintain backward compatibility, since the original method was internal. 

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28450
