### PR TITLE
[Windows] Fix for Scrollview.ScrollTo execution only returns after manual scroll

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
@@ -30,7 +30,6 @@ public class Issue15508 : ContentPage
 			BackgroundColor = Colors.Gray
 		};
 
-		// Create the button and set up its click event
 		_scrollButton = new Button
 		{
 			Text = "Scroll activated through message",
@@ -41,12 +40,10 @@ public class Issue15508 : ContentPage
 
 		_scrollButton.Clicked += OnScrollButtonClicked;
 
-		// Set up the layout for the button
 		var buttonLayout = new VerticalStackLayout();
 		buttonLayout.Children.Add(_scrollButton);
 		mainGrid.Add(buttonLayout, 1, 0);
 
-		// Set up the ScrollView and its content
 		_scrollView = new ScrollView
 		{
 			BackgroundColor = Colors.LightCoral,
@@ -56,7 +53,6 @@ public class Issue15508 : ContentPage
 			WidthRequest = 150
 		};
 
-		// Create the label content for the ScrollView
 		_scrollLabel = new Label
 		{
 			AutomationId = "ScrollLabel",
@@ -66,13 +62,11 @@ public class Issue15508 : ContentPage
 		_scrollView.Content = _scrollLabel;
 		mainGrid.Add(_scrollView, 0, 0);
 
-		// Set the content of the page
 		Content = mainGrid;
 	}
 
 	string GenerateLabelText()
 	{
-		// Generates the long text for the label dynamically
 		var textBuilder = new StringBuilder();
 
 		for (char c = 'a'; c <= 'z'; c++)
@@ -85,7 +79,6 @@ public class Issue15508 : ContentPage
 
 	void OnScrollButtonClicked(object sender, EventArgs e)
 	{
-		// Scroll to the top of the ScrollView
 		Application.Current?.Dispatcher.DispatchAsync(async () =>
 		{
 			await _scrollView.ScrollToAsync(0, 0, true);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-
-namespace Controls.TestCases.HostApp.Issues;
+﻿namespace Controls.TestCases.HostApp.Issues;
 
 [Issue(IssueTracker.Github, 15508, "Scrollview.ScrollTo execution only returns after manual scroll", PlatformAffected.UWP)]
 public class Issue15508 : ContentPage
@@ -48,7 +46,6 @@ public class Issue15508 : ContentPage
 		{
 			BackgroundColor = Colors.LightCoral,
 			VerticalOptions = LayoutOptions.Start,
-			VerticalScrollBarVisibility = ScrollBarVisibility.Always,
 			MaximumHeightRequest = 70,
 			WidthRequest = 150
 		};
@@ -56,7 +53,7 @@ public class Issue15508 : ContentPage
 		_scrollLabel = new Label
 		{
 			AutomationId = "ScrollLabel",
-			Text = GenerateLabelText()
+			Text = "Not Scrolled"
 		};
 
 		_scrollView.Content = _scrollLabel;
@@ -65,24 +62,12 @@ public class Issue15508 : ContentPage
 		Content = mainGrid;
 	}
 
-	string GenerateLabelText()
-	{
-		var textBuilder = new StringBuilder();
-
-		for (char c = 'a'; c <= 'z'; c++)
-		{
-			textBuilder.AppendLine(c.ToString());
-		}
-
-		return textBuilder.ToString();
-	}
-
 	void OnScrollButtonClicked(object sender, EventArgs e)
 	{
 		Application.Current?.Dispatcher.DispatchAsync(async () =>
 		{
 			await _scrollView.ScrollToAsync(0, 0, true);
-			_scrollLabel.Text = "The text is successfully changed";
+			_scrollLabel.Text = "Scroll Completed";
 		});
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
@@ -5,7 +5,6 @@ public class Issue15508 : ContentPage
 {
 	ScrollView _scrollView;
 	Label _scrollLabel;
-	Button _scrollButton;
 	public Issue15508()
 	{
 		InitializeComponent();
@@ -24,16 +23,15 @@ public class Issue15508 : ContentPage
 				{
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star }
-				},
-			BackgroundColor = Colors.Gray
+				}
 		};
 
-		_scrollButton = new Button
+		Button _scrollButton = new Button
 		{
-			Text = "Scroll activated through message",
+			Text = "Scroll",
 			WidthRequest = 250,
 			HorizontalOptions = LayoutOptions.Start,
-			AutomationId = "ButtonToScroll"
+			AutomationId = "Button"
 		};
 
 		_scrollButton.Clicked += OnScrollButtonClicked;
@@ -44,7 +42,6 @@ public class Issue15508 : ContentPage
 
 		_scrollView = new ScrollView
 		{
-			BackgroundColor = Colors.LightCoral,
 			VerticalOptions = LayoutOptions.Start,
 			MaximumHeightRequest = 70,
 			WidthRequest = 150
@@ -52,7 +49,7 @@ public class Issue15508 : ContentPage
 
 		_scrollLabel = new Label
 		{
-			AutomationId = "ScrollLabel",
+			AutomationId = "Label",
 			Text = "Not Scrolled"
 		};
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 15508, "Scrollview.ScrollTo execution only returns after manual scroll", PlatformAffected.UWP)]
+public class Issue15508 : ContentPage
+{
+	ScrollView scrollView;
+	Label label1;
+	public Issue15508()
+	{
+
+		var grid = new Grid()
+		{
+			ColumnDefinitions = new ColumnDefinitionCollection()
+			{
+				new ColumnDefinition() { Width = GridLength.Auto},
+				new ColumnDefinition() { Width = GridLength.Star},
+			},
+			RowDefinitions = new RowDefinitionCollection()
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star },
+			},
+			BackgroundColor = Colors.Gray
+		};
+
+		var verticalStack = new VerticalStackLayout();
+
+		Button button = new Button()
+		{
+			Text = "Scroll activated through message",
+			WidthRequest = 250,
+			HorizontalOptions = LayoutOptions.Start,
+			AutomationId = "ButtonToScroll",
+		};
+
+		button.Clicked += button_clicked;
+
+		verticalStack.Children.Add(button);
+
+		grid.Add(verticalStack, 1, 0);
+
+		scrollView = new ScrollView
+		{
+			BackgroundColor = Colors.LightCoral,
+			VerticalOptions = LayoutOptions.Start,
+			VerticalScrollBarVisibility = ScrollBarVisibility.Always,
+			MaximumHeightRequest = 70,
+			WidthRequest = 150
+		};
+
+		label1 = new Label()
+		{
+			AutomationId = "ScrollLabel",
+			Text =
+			"a" + Environment.NewLine +
+			"b" + Environment.NewLine +
+			"c" + Environment.NewLine +
+			"d" + Environment.NewLine +
+			"e" + Environment.NewLine +
+			"f" + Environment.NewLine +
+			"g" + Environment.NewLine +
+			"h" + Environment.NewLine +
+			"i" + Environment.NewLine +
+			"j" + Environment.NewLine +
+			"k" + Environment.NewLine +
+			"l" + Environment.NewLine +
+			"m" + Environment.NewLine +
+			"n" + Environment.NewLine +
+			"o" + Environment.NewLine +
+			"p" + Environment.NewLine +
+			"q" + Environment.NewLine +
+			"r" + Environment.NewLine +
+			"s" + Environment.NewLine +
+			"t" + Environment.NewLine +
+			"u" + Environment.NewLine +
+			"v" + Environment.NewLine +
+			"w" + Environment.NewLine +
+			"x" + Environment.NewLine +
+			"y" + Environment.NewLine +
+			"z" + Environment.NewLine +
+			"a" + Environment.NewLine +
+			"b" + Environment.NewLine +
+			"c" + Environment.NewLine +
+			"d" + Environment.NewLine +
+			"e" + Environment.NewLine +
+			"f" + Environment.NewLine +
+			"g" + Environment.NewLine +
+			"h" + Environment.NewLine +
+			"i" + Environment.NewLine +
+			"j" + Environment.NewLine +
+			"k" + Environment.NewLine +
+			"l" + Environment.NewLine +
+			"m" + Environment.NewLine +
+			"n" + Environment.NewLine +
+			"o" + Environment.NewLine +
+			"p" + Environment.NewLine +
+			"q" + Environment.NewLine +
+			"r" + Environment.NewLine +
+			"s" + Environment.NewLine +
+			"t" + Environment.NewLine +
+			"u" + Environment.NewLine +
+			"v" + Environment.NewLine +
+			"w" + Environment.NewLine +
+			"x" + Environment.NewLine +
+			"y" + Environment.NewLine +
+			"z" + Environment.NewLine
+		};
+
+		scrollView.Content = label1;
+		grid.Add(scrollView, 0, 0);
+		Content = grid;
+	}
+
+	void button_clicked(object sender, EventArgs e)
+	{
+		Application.Current?.Dispatcher.DispatchAsync(async () =>
+		{
+			await scrollView.ScrollToAsync(0, 0, true);
+			label1.Text = "The text is successfully changed";
+		});
+	}
+}
+

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15508.cs
@@ -1,51 +1,53 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace Controls.TestCases.HostApp.Issues;
 
 [Issue(IssueTracker.Github, 15508, "Scrollview.ScrollTo execution only returns after manual scroll", PlatformAffected.UWP)]
 public class Issue15508 : ContentPage
 {
-	ScrollView scrollView;
-	Label label1;
+	ScrollView _scrollView;
+	Label _scrollLabel;
+	Button _scrollButton;
 	public Issue15508()
 	{
+		InitializeComponent();
+	}
 
-		var grid = new Grid()
+	void InitializeComponent()
+	{
+		var mainGrid = new Grid
 		{
-			ColumnDefinitions = new ColumnDefinitionCollection()
-			{
-				new ColumnDefinition() { Width = GridLength.Auto},
-				new ColumnDefinition() { Width = GridLength.Star},
-			},
-			RowDefinitions = new RowDefinitionCollection()
-			{
-				new RowDefinition { Height = GridLength.Auto },
-				new RowDefinition { Height = GridLength.Star },
-			},
+			ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLength.Auto },
+					new ColumnDefinition { Width = GridLength.Star }
+				},
+			RowDefinitions =
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star }
+				},
 			BackgroundColor = Colors.Gray
 		};
 
