### PR TITLE
[iOS] - Resolved Proper Rendering of Dynamic Header/Footer Updates in CV2

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			[StructuredItemsView.FooterTemplateProperty.PropertyName] = MapFooterTemplate,
 			[StructuredItemsView.HeaderProperty.PropertyName] = MapHeaderTemplate,
 			[StructuredItemsView.FooterProperty.PropertyName] = MapFooterTemplate,
+			[GroupableItemsView.GroupHeaderTemplateProperty.PropertyName] = MapHeaderTemplate,
+			[GroupableItemsView.GroupFooterTemplateProperty.PropertyName] = MapFooterTemplate,
 		};
 	}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
@@ -133,7 +133,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			var bindingContext = ItemsSource.Group(indexPath);
 
+			cell.isHeaderOrFooterChanged = true;
 			cell.Bind(template, bindingContext, ItemsView);
+			cell.isHeaderOrFooterChanged = false;
 
 			// if (cell is ItemsViewCell2)
 			// {

--- a/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		void UpdateTemplatedSupplementaryView(TemplatedCell2 cell, NSString elementKind)
 		{
 			bool isHeader = elementKind == UICollectionElementKindSectionKey.Header;
+			cell.isHeaderOrFooterChanged = true;
 
 			if (isHeader)
 			{
@@ -137,6 +138,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				}
 				cell.Tag = FooterTag;
 			}
+
+			cell.isHeaderOrFooterChanged = false;
 		}
 
 		string DetermineViewReuseId(DataTemplate template, object item)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -134,8 +134,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
 		{
-			var virtualView = PlatformHandler?.VirtualView as View ?? 
-			                  template.CreateContent(bindingContext, itemsView) as View;
+			View virtualView = null;
+			if (CurrentTemplate != template)
+			{
+				CurrentTemplate = template;
+				virtualView = template.CreateContent(bindingContext, itemsView) as View;
+			}
+			else if (PlatformHandler?.VirtualView is View existingView)
+			{
+				virtualView = existingView;
+			}
 
 			BindVirtualView(virtualView, bindingContext, itemsView, false);
 		}
