### PR TITLE
[Windows] Fixed the issue with SearchBar focus and unfocus events.

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28419.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28419.cs
@@ -1,0 +1,28 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28419, "SearchBar focus/unfocus do not fire on Windows", PlatformAffected.UWP)]
+public class Issue28419 : ContentPage
+{
+    public Issue28419()
+    {
+        var label = new Label();
+        var searchBar = new SearchBar { Placeholder = "SearchBar", AutomationId = "SearchBar" };
+        var entry = new Entry { Placeholder = "Entry", AutomationId = "Entry" };
+
+        searchBar.Focused += (sender, e) =>
+        {
+            label.Text = "SearchBar Focused";
+        };
+
+        searchBar.Unfocused += (sender, e) =>
+        {
+            label.Text = "SearchBar Unfocused";
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Spacing = 10,
+            Children = { label, searchBar, entry }
+        };
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28419.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28419.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue28419 : _IssuesUITest
+{
+    public Issue28419(TestDevice device) : base(device) { }
+
+    public override string Issue => "SearchBar focus/unfocus do not fire on Windows";
+
+    [Test]
+    [Category(UITestCategories.SearchBar)]
+    public void SearchBarShouldTriggerFocusedAndUnFocusedEvents()
+    {
+        App.WaitForElement("SearchBar");
+        App.Tap("SearchBar");
+        App.WaitForElement("SearchBar Focused");
+        App.Tap("Entry");
+        App.WaitForElement("SearchBar Unfocused");
+    }
+}

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -18,6 +18,12 @@ namespace Microsoft.Maui.Handlers
 			platformView.Loaded += OnLoaded;
 			platformView.QuerySubmitted += OnQuerySubmitted;
 			platformView.TextChanged += OnTextChanged;
+			//In ViewHandler.Windows, FocusManager.GotFocus and LostFocus are handled for other controls. 
+			// However, for AutoSuggestBox, when handling the GotFocus or LostFocus methods, tapping the AutoSuggestBox causes e.NewFocusedElement and e.OldFocusedElement to be a TextBox (which receives the focus). 
+			// As a result, when comparing the PlatformView with the appropriate handler in FocusManagerMapping, the condition is not satisfied, causing the focus and unfocus methods to not work correctly. 
+			// To address this, I have specifically handled the focus and unfocus events for AutoSuggestBox here. 
+			platformView.GotFocus += OnGotFocus;
+			platformView.LostFocus += OnLostFocus;
 		}
 
 		protected override void DisconnectHandler(AutoSuggestBox platformView)
@@ -25,6 +31,8 @@ namespace Microsoft.Maui.Handlers
 			platformView.Loaded -= OnLoaded;
 			platformView.QuerySubmitted -= OnQuerySubmitted;
 			platformView.TextChanged -= OnTextChanged;
+			platformView.GotFocus -= OnGotFocus;
+			platformView.LostFocus -= OnLostFocus;
 		}
 
 		public static void MapBackground(ISearchBarHandler handler, ISearchBar searchBar)
@@ -147,6 +155,22 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			VirtualView.Text = sender.Text;
+		}
+
+		void OnGotFocus(object sender, UI.Xaml.RoutedEventArgs e)
+		{
+			if (VirtualView is not null)
+			{
+				VirtualView.IsFocused = true;
+			}
+		}
+
+		void OnLostFocus(object sender, UI.Xaml.RoutedEventArgs e)
+		{
+			if (VirtualView is not null)
+			{
+				VirtualView.IsFocused = false;
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -159,18 +159,12 @@ namespace Microsoft.Maui.Handlers
 
 		void OnGotFocus(object sender, UI.Xaml.RoutedEventArgs e)
 		{
-			if (VirtualView is not null)
-			{
-				VirtualView.IsFocused = true;
-			}
+			UpdateIsFocused(true);
 		}
 
 		void OnLostFocus(object sender, UI.Xaml.RoutedEventArgs e)
 		{
-			if (VirtualView is not null)
-			{
-				VirtualView.IsFocused = false;
-			}
+			UpdateIsFocused(false);
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		void UpdateIsFocused(bool isFocused)
+		private protected void UpdateIsFocused(bool isFocused)
 		{
 			if (VirtualView is not { } virtualView)
 			{


### PR DESCRIPTION
### Root Cause of the issue



- In `ViewHandler`.Windows, `FocusManager`.GotFocus and LostFocus are handled for other controls. However, for `AutoSuggestBox`, when handling the GotFocus or LostFocus methods, tapping the AutoSuggestBox causes e.NewFocusedElement and e.OldFocusedElement to be a `TextBox` (which is the ControlTemplate of AutoSuggestBox and receives the focus). As a result, when comparing the PlatformView with the appropriate handler in `FocusManagerMapping`, the condition is not satisfied, causing the focus and unfocus events to not work correctly. 



### Description of Change



- To address this, I have specifically handled the focus and unfocus events for AutoSuggestBox in `SearchBarHandler`.Windows. 


### Regressed PR

- #24695 

 



### Issues Fixed



Fixes #28419 



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/b5acd0f4-3626-4850-9cbb-b41f2587ba3b"> | <video src="https://github.com/user-attachments/assets/00687608-b59b-41cc-b091-da34ca54cee2"> |
