### PR TITLE
Fixed iOS cell resizing issue #23319

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var tv = VirtualView.TableView;
 			VirtualView.ReusableCell = null;
 			VirtualView.TableView = null;
+			_tableView = new(tv);
 			return GetCell(VirtualView, reusableCell, tv);
 		}
 
 		public virtual UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
-			_tableView = new(tv);
 			Performance.Start(out string reference);
 
 			var tvc = reusableCell as CellTableViewCell ?? new CellTableViewCell(UITableViewCellStyle.Default, item.GetType().FullName);


### PR DESCRIPTION
CellRenderer.GetCell may not be called when GetCell is overridden in a derived class and _tableView stays null, instead initializing _tableView in CreatePlatformElement

### Description of Change

Fixed iOS cell resizing issue #23319

### Issues Fixed

Fixes #23319
