### PR TITLE
[iOS] Fixed memory leak with PopToRootAsync when using TitleView

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -311,7 +311,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			var task = GetAppearedOrDisappearedTask(page);
 
-			PopToRootViewController(animated);
+			var poppedControllers = PopToRootViewController(animated);
+
+			if (poppedControllers is not null)
+			{
+				foreach (var poppedController in poppedControllers)
+				{
+					if (poppedController is ParentingViewController parentingViewController)
+					{
+						parentingViewController.Disconnect(false);
+					}
+					else
+					{
+						poppedController?.Dispose();
+					}
+				}
+			}
 
 			_ignorePopCall = false;
 			var success = !await task;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -313,6 +313,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			var poppedControllers = PopToRootViewController(animated);
 
+			_ignorePopCall = false;
+			var success = !await task;
+
 			if (poppedControllers is not null)
 			{
 				foreach (var poppedController in poppedControllers)
@@ -327,9 +330,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					}
 				}
 			}
-
-			_ignorePopCall = false;
-			var success = !await task;
 
 			UpdateToolBarVisible();
 			return success;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28201.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28201.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          x:Class="Maui.Controls.Sample.Issues.Issue28201MainPage"
+                          xmlns:controls="clr-namespace:Maui.Controls.Sample.Issues">
+  <NavigationPage.TitleView>
+    <Label>Test</Label>
+  </NavigationPage.TitleView>
+  <ScrollView>
+    <VerticalStackLayout
+      Padding="30,0"
+      Spacing="25">
+      <Button x:Name="PushBtn"
+              Text="Push"
+              Clicked="OnPushClicked"
+              AutomationId="pushButton"
+              HorizontalOptions="Fill"/>
+      <Button x:Name="PopToRootBtn"
+              Text="Pop To Root"
+              AutomationId="popButton"
+              Clicked="OnPopToRootClicked"
+              HorizontalOptions="Fill"/>
+      <Button x:Name="CheckStatusButton"
+              Text="Check Status"
+              AutomationId="checkStatusButton"
+              Clicked="OnCheckStatusClicked"
+              HorizontalOptions="Fill"/>
+
+      <Label x:Name="StatusLabel"
+             Text="Page created"
+             AutomationId="label"
+             HorizontalOptions="Fill"/>
+    </VerticalStackLayout>
+  </ScrollView>
+
+</controls:TestContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28201.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28201.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 28201, "TiteView disposed when Page is disposed", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 28201, "TitleView disposed when Page is disposed", PlatformAffected.iOS)]
 public class Issue28201 : NavigationPage
 {
 	public Issue28201()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28201.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28201.xaml.cs
@@ -1,0 +1,46 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28201, "TiteView disposed when Page is disposed", PlatformAffected.iOS)]
+public class Issue28201 : NavigationPage
+{
+	public Issue28201()
+	{
+		Navigation.PushAsync(new Issue28201MainPage());
+	}
+}
+
+public partial class Issue28201MainPage : TestContentPage
+{
+	public static bool isPageDestroyed = false;
+	public Issue28201MainPage()
+	{
+		InitializeComponent();
+	}
+
+	protected override void Init()
+	{
+
+	}
+
+	private void OnPushClicked(object sender, EventArgs e)
+	{
+		isPageDestroyed = false;
+		Navigation.PushAsync(new Issue28201MainPage(), true);
+	}
+
+	private void OnPopToRootClicked(object sender, EventArgs e)
+	{
+		Navigation.PopToRootAsync(true);
+		GC.Collect();
+	}
+
+	private void OnCheckStatusClicked(object sender, EventArgs e)
+	{
+		StatusLabel.Text = isPageDestroyed ? "Page Destroyed" : "Page Active";
+	}
+
+	~Issue28201MainPage()
+	{
+		isPageDestroyed = true;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
@@ -10,7 +10,7 @@ public class Issue28201 : _IssuesUITest
 	public Issue28201(TestDevice testDevice) : base(testDevice)
 	{
 	}
-	public override string Issue => "TiteView disposed when Page is disposed";
+	public override string Issue => "TitleView disposed when Page is disposed";
 
 	[Test]
 	[Category(UITestCategories.TitleView)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
@@ -16,12 +16,14 @@ public class Issue28201 : _IssuesUITest
 	[Category(UITestCategories.TitleView)]
 	public void TitleViewDisposed()
 	{
+		string pushButton = "pushButton";
+		string popButton = "popButton";
 		for (int i = 0; i < 3; i++)
 		{
-			App.WaitForElement("pushButton");
-			App.Tap("pushButton");
-			App.WaitForElement("popButton");
-			App.Tap("popButton");
+			App.WaitForElement(pushButton);
+			App.Tap(pushButton);
+			App.WaitForElement(popButton);
+			App.Tap(popButton);
 		}
 		var label = App.WaitForElement("label");
 		App.Tap("checkStatusButton");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
@@ -1,0 +1,31 @@
+﻿#if IOS || MACCATALYST
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28201 : _IssuesUITest
+{
+	public Issue28201(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "TiteView disposed when Page is disposed";
+
+	[Test]
+	[Category(UITestCategories.TitleView)]
+	public void TitleViewDisposed()
+	{
+		for (int i = 0; i < 3; i++)
+		{
+			App.WaitForElement("pushButton");
+			App.Tap("pushButton");
+			App.WaitForElement("popButton");
+			App.Tap("popButton");
+		}
+		var label = App.WaitForElement("label");
+		App.Tap("checkStatusButton");
+		Assert.That(label.GetText(), Is.EqualTo("Page Destroyed"));
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28201.cs
@@ -1,4 +1,4 @@
-﻿#if IOS || MACCATALYST
+﻿#if TEST_FAILS_ON_ANDROID // Destructor not triggered on Android: https://github.com/dotnet/maui/issues/28549
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
### Issue Detail
When navigating using PushAsync and PopToRootAsync, the destructor was not invoked when using PopToRootAsync.
 
### Root Cause
The TitleView was not properly disposed when using PopToRootAsync.
 
### Description of Change
Resolved the issue by disposing the TitleView using Disconnect, similar to PopAsync.

Reference: https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs#L345

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28201

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/23f571a4-f6f9-4978-b6d8-0a334b2dd593"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/0c7e5202-bf49-4fbd-98b1-3028c1cbc8c8">) |