### PR TITLE
Fix Binding for ListView.IsRefreshing

### DIFF
--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Maui.Controls
 			if (!RefreshAllowed)
 				return;
 
-			SetValue(IsRefreshingProperty, true);
+			SetValue(IsRefreshingProperty, true, SetterSpecificity.FromHandler);
 			OnRefreshing(EventArgs.Empty);
 
 			ICommand command = RefreshCommand;
@@ -368,7 +368,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='EndRefresh']/Docs/*" />
 		public void EndRefresh()
 		{
-			SetValue(IsRefreshingProperty, false);
+			SetValue(IsRefreshingProperty, false, SetterSpecificity.FromHandler);
 		}
 
 		public event EventHandler<ItemVisibilityEventArgs> ItemAppearing;

--- a/src/Controls/tests/Core.UnitTests/ListViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ListViewTests.cs
@@ -1324,6 +1324,38 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public void SendRefreshingCanBind()
+		{
+			var lv = new ListView();
+			MockViewModel vm;
+			lv.BindingContext = vm = new MockViewModel();
+			lv.SetBinding(ListView.IsRefreshingProperty, nameof(MockViewModel.Boolean), mode: BindingMode.OneWay);
+
+			bool isRefreshing = false;
+			lv.PropertyChanged += (sender, arg) =>
+			{
+				if (arg.PropertyName == ListView.IsRefreshingProperty.PropertyName)
+					isRefreshing = !isRefreshing;
+			};
+
+			//pull down to refresh
+			IListViewController controller = lv;
+			controller.SendRefreshing(); //called by renderer
+			Assert.True(isRefreshing);
+			Assert.True(lv.IsRefreshing);
+
+			//start to execute command
+			vm.Boolean = true;
+			Assert.True(isRefreshing);
+			Assert.True(lv.IsRefreshing);
+
+			//stop refresh after finish command
+			vm.Boolean = false;
+			Assert.False(isRefreshing);
+			Assert.False(lv.IsRefreshing);
+		}
+
+		[Fact]
 		public void RefreshCommand()
 		{
 			var lv = new ListView();

--- a/src/Controls/tests/Core.UnitTests/MockViewModel.cs
+++ b/src/Controls/tests/Core.UnitTests/MockViewModel.cs
@@ -26,6 +26,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
+		bool _boolean;
+		public virtual bool Boolean
+		{
+			get { return _boolean; }
+			set
+			{
+				if (_boolean == value)
+					return;
+
+				_boolean = value;
+				OnPropertyChanged("Boolean");
+			}
+		}
+
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));


### PR DESCRIPTION

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Set IsRefreshingProperty with SetterSpecificity.FromHandler,
to avoid break Binding.


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #28514

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
