### PR TITLE
Fixed Refresh Color not applying to RefreshView initially.

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16973.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16973.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 16973, "RefreshView RefreshColor is not working", PlatformAffected.UWP)]
+public class Issue16973 : ContentPage
+{
+	public Issue16973()
+	{
+		var grid = new Grid
+		{
+			RowDefinitions = new RowDefinitionCollection
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = new GridLength(500) }
+			}
+		};
+		var label = new Label
+		{
+			AutomationId = "label",
+			Text = "Tap the button to change the refresh color."
+		};
+		Grid.SetRow(label, 0);
+
+		var button = new Button
+		{
+			Text = "Change Refresh Color",
+			AutomationId = "button",
+			WidthRequest = 200,
+		};
+		Grid.SetRow(button, 1);
+
+		var refreshView = new RefreshView
+		{
+			RefreshColor = Colors.Red,
+			IsRefreshing = true,
+		};
+		Grid.SetRow(refreshView, 2);
+
+		var scrollView = new ScrollView();
+		var label2 = new Label
+		{
+			Text = "If the color matches, the test has passed successfully.",
+		};
+		scrollView.Content = label2;
+		refreshView.Content = scrollView;
+
+		button.Clicked += (s, e) =>
+		{
+#if WINDOWS
+			if (refreshView.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.RefreshContainer refreshContainer)
+			{
+				var refreshColor = refreshView.RefreshColor.ToWindowsColor();
+				var visualizerForeground = (refreshContainer.Visualizer.Foreground as Microsoft.UI.Xaml.Media.SolidColorBrush)?.Color;
+
+				label.Text = (refreshColor == visualizerForeground) ? "Color matches" : "Color does not match";
+			}
+#endif
+		};
+		grid.Children.Add(label);
+		grid.Children.Add(button);
+		grid.Children.Add(refreshView);
+		Content = grid;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16973.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16973.cs
@@ -5,6 +5,8 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 16973, "RefreshView RefreshColor is not working", PlatformAffected.UWP)]
 public class Issue16973 : ContentPage
 {
+	Label label;
+	RefreshView refreshView;
 	public Issue16973()
 	{
 		var grid = new Grid
@@ -16,7 +18,7 @@ public class Issue16973 : ContentPage
 				new RowDefinition { Height = new GridLength(500) }
 			}
 		};
-		var label = new Label
+		label = new Label
 		{
 			AutomationId = "label",
 			Text = "Tap the button to change the refresh color."
@@ -31,7 +33,7 @@ public class Issue16973 : ContentPage
 		};
 		Grid.SetRow(button, 1);
 
-		var refreshView = new RefreshView
+		refreshView = new RefreshView
 		{
 			RefreshColor = Colors.Red,
 			IsRefreshing = true,
@@ -48,6 +50,20 @@ public class Issue16973 : ContentPage
 
 		button.Clicked += (s, e) =>
 		{
+#if __IOS__ || __MACCATALYST__
+			VerifyRefreshColorMatchIOS();
+#elif WINDOWS
+			VerifyRefreshColorMatchWindows();
+#endif
+		};
+		grid.Children.Add(label);
+		grid.Children.Add(button);
+		grid.Children.Add(refreshView);
+		Content = grid;
+	}
+
+	void VerifyRefreshColorMatchWindows()
+	{
 #if WINDOWS
 			if (refreshView.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.RefreshContainer refreshContainer)
 			{
@@ -57,10 +73,31 @@ public class Issue16973 : ContentPage
 				label.Text = (refreshColor == visualizerForeground) ? "Color matches" : "Color does not match";
 			}
 #endif
-		};
-		grid.Children.Add(label);
-		grid.Children.Add(button);
-		grid.Children.Add(refreshView);
-		Content = grid;
+	}
+
+	void VerifyRefreshColorMatchIOS()
+	{
+#if __IOS__ || __MACCATALYST__
+		if (refreshView.Handler?.PlatformView is MauiRefreshView refreshControl)
+		{
+			var refreshColor = refreshView.RefreshColor.ToPlatform();
+			var visualizerForeground = refreshControl.RefreshControl.TintColor;
+
+			bool AreColorsEqual(UIKit.UIColor color1, UIKit.UIColor color2)
+			{
+				if (color1 == null || color2 == null)
+					return false;
+
+				color1.GetRGBA(out nfloat r1, out nfloat g1, out nfloat b1, out nfloat a1);
+				color2.GetRGBA(out nfloat r2, out nfloat g2, out nfloat b2, out nfloat a2);
+
+				return (r1 == r2) && (g1 == g2) && (b1 == b2) && (a1 == a2);
+			}
+
+			label.Text = visualizerForeground != null && AreColorsEqual(refreshColor, visualizerForeground)
+				? "Color matches"
+				: "Color does not match";
+		}
+#endif
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16973.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16973.cs
@@ -1,0 +1,23 @@
+﻿#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue16973 : _IssuesUITest
+{
+	public Issue16973(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "RefreshView RefreshColor is not working";
+	[Test]
+	[Category(UITestCategories.RefreshView)]
+	public void Issue16973ValidateRefreshColor()
+	{
+		App.WaitForElement("label");
+		App.Tap("button");
+		var text = App.FindElement("label").GetText();
+		Assert.That(text, Is.EqualTo("Color matches"));
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16973.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16973.cs
@@ -1,4 +1,4 @@
-﻿#if WINDOWS
+﻿#if TEST_FAILS_ON_ANDROID // Skipping test: Unable to retrieve the native refresh color on Android.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -14,11 +14,14 @@ namespace Microsoft.Maui.Handlers
 
 		protected override RefreshContainer CreatePlatformView()
 		{
-			return new RefreshContainer
+			var refreshControl = new RefreshContainer
 			{
 				PullDirection = RefreshPullDirection.TopToBottom,
 				Content = new ContentPanel()
 			};
+
+			SetRefreshColorCallback(refreshControl);
+			return refreshControl;
 		}
 
 		protected override void ConnectHandler(RefreshContainer nativeView)
@@ -148,6 +151,20 @@ namespace Microsoft.Maui.Handlers
 				_refreshCompletionDeferral.Dispose();
 				_refreshCompletionDeferral = null;
 			}
+		}
+
+		void SetRefreshColorCallback(RefreshContainer refreshControl)
+		{
+			long callbackToken = 0;
+			callbackToken = refreshControl.RegisterPropertyChangedCallback(RefreshContainer.VisualizerProperty,
+				(_, __) =>
+				{
+					if (refreshControl?.Visualizer == null)
+						return;
+
+					UpdateRefreshColor(this);
+					refreshControl.UnregisterPropertyChangedCallback(RefreshContainer.VisualizerProperty, callbackToken);
+				});
 		}
 	}
 }


### PR DESCRIPTION
### Issue Details
RefreshView RefreshColor does not work initially.

### Root Cause
The RefreshViewVisualizer instance is initially null, preventing the RefreshColor from being set when the control is created. Since Visualizer is assigned asynchronously by the system, any attempt to set its properties too early fails.

### Description of Change
To ensure that RefreshColor is applied when Visualizer becomes available, a property change callback was registered on RefreshContainer.VisualizerProperty. This callback waits until Visualizer is assigned and then applies the correct RefreshColor. Once the color is set, the callback is unregistered to avoid redundant calls.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
 
### Issues Fixed
  
Fixes #16973 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/2165d90e-ee05-4745-a919-548b2b630c47" >| <video src="https://github.com/user-attachments/assets/25711cc3-c0d4-4179-92c7-5fedcd2c325e">|
