### PR TITLE
Implements `SecureStorage.GetOrSetAsync(key, value?)` (for #27966)

### DIFF
--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -1315,3 +1315,5 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -1315,5 +1315,3 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,7 +1,5 @@
 #nullable enable
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -1313,5 +1313,4 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -1313,3 +1313,5 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -1313,5 +1313,4 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -1313,3 +1313,5 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -1254,5 +1254,4 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -1254,3 +1254,5 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -1257,3 +1257,5 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -1257,5 +1257,4 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1228,5 +1228,3 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -1228,3 +1228,5 @@ static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Png -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Videos -> Microsoft.Maui.Storage.FilePickerFileType!
 virtual Microsoft.Maui.Storage.FilePickerFileType.GetPlatformFileType(Microsoft.Maui.Devices.DevicePlatform platform) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -845,7 +845,6 @@ Microsoft.Maui.Storage.IPreferences.Remove(string! key, string? sharedName = nul
 Microsoft.Maui.Storage.IPreferences.Set<T>(string! key, T value, string? sharedName = null) -> void
 Microsoft.Maui.Storage.ISecureStorage
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Storage.ISecureStorage.Remove(string! key) -> bool
 Microsoft.Maui.Storage.ISecureStorage.RemoveAll() -> void
 Microsoft.Maui.Storage.ISecureStorage.SetAsync(string! key, string! value) -> System.Threading.Tasks.Task!
@@ -1223,7 +1222,7 @@ static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Thre
 static Microsoft.Maui.Storage.SecureStorage.Remove(string! key) -> bool
 static Microsoft.Maui.Storage.SecureStorage.RemoveAll() -> void
 static Microsoft.Maui.Storage.SecureStorage.SetAsync(string! key, string! value) -> System.Threading.Tasks.Task!
-static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Images -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Jpeg -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.Storage.FilePickerFileType!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -845,6 +845,7 @@ Microsoft.Maui.Storage.IPreferences.Remove(string! key, string? sharedName = nul
 Microsoft.Maui.Storage.IPreferences.Set<T>(string! key, T value, string? sharedName = null) -> void
 Microsoft.Maui.Storage.ISecureStorage
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Storage.ISecureStorage.Remove(string! key) -> bool
 Microsoft.Maui.Storage.ISecureStorage.RemoveAll() -> void
 Microsoft.Maui.Storage.ISecureStorage.SetAsync(string! key, string! value) -> System.Threading.Tasks.Task!
@@ -1222,6 +1223,7 @@ static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Thre
 static Microsoft.Maui.Storage.SecureStorage.Remove(string! key) -> bool
 static Microsoft.Maui.Storage.SecureStorage.RemoveAll() -> void
 static Microsoft.Maui.Storage.SecureStorage.SetAsync(string! key, string! value) -> System.Threading.Tasks.Task!
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Images -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Jpeg -> Microsoft.Maui.Storage.FilePickerFileType!
 static readonly Microsoft.Maui.Storage.FilePickerFileType.Pdf -> Microsoft.Maui.Storage.FilePickerFileType!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
+

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -3,4 +3,5 @@ static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value) -> void
-
+static Microsoft.Maui.Storage.SecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Maui.Storage.ISecureStorage.GetOrSetAsync(string! key, string? defaultValue) -> System.Threading.Tasks.Task<string?>!

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Storage
 		Task<string?> GetAsync(string key);
 		
 		/// <summary>
-		/// Gets and decrypts the value for a given key.
+		/// Gets and decrypts the value for a given key or sets and returns a value if the current one is <see langword="null"/>.
 		/// </summary>
 		/// <param name="key">The key to retrieve the value for.</param>
 		/// <param name="defaultValue">The default value in case the key does not exist.</param>
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Storage
 			Current.GetAsync(key);
 			
 		/// <summary>
-		/// Gets and decrypts the value for a given key.
+		/// Gets and decrypts the value for a given key or sets and returns a value if the current one is <see langword="null"/>.
 		/// </summary>
 		/// <param name="key">The key to retrieve the value for.</param>
 		/// <param name="defaultValue">The default value in case the key does not exist.</param>

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -15,6 +15,14 @@ namespace Microsoft.Maui.Storage
 		/// <param name="key">The key to retrieve the value for.</param>
 		/// <returns>The decrypted string value or <see langword="null"/> if a value was not found.</returns>
 		Task<string?> GetAsync(string key);
+		
+		/// <summary>
+		/// Gets and decrypts the value for a given key.
+		/// </summary>
+		/// <param name="key">The key to retrieve the value for.</param>
+		/// <param name="defaultValue">The default value in case the key does not exist.</param>
+		/// <returns>The decrypted string value or <b>defaultValue</b> if a value was not found.</returns>
+		Task<string?> GetOrSetAsync(string key, string? defaultValue);
 
 		/// <summary>
 		/// Sets and encrypts a value for a given key.
@@ -86,6 +94,15 @@ namespace Microsoft.Maui.Storage
 		/// <returns>The decrypted string value or <see langword="null"/> if a value was not found.</returns>
 		public static Task<string?> GetAsync(string key) =>
 			Current.GetAsync(key);
+			
+		/// <summary>
+		/// Gets and decrypts the value for a given key.
+		/// </summary>
+		/// <param name="key">The key to retrieve the value for.</param>
+		/// <param name="defaultValue">The default value in case the key does not exist.</param>
+		/// <returns>The decrypted string value or <b>defaultValue</b> if a value was not found.</returns>
+		public static Task<string?> GetOrSetAsync(string key, string? defaultValue) =>
+			Current.GetOrSetAsync(key, defaultValue);
 
 		/// <summary>
 		/// Sets and encrypts a value for a given key.
@@ -213,6 +230,21 @@ namespace Microsoft.Maui.Storage
 				throw new ArgumentNullException(nameof(key));
 
 			return PlatformGetAsync(key);
+		}
+		
+		public async Task<string?> GetOrSetAsync(string key, string? defaultValue)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+				throw new ArgumentNullException(nameof(key));
+			
+			var existingValue = await PlatformGetAsync(key);
+			if (existingValue == null && defaultValue != null)
+			{
+				await SetAsync(key, defaultValue);
+				return defaultValue;
+			}
+			
+			return existingValue;
 		}
 
 		public Task SetAsync(string key, string value)

