### PR TITLE
Fixed ListView leak caused by not disposed ContextActionsCell

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -1495,7 +1495,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				if (disposing)
 				{
-					if (!_list.TryGetTarget(out var list))
+					if (_list.TryGetTarget(out var list))
 					{
 						list.ItemSelected -= OnItemSelected;
 						WatchShortNameCollection(false);

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -986,6 +986,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			readonly WeakReference<UITableView> _uiTableView;
 			readonly WeakReference<FormsUITableViewController> _uiTableViewController;
 			protected readonly WeakReference<ListView> _list;
+			readonly HashSet<ContextActionsCell> _contextActionsCells = new();
 			bool _isDragging;
 			bool _setupSelection;
 			bool _selectionFromNative;
@@ -1113,6 +1114,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				SetCellBackgroundColor(platformCell, bgColor);
 				PreserveActivityIndicatorState(cell);
 				Performance.Stop(reference);
+
+				if(platformCell is ContextActionsCell contextActionsCell)
+					_contextActionsCells.Add(contextActionsCell);
+
 				return platformCell;
 			}
 
@@ -1500,6 +1505,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						list.ItemSelected -= OnItemSelected;
 						WatchShortNameCollection(false);
 					}
+
+					foreach (var cell in _contextActionsCells)
+						cell.Dispose();
+					_contextActionsCells.Clear();
 
 					_templateToId = null;
 				}


### PR DESCRIPTION
### Description of Change

In some cases ContextActionsCell is not disposed and this causes memory leak.
Remembering all instances and disposing them later so that there is no leak.
Tests show that number of instances is less than 30 even for 40k records in the data source collection.
It is not "proper" solution but it works, at least for scenarios tested so far.

Also first commit fixes apparent copy/paste bug.

### Issues Fixed

Fixes #28689