### PR TITLE
[Android] Fix: Modal Animation Repeats When Returning from Background

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -320,9 +320,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 				_navigationRootManager = modalContext.GetNavigationRootManager();
 				_navigationRootManager.Connect(_modal, modalContext);
-
+				
 				UpdateBackgroundColor();
-				if (IsAnimated && _navigationRootManager is not null && _navigationRootManager.RootView is not null)
+
+				var rootView = _navigationRootManager?.RootView ??
+					throw new InvalidOperationException("Root view not initialized");
+
+				if (IsAnimated)
 				{
 					_ = new GenericGlobalLayoutListener((listner,view) =>
 					{
@@ -335,8 +339,7 @@ namespace Microsoft.Maui.Controls.Platform
 						}
 					},_navigationRootManager.RootView);
 				}
-				return _navigationRootManager?.RootView ??
-					throw new InvalidOperationException("Root view not initialized");
+				return rootView;
 			}
 			void OnAnimationEnded(object? sender, AAnimation.AnimationEndEventArgs e)
 			{

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -327,10 +327,12 @@ namespace Microsoft.Maui.Controls.Platform
 					_ = new GenericGlobalLayoutListener((listner,view) =>
 					{
 						listner.Invalidate();
-
-						var animation = AnimationUtils.LoadAnimation(_mauiWindowContext.Context, Resource.Animation.nav_modal_default_enter_anim)!;
-						_navigationRootManager.RootView.StartAnimation(animation);
-						animation.AnimationEnd += OnAnimationEnded;
+						if(view is not null)
+						{
+							var animation = AnimationUtils.LoadAnimation(view.Context, Resource.Animation.nav_modal_default_enter_anim)!;
+							view.StartAnimation(animation);
+							animation.AnimationEnd += OnAnimationEnded;
+						}
 					},_navigationRootManager.RootView);
 				}
 				return _navigationRootManager?.RootView ??

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -322,9 +322,27 @@ namespace Microsoft.Maui.Controls.Platform
 				_navigationRootManager.Connect(_modal, modalContext);
 
 				UpdateBackgroundColor();
+				if (IsAnimated && _navigationRootManager is not null && _navigationRootManager.RootView is not null)
+				{
+					_ = new GenericGlobalLayoutListener((listner,view) =>
+					{
+						_navigationRootManager.RootView.ViewTreeObserver?.RemoveOnGlobalLayoutListener(listner);
 
+						var animation = AnimationUtils.LoadAnimation(_mauiWindowContext.Context, Resource.Animation.nav_modal_default_enter_anim)!;
+						_navigationRootManager.RootView.StartAnimation(animation);
+						animation.AnimationEnd += OnAnimationEnded;
+					},_navigationRootManager.RootView);
+				}
 				return _navigationRootManager?.RootView ??
 					throw new InvalidOperationException("Root view not initialized");
+			}
+			void OnAnimationEnded(object? sender, AAnimation.AnimationEndEventArgs e)
+			{
+				if (sender is not AAnimation animation)
+					return;
+
+				animation.AnimationEnd -= OnAnimationEnded;
+			    FireAnimationEnded();
 			}
 
 			public override void OnCreate(Bundle? savedInstanceState)
@@ -344,26 +362,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				int width = ViewGroup.LayoutParams.MatchParent;
 				int height = ViewGroup.LayoutParams.MatchParent;
-				dialog.Window.SetLayout(width, height);
-
-				if (IsAnimated)
-				{
-					var animation = AnimationUtils.LoadAnimation(_mauiWindowContext.Context, Resource.Animation.nav_modal_default_enter_anim)!;
-					View.StartAnimation(animation);
-
-					animation.AnimationEnd += OnAnimationEnded;
-				}
-
-				void OnAnimationEnded(object? sender, AAnimation.AnimationEndEventArgs e)
-				{
-					if (sender is not AAnimation animation)
-					{
-						return;
-					}
-
-					animation.AnimationEnd -= OnAnimationEnded;
-					FireAnimationEnded();
-				}
+				dialog.Window.SetLayout(width, height);		
 			}
 
 			public override void OnDismiss(IDialogInterface dialog)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -331,7 +331,6 @@ namespace Microsoft.Maui.Controls.Platform
 						var animation = AnimationUtils.LoadAnimation(_mauiWindowContext.Context, Resource.Animation.nav_modal_default_enter_anim)!;
 						_navigationRootManager.RootView.StartAnimation(animation);
 						animation.AnimationEnd += OnAnimationEnded;
-						listner.Dispose();
 					},_navigationRootManager.RootView);
 				}
 				return _navigationRootManager?.RootView ??

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -331,6 +331,7 @@ namespace Microsoft.Maui.Controls.Platform
 						var animation = AnimationUtils.LoadAnimation(_mauiWindowContext.Context, Resource.Animation.nav_modal_default_enter_anim)!;
 						_navigationRootManager.RootView.StartAnimation(animation);
 						animation.AnimationEnd += OnAnimationEnded;
+						listner.Dispose();
 					},_navigationRootManager.RootView);
 				}
 				return _navigationRootManager?.RootView ??

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					_ = new GenericGlobalLayoutListener((listner,view) =>
 					{
-						_navigationRootManager.RootView.ViewTreeObserver?.RemoveOnGlobalLayoutListener(listner);
+						listner.Invalidate();
 
 						var animation = AnimationUtils.LoadAnimation(_mauiWindowContext.Context, Resource.Animation.nav_modal_default_enter_anim)!;
 						_navigationRootManager.RootView.StartAnimation(animation);

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -556,6 +556,36 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact("Dont leak with Animation")]
+		public async Task ModalPageDontLeakWithAnimation()
+		{
+			SetupBuilder();
+			var references = new List<WeakReference>();
+
+
+			var page = new ContentPage();
+			var window = new Window(page);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async handler =>
+			{
+				var modalPage = new ContentPage
+				{
+					Content = new Label { Text = "Modal Content" }
+				};
+				await page.Navigation.PushModalAsync(modalPage,true);
+				await OnLoadedAsync(modalPage);
+
+				references.Add(new WeakReference(modalPage));
+				references.Add(new WeakReference(modalPage.Handler));
+				references.Add(new WeakReference(modalPage.Handler.PlatformView));
+
+				await page.Navigation.PopModalAsync();
+				await OnUnloadedAsync(modalPage);
+			});
+
+			await AssertionExtensions.WaitForGC(references.ToArray());
+		}
+
 		class PageTypes : IEnumerable<object[]>
 		{
 			public IEnumerator<object[]> GetEnumerator()


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
This PR provides a fix for #28492 and is an alternative to #28522. It ensures that modal animations only play once when the modal is first displayed and do not replay when the app returns from the background.

Rather than starting the animation in `OnStart()`,this fix attaches a `GlobalLayoutListener` to the view inside `OnCreateView()`. When the view's layout is complete for the first time, the listener invokes the animation and then removes itself to prevent any further invocations. Additionally, the `OnAnimationEnded` method has been moved out of the lambda for improved readability.

**After Fix:**

https://github.com/user-attachments/assets/bf28a45f-dcde-4b26-bdb3-1342dc9d4a3c



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #28492

Related PR #28522

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