-		var verticalStack = new VerticalStackLayout();
-
-		Button button = new Button()
+		// Create the button and set up its click event
+		_scrollButton = new Button
 		{
 			Text = "Scroll activated through message",
 			WidthRequest = 250,
 			HorizontalOptions = LayoutOptions.Start,
-			AutomationId = "ButtonToScroll",
+			AutomationId = "ButtonToScroll"
 		};
 
-		button.Clicked += button_clicked;
+		_scrollButton.Clicked += OnScrollButtonClicked;
 
-		verticalStack.Children.Add(button);
+		// Set up the layout for the button
+		var buttonLayout = new VerticalStackLayout();
+		buttonLayout.Children.Add(_scrollButton);
+		mainGrid.Add(buttonLayout, 1, 0);
 
-		grid.Add(verticalStack, 1, 0);
-
-		scrollView = new ScrollView
+		// Set up the ScrollView and its content
+		_scrollView = new ScrollView
 		{
 			BackgroundColor = Colors.LightCoral,
 			VerticalOptions = LayoutOptions.Start,
@@ -54,75 +56,40 @@ public class Issue15508 : ContentPage
 			WidthRequest = 150
 		};
 
-		label1 = new Label()
+		// Create the label content for the ScrollView
+		_scrollLabel = new Label
 		{
 			AutomationId = "ScrollLabel",
-			Text =
-			"a" + Environment.NewLine +
-			"b" + Environment.NewLine +
-			"c" + Environment.NewLine +
-			"d" + Environment.NewLine +
-			"e" + Environment.NewLine +
-			"f" + Environment.NewLine +
-			"g" + Environment.NewLine +
-			"h" + Environment.NewLine +
-			"i" + Environment.NewLine +
-			"j" + Environment.NewLine +
-			"k" + Environment.NewLine +
-			"l" + Environment.NewLine +
-			"m" + Environment.NewLine +
-			"n" + Environment.NewLine +
-			"o" + Environment.NewLine +
-			"p" + Environment.NewLine +
-			"q" + Environment.NewLine +
-			"r" + Environment.NewLine +
-			"s" + Environment.NewLine +
-			"t" + Environment.NewLine +
-			"u" + Environment.NewLine +
-			"v" + Environment.NewLine +
-			"w" + Environment.NewLine +
-			"x" + Environment.NewLine +
-			"y" + Environment.NewLine +
-			"z" + Environment.NewLine +
-			"a" + Environment.NewLine +
-			"b" + Environment.NewLine +
-			"c" + Environment.NewLine +
-			"d" + Environment.NewLine +
-			"e" + Environment.NewLine +
-			"f" + Environment.NewLine +
-			"g" + Environment.NewLine +
-			"h" + Environment.NewLine +
-			"i" + Environment.NewLine +
-			"j" + Environment.NewLine +
-			"k" + Environment.NewLine +
-			"l" + Environment.NewLine +
-			"m" + Environment.NewLine +
-			"n" + Environment.NewLine +
-			"o" + Environment.NewLine +
-			"p" + Environment.NewLine +
-			"q" + Environment.NewLine +
-			"r" + Environment.NewLine +
-			"s" + Environment.NewLine +
-			"t" + Environment.NewLine +
-			"u" + Environment.NewLine +
-			"v" + Environment.NewLine +
-			"w" + Environment.NewLine +
-			"x" + Environment.NewLine +
-			"y" + Environment.NewLine +
-			"z" + Environment.NewLine
+			Text = GenerateLabelText()
 		};
 
