### PR TITLE
[xamlc] convert `{OnIdiom}` to `OnIdiomExtension<T>`

### DIFF
--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using Microsoft.Maui.Controls.Xaml;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using static Mono.Cecil.Cil.Instruction;
 using static Mono.Cecil.Cil.OpCodes;
 
@@ -92,6 +93,39 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				Context.IL.Append(PushValueFromLanguagePrimitive(typedef, node));
 				Context.IL.Emit(Stloc, vardef);
 				return;
+			}
+
+			// Convert OnIdiomExtension to OnIdiomExtension<T>
+			if (typeref.FullName == "Microsoft.Maui.Controls.Xaml.OnIdiomExtension")
+			{
+				// Find the property being set with {OnIdiom}
+				XmlName propertyName = XmlName.Empty;
+				SetPropertiesVisitor.TryGetPropertyName(node, node.Parent, out propertyName);
+				var localName = propertyName.LocalName;
+				var parentType = Module.ImportReference((node.Parent as IElementNode).XmlType.GetTypeReference(Context.Cache, Module, node));
+				var bpRef = SetPropertiesVisitor.GetBindablePropertyReference(parentType, propertyName.NamespaceURI, ref localName, out _, Context, node);
+
+				// Lookup the target type for OnIdiomExtension<T>
+				TypeReference targetType = null;
+				if (bpRef is not null)
+				{
+					targetType = Module.ImportReference(bpRef.GetBindablePropertyType(Context.Cache, node, Module));
+				}
+				else
+				{
+					var propertyRef = parentType.GetProperty(Context.Cache, pd => pd.Name == localName, out var declaringTypeReference);
+					if (propertyRef != null)
+					{
+						targetType = Module.ImportReference(propertyRef.PropertyType.ResolveGenericParameters(declaringTypeReference));
+					}
+				}
+
+				// Change typeref to OnIdiomExtension<T>
+				if (targetType is not null)
+				{
+					var onIdiomExtensionType = Module.ImportReference(Context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "OnIdiomExtension`1"));
+					typeref = onIdiomExtensionType.MakeGenericInstanceType(targetType);
+				}
 			}
 
 			//if this is a MarkupExtension that can be compiled directly, compile and returns the value

--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				// Change typeref to OnIdiomExtension<T>
 				if (targetType is not null)
 				{
-					var onIdiomExtensionType = Module.ImportReference(Context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml", "OnIdiomExtension`1"));
+					var onIdiomExtensionType = Module.ImportReference(Context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Xaml.Internals", "OnIdiomExtension`1"));
 					typeref = onIdiomExtensionType.MakeGenericInstanceType(targetType);
 				}
 			}

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
@@ -121,8 +122,12 @@ namespace Microsoft.Maui.Controls.Xaml
 			return Default;
 		}
 	}
+}
 
-	// NOTE: currently internal, to be used by XamlC compiler
+// NOTE: currently in *.Internals, to be used by XamlC compiler
+namespace Microsoft.Maui.Controls.Xaml.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	[ContentProperty(nameof(Default))]
 	[RequireService(
 		[typeof(IProvideValueTarget),

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -121,4 +121,115 @@ namespace Microsoft.Maui.Controls.Xaml
 			return Default;
 		}
 	}
+
+	// NOTE: currently internal, to be used by XamlC compiler
+	[ContentProperty(nameof(Default))]
+	[RequireService(
+		[typeof(IProvideValueTarget),
+		 typeof(IValueConverterProvider),
+		 typeof(IXmlLineInfoProvider),
+		 typeof(IConverterOptions)])]
+	internal class OnIdiomExtension<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : IMarkupExtension
+	{
+		// See Device.Idiom
+
+		public object Default { get; set; }
+		public object Phone { get; set; }
+		public object Tablet { get; set; }
+		public object Desktop { get; set; }
+		public object TV { get; set; }
+		public object Watch { get; set; }
+
+		public IValueConverter Converter { get; set; }
+
+		public object ConverterParameter { get; set; }
+
+		public object ProvideValue(IServiceProvider serviceProvider)
+		{
+			if (Default == null
+				&& Phone == null
+				&& Tablet == null
+				&& Desktop == null
+				&& TV == null
+				&& Watch == null)
+				throw new XamlParseException("OnIdiomExtension requires a non-null value to be specified for at least one idiom or Default.", serviceProvider);
+
+			var valueProvider = serviceProvider?.GetService<IProvideValueTarget>() ?? throw new ArgumentException();
+
+			BindableProperty bp;
+			PropertyInfo pi = null;
+			Type propertyType = typeof(T);
+
+			if (valueProvider.TargetObject is Setter setter)
+			{
+				bp = setter.Property;
+			}
+			else
+			{
+				bp = valueProvider.TargetProperty as BindableProperty;
+				pi = valueProvider.TargetProperty as PropertyInfo;
+			}
+
+			var value = GetValue();
+			if (value == null && propertyType.IsValueType)
+				return Activator.CreateInstance<T>();
+
+			if (Converter != null)
+				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+
+			var converterProvider = serviceProvider?.GetService<IValueConverterProvider>();
+			if (converterProvider != null)
+			{
+				MemberInfo minforetriever()
+				{
+					if (pi != null)
+						return pi;
+
+					MemberInfo minfo = null;
+					try
+					{
+						minfo = bp.DeclaringType.GetRuntimeProperty(bp.PropertyName);
+					}
+					catch (AmbiguousMatchException e)
+					{
+						throw new XamlParseException($"Multiple properties with name '{bp.DeclaringType}.{bp.PropertyName}' found.", serviceProvider, innerException: e);
+					}
+					if (minfo != null)
+						return minfo;
+					try
+					{
+						return bp.DeclaringType.GetRuntimeMethod("Get" + bp.PropertyName, new[] { typeof(BindableObject) });
+					}
+					catch (AmbiguousMatchException e)
+					{
+						throw new XamlParseException($"Multiple methods with name '{bp.DeclaringType}.Get{bp.PropertyName}' found.", serviceProvider, innerException: e);
+					}
+				}
+
+				return converterProvider.Convert(value, propertyType, minforetriever, serviceProvider);
+			}
+			if (converterProvider != null)
+				return converterProvider.Convert(value, propertyType, () => pi, serviceProvider);
+
+			var ret = value.ConvertTo(propertyType, () => pi, serviceProvider, out Exception exception);
+			if (exception != null)
+				throw exception;
+			return ret;
+		}
+
+		object GetValue()
+		{
+			if (DeviceInfo.Idiom == DeviceIdiom.Phone)
+				return Phone ?? Default;
+			if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
+				return Tablet ?? Default;
+			if (DeviceInfo.Idiom == DeviceIdiom.Desktop)
+				return Desktop ?? Default;
+			if (DeviceInfo.Idiom == DeviceIdiom.TV)
+				return TV ?? Default;
+			if (DeviceInfo.Idiom == DeviceIdiom.Watch)
+				return Watch ?? Default;
+			return Default;
+		}
+	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/OnIdiom.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/OnIdiom.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.OnIdiom">
+  <Label x:Name="Label" Text="{OnIdiom Default=default, Desktop=desktop, Phone=phone}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/OnIdiom.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnIdiom.xaml.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Devices;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class OnIdiom : ContentPage
+	{
+		public OnIdiom()
+		{
+			InitializeComponent();
+		}
+
+		public OnIdiom(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			MockDeviceInfo mockDeviceInfo;
+
+			[SetUp]
+			public void Setup()
+			{
+				DeviceInfo.SetCurrent(mockDeviceInfo = new MockDeviceInfo());
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				DeviceInfo.SetCurrent(null);
+			}
+
+			[Test]
+			public void Label_Text()
+			{
+				MockCompiler.Compile(typeof(OnIdiom), out var md, out bool hasLoggedErrors);
+				Assert.That(md.Body.Instructions.Any(static i => i.OpCode == OpCodes.Newobj && i.Operand.ToString() == "System.Void Microsoft.Maui.Controls.Xaml.OnIdiomExtension`1<System.String>::.ctor()"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/22142

The `dotnet new maui -sc` template has trimmer warnings such as:

    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_Styles.xaml.sg.cs(33): Trim analysis warning IL2026: __XamlGeneratedCode__.__Type608CCEEBECE9213C.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_Styles.xaml.sg.cs(33): Trim analysis warning IL2026: __XamlGeneratedCode__.__Type608CCEEBECE9213C.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_AppStyles.xaml.sg.cs(33): Trim analysis warning IL2026: __XamlGeneratedCode__.__Type675A47C870224F5D.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_AppStyles.xaml.sg.cs(33): Trim analysis warning IL2026: __XamlGeneratedCode__.__Type675A47C870224F5D.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_AppStyles.xaml.sg.cs(33): Trim analysis warning IL2026: __XamlGeneratedCode__.__Type675A47C870224F5D.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Resources_Styles_AppStyles.xaml.sg.cs(33): Trim analysis warning IL2026: __XamlGeneratedCode__.__Type675A47C870224F5D.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_Controls_TaskView.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.Controls.TaskView.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_Controls_TaskView.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.Controls.TaskView.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_Controls_CategoryChart.xaml.sg.cs(27): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.Controls.CategoryChart.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_ManageMetaPage.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.ManageMetaPage.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_ManageMetaPage.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.ManageMetaPage.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_ManageMetaPage.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.ManageMetaPage.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_TaskDetailPage.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.TaskDetailPage.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    obj/Release/net10.0-ios/ios-arm64/Microsoft.Maui.Controls.SourceGen/Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator/Pages_ProjectDetailPage.xaml.sg.cs(25): Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.ProjectDetailPage.InitializeComponent(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    ILC : Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.ProjectDetailPage.<InitializeComponent>_anonXamlCDataTemplate_5.LoadDataTemplate(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.
    ILC : Trim analysis warning IL2026: dotnet_new_maui_samplecontent.Pages.ProjectDetailPage.<InitializeComponent>_anonXamlCDataTemplate_6.LoadDataTemplate(): Using member 'Microsoft.Maui.Controls.Xaml.OnIdiomExtension.OnIdiomExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The OnIdiomExtension is not trim safe. Use OnIdiom<T> instead.

Most these are due to simple `{OnIdiom}` usage in XAML files like:

```xml
<Label Text="{OnIdiom Default=default, Desktop=desktop, Phone=phone}" />
````

One way we could fix this:

* Make an internal `OnIdiomExtension<T>` class with no trimmer warnings

* XamlC looks up the target type for `{OnIdiom}` and uses `OnIdiomExtension<T>` instead of `OnIdiomExtension` when generating the code.

This currently duplicates the `OnIdiomExtension` class, which I'll investigate if that can be done a different way.