### PR TITLE
[Testing] Migration of Compatibility.Core platform-specific unit tests into device tests - 8

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs
@@ -1,7 +1,14 @@
 ﻿#nullable enable
+using Xunit;
+using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml.Controls;
+using WFlowDirection = Microsoft.UI.Xaml.FlowDirection;
+using WTextAlignment = Microsoft.UI.Xaml.TextAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -40,6 +47,36 @@ namespace Microsoft.Maui.DeviceTests
 				var nativeView = GetPlatformControl(editorHandler);
 				return nativeView.Visibility == Microsoft.UI.Xaml.Visibility.Visible;
 			});
+		}
+		//src/Compatibility/Core/tests/WinUI/FlowDirectionTests.cs
+		[Theory]
+		[InlineData(true, FlowDirection.RightToLeft, WTextAlignment.Left, WFlowDirection.RightToLeft)]
+		[InlineData(true, FlowDirection.LeftToRight, WTextAlignment.Left, WFlowDirection.LeftToRight)]
+		[InlineData(false, FlowDirection.LeftToRight, WTextAlignment.Left, WFlowDirection.LeftToRight)]
+		[Description("The Editor's text alignment and flow direction should match the expected values when FlowDirection is applied explicitly or implicitly.")]
+		public async Task EditorAlignmentMatchesFlowDirection(bool isExplicit, FlowDirection flowDirection, WTextAlignment expectedAlignment, WFlowDirection expectedFlowDirection)
+		{
+			var editor = new Editor { Text = " تسجيل الدخول" };
+			var contentPage = new ContentPage { Title = "Flow Direction", Content = editor };
+
+			if (isExplicit)
+			{
+				editor.FlowDirection = flowDirection;
+			}
+			else
+			{
+				contentPage.FlowDirection = flowDirection;
+			}
+
+			var handler = await CreateHandlerAsync<EditorHandler>(editor);
+			var (nativeAlignment, nativeFlowDirection) = await contentPage.Dispatcher.DispatchAsync(() =>
+			{
+				var textField = GetPlatformControl(handler);
+				return (textField.TextAlignment, textField.FlowDirection);
+			});
+
+			Assert.Equal(expectedAlignment, nativeAlignment);
+			Assert.Equal(expectedFlowDirection, nativeFlowDirection);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs
@@ -1,11 +1,14 @@
-﻿using System.Linq;
+﻿using UIKit;
+using Xunit;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
-using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -48,7 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetPlatformControl(editorHandler);
-				return (float)nativeView.Alpha; 
+				return (float)nativeView.Alpha;
 			});
 		}
 
@@ -102,6 +105,36 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(expectedFontFamily, placeholderLabel?.Font?.FamilyName);
 				});
 			}
+		}
+
+		//src/Compatibility/Core/tests/iOS/FlowDirectionTests.cs
+		[Theory]
+		[InlineData(true, FlowDirection.LeftToRight, UITextAlignment.Left)]
+		[InlineData(true, FlowDirection.RightToLeft, UITextAlignment.Right)]
+		[InlineData(false, FlowDirection.LeftToRight, UITextAlignment.Left)]
+		[Description("The Editor's text alignment should match the expected alignment when FlowDirection is applied explicitly or implicitly")]
+		public async Task EditorAlignmentMatchesFlowDirection(bool isExplicit, FlowDirection flowDirection, UITextAlignment expectedAlignment)
+		{
+			var editor = new Editor { Text = "Checking flow direction" };
+			var contentPage = new ContentPage { Title = "Flow Direction", Content = editor };
+
+			if (isExplicit)
+			{
+				editor.FlowDirection = flowDirection;
+			}
+			else
+			{
+				contentPage.FlowDirection = flowDirection;
+			}
+
+			var handler = await CreateHandlerAsync<EditorHandler>(editor);
+			var nativeAlignment = await contentPage.Dispatcher.DispatchAsync(() =>
+			{
+				var textField = GetPlatformControl(handler);
+				return textField.TextAlignment;
+			});
+
+			Assert.Equal(expectedAlignment, nativeAlignment);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
@@ -1,7 +1,12 @@
 ﻿#nullable enable
+using Xunit;
+using System.ComponentModel;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml.Controls;
+using WTextAlignment = Microsoft.UI.Xaml.TextAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -40,6 +45,36 @@ namespace Microsoft.Maui.DeviceTests
 				var nativeView = GetPlatformControl(entryHandler);
 				return nativeView.Visibility == Microsoft.UI.Xaml.Visibility.Visible;
 			});