-		scrollView.Content = label1;
-		grid.Add(scrollView, 0, 0);
-		Content = grid;
+		_scrollView.Content = _scrollLabel;
+		mainGrid.Add(_scrollView, 0, 0);
+
+		// Set the content of the page
+		Content = mainGrid;
 	}
 
-	void button_clicked(object sender, EventArgs e)
+	string GenerateLabelText()
 	{
+		// Generates the long text for the label dynamically
+		var textBuilder = new StringBuilder();
+
+		for (char c = 'a'; c <= 'z'; c++)
+		{
+			textBuilder.AppendLine(c.ToString());
+		}
+
+		return textBuilder.ToString();
+	}
+
+	void OnScrollButtonClicked(object sender, EventArgs e)
+	{
+		// Scroll to the top of the ScrollView
 		Application.Current?.Dispatcher.DispatchAsync(async () =>
 		{
-			await scrollView.ScrollToAsync(0, 0, true);
-			label1.Text = "The text is successfully changed";
+			await _scrollView.ScrollToAsync(0, 0, true);
+			_scrollLabel.Text = "The text is successfully changed";
 		});
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -16,9 +16,9 @@ public class Issue15508 : _IssuesUITest
 	{
 		App.WaitForElement("Button");
 		App.Tap("Button");
-		Thread.Sleep(1000);
 		var scrollLabel = App.WaitForElement("Label");
-		Assert.That(scrollLabel.GetText(), Is.EqualTo("Scroll Completed"));
+		var isTextPresent = App.WaitForTextToBePresentInElement("Label", "Scroll Completed");
+		Assert.That(isTextPresent, Is.True, "The text 'Scroll Completed' was not found in the element.");
 	}
 }
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue15508 : _IssuesUITest
+{
+	public Issue15508(TestDevice device) : base(device) { }
+
+	public override string Issue => "Scrollview.ScrollTo execution only returns after manual scroll";
+	const string ButtonToScroll = "ButtonToScroll";
+
+	[Test]
+	[Category(UITestCategories.ScrollView)]
+	public void ScrollViewinAwait()
+	{
+		App.WaitForElement(ButtonToScroll);
+		App.Tap(ButtonToScroll);
+		Assert.That(App.FindElement("ScrollLabel").GetText(), Is.EqualTo("The text is successfully changed"));
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -16,7 +16,6 @@ public class Issue15508 : _IssuesUITest
 	{
 		App.WaitForElement("Button");
 		App.Tap("Button");
-		var scrollLabel = App.WaitForElement("Label");
 		var isTextPresent = App.WaitForTextToBePresentInElement("Label", "Scroll Completed");
 		Assert.That(isTextPresent, Is.True, "The text 'Scroll Completed' was not found in the element.");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -16,6 +16,7 @@ public class Issue15508 : _IssuesUITest
 	{
 		App.WaitForElement("Button");
 		App.Tap("Button");
+		Thread.Sleep(500);
 		var scrollLabel = App.FindElement("Label");
 		Assert.That(scrollLabel.GetText(), Is.EqualTo("Scroll Completed"));
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -9,15 +9,14 @@ public class Issue15508 : _IssuesUITest
 	public Issue15508(TestDevice device) : base(device) { }
 
 	public override string Issue => "Scrollview.ScrollTo execution only returns after manual scroll";
-	const string ButtonToScroll = "ButtonToScroll";
 
 	[Test]
 	[Category(UITestCategories.ScrollView)]
 	public void ScrollViewinAwait()
 	{
-		App.WaitForElement(ButtonToScroll);
-		App.Tap(ButtonToScroll);
-		var scrollLabel = App.FindElement("ScrollLabel");
+		App.WaitForElement("Button");
+		App.Tap("Button");
+		var scrollLabel = App.FindElement("Label");
 		Assert.That(scrollLabel.GetText(), Is.EqualTo("Scroll Completed"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -17,7 +17,8 @@ public class Issue15508 : _IssuesUITest
 	{
 		App.WaitForElement(ButtonToScroll);
 		App.Tap(ButtonToScroll);
-		Assert.That(App.FindElement("ScrollLabel").GetText(), Is.EqualTo("The text is successfully changed"));
+		var scrollLabel = App.FindElement("ScrollLabel");
+		Assert.That(scrollLabel.GetText(), Is.EqualTo("Scroll Completed"));
 	}
 }
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -16,8 +16,8 @@ public class Issue15508 : _IssuesUITest
 	{
 		App.WaitForElement("Button");
 		App.Tap("Button");
-		Thread.Sleep(500);
-		var scrollLabel = App.FindElement("Label");
+		Thread.Sleep(1000);
+		var scrollLabel = App.WaitForElement("Label");
 		Assert.That(scrollLabel.GetText(), Is.EqualTo("Scroll Completed"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15508.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
+				if (request.VerticalOffset == handler.PlatformView.VerticalOffset && request.HorizontalOffset == handler.PlatformView.HorizontalOffset)
+				{
+					handler.VirtualView.ScrollFinished();
+				}
+
 				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
 			}
 		}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -78,7 +78,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is ScrollToRequest request)
 			{
-				if (request.VerticalOffset == handler.PlatformView.VerticalOffset && request.HorizontalOffset == handler.PlatformView.HorizontalOffset)
+				bool isAlreadyAtRequestedPosition = request.VerticalOffset == handler.PlatformView.VerticalOffset && request.HorizontalOffset == handler.PlatformView.HorizontalOffset;
+				if (isAlreadyAtRequestedPosition)
 				{
 					handler.VirtualView.ScrollFinished();
 				}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -82,8 +82,10 @@ namespace Microsoft.Maui.Handlers
 				{
 					handler.VirtualView.ScrollFinished();
 				}
-
-				handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
+				else
+				{
+					handler.PlatformView.ChangeView(request.HorizontalOffset, request.VerticalOffset, null, request.Instant);
+				}
 			}
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.Handlers
 				var minScrollVertical = Math.Min(request.VerticalOffset, availableScrollHeight);
 				uiScrollView.SetContentOffset(new CGPoint(minScrollHorizontal, minScrollVertical), !request.Instant);
 
-				if (request.Instant)
+				if (request.Instant || (minScrollHorizontal == uiScrollView.ContentOffset.X && minScrollVertical == uiScrollView.ContentOffset.Y))
 				{
 					scrollView.ScrollFinished();
 				}


### PR DESCRIPTION
### Root Cause of the issue

- When the scroll offset is set to the same value as the current view, the scroll view doesn't change. As a result, the scroll operation never completes, causing the await method to wait indefinitely. Consequently, the code after the await will not be executed.

### Description of Change

- To address this issue, I have implemented a check to mark the scroll as finished when the requested offset is the same as the current platform offset

### Issues Fixed

Fixes #15508 

### Tested the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac   

### Output

| Before Fix | After Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/4ee01814-ed0a-4c93-8fd8-8ca951035b38"> | <video src="https://github.com/user-attachments/assets/c7ddc0b7-6b8d-405d-9315-ed92e3dd234a"> |