### PR TITLE
[net10.0] Enable back GetDrawableAsync 

### DIFF
--- a/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.DeviceTests
 			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext));
 		}
 
-#if !ANDROID //https://github.com/dotnet/maui/issues/27486
 		[Theory]
 		[InlineData("#FF0000")]
 		[InlineData("#00FF00")]
@@ -45,6 +44,5 @@ namespace Microsoft.Maui.DeviceTests
 
 			await bitmap.AssertContainsColor(expectedColor).ConfigureAwait(false);
 		}
-#endif
 	}
 }

--- a/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/StreamImageSourceServiceTests.Android.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var bitmap = bitmapDrawable.Bitmap;
 
-			bitmap.AssertColorAtCenter(expectedColor);
+			await bitmap.AssertContainsColor(expectedColor).ConfigureAwait(false);
 		}
 #endif
 	}


### PR DESCRIPTION
### Description of Change

Enable back some image tests GetDrawableAsync on Android 

### Issues Fixed

Fixes #27486