+		}
+		//src/Compatibility/Core/tests/WinUI/FlowDirectionTests.cs
+		[Theory]
+		[InlineData(true, FlowDirection.LeftToRight, WTextAlignment.Left)]
+		[InlineData(true, FlowDirection.RightToLeft, WTextAlignment.Left)]
+		[InlineData(false, FlowDirection.LeftToRight, WTextAlignment.Left)]
+		[InlineData(false, FlowDirection.RightToLeft, WTextAlignment.Left)]
+		[Description("The Entry's text alignment should match the expected alignment when FlowDirection is applied explicitly or implicitly.")]
+		public async Task EntryAlignmentMatchesFlowDirection(bool isExplicit, FlowDirection flowDirection, WTextAlignment expectedAlignment)
+		{
+			var entry = new Entry { Text = "Checking flow direction", HorizontalTextAlignment = TextAlignment.Start };
+			var contentPage = new ContentPage { Title = "Flow Direction", Content = entry };
+
+			if (isExplicit)
+			{
+				entry.FlowDirection = flowDirection;
+			}
+			else
+			{
+				contentPage.FlowDirection = flowDirection;
+			}
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			var nativeAlignment = await contentPage.Dispatcher.DispatchAsync(() =>
+			{
+				var textField = GetPlatformControl(handler);
+				return textField.TextAlignment;
+			});
+
+			Assert.Equal(expectedAlignment, nativeAlignment);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -1,13 +1,15 @@
-﻿using System.Linq;
+﻿using UIKit;
+using Xunit;
+using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.DeviceTests.TestCases;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
-using UIKit;
-using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
@@ -44,13 +46,13 @@ namespace Microsoft.Maui.DeviceTests
 
 			return -1;
 		}
-		
+
 		Task<float> GetPlatformOpacity(EntryHandler entryHandler)
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
 				var nativeView = GetPlatformControl(entryHandler);
-				return (float)nativeView.Alpha; 
+				return (float)nativeView.Alpha;
 			});
 		}
 
@@ -331,6 +333,36 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(expectedFontFamily, placeholderLabel?.Font?.FamilyName);
 				});
 			}
