### PR TITLE
[iOS] Back-navigation with swipe-back navigates back twice - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -610,6 +610,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override UIViewController PopViewController(bool animated)
 		{
+			_popRequested = true;
 			_pendingViewControllers = null;
 			if (IsInMoreTab && ParentViewController is UITabBarController tabBarController)
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28485.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28485.cs
@@ -1,0 +1,62 @@
+﻿namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 28485, "Back-navigation with swipe-back navigates back twice", PlatformAffected.iOS)]
+public class Issue28485 : Shell
+{
+	public Issue28485()
+	{
+		Routing.RegisterRoute("page2", typeof(Issue28485Page2));
+		Routing.RegisterRoute("page3", typeof(Issue28485Page3));
+
+		var page1 = new ShellContent
+		{
+			Title = "Page 1",
+			Content = new ContentPage()
+			{
+				Content = new Button
+				{
+					Text = "Go to Page 2",
+					AutomationId = "GotoPage2",
+					Command = new Command(async () =>
+					{
+						await Shell.Current.GoToAsync("page2", false);
+					})
+				}
+			}
+		};
+
+		Items.Add(page1);
+	}
+
+	class Issue28485Page2 : ContentPage
+	{
+		public Issue28485Page2()
+		{
+			Title = "Page 1";
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label { Text = "Welcome to Page 2", AutomationId="Page2Label" },
+					new Button
+					{
+						Text = "Go to Page 3",
+						AutomationId = "GotoPage3",
+						Command = new Command(async () =>
+						{
+							await Shell.Current.GoToAsync("page3", false);
+						})
+					}
+				}
+			};
+		}
+	}
+
+	class Issue28485Page3 : ContentPage
+	{
+		public Issue28485Page3()
+		{
+			Title = "Page 3";
+			Content = new Label { Text = "Welcome to Page 3", AutomationId = "Page3Label" };
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28485.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28485.cs
@@ -1,0 +1,31 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28485 : _IssuesUITest
+{
+	public Issue28485(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Back-navigation with swipe-back navigates back twice";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	[Category(UITestCategories.Navigation)]
+	public void SwipeBackGestureShouldNavigateOnce()
+	{
+		App.WaitForElement("GotoPage2");
+		App.Click("GotoPage2");
+		App.WaitForElement("GotoPage3");
+		App.Click("GotoPage3");
+		App.Click("Page3Label");
+		App.InteractivePopGesture();
+		App.WaitForElement("Page2Label");
+		App.WaitForNoElement("GotoPage2");
+	}
+}
+#endif

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSSpecificActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSSpecificActions.cs
@@ -1,4 +1,5 @@
-﻿using OpenQA.Selenium.Appium.iOS;
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.iOS;
 using UITest.Core;
 
 namespace UITest.Appium
@@ -6,12 +7,14 @@ namespace UITest.Appium
 	public class AppiumIOSSpecificActions : ICommandExecutionGroup
 	{
 		const string ShakeDeviceCommand = "shake";
+		const string InteractivePopGesture = "interactivePopGesture";
 
 		readonly AppiumApp _appiumApp;
 
 		readonly List<string> _commands = new()
 		{
 			ShakeDeviceCommand,
+			InteractivePopGesture
 		};
 
 		public AppiumIOSSpecificActions(AppiumApp appiumApp)
@@ -29,8 +32,30 @@ namespace UITest.Appium
 			return commandName switch
 			{
 				ShakeDeviceCommand => ShakeDevice(parameters),
+				InteractivePopGesture => PerformInteractivePopGesture(parameters),
 				_ => CommandResponse.FailedEmptyResponse,
 			};
+		}
+
+		CommandResponse PerformInteractivePopGesture(IDictionary<string, object> parameters)
+		{
+			if (_appiumApp.Driver is IOSDriver iOSDriver)
+			{
+				var sceenSize = iOSDriver.Manage().Window.Size;
+				var args = new Dictionary<string, object>
+				{
+					{ "fromX", 0 },
+					{ "toX", sceenSize.Width * 0.8 },
+					{ "fromY", sceenSize.Height / 2 },
+					{ "toY", sceenSize.Height / 2 },
+					{ "duration", 1 }
+				};
+
+				iOSDriver.ExecuteScript("mobile: dragFromToForDuration", args);
+				return CommandResponse.SuccessEmptyResponse;
+			}
+
+			return CommandResponse.FailedEmptyResponse;
 		}
 
 		CommandResponse ShakeDevice(IDictionary<string, object> parameters)

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1764,6 +1764,21 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Triggers the interactive pop gesture on an iOS device, simulating the default swipe-back navigation.
+		/// </summary>
+		/// <param name="app">The application instance used to execute the gesture.</param>
+		/// <exception cref="InvalidOperationException">Thrown if the method is called on a non-iOS Appium instance.</exception>
+		public static void InteractivePopGesture(this IApp app)
+		{
+			if (app is not AppiumIOSApp)
+			{
+				throw new InvalidOperationException($"Interactive Pop Gesture is only supported on AppiumIOSAppp");
+			}
+
+			app.CommandExecutor.Execute("interactivePopGesture", ImmutableDictionary<string, object>.Empty);
+		}
+
+		/// <summary>
 		/// Start recording screen.
 		/// Functionality that's only available on Android, iOS and Windows.
 		/// </summary>


### PR DESCRIPTION
## Description

I've made changes to iOS special back navigation in this PR: https://github.com/dotnet/maui/pull/24003, but didn't account for the siwpe gesture that behaves differently that the callout-menu-click navigation

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28446
Fixes https://github.com/dotnet/maui/issues/28572

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/033e476b-3296-4686-983a-afeb8fcf59c6" width="300px"/>|<video src="https://github.com/user-attachments/assets/65efeb4c-d9a6-42f6-b084-8ad71b2b77e3" width="300px"/>|
