### PR TITLE
Fix to wrong CancellationToken on IStreamImageSource.GetStreamAsync

### DIFF
--- a/src/Controls/src/Core/StreamImageSource.cs
+++ b/src/Controls/src/Core/StreamImageSource.cs
@@ -36,19 +36,19 @@ namespace Microsoft.Maui.Controls
 				return null;
 
 			await OnLoadingStarted();
-			userToken.Register(CancellationTokenSource.Cancel);
+			
 			Stream stream = null;
 			try
 			{
-				stream = await Stream(CancellationTokenSource.Token);
+				stream = await Stream(userToken);
 				await OnLoadingCompleted(false);
+				return stream;
 			}
 			catch (OperationCanceledException)
 			{
 				await OnLoadingCompleted(true);
 				throw;
 			}
-			return stream;
 		}
 	}
 }


### PR DESCRIPTION
Fix the issue https://github.com/dotnet/maui/issues/28684

Uncoordinated image loading and UI lifecycle events, compounded by inadequate `TaskCanceledException` handling in `FireAndForget`.

![image](https://github.com/user-attachments/assets/47a1c6a7-7eae-416f-a6d6-1d4441e4002f)

![image](https://github.com/user-attachments/assets/aacc4265-ff8f-4c97-b7a9-1f9600a73831)