--- a/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
@@ -225,8 +225,9 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Theory]
-		[InlineData("myKey", "value123")]
-		[InlineData("myKey", "")]
+		[InlineData("myKey1", "value123")]
+		[InlineData("myKey2", " ")]
+		[InlineData("myKey3", null)]
 		public async Task Get_Or_Set_Async_Returns_Value(string key, string value)
 		{
 			var result = await SecureStorage.GetOrSetAsync(key, value);

--- a/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
@@ -223,5 +223,14 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 				Assert.Null(fetched);
 			});
 		}
+
+		[Theory]
+		[InlineData("myKey", "value123")]
+		[InlineData("myKey", "")]
+		public async Task Get_Or_Set_Async_Returns_Value(string key, string value)
+		{
+			var result = await SecureStorage.GetOrSetAsync(key, value);
+			Assert.Equal(value, result);
+		}
 	}
 }

--- a/src/Essentials/test/UnitTests/SecureStorage_Tests.cs
+++ b/src/Essentials/test/UnitTests/SecureStorage_Tests.cs
@@ -8,6 +8,12 @@ namespace Tests
 	public class SecureStorage_Tests
 	{
 		[Fact]
+		public async Task SecureStorage_LoadOrSaveAsync_Fail_On_NetStandard()
+		{
+			await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => SecureStorage.GetOrSetAsync("key", "value"));
+		}
+		
+		[Fact]
 		public async Task SecureStorage_LoadAsync_Fail_On_NetStandard()
 		{
 			await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => SecureStorage.GetAsync("key"));


### PR DESCRIPTION
### Description of Change

This PR addresses a recently created issue that suggests the creation of the method `SecureStorage.GetOrSetAsync(key, value?)` that is focused in providing an easy interface to work with various operations that involve retrieving data from SecureStorage when there is not guarantee that the data already exists, allowing the developer to set a default value directly inside the operation chain instead of creating if statements and checks.

Usage example:

```cs
var tasks = new List<Task>
{
    SecureStorage.Default.GetOrSetAsync("user_email", ExternalBackendService.GetUserEmail()),
    SecureStorage.Default.GetOrSetAsync("user_id", ExternalBackendService.GetUserId()),
};

var result = await Task.WhenAll(tasks);
SomeStateFunction(result);
```

Current (unoptimized) way to achieve the same result today:

```cs
var userEmail = await SecureStorage.Default.GetAsync("user_email");
var userId = await SecureStorage.Default.GetAsync("user_id");

if (userEmail is null)
{
    var thisUserEmail = ExternalBackendService.GetUserEmail();
    await SecureStorage.Default.SetAsync("user_email", thisUserEmail);
    userEmail = thisUserEmail;
}

if (userId is null)
{
    var thisUserId = ExternalBackendService.GetUserIdl();
    await SecureStorage.Default.SetAsync("user_email", thisUserId);
    userId = thisUserId;
}
SomeStateFunction(userEmail);
SomeOtherStateFunction(userId);
```

### Public API Changes

```cs
string result = await SecureStorage.[Profile].GetOrSetAsync("key", "value"); //New Api
```

### Issues Fixed

https://github.com/dotnet/maui/issues/27966 - To https://github.com/dotnet/maui/milestone/14

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Extra Statements

- I am not familiarized with the public API files present in that repository, so I basically updated all `Shipped` files with the public API changes, I didn't find more documentation about how properly deal with that and I can change my PR based on the next comments;
- I have added basic tests that ensure the basic functionality of the new method, but if needed, I'd love to add new tests such as race condition specific verifications and other possible suggestions;
- A little more details can be found in the issue itself, but feel free to discuss anything you want (as a reviewer) here!