### PR TITLE
Cleanup virtual layer measure invalidation

### DIFF
--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -130,10 +130,5 @@ namespace Microsoft.Maui.Controls
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}
-
-		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
-		{
-			base.InvalidateMeasureLegacy(trigger, depth, 1);
-		}
 	}
 }

--- a/src/Controls/src/Core/InvalidationEventArgs.cs
+++ b/src/Controls/src/Core/InvalidationEventArgs.cs
@@ -10,15 +10,7 @@ namespace Microsoft.Maui.Controls
 		{
 			Trigger = trigger;
 		}
-		public InvalidationEventArgs(InvalidationTrigger trigger, int depth) : this(trigger)
-		{
-			CurrentInvalidationDepth = depth;
-		}
-
 
 		public InvalidationTrigger Trigger { get; private set; }
-
-
-		public int CurrentInvalidationDepth { set; get; }
 	}
 }

--- a/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
@@ -92,12 +92,18 @@ namespace Microsoft.Maui.Controls.Compatibility
 			return result;
 		}
 
+		internal override void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
+		{
+			_layoutInformation = new LayoutInformation();
+			base.OnChildMeasureInvalidated(child, trigger);
+		}
+
 		internal override void ComputeConstraintForView(View view)
 		{
 			ComputeConstraintForView(view, false);
 		}
 
-		internal override void InvalidateMeasureInternal(InvalidationEventArgs trigger)
+		internal override void InvalidateMeasureInternal(InvalidationTrigger trigger)
 		{
 			_layoutInformation = new LayoutInformation();
 			base.InvalidateMeasureInternal(trigger);

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -506,10 +506,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 
-		internal override void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger, int depth)
+		internal override void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
 		{
-			// TODO: once we remove old Xamarin public signatures we can invoke `OnChildMeasureInvalidated(VisualElement, InvalidationTrigger)` directly
-			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger, depth));
+			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+			var propagatedTrigger = GetPropagatedTrigger(trigger);
+			InvokeMeasureInvalidated(propagatedTrigger);
 		}
 
 		/// <summary>
@@ -519,19 +520,6 @@ namespace Microsoft.Maui.Controls
 		/// <param name="e">The event arguments.</param>
 		protected virtual void OnChildMeasureInvalidated(object sender, EventArgs e)
 		{
-			var depth = 0;
-			InvalidationTrigger trigger;
-			if (e is InvalidationEventArgs args)
-			{
-				trigger = args.Trigger;
-				depth = args.CurrentInvalidationDepth;
-			}
-			else
-			{
-				trigger = InvalidationTrigger.Undefined;
-			}
-
-			OnChildMeasureInvalidated((VisualElement)sender, trigger, depth);
 		}
 
 		/// <summary>
@@ -607,36 +595,6 @@ namespace Microsoft.Maui.Controls
 						return;
 					}
 				}
-			}
-		}
-
-		internal virtual void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger, int depth)
-		{
-			var container = this as IPageContainer<Page>;
-			if (container != null)
-			{
-				Page page = container.CurrentPage;
-				if (page != null && page.IsVisible && (!page.IsPlatformEnabled || !page.IsPlatformStateConsistent))
-					return;
-			}
-			else
-			{
-				var logicalChildren = this.InternalChildren;
-				for (var i = 0; i < logicalChildren.Count; i++)
-				{
-					var v = logicalChildren[i] as VisualElement;
-					if (v != null && v.IsVisible && (!v.IsPlatformEnabled || !v.IsPlatformStateConsistent))
-						return;
-				}
-			}
-
-			if (depth <= 1)
-			{
-				InvalidateMeasureInternal(new InvalidationEventArgs(InvalidationTrigger.MeasureChanged, depth));
-			}
-			else
-			{
-				FireMeasureChanged(trigger, depth);
 			}
 		}
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -69,6 +69,7 @@ const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCol
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -205,6 +205,7 @@ const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCol
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.Dispose() -> void
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.OnLayoutSubviews() -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -206,6 +206,7 @@ const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCol
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.Dispose() -> void
 *REMOVED*Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.OnLayoutSubviews() -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -68,6 +68,7 @@ const Microsoft.Maui.Controls.TitleBar.TitleVisibleState = "TitleVisible" -> str
 const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCollapsed" -> string!
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -70,6 +70,7 @@ const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCol
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.Embedding.EmbeddingExtensions
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -68,6 +68,7 @@ const Microsoft.Maui.Controls.TitleBar.TitleVisibleState = "TitleVisible" -> str
 const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCollapsed" -> string!
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -68,6 +68,7 @@ const Microsoft.Maui.Controls.TitleBar.TitleVisibleState = "TitleVisible" -> str
 const Microsoft.Maui.Controls.TitleBar.TrailingHiddenState = "TrailingContentCollapsed" -> string!
 const Microsoft.Maui.Controls.TitleBar.TrailingVisibleState = "TrailingContentVisible" -> string!
 Microsoft.Maui.Controls.HandlerProperties
