### PR TITLE
[Testing] Fix for flaky UITests Issue18896 and disable Issue14471 test which fails in CI randomly 

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,6 +8,6 @@
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25161.4"
   },
   "sdk": {
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18896.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18896.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.ManualTest, "C3", "Can scroll ListView inside RefreshView", PlatformAffected.All)]
+	[Issue(IssueTracker.ManualTest, "C3", "Can scroll ListView inside RefreshView", PlatformAffected.All, isInternetRequired: true)]
 	public partial class Issue18896 : ContentPage
 	{
 		public Issue18896()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14471.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14471.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_ANDROID // For more information, see : https://github.com/dotnet/maui/issues/24243
+﻿#if TEST_FAILS_ON_ANDROID // This test fails randomly, likely because the image source has disappeared sometimes in CI, not able to reproduce locally. For now, we have ignored the test for Android. Issue for re-enabling: https://github.com/dotnet/maui/issues/24243
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14471.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14471.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAILS_ON_ANDROID // For more information, see : https://github.com/dotnet/maui/issues/24243
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -24,3 +25,4 @@ public class Issue14471 : _IssuesUITest
 		VerifyScreenshot();
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[FailsOnWindowsWhenRunningOnXamarinUITest("Currently fails on Windows; see https://github.com/dotnet/maui/issues/15994")]
 		public void Issue18896Test()
 		{
+			VerifyInternetConnectivity();
 			App.WaitForElement("WaitForStubControl");
 
 			App.ScrollDown(ListView);


### PR DESCRIPTION
This pull request includes several updates to the test cases in the src/Controls/tests/TestCases.Shared.Tests/Tests/Issues directory. The changes mainly focus on adding internet connectivity checks and conditional compilation for specific platforms.

### Test Case Updates:

* [`src/Controls/tests/TestCases.HostApp/Issues/Issue18896.xaml.cs`](diffhunk://#diff-464168975a6329c67a7591b861b5c701a3cadd43e8a034a9b922e4732ad57ce2L3-R3): Added an `isInternetRequired` parameter to the `Issue` attribute for issue 18896 to indicate that internet connectivity is required.
* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs`](diffhunk://#diff-c9606dd00ec880b1ca731f4c65f7d22cecf0e3308c1ab62d4764471ebf9087abR25): Added a call to `VerifyInternetConnectivity()` in the `Issue18896Test` method to ensure internet connectivity is verified before running the test.

### Platform-Specific Conditional Compilation:

* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14471.cs`](diffhunk://#diff-0d99ae9e19a65b0de5d0c5bb399e012a91b184f9ba121c52238bb9121c8dd340L1-R2): Added a conditional compilation directive to exclude the test on Android due to intermittent failures in CI environments. Included a reference to the issue for re-enabling the test. [1] [2]

## TestCases

- Issue18896
- Issue14471
