### PR TITLE
[.Net10][Proposal]TabbedPage.PopToRootOnTabReselect property

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -131,6 +131,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				view.Arrange(View.Bounds.ToRectangle());
 		}
 
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+			ShouldSelectViewController = (tabController, viewController) =>
+			{
+				if (viewController == tabController.SelectedViewController && !TabbedPage.GetPopToRootOnTabReselect(Tabbed))
+				{
+					return false;
+				}
+
+				return true;
+			};
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -989,6 +989,13 @@ namespace Microsoft.Maui.Controls.Handlers
 				{
 					if (_tabbedPageManager._bottomNavigationView.SelectedItemId != item.ItemId && _tabbedPageManager.Element.Children.Count > item.ItemId)
 						_tabbedPageManager.Element.CurrentPage = _tabbedPageManager.Element.Children[item.ItemId];
+					else
+					{
+						if (TabbedPage.GetPopToRootOnTabReselect(_tabbedPageManager.Element) && _tabbedPageManager.Element.CurrentPage.Navigation.NavigationStack.Count > 1)
+						{
+							_tabbedPageManager.Element.CurrentPage.Navigation.PopToRootAsync();
+						}
+					}
 				}
 
 				return true;

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -149,3 +149,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -349,3 +349,7 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Up
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.MovedToWindow() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer.ViewDidLoad() -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -349,3 +349,7 @@ virtual Microsoft.Maui.Controls.Handlers.Items2.ItemsViewHandler2<TItemsView>.Up
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 *REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.MovedToWindow() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer<TElement>.MovedToWindow() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer.ViewDidLoad() -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -144,3 +144,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -150,3 +150,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -144,3 +144,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -144,3 +144,6 @@ static readonly Microsoft.Maui.Controls.TitleBar.TitleProperty -> Microsoft.Maui
 static readonly Microsoft.Maui.Controls.TitleBar.TrailingContentProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Window.TitleBarProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.Application.ActivateWindow(Microsoft.Maui.Controls.Window! window) -> void
+~static readonly Microsoft.Maui.Controls.TabbedPage.PopToRootOnTabReselectProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.TabbedPage.GetPopToRootOnTabReselect(Microsoft.Maui.Controls.BindableObject element) -> bool
+~static readonly Microsoft.Maui.Controls.BaseShellItem.FlyoutItemIsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.cs
@@ -59,6 +59,25 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SelectedTabColorProperty, value);
 		}
 
+		/// <summary>
+		/// Determines whether the navigation stack should be reset to the root when the currently selected tab is reselected.
+		/// </summary>
+		public static readonly BindableProperty PopToRootOnTabReselectProperty = BindableProperty.Create("PopToRootOnTabReselect", typeof(bool), typeof(TabbedPage), false);
+
+		/// <summary>
+		/// Gets a value indicating whether the navigation stack should be reset to the root when the currently selected tab is reselected.
+		/// </summary>
+		/// <param name="element">The object that controls tab navigation behavior.</param>
+		/// <returns><see langword="true"/> if the navigation stack should reset to the root on tab reselection; otherwise, <see langword="false"/>.</returns>
+		public static bool GetPopToRootOnTabReselect(BindableObject element) => (bool)element.GetValue(PopToRootOnTabReselectProperty);
+
+		/// <summary>
+		/// Sets a value indicating whether the navigation stack should be reset to the root when the currently selected tab is reselected.
+		/// </summary>
+		/// <param name="element">The object that controls tab navigation behavior.</param>
+		/// <param name="value"><see langword="true"/> to reset the navigation stack to the root on tab reselection; otherwise, <see langword="false"/>.</param>
+		public static void SetPopToRootOnTabReselect(BindableObject element, bool value) => element.SetValue(PopToRootOnTabReselectProperty, value);
+
 		protected override Page CreateDefault(object item)
 		{
 			var page = new Page();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27401TabbedPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27401TabbedPage.cs
@@ -1,0 +1,56 @@
+﻿
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, "27401TabbedPage", "TabbedPage.PopToRootOnTabReselect", PlatformAffected.Android)]
+public class Issue27401TabbedPage : TabbedPage
+{
+	public Issue27401TabbedPage()
+	{
+		Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.SetToolbarPlacement(this, Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Bottom);
+		TabbedPage.SetPopToRootOnTabReselect(this, true);
+		
+		var rootPage = new ContentPage
+		{
+			Title = "Root Page"
+		};
+
+		var button = new Button
+		{
+			Text = "Deep 0",
+			AutomationId = "Deep0Button",
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var navPage = new NavigationPage(rootPage) { Title = "Tab 1" };
+		button.Command = new Command(() =>
+		{
+			navPage.PushAsync(new ContentPage()
+			{
+				Title = "Deep 1",
+				Content = new Button()
+				{
+					Text = "Deep 1",
+					AutomationId = "Deep1Button",
+					VerticalOptions = LayoutOptions.Center,
+					Command = new Command(() =>
+					{
+						navPage.PushAsync(new ContentPage()
+						{
+							Title = "Deep 2",
+							Content = new Button()
+							{
+								Text = "Deep 2",
+								VerticalOptions = LayoutOptions.Center,
+								AutomationId = "Deep2Label"
+							}
+						});
+					})
+				}
+			});
+		});
+
+		rootPage.Content = button;
+		Children.Add(navPage);
+		Children.Add(new ContentPage { Title = "Ignore Me" });
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27401TabbedPage.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27401TabbedPage.cs
@@ -1,0 +1,29 @@
+﻿#if ANDROID || IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue27401TabbedPage : _IssuesUITest
+	{
+		public Issue27401TabbedPage(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "TabbedPage.PopToRootOnTabReselect";
+
+		[Test]
+		[Category(UITestCategories.TabbedPage)]
+		public void ClickingCurrentTabShouldNavigateToRoot()
+		{
+			App.WaitForElement("Deep0Button");
+			App.Click("Deep0Button");
+			App.WaitForElement("Deep1Button");
+			App.Click("Deep1Button");
+			App.Click("Tab 1");
+			App.WaitForElement("Deep0Button");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

This PR introduces a property called `TabbedPage.PopToRootOnTabReselectProperty` in .NET MAUI TabbedPage. This property allows developers to control whether reselecting the currently active tab should automatically pop its navigation stack to the root page. 

#### Motivation
In many tab-based applications, users expect that tapping an already selected tab should reset its navigation stack, bringing them back to the root of that section. Currently, this behavior must be manually implemented with lots of additional workarounds. This property provides a built-in way to achieve this functionality, improving developer experience and reducing boilerplate code.

### Demo

|Android|iOS|
|--|--|
|<video src="https://github.com/user-attachments/assets/e9a6e592-f662-45f5-8564-443d10761607" width="300px"/>|<video src="https://github.com/user-attachments/assets/d5949d1e-be51-44b2-a295-bfa6fb4b95dc" width="300px"/>|

### Usage
```
<TabbedPage
        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        x:Class="Maui.Controls.Sample.MainPage"
        TabbedPage.PopToRootOnTabReselect="True">
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/27401
Fixes https://github.com/dotnet/maui/issues/15301


