### PR TITLE
Fix HideSoftInputOnTapped Not Working Net9 

### DIFF
--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Android.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Android.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var page in _contentPages)
 			{
-				if ((page.HasNavigatedTo || (page is ContentPage && _contentPages.Count == 1)) &&
+				if ((page.HasNavigatedTo || page.Parent is Window) &&
 					page.HideSoftInputOnTapped &&
 					page.Handler is IPlatformViewHandler pvh &&
 					pvh.MauiContext?.Context is not null)

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Android.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Android.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var page in _contentPages)
 			{
-				if (page.HasNavigatedTo &&
+				if ((page.HasNavigatedTo || (page is ContentPage && _contentPages.Count == 1)) &&
 					page.HideSoftInputOnTapped &&
 					page.Handler is IPlatformViewHandler pvh &&
 					pvh.MauiContext?.Context is not null)

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Platform.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.Platform.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 
 		internal void UpdatePage(ContentPage page)
 		{
-			if (page.HideSoftInputOnTapped && page.HasNavigatedTo)
+			if (page.HideSoftInputOnTapped && (page.HasNavigatedTo || page.Parent is Window))
 			{
 				if (!_contentPages.Contains(page))
 				{

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 			{
 				foreach (var page in _contentPages)
 				{
-					if (page.HideSoftInputOnTapped && page.HasNavigatedTo)
+					if (page.HideSoftInputOnTapped && (page.HasNavigatedTo || (page is ContentPage && _contentPages.Count == 1)))
 						return true;
 				}
 				return false;

--- a/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.cs
+++ b/src/Controls/src/Core/ContentPage/HideSoftInputOnTappedChanged/HideSoftInputOnTappedChangedManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 			{
 				foreach (var page in _contentPages)
 				{
-					if (page.HideSoftInputOnTapped && (page.HasNavigatedTo || (page is ContentPage && _contentPages.Count == 1)))
+					if (page.HideSoftInputOnTapped && (page.HasNavigatedTo || page.Parent is Window))
 						return true;
 				}
 				return false;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26792.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26792.cs
@@ -1,40 +1,40 @@
-namespace Maui.Controls.Sample.Issues
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 26792, "HideSoftInputOnTapped Not Working", PlatformAffected.Android)]
+public class Issue26792 : ContentPage
 {
-	[Issue(IssueTracker.Github, 26792, "HideSoftInputOnTapped Not Working", PlatformAffected.Android)]
-	public class Issue26792 : ContentPage
+
+	VerticalStackLayout stackLayout;
+	Button _button;
+
+	Entry _entry;
+	public Issue26792()
 	{
-
-		VerticalStackLayout stackLayout;
-		Button _button;
-
-		Entry _entry;
-		public Issue26792()
+		this.HideSoftInputOnTapped = true;
+		stackLayout = new VerticalStackLayout
 		{
-			this.HideSoftInputOnTapped = true;
-			stackLayout = new VerticalStackLayout
-			{
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center,
-				AutomationId = "Issue26792StackLayout",
-			};
-			_button = new Button
-			{
-				Text = "Click Me",
-				AutomationId = "Issue26792Button",
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center,
-			};
-			_entry = new Entry
-			{
-				Placeholder = "Enter text",
-				AutomationId = "Issue26792Entry",
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center,
-			};
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			AutomationId = "Issue26792StackLayout",
+		};
+		_button = new Button
+		{
+			Text = "Click Me",
+			AutomationId = "Issue26792Button",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+		_entry = new Entry
+		{
+			Placeholder = "Enter text",
+			AutomationId = "Issue26792Entry",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
 
-			stackLayout.Children.Add(_button);
-			stackLayout.Children.Add(_entry);
-			Content = stackLayout;
-		}
+		stackLayout.Children.Add(_button);
+		stackLayout.Children.Add(_entry);
+		Content = stackLayout;
 	}
 }
+

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26792.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26792.cs
@@ -1,0 +1,40 @@
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 26792, "HideSoftInputOnTapped Not Working", PlatformAffected.Android)]
+	public class Issue26792 : ContentPage
+	{
+
+		VerticalStackLayout stackLayout;
+		Button _button;
+
+		Entry _entry;
+		public Issue26792()
+		{
+			this.HideSoftInputOnTapped = true;
+			stackLayout = new VerticalStackLayout
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				AutomationId = "Issue26792StackLayout",
+			};
+			_button = new Button
+			{
+				Text = "Click Me",
+				AutomationId = "Issue26792Button",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+			};
+			_entry = new Entry
+			{
+				Placeholder = "Enter text",
+				AutomationId = "Issue26792Entry",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+			};
+
+			stackLayout.Children.Add(_button);
+			stackLayout.Children.Add(_entry);
+			Content = stackLayout;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26792.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26792.cs
@@ -1,4 +1,4 @@
-#if ANDROID || IOS // On other platforms as SoftKeyboard is not supported 
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS //As SoftKeyboard is not supported
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26792.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26792.cs
@@ -1,0 +1,29 @@
+#if ANDROID || IOS // On other platforms as SoftKeyboard is not supported 
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue26792 : _IssuesUITest
+{
+	public Issue26792(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "HideSoftInputOnTapped Not Working";
+
+	[Test]
+	[Category(UITestCategories.Page)]
+	public void SoftInputShouldHiddenOnTap()
+	{
+		App.WaitForElement("Issue26792Entry");
+		App.Tap("Issue26792Entry");
+		App.WaitForElement("Issue26792Button");
+		App.Tap("Issue26792Button");
+		App.WaitForElement("Issue26792Entry");
+		Assert.That(App.IsKeyboardShown(), Is.False);
+
+	}
+}
+#endif


### PR DESCRIPTION
### Issue Description
When the `MainPage` is set as the direct window, enabling `HideSoftInputOnTapped` prevents the keyboard from hiding when tapping on the screen.

### Root Cause
The page receives touch input through `ResignFirstResponderTouchGestureRecognizer`, controlled by the `HasNavigatedTo` value. This mechanism applies to both `UpdateFocusForView` and `SetHideSoftInputTapped`. For a direct `ContentPage`,` HasNavigatedTo` remains `false` but updates to `true` in `SendNavigatingTo` when used within `NavigationPage`. Hence this works fine for the navigation page.

### Description of Change 
During `UpdatePage`, when adding the page to the collection, the parent is checked. If it is a direct window, the page is added to the collection. Additionally, the `page count` is considered for `FeatureEnabled` and the `OnTapped `event to handle `HideSoftInput`.

### Issues Fixed
Fixes #26792 
Fixes #21681 

### Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [x] iOS
- [ ] Mac


### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="500" height="500" alt="Before Fix video" src="https://github.com/user-attachments/assets/78ec3ae8-0d15-4f16-ad8a-c2d5af13ac87">|<video width="500" height="500" alt="After Fix video"  src="https://github.com/user-attachments/assets/f317a273-dbc2-4c1b-84a7-fd6c9c28d3f8" >|

