### PR TITLE
[iOS] Fixed NavigationStack not updating when OnAppearing is invoked

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
@@ -59,10 +59,13 @@ namespace Microsoft.Maui.Controls
 			if (!removed && !fast)
 				return CurrentPage;
 
+			bool isLastPage = InternalChildren.Last() == page;
 			RemoveFromInnerChildren(page);
 
-			if (InternalChildren.Last() == page)
+			if (isLastPage)
+			{
 				FireAppearing((Page)InternalChildren[NavigationPageController.StackDepth - 2]);
+			}
 
 			CurrentPage = (Page)InternalChildren.Last();
 

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls
 			bool isLastPage = InternalChildren.Last() == page;
 			RemoveFromInnerChildren(page);
 
-			if (isLastPage)
+			if (isLastPage && NavigationPageController.StackDepth >= 2)
 			{
 				FireAppearing((Page)InternalChildren[NavigationPageController.StackDepth - 2]);
 			}

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
@@ -43,9 +43,6 @@ namespace Microsoft.Maui.Controls
 
 			FireDisappearing(page);
 
-			if (InternalChildren.Last() == page)
-				FireAppearing((Page)InternalChildren[NavigationPageController.StackDepth - 2]);
-
 			var args = new NavigationRequestedEventArgs(page, animated);
 
 			var removed = true;
@@ -63,6 +60,9 @@ namespace Microsoft.Maui.Controls
 				return CurrentPage;
 
 			RemoveFromInnerChildren(page);
+
+			if (InternalChildren.Last() == page)
+				FireAppearing((Page)InternalChildren[NavigationPageController.StackDepth - 2]);
 
 			CurrentPage = (Page)InternalChildren.Last();
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28414.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28414.cs
@@ -1,0 +1,111 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28414, "NavigationStack updated when OnAppearing triggered", PlatformAffected.iOS)]
+
+public class Issue28414 : NavigationPage
+{
+	public Issue28414() : base(new Issue28414FirstPage())
+	{
+
+	}
+}
+
+public class Issue28414FirstPage : ContentPage
+{
+	public Issue28414FirstPage()
+	{
+		Title = "FirstPage";
+
+		var navigateButton = new Button
+		{
+			Text = "Go to second page",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "FirstPageButton"
+		};
+
+		navigateButton.Clicked += async (sender, args) =>
+		{
+			await Navigation.PushAsync(new Issue28414SecondPage());
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Children = { navigateButton }
+		};
+	}
+}
+
+public class Issue28414SecondPage : ContentPage
+{
+	private Label label;
+
+	public Issue28414SecondPage()
+	{
+		Title = "SecondPage";
+
+		label = new Label
+		{
+			Text = "Initial state",
+			AutomationId = "OnAppearingLabel"
+		};
+
+		var navigateButton = new Button
+		{
+			Text = "Go to third page",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "SecondPageButton"
+		};
+
+		navigateButton.Clicked += async (sender, args) =>
+		{
+			label.Text = string.Empty;
+			await Navigation.PushAsync(new Issue28414ThirdPage());
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Children = { label, navigateButton }
+		};
+	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		if (Navigation.NavigationStack.Count == 2)
+		{
+			label.Text = $"Stack has {Navigation.NavigationStack.Count} pages";
+		}
+		else
+		{
+			label.Text = "Page not popped yet";
+		}
+	}
+}
+
+public class Issue28414ThirdPage : ContentPage
+{
+	public Issue28414ThirdPage()
+	{
+		Title = "ThirdPage";
+
+		var button = new Button
+		{
+			Text = "Go Back",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			AutomationId = "ThirdPageButton"
+		};
+
+		button.Clicked += async (sender, args) =>
+		{
+			await Navigation.PopAsync();
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Children = { button }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28414.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28414.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28414 : _IssuesUITest
+{
+	public Issue28414(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "NavigationStack updated when OnAppearing triggered";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void NavigationStackUpdatesOnPop()
+	{
+		App.WaitForElement("FirstPageButton");
+		App.Tap("FirstPageButton");
+		App.WaitForElement("SecondPageButton");
+		App.Tap("SecondPageButton");
+		App.WaitForElement("ThirdPageButton");
+		App.Tap("ThirdPageButton");
+		var label = App.WaitForElement("OnAppearingLabel");
+		Assert.That(label.GetText(), Is.EqualTo("Stack has 2 pages"));
+	}
+}


### PR DESCRIPTION
### Issue Detail
The NavigationStack was not updated when OnAppearing was invoked.

### Root Cause
The OnAppearing event was triggered before the popped page was removed from the stack in the RemoveAsyncInner method. This method is triggered on iOS when popping pages.

### Description of Change
Triggering the OnAppearing event after updating the stack resolves the issue.

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28414

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/c78943b3-1d7e-4a16-aab3-0134cfc4e8cf"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/3257f900-f90f-4d65-8072-906cc50947cd">) |
