### PR TITLE
[Documentation] Page.DisplayAlert wrong documentation (Task vs Task<bool>) - fix

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -305,6 +305,7 @@ namespace Microsoft.Maui.Controls
 			return args.Result.Task;
 		}
 
+		/// <returns>A <see cref="Task"/> that completes when the alert is dismissed.</returns>
 		/// <inheritdoc cref="DisplayAlert(string, string, string, string, FlowDirection)"/>
 		public Task DisplayAlert(string title, string message, string cancel)
 		{
@@ -317,6 +318,7 @@ namespace Microsoft.Maui.Controls
 			return DisplayAlert(title, message, accept, cancel, FlowDirection.MatchParent);
 		}
 
+		/// <returns>A <see cref="Task"/> that completes when the alert is dismissed.</returns>
 		/// <inheritdoc cref="DisplayAlert(string, string, string, string, FlowDirection)"/>
 		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection)
 		{


### PR DESCRIPTION
### Description of Change

I've overwritten the docs for methods that return Task instead of Task<bool>

#### Default
![Screenshot 2025-03-19 at 19 59 34](https://github.com/user-attachments/assets/0571b4f3-0d43-4133-965e-e3916c28a20d)

#### New one for the 2 methods that return Task
![Screenshot 2025-03-19 at 19 59 21](https://github.com/user-attachments/assets/23e8bacb-e4ea-410b-8b68-fabe713d7970)
![Screenshot 2025-03-19 at 19 59 05](https://github.com/user-attachments/assets/fef83b1f-3039-4d74-8a44-3e23b5a520bd)


### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28517

