### PR TITLE
[Windows] Upgrade to Windows App SDK 1.7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.7.250310001</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.7.250401001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.2903.40</MicrosoftWindowsWebView2PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.6.250228001</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.7.250310001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.2903.40</MicrosoftWindowsWebView2PackageVersion>

--- a/src/Templates/tests/Directory.Build.targets
+++ b/src/Templates/tests/Directory.Build.targets
@@ -4,4 +4,7 @@
     <Error Text="The build did not make use of the BuildTools package but instead ran the fallback target '_GetMakeAppxToolPath' to try and locate the tool." />
   </Target>
 
+  <!-- we flip things around in the templates -->
+  <Target Name="VerifyLaunchSettings" />
+
 </Project>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
@@ -22,7 +22,9 @@ public class WindowsTemplateTest : BaseTemplateTests
 
 		// TODO: remove this if as we should be able to build tizen net8
 		if (framework != DotNetPrevious)
+		{
 			EnableTizen(projectFile);
+		}
 
 		if (framework == DotNetPrevious)
 		{
@@ -54,7 +56,9 @@ public class WindowsTemplateTest : BaseTemplateTests
 	public void BuildWindowsAppSDKSelfContained(string id, bool wasdkself, bool netself, string packageType)
 	{
 		if (TestEnvironment.IsMacOS)
+		{
 			Assert.Ignore("This test is designed for testing a windows build.");
+		}
 
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -82,10 +86,12 @@ public class WindowsTemplateTest : BaseTemplateTests
 	[TestCase("maui", true, "MSIX")]
 	[TestCase("maui", false, "None")]
 	[TestCase("maui", false, "MSIX")]
-	public void BuildWindowsRidGraph(string id, bool useridgraph, string packageType)
+	public void BuildWindowsRidGraph(string id, bool useRidGraph, string packageType)
 	{
 		if (TestEnvironment.IsMacOS)
+		{
 			Assert.Ignore("This test is designed for testing a windows build.");
+		}
 
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -96,7 +102,7 @@ public class WindowsTemplateTest : BaseTemplateTests
 		FileUtilities.ReplaceInFile(projectFile,
 			"<WindowsPackageType>None</WindowsPackageType>",
 			$"""
-			<UseRidGraph>{useridgraph}</UseRidGraph>
+			<UseRidGraph>{useRidGraph}</UseRidGraph>
 			<WindowsPackageType>{packageType}</WindowsPackageType>
 			""");
 
@@ -115,7 +121,9 @@ public class WindowsTemplateTest : BaseTemplateTests
 	public void PublishUnpackaged(string id, string framework, string config)
 	{
 		if (!TestEnvironment.IsWindows)
+		{
 			Assert.Ignore("Running Windows templates is only supported on Windows.");
+		}
 
 		var projectDir = TestDirectory;
 		var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
@@ -164,7 +172,9 @@ public class WindowsTemplateTest : BaseTemplateTests
 	public void PublishPackaged(string id, string framework, string config)
 	{
 		if (!TestEnvironment.IsWindows)
+		{
 			Assert.Ignore("Running Windows templates is only supported on Windows.");
+		}
 
 		var projectDir = TestDirectory;
 		var name = Path.GetFileName(projectDir);


### PR DESCRIPTION
### Description of Change

Upgrade Windows App SDK from 1.6 to 1.7. See [release](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/stable-channel#version-170-17250310001) [notes](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/stable-channel#version-171-17250401001) and GitHub release notes:

* https://github.com/microsoft/WindowsAppSDK/releases/tag/v1.7.0
* https://github.com/microsoft/microsoft-ui-xaml/releases/tag/winui3/release/1.7.0

I'm not sure what the plans regarding upgrading are[^1]. I just noticed that it seems much easier to [upgrade than from 1.5 to 1.6](https://github.com/dotnet/maui/pull/24266).

[^1]: Should it be done in .NET 9 servicing or in .NET 10?