+		}
+
+		//src/Compatibility/Core/tests/iOS/FlowDirectionTests.cs
+		[Theory]
+		[InlineData(true, FlowDirection.LeftToRight, UITextAlignment.Left)]
+		[InlineData(true, FlowDirection.RightToLeft, UITextAlignment.Right)]
+		[InlineData(false, FlowDirection.LeftToRight, UITextAlignment.Left)]
+		[Description("The Entry's text alignment should match the expected alignment when FlowDirection is applied explicitly or implicitly")]
+		public async Task EntryAlignmentMatchesFlowDirection(bool isExplicit, FlowDirection flowDirection, UITextAlignment expectedAlignment)
+		{
+			var entry = new Entry { Text = "Checking flow direction", HorizontalTextAlignment = TextAlignment.Start };
+			var contentPage = new ContentPage { Title = "Flow Direction", Content = entry };
+
+			if (isExplicit)
+			{
+				entry.FlowDirection = flowDirection;
+			}
+			else
+			{
+				contentPage.FlowDirection = flowDirection;
+			}
+
+			var handler = await CreateHandlerAsync<EntryHandler>(entry);
+			var nativeAlignment = await contentPage.Dispatcher.DispatchAsync(() =>
+			{
+				var textField = GetPlatformControl(handler);
+				return textField.TextAlignment;
+			});
+
+			Assert.Equal(expectedAlignment, nativeAlignment);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.DeviceTests
 		//src/Compatibility/Core/tests/iOS/NavigationTests.cs
 		[Fact]
 		[Description("Multiple calls to NavigationRenderer.Dispose shouldn't crash")]
-		public void NavigationRendererDoubleDisposal()
+		public async Task NavigationRendererDoubleDisposal()
 		{
 			SetupBuilder();
 
@@ -81,14 +81,14 @@ namespace Microsoft.Maui.DeviceTests
 				Content = new Label { Text = "Hello" }
 			};
 
-			root.Dispatcher.DispatchAsync(() =>
+			await root.Dispatcher.DispatchAsync(() =>
 			{
 				var navPage = new NavigationPage(root);
 				var handler = CreateHandler(navPage);
 
 				// Calling Dispose more than once should be fine
-				(handler.PlatformView as NavigationRenderer).Dispose();
-				(handler.PlatformView as NavigationRenderer).Dispose();
+				(handler as NavigationRenderer).Dispose();
+				(handler as NavigationRenderer).Dispose();
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
@@ -64,6 +66,30 @@ namespace Microsoft.Maui.DeviceTests
 
 			var translucent = await GetValueAsync(navPage, (handler) => (handler.ViewController as UINavigationController).NavigationBar.Translucent);
 			Assert.Equal(enabled, translucent);
+		}
+
+		//src/Compatibility/Core/tests/iOS/NavigationTests.cs
+		[Fact]
+		[Description("Multiple calls to NavigationRenderer.Dispose shouldn't crash")]
+		public void NavigationRendererDoubleDisposal()
+		{
+			SetupBuilder();
+
+			var root = new ContentPage()
+			{
+				Title = "root",
+				Content = new Label { Text = "Hello" }
+			};
+
+			root.Dispatcher.DispatchAsync(() =>
+			{
+				var navPage = new NavigationPage(root);
+				var handler = CreateHandler(navPage);
+
+				// Calling Dispose more than once should be fine
+				(handler.PlatformView as NavigationRenderer).Dispose();
+				(handler.PlatformView as NavigationRenderer).Dispose();
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Page/PageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Page/PageTests.Android.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+using AView = Android.Views.View;
+using AndroidX.Fragment.App;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class PageTests : ControlsHandlerTestBase
+	{
+		//src/Compatibility/Core/tests/Android/EmbeddingTests.cs
+		[Fact(DisplayName = "Can Create Platform View From ContentPage")]
+		public async Task CanCreatePlatformViewFromContentPage()
+		{
+
+			var contentPage = new ContentPage { Title = "Embedded Page" };
+			var handler = CreateHandler<PageHandler>(contentPage);
+			var mauiContext = handler.MauiContext;
+
+			await contentPage.Dispatcher.DispatchAsync(() =>
+			{
+
+				AView platformView = contentPage.ToPlatform(mauiContext);
+				if (platformView is FragmentContainerView containerView)
+				{
+					var activity = mauiContext.Context as AndroidX.Fragment.App.FragmentActivity;
+					var fragmentManager = activity.SupportFragmentManager;
+					var fragment = fragmentManager.FindFragmentById(containerView.Id);
+					Assert.NotNull(fragment);
+				}
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Page/PageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Page/PageTests.iOS.cs
@@ -3,9 +3,12 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.PlatformConfiguration;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -38,6 +41,24 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					Assert.NotEqual(shellPage.CurrentPage.On<iOS>().SafeAreaInsets(), Thickness.Zero);
 				}
+			});
+		}
+
+		//src/Compatibility/Core/tests/iOS/EmbeddingTests.cs
+		[Fact(DisplayName = "Can Create Platform View From ContentPage")]
+		public async Task CanCreateViewControllerFromContentPage()
+		{
+			var contentPage = new ContentPage { Title = "Embedded Page" };
+			await contentPage.Dispatcher.DispatchAsync(async () =>
+			{
+				var handler = CreateHandler<PageHandler>(contentPage);
+				var mauiContext = handler.MauiContext;
+
+				await contentPage.Dispatcher.DispatchAsync(() =>
+				{
+					UIViewController viewController = contentPage.ToUIViewController(mauiContext);
+					Assert.NotNull(viewController);
+				});
 			});
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.iOS.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using CoreGraphics;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -40,6 +41,22 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.PlatformViewValue);
 		}
 
+		//src/Compatibility/Core/tests/iOS/ImageButtonTests.cs
+		[Fact]
+		[Trait("Category", "ImageButton")]
+		public async Task CreatedWithCorrectButtonType()
+		{
+			var imageButton = new ImageButton();
+			var handler = await CreateHandlerAsync(imageButton);
+
+			var buttonType = await InvokeOnMainThreadAsync(() =>
+			{
+				var uiButton = GetPlatformImageButton(handler);
+				return uiButton.ButtonType;
+			});
+
+			Assert.NotEqual(UIButtonType.Custom, buttonType);
+		}
 		UIButton GetPlatformImageButton(ImageButtonHandler imageButtonHandler) =>
 			imageButtonHandler.PlatformView;
 


### PR DESCRIPTION
### Description of Change
Migration of Compatibility.Core platform-specific unit tests to device tests. Here the migrated cases which ensuring that the IsEnabled and CornerRadius consistency of different elements matches their native counterparts. We are going to migrate tests in blocks in different PRs. This is the 8st group.

There are unit tests under:

- src\Compatibility\Core\tests\Android
- src\Compatibility\Core\tests\iOS
- src\Compatibility\Core\tests\WinUI

That are not running right now. these cases from Xamarin.Forms where they could run as unit tests, but now with .NET MAUI this is not possible. So here I migrated the following cases in device tests.

 
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/WinUI/FlowDirectionTests.cs
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/iOS/FlowDirectionTests.cs
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/iOS/NavigationTests.cs
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/Android/EmbeddingTests.cs
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/iOS/EmbeddingTests.cs
- https://github.com/dotnet/maui/blob/main/src/Compatibility/Core/tests/iOS/ImageButtonTests.cs

This pull request includes updates to various test files to add new tests and improve the existing ones. The key changes include adding new tests to verify text alignment and flow direction for `Editor` and `Entry` controls, as well as tests for navigation and embedding functionalities.

### New Tests for Text Alignment and Flow Direction

* [`src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Windows.cs`](diffhunk://#diff-61dd12c8a4febadd64e1a5e6675987de1e4b8613eed7142a54840e1a6a7b3d27R42-R72): Added a test to verify that the `Editor`'s text alignment and flow direction match the expected values when `FlowDirection` is applied explicitly or implicitly.
* [`src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.iOS.cs`](diffhunk://#diff-8525460953f8d193307843142390752e2cf9eadf152a73b0019021b0f069a6aeR100-R129): Added a test to verify that the `Editor`'s text alignment matches the expected alignment when `FlowDirection` is applied explicitly or implicitly.
* [`src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs`](diffhunk://#diff-39c20900654372817b00cdc06ffff46496954fb5effadfeb405a2baa6bb7aff5R40-R70): Added a test to verify that the `Entry`'s text alignment matches the expected alignment when `FlowDirection` is applied explicitly or implicitly.
* [`src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs`](diffhunk://#diff-c54f6d2d29b9265b5684bf7d7423094767d4a8c00e7833615ec1be1e7be40cd2R328-R357): Added a test to verify that the `Entry`'s text alignment matches the expected alignment when `FlowDirection` is applied explicitly or implicitly.

### Navigation and Embedding Tests

* [`src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs`](diffhunk://#diff-a109c23433122d79e57946eb606f478c5999c2a6058095cd834e3380afe10665R70-R93): Added a test to ensure that multiple calls to `NavigationRenderer.Dispose` do not cause a crash.
* [`src/Controls/tests/DeviceTests/Elements/Page/PageTests.Android.cs`](diffhunk://#diff-a9b9462d20748d801be49aa3c073eeb1b7cf468ab5faadb97aa35966adf60bf2R1-R37): Added a test to verify that a platform view can be created from a `ContentPage`.
* [`src/Controls/tests/DeviceTests/Elements/Page/PageTests.iOS.cs`](diffhunk://#diff-f45ff084337f84ca8041bc4138c9f95c9741d261d3e059e0eedf6c178b33df1dR46-R63): Added a test to verify that a view controller can be created from a `ContentPage`.

### Other Updates

* [`src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.iOS.cs`](diffhunk://#diff-457d6abe16352b000e6a35d1f61f3b5613eb5a3e2d93a073da4f757d64aa38bcR44-R59): Added a test to verify that an `ImageButton` is created with the correct button type.

### Issues Fixed

Fixes #27303