### PR TITLE
[Android] Fixed DragGestureRecognizer.DropCompleted event not firing

### DIFF
--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public bool HasAnyDragAndDropGestures()
 		{
 			var gestures = GetView()?.GestureRecognizers;
-			if (gestures == null || gestures.Count == 0)
+			if (gestures is null || gestures.Count == 0)
 				return false;
 
 			foreach (var gesture in gestures)
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			view = view ?? GetView();
 
-			if (view == null)
+			if (view is null)
 				return;
 
 			var gestures =
@@ -86,7 +86,7 @@ namespace Microsoft.Maui.Controls.Platform
 					.GestureRecognizers?
 					.OfType<TRecognizer>();
 
-			if (gestures == null)
+			if (gestures is null)
 				return;
 
 			foreach (var gesture in gestures)
@@ -106,7 +106,7 @@ namespace Microsoft.Maui.Controls.Platform
 			package = localStateData?.DataPackage;
 			var dragSourceElement = _currentCustomLocalStateData?.SourceElement;// ?? dragSourceRenderer?.Element;
 
-			if (package == null)
+			if (package is null)
 			{
 				package = new DataPackage();
 				_currentCustomLocalStateData.DataPackage = package;
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 
 			var datapackage = customLocalStateData.DataPackage;
-			if (e.LocalState == null)
+			if (e.LocalState is null)
 			{
 				string text = String.Empty;
 				if (e.ClipData?.ItemCount > 0)
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Controls.Platform
 					var clipData = e.ClipData.GetItemAt(0);
 					var control = GetControl();
 
-					if (control?.Context != null)
+					if (control?.Context is not null)
 						text = clipData.CoerceToText(control?.Context);
 					else
 						text = clipData.Text;
@@ -214,7 +214,7 @@ namespace Microsoft.Maui.Controls.Platform
 				if (String.IsNullOrWhiteSpace(datapackage.Text))
 					datapackage.Text = text;
 
-				if (datapackage.Image == null)
+				if (datapackage.Image is null)
 					datapackage.Image = text;
 			}
 
@@ -274,7 +274,7 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						ClipData.Item item = null;
 
-						if (args.Data.Image != null)
+						if (args.Data.Image is not null)
 						{
 							mimeTypes.Add("image/jpeg");
 							item = ConvertToClipDataItem(args.Data.Image, mimeTypes);
@@ -296,13 +296,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 						var dataPackage = args.Data;
 						ClipData.Item userItem = null;
-						if (dataPackage.Image != null)
+						if (dataPackage.Image is not null)
 							userItem = ConvertToClipDataItem(dataPackage.Image, mimeTypes);
 
-						if (dataPackage.Text != null)
+						if (dataPackage.Text is not null)
 							userItem = new ClipData.Item(dataPackage.Text);
 
-						if (item == null)
+						if (item is null)
 						{
 							item = userItem;
 							userItem = null;
@@ -310,7 +310,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 						data = new ClipData(clipDescription, mimeTypes.ToArray(), item);
 
-						if (userItem != null)
+						if (userItem is not null)
 							data.AddItem(userItem);
 					}
 

--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return false;
 
 			foreach (var gesture in gestures)
-				if (gesture is DragGestureRecognizer)
+				if (gesture is DragGestureRecognizer || gesture is DropGestureRecognizer)
 					return true;
 
 			return false;

--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -32,17 +32,35 @@ namespace Microsoft.Maui.Controls.Platform
 		Func<View> GetView { get; }
 		Func<AView> GetControl { get; }
 
-		public bool HasAnyDragAndDropGestures()
+		public bool HasAnyDragGestures()
 		{
 			var gestures = GetView()?.GestureRecognizers;
 			if (gestures is null || gestures.Count == 0)
 				return false;
 
 			foreach (var gesture in gestures)
-				if (gesture is DragGestureRecognizer || gesture is DropGestureRecognizer)
+				if (gesture is DragGestureRecognizer)
 					return true;
 
 			return false;
+		}
+
+		public bool HasAnyDropGestures()
+		{
+			var gestures = GetView()?.GestureRecognizers;
+			if (gestures is null || gestures.Count == 0)
+				return false;
+
+			foreach (var gesture in gestures)
+				if (gesture is DropGestureRecognizer)
+					return true;
+
+			return false;
+		}
+
+		bool HasAnyDragAndDropGestures()
+		{
+			return HasAnyDragGestures() || HasAnyDropGestures();
 		}
 
 		public void SetupHandlerForDrop()
@@ -237,7 +255,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public void OnLongPress(MotionEvent e)
 		{
-			if (!HasAnyDragAndDropGestures())
+			if (!HasAnyDragGestures())
 				return;
 
 			SendEventArgs<DragGestureRecognizer>(rec =>

--- a/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/DragAndDropGestureHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Platform
 		Func<View> GetView { get; }
 		Func<AView> GetControl { get; }
 
-		public bool HasAnyDragGestures()
+		public bool HasAnyDragAndDropGestures()
 		{
 			var gestures = GetView()?.GestureRecognizers;
 			if (gestures == null || gestures.Count == 0)
@@ -45,22 +45,9 @@ namespace Microsoft.Maui.Controls.Platform
 			return false;
 		}
 
-		public bool HasAnyDropGestures()
-		{
-			var gestures = GetView()?.GestureRecognizers;
-			if (gestures == null || gestures.Count == 0)
-				return false;
-
-			foreach (var gesture in gestures)
-				if (gesture is DropGestureRecognizer)
-					return true;
-
-			return false;
-		}
-
 		public void SetupHandlerForDrop()
 		{
-			if (HasAnyDropGestures())
+			if (HasAnyDragAndDropGestures())
 				GetControl()?.SetOnDragListener(this);
 			else
 				GetControl()?.SetOnDragListener(null);
@@ -250,7 +237,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public void OnLongPress(MotionEvent e)
 		{
-			if (!HasAnyDragGestures())
+			if (!HasAnyDragAndDropGestures())
 				return;
 
 			SendEventArgs<DragGestureRecognizer>(rec =>

--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		public bool EnableLongPressGestures =>
-			_dragAndDropGestureHandler.HasAnyDragAndDropGestures();
+			_dragAndDropGestureHandler.HasAnyDragGestures();
 
 		bool HasAnyGestures()
 		{

--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		public bool EnableLongPressGestures =>
-			_dragAndDropGestureHandler.HasAnyDragGestures();
+			_dragAndDropGestureHandler.HasAnyDragAndDropGestures();
 
 		bool HasAnyGestures()
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue17554.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue17554.cs
@@ -1,0 +1,92 @@
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 17554, "[Android] DragGestureRecognizer.DropCompleted event not firing", PlatformAffected.iOS)]
+public class Issue17554 : TestContentPage
+{
+	Label eventText;
+	protected override void Init()
+	{
+		var rootGrid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+				new RowDefinition { Height = 50 }
+			},
+			Margin = new Thickness(30)
+		};
+
+		var outerBorder = new Border
+		{
+			Stroke = Colors.Gray,
+			StrokeThickness = 1.5,
+			StrokeShape = new RoundRectangle() { CornerRadius = 4 },
+			VerticalOptions = LayoutOptions.Fill
+		};
+
+		var innerStack = new StackLayout();
+
+		var innerBorder = new Border
+		{
+			Stroke = Colors.Gray,
+			StrokeThickness = 1,
+			BackgroundColor = Colors.WhiteSmoke
+		};
+
+		var label = new Label
+		{
+			Text = "A",
+			AutomationId = "DragTarget",
+			FontSize = 32,
+			FontAttributes = FontAttributes.Bold,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var dragGestureRecognizer = new DragGestureRecognizer();
+		dragGestureRecognizer.DragStarting += DragStart;
+		dragGestureRecognizer.DropCompleted += DropCompleted;
+
+		innerBorder.GestureRecognizers.Add(dragGestureRecognizer);
+		innerBorder.Content = label;
+		innerStack.Children.Add(innerBorder);
+		outerBorder.Content = innerStack;
+
+		rootGrid.Add(outerBorder, 0, 0);
+
+		var eventStack = new HorizontalStackLayout();
+
+		var eventLabel = new Label
+		{
+			Text = "Event:",
+			AutomationId = "DropTarget",
+			Padding = new Thickness(4)
+		};
+
+		eventText = new Label
+		{
+			AutomationId = "eventText",
+			Text = "Start dragging the 'A' label and drop it here",
+			Padding = new Thickness(4),
+			HorizontalOptions = LayoutOptions.FillAndExpand
+		};
+
+		eventStack.Children.Add(eventLabel);
+		eventStack.Children.Add(eventText);
+		rootGrid.Add(eventStack, 0, 1);
+
+		Content = rootGrid;
+	}
+
+	private void DragStart(object sender, DragStartingEventArgs e)
+	{
+		eventText.Text = $"DragStarting";
+	}
+
+	private void DropCompleted(object sender, DropCompletedEventArgs e)
+	{
+		eventText.Text = $"DropCompleted";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17554.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17554.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue17554 : _IssuesUITest
+	{
+		const string DropTarget = "DropTarget";
+		const string DragTarget = "DragTarget";
+
+		public Issue17554(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "[Android] DragGestureRecognizer.DropCompleted event not firing";
+
+		[Test]
+		[Category(UITestCategories.Gestures)]
+		public void DropCompletedEventShouldFire()
+		{
+			App.WaitForElement(DropTarget);
+			App.DragAndDrop(DragTarget, DropTarget);
+			Thread.Sleep(500); // Wait for the event to fire
+			var text = App.WaitForElement("eventText").GetText();
+			Assert.That(text, Is.EqualTo("DropCompleted"));
+		}
+	}
+}


### PR DESCRIPTION
### Issue Details:
The DragGestureRecognizer.DropCompleted event not firing in Android platform.

### Root Cause:
Before setting the listener, the condition checks only if drop gesture is present. As a result the Listener is set to null causing the event not to fire.

### Description of Change:
Added a condition to check for both Drag and Drop gesture presence. SInce Drag gesture contains Drop completed event.

Validated the behaviour in the following platforms

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes #17554

### Output

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/e679b6d5-0e8d-4bf4-885a-fd9566244289">| <video src="https://github.com/user-attachments/assets/08f32641-7cc6-499b-8093-55be235c1d1b">|
