### PR TITLE
[.Net10][Proposal][Shell] Shell.PopToRootOnTabReselect property

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRenderer.cs
@@ -420,6 +420,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void OnTabReselected(ShellSection shellSection)
 		{
+			if (Shell.GetPopToRootOnTabReselect(ShellItem) && shellSection.Navigation.NavigationStack.Count > 1)
+			{
+				shellSection.Navigation.PopToRootAsync();
+			}
 		}
 
 		protected virtual void ResetAppearance() => _appearanceTracker.ResetAppearance(_bottomView);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -117,6 +117,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (r != null)
 					accept = ((IShellItemController)ShellItem).ProposeSection(r.ShellSection, false);
 
+				if (viewController == tabController.SelectedViewController && !Shell.GetPopToRootOnTabReselect(r.ShellSection))
+				{
+					return false;
+				}
+
 				return accept;
 			};
 		}

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == Shell.TabBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.TabBarIsVisibleProperty, element);
 
+			if (propertyName == null || propertyName == Shell.PopToRootOnTabReselectProperty.PropertyName)
+				BaseShellItem.PropagateFromParent(Shell.PopToRootOnTabReselectProperty, element);
+
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -149,3 +149,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -349,3 +349,6 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Up
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.MovedToWindow() -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -349,3 +349,6 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Up
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.MovedToWindow() -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -144,3 +144,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -150,3 +150,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -144,3 +144,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -144,3 +144,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.Shell.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.Shell.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj) -> bool
+~static Microsoft.Maui.Controls.Shell.SetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject obj, bool value) -> void

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -137,6 +137,14 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TabBarIsVisibleProperty =
 			BindableProperty.CreateAttached("TabBarIsVisible", typeof(bool), typeof(Shell), true);
 
+
+		/// <summary>
+		/// Determines whether the navigation stack should be reset to the root when the currently selected tab is reselected.
+		/// </summary>
+		public static readonly BindableProperty PopToRootOnTabReselectProperty =
+			BindableProperty.CreateAttached("PopToRootOnTabReselect", typeof(bool), typeof(Shell), false);
+
+
 		/// <summary>
 		/// Enables any <see cref = "View" /> to be displayed in the navigation bar.
 		/// </summary>
@@ -327,6 +335,20 @@ namespace Microsoft.Maui.Controls
 		/// <param name="obj">The object that modifies the tabs visibility.</param>
 		/// <param name="value"><see langword="true"/> to set the tab bar as visible; otherwise, <see langword="false"/>.</param>
 		public static void SetTabBarIsVisible(BindableObject obj, bool value) => obj.SetValue(TabBarIsVisibleProperty, value);
+
+		/// <summary>
+		/// Gets a value indicating whether the navigation stack should be reset to the root when the currently selected tab is reselected.
+		/// </summary>
+		/// <param name="obj">The object that controls tab navigation behavior.</param>
+		/// <returns><see langword="true"/> if the navigation stack should reset to the root on tab reselection; otherwise, <see langword="false"/>.</returns>
+		public static bool GetPopToRootOnTabReselect(BindableObject obj) => (bool)obj.GetValue(PopToRootOnTabReselectProperty);
+
+		/// <summary>
+		/// Sets a value indicating whether the navigation stack should be reset to the root when the currently selected tab is reselected.
+		/// </summary>
+		/// <param name="obj">The object that controls tab navigation behavior.</param>
+		/// <param name="value"><see langword="true"/> to reset the navigation stack to the root on tab reselection; otherwise, <see langword="false"/>.</param>
+		public static void SetPopToRootOnTabReselect(BindableObject obj, bool value) => obj.SetValue(PopToRootOnTabReselectProperty, value);
 
 		/// <summary>
 		/// Gets any <see cref = "View" /> to be displayed in the navigation bar when the given <paramref name="obj"/> is active.

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27401Shell.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27401Shell.cs
@@ -1,0 +1,39 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, "27401Shell", "Shell.PopToRootOnTabReselect", PlatformAffected.Android | PlatformAffected.iOS)]
+	public class Issue27401Shell : TestShell
+	{
+		protected override void Init()
+		{
+			SetPopToRootOnTabReselect(this, true);
+			var contentPage = AddBottomTab("Tab 1");
+			Items[0].CurrentItem.AutomationId = "Tab1AutomationId";
+			AddBottomTab("Ignore Me");
+
+			contentPage.Content = new Button
+			{
+				Text = "Deep 0",
+				AutomationId = "Deep0Button",
+				VerticalOptions = LayoutOptions.Center,
+				Command = new Command(() => Navigation.PushAsync(new ContentPage()
+				{
+					Content = new Button()
+					{
+						Text = "Deep 1",
+						AutomationId = "Deep1Button",
+						VerticalOptions = LayoutOptions.Center,
+						Command = new Command(() => Navigation.PushAsync(new ContentPage()
+						{
+							Content = new Button()
+							{
+								Text = "Deep 2",
+								VerticalOptions = LayoutOptions.Center,
+								AutomationId = "Deep2Label"
+							}
+						}))
+					}
+				}))
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27401Shell.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27401Shell.cs
@@ -1,0 +1,29 @@
+﻿#if ANDROID || IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27401Shell : _IssuesUITest
+	{
+		public Issue27401Shell(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Shell.PopToRootOnTabReselect";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void ClickingCurrentTabShouldNavigateToRoot()
+		{
+			App.WaitForElement("Deep0Button");
+			App.Click("Deep0Button");
+			App.WaitForElement("Deep1Button");
+			App.Click("Deep1Button");
+			App.Click("Tab 1");
+			App.WaitForElement("Deep0Button");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

This PR introduces a new BindableProperty called `PopToRootOnTabReselectProperty` in .NET MAUI Shell. This property allows developers to control whether reselecting the currently active tab should automatically pop its navigation stack to the root page. 

#### Motivation
In many tab-based applications, users expect that tapping an already selected tab should reset its navigation stack, bringing them back to the root of that section. Currently, this behavior must be manually implemented with lots of additional workarounds. This property provides a built-in way to achieve this functionality, improving developer experience and reducing boilerplate code.

### Demo

|Android|iOS|
|--|--|
|<video src="https://github.com/user-attachments/assets/e482aa03-1faf-48a9-a017-e253b944d5a2" width="300px"/>|<video src="https://github.com/user-attachments/assets/bb774a44-daf2-4d1a-bcda-ad399117be3a" width="300px"/>|

### Usage
```
<Shell
    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
    x:Class="Maui.Controls.Sample.SandboxShell"
    Shell.PopToRootOnTabReselect = "True">
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/27401
Fixes https://github.com/dotnet/maui/issues/15301
Fixes https://github.com/dotnet/maui/issues/29395