@@ -147,6 +155,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		void BindVirtualView(View virtualView, object bindingContext, ItemsView itemsView, bool needsContainer)
 		{
+			var oldElement = PlatformHandler?.VirtualView as View;
+
+			if (oldElement is not null && oldElement != virtualView)
+			{
+				oldElement.BindingContext = null;
+				itemsView.RemoveLogicalChild(oldElement);
+				PlatformHandler = null;
+				PlatformView?.RemoveFromSuperview();
+			}
+
 			if (PlatformHandler is null && virtualView is not null)
 			{
 				var mauiContext = itemsView.FindMauiContext()!;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		Size _cachedConstraints;
 
 		internal bool MeasureInvalidated => _measureInvalidated;
+
+		// Flags changes confined to the header/footer, preventing unnecessary recycling and revalidation of templated cells.
 		internal bool isHeaderOrFooterChanged = false;
 
 		public DataTemplate CurrentTemplate

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		Size _cachedConstraints;
 
 		internal bool MeasureInvalidated => _measureInvalidated;
+		internal bool isHeaderOrFooterChanged = false;
 
 		public DataTemplate CurrentTemplate
 		{
@@ -157,7 +158,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var oldElement = PlatformHandler?.VirtualView as View;
 
-			if (oldElement is not null && oldElement != virtualView)
+			if (oldElement is not null && oldElement != virtualView && isHeaderOrFooterChanged)
 			{
 				oldElement.BindingContext = null;
 				itemsView.RemoveLogicalChild(oldElement);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28509.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28509.cs
@@ -250,7 +250,7 @@ public class Issue28509TemplatedHeaderFooter : TestContentPage
 			}),
 			HeaderTemplate = new DataTemplate(() =>
 			{
-				return new Entry
+				return new Label
 				{
 					Text = "Header(added)",
 					HeightRequest = 100,
@@ -259,7 +259,7 @@ public class Issue28509TemplatedHeaderFooter : TestContentPage
 			}),
 			FooterTemplate = new DataTemplate(() =>
 			{
-				return new Entry
+				return new Label
 				{
 					Text = "Footer(added)",
 					HeightRequest = 100,
@@ -276,7 +276,7 @@ public class Issue28509TemplatedHeaderFooter : TestContentPage
 	{
 		collectionView.FooterTemplate = new DataTemplate(() =>
 		{
-			return new Entry
+			return new Label
 			{
 				Text = "FooterTemplate Changed",
 				HeightRequest = 100,
@@ -289,7 +289,7 @@ public class Issue28509TemplatedHeaderFooter : TestContentPage
 	{
 		collectionView.HeaderTemplate = new DataTemplate(() =>
 		{
-			return new Entry
+			return new Label
 			{
 				Text = "HeaderTemplate Changed",
 				HeightRequest = 100,
@@ -359,14 +359,14 @@ public class Issue28509ItemsViewHeaderFooter : TestContentPage
 			}),
 
 			Header =
-				new Entry
+				new Label
 				{
 					Text = "Header (added)",
 					HeightRequest = 100,
 					BackgroundColor = Colors.Red
 				},
 
-			Footer = new Entry
+			Footer = new Label
 			{
 				Text = "Footer (added)",
 				HeightRequest = 100,
@@ -382,7 +382,7 @@ public class Issue28509ItemsViewHeaderFooter : TestContentPage
 
 	private void ToggleFooter(object sender, EventArgs e)
 	{
-		collectionView.Footer = new Entry
+		collectionView.Footer = new Label
 		{
 			Text = "Footer Changed",
 			HeightRequest = 100,
@@ -392,7 +392,7 @@ public class Issue28509ItemsViewHeaderFooter : TestContentPage
 
 	private void ToggleHeader(object sender, EventArgs e)
 	{
-		collectionView.Header = new Entry
+		collectionView.Header = new Label
 		{
 			Text = "Header Changed",
 			HeightRequest = 100,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28509.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28509.cs
@@ -1,0 +1,402 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28509, "Dynamically Setting Header and Footer in CV2 Does Not Update Properly", PlatformAffected.iOS)]
+public class Issue28509NavigationPage : TestNavigationPage
+{
+	protected override void Init()
+	{
+		var root = CreateRootContentPage();
+		PushAsync(root);
+	}
+
+	ContentPage CreateRootContentPage()
+	{
+		ContentPage ContentPage = new ContentPage();
+		VerticalStackLayout rootLayout = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = new Thickness(10),
+		};
+
+		Button collectionViewGroupButton = new Button
+		{
+			Text = "CollectionView Group Header/Footer Toggle",
+			AutomationId = "GroupHeaderFooterButton"
+		};
+		collectionViewGroupButton.Clicked += (s, e) => Navigation.PushAsync(new Issue28509GroupHeaderFooter());
+
+		Button collectionViewTemplatedButton = new Button
+		{
+			Text = "CollectionView Templated Header/Footer Toggle",
+			AutomationId = "ItemsViewTemplatedHeaderFooterButton"
+		};
+		collectionViewTemplatedButton.Clicked += (s, e) => Navigation.PushAsync(new Issue28509TemplatedHeaderFooter());
+
+		Button collectionViewItemsViewButton = new Button
+		{
+			Text = "CollectionView ItemsView Header/Footer Toggle",
+			AutomationId = "ItemsViewHeaderFooterButton"
+		};
+		collectionViewItemsViewButton.Clicked += (s, e) => Navigation.PushAsync(new Issue28509ItemsViewHeaderFooter());
+
+		rootLayout.Add(collectionViewGroupButton);
+		rootLayout.Add(collectionViewTemplatedButton);
+		rootLayout.Add(collectionViewItemsViewButton);
+
+		ContentPage.Content = rootLayout;
+		return ContentPage;
+	}
+}
+
+public class Issue28509GroupHeaderFooter : TestContentPage
+{
+	ObservableCollection<Issue28509Group> _source;
+	CollectionView2 _collectionView;
+
+	protected override void Init()
+	{
+		_source = new ObservableCollection<Issue28509Group>();
+		_collectionView = new CollectionView2 { AutomationId = "CollectionView", IsGrouped = true };
+
+		Grid layoutGrid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		Button toggleHeaderButton = new Button
+		{
+			AutomationId = "ToggleHeaderButton",
+			Text = "Toggle Header"
+		};
+		toggleHeaderButton.Clicked += ToggleHeader;
+
+		Button toggleFooterButton = new Button
+		{
+			AutomationId = "ToggleFooterButton",
+			Text = "Toggle Footer"
+		};
+		toggleFooterButton.Clicked += ToggleFooter;
+
+		HorizontalStackLayout buttonsLayout = new HorizontalStackLayout
+		{
+			Padding = 20,
+			HorizontalOptions = LayoutOptions.Center,
+			Spacing = 20,
+			Children = { toggleHeaderButton, toggleFooterButton }
+		};
+
+		layoutGrid.Add(buttonsLayout, 0, 0);
+
+		_collectionView.GroupHeaderTemplate = new DataTemplate(() =>
+		{
+			var label = new Label
+			{
+				BackgroundColor = Colors.HotPink,
+				FontSize = 22
+			};
+			label.SetBinding(Label.TextProperty, "Header");
+			return label;
+		});
+
+		_collectionView.GroupFooterTemplate = new DataTemplate(() =>
+		{
+			var label = new Label
+			{
+				BackgroundColor = Colors.HotPink,
+				FontSize = 22
+			};
+			label.SetBinding(Label.TextProperty, "Footer");
+			return label;
+		});
+
+		_collectionView.ItemTemplate = new DataTemplate(() =>
+		{
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, "Name");
+			return label;
+		});
+
+		_collectionView.ItemsSource = _source;
+
+		layoutGrid.Add(_collectionView, 0, 1);
+		Content = layoutGrid;
+
+		Appearing += (sender, args) => AddItems();
+	}
+
+	void ToggleHeader(object sender, EventArgs e)
+	{
+		_collectionView.GroupHeaderTemplate = new DataTemplate(() =>
+		{
+			return new Label
+			{
+				BackgroundColor = Colors.HotPink,
+				FontSize = 22,
+				Text = "GroupHeaderTemplate Changed"
+			};
+		});
+	}
+
+	void ToggleFooter(object sender, EventArgs e)
+	{
+		_collectionView.GroupFooterTemplate = new DataTemplate(() =>
+		{
+			return new Label
+			{
+				BackgroundColor = Colors.HotPink,
+				FontSize = 22,
+				Text = "GroupFooterTemplate Changed"
+			};
+		});
+	}
+
+	void AddItems()
+	{
+		var groupIndex = _source.Count + 1;
+		if (groupIndex > 2)
+			return;
+
+		var group = new Issue28509Group
+		{
+			Header = $"{groupIndex} Header (added)",
+			Footer = $"{groupIndex} Footer (added)"
+		};
+
+		for (int itemIndex = 0; itemIndex < 3; itemIndex++)
+		{
+			var item = new Issue28509ViewItem { Name = $"{groupIndex}.{itemIndex} Item (added)" };
+			group.Add(item);
+		}
+
+		_source.Add(group);
+	}
+
+	class Issue28509ViewItem
+	{
+		public string Name { get; set; }
+	}
+
+	class Issue28509Group : ObservableCollection<Issue28509ViewItem>
+	{
+		public string Header { get; set; }
+		public string Footer { get; set; }
+	}
+}
+
+public class Issue28509TemplatedHeaderFooter : TestContentPage
+{
+	CollectionView collectionView;
+	ObservableCollection<string> Items { get; set; }
+
+	protected override void Init()
+	{
+		Grid layoutGrid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		Button toggleHeaderButton = new Button
+		{
+			AutomationId = "ToggleHeaderButton",
+			Text = "Toggle Header"
+		};
+		toggleHeaderButton.Clicked += ToggleHeader;
+
+		Button toggleFooterButton = new Button
+		{
+			AutomationId = "ToggleFooterButton",
+			Text = "Toggle Footer"
+		};
+		toggleFooterButton.Clicked += ToggleFooter;
+
+		HorizontalStackLayout buttonsLayout = new HorizontalStackLayout
+		{
+			Padding = 20,
+			HorizontalOptions = LayoutOptions.Center,
+			Spacing = 20,
+			Children = { toggleHeaderButton, toggleFooterButton }
+		};
+
+		layoutGrid.Add(buttonsLayout, 0, 0);
+		Items = new ObservableCollection<string>
+		{
+			"Test 1", "Test 2", "Test 3", "Test 4", "Test 5",
+			"Test 6", "Test 7", "Test 8", "Test 9", "Test 10",
+		};
+
+		collectionView = new CollectionView
+		{
+			AutomationId = "CollectionView",
+			ItemsSource = Items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				Label label = new Label
+				{
+					TextColor = Colors.Black,
+				};
+
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			}),
+			HeaderTemplate = new DataTemplate(() =>
+			{
+				return new Entry
+				{
+					Text = "Header(added)",
+					HeightRequest = 100,
+					BackgroundColor = Colors.Red
+				};
+			}),
+			FooterTemplate = new DataTemplate(() =>
+			{
+				return new Entry
+				{
+					Text = "Footer(added)",
+					HeightRequest = 100,
+					BackgroundColor = Colors.Green
+				};
+			})
+		};
+
+		layoutGrid.Add(collectionView, 0, 1);
+		Content = layoutGrid;
+	}
+
+	private void ToggleFooter(object sender, EventArgs e)
+	{
+		collectionView.FooterTemplate = new DataTemplate(() =>
+		{
+			return new Entry
+			{
+				Text = "FooterTemplate Changed",
+				HeightRequest = 100,
+				BackgroundColor = Colors.Green
+			};
+		});
+	}
+
+	private void ToggleHeader(object sender, EventArgs e)
+	{
+		collectionView.HeaderTemplate = new DataTemplate(() =>
+		{
+			return new Entry
+			{
+				Text = "HeaderTemplate Changed",
+				HeightRequest = 100,
+				BackgroundColor = Colors.Red
+			};
+		});
+	}
+}
+
+public class Issue28509ItemsViewHeaderFooter : TestContentPage
+{
+	CollectionView collectionView;
+	ObservableCollection<string> Items { get; set; }
+
+	protected override void Init()
+	{
+		Grid layoutGrid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		Button toggleHeaderButton = new Button
+		{
+			AutomationId = "ToggleHeaderButton",
+			Text = "Toggle Header"
+		};
+		toggleHeaderButton.Clicked += ToggleHeader;
+
+		Button toggleFooterButton = new Button
+		{
+			AutomationId = "ToggleFooterButton",
+			Text = "Toggle Footer"
+		};
+		toggleFooterButton.Clicked += ToggleFooter;
+
+		HorizontalStackLayout buttonsLayout = new HorizontalStackLayout
+		{
+			Padding = 20,
+			HorizontalOptions = LayoutOptions.Center,
+			Spacing = 20,
+			Children = { toggleHeaderButton, toggleFooterButton }
+		};
+
+		Items = new ObservableCollection<string>
+		{
+			"Test 1", "Test 2", "Test 3", "Test 4", "Test 5",
+			"Test 6", "Test 7", "Test 8", "Test 9", "Test 10",
+		};
+
+		collectionView = new CollectionView
+		{
+			AutomationId = "CollectionView",
+			ItemsSource = Items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				Label label = new Label
+				{
+					TextColor = Colors.Black,
+				};
+
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			}),
+
+			Header =
+				new Entry
+				{
+					Text = "Header (added)",
+					HeightRequest = 100,
+					BackgroundColor = Colors.Red
+				},
+
+			Footer = new Entry
+			{
+				Text = "Footer (added)",
+				HeightRequest = 100,
+				BackgroundColor = Colors.Red
+			},
+
+		};
+
+		layoutGrid.Add(buttonsLayout, 0, 0);
+		layoutGrid.Add(collectionView, 0, 1);
+		Content = layoutGrid;
+	}
+
+	private void ToggleFooter(object sender, EventArgs e)
+	{
+		collectionView.Footer = new Entry
+		{
+			Text = "Footer Changed",
+			HeightRequest = 100,
+			BackgroundColor = Colors.Red
+		};
+	}
+
+	private void ToggleHeader(object sender, EventArgs e)
+	{
+		collectionView.Header = new Entry
+		{
+			Text = "Header Changed",
+			HeightRequest = 100,
+			BackgroundColor = Colors.Red
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28509.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28509.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28509 : _IssuesUITest
+{
+	public override string Issue => "Dynamically Setting Header and Footer in CV2 Does Not Update Properly";
+
+	public Issue28509(TestDevice device) : base(device)
+	{
+	}
+
+	[Test, Order(1)]
+	[Category(UITestCategories.CollectionView)]
+	public void UpdateGroupHeaderAndFooterDynamically()
+	{
+		App.WaitForElement("GroupHeaderFooterButton");
+		App.Click("GroupHeaderFooterButton");
+		App.WaitForElement("CollectionView");
+		App.Click("ToggleHeaderButton");
+		App.WaitForElement("GroupHeaderTemplate Changed");
+		App.Click("ToggleFooterButton");
+		App.WaitForElement("GroupFooterTemplate Changed");
+		App.TapBackArrow();
+	}
+
+	[Test, Order(2)]
+	[Category(UITestCategories.CollectionView)]
+	public void UpdateHeaderFooterTemplateDynamically()
+	{
+		App.WaitForElement("ItemsViewTemplatedHeaderFooterButton");
+		App.Click("ItemsViewTemplatedHeaderFooterButton");
+		App.WaitForElement("CollectionView");
+		App.Click("ToggleHeaderButton");
+		App.WaitForElement("HeaderTemplate Changed");
+		App.Click("ToggleFooterButton");
+		App.WaitForElement("FooterTemplate Changed");
+		App.TapBackArrow();
+	}
+
+	[Test, Order(3)]
+	[Category(UITestCategories.CollectionView)]
+	public void UpdateHeaderFooterDynamically()
+	{
+		App.WaitForElement("ItemsViewHeaderFooterButton");
+		App.Click("ItemsViewHeaderFooterButton");
+		App.WaitForElement("CollectionView");
+		App.Click("ToggleHeaderButton");
+		App.WaitForElement("Header Changed");
+		App.Click("ToggleFooterButton");
+		App.WaitForElement("Footer Changed");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28509.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28509.cs
@@ -1,3 +1,5 @@
+#if TEST_FAILS_ON_ANDROID
+// https://github.com/dotnet/maui/issues/28676
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -53,3 +55,4 @@ public class Issue28509 : _IssuesUITest
 		App.WaitForElement("Footer Changed");
 	}
 }
+#endif


### PR DESCRIPTION
### Issue Details:
 
- When the Group Header/Footer Template is not initially set and is later assigned at runtime, the CollectionView does not properly update to reflect the new Group Header/Footer content.

- When the Header or Footer of a CollectionView is initially set and later updated dynamically with a new DataTemplate or object, the UI does not correctly reflect the updated value.
 
### Root Cause:

The PlatformHandler retains the handler for the initial Header/Footer view even after it is dynamically replaced. As a result:
- The old view remains in the UI hierarchy.
- The new view is not properly added to the ItemsView.

### Description of Change

- Mapped GroupHeaderTemplate and GroupFooterTemplate in the handler to trigger a layout update, ensuring the CollectionView dynamically reflects template changes.

- This update enhances the handling of dynamic CollectionView header and footer updates by ensuring proper cleanup of previous view references. When the header or footer content is changed, the previous handler is nullified, the old view is removed from the UI hierarchy, and binding contexts are cleared. These improvements ensure that the new content is rendered correctly without retaining outdated references.

**Tested the behaviour in the following platforms**

- [ ] Android
- [x]  Windows
- [x]  iOS
- [x] Mac

### Issues Fixed

Fixes #28509 
Fixes #28504 

### Output

| Before| After|
|--|--|
| <video src="https://github.com/user-attachments/assets/08e5bcfd-2167-4ac5-80be-4b341e999fa8"> | <video src="https://github.com/user-attachments/assets/f87e68a4-f172-4649-82ee-97b3a03ef534"> |