### PR TITLE
Provisioning: Only install specific Android API levels if requested

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "androidsdk.tool": {
-      "version": "0.19.0",
+      "version": "0.21.0",
       "commands": [
         "android"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "androidsdk.tool": {
-      "version": "0.22.0",
+      "version": "0.23.0",
       "commands": [
         "android"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "androidsdk.tool": {
-      "version": "0.21.0",
+      "version": "0.22.0",
       "commands": [
         "android"
       ],

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -164,27 +164,28 @@ steps:
 
   # Provisioning Android - Android SDK platform APIs (eg: platforms;android-29, platforms;android-30)
   - ${{ if ne(parameters.skipAndroidPlatformApis, 'true') }}:
-    - pwsh: dotnet build -t:ProvisionAndroidSdkPlatformApiPackages -p:AndroidSdkProvisionDefaultApiLevelsOnly="$Env:AndroidSdkProvisionDefaultApiLevelsOnly" -bl:"$(LogDirectory)/provision-androidsdk-platform-apis.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+    - pwsh: dotnet build -t:ProvisionAndroidSdkPlatformApiPackages -p:AndroidSdkRequestedApiLevels="$Env:AndroidSdkRequestedApiLevels" -p:AndroidSdkProvisionDefaultApiLevelsOnly="$Env:AndroidSdkProvisionDefaultApiLevelsOnly" -bl:"$(LogDirectory)/provision-androidsdk-platform-apis.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
       displayName: 'Provision Android SDK - Platform APIs'
       condition: succeeded()
       env:
         AndroidSdkProvisionDefaultApiLevelsOnly: ${{ parameters.onlyAndroidPlatformDefaultApis }}
+        AndroidSdkRequestedApiLevels: ${{ parameters.androidEmulatorApiLevel }}
 
   # Provisioning Android - Emulator images (eg: system-images;android-34;google_apis;aarch64)
   - ${{ if ne(parameters.skipAndroidEmulatorImages, 'true') }}:
-    - pwsh: dotnet build -t:ProvisionAndroidSdkEmulatorImagePackages -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-emulator-images.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+    - pwsh: dotnet build -t:ProvisionAndroidSdkEmulatorImagePackages -p:AndroidSdkRequestedApiLevels="$Env:AndroidSdkRequestedApiLevels" -bl:"$(LogDirectory)/provision-androidsdk-emulator-images.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
       displayName: 'Provision Android SDK - Emulator Images'
       condition: succeeded()
       env:
-        AndroidSdkProvisionApiLevel: ${{ parameters.androidEmulatorApiLevel }}
+        AndroidSdkRequestedApiLevels: ${{ parameters.androidEmulatorApiLevel }}
 
   # Provisioning Android - Android AVDs (actual emulator virtual devices)
   - ${{ if ne(parameters.skipAndroidCreateAvds, 'true') }}:
-    - pwsh: dotnet build -t:ProvisionAndroidSdkAvdCreateAvds -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-create-avds.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+    - pwsh: dotnet build -t:ProvisionAndroidSdkAvdCreateAvds -p:AndroidSdkRequestedApiLevels="$Env:AndroidSdkRequestedApiLevels" -bl:"$(LogDirectory)/provision-androidsdk-create-avds.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
       displayName: 'Provision Android SDK - Create AVDs'
       condition: succeeded()
       env:
-        AndroidSdkProvisionApiLevel: ${{ parameters.androidEmulatorApiLevel }}
+        AndroidSdkRequestedApiLevels: ${{ parameters.androidEmulatorApiLevel }}
 
 
   ##################################################

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -98,7 +98,7 @@ steps:
 
   - pwsh: |
       $skipAppiumDoctor = if ($IsMacOS) { "true" } else { "false" }
-      dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -bl:"$(LogDirectory)/provision-appium.binlog"
+      dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -p:AndroidSdkRequestedApiLevels="${{ parameters.version }}" -bl:"$(LogDirectory)/provision-appium.binlog"
     displayName: "Install Appium"
     continueOnError: false
     retryCountOnTaskFailure: 1

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -144,8 +144,13 @@
 
 	<Target Name="ProvisionAppiumDrivers" DependsOnTargets="InstallAppium">
 
+		<PropertyGroup>
+			<AppiumCommand>appium</AppiumCommand>
+			<AppiumCommand Condition=" '$(AppiumNpmInstallLocation)' != 'global' ">node ./node_modules/.bin/appium</AppiumCommand>
+		</PropertyGroup>
+
 		<!-- Get a json output list of the installed appium drivers with their version info -->
-		<Exec Command="node appium driver list --installed --json" ConsoleToMSBuild="True" IgnoreExitCode="True">
+		<Exec Command="$(AppiumCommand) driver list --installed --json" ConsoleToMSBuild="True" IgnoreExitCode="True">
 			<Output TaskParameter="ConsoleOutput" ItemName="_AppiumDriverListInstalledJsonLines" />
 		</Exec>
 
@@ -167,16 +172,16 @@
 
 
 		<!-- Update any drivers needing an update (if any) -->
-		<Exec Command="node appium driver update %(AppiumDriversToUpdate.Identity)" Condition=" '@(AppiumDriversToUpdate)' != '' " />
+		<Exec Command="$(AppiumCommand) driver update %(AppiumDriversToUpdate.Identity)" Condition=" '@(AppiumDriversToUpdate)' != '' " />
 
 		<!-- Install any drivers not yet installed (if any) -->
-		<Exec Command="node appium driver install %(AppiumDriversToInstall.Identity)@%(AppiumDriversToInstall.Version)" Condition=" '@(AppiumDriversToInstall)' != '' " />
+		<Exec Command="$(AppiumCommand) driver install %(AppiumDriversToInstall.Identity)@%(AppiumDriversToInstall.Version)" Condition=" '@(AppiumDriversToInstall)' != '' " />
 
 		<!-- Run doctor command just so we have some output -->
-		<Exec Command="node appium driver doctor %(AppiumDrivers.Identity)" ContinueOnError="true" Condition=" '$(SkipAppiumDoctor)' != 'True' " />
+		<Exec Command="$(AppiumCommand) driver doctor %(AppiumDrivers.Identity)" ContinueOnError="true" Condition=" '$(SkipAppiumDoctor)' != 'True' " />
 
 		<!-- Run driver list again for our records -->
-		<Exec Command="node appium driver list --installed" ContinueOnError="true" />
+		<Exec Command="$(AppiumCommand) driver list --installed" ContinueOnError="true" />
 	</Target>
 
 	<Target Name="InstallAppium">

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -97,7 +97,7 @@
 
 		<!-- Install SDK Packages -->
 		<Exec Command="dotnet android sdk install --package &quot;%(AndroidSdkEmulatorImagePackages.Identity)&quot;" 
-		 	  Condition="'$(AndroidSdkProvisionApiLevel)' == '' or '%(AndroidSdkEmulatorImagePackages.ApiLevel)' == '$(AndroidSdkProvisionApiLevel)'" />
+		 	  Condition=" '@(AndroidSdkEmulatorImagePackages)' != '' " />
 
 		<Exec Command="dotnet android sdk list --installed" ConsoleToMSBuild="True" IgnoreExitCode="True" />
 	</Target>
@@ -112,7 +112,7 @@
 
 		<!-- Create all the AVD's we need based on the api levels specified -->
 		<Exec Command="dotnet android avd create --name &quot;Emulator_%(AndroidSdkAvdPackages.ApiLevel)&quot; --sdk &quot;%(AndroidSdkAvdPackages.Identity)&quot; --device &quot;%(AndroidSdkAvdPackages.DeviceType)&quot; --force" 
-			  Condition="'$(AndroidSdkProvisionApiLevel)' == '' or '%(AndroidSdkAvdPackages.ApiLevel)' == '$(AndroidSdkProvisionApiLevel)'" />
+			  Condition=" '@(AndroidSdkAvdPackages)' != '' " />
 
 		<Exec Command="dotnet android avd list" ConsoleToMSBuild="True" IgnoreExitCode="True" />
 	</Target>

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -117,6 +117,20 @@
 		<Exec Command="dotnet android avd list" ConsoleToMSBuild="True" IgnoreExitCode="True" />
 	</Target>
 
+	<Target Name="InstallAndroidSdk">
+		<Message Text="Installing Android SDK" />
+
+		<PropertyGroup>
+			<AndroidSdkVersion Condition=" '$(AndroidSdkVersion)' == '' ">$(AndroidSdkCmdLineToolsVersion)</AndroidSdkVersion>
+			<AndroidSdkVersion Condition=" '$(AndroidSdkVersion)' == '' ">13.0</AndroidSdkVersion>
+		</PropertyGroup>
+
+		<!-- Download SDK Common Packages -->
+		<Exec Command="sdk download --home=&quot;$(AndroidSdkHome)&quot; --version=&quot;$(AndroidSdkVersion)&quot;" ConsoleToMSBuild="True" />
+
+		<Exec Command="sdk dotnet-prefer --home=&quot;$(AndroidSdkHome)&quot; list --installed" ConsoleToMSBuild="True" IgnoreExitCode="True" />
+	</Target>
+
 	<Target Name="ProvisionAndroidSdk" DependsOnTargets="ProvisionAndroidSdkCommonPackages;ProvisionAndroidSdkPlatformApiPackages;ProvisionAndroidSdkEmulatorImagePackages;ProvisionAndroidSdkAvdCreateAvds">
 		<Error
 			Condition=" '$(MSBuildRuntimeType)' != 'Core' "

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -42,6 +42,18 @@
 		<AndroidSdkPackages Include="emulator" />
 	</ItemGroup>
 
+	<!-- If an explicit list of API levels was requested, only include those -->
+	<ItemGroup Condition=" '$(AndroidSdkRequestedApiLevels)' != '' ">
+		<!-- Create a temporary item with each API level from the semicolon-delimited list -->
+		<_RequestedAndroidSdkApiLevels Include="$(AndroidSdkRequestedApiLevels.Split(';'))" />
+
+		<!-- Get the list of API levels to remove by copying the full list but excluding the ones to keep -->
+		<_AndroidSdkApiLevelsToRemove Include="@(AndroidSdkApiLevels)" Exclude="@(_RequestedAndroidSdkApiLevels)" />
+		
+		<!-- Now Remove AndroidSdkApiLevels that aren't the ones requested -->
+		<AndroidSdkApiLevels Remove="@(_AndroidSdkApiLevelsToRemove)" />
+	</ItemGroup>
+	
 	<Target Name="ProvisionAndroidSdkCommonPackages">
 		<Message Text="Provisioning Android SDK Common Packages" />
 

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -128,7 +128,7 @@
 		<!-- Download SDK Common Packages -->
 		<Exec Command="dotnet android sdk download --home=&quot;$(AndroidSdkHome)&quot; --version=&quot;$(AndroidSdkVersion)&quot;" ConsoleToMSBuild="True" />
 
-		<Exec Command="dotnet android sdk dotnet-prefer --home=&quot;$(AndroidSdkHome)&quot; list --installed" ConsoleToMSBuild="True" IgnoreExitCode="True" />
+		<Exec Command="dotnet android sdk dotnet-prefer --home=&quot;$(AndroidSdkHome)&quot;" ConsoleToMSBuild="True" IgnoreExitCode="True" />
 	</Target>
 
 	<Target Name="ProvisionAndroidSdk" DependsOnTargets="ProvisionAndroidSdkCommonPackages;ProvisionAndroidSdkPlatformApiPackages;ProvisionAndroidSdkEmulatorImagePackages;ProvisionAndroidSdkAvdCreateAvds">

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -131,7 +131,7 @@
 	<Target Name="ProvisionAppiumDrivers" DependsOnTargets="InstallAppium">
 
 		<!-- Get a json output list of the installed appium drivers with their version info -->
-		<Exec Command="appium driver list --installed --json" ConsoleToMSBuild="True" IgnoreExitCode="True">
+		<Exec Command="node appium driver list --installed --json" ConsoleToMSBuild="True" IgnoreExitCode="True">
 			<Output TaskParameter="ConsoleOutput" ItemName="_AppiumDriverListInstalledJsonLines" />
 		</Exec>
 
@@ -153,22 +153,27 @@
 
 
 		<!-- Update any drivers needing an update (if any) -->
-		<Exec Command="appium driver update %(AppiumDriversToUpdate.Identity)" Condition=" '@(AppiumDriversToUpdate)' != '' " />
+		<Exec Command="node appium driver update %(AppiumDriversToUpdate.Identity)" Condition=" '@(AppiumDriversToUpdate)' != '' " />
 
 		<!-- Install any drivers not yet installed (if any) -->
-		<Exec Command="appium driver install %(AppiumDriversToInstall.Identity)@%(AppiumDriversToInstall.Version)" Condition=" '@(AppiumDriversToInstall)' != '' " />
+		<Exec Command="node appium driver install %(AppiumDriversToInstall.Identity)@%(AppiumDriversToInstall.Version)" Condition=" '@(AppiumDriversToInstall)' != '' " />
 
 		<!-- Run doctor command just so we have some output -->
-		<Exec Command="appium driver doctor %(AppiumDrivers.Identity)" ContinueOnError="true" Condition=" '$(SkipAppiumDoctor)' != 'True' " />
+		<Exec Command="node appium driver doctor %(AppiumDrivers.Identity)" ContinueOnError="true" Condition=" '$(SkipAppiumDoctor)' != 'True' " />
 
 		<!-- Run driver list again for our records -->
-		<Exec Command="appium driver list --installed" ContinueOnError="true" />
+		<Exec Command="node appium driver list --installed" ContinueOnError="true" />
 	</Target>
 
 	<Target Name="InstallAppium">
+
+		<PropertyGroup>
+			<AppiumNpmInstallLocation Condition=" '$(AppiumNpmInstallLocation)' == '' ">global</AppiumNpmInstallLocation>
+		</PropertyGroup>
+
 		<!-- Get the NPM package version for appium if installed -->
 		<!-- this uses loglevel error to prevent extra noise in the console output that isn't json -->
-		<Exec Command="npm list -g appium --json --depth 1 --loglevel error" ConsoleToMSBuild="True" IgnoreExitCode="True">
+		<Exec Command="npm list --location=$(AppiumNpmInstallLocation) appium --json --depth 1 --loglevel error" ConsoleToMSBuild="True" IgnoreExitCode="True">
 			<Output TaskParameter="ConsoleOutput" ItemName="_AppiumNpmListOutputLines" />
 		</Exec>
 
@@ -183,7 +188,7 @@
 		</JsonPeek>
 
 		<!-- Install appium at the specified version if necessary -->
-		<Exec Command="npm i --location=global appium@$(AppiumVersion)" Condition=" '$(_AppiumNpmListVersion)' != '$(AppiumVersion)' " />
+		<Exec Command="npm i --location=$(AppiumNpmInstallLocation) appium@$(AppiumVersion)" Condition=" '$(_AppiumNpmListVersion)' != '$(AppiumVersion)' " />
 	</Target>
 
 	<Target Name="ProvisionAppium" DependsOnTargets="InstallAppium;ProvisionAppiumDrivers">

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -22,7 +22,7 @@
 		<AppiumDrivers Include="xcuitest" Version="$(AppiumXCUITestDriverVersion)" Condition=" '$(IsMacOS)' == 'True' AND '$(AppiumXCUITestDriverVersion)' != '' " />
 	</ItemGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition=" '$(AndroidSdkHostAbi)' == '' ">
 		<!-- Get the right ABI string for android avd's based on host os this is running on -->
 		<AndroidSdkHostAbi Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">x86_64</AndroidSdkHostAbi>
 		<AndroidSdkHostAbi Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'X64' ">arm64-v8a</AndroidSdkHostAbi>

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -146,7 +146,8 @@
 
 		<PropertyGroup>
 			<AppiumCommand>appium</AppiumCommand>
-			<AppiumCommand Condition=" '$(AppiumNpmInstallLocation)' != 'global' ">node ./node_modules/.bin/appium</AppiumCommand>
+			<AppiumCommand Condition=" '$(AppiumNpmInstallLocation)' != 'global' ">./node_modules/.bin/appium</AppiumCommand>
+			<AppiumCommand Condition="$(IsWindows)">$(AppiumCommand).exe</AppiumCommand>
 		</PropertyGroup>
 
 		<!-- Get a json output list of the installed appium drivers with their version info -->

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -126,9 +126,9 @@
 		</PropertyGroup>
 
 		<!-- Download SDK Common Packages -->
-		<Exec Command="sdk download --home=&quot;$(AndroidSdkHome)&quot; --version=&quot;$(AndroidSdkVersion)&quot;" ConsoleToMSBuild="True" />
+		<Exec Command="dotnet android sdk download --home=&quot;$(AndroidSdkHome)&quot; --version=&quot;$(AndroidSdkVersion)&quot;" ConsoleToMSBuild="True" />
 
-		<Exec Command="sdk dotnet-prefer --home=&quot;$(AndroidSdkHome)&quot; list --installed" ConsoleToMSBuild="True" IgnoreExitCode="True" />
+		<Exec Command="dotnet android sdk dotnet-prefer --home=&quot;$(AndroidSdkHome)&quot; list --installed" ConsoleToMSBuild="True" IgnoreExitCode="True" />
 	</Target>
 
 	<Target Name="ProvisionAndroidSdk" DependsOnTargets="ProvisionAndroidSdkCommonPackages;ProvisionAndroidSdkPlatformApiPackages;ProvisionAndroidSdkEmulatorImagePackages;ProvisionAndroidSdkAvdCreateAvds">


### PR DESCRIPTION
You can now set `AndroidSdkRequestedApiLevels` now to a semi-colon delimited list of api level numbers to only install the specifically requested api levels for android sdk provisioning.

WIP: Still needs to use this property when we invoke the provisioning for tests so we aren't installing way more than we need for each matrix.