### PR TITLE
Obsolete ListView and Cell types

### DIFF
--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Maui.Controls
 {
 	// Don't add IElementConfiguration<Cell> because it kills performance on UWP structures that use Cells
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="Type[@FullName='Microsoft.Maui.Controls.Cell']/Docs/*" />
-	[Obsolete("The controls which use Cell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	public abstract class Cell : Element, ICellController, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IVisualTreeElement
 	{
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='DefaultCellHeight']/Docs/*" />
@@ -139,11 +138,11 @@ namespace Microsoft.Maui.Controls
 			{
 #pragma warning disable CS0618 // Type or member is obsolete
 				var table = RealParent as TableView;
-#pragma warning restore CS0618 // Type or member is obsolete
 				if (table != null)
 					return table.HasUnevenRows && Height > 0 ? Height : table.RowHeight;
 
 				var list = RealParent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (list != null)
 					return list.HasUnevenRows && Height > 0 ? Height : list.RowHeight;
 
@@ -232,7 +231,9 @@ namespace Microsoft.Maui.Controls
 		{
 			OnAppearing();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var container = RealParent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 			container?.SendCellAppearing(this);
 		}
 
@@ -242,7 +243,9 @@ namespace Microsoft.Maui.Controls
 		{
 			OnDisappearing();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var container = RealParent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 			container?.SendCellDisappearing(this);
 		}
 

--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Controls
 {
 	// Don't add IElementConfiguration<Cell> because it kills performance on UWP structures that use Cells
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="Type[@FullName='Microsoft.Maui.Controls.Cell']/Docs/*" />
+	[Obsolete("The controls which use Cell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	public abstract class Cell : Element, ICellController, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController, IVisualTreeElement
 	{
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='DefaultCellHeight']/Docs/*" />

--- a/src/Controls/src/Core/Cells/EntryCell.cs
+++ b/src/Controls/src/Core/Cells/EntryCell.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/EntryCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.EntryCell']/Docs/*" />
+	[Obsolete("The controls which use EntryCell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	public class EntryCell : Cell, ITextAlignmentElement, IEntryCellController, ITextAlignment
 	{
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>

--- a/src/Controls/src/Core/Cells/ImageCell.cs
+++ b/src/Controls/src/Core/Cells/ImageCell.cs
@@ -4,6 +4,7 @@ using System;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ImageCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.ImageCell']/Docs/*" />
+	[Obsolete("The controls which use ImageCell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	public class ImageCell : TextCell
 	{
 		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>

--- a/src/Controls/src/Core/Cells/SwitchCell.cs
+++ b/src/Controls/src/Core/Cells/SwitchCell.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/SwitchCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.SwitchCell']/Docs/*" />
+	[Obsolete("The controls which use SwitchCell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	public class SwitchCell : Cell
 	{
 		/// <summary>Bindable property for <see cref="On"/>.</summary>

--- a/src/Controls/src/Core/Cells/TextCell.cs
+++ b/src/Controls/src/Core/Cells/TextCell.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.TextCell']/Docs/*" />
+	[Obsolete("The controls which use TextCell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	public class TextCell : Cell
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>

--- a/src/Controls/src/Core/Cells/ViewCell.cs
+++ b/src/Controls/src/Core/Cells/ViewCell.cs
@@ -1,10 +1,12 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ViewCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.ViewCell']/Docs/*" />
+	[Obsolete("The controls which use ViewCell (ListView and TableView) are obsolete. Please use CollectionView instead.")]
 	[ContentProperty("View")]
 	public class ViewCell : Cell
 	{

--- a/src/Controls/src/Core/Compatibility/Android/Extensions/ViewCellExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/Android/Extensions/ViewCellExtensions.cs
@@ -11,10 +11,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			var parent = element.Parent;
 			while (parent != null)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (parent is ViewCell)
 				{
 					return true;
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 				parent = parent.Parent;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/BaseCellView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/BaseCellView.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public const double DefaultMinHeight = 44;
 
 		readonly Color _androidDefaultTextColor;
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell _cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 		readonly AppCompatTextView _detailText;
 		readonly ImageView _imageView;
 		readonly AppCompatTextView _mainText;
@@ -31,7 +33,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		Color _mainTextColor;
 		string _mainTextText;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public BaseCellView(Context context, Cell cell) : base(context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			_cell = cell;
 			SetMinimumWidth((int)context.ToPixels(25));

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellAdapter.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		readonly Context _context;
 		ActionMode _actionMode;
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell _actionModeContext;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		bool _actionModeNeedsUpdates;
 		AView _contextView;
@@ -33,7 +35,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_context = context;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal Cell ActionModeContext
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			get { return _actionModeContext; }
 			set
@@ -154,7 +158,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return HandleContextMode(view, position);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected abstract Cell GetCellForPosition(int position);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		protected virtual void HandleItemClick(AdapterView parent, AView view, int position, long id)
 		{
@@ -221,7 +227,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (view is EditText || view is TextView || view is SearchView)
 				return false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell cell = GetCellForPosition(position);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (cell == null)
 				return false;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellFactory.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellFactory.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public static class CellFactory
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static AView GetCell(Cell item, AView convertView, ViewGroup parent, Context context, View view)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			// If the convert view coming in is null that means this cell is going to need a new view generated for it
 			// This should probably be copied over to ListView once all sets of these TableView changes are propagated There
@@ -53,7 +55,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				view.SetMinimumHeight((int)context.ToPixels(table.RowHeight));
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateMinimumHeightFromParent(Context context, AView view, ListView listView)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (!listView.HasUnevenRows && listView.RowHeight > 0)
 				view.SetMinimumHeight((int)context.ToPixels(listView.RowHeight));

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellRenderer.cs
@@ -11,15 +11,25 @@ using Object = Java.Lang.Object;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	public class CellRenderer : ElementHandler<Cell, AView>, IRegisterable
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
 		static readonly PropertyChangedEventHandler PropertyChangedHandler = OnGlobalCellPropertyChanged;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static PropertyMapper<Cell, CellRenderer> Mapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				new PropertyMapper<Cell, CellRenderer>(ElementHandler.ElementMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static CommandMapper<Cell, CellRenderer> CommandMapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			new CommandMapper<Cell, CellRenderer>(ElementHandler.ElementCommandMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public CellRenderer() : base(Mapper, CommandMapper)
 		{
@@ -27,7 +37,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public View ParentView { get; set; }
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected Cell Cell { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		protected override AView CreatePlatformElement()
 		{
@@ -36,7 +48,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return GetCell(VirtualView, creationArgs, null, (MauiContext.Context));
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public AView GetCell(Cell item, AView convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (item.Parent is View parentView)
 				ParentView = parentView;
@@ -57,7 +71,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Object tag = convertView.Tag;
 				CellRenderer renderer = (tag as RendererHolder)?.Renderer;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				Cell oldCell = renderer?.Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (oldCell != null)
 				{
@@ -88,7 +104,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return view;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected virtual AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			Performance.Start(out string reference, "GetCellCore");
 
@@ -110,7 +128,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected void WireUpForceUpdateSizeRequested(Cell cell, AView platformCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			ICellController cellController = cell;
 			cellController.ForceUpdateSizeRequested -= OnForceUpdateSizeRequested;
@@ -127,8 +147,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		static void OnForceUpdateSizeRequested(object sender, EventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (sender is not Cell cellInner)
 				return;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (cellInner.Handler is not IElementHandler elementHandler ||
 				elementHandler.PlatformView is not AView pCell ||
@@ -144,14 +166,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			pCell.SetMinimumWidth(pCell.MeasuredWidth);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal static CellRenderer GetRenderer(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return (CellRenderer)cell.Handler;
 		}
 
 		static void OnGlobalCellPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (Cell)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
 			CellRenderer renderer = GetRenderer(cell);
 			if (renderer == null)
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ConditionalFocusLayout.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ConditionalFocusLayout.cs
@@ -24,14 +24,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return false;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal void ApplyTouchListenersToSpecialCells(Cell item)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			DescendantFocusability = DescendantFocusability.BlockDescendants;
 
 			global::Android.Views.View aView = GetChildAt(0);
 			(aView as EntryCellView)?.EditText.SetOnTouchListener(this);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var viewCell = item as ViewCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (viewCell?.View == null)
 				return;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellRenderer.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		EntryCellView _view;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override global::Android.Views.View GetCellCore(Cell item, global::Android.Views.View convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			Disconnect();
 			if ((_view = convertView as EntryCellView) == null)
@@ -45,16 +47,23 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			base.OnCellPropertyChanged(sender, e);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (e.PropertyName == EntryCell.LabelProperty.PropertyName)
 				UpdateLabel();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.TextProperty.PropertyName)
 				UpdateText();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.PlaceholderProperty.PropertyName)
 				UpdatePlaceholder();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.KeyboardProperty.PropertyName)
 				UpdateKeyboard();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.LabelColorProperty.PropertyName)
 				UpdateLabelColor();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.HorizontalTextAlignmentProperty.PropertyName)
 				UpdateHorizontalTextAlignment();
 			else if (e.PropertyName == EntryCell.VerticalTextAlignmentProperty.PropertyName)
@@ -68,6 +77,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateFlowDirection();
 				UpdateHorizontalTextAlignment();
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		protected virtual NumberKeyListener GetDigitsKeyListener(InputTypes inputTypes)
@@ -86,10 +102,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnTextChanged(string text)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			entryCell
 				.SetValue(EntryCell.TextProperty, text, specificity: SetterSpecificity.FromHandler);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateHeight()
@@ -99,25 +119,33 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateHorizontalTextAlignment()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			_view.EditText.UpdateHorizontalAlignment(entryCell.HorizontalTextAlignment);
 		}
 
 		void UpdateVerticalTextAlignment()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			_view.EditText.UpdateVerticalAlignment(entryCell.VerticalTextAlignment);
 		}
 
 		void UpdateIsEnabled()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			_view.EditText.Enabled = entryCell.IsEnabled;
 		}
 
 		void UpdateKeyboard()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var keyboard = entryCell.Keyboard;
 			_view.EditText.InputType = keyboard.ToInputType();
 
@@ -129,12 +157,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateLabel()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			_view.LabelText = ((EntryCell)Cell).Label;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateLabelColor()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			_view.SetLabelTextColor(((EntryCell)Cell).LabelColor, global::Android.Resource.Attribute.TextColor);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateFlowDirection()
@@ -144,13 +176,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdatePlaceholder()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			_view.EditText.Hint = entryCell.Placeholder;
 		}
 
 		void UpdateText()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (_view.EditText.Text == entryCell.Text)
 				return;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellView.cs
@@ -18,13 +18,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		public const double DefaultMinHeight = 55;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		readonly Cell _cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 		readonly AppCompatTextView _label;
 
 		Color _labelTextColor;
 		string _labelTextText;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public EntryCellView(Context context, Cell cell) : base(context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			_cell = cell;
 			SetMinimumWidth((int)context.ToPixels(50));

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/GroupedListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/GroupedListViewAdapter.cs
@@ -18,7 +18,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			public int Start { get; set; }
 			public int End => Start + Length;
 		}
+#pragma warning disable CS0618 // Type or member is obsolete
 		public GroupedListViewAdapter(Context context, AListView realListView, ListView listView) : base(context, realListView, listView)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ImageCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ImageCellRenderer.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class ImageCellRenderer : TextCellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override global::Android.Views.View GetCellCore(Cell item, global::Android.Views.View convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var result = (BaseCellView)base.GetCellCore(item, convertView, parent, context);
 
@@ -20,15 +22,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected override void OnCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			base.OnCellPropertyChanged(sender, args);
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (args.PropertyName == ImageCell.ImageSourceProperty.PropertyName)
 				UpdateImage();
 			else if (args.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateImage()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (ImageCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (cell.ImageSource != null)
 			{
 				View.SetImageVisible(true);

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -25,10 +25,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		static int s_dividerHorizontalDarkId = int.MinValue;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal static readonly BindableProperty IsSelectedProperty = BindableProperty.CreateAttached("IsSelected", typeof(bool), typeof(Cell), false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		readonly Context _context;
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected readonly ListView _listView;
+#pragma warning restore CS0618 // Type or member is obsolete
 		readonly AListView _realListView;
 		readonly Dictionary<DataTemplate, int> _templateToId = new Dictionary<DataTemplate, int>();
 		readonly Dictionary<int, ConditionalFocusLayout> _layoutsCreated = new Dictionary<int, ConditionalFocusLayout>();
@@ -39,26 +43,38 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		// To prevent a conflict in the event that a ListView supports both templates and non-templates, we will start the DataTemplate key at 2.
 
 		int _listCount = -1; // -1 we need to get count from the list
+#pragma warning disable CS0618 // Type or member is obsolete
 		Dictionary<object, Cell> _prototypicalCellByTypeOrDataTemplate;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		bool _fromNative;
 		AView _lastSelected;
+#pragma warning disable CS0618 // Type or member is obsolete
 		WeakReference<Cell> _selectedCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		IListViewController Controller => _listView;
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected ITemplatedItemsView<Cell> TemplatedItemsView => _listView;
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public ListViewAdapter(Context context, AListView realListView, ListView listView) : base(context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			_context = context;
 			_realListView = realListView;
 			_listView = listView;
+#pragma warning disable CS0618 // Type or member is obsolete
 			_prototypicalCellByTypeOrDataTemplate = new Dictionary<object, Cell>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (listView.SelectedItem != null)
 				SelectItem(listView.SelectedItem);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var templatedItems = ((ITemplatedItemsView<Cell>)listView).TemplatedItems;
+#pragma warning restore CS0618 // Type or member is obsolete
 			templatedItems.CollectionChanged += OnCollectionChanged;
 			templatedItems.GroupedCollectionChanged += OnGroupedCollectionChanged;
 			listView.ItemSelected += OnItemSelected;
@@ -111,7 +127,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (_listView.IsGroupingEnabled)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					Cell cell = GetCellForPosition(index);
+#pragma warning restore CS0618 // Type or member is obsolete
 					return cell.BindingContext;
 				}
 
@@ -217,7 +235,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override AView GetView(int position, AView convertView, ViewGroup parent)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell cell = null;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Performance.Start(out string reference);
 
@@ -227,12 +247,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (_listView.IsGroupingEnabled)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					List<Cell> cells = GetCellsFromPosition(position, 2);
+#pragma warning restore CS0618 // Type or member is obsolete
 					if (cells.Count > 0)
 						cell = cells[0];
 
 					if (cells.Count == 2)
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 						nextCellIsHeader = cells[1].GetIsGroupHeader<ItemsView<Cell>, Cell>();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 
 				if (cell == null)
@@ -287,7 +313,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					throw new InvalidOperationException($"View for cell must implement {nameof(INativeElementView)} to enable recycling.");
 				}
+#pragma warning disable CS0618 // Type or member is obsolete
 				cell = (Cell)boxedCell.Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				ICellController cellController = cell;
 				cellController.SendDisappearing();
@@ -351,7 +379,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			Performance.Stop(reference, "AddView");
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			bool isHeader = cell.GetIsGroupHeader<ItemsView<Cell>, Cell>();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			AView bline;
 
@@ -385,11 +417,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_prototypicalCellByTypeOrDataTemplate.Clear();
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal ITemplatedItemsList<Cell> GetTemplatedItemsListForPath(int indexPath)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var templatedItems = TemplatedItemsView.TemplatedItems;
 			if (_listView.IsGroupingEnabled)
+#pragma warning disable CS0618 // Type or member is obsolete
 				templatedItems = (ITemplatedItemsList<Cell>)((IList)templatedItems)[indexPath];
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return templatedItems;
 		}
@@ -408,14 +444,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return item.GetType();
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal Cell GetCellForPath(int indexPath)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var templatedItemsList = GetTemplatedItemsListForPath(indexPath);
 			var cell = templatedItemsList[indexPath];
 			return cell;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal Cell GetPrototypicalCell(int indexPath)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var itemTypeOrDataTemplate = default(object);
 
@@ -432,7 +472,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (itemTypeOrDataTemplate == null)
 				itemTypeOrDataTemplate = DefaultItemTypeOrDataTemplate;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell protoCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (!_prototypicalCellByTypeOrDataTemplate.TryGetValue(itemTypeOrDataTemplate, out protoCell))
 			{
 				// cache prototypical cell by item type; Items of the same Type share
@@ -447,9 +489,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override bool IsEnabled(int position)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			ListView list = _listView;
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			ITemplatedItemsView<Cell> templatedItemsView = list;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (list.IsGroupingEnabled)
 			{
 				int leftOver;
@@ -457,7 +503,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return leftOver > 0;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell item = GetPrototypicalCell(position);
+#pragma warning restore CS0618 // Type or member is obsolete
 			return item?.IsEnabled ?? false;
 		}
 
@@ -497,14 +545,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			base.Dispose(disposing);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override Cell GetCellForPosition(int position)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return GetCellsFromPosition(position, 1).FirstOrDefault();
 		}
 
 		protected override void HandleItemClick(AdapterView parent, AView view, int position, long id)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell cell = null;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if ((Controller.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
 			{
@@ -512,7 +564,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				var layout = cellOwner as ConditionalFocusLayout;
 				if (layout != null)
 					cellOwner = layout.GetChildAt(0);
+#pragma warning disable CS0618 // Type or member is obsolete
 				cell = (Cell)(cellOwner as INativeElementView)?.Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			// All our ListView's have called AddHeaderView. This effectively becomes index 0, so our index 0 is index 1 to the listView.
@@ -548,7 +602,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var renderedView = layout?.GetChildAt(0);
 
 			var element = (renderedView as INativeElementView)?.Element;
+#pragma warning disable CS0618 // Type or member is obsolete
 			var view = (element as ViewCell)?.View;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (renderedView is ViewGroup vg && view?.Handler?.PlatformView is AView aView)
 				vg.RemoveView(aView);
@@ -558,9 +614,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		// TODO: We can optimize this by storing the last position, group index and global index
 		// and increment/decrement from that starting place.	
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal List<Cell> GetCellsFromPosition(int position, int take)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cells = new List<Cell>(take);
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (position < 0)
 				return cells;
 
@@ -672,7 +732,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (_lastSelected != null)
 			{
 				UnsetSelectedBackground(_lastSelected);
+#pragma warning disable CS0618 // Type or member is obsolete
 				Cell previousCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (_selectedCell.TryGetTarget(out previousCell))
 					previousCell.SetValue(IsSelectedProperty, false);
 			}
@@ -682,9 +744,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (index == -1)
 				return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell cell = GetCellForPosition(index);
+#pragma warning restore CS0618 // Type or member is obsolete
 			cell.SetValue(IsSelectedProperty, true);
+#pragma warning disable CS0618 // Type or member is obsolete
 			_selectedCell = new WeakReference<Cell>(cell);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (view != null)
 				SetSelectedBackground(view);
@@ -703,7 +769,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Select(position, view);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateSeparatorVisibility(Cell cell, bool cellIsBeingReused, bool isHeader, bool nextCellIsHeader, bool isSeparatorVisible, ConditionalFocusLayout layout, out AView bline)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			bline = null;
 			if (cellIsBeingReused && layout.ChildCount > 1)
@@ -752,9 +820,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell GetNewGroupHeaderCell(ITemplatedItemsList<Cell> group)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var groupHeaderCell = _listView.TemplatedItems.GroupHeaderTemplate?.CreateContent(group.ItemsSource, _listView) as Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (groupHeaderCell != null)
 			{
@@ -762,13 +836,23 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 			else
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				groupHeaderCell = new TextCell();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				groupHeaderCell.SetBinding(TextCell.TextProperty, static (ITemplatedItemsList<Cell> g) => g.Name);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 				groupHeaderCell.BindingContext = group;
 			}
 
 			groupHeaderCell.Parent = _listView;
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			groupHeaderCell.SetIsGroupHeader<ItemsView<Cell>, Cell>(true);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 			return groupHeaderCell;
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -821,14 +821,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		}
 
 #pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 		Cell GetNewGroupHeaderCell(ITemplatedItemsList<Cell> group)
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 		{
-#pragma warning disable CS0618 // Type or member is obsolete
 			var groupHeaderCell = _listView.TemplatedItems.GroupHeaderTemplate?.CreateContent(group.ItemsSource, _listView) as Cell;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (groupHeaderCell != null)
 			{
@@ -836,25 +831,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 			else
 			{
-#pragma warning disable CS0618 // Type or member is obsolete
 				groupHeaderCell = new TextCell();
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 				groupHeaderCell.SetBinding(TextCell.TextProperty, static (ITemplatedItemsList<Cell> g) => g.Name);
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 				groupHeaderCell.BindingContext = group;
 			}
 
 			groupHeaderCell.Parent = _listView;
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 			groupHeaderCell.SetIsGroupHeader<ItemsView<Cell>, Cell>(true);
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
+
 			return groupHeaderCell;
 		}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		enum CellType
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
@@ -16,13 +16,23 @@ using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	public class ListViewRenderer : ViewRenderer<ListView, AListView>
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static PropertyMapper<ListView, ListViewRenderer> Mapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			new PropertyMapper<ListView, ListViewRenderer>(VisualElementRendererMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static CommandMapper<ListView, ListViewRenderer> CommandMapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			new CommandMapper<ListView, ListViewRenderer>(VisualElementRendererCommandMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		ListViewAdapter _adapter;
 		IPlatformViewHandler _headerRenderer;
@@ -35,7 +45,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		SwipeRefreshLayout _refresh;
 		IListViewController Controller => Element;
+#pragma warning disable CS0618 // Type or member is obsolete
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		ScrollBarVisibility _defaultHorizontalScrollVisibility = 0;
 		ScrollBarVisibility _defaultVerticalScrollVisibility = 0;
@@ -120,7 +132,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		//		oldParent?.AddView(ContainerView);
 		//}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			base.OnElementChanged(e);
 
@@ -221,16 +235,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateHeader();
 			else if (e.PropertyName == "FooterElement")
 				UpdateFooter();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == "RefreshAllowed")
 				UpdateIsSwipeToRefreshEnabled();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.IsPullToRefreshEnabledProperty.PropertyName)
 				UpdateIsSwipeToRefreshEnabled();
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.IsRefreshingProperty.PropertyName)
 				UpdateIsRefreshing();
 			else if (e.PropertyName == ListView.SeparatorColorProperty.PropertyName || e.PropertyName == ListView.SeparatorVisibilityProperty.PropertyName)
 				_adapter.NotifyDataSetChanged();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.ListView.IsFastScrollEnabledProperty.PropertyName)
 				UpdateFastScrollEnabled();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.SelectionModeProperty.PropertyName)
 				UpdateSelectionMode();
 			else if (e.PropertyName == ListView.RefreshControlColorProperty.PropertyName)
@@ -239,6 +259,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateHorizontalScrollBarVisibility();
 			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
 				UpdateVerticalScrollBarVisibility();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/*
@@ -319,7 +345,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			int scrollPosition;
 			var scrollArgs = (ITemplatedItemsListScrollToRequestedEventArgs)e;
 
@@ -727,7 +755,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			readonly ListView _element;
+#pragma warning restore CS0618 // Type or member is obsolete
 			readonly float _density;
 			int _contentOffset;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/SwitchCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/SwitchCellRenderer.cs
@@ -15,9 +15,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		SwitchCellView _view;
 		Drawable _defaultTrackDrawable;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (SwitchCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if ((_view = convertView as SwitchCellView) == null)
 				_view = new SwitchCellView(context, item);
@@ -40,29 +44,45 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected override void OnCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (args.PropertyName == SwitchCell.TextProperty.PropertyName)
 				UpdateText();
 			else if (args.PropertyName == SwitchCell.OnProperty.PropertyName)
 			{
 				UpdateChecked();
+#pragma warning disable CS0618 // Type or member is obsolete
 				UpdateOnColor(_view, (SwitchCell)sender);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 			else if (args.PropertyName == "RenderHeight")
 				UpdateHeight();
 			else if (args.PropertyName == Cell.IsEnabledProperty.PropertyName)
+#pragma warning disable CS0618 // Type or member is obsolete
 				UpdateIsEnabled(_view, (SwitchCell)sender);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (args.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
 			else if (args.PropertyName == SwitchCell.OnColorProperty.PropertyName)
+#pragma warning disable CS0618 // Type or member is obsolete
 				UpdateOnColor(_view, (SwitchCell)sender);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateChecked()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			((ASwitch)_view.AccessoryView).Checked = ((SwitchCell)Cell).On;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateIsEnabled(SwitchCellView cell, SwitchCell switchCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.Enabled = switchCell.IsEnabled;
 			var aSwitch = cell.AccessoryView as ASwitch;
@@ -82,10 +102,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateText()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			_view.MainText = ((SwitchCell)Cell).Text;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateOnColor(SwitchCellView cell, SwitchCell switchCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var aSwitch = cell.AccessoryView as ASwitch;
 			if (aSwitch != null)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/SwitchCellView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/SwitchCellView.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class SwitchCellView : BaseCellView, CompoundButton.IOnCheckedChangeListener
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public SwitchCellView(Context context, Cell cell) : base(context, cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var sw = new global::Android.Widget.Switch(context);
 			sw.SetOnCheckedChangeListener(this);
@@ -16,7 +18,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			SetImageVisible(false);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public SwitchCell Cell { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public void OnCheckedChanged(CompoundButton buttonView, bool isChecked)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/TextCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/TextCellRenderer.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		internal TextCellView View { get; private set; }
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if ((View = convertView as TextCellView) == null)
 				View = new TextCellView(context, item);
@@ -34,6 +36,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (args.PropertyName == TextCell.TextProperty.PropertyName || args.PropertyName == TextCell.TextColorProperty.PropertyName)
 				UpdateMainText();
 			else if (args.PropertyName == TextCell.DetailProperty.PropertyName || args.PropertyName == TextCell.DetailColorProperty.PropertyName)
@@ -46,6 +52,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateFlowDirection();
 			else if (args.PropertyName == VisualElement.AutomationIdProperty.PropertyName)
 				UpdateAutomationId();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateAutomationId()
@@ -55,7 +65,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateDetailText()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (TextCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			View.DetailText = cell.Detail;
 			View.SetDetailTextColor(cell.DetailColor);
 		}
@@ -67,7 +79,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateIsEnabled()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (TextCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			View.SetIsEnabled(cell.IsEnabled);
 		}
 
@@ -78,13 +92,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateMainText()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (TextCell)Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			View.MainText = cell.Text;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!cell.GetIsGroupHeader<ItemsView<Cell>, Cell>())
 				View.SetDefaultMainTextColor(Application.AccentColor);
 			else
 				View.SetDefaultMainTextColor(null);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			View.SetMainTextColor(cell.TextColor);
 
@@ -94,7 +114,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		// ensure we don't get other people's BaseCellView's
 		internal sealed class TextCellView : BaseCellView
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			public TextCellView(Context context, Cell cell) : base(context, cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -14,10 +14,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class ViewCellRenderer : CellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override AView GetCellCore(Cell item, AView convertView, ViewGroup parent, Context context)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			Performance.Start(out string reference, "GetCellCore");
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = (ViewCell)item;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var container = convertView as ViewCellContainer;
 			if (container is not null)
@@ -85,7 +89,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			readonly BindableProperty _rowHeight;
 			readonly BindableProperty _unevenRows;
 			IPlatformViewHandler _viewHandler;
+#pragma warning disable CS0618 // Type or member is obsolete
 			ViewCell _viewCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			GestureDetector _tapGestureDetector;
 			GestureDetector _longPressGestureDetector;
 			ListViewRenderer _listViewRenderer;
@@ -101,7 +107,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						return _listViewRenderer;
 					}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					var listView = _parent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 					if (listView == null)
 					{
@@ -147,7 +155,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				// Added default constructor to prevent crash when accessing selected row in ListViewAdapter.Dispose
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			public ViewCellContainer(Context context, IPlatformViewHandler view, ViewCell viewCell, View parent,
+#pragma warning restore CS0618 // Type or member is obsolete
 				BindableProperty unevenRows, BindableProperty rowHeight) : base(context)
 			{
 				_viewHandler = (IPlatformViewHandler)view;
@@ -196,7 +206,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return handled;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			public void Update(ViewCell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				// This cell could have a handler that was used for the measure pass for the ListView height calculations
 				//cell.View.Handler.DisconnectHandler();

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -24,12 +24,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 	public partial class CellControl : ContentControl
 	{
 		public static readonly DependencyProperty CellProperty = DependencyProperty.Register("Cell", typeof(object), typeof(CellControl),
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			new PropertyMetadata(null, (o, e) => ((CellControl)o).SetSource((Cell)e.OldValue, (Cell)e.NewValue)));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public static readonly DependencyProperty IsGroupHeaderProperty = DependencyProperty.Register("IsGroupHeader", typeof(bool), typeof(CellControl), null);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal static readonly BindableProperty MeasuredEstimateProperty = BindableProperty.Create("MeasuredEstimate", typeof(double), typeof(ListView), -1d);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		readonly Lazy<ListView> _listView;
+#pragma warning restore CS0618 // Type or member is obsolete
 		readonly PropertyChangedEventHandler _propertyChangedHandler;
 		WBrush _defaultOnColor;
 
@@ -40,7 +48,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public CellControl()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			_listView = new Lazy<ListView>(GetListView);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			DataContextChanged += OnDataContextChanged;
 
@@ -70,14 +80,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// 🚀 unsubscribe from propertychanged
 			Cell.PropertyChanged -= _propertyChangedHandler;
 			// Allows the Cell to unsubscribe from Parent.PropertyChanged
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (Cell.Parent is ListView)
 				Cell.Parent = null;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public Cell Cell
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			get { return (Cell)GetValue(CellProperty); }
+#pragma warning restore CS0618 // Type or member is obsolete
 			set { SetValue(CellProperty, value); }
 		}
 
@@ -94,7 +110,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			ListView lv = _listView.Value;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			// set the Cell now that we have a reference to the ListView, since it will have been skipped
 			// on DataContextChanged.
@@ -140,7 +158,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			return result;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		ListView GetListView()
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			DependencyObject parent = VisualTreeHelper.GetParent(this);
 			while (parent != null)
@@ -158,7 +178,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			return null;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		Microsoft.UI.Xaml.DataTemplate GetTemplate(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return (UI.Xaml.DataTemplate)cell.ToHandler(cell.FindMauiContext()).PlatformView;
 		}
@@ -169,19 +191,25 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				SetupContextMenu();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection(Cell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == SwitchCell.OnProperty.PropertyName ||
 				e.PropertyName == SwitchCell.OnColorProperty.PropertyName)
 			{
 				UpdateOnColor();
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateOnColor()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (!(Cell is SwitchCell switchCell))
 				return;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var color = switchCell.OnColor.IsDefault()
 				? _defaultOnColor
@@ -243,6 +271,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void SetDefaultSwitchColor()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (_defaultOnColor == null && Cell is SwitchCell)
 			{
 				var nativeSwitch = this.GetFirstDescendant<ToggleSwitch>();
@@ -251,6 +280,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					_defaultOnColor = rect.Fill;
 				UpdateOnColor();
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnContextActionsChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -272,10 +302,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// Cell has an ItemTemplate. Instead, we'll store the new data item, and it will be
 			// set on MeasureOverrideDelegate. However, if the parent is a TableView, we'll already 
 			// have a complete Cell object to work with, so we can move ahead.
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (_isListViewRealized || args.NewValue is Cell)
 				SetCell(args.NewValue);
 			else if (args.NewValue != null)
 				_newValue = args.NewValue;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		private void OnCellContentRightTapped(object sender, RightTappedRoutedEventArgs e)
@@ -330,7 +362,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void SetCell(object newContext)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = newContext as Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (cell != null)
 			{
@@ -343,11 +377,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			// If there is a ListView, load the Cell content from the ItemTemplate.
 			// Otherwise, the given Cell is already a templated Cell from a TableView.
+#pragma warning disable CS0618 // Type or member is obsolete
 			ListView lv = _listView.Value;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (lv != null)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				Cell oldCell = Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 				bool isGroupHeader = IsGroupHeader;
 				DataTemplate template = isGroupHeader ? lv.GroupHeaderTemplate : lv.ItemTemplate;
 				object bindingContext = newContext;
@@ -376,7 +414,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				}
 				else if (template != null)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					cell = template.CreateContent() as Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 				else
 				{
@@ -395,7 +435,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				// This provides the Group Header styling (e.g., larger font, etc.) when the
 				// template is loaded later.
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				cell.SetIsGroupHeader<ItemsView<Cell>, Cell>(isGroupHeader);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			// 🚀 Only set the cell if it DID change
@@ -413,7 +457,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		void SetSource(Cell oldCell, Cell newCell)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (oldCell != null)
 			{
@@ -471,7 +519,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateContent(Cell newCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			Microsoft.UI.Xaml.DataTemplate dt = GetTemplate(newCell);
 			if (dt != _currentTemplate || Content == null)
@@ -488,10 +538,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			return new FrameworkElementAutomationPeer(this);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateFlowDirection(Cell newCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (newCell is ViewCell)
 				return;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			this.UpdateFlowDirection(newCell.Parent as VisualElement);
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ICellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ICellRenderer.cs
@@ -3,6 +3,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public interface ICellRenderer : IRegisterable
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		Microsoft.UI.Xaml.DataTemplate GetTemplate(Cell cell);
+#pragma warning restore CS0618 // Type or member is obsolete
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -31,6 +31,7 @@ using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEv
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	public partial class ListViewRenderer : ViewRenderer<ListView, FrameworkElement>
 	{
 		public static PropertyMapper<ListView, ListViewRenderer> Mapper =
@@ -40,6 +41,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			new CommandMapper<ListView, ListViewRenderer>(VisualElementRendererCommandMapper);
 
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 		bool _collectionIsWrapped;
 		IList _collection = null;
 		bool _itemWasClicked;
@@ -81,7 +83,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			base.OnElementChanged(e);
 
@@ -89,7 +93,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				e.OldElement.ItemSelected -= OnElementItemSelected;
 				e.OldElement.ScrollToRequested -= OnElementScrollToRequested;
+#pragma warning disable CS0618 // Type or member is obsolete
 				((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems.CollectionChanged -= OnCollectionChanged;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (Control != null)
 				{
 					Control.Loaded -= ControlOnLoaded;
@@ -100,7 +106,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				e.NewElement.ItemSelected += OnElementItemSelected;
 				e.NewElement.ScrollToRequested += OnElementScrollToRequested;
+#pragma warning disable CS0618 // Type or member is obsolete
 				((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems.CollectionChanged += OnCollectionChanged;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (List == null)
 				{
@@ -267,26 +275,33 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			base.OnElementPropertyChanged(sender, e);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (e.PropertyName == ListView.IsGroupingEnabledProperty.PropertyName)
 			{
 				UpdateGrouping();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.HeaderProperty.PropertyName || e.PropertyName == "HeaderElement")
 			{
 				UpdateHeader();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.FooterProperty.PropertyName || e.PropertyName == "FooterElement")
 			{
 				UpdateFooter();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.RowHeightProperty.PropertyName)
 			{
 				ClearSizeEstimate();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.HasUnevenRowsProperty.PropertyName)
 			{
 				ClearSizeEstimate();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.ItemTemplateProperty.PropertyName)
 			{
 				ClearSizeEstimate();
@@ -295,10 +310,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				UpdateSelectionMode();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Specifics.SelectionModeProperty.PropertyName)
 			{
 				UpdateWindowsSpecificSelectionMode();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == ListView.VerticalScrollBarVisibilityProperty.PropertyName)
 			{
 				UpdateVerticalScrollBarVisibility();
@@ -307,6 +324,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				UpdateHorizontalScrollBarVisibility();
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		protected override void Dispose(bool disposing)
@@ -807,10 +833,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		private protected override void DisconnectHandlerCore()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (Element is ITemplatedItemsView<Cell> templatedItemsView)
 			{
 				templatedItemsView.TemplatedItems.CollectionChanged -= OnCollectionChanged;
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			CleanUpResources();
 			base.DisconnectHandlerCore();
@@ -830,7 +858,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				if (_itemWasClicked)
 					List.SelectedItem = Element.SelectedItem;
 				else
+#pragma warning disable CS0618 // Type or member is obsolete
 					((IElementController)Element).SetValueFromRenderer(ListView.SelectedItemProperty, List.SelectedItem);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			_itemWasClicked = false;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/TextCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/TextCellRenderer.cs
@@ -7,7 +7,9 @@ using WDataTemplate = Microsoft.UI.Xaml.DataTemplate;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	public abstract class CellRenderer : ElementHandler<Cell, WDataTemplate>, IRegisterable, ICellRenderer
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
 		public CellRenderer() : base(ElementHandler.ElementMapper)
 		{
@@ -16,20 +18,30 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected override WDataTemplate CreatePlatformElement() =>
 			GetTemplate(VirtualView);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public abstract WDataTemplate GetTemplate(Cell cell);
+#pragma warning restore CS0618 // Type or member is obsolete
 	}
 
 	public class TextCellRenderer : CellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override WDataTemplate GetTemplate(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (cell.RealParent is ListView)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (cell.GetIsGroupHeader<ItemsView<Cell>, Cell>())
 					return (WDataTemplate)WApplication.Current.Resources["ListViewHeaderTextCell"];
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				//return (WDataTemplate) WApplication.Current.Resources["ListViewTextCell"];
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return (WDataTemplate)WApplication.Current.Resources["TextCell"];
 		}
@@ -55,7 +67,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 	public class EntryCellRenderer : CellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override WDataTemplate GetTemplate(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return (WDataTemplate)WApplication.Current.Resources["EntryCell"];
 		}
@@ -63,7 +77,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 	public class ViewCellRenderer : CellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override WDataTemplate GetTemplate(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return (WDataTemplate)WApplication.Current.Resources["ViewCell"];
 		}
@@ -71,7 +87,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 	public class SwitchCellRenderer : CellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override WDataTemplate GetTemplate(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return (WDataTemplate)WApplication.Current.Resources["SwitchCell"];
 		}
@@ -79,7 +97,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 	public class ImageCellRenderer : CellRenderer
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override WDataTemplate GetTemplate(Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			//if (cell.Parent is ListView)
 			//	return (WDataTemplate)WApplication.Current.Resources["ListImageCell"];

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
@@ -7,17 +7,29 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	public class CellRenderer : ElementHandler<Cell, UITableViewCell>, IRegisterable
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		static readonly BindableProperty RealCellProperty = BindableProperty.CreateAttached("RealCell", typeof(UITableViewCell), typeof(Cell), null);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		readonly UIColor _defaultCellBgColor = (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13)) ? UIColor.Clear : UIColor.White;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static PropertyMapper<Cell, CellRenderer> Mapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				new PropertyMapper<Cell, CellRenderer>(ElementHandler.ElementMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static CommandMapper<Cell, CellRenderer> CommandMapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			new CommandMapper<Cell, CellRenderer>(ElementHandler.ElementCommandMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 		WeakReference<UITableView>? _tableView;
 
 		private protected event PropertyChangedEventHandler? CellPropertyChanged;
@@ -35,7 +47,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return GetCell(VirtualView, reusableCell, tv);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public virtual UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			_tableView = new(tv);
 			Performance.Start(out string reference);
@@ -62,7 +76,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return tvc;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public virtual void SetAccessibility(UITableViewCell tableViewCell, Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (cell.IsSet(AutomationProperties.IsInAccessibleTreeProperty))
 				tableViewCell.IsAccessibilityElement = cell.GetValue(AutomationProperties.IsInAccessibleTreeProperty).Equals(true);
@@ -88,7 +104,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public virtual void SetBackgroundColor(UITableViewCell tableViewCell, Cell cell, UIColor color)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (OperatingSystem.IsIOSVersionAtLeast(14))
 			{
@@ -104,7 +122,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			tableViewCell.BackgroundColor = color;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected void UpdateBackground(UITableViewCell tableViewCell, Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var uiBgColor = UITableView.Appearance.BackgroundColor ?? _defaultCellBgColor;
 
@@ -119,6 +139,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 			else
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (cell.GetIsGroupHeader<ItemsView<Cell>, Cell>())
 				{
 					uiBgColor = Microsoft.Maui.Platform.ColorExtensions.GroupedBackground;
@@ -128,6 +150,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					if (cell.RealParent is VisualElement element && element.BackgroundColor != null)
 						uiBgColor = element.BackgroundColor.ToPlatform();
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			SetBackgroundColor(tableViewCell, cell, uiBgColor);
@@ -178,10 +202,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				_tableView.TryGetTarget(out var tableView))
 			{
 				var index = tableView.IndexPathForCell(ctv);
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (index == null && VirtualView is Cell c)
 				{
 					index = Controls.Compatibility.Platform.iOS.CellExtensions.GetIndexPath(c);
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (index != null)
 					tableView.ReloadRows(new[] { index }, UITableViewRowAnimation.None);
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellTableViewCell.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class CellTableViewCell : UITableViewCell, INativeElementView
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		WeakReference<Cell> _cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public Action<object, PropertyChangedEventArgs> PropertyChanged;
 
@@ -19,7 +21,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public Cell Cell
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			get => _cell?.GetTargetOrDefault();
 			set
@@ -51,7 +55,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public void HandlePropertyChanged(object sender, PropertyChangedEventArgs e) => PropertyChanged?.Invoke(sender, e);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal static UITableViewCell GetPlatformCell(UITableView tableView, Cell cell, bool recycleCells = false, string templateId = "")
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var id = cell.GetType().FullName;
 
@@ -114,10 +120,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (disposing)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (Cell is Cell cell)
 				{
 					CellRenderer.SetRealCell(cell, null);
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 				_cell = null;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
@@ -143,7 +143,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				((INotifyCollectionChanged)cell.ContextActions).CollectionChanged += OnContextItemsChanged;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var height = Frame.Height + (parentListView != null && parentListView.SeparatorVisibility == SeparatorVisibility.None ? 0.5f : 0f);
+#pragma warning restore CS0618 // Type or member is obsolete
 			var width = ContentView.Frame.Width;
 
 			nativeCell.Frame = new RectangleF(0, 0, width, height);

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextActionCell.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		readonly List<UIButton> _buttons = new List<UIButton>();
 		readonly List<MenuItem> _menuItems = new List<MenuItem>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell _cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 		UIButton _moreButton;
 		UIScrollView _scroller;
 		UITableView _tableView;
@@ -124,9 +126,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Dispose(true);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public void Update(UITableView tableView, Cell cell, UITableViewCell nativeCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var parentListView = cell.RealParent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var recycling = parentListView != null &&
 				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (_cell != cell && recycling)
@@ -214,6 +220,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				//Hack: if we have a ImageCell the insets are slightly different,
 				//the inset numbers user below were taken using the Reveal app from the default cells
+#pragma warning disable CS0618 // Type or member is obsolete
 				if ((ContentCell as CellTableViewCell)?.Cell is ImageCell)
 				{
 					nfloat imageCellInsetLeft = 57;
@@ -225,6 +232,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					}
 					SeparatorInset = new UIEdgeInsets(0, imageCellInsetLeft, 0, imageCellInsetRight);
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				_scroller.AddSubview(nativeCell);
 			}
@@ -441,8 +449,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				if (_cell == null)
 					return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				var recycling = _cell.RealParent is ListView parentListView &&
 					((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (!recycling)
 					ReloadRow();
@@ -451,7 +461,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnContextItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var parentListView = _cell?.RealParent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var recycling = parentListView != null &&
 				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (recycling)
@@ -463,7 +475,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnMenuItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var parentListView = _cell.RealParent as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var recycling = parentListView != null &&
 				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (recycling)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextScrollViewDelegate.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ContextScrollViewDelegate.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override void LayoutSubviews()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var width = Frame.Width;
+#pragma warning restore CS0618 // Type or member is obsolete
 			nfloat takenSpace = 0;
 
 			for (var i = 0; i < Subviews.Length; i++)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
@@ -206,8 +206,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 #pragma warning disable CA1416, CA1422 // TODO:  'UITableViewCell.TextLabel' is unsupported on: 'ios' 14.0 and late
 				// simple algorithm to generally line up entries
+#pragma warning disable CS0618 // Type or member is obsolete
 				var start = (nfloat)Math.Round(Math.Max(Frame.Width * 0.3, TextLabel.Frame.Right + 10));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				TextField.Frame = new RectangleF(start, (Frame.Height - 30) / 2, Frame.Width - TextLabel.Frame.Left - start, 30);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CA1416, CA1422
 				// Centers TextField Content  (iOS6)
 				TextField.VerticalAlignment = UIControlContentVerticalAlignment.Center;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
@@ -22,9 +22,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		[UnsupportedOSPlatform("ios14.0")]
 		[UnsupportedOSPlatform("tvos14.0")]
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)item;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var tvc = reusableCell as EntryCellTableViewCell;
 			if (tvc == null)
@@ -61,25 +65,41 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		[UnsupportedOSPlatform("tvos14.0")]
 		static void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var entryCell = (EntryCell)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var realCell = (EntryCellTableViewCell)GetRealCell(entryCell);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (e.PropertyName == EntryCell.LabelProperty.PropertyName)
 				UpdateLabel(realCell, entryCell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.TextProperty.PropertyName)
 				UpdateText(realCell, entryCell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.PlaceholderProperty.PropertyName)
 				UpdatePlaceholder(realCell, entryCell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.KeyboardProperty.PropertyName)
 				UpdateKeyboard(realCell, entryCell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.LabelColorProperty.PropertyName)
 				UpdateLabelColor(realCell, entryCell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == EntryCell.HorizontalTextAlignmentProperty.PropertyName)
 				UpdateHorizontalTextAlignment(realCell, entryCell);
 			else if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(realCell, entryCell);
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateHorizontalTextAlignment(realCell, entryCell);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		static void OnKeyBoardDoneButtonPressed(object sender, EventArgs e)
@@ -93,20 +113,28 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		static void OnTextFieldTextChanged(object sender, EventArgs eventArgs)
 		{
 			var cell = (EntryCellTableViewCell)sender;
+#pragma warning disable CS0618 // Type or member is obsolete
 			var model = (EntryCell)cell.Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			model
 				.SetValue(EntryCell.TextProperty, cell.TextField.Text, specificity: SetterSpecificity.FromHandler);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateHorizontalTextAlignment(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.TextField.UpdateHorizontalTextAlignment(entryCell);
 		}
 
 		[UnsupportedOSPlatform("ios14.0")]
 		[UnsupportedOSPlatform("tvos14.0")]
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateIsEnabled(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.UserInteractionEnabled = entryCell.IsEnabled;
 			cell.TextLabel.Enabled = entryCell.IsEnabled;
@@ -114,31 +142,41 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			cell.TextField.Enabled = entryCell.IsEnabled;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateKeyboard(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.TextField.ApplyKeyboard(entryCell.Keyboard);
 		}
 
 		[UnsupportedOSPlatform("ios14.0")]
 		[UnsupportedOSPlatform("tvos14.0")]
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateLabel(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.TextLabel.Text = entryCell.Label;
 		}
 
 		[UnsupportedOSPlatform("ios14.0")]
 		[UnsupportedOSPlatform("tvos14.0")]
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateLabelColor(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.TextLabel.TextColor = entryCell.LabelColor?.ToPlatform() ?? DefaultTextColor.ToPlatform();
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdatePlaceholder(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.TextField.Placeholder = entryCell.Placeholder;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateText(EntryCellTableViewCell cell, EntryCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (cell.TextField.Text == entryCell.Text)
 				return;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ImageCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ImageCellRenderer.cs
@@ -14,11 +14,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var result = (CellTableViewCell)base.GetCell(item, reusableCell, tv);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var imageCell = (ImageCell)item;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			SetImage(imageCell, result);
 
@@ -27,16 +31,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected override void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var imageCell = (ImageCell)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var tvc = (CellTableViewCell)GetRealCell(imageCell);
 
 			base.HandleCellPropertyChanged(sender, args);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (args.PropertyName == ImageCell.ImageSourceProperty.PropertyName)
 				SetImage(imageCell, tvc);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void SetImage(ImageCell cell, CellTableViewCell target)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var source = cell.ImageSource;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -99,8 +99,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				OnScrollToRequested(this, request);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (_previousFrame != Frame)
+#pragma warning disable CS0618 // Type or member is obsolete
 				_previousFrame = Frame;
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		protected override void SetBackground(Brush brush)
@@ -1665,7 +1669,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			? UITableViewStyle.Plain
 			  : UITableViewStyle.Grouped)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			TableView.CellLayoutMarginsFollowReadableWidth = false;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			_usingLargeTitles = usingLargeTitles;
 
@@ -1690,6 +1696,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					//hack: On iOS11 with large titles we need to adjust the scroll offset manually
 					//since our UITableView is not the first child of the UINavigationController
 					//This also forces the spinner color to be correct if we started refreshing immediately after changing it.
+#pragma warning disable CS0618 // Type or member is obsolete
 					UpdateContentOffset(TableView.ContentOffset.Y - _refresh.Frame.Height, () =>
 					{
 						if (_refresh == null || _disposed)
@@ -1701,8 +1708,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 						//hack: when we don't have cells in our UITableView the spinner fails to appear
 						CheckContentSize();
+#pragma warning disable CS0618 // Type or member is obsolete
 						TableView.ScrollRectToVisible(new RectangleF(0, 0, _refresh.Bounds.Width, _refresh.Bounds.Height), true);
+#pragma warning restore CS0618 // Type or member is obsolete
 					});
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			}
 			else
@@ -1769,7 +1779,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (!_refresh.Refreshing && !_isRefreshing)
 			{
 				_isRefreshing = true;
+#pragma warning disable CS0618 // Type or member is obsolete
 				UpdateContentOffset(TableView.ContentOffset.Y - _refresh.Frame.Height, StartRefreshing);
+#pragma warning restore CS0618 // Type or member is obsolete
 				list.SendRefreshing();
 			}
 		}
@@ -1789,7 +1801,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override void ViewWillAppear(bool animated)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			(TableView?.Source as ListViewRenderer.ListViewDataSource)?.Cleanup();
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (!_list.TryGetTarget(out var list))
 				return;
 			if (!list.IsRefreshing || !_refresh.Refreshing)
@@ -1802,7 +1816,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override void ViewWillLayoutSubviews()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			(TableView?.Source as ListViewRenderer.ListViewDataSource)?.DetermineEstimatedRowHeight();
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public void UpdateRefreshControlColor(UIColor color)
@@ -1835,9 +1851,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void CheckContentSize()
 		{
 			//adding a default height of at least 1 pixel tricks iOS to show the spinner
+#pragma warning disable CS0618 // Type or member is obsolete
 			var contentSize = TableView.ContentSize;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (contentSize.Height == 0)
+#pragma warning disable CS0618 // Type or member is obsolete
 				TableView.ContentSize = new SizeF(contentSize.Width, 1);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnRefreshingChanged(object sender, EventArgs eventArgs)
@@ -1863,7 +1883,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateContentOffset(nfloat offset, Action completed = null)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			UIView.Animate(0.2, () => TableView.ContentOffset = new CoreGraphics.CGPoint(TableView.ContentOffset.X, offset), completed);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -20,13 +20,23 @@ using Specifics = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.List
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	public class ListViewRenderer : ViewRenderer<ListView, UITableView>
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static PropertyMapper<ListView, ListViewRenderer> Mapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				new PropertyMapper<ListView, ListViewRenderer>(VisualElementRendererMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static CommandMapper<ListView, ListViewRenderer> CommandMapper =
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			new CommandMapper<ListView, ListViewRenderer>(VisualElementRendererCommandMapper);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		const int DefaultRowHeight = 44;
 
@@ -39,8 +49,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		ScrollToRequestedEventArgs _requestedScroll;
 
 		FormsUITableViewController _tableViewController;
+#pragma warning disable CS0618 // Type or member is obsolete
 		ListView ListView => Element;
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		ITemplatedItemsView<Cell> TemplatedItemsView => Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 		public override UIViewController ViewController => _tableViewController;
 		//bool _disposed;
 		bool _usingLargeTitles;
@@ -197,7 +211,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
 			Control?.TableFooterView?.Dispose();
 		}
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			_requestedScroll = null;
 
@@ -213,7 +229,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
 
 				listView.ScrollToRequested -= OnScrollToRequested;
+#pragma warning disable CS0618 // Type or member is obsolete
 				var templatedItems = ((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				templatedItems.CollectionChanged -= OnCollectionChanged;
 				templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
@@ -248,7 +266,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				var listView = e.NewElement;
 
 				listView.ScrollToRequested += OnScrollToRequested;
+#pragma warning disable CS0618 // Type or member is obsolete
 				var templatedItems = ((ITemplatedItemsView<Cell>)e.NewElement).TemplatedItems;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				templatedItems.CollectionChanged += OnCollectionChanged;
 				templatedItems.GroupedCollectionChanged += OnGroupedCollectionChanged;
@@ -279,19 +299,26 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (e.PropertyName == Microsoft.Maui.Controls.ListView.RowHeightProperty.PropertyName)
 				UpdateRowHeight();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.IsGroupingEnabledProperty.PropertyName)
 				_dataSource.UpdateGrouping();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.HasUnevenRowsProperty.PropertyName)
 			{
 				Control.Source = _dataSource = Element.HasUnevenRows ? new UnevenListViewDataSource(_dataSource) : new ListViewDataSource(_dataSource);
 				ReloadData();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.IsPullToRefreshEnabledProperty.PropertyName)
 				UpdatePullToRefreshEnabled();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.IsRefreshingProperty.PropertyName)
 				UpdateIsRefreshing();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.SeparatorColorProperty.PropertyName)
 				UpdateSeparatorColor();
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.SeparatorVisibilityProperty.PropertyName)
@@ -300,8 +327,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateHeader();
 			else if (e.PropertyName == "FooterElement")
 				UpdateFooter();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == "RefreshAllowed")
 				UpdatePullToRefreshEnabled();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.SelectionModeProperty.PropertyName)
 				UpdateSelectionMode();
 			else if (e.PropertyName == Microsoft.Maui.Controls.ListView.RefreshControlColorProperty.PropertyName)
@@ -310,6 +339,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateVerticalScrollBarVisibility();
 			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
 				UpdateHorizontalScrollBarVisibility();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
@@ -406,7 +444,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnGroupedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			var til = (TemplatedItemsList<ItemsView<Cell>, Cell>)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var templatedItems = TemplatedItemsView.TemplatedItems;
 			var groupIndex = templatedItems.IndexOf(til.HeaderContent);
@@ -802,9 +844,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			IPlatformViewHandler _prototype;
 			bool _disposed;
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			Dictionary<object, Cell> _prototypicalCellByTypeOrDataTemplate = new Dictionary<object, Cell>();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			public UnevenListViewDataSource(ListView list, FormsUITableViewController uiTableViewController) : base(list, uiTableViewController)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 			}
 
@@ -823,7 +871,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					return 0;
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				var templatedItems = ((ITemplatedItemsView<Cell>)list).TemplatedItems;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (templatedItems.Count == 0)
 				{
@@ -873,7 +923,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					tableView.EstimatedRowHeight = estimatedRowHeight;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			internal Cell GetPrototypicalCell(NSIndexPath indexPath)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				if (!_list.TryGetTarget(out var list))
 					return null;
@@ -890,8 +942,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					return GetCellForPath(indexPath);
 
 				if (itemTypeOrDataTemplate == null)
+#pragma warning disable CS0618 // Type or member is obsolete
 					itemTypeOrDataTemplate = typeof(TextCell);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (!_prototypicalCellByTypeOrDataTemplate.TryGetValue(itemTypeOrDataTemplate, out Cell protoCell))
 				{
 					// cache prototypical cell by item type; Items of the same Type share
@@ -899,6 +954,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					protoCell = GetCellForPath(indexPath);
 					_prototypicalCellByTypeOrDataTemplate[itemTypeOrDataTemplate] = protoCell;
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				var templatedItems = GetTemplatedItemsListForPath(indexPath);
 				return templatedItems.UpdateContent(protoCell, indexPath.Row);
@@ -912,16 +968,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				var cell = GetPrototypicalCell(indexPath);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (_list.TryGetTarget(out var list) && list.RowHeight == -1 && cell.Height == -1 && cell is ViewCell)
 					return UITableView.AutomaticDimension;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				var renderHeight = cell.RenderHeight;
 				return renderHeight > 0 ? (nfloat)renderHeight : DefaultRowHeight;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			internal nfloat CalculateHeightForCell(UITableView tableView, Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				var viewCell = cell as ViewCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (viewCell != null && viewCell.View != null)
 				{
 					var target = viewCell.View;
@@ -985,7 +1047,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Dictionary<DataTemplate, int> _templateToId = new Dictionary<DataTemplate, int>();
 			readonly WeakReference<UITableView> _uiTableView;
 			readonly WeakReference<FormsUITableViewController> _uiTableViewController;
+#pragma warning disable CS0618 // Type or member is obsolete
 			protected readonly WeakReference<ListView> _list;
+#pragma warning restore CS0618 // Type or member is obsolete
 			bool _isDragging;
 			bool _setupSelection;
 			bool _selectionFromNative;
@@ -1006,7 +1070,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Counts = new Dictionary<int, int>();
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			public ListViewDataSource(ListView list, FormsUITableViewController uiTableViewController)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				_uiTableViewController = new(uiTableViewController);
 				_uiTableView = new(uiTableViewController.TableView);
@@ -1061,7 +1127,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				Cell cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 				UITableViewCell platformCell;
 
 				Performance.Start(out string reference);
@@ -1088,7 +1156,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					{
 						var templatedList = list.TemplatedItems.GetGroup(indexPath.Section);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 						cell = (Cell)((INativeElementView)platformCell).Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 						cell.SendDisappearing();
 
 						templatedList.UpdateContent(cell, indexPath.Row);
@@ -1236,9 +1306,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				if (!_list.TryGetTarget(out var list))
 					return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				Cell formsCell = null;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if ((list.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0)
+#pragma warning disable CS0618 // Type or member is obsolete
 					formsCell = (Cell)((INativeElementView)cell).Element;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				SetCellBackgroundColor(cell, UIColor.Clear);
 
@@ -1356,26 +1430,36 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (!_list.TryGetTarget(out var list))
 					return false;
+#pragma warning disable CS0618 // Type or member is obsolete
 				var templatedItems = ((ITemplatedItemsView<Cell>)list).TemplatedItems;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (list.IsGroupingEnabled)
 				{
 					var section = indexPath.Section;
 					if (section < 0 || section >= templatedItems.Count)
 						return false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					templatedItems = (ITemplatedItemsList<Cell>)((IList)templatedItems)[indexPath.Section];
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 
 				return templatedItems.ListProxy.TryGetValue(indexPath.Row, out var _);
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			protected ITemplatedItemsList<Cell> GetTemplatedItemsListForPath(NSIndexPath indexPath)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				if (!_list.TryGetTarget(out var list))
 					return null;
+#pragma warning disable CS0618 // Type or member is obsolete
 				var templatedItems = ((ITemplatedItemsView<Cell>)list).TemplatedItems;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (list.IsGroupingEnabled)
+#pragma warning disable CS0618 // Type or member is obsolete
 					templatedItems = (ITemplatedItemsList<Cell>)((IList)templatedItems)[indexPath.Section];
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				return templatedItems;
 			}
@@ -1394,7 +1478,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return item.GetType();
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			protected Cell GetCellForPath(NSIndexPath indexPath)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				var templatedItems = GetTemplatedItemsListForPath(indexPath);
 				var cell = templatedItems[indexPath.Row];
@@ -1538,7 +1624,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		UITableViewCell _tableViewCell;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public Cell Cell { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public void SetTableViewCell(UITableViewCell value)
 		{
@@ -1559,7 +1647,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 	internal sealed class FormsUITableViewController : UITableViewController
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		readonly WeakReference<ListView> _list;
+#pragma warning restore CS0618 // Type or member is obsolete
 		UIRefreshControl _refresh;
 
 		bool _refreshAdded;
@@ -1568,7 +1658,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		bool _isRefreshing;
 		bool _isStartRefreshingPending;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public FormsUITableViewController(ListView element, bool usingLargeTitles)
+#pragma warning restore CS0618 // Type or member is obsolete
 		: base(element.OnThisPlatform().GetGroupHeaderStyle() == GroupHeaderStyle.Plain
 			? UITableViewStyle.Plain
 			  : UITableViewStyle.Grouped)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/SwitchCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/SwitchCellRenderer.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var tvc = reusableCell as CellTableViewCell;
 			UISwitch uiSwitch = null;
@@ -40,7 +42,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				tvc.AccessoryView = uiSwitch;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var boolCell = (SwitchCell)item;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			_defaultOnColor = UISwitch.Appearance.OnTintColor;
 
@@ -63,24 +67,34 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var boolCell = (SwitchCell)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var realCell = (CellTableViewCell)GetRealCell(boolCell);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (e.PropertyName == SwitchCell.OnProperty.PropertyName)
 			{
 				((UISwitch)realCell.AccessoryView).SetState(boolCell.On, true);
 				UpdateOnColor(realCell, boolCell);
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == SwitchCell.TextProperty.PropertyName)
 #pragma warning disable CA1416, CA1422 // TODO: 'UITableViewCell.TextLabel' is unsupported on: 'ios' 14.0 and later
 				realCell.TextLabel.Text = boolCell.Text;
 #pragma warning restore CA1416, CA1422
 			else if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(realCell, boolCell);
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection(realCell, boolCell);
 			else if (e.PropertyName == SwitchCell.OnColorProperty.PropertyName)
 				UpdateOnColor(realCell, boolCell);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		static void OnSwitchValueChanged(object sender, EventArgs eventArgs)
@@ -96,17 +110,23 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 
 			if (realCell != null)
+#pragma warning disable CS0618 // Type or member is obsolete
 				((SwitchCell)realCell.Cell).On = sw.On;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateFlowDirection(CellTableViewCell cell, SwitchCell switchCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var uiSwitch = cell.AccessoryView as UISwitch;
 
 			uiSwitch.UpdateFlowDirection((IView)switchCell.Parent);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateIsEnabled(CellTableViewCell cell, SwitchCell switchCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.UserInteractionEnabled = switchCell.IsEnabled;
 #pragma warning disable CA1416, CA1422 // TODO: 'UITableViewCell.TextLabel', DetailTextLabel is unsupported on: 'ios' 14.0 and later
@@ -118,7 +138,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				uiSwitch.Enabled = switchCell.IsEnabled;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateOnColor(CellTableViewCell cell, SwitchCell switchCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var uiSwitch = cell.AccessoryView as UISwitch;
 			if (uiSwitch != null)

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/TextCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/TextCellRenderer.cs
@@ -17,9 +17,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var textCell = (TextCell)item;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (!(reusableCell is CellTableViewCell tvc))
 				tvc = new CellTableViewCell(UITableViewCellStyle.Subtitle, item.GetType().FullName);
@@ -50,33 +54,53 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected virtual void HandleCellPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var textCell = (TextCell)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
 			var tvc = (CellTableViewCell)GetRealCell(textCell);
 
 #pragma warning disable CA1416, CA1422 // TODO: 'UITableViewCell.TextLabel', DetailTextLabel is unsupported on: 'ios' 14.0 and later
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (args.PropertyName == TextCell.TextProperty.PropertyName)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				tvc.TextLabel.Text = ((TextCell)tvc.Cell).Text;
+#pragma warning restore CS0618 // Type or member is obsolete
 				tvc.TextLabel.SizeToFit();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (args.PropertyName == TextCell.DetailProperty.PropertyName)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				tvc.DetailTextLabel.Text = ((TextCell)tvc.Cell).Detail;
+#pragma warning restore CS0618 // Type or member is obsolete
 				tvc.DetailTextLabel.SizeToFit();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (args.PropertyName == TextCell.TextColorProperty.PropertyName)
 				tvc.TextLabel.TextColor = textCell.TextColor?.ToPlatform() ?? DefaultTextColor.ToPlatform();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (args.PropertyName == TextCell.DetailColorProperty.PropertyName)
 				tvc.DetailTextLabel.TextColor = textCell.DetailColor?.ToPlatform() ?? DefaultTextColor.ToPlatform();
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (args.PropertyName == Cell.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled(tvc, textCell);
 			else if (args.PropertyName == TextCell.AutomationIdProperty.PropertyName)
 				UpdateAutomationId(tvc, textCell);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CA1416, CA1422
 
 			HandlePropertyChanged(tvc, args);
 		}
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateAutomationId(CellTableViewCell tvc, TextCell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			tvc.AccessibilityIdentifier = cell.AutomationId;
 		}
@@ -89,7 +113,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		[System.Runtime.Versioning.UnsupportedOSPlatform("ios14.0")]
 		[System.Runtime.Versioning.UnsupportedOSPlatform("tvos14.0")]
+#pragma warning disable CS0618 // Type or member is obsolete
 		static void UpdateIsEnabled(CellTableViewCell cell, TextCell entryCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			cell.UserInteractionEnabled = entryCell.IsEnabled;
 			cell.TextLabel.Enabled = entryCell.IsEnabled;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
@@ -17,11 +17,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			Performance.Start(out string reference);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var viewCell = (ViewCell)item;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var cell = reusableCell as ViewTableCell;
 			if (cell == null)
@@ -43,7 +47,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			IMauiContext MauiContext => ViewCell?.FindMauiContext();
 			WeakReference<IPlatformViewHandler> _rendererRef;
+#pragma warning disable CS0618 // Type or member is obsolete
 			WeakReference<ViewCell> _viewCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Element INativeElementView.Element => ViewCell;
 			internal bool SupressSeparator { get; set; }
@@ -53,7 +59,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			public ViewCell ViewCell
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				get => _viewCell?.GetTargetOrDefault();
 				set
@@ -78,11 +86,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			void ViewCellPropertyChanged(object sender, PropertyChangedEventArgs e)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				var viewCell = (ViewCell)sender;
+#pragma warning restore CS0618 // Type or member is obsolete
 				var realCell = (ViewTableCell)GetRealCell(viewCell);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (e.PropertyName == Cell.IsEnabledProperty.PropertyName)
 					UpdateIsEnabled(viewCell.IsEnabled);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			public override void LayoutSubviews()
@@ -149,12 +161,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						_rendererRef = null;
 					}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					if (ViewCell is ViewCell viewCell)
 					{
 						viewCell.PropertyChanged -= ViewCellPropertyChanged;
 						viewCell.View.MeasureInvalidated -= OnMeasureInvalidated;
 						SetRealCell(viewCell, null);
 					}
+#pragma warning restore CS0618 // Type or member is obsolete
 					_viewCell = null;
 				}
 
@@ -165,8 +179,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			IPlatformViewHandler GetNewRenderer()
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (ViewCell is not ViewCell viewCell || viewCell.View == null)
 					throw new InvalidOperationException($"ViewCell must have a {nameof(viewCell.View)}");
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				var newRenderer = viewCell.View.ToHandler(viewCell.View.FindMauiContext());
 				_rendererRef = new WeakReference<IPlatformViewHandler>(newRenderer);
@@ -175,16 +191,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return (IPlatformViewHandler)newRenderer;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			void UpdateCell(ViewCell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				Performance.Start(out string reference);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (ViewCell is ViewCell oldCell)
 				{
 					BeginInvokeOnMainThread(oldCell.SendDisappearing);
 					oldCell.PropertyChanged -= ViewCellPropertyChanged;
 					oldCell.View.MeasureInvalidated -= OnMeasureInvalidated;
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (cell is null)
 				{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ViewCellRenderer.cs
@@ -107,7 +107,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				//TODO: Determine how best to hide the separator line when there is an accessory on the cell
 				if (SupressSeparator && Accessory == UITableViewCellAccessory.None)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					var oldFrame = Frame;
+#pragma warning restore CS0618 // Type or member is obsolete
 					ContentView.Bounds = new RectangleF(oldFrame.Location, new SizeF(oldFrame.Width, oldFrame.Height + 0.5f));
 				}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					void ScrollViewScrolled(object sender, ScrolledEventArgs e) =>
 						OnScrolled((nfloat)sv.ScrollY);
 				}
+#pragma warning disable CS0618 // Type or member is obsolete
 				else if (Content is CollectionView cv)
 				{
 					cv.Scrolled += CollectionViewScrolled;
@@ -96,6 +97,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					void ListViewScrolled(object sender, ScrolledEventArgs e) =>
 						OnScrolled((nfloat)e.ScrollY);
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSearchResultsRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSearchResultsRenderer.cs
@@ -171,7 +171,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				((INotifyCollectionChanged)e.OldList).CollectionChanged -= OnProxyCollectionChanged;
 			}
 			// Full reset
+#pragma warning disable CS0618 // Type or member is obsolete
 			TableView.ReloadData();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (e.NewList != null)
 			{
@@ -189,25 +191,39 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					if (e.NewStartingIndex == -1)
 						goto case NotifyCollectionChangedAction.Reset;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.BeginUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.InsertRows(GetPaths(section, e.NewStartingIndex, e.NewItems.Count), InsertRowsAnimation);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.EndUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 					break;
 
 				case NotifyCollectionChangedAction.Remove:
 					if (e.OldStartingIndex == -1)
 						goto case NotifyCollectionChangedAction.Reset;
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.BeginUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.DeleteRows(GetPaths(section, e.OldStartingIndex, e.OldItems.Count), DeleteRowsAnimation);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.EndUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
 					break;
 
 				case NotifyCollectionChangedAction.Move:
 					if (e.OldStartingIndex == -1 || e.NewStartingIndex == -1)
 						goto case NotifyCollectionChangedAction.Reset;
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.BeginUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
 					for (var i = 0; i < e.OldItems.Count; i++)
 					{
 						var oldIndex = e.OldStartingIndex;
@@ -219,21 +235,33 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 							newIndex += i;
 						}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 						TableView.MoveRow(NSIndexPath.FromRowSection(oldIndex, section), NSIndexPath.FromRowSection(newIndex, section));
+#pragma warning restore CS0618 // Type or member is obsolete
 					}
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.EndUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
 					break;
 
 				case NotifyCollectionChangedAction.Replace:
 					if (e.OldStartingIndex == -1)
 						goto case NotifyCollectionChangedAction.Reset;
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.BeginUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.ReloadRows(GetPaths(section, e.OldStartingIndex, e.OldItems.Count), ReloadRowsAnimation);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.EndUpdates();
+#pragma warning restore CS0618 // Type or member is obsolete
 					break;
 
 				case NotifyCollectionChangedAction.Reset:
+#pragma warning disable CS0618 // Type or member is obsolete
 					TableView.ReloadData();
+#pragma warning restore CS0618 // Type or member is obsolete
 					return;
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs
@@ -65,7 +65,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		void OnFlyoutItemsChanged(object sender, EventArgs e)
 		{
 			_source.ReSyncCache();
+#pragma warning disable CS0618 // Type or member is obsolete
 			TableView.ReloadData();
+#pragma warning restore CS0618 // Type or member is obsolete
 			ShellFlyoutContentManager.UpdateVerticalScrollMode();
 		}
 
@@ -76,17 +78,23 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			base.ViewDidLoad();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			TableView.SeparatorStyle = UITableViewCellSeparatorStyle.None;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)
 #if TVOS
 				|| OperatingSystem.IsTvOSVersionAtLeast(11)
 #endif
 			)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				TableView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			TableView.Source = _source;
+#pragma warning restore CS0618 // Type or member is obsolete
 			ShellFlyoutContentManager.ViewDidLoad();
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewSource.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewSource.cs
@@ -248,7 +248,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			public override void LayoutSubviews()
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				_line.Frame = new CoreGraphics.CGRect(15, 0, Frame.Width - 30, 1);
+#pragma warning restore CS0618 // Type or member is obsolete
 				base.LayoutSubviews();
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
@@ -117,7 +117,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 
 			var height = Height ?? MeasuredHeight;
+#pragma warning disable CS0618 // Type or member is obsolete
 			var width = Width ?? Frame.Width;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (double.IsNaN(height))
 				return;

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/Android/TableViewModelRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/Android/TableViewModelRenderer.cs
@@ -17,10 +17,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 #pragma warning restore CS0618 // Type or member is obsolete
 		protected readonly Context Context;
 		ITableViewController Controller => _view;
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell _restoreFocus;
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell[] _cellCache;
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell[] CellCache
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			get
 			{
@@ -136,7 +142,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override AView GetView(int position, AView convertView, ViewGroup parent)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell item = GetCellForPosition(position, out var isHeader, out var nextIsHeader);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (item == null)
 			{
@@ -199,7 +207,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			divider.SetBackgroundResource(DividerResourceId);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateCellFocus(Cell cell, AView nativeCell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			// If this cell is the one that's supposed to have focus, then request focus for the native cell
 			if (_restoreFocus == cell)
@@ -223,11 +233,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public override bool IsEnabled(int position)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Cell item = GetCellForPosition(position, out var isHeader, out _);
+#pragma warning restore CS0618 // Type or member is obsolete
 			return !isHeader && item.IsEnabled;
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		protected override Cell GetCellForPosition(int position)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			bool isHeader, nextIsHeader;
 			return GetCellForPosition(position, out isHeader, out nextIsHeader);
@@ -246,7 +260,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			model.RowSelected(CellCache[position]);
 		}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell GetCellForPosition(int position, out bool isHeader, out bool nextIsHeader)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			isHeader = false;
 			nextIsHeader = false;
@@ -264,7 +280,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			ITableModel model = Controller.Model;
 			int sectionCount = model.GetSectionCount();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var newCellCache = new List<Cell>();
+#pragma warning restore CS0618 // Type or member is obsolete
 			var newIsHeaderCache = new List<bool>();
 			var newNextIsHeaderCache = new List<bool>();
 
@@ -276,9 +294,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				if (!string.IsNullOrEmpty(sectionTitle))
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					Cell headerCell = model.GetHeaderCell(sectionIndex);
+#pragma warning restore CS0618 // Type or member is obsolete
 					if (headerCell == null)
+#pragma warning disable CS0618 // Type or member is obsolete
 						headerCell = new TextCell { Text = sectionTitle, TextColor = sectionTextColor };
+#pragma warning restore CS0618 // Type or member is obsolete
 					headerCell.Parent = _view;
 
 					newIsHeaderCache.Add(true);
@@ -290,7 +312,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					newIsHeaderCache.Add(false);
 					newNextIsHeaderCache.Add(i == sectionRowCount - 1 && sectionIndex < sectionCount - 1);
+#pragma warning disable CS0618 // Type or member is obsolete
 					newCellCache.Add((Cell)model.GetItem(sectionIndex, i));
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/Android/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/Android/TableViewRenderer.cs
@@ -147,7 +147,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					int adapterCount = _adapter.Count;
 					for (int i = 0; i < adapterCount; i++)
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						var cell = (Cell)_adapter[i];
+#pragma warning restore CS0618 // Type or member is obsolete
 						if (cell.Height > -1)
 						{
 							totalHeight += cell.Height;

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/Windows/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/Windows/TableViewRenderer.cs
@@ -94,12 +94,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				foreach (object item in e.AddedItems)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					if (item is Cell cell)
 					{
 						if (cell.IsEnabled)
 							Element.Model.RowSelected(cell);
 						break;
 					}
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/iOS/TableViewModelRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/iOS/TableViewModelRenderer.cs
@@ -10,7 +10,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class TableViewModelRenderer : UITableViewSource
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		readonly Dictionary<nint, Cell> _headerCells = new Dictionary<nint, Cell>();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		protected bool HasBoundGestures;
 
@@ -205,12 +209,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var cell = table.Model.GetCell(indexPath.Section, indexPath.Row);
 			var h = cell.Height;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (table.RowHeight == -1 && h == -1 && cell is ViewCell)
 			{
 				return UITableView.AutomaticDimension;
 			}
 			else if (h == -1)
 				return tableView.RowHeight;
+#pragma warning restore CS0618 // Type or member is obsolete
 			return (nfloat)h;
 		}
 	}

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/iOS/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/iOS/TableViewRenderer.cs
@@ -31,8 +31,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			base.LayoutSubviews();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (_previousFrame != Frame)
+#pragma warning disable CS0618 // Type or member is obsolete
 				_previousFrame = Frame;
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/MauiNavigationBar.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/MauiNavigationBar.cs
@@ -66,18 +66,36 @@ internal class MauiNavigationBar : UINavigationBar
             var currentSafeAreaTop = SafeAreaInsets.Top;
             var titleBarHeight = controller._contentWrapperTopConstraint?.Constant ?? 0;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (currentSafeAreaTop > 0 && Frame.Y < originalSafeAreaConstant && titleBarHeight == 0)
             {
                 controller.IsFirstLayout = false;
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 Frame = new CGRect(Frame.X, originalSafeAreaConstant, Frame.Width, Frame.Height);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
                 TitleBarNeedsRefresh = true;
             }
             else if (controller.IsFirstLayout)
             {
                 controller.IsFirstLayout = false;
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 Frame = new CGRect(Frame.X, Math.Max(originalSafeAreaConstant - titleBarHeight, 0), Frame.Width, Frame.Height);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
                 TitleBarNeedsRefresh = true;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 #endif

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/CellExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/CellExtensions.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
 	internal static class CellExtensions
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		internal static NSIndexPath GetIndexPath(this Cell self)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if (self == null)
 				throw new ArgumentNullException(nameof(self));

--- a/src/Controls/src/Core/DataTemplateSelector.cs
+++ b/src/Controls/src/Core/DataTemplateSelector.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplateSelector.xml" path="//Member[@MemberName='SelectTemplate']/Docs/*" />
 		public DataTemplate SelectTemplate(object item, BindableObject container)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = container as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var recycle = listView == null ? false :
 				(listView.CachingStrategy & ListViewCachingStrategy.RecycleElementAndDataTemplate) ==

--- a/src/Controls/src/Core/Handlers/Items/iOS/HorizontalDefaultCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/HorizontalDefaultCell.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
 		public HorizontalDefaultCell(CGRect frame) : base(frame)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.HeightAnchor.ConstraintEqualTo(Frame.Height);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/HorizontalDefaultSupplementalView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/HorizontalDefaultSupplementalView.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			Label.Font = UIFont.PreferredHeadline;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.HeightAnchor.ConstraintEqualTo(Frame.Height);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/VerticalDefaultCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/VerticalDefaultCell.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
 		public VerticalDefaultCell(CGRect frame) : base(frame)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.WidthAnchor.ConstraintEqualTo(Frame.Width);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/VerticalDefaultSupplementalView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/VerticalDefaultSupplementalView.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			Label.Font = UIFont.PreferredHeadline;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.WidthAnchor.ConstraintEqualTo(Frame.Width);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/HorizontalDefaultCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/HorizontalDefaultCell2.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
 		public HorizontalDefaultCell2(CGRect frame) : base(frame)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.HeightAnchor.ConstraintEqualTo(Frame.Height);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/HorizontalDefaultSupplementalView2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/HorizontalDefaultSupplementalView2.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			Label.Font = UIFont.PreferredHeadline;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.HeightAnchor.ConstraintEqualTo(Frame.Height);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/VerticalDefaultCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/VerticalDefaultCell2.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
 		public VerticalDefaultCell2(CGRect frame) : base(frame)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.WidthAnchor.ConstraintEqualTo(Frame.Width);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/VerticalDefaultSupplementalView2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/VerticalDefaultSupplementalView2.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			Label.Font = UIFont.PreferredHeadline;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Constraint = Label.WidthAnchor.ConstraintEqualTo(Frame.Width);
+#pragma warning restore CS0618 // Type or member is obsolete
 			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -123,14 +123,28 @@ public static partial class AppHostBuilderExtensions
 #pragma warning restore CA1416
 
 #if WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(ListView), typeof(Handlers.Compatibility.ListViewRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
 #if !TIZEN
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(Cell), typeof(Handlers.Compatibility.CellRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(ImageCell), typeof(Handlers.Compatibility.ImageCellRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(EntryCell), typeof(Handlers.Compatibility.EntryCellRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(TextCell), typeof(Handlers.Compatibility.TextCellRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(ViewCell), typeof(Handlers.Compatibility.ViewCellRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(SwitchCell), typeof(Handlers.Compatibility.SwitchCellRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 #pragma warning disable CS0618 // Type or member is obsolete
 		handlersCollection.AddHandler(typeof(TableView), typeof(Handlers.Compatibility.TableViewRenderer));

--- a/src/Controls/src/Core/ITableModel.cs
+++ b/src/Controls/src/Core/ITableModel.cs
@@ -5,8 +5,12 @@ namespace Microsoft.Maui.Controls
 {
 	public interface ITableModel
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell GetCell(int section, int row);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell GetHeaderCell(int section);
+#pragma warning restore CS0618 // Type or member is obsolete
 		object GetItem(int section, int row);
 		int GetRowCount(int section);
 		int GetSectionCount();

--- a/src/Controls/src/Core/Internals/CellExtensions.cs
+++ b/src/Controls/src/Core/Internals/CellExtensions.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Maui.Controls.Internals
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static Tuple<int, int> GetPath(this Cell cell)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 #pragma warning disable CS0618 // Type or member is obsolete
 			return TableView.TableSectionModel.GetPath(cell);

--- a/src/Controls/src/Core/ListView/IListViewController.cs
+++ b/src/Controls/src/Core/ListView/IListViewController.cs
@@ -12,14 +12,28 @@ namespace Microsoft.Maui.Controls
 		Element HeaderElement { get; }
 		bool RefreshAllowed { get; }
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		Cell CreateDefaultCell(object item);
+#pragma warning restore CS0618 // Type or member is obsolete
 		string GetDisplayTextFromGroup(object cell);
+#pragma warning disable CS0618 // Type or member is obsolete
 		void NotifyRowTapped(int index, int inGroupIndex, Cell cell);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		void NotifyRowTapped(int index, int inGroupIndex, Cell cell, bool isContextMenuRequested);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		void NotifyRowTapped(int index, Cell cell);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		void NotifyRowTapped(int index, Cell cell, bool isContextMenuRequested);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		void SendCellAppearing(Cell cell);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		void SendCellDisappearing(Cell cell);
+#pragma warning restore CS0618 // Type or member is obsolete
 		void SendRefreshing();
 	}
 }

--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -16,6 +16,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="Type[@FullName='Microsoft.Maui.Controls.ListView']/Docs/*" />
+	[Obsolete("Please use CollectionView instead.")]
 	public class ListView : ItemsView<Cell>, IListViewController, IElementConfiguration<ListView>, IVisualTreeElement
 	{
 		// The ListViewRenderer has some odd behavior with LogicalChildren

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -22,13 +22,19 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='IsFastScrollEnabled']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static bool IsFastScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return GetIsFastScrollEnabled(config.Element);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsFastScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			SetIsFastScrollEnabled(config.Element, value);
 			return config;

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
@@ -8,11 +8,15 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 	public static class ViewCell
 	{
 		/// <summary>Bindable property for attached property <c>IsContextActionsLegacyModeEnabled</c>.</summary>
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static readonly BindableProperty IsContextActionsLegacyModeEnabledProperty = BindableProperty.Create("IsContextActionsLegacyModeEnabled", typeof(bool), typeof(Maui.Controls.ViewCell), false, propertyChanged: OnIsContextActionsLegacyModeEnabledPropertyChanged);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		private static void OnIsContextActionsLegacyModeEnabledPropertyChanged(BindableObject element, object oldValue, object newValue)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = element as FormsCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			cell.IsContextActionsLegacyModeEnabled = (bool)newValue;
 		}
 
@@ -29,13 +33,19 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static bool GetIsContextActionsLegacyModeEnabled(this IPlatformElementConfiguration<Android, FormsCell> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return GetIsContextActionsLegacyModeEnabled(config.Element);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<Android, FormsCell> SetIsContextActionsLegacyModeEnabled(this IPlatformElementConfiguration<Android, FormsCell> config, bool value)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			SetIsContextActionsLegacyModeEnabled(config.Element, value);
 			return config;

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
@@ -28,14 +28,20 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static ListViewSelectionMode GetSelectionMode(this IPlatformElementConfiguration<Windows, FormsElement> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return (ListViewSelectionMode)config.Element.GetValue(SelectionModeProperty);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetSelectionMode(
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			this IPlatformElementConfiguration<Windows, FormsElement> config, ListViewSelectionMode value)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			config.Element.SetValue(SelectionModeProperty, value);
 			return config;

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
@@ -19,11 +19,17 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			=> element.SetValue(DefaultBackgroundColorProperty, value);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='DefaultBackgroundColor']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static Color DefaultBackgroundColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 			=> GetDefaultBackgroundColor(config.Element);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetDefaultBackgroundColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			SetDefaultBackgroundColor(config.Element, value);
 			return config;

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	public static class ListView
 	{
 		/// <summary>Bindable property for <see cref="SeparatorStyle"/>.</summary>
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static readonly BindableProperty SeparatorStyleProperty = BindableProperty.Create(nameof(SeparatorStyle), typeof(SeparatorStyle), typeof(FormsElement), SeparatorStyle.Default);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle'][1]/Docs/*" />
 		public static SeparatorStyle GetSeparatorStyle(BindableObject element)
@@ -22,20 +24,28 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static SeparatorStyle GetSeparatorStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return GetSeparatorStyle(config.Element);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSeparatorStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, SeparatorStyle value)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			SetSeparatorStyle(config.Element, value);
 			return config;
 		}
 
 		/// <summary>Bindable property for <see cref="GroupHeaderStyle"/>.</summary>
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static readonly BindableProperty GroupHeaderStyleProperty = BindableProperty.Create(nameof(GroupHeaderStyle), typeof(GroupHeaderStyle), typeof(FormsElement), GroupHeaderStyle.Plain);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle'][1]/Docs/*" />
 		public static GroupHeaderStyle GetGroupHeaderStyle(BindableObject element)
@@ -50,13 +60,19 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static GroupHeaderStyle GetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return GetGroupHeaderStyle(config.Element);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, GroupHeaderStyle value)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			SetGroupHeaderStyle(config.Element, value);
 			return config;
@@ -78,14 +94,20 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled'][2]/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetRowAnimationsEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			SetRowAnimationsEnabled(config.Element, value);
 			return config;
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='RowAnimationsEnabled']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public static bool RowAnimationsEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return GetRowAnimationsEnabled(config.Element);
 		}

--- a/src/Controls/src/Core/SwipeView/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeView.cs
@@ -292,11 +292,13 @@ namespace Microsoft.Maui.Controls
 					scrollView.Scrolled -= OnParentScrolled;
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (_scrollParent is ListView listView)
 				{
 					listView.Scrolled -= OnParentScrolled;
 					return;
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (_scrollParent is Microsoft.Maui.Controls.CollectionView collectionView)
 				{
@@ -318,13 +320,17 @@ namespace Microsoft.Maui.Controls
 					return;
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				_scrollParent = this.FindParentOfType<ListView>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (_scrollParent is ListView listView)
 				{
 					listView.Scrolled += OnParentScrolled;
 					return;
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				_scrollParent = this.FindParentOfType<Microsoft.Maui.Controls.CollectionView>();
 

--- a/src/Controls/src/Core/TableView/TableModel.cs
+++ b/src/Controls/src/Core/TableView/TableModel.cs
@@ -11,18 +11,26 @@ namespace Microsoft.Maui.Controls.Internals
 	public abstract class TableModel : ITableModel
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='GetCell']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public virtual Cell GetCell(int section, int row)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			object item = GetItem(section, row);
+#pragma warning disable CS0618 // Type or member is obsolete
 			var cell = item as Cell;
+#pragma warning restore CS0618 // Type or member is obsolete
 			if (cell != null)
 				return cell;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			return new TextCell { Text = item.ToString() };
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='GetHeaderCell']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 		public virtual Cell GetHeaderCell(int section)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			return null;
 		}

--- a/src/Controls/src/Core/TableView/TableSection.cs
+++ b/src/Controls/src/Core/TableView/TableSection.cs
@@ -162,7 +162,9 @@ namespace Microsoft.Maui.Controls
 	}
 
 	/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="Type[@FullName='Microsoft.Maui.Controls.TableSection']/Docs/*" />
+#pragma warning disable CS0618 // Type or member is obsolete
 	public sealed class TableSection : TableSectionBase<Cell>
+#pragma warning restore CS0618 // Type or member is obsolete
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor'][1]/Docs/*" />
 		public TableSection()

--- a/src/Controls/src/Core/TemplatedItemsList.cs
+++ b/src/Controls/src/Core/TemplatedItemsList.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 		static readonly BindableProperty IndexProperty = BindableProperty.Create("Index", typeof(int), typeof(TItem), -1);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		static readonly BindablePropertyKey IsGroupHeaderPropertyKey = BindableProperty.CreateAttachedReadOnly("IsGroupHeader", typeof(bool), typeof(Cell), false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		readonly BindableProperty _itemSourceProperty;
 		readonly BindableProperty _itemTemplateProperty;
@@ -189,7 +191,9 @@ namespace Microsoft.Maui.Controls.Internals
 		{
 			get
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				var listView = _itemsView as ListView;
+#pragma warning restore CS0618 // Type or member is obsolete
 				if (listView == null)
 					return ListViewCachingStrategy.RetainElement;
 
@@ -760,12 +764,14 @@ namespace Microsoft.Maui.Controls.Internals
 				groupProxy.HeaderContent.BindingContext = groupProxy;
 				// TODO: the interceptor doesn't support generics at the moment
 				// groupProxy.HeaderContent.SetBinding(TextCell.TextProperty, static (TemplatedItemsList<TView, TItem> list) => list.Name);
+#pragma warning disable CS0618 // Type or member is obsolete
 				groupProxy.HeaderContent.SetBinding(
 					TextCell.TextProperty,
 					TypedBinding.ForSingleNestingLevel(
 						nameof(TemplatedItemsList<TView, TItem>.Name),
 						getter: static (TemplatedItemsList<TView, TItem> list) => list.Name,
 						setter: static (list, val) => list.Name = val));
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			SetIndex(groupProxy.HeaderContent, index);

--- a/src/Controls/tests/Core.UnitTests/ListViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ListViewTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-
+#pragma warning disable CS0618 // Type or member is obsolete
 	public class ListViewTests : BaseTestFixture
 	{
 		MockDeviceInfo mockDeviceInfo;
@@ -1671,4 +1671,5 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			element.ForceUpdateSize();
 		}
 	}
+	#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -145,16 +145,22 @@ namespace Microsoft.Maui.DeviceTests
 					ReturnType = ReturnType.Next
 				};
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				var listView = new ListView()
 				{
 					ItemTemplate = new DataTemplate(() =>
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						var cell = new EntryCell();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 						cell.SetBinding(EntryCell.TextProperty, ".");
+#pragma warning restore CS0618 // Type or member is obsolete
 						return cell;
 					}),
 					ItemsSource = Enumerable.Range(0, 10).Select(i => $"EntryCell {i}").ToList()
 				};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				var layout = new VerticalStackLayout()
 				{

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -123,13 +123,15 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					builder.ConfigureMauiHandlers(handlers =>
 					{
-						handlers.AddHandler<ListView, ListViewRenderer>();
 #pragma warning disable CS0618 // Type or member is obsolete
+						handlers.AddHandler<ListView, ListViewRenderer>();
 						handlers.AddHandler<TableView, TableViewRenderer>();
 #pragma warning restore CS0618 // Type or member is obsolete
 						handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 						handlers.AddHandler<Entry, EntryHandler>();
+#pragma warning disable CS0618 // Type or member is obsolete
 						handlers.AddHandler<EntryCell, EntryCellRenderer>();
+#pragma warning restore CS0618 // Type or member is obsolete
 					});
 				});
 			}
@@ -150,17 +152,13 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					ItemTemplate = new DataTemplate(() =>
 					{
-#pragma warning disable CS0618 // Type or member is obsolete
 						var cell = new EntryCell();
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 						cell.SetBinding(EntryCell.TextProperty, ".");
 #pragma warning restore CS0618 // Type or member is obsolete
 						return cell;
 					}),
 					ItemsSource = Enumerable.Range(0, 10).Select(i => $"EntryCell {i}").ToList()
 				};
-#pragma warning restore CS0618 // Type or member is obsolete
 
 				var layout = new VerticalStackLayout()
 				{

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Android.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.ListView)]
 	public partial class ListViewTests
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		void ValidatePlatformCells(ListView listView)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			var renderer = (ListViewRenderer)listView.Handler;
 

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.ListView)]
 	public partial class ListViewTests
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		void ValidatePlatformCells(ListView listView)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 
 		}
@@ -28,10 +30,12 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 
 			var data = new ObservableCollection<string>();
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView()
 			{
 				ItemsSource = data
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var layout = new VerticalStackLayout()
 			{

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
+#pragma warning disable CS0618 // Type or member is obsolete
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	[Category(TestCategory.ListView)]
 	public partial class ListViewTests : ControlsHandlerTestBase
@@ -455,4 +456,5 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 	}
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -51,20 +51,25 @@ namespace Microsoft.Maui.DeviceTests
 
 			var template1 = new DataTemplate(() =>
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				return new ViewCell()
 				{
 					View = new Label()
 				};
+#pragma warning restore CS0618 // Type or member is obsolete
 			});
 
 			var template2 = new DataTemplate(() =>
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				return new ViewCell()
 				{
 					View = new Entry()
 				};
+#pragma warning restore CS0618 // Type or member is obsolete
 			});
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView()
 			{
 				HasUnevenRows = true,
@@ -75,6 +80,7 @@ namespace Microsoft.Maui.DeviceTests
 				IsGroupingEnabled = true,
 				ItemsSource = new ObservableCollection<ObservableCollection<string>>() { data1 }
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			await CreateHandlerAndAddToWindow<LayoutHandler>(new VerticalStackLayout() { listView }, async (handler) =>
 			{
@@ -94,10 +100,12 @@ namespace Microsoft.Maui.DeviceTests
 				"catdog"
 			};
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView()
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					return new ViewCell()
 					{
 						View = new VerticalStackLayout()
@@ -105,9 +113,11 @@ namespace Microsoft.Maui.DeviceTests
 							new Label()
 						}
 					};
+#pragma warning restore CS0618 // Type or member is obsolete
 				}),
 				ItemsSource = data
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var layout = new VerticalStackLayout()
 			{
@@ -135,10 +145,12 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task ReAssigninListViewInVSLCrashes()
 		{
 			SetupBuilder();
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView()
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					return new ViewCell()
 					{
 						View = new VerticalStackLayout()
@@ -149,8 +161,10 @@ namespace Microsoft.Maui.DeviceTests
 							}
 						}
 					};
+#pragma warning restore CS0618 // Type or member is obsolete
 				})
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var layout = new VerticalStackLayout()
 			{
@@ -178,16 +192,22 @@ namespace Microsoft.Maui.DeviceTests
 				vm
 			};
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView()
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					var cell = new EntryCell();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					cell.SetBinding(EntryCell.TextProperty, "Value");
+#pragma warning restore CS0618 // Type or member is obsolete
 					return cell;
 				}),
 				ItemsSource = data
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var layout = new VerticalStackLayout()
 			{
@@ -197,7 +217,9 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
 			{
 				await Task.Yield();
+#pragma warning disable CS0618 // Type or member is obsolete
 				var entryCell = listView.TemplatedItems[0] as EntryCell;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				// Initial Value is correct
 				Assert.Equal(vm.Value, entryCell.Text);
@@ -235,10 +257,12 @@ namespace Microsoft.Maui.DeviceTests
 				"catdog"
 			};
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView(ListViewCachingStrategy.RecycleElement)
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					return new ViewCell()
 					{
 						View = new VerticalStackLayout()
@@ -246,10 +270,12 @@ namespace Microsoft.Maui.DeviceTests
 							new Label()
 						}
 					};
+#pragma warning restore CS0618 // Type or member is obsolete
 				}),
 				HasUnevenRows = true,
 				ItemsSource = data
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var layout = new VerticalStackLayout()
 			{
@@ -280,10 +306,12 @@ namespace Microsoft.Maui.DeviceTests
 				"catdog"
 			};
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView(ListViewCachingStrategy.RecycleElement)
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					return new ViewCell
 					{
 						View = new VerticalStackLayout
@@ -291,9 +319,11 @@ namespace Microsoft.Maui.DeviceTests
 							new Label()
 						}
 					};
+#pragma warning restore CS0618 // Type or member is obsolete
 				}),
 				ItemsSource = data
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var layout = new VerticalStackLayout
 			{
@@ -335,15 +365,19 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 
 			var references = new List<WeakReference>();
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					var cell = new TextCell();
+#pragma warning restore CS0618 // Type or member is obsolete
 					references.Add(new(cell));
 					return cell;
 				})
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			await CreateHandlerAndAddToWindow<ListViewRenderer>(listView, async _ =>
 			{
@@ -363,18 +397,26 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			SetupBuilder();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			List<TextCell> cells = null;
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var listView = new ListView
 			{
 				ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					var cell = new TextCell();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					cell.SetBinding(TextCell.TextProperty, new Binding("."));
+#pragma warning restore CS0618 // Type or member is obsolete
 					cells?.Add(cell);
 					return cell;
 				})
 			};
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			await CreateHandlerAndAddToWindow<ListViewRenderer>(listView, async _ =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.iOS.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.ListView)]
 	public partial class ListViewTests
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		void ValidatePlatformCells(ListView listView)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 
 		}

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -156,7 +156,9 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(IndicatorView))]
 	[InlineData(typeof(Line))]
 	[InlineData(typeof(Label))]
+#pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(ListView))]
+#pragma warning restore CS0618 // Type or member is obsolete
 	[InlineData(typeof(Path))]
 	[InlineData(typeof(Picker))]
 	[InlineData(typeof(Polygon))]
@@ -183,8 +185,10 @@ public class MemoryTests : ControlsHandlerTestBase
 
 #if ANDROID
 		// NOTE: skip certain controls on older Android devices
+#pragma warning disable CS0618 // Type or member is obsolete
 		if ((type == typeof(DatePicker) || type == typeof(ListView)) && !OperatingSystem.IsAndroidVersionAtLeast(30))
 				return;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		if (type == typeof(HybridWebView) && !OperatingSystem.IsAndroidVersionAtLeast(24))
 		{
@@ -214,6 +218,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				border.StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(10) };
 				border.Content = new Label();
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (view is ContentView content)
 			{
 				content.Content = new Label();
@@ -222,8 +227,12 @@ public class MemoryTests : ControlsHandlerTestBase
 			{
 				listView.ItemTemplate = new DataTemplate(() =>
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					var cell = new TextCell();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					cell.SetBinding(TextCell.TextProperty, ".");
+#pragma warning restore CS0618 // Type or member is obsolete
 					return cell;
 				});
 				listView.ItemsSource = observable;
@@ -257,6 +266,7 @@ public class MemoryTests : ControlsHandlerTestBase
 						Content = new Grid { Children = { new Ellipse(), new ContentPresenter() } }
 					});
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 			var handler = CreateHandler<LayoutHandler>(layout);
 			viewReference = new WeakReference(view);
 			handlerReference = new WeakReference(view.Handler);
@@ -372,11 +382,21 @@ public class MemoryTests : ControlsHandlerTestBase
 	}
 
 	[Theory("Cells Do Not Leak")]
+#pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(TextCell))]
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(EntryCell))]
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(ImageCell))]
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(SwitchCell))]
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 	[InlineData(typeof(ViewCell))]
+#pragma warning restore CS0618 // Type or member is obsolete
 	public async Task CellsDoNotLeak(Type type)
 	{
 		SetupBuilder();
@@ -387,27 +407,34 @@ public class MemoryTests : ControlsHandlerTestBase
 
 		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			await navPage.Navigation.PushAsync(new ContentPage
 			{
 				Content = new ListView
 				{
 					ItemTemplate = new DataTemplate(() =>
 					{
+#pragma warning disable CS0618 // Type or member is obsolete
 						var cell = (Cell)Activator.CreateInstance(type);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 						if (cell is ViewCell viewCell)
 						{
 							viewCell.View = new Label();
 						}
+#pragma warning restore CS0618 // Type or member is obsolete
 						references.Add(new(cell));
 						return cell;
 					}),
 					ItemsSource = observable
 				}
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Assert.NotEmpty(references);
 			foreach (var reference in references.ToArray())
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (reference.Target is Cell cell)
 				{
 					Assert.NotNull(cell.Handler);
@@ -415,6 +442,7 @@ public class MemoryTests : ControlsHandlerTestBase
 					Assert.NotNull(cell.Handler.PlatformView);
 					references.Add(new(cell.Handler.PlatformView));
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			await navPage.Navigation.PopAsync();

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -35,7 +35,6 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<DatePicker, DatePickerHandler>();
 				handlers.AddHandler<Shape, ShapeViewHandler>();
 				handlers.AddHandler<Entry, EntryHandler>();
-				handlers.AddHandler<EntryCell, EntryCellRenderer>();
 				handlers.AddHandler<Editor, EditorHandler>();
 #pragma warning disable CS0618 // Type or member is obsolete
 				handlers.AddHandler<Frame, FrameRenderer>();
@@ -43,7 +42,6 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<GraphicsView, GraphicsViewHandler>();
 				handlers.AddHandler<HybridWebView, HybridWebViewHandler>();
 				handlers.AddHandler<Label, LabelHandler>();
-				handlers.AddHandler<ListView, ListViewRenderer>();
 				handlers.AddHandler<Layout, LayoutHandler>();
 				handlers.AddHandler<Picker, PickerHandler>();
 				handlers.AddHandler<Polygon, PolygonHandler>();
@@ -51,7 +49,6 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<IContentView, ContentViewHandler>();
 				handlers.AddHandler<Image, ImageHandler>();
 				handlers.AddHandler<ImageButton, ImageButtonHandler>();
-				handlers.AddHandler<ImageCell, ImageCellRenderer>();
 				handlers.AddHandler<IndicatorView, IndicatorViewHandler>();
 				handlers.AddHandler<RadioButton, RadioButtonHandler>();
 				handlers.AddHandler<RefreshView, RefreshViewHandler>();
@@ -61,15 +58,19 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<Stepper, StepperHandler>();
 				handlers.AddHandler<SwipeView, SwipeViewHandler>();
 				handlers.AddHandler<Switch, SwitchHandler>();
-				handlers.AddHandler<SwitchCell, SwitchCellRenderer>();
 #pragma warning disable CS0618 // Type or member is obsolete
+				handlers.AddHandler<SwitchCell, SwitchCellRenderer>();
 				handlers.AddHandler<TableView, TableViewRenderer>();
-#pragma warning restore CS0618 // Type or member is obsolete
 				handlers.AddHandler<TextCell, TextCellRenderer>();
+				handlers.AddHandler<ViewCell, ViewCellRenderer>();
+				handlers.AddHandler<ImageCell, ImageCellRenderer>();
+				handlers.AddHandler<ListView, ListViewRenderer>();
+				handlers.AddHandler<EntryCell, EntryCellRenderer>();
+#pragma warning restore CS0618 // Type or member is obsolete
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<Toolbar, ToolbarHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
-				handlers.AddHandler<ViewCell, ViewCellRenderer>();
+				
 #if IOS || MACCATALYST
 				handlers.AddHandler<NavigationPage, NavigationRenderer>();
 				handlers.AddHandler<TabbedPage, TabbedRenderer>();

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsViewTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsViewTypesTestCases.cs
@@ -88,7 +88,9 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 #pragma warning restore CS0618 // Type or member is obsolete
 				handlers.AddHandler<GraphicsView, GraphicsViewHandler>();
 				handlers.AddHandler<Label, LabelHandler>();
+#pragma warning disable CS0618 // Type or member is obsolete
 				handlers.AddHandler<ListView, ListViewRenderer>();
+#pragma warning restore CS0618 // Type or member is obsolete
 				handlers.AddHandler<Picker, PickerHandler>();
 				handlers.AddHandler<Polygon, PolygonHandler>();
 				handlers.AddHandler<Polyline, PolylineHandler>();

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsViewTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsViewTypesTestCases.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Maui.DeviceTests.TestCases
 			new object[] { typeof(IndicatorView) },
 			new object[] { typeof(Label) },
 			new object[] { typeof(Line) },
+#pragma warning disable CS0618 // Type or member is obsolete
 			new object[] { typeof(ListView) },
+#pragma warning restore CS0618 // Type or member is obsolete
 			new object[] { typeof(Picker) },
 			new object[] { typeof(Polygon) },
 			new object[] { typeof(Polyline) },


### PR DESCRIPTION
### Description of Change

Mark `ListView` and all Cell types as obsolete for .NET 10

`Cell` is intentionally not marked as obsolete as it is used for source generation and if we mark it as obsolete, the source generator will generate deprecated code. Since everything else around it is marked as obsolete, I am going to assume that users will understand that this also counts for `Cell`.

### Issues Fixed

Fixes #28699