### PR TITLE
Update CommunityToolkit.Maui reference in sample content template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -86,7 +86,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
 <!--#endif-->
 <!--#if (Framework == "net9.0") -->
-		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.1" />
 <!--#endif-->
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -82,7 +82,12 @@
 <!--#if (IncludeSampleContent) -->
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+<!--#if (Framework == "net8.0") -->
+		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
+<!--#endif-->
+<!--#if (Framework == "net9.0") -->
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
+<!--#endif-->
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.4" />

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -81,7 +81,7 @@
 
 <!--#if (IncludeSampleContent) -->
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -81,8 +81,8 @@
 
 <!--#if (IncludeSampleContent) -->
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.4" />

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
@@ -83,7 +83,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
 <!--#if (Framework == "net8.0") -->
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
 <!--#endif-->
 <!--#if (Framework == "net9.0") -->
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />

--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -8,16 +8,20 @@
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="MauiApp._1.Pages.MainPage"
              x:DataType="pageModels:MainPageModel"
+             x:Name="OverviewPage"
              Title="{Binding Today}">
 
     <ContentPage.Behaviors>
         <toolkit:EventToCommandBehavior
+                BindingContext="{Binding Path=BindingContext, Source={x:Reference OverviewPage}, x:DataType=ContentPage}"
                 EventName="NavigatedTo"
                 Command="{Binding NavigatedToCommand}" />
         <toolkit:EventToCommandBehavior
+                BindingContext="{Binding Path=BindingContext, Source={x:Reference OverviewPage}, x:DataType=ContentPage}"
                 EventName="NavigatedFrom"
                 Command="{Binding NavigatedFromCommand}" />
         <toolkit:EventToCommandBehavior
+                BindingContext="{Binding Path=BindingContext, Source={x:Reference OverviewPage}, x:DataType=ContentPage}"
                 EventName="Appearing"                
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -6,11 +6,12 @@
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:DataType="pageModels:ManageMetaPageModel"
              x:Class="MauiApp._1.Pages.ManageMetaPage"
+             x:Name="MetaPage"
              Title="Categories and Tags">
-
 
     <ContentPage.Behaviors>
         <toolkit:EventToCommandBehavior
+                BindingContext="{Binding Path=BindingContext, Source={x:Reference MetaPage}, x:DataType=ContentPage}"
                 EventName="Appearing"                
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
@@ -61,7 +62,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>
@@ -103,7 +104,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -63,10 +63,10 @@
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
 <!--#if (Framework == "net8.0") -->
-                                        Flags="ValidateOnUnfocused"
+                                        Flags="ValidateOnUnfocusing"
 <!--#endif -->
 <!--#if (Framework == "net9.0") -->
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
 <!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
@@ -110,10 +110,10 @@
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
 <!--#if (Framework == "net8.0") -->
-                                        Flags="ValidateOnUnfocused"
+                                        Flags="ValidateOnUnfocusing"
 <!--#endif -->
 <!--#if (Framework == "net9.0") -->
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
 <!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -62,7 +62,12 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
+<!--#if (Framework == "net8.0") -->
                                         Flags="ValidateOnUnfocused"
+<!--#endif -->
+<!--#if (Framework == "net9.0") -->
+                                        Flags="ValidateOnUnfocusing"
+<!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>
@@ -104,7 +109,12 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
+<!--#if (Framework == "net8.0") -->
                                         Flags="ValidateOnUnfocused"
+<!--#endif -->
+<!--#if (Framework == "net9.0") -->
+                                        Flags="ValidateOnUnfocusing"
+<!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>


### PR DESCRIPTION
### Description of Change

Updates the `CommunityToolkit.Maui` reference in the new project template to the latest versions.

Note that depending on targeting .NET 8 or 9 there will be a different version of `CommunityToolkit.Maui` referenced in the project file and 2 lines in the ManageMetaPage.xaml because of a breaking change between Toolkit versions.

As of version 10 of the Toolkit .NET 8 is no longer supported. So for .NET 8 we include the latest version of the Toolkit that works with .NET 8 (which is 9.1.1), when targeting .NET 9 we include the 11.1.1 version, which is the version that works with .NET MAUI 9.0.40. As of 11.2.0 .NET MAUI 9.0.50 is required and this change is meant to be inserted into Visual Studio with 9.0.40.

Also see: https://github.com/CommunityToolkit/Maui/pull/2613