### PR TITLE
[Testing] Make tests depending on GC less flaky

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var weakReference = CreateReference();
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(weakReference.IsAlive);
 
@@ -627,14 +627,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			// First GC
 			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			Assert.False(controllerRef.IsAlive, "BindableLayoutController should not be alive!");
 
 			// Second GC
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			Assert.False(proxyRef.IsAlive, "WeakCollectionChangedProxy should not be alive!");
 		}
 
@@ -648,9 +645,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(2, layout.Children.Count);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			list.Add("Baz");
 			Assert.Equal(3, layout.Children.Count);

--- a/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingBaseUnitTests.cs
@@ -647,8 +647,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWay)
 				Assert.False(weakViewModel.IsAlive, "ViewModel wasn't collected");
@@ -760,8 +759,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.False(weakCollection.IsAlive);
 			Assert.False(weakContext.IsAlive);
@@ -796,8 +794,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.False(weakCollection.IsAlive);
 			Assert.False(weakContext.IsAlive);

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1244,9 +1244,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			create();
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWay)
 				Assert.False(weakViewModel.IsAlive, "ViewModel wasn't collected");
@@ -1255,9 +1253,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Assert.False(weakBindable.IsAlive, "Bindable wasn't collected");
 
 			// WeakPropertyChangedProxy won't go away until the second GC, BindingExpressionPart unsubscribes in its finalizer
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			foreach (var proxy in proxies)
 			{
@@ -1279,8 +1275,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			HackAroundMonoSucking(0, property, binding, out weakViewModel, out weakBindable);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWay)
 				Assert.False(weakViewModel.IsAlive, "ViewModel wasn't collected");
@@ -2196,7 +2191,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewModel.InvocationListSize());
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			viewModel.OnPropertyChanged("Foo");
 
@@ -2226,7 +2221,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewModel.InvocationListSize());
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(bindingRef.IsAlive, "Binding should not be alive!");
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 
 			WeakReference reference = CreateReference();
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "Grid should not be alive!");
 
@@ -223,9 +223,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 				reference = new(grid);
 			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "Grid should not be alive!");
 		}

--- a/src/Controls/tests/Core.UnitTests/ListProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ListProxyTests.cs
@@ -382,9 +382,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 
 			Assert.False(weakProxy.IsAlive);
 		}
@@ -439,15 +437,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(list.AddObject(), "GC hasn't run");
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.True(list.AddObject(), "GC run, but proxy should still hold a reference");
 
 			_proxyForWeakToWeakTest = null;
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.False(list.AddObject(), "Proxy is gone and GC has run");
 		}

--- a/src/Controls/tests/Core.UnitTests/ListViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ListViewTests.cs
@@ -583,8 +583,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				var header = list.TemplatedItems.GetGroup(0).HeaderContent;
 			}
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			// use less or equal because mono will keep the last header var alive no matter what
 			Assert.True(TestCell.NumberOfCells <= 6, $"{TestCell.NumberOfCells} <= 6");

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var weakReference = CreateReference();
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(weakReference.IsAlive);
 

--- a/src/Controls/tests/Core.UnitTests/MessagingCenterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MessagingCenterTests.cs
@@ -202,8 +202,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				MessagingCenter.Subscribe<TestPublisher>(subscriber, "test", p => throw new XunitException("The subscriber should have been collected."));
 			})();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			var pub = new TestPublisher();
 			pub.Test(); // Assert.Fail() shouldn't be called, because the TestSubcriber object should have ben GCed
@@ -223,8 +222,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				subscriber.SubscribeToTestMessages();
 			})();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			var pub = new TestPublisher();
 			pub.Test();
@@ -248,8 +246,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				MessagingCenter.Subscribe<TestPublisher>(subscriber, "test", p => subscriber.SetSuccess());
 			})();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.True(wr.IsAlive); // The closure in Subscribe should be keeping the subscriber alive
 			Assert.NotNull(wr.Target as TestSubcriber);
@@ -287,7 +284,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var wr = CreateReference();
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(wr.IsAlive); // The Action target and subscriber were the same object, so both could be collected
 		}
@@ -301,8 +298,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			MessagingCenter.Subscribe<TestPublisher>(_subscriber, "test", p => MessagingCenterTestsCallbackSource.Increment(ref i));
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			var pub = new TestPublisher();
 			pub.Test();
@@ -320,8 +316,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var source = new MessagingCenterTestsCallbackSource();
 			MessagingCenter.Subscribe<TestPublisher>(_subscriber, "test", p => source.SuccessCallback(ref success));
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			var pub = new TestPublisher();
 			pub.Test();

--- a/src/Controls/tests/Core.UnitTests/MultiPageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiPageTests.cs
@@ -874,8 +874,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// the collection changed handlers in ListProxy; without the GC calls if we introduce
 			// a reference bug the tests will still usually pass on Debug builds and only intermittently
 			// fail on Release builds. We don't want these bugs to accidentally slip by.
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -719,8 +719,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			await Task.Delay(100);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.True(isFinalized);
 		}

