### PR TITLE
Fix Tizen method parameter name misspelling

### DIFF
--- a/src/Core/src/Fonts/FontManager.Tizen.cs
+++ b/src/Core/src/Fonts/FontManager.Tizen.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Maui
 		}
 
 		/// <inheritdoc/>
-		public string GetFontFamily(string? fontFamliy) //TODO: this is a misspelling in public ABI; consider changing in NET8
+		public string GetFontFamily(string? fontFamily)
 		{
-			if (string.IsNullOrEmpty(fontFamliy))
+			if (string.IsNullOrEmpty(fontFamily))
 				return "";
 
-			var cleansedFont = CleanseFontName(fontFamliy ?? string.Empty);
+			var cleansedFont = CleanseFontName(fontFamily ?? string.Empty);
 			if (cleansedFont == null)
 				return "";
 

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -312,7 +312,6 @@ Microsoft.Maui.FontManager
 Microsoft.Maui.FontManager.DefaultFontSize.get -> double
 Microsoft.Maui.FontManager.FontManager(Microsoft.Maui.IFontRegistrar! fontRegistrar, System.IServiceProvider? serviceProvider = null) -> void
 Microsoft.Maui.FontManager.GetFont(Microsoft.Maui.Font font) -> string!
-Microsoft.Maui.FontManager.GetFontFamily(string? fontFamliy) -> string!
 Microsoft.Maui.FontRegistrar
 Microsoft.Maui.FontRegistrar.FontRegistrar(Microsoft.Maui.IEmbeddedFontLoader! fontLoader, System.IServiceProvider? serviceProvider = null) -> void
 Microsoft.Maui.FontRegistrar.GetFont(string! font) -> string?

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -312,6 +312,7 @@ Microsoft.Maui.FontManager
 Microsoft.Maui.FontManager.DefaultFontSize.get -> double
 Microsoft.Maui.FontManager.FontManager(Microsoft.Maui.IFontRegistrar! fontRegistrar, System.IServiceProvider? serviceProvider = null) -> void
 Microsoft.Maui.FontManager.GetFont(Microsoft.Maui.Font font) -> string!
+Microsoft.Maui.FontManager.GetFontFamily(string? fontFamliy) -> string!
 Microsoft.Maui.FontRegistrar
 Microsoft.Maui.FontRegistrar.FontRegistrar(Microsoft.Maui.IEmbeddedFontLoader! fontLoader, System.IServiceProvider? serviceProvider = null) -> void
 Microsoft.Maui.FontRegistrar.GetFont(string! font) -> string?

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 Microsoft.Maui.ElementHandlerExtensions
+*REMOVED*Microsoft.Maui.FontManager.GetFontFamily(string? fontFamliy) -> string!
+Microsoft.Maui.FontManager.GetFontFamily(string? fontFamily) -> string!
 Microsoft.Maui.HandlerDisconnectPolicy
 Microsoft.Maui.HandlerDisconnectPolicy.Automatic = 0 -> Microsoft.Maui.HandlerDisconnectPolicy
 Microsoft.Maui.HandlerDisconnectPolicy.Manual = 1 -> Microsoft.Maui.HandlerDisconnectPolicy


### PR DESCRIPTION
### Description of Change

Fixes a misspelling in the `GetFontFamily` method parameter name in the `FontManager.Tizen.cs` file.