+*REMOVED*override Microsoft.Maui.Controls.Compatibility.Layout.InvalidateMeasureOverride() -> void
 Microsoft.Maui.Controls.HybridWebView
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.get -> string?
 Microsoft.Maui.Controls.HybridWebView.DefaultFile.set -> void

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -478,11 +478,6 @@ namespace Microsoft.Maui.Controls
 			return bounds.Size;
 		}
 
-		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
-		{
-			base.InvalidateMeasureLegacy(trigger, depth, 1);
-		}
-
 		private protected override string GetDebuggerDisplay()
 		{
 			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Content), Content);

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -150,11 +150,6 @@ namespace Microsoft.Maui.Controls
 			return bounds.Size;
 		}
 
-		private protected override void InvalidateMeasureLegacy(InvalidationTrigger trigger, int depth, int depthLeveltoInvalidate)
-		{
-			base.InvalidateMeasureLegacy(trigger, depth, 1);
-		}
-
 #nullable disable
 
 	}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1384,6 +1384,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		// TODO: .NET10 this should be made public so whoever implements a custom layout can leverage this
 		internal virtual void ComputeConstraintForView(View view) => view.ComputedConstraint = LayoutConstraint.None;
 
 		/// <summary>
@@ -1408,23 +1409,25 @@ namespace Microsoft.Maui.Controls
 			InvalidateMeasureInternal(trigger);
 		}
 
-		internal void InvalidateMeasureInternal(InvalidationTrigger trigger)
+		internal virtual void InvalidateMeasureInternal(InvalidationTrigger trigger)
 		{
-			InvalidateMeasureInternal(new InvalidationEventArgs(trigger, 0));
-		}
+			InvalidateMeasureCache();
 
-		internal virtual void InvalidateMeasureInternal(InvalidationEventArgs eventArgs)
-		{
-			_measureCache.Clear();
 
-			// TODO ezhart Once we get InvalidateArrange sorted, HorizontalOptionsChanged and 
-			// VerticalOptionsChanged will need to call ParentView.InvalidateArrange() instead
-
-			switch (eventArgs.Trigger)
+			switch (trigger)
 			{
 				case InvalidationTrigger.MarginChanged:
+					ParentView?.InvalidateMeasure();
+					break;
 				case InvalidationTrigger.HorizontalOptionsChanged:
 				case InvalidationTrigger.VerticalOptionsChanged:
+					if (this is View thisView && Parent is VisualElement visualParent)
+					{
+						visualParent.ComputeConstraintForView(thisView);
+					}
+
+					// TODO ezhart Once we get InvalidateArrange sorted, HorizontalOptionsChanged and 
+					// VerticalOptionsChanged will need to call ParentView.InvalidateArrange() instead
 					ParentView?.InvalidateMeasure();
 					break;
 				default:
@@ -1432,50 +1435,47 @@ namespace Microsoft.Maui.Controls
 					break;
 			}
 
-			FireMeasureChanged(eventArgs);
+			InvokeMeasureInvalidated(trigger);
+#pragma warning disable CS0618 // Type or member is obsolete
+			(Parent as VisualElement)?.OnChildMeasureInvalidated(this, trigger);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
-		private protected void FireMeasureChanged(InvalidationTrigger trigger, int depth)
+		private protected void InvokeMeasureInvalidated(InvalidationTrigger trigger)
 		{
-			FireMeasureChanged(new InvalidationEventArgs(trigger, depth));
+			MeasureInvalidated?.Invoke(this, new InvalidationEventArgs(trigger));
 		}
 
+		/// <summary>
+        /// A flag that determines whether the measure invalidated event should not be propagated up the visual tree.
+        /// </summary>
+        /// <remarks>
+        /// Propagation will still occur within legacy layout subtrees.
+        /// </remarks>
+        internal static bool SkipMeasureInvalidatedPropagation { get; set /* for testing purpose */; } =
+        	AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.SkipMeasureInvalidatedPropagation", out var enabled) && enabled;
 
-		private protected void FireMeasureChanged(InvalidationEventArgs args)
+		internal virtual void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
 		{
-			var depth = args.CurrentInvalidationDepth;
-			MeasureInvalidated?.Invoke(this, args);
-			(Parent as VisualElement)?.OnChildMeasureInvalidatedInternal(this, args.Trigger, ++depth);
-		}
-
-		// We don't want to change the execution path of Page or Layout when they are calling "InvalidationMeasure"
-		// If you look at page it calls OnChildMeasureInvalidated from OnChildMeasureInvalidatedInternal
-		// Because OnChildMeasureInvalidated is public API and the user might override it, we need to keep it as is
-		//private protected int CurrentInvalidationDepth { get; set; }
-
-		internal virtual void OnChildMeasureInvalidatedInternal(VisualElement child, InvalidationTrigger trigger, int depth)
-		{
-			switch (trigger)
+			if (SkipMeasureInvalidatedPropagation)
 			{
-				case InvalidationTrigger.VerticalOptionsChanged:
-				case InvalidationTrigger.HorizontalOptionsChanged:
-					// When a child changes its HorizontalOptions or VerticalOptions
-					// the size of the parent won't change, so we don't have to invalidate the measure
-					return;
-				case InvalidationTrigger.RendererReady:
-				// Undefined happens in many cases, including when `IsVisible` changes
-				case InvalidationTrigger.Undefined:
-					FireMeasureChanged(trigger, depth);
-					return;
-				default:
-					// When visibility changes `InvalidationTrigger.Undefined` is used,
-					// so here we're sure that visibility didn't change
-					if (child.IsVisible)
-					{
-						FireMeasureChanged(InvalidationTrigger.MeasureChanged, depth);
-					}
-					return;
+				return;
 			}
+
+			var propagatedTrigger = GetPropagatedTrigger(trigger);
+			InvokeMeasureInvalidated(propagatedTrigger);
+			(Parent as VisualElement)?.OnChildMeasureInvalidated(this, propagatedTrigger);
+		}
+
+		private protected static InvalidationTrigger GetPropagatedTrigger(InvalidationTrigger trigger)
+		{
+			var propagatedTrigger = trigger == InvalidationTrigger.RendererReady ? trigger : InvalidationTrigger.MeasureChanged;
+			return propagatedTrigger;
+		}
+
+		private protected void InvalidateMeasureCache()
+		{
+			_measureCache.Clear();
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### Description of Change

Now that we have merged #28225, and soon will merge #28670, we can finally start getting rid of `MeasureInvalidated` event and also enhance some features.

- Removed `Compatibility.Layout` useless and harming code (causing additional unneeded invalidations/arranges)
- Moved `ComputeConstraintForView` from `Compatibility.Layout` to `VisualElement` so new layouts will be able to use it out of the box so that we can leverage #28479
- Adds an app switch to disable `MeasureInvalidated` total propagation, basically "revert"s #23052 and goes back to 8.0.82 behavior where the propagation was happening only while using legacy layouts

```cs
/// <summary>
/// A flag that determines whether the measure invalidated event should not be propagated up the visual tree.
/// </summary>
/// <remarks>
/// Propagation will still occur within legacy layout subtrees.
/// </remarks>
internal static bool SkipMeasureInvalidatedPropagation { get; set /* for testing purpose */; } =
	AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.SkipMeasureInvalidatedPropagation", out var enabled) && enabled;
```

### Issues Fixed

Fixes #25264