--- a/src/Controls/tests/Core.UnitTests/PlatformBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PlatformBindingTests.cs
@@ -200,8 +200,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
 
 			//this should collect the ConditionalWeakTable
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 		}
 
 		public void Dispose() => DispatcherProvider.SetCurrent(null);
@@ -342,9 +341,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 
 			Assert.False(wr.IsAlive);
 		}
@@ -378,9 +375,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 
 			Assert.False(wr.IsAlive);
 		}

--- a/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -46,11 +46,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			list.Remove(SetterSpecificity.FromBinding);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(weakReference.TryGetTarget(out _));
+			var isAlive = await TestHelpers.WaitForCollect(weakReference);
+			Assert.False(isAlive);
 		}
 
 		[Fact]
@@ -67,11 +64,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			list.Remove(SetterSpecificity.ManualValueSetter);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(weakReference.TryGetTarget(out _));
+			var isAlive = await TestHelpers.WaitForCollect(weakReference);
+			Assert.False(isAlive);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	internal static class TestHelpers
 	{
-		public static void Collect(int count = 3)
+		public static void Collect(int count = 10)
 		{
 			for (int i = 0; i < count; i++)
 			{
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
-		public static async Task CollectAsync(int count = 3)
+		public static async Task CollectAsync(int count = 10)
 		{
 			for (int i = 0; i < count; i++)
 			{

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -1,17 +1,28 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	internal static class TestHelpers
 	{
-		public static async Task Collect()
+		public static void Collect(int count = 3)
 		{
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			for (int i = 0; i < count; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
 		}
 
+		public static async Task CollectAsync(int count = 3)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+		}
 
 		public static async Task<bool> WaitForCollect(this WeakReference reference)
 		{

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -23,6 +23,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			return reference.IsAlive;
+		}
+
+		public static async Task<bool> WaitForCollect<T>(this WeakReference<T> reference)
+			where T : class
+		{
+			for (int i = 0; i < 40; i++)
+			{
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+
+				if (!reference.TryGetTarget(out _))
+				{
+					return false;
+				}
+			}
+
+			return true;
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/TitleBarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TitleBarTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var reference = CreateReference();
 
 			// GC
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "TitleBar should not be alive!");
 

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -736,9 +736,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			create();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 
 			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWay)
 				Assert.False(weakViewModel.IsAlive, "ViewModel wasn't collected");
@@ -1437,9 +1435,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewmodel.InvocationListSize());
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			viewmodel.OnPropertyChanged("Foo");
 
@@ -1491,17 +1487,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewModel.InvocationListSize());
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(bindingRef.IsAlive, "Binding should not be alive!");
 			Assert.False(buttonRef.IsAlive, "Button should not be alive!");
 
 			// WeakPropertyChangedProxy won't go away until the second GC, PropertyChangedProxy unsubscribes in its finalizer
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			Assert.False(proxyRef.IsAlive, "WeakPropertyChangedProxy should not be alive!");
 		}
 
@@ -1642,9 +1634,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					new Tuple<Func<MockViewModel, object>, string> (mvm=>mvm, "Text")
 				});
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			var swtb = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
 			{
@@ -1659,9 +1649,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				setter: (mvm, s) => mvm.Text = s,
 				handlers: null);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			var swtbh = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
 			{
@@ -1672,9 +1660,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Bar", bindable.GetValue(property));
 
 			binding = new Binding("Text");
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			var swb = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
 			{
@@ -1684,9 +1670,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			swb.Stop();
 			Assert.Equal("Bar", bindable.GetValue(property));
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			var swsv = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
 				bindable.SetValue(property, (i % 2 == 0 ? vm0 : vm1).Text);
@@ -1713,9 +1697,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					new Tuple<Func<MockViewModel, object>, string> (mvm=>mvm, "Text")
 				});
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			bindable.SetBinding(property, binding);
 			var swtb = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
@@ -1728,9 +1710,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				setter: (mvm, s) => mvm.Text = s,
 				handlers: null);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			bindable.SetBinding(property, binding);
 			var swtbh = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
@@ -1739,9 +1719,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Bar", bindable.GetValue(property));
 
 			binding = new Binding("Text");
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			bindable.SetBinding(property, binding);
 			var swb = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)
@@ -1749,9 +1727,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			swb.Stop();
 			Assert.Equal("Bar", bindable.GetValue(property));
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+			TestHelpers.Collect();
 			bindable.SetBinding(property, binding);
 			var swsv = Stopwatch.StartNew();
 			for (var i = 0; i < it; i++)

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var reference = CreateReference();
 
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "VisualElement should not be alive!");
 
@@ -154,9 +154,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(visual);
 
 			gradient.GradientStops.Add(new GradientStop(Colors.CornflowerBlue, 1));
@@ -187,9 +185,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(visual);
 
 			geometry.Rect = new Rect(1, 2, 3, 4);
@@ -209,9 +205,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(visualElement);
 
 			shadow.Brush = new SolidColorBrush(Colors.Green);
@@ -230,9 +224,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var reference = new WeakReference(new VisualElement { Shadow = shadow });
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "VisualElement should not be alive!");
 		}

--- a/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
@@ -22,9 +22,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				reference = new WeakReference(subscriber);
 			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "Subscriber should not be alive!");
 		}
@@ -40,9 +38,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			NotifyCollectionChangedEventHandler handler = (s, e) => fired = true;
 			proxy.Subscribe(list, handler);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(handler);
 
 			list.Add("a");

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -726,7 +726,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var reference = CreateReference();
 
 			// GC
-			await TestHelpers.Collect();
+			await TestHelpers.CollectAsync();
 
 			Assert.False(reference.IsAlive, "Window should not be alive!");
 
@@ -756,9 +756,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			// GC collect the original key
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 
 			// Same window, doesn't create a new one
 			var actual = ((IApplication)application).CreateWindow(new ActivationState(new MockMauiContext(), new PersistedState

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -69,7 +69,9 @@ namespace Microsoft.Maui.DeviceTests
 					window.Close();
 				}
 
-				TestHelpers.Collect();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
 				GC.WaitForFullGCComplete();
 
 				Assert.True(weakReferences.Count(r => r.IsAlive) == 0);

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Maui.DeviceTests
 					window.Close();
 				}
 
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
+				TestHelpers.Collect();
 				GC.WaitForFullGCComplete();
 
 				Assert.True(weakReferences.Count(r => r.IsAlive) == 0);

--- a/src/Core/tests/UnitTests/MauiContextTests.cs
+++ b/src/Core/tests/UnitTests/MauiContextTests.cs
@@ -50,8 +50,7 @@ namespace Microsoft.Maui.UnitTests
 
 			DoAdd(context);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.NotNull(context.Services.GetService<TestThing>());
 
@@ -71,8 +70,7 @@ namespace Microsoft.Maui.UnitTests
 
 			DoAdd(context);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.Null(context.Services.GetService<TestThing>());
 

--- a/src/Core/tests/UnitTests/TestHelpers.cs
+++ b/src/Core/tests/UnitTests/TestHelpers.cs
@@ -16,5 +16,24 @@ namespace Microsoft.Maui.UnitTests
 
 			return reference.IsAlive;
 		}
+
+		public static void Collect(int count = 10)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+		}
+
+		public static async Task CollectAsync(int count = 10)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				await Task.Yield();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Views/BorderTests.cs
+++ b/src/Core/tests/UnitTests/Views/BorderTests.cs
@@ -63,9 +63,7 @@ namespace Microsoft.Maui.UnitTests.Views
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(border);
 
 			strokeShape.CornerRadius = new CornerRadius(24);
@@ -86,9 +84,7 @@ namespace Microsoft.Maui.UnitTests.Views
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(border);
 
 			stroke.Color = Colors.Green;

--- a/src/Core/tests/UnitTests/Views/ShapeTests.cs
+++ b/src/Core/tests/UnitTests/Views/ShapeTests.cs
@@ -23,9 +23,7 @@ namespace Microsoft.Maui.UnitTests.Views
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(shape);
 
 			fill.Color = Colors.Green;
@@ -55,9 +53,7 @@ namespace Microsoft.Maui.UnitTests.Views
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.CollectAsync();
 			GC.KeepAlive(shape);
 
 			stroke.Color = Colors.Green;

--- a/src/Core/tests/UnitTests/WeakEventManagerTests.cs
+++ b/src/Core/tests/UnitTests/WeakEventManagerTests.cs
@@ -262,8 +262,7 @@ namespace Microsoft.Maui.UnitTests
 				ts.Subscribe(source);
 			})();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 
 			Assert.NotNull(wr);
 			Assert.False(wr?.IsAlive);
@@ -286,8 +285,7 @@ namespace Microsoft.Maui.UnitTests
 				ts.Subscribe(source);
 			})();
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			TestHelpers.Collect();
 			new TestSubscriber().Unsubscribe(source);
 
 			Assert.NotNull(wr);


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR is motivated by frequently failing `SetterSpecificityListTests.RemovingLastValueDoesNotLeak`. It is often not enough to call `GC.Collect() + GC.WaitForPendingFinalizers()` once to ensure that the objects are collected (for some reason). Even in tests in dotnet/runtime, we call GC multiple times to reduce the chance it does not collect what we need (for example https://github.com/dotnet/runtime/blob/367cf39652b1193d04ce3ac345a6384ecba53382/src/tests/nativeaot/SmokeTests/DynamicGenerics/dictionaries.cs#L1516-L1521)

Related to #28357 