### PR TITLE
Include all platforms in multi project template

### DIFF
--- a/src/Templates/src/templates/maui-multiproject/.template.config/template.json
+++ b/src/Templates/src/templates/maui-multiproject/.template.config/template.json
@@ -199,13 +199,13 @@
           ]
         }
       },
-      "XmlEncodedAppNameParam": {
+    "XmlEncodedAppNameParam": {
         "type": "derived",
         "valueSource": "name",
         "valueTransform": "encode",
         "replaces": "XmlEncodedAppName"
       },
-      "defaultAppId":{
+    "defaultAppId":{
       "type": "generated",
       "generator": "join",
       "parameters": {

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/Info.plist
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleDisplayName</key>
-    <string>MauiApp.1</string>
+    <string>XmlEncodedAppName</string>
     <key>CFBundleIdentifier</key>
     <string>com.companyname.mauiapp</string>
     <key>CFBundleShortVersionString</key>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/Info.plist
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleDisplayName</key>
-    <string>MauiApp.1</string>
+    <string>XmlEncodedAppName</string>
     <key>CFBundleIdentifier</key>
     <string>com.companyname.mauiapp</string>
     <key>CFBundleShortVersionString</key>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.sln
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.sln
@@ -3,19 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-#if (winui)
+#if (AllPlatforms || winui)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp.1.WinUI", "MauiApp.1.WinUI\MauiApp.1.WinUI.csproj", "{1AA5F22B-62F8-414F-AE50-635E99EB3F76}"
 EndProject
 #endif
-#if (maccatalyst)
+#if (AllPlatforms || maccatalyst)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp.1.Mac", "MauiApp.1.Mac\MauiApp.1.Mac.csproj", "{C2800ABA-8C19-4553-A552-BFF679BEB039}"
 EndProject
 #endif
-#if (ios)
+#if (AllPlatforms || ios)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp.1.iOS", "MauiApp.1.iOS\MauiApp.1.iOS.csproj", "{7C064C71-30BE-4D8D-9B68-E7249ED18FA1}"
 EndProject
 #endif
-#if (android)
+#if (AllPlatforms || android)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp.1.Droid", "MauiApp.1.Droid\MauiApp.1.Droid.csproj", "{9E30318E-74DD-491B-9BAF-814DC9E892B8}"
 EndProject
 #endif
@@ -33,7 +33,7 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-#if (winui)
+#if (AllPlatforms || winui)
 		{1AA5F22B-62F8-414F-AE50-635E99EB3F76}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{1AA5F22B-62F8-414F-AE50-635E99EB3F76}.Debug|Any CPU.Build.0 = Debug|x64
 		{1AA5F22B-62F8-414F-AE50-635E99EB3F76}.Debug|Any CPU.Deploy.0 = Debug|x64
@@ -59,7 +59,7 @@ Global
 		{1AA5F22B-62F8-414F-AE50-635E99EB3F76}.Release|x86.Build.0 = Release|x86
 		{1AA5F22B-62F8-414F-AE50-635E99EB3F76}.Release|x86.Deploy.0 = Release|x86
 #endif
-#if (maccatalyst)
+#if (AllPlatforms || maccatalyst)
 		{C2800ABA-8C19-4553-A552-BFF679BEB039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C2800ABA-8C19-4553-A552-BFF679BEB039}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2800ABA-8C19-4553-A552-BFF679BEB039}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
@@ -85,7 +85,7 @@ Global
 		{C2800ABA-8C19-4553-A552-BFF679BEB039}.Release|x86.Build.0 = Release|Any CPU
 		{C2800ABA-8C19-4553-A552-BFF679BEB039}.Release|x86.Deploy.0 = Release|Any CPU
 #endif
-#if (ios)
+#if (AllPlatforms || ios)
 		{7C064C71-30BE-4D8D-9B68-E7249ED18FA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7C064C71-30BE-4D8D-9B68-E7249ED18FA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C064C71-30BE-4D8D-9B68-E7249ED18FA1}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
@@ -111,7 +111,7 @@ Global
 		{7C064C71-30BE-4D8D-9B68-E7249ED18FA1}.Release|x86.Build.0 = Release|Any CPU
 		{7C064C71-30BE-4D8D-9B68-E7249ED18FA1}.Release|x86.Deploy.0 = Release|Any CPU
 #endif
-#if (android)
+#if (AllPlatforms || android)
 		{9E30318E-74DD-491B-9BAF-814DC9E892B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9E30318E-74DD-491B-9BAF-814DC9E892B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E30318E-74DD-491B-9BAF-814DC9E892B8}.Debug|Any CPU.Deploy.0 = Debug|Any CPU

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
@@ -23,6 +23,9 @@ public class MultiProjectTemplateTest : BaseTemplateTests
 				$"Unable to remove WinUI project from solution. Check test output for errors.");
 		}
 
+		// TODO, we should not need this but hitting: https://github.com/dotnet/maui/issues/19840
+		BuildProps.Add("ResizetizerErrorOnDuplicateOutputFilename=false");
+
 		Assert.IsTrue(DotnetInternal.Build(solutionFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
 			$"Solution {name} failed to build. Check test output/attachments for errors.");
 	}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
@@ -24,9 +24,10 @@ public class MultiProjectTemplateTest : BaseTemplateTests
 		}
 
 		// TODO, we should not need this but hitting: https://github.com/dotnet/maui/issues/19840
-		BuildProps.Add("ResizetizerErrorOnDuplicateOutputFilename=false");
+		var buildProps = BuildProps;
+		buildProps.Add("ResizetizerErrorOnDuplicateOutputFilename=false");
 
-		Assert.IsTrue(DotnetInternal.Build(solutionFile, config, properties: BuildProps, msbuildWarningsAsErrors: true),
+		Assert.IsTrue(DotnetInternal.Build(solutionFile, config, properties: buildProps, msbuildWarningsAsErrors: true),
 			$"Solution {name} failed to build. Check test output/attachments for errors.");
 	}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
@@ -17,7 +17,11 @@ public class MultiProjectTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.New("maui-multiproject", projectDir, DotNetCurrent),
 			$"Unable to create template maui-multiproject. Check test output for errors.");
 
-		if (!TestEnvironment.IsWindows)
+		// Always remove WinUI project if the project name contains special characters that cause WinRT source generator issues
+		// See: https://github.com/microsoft/CsWinRT/issues/1809 (under "Special characters in assembly name" section)
+		bool containsSpecialChars = projectName.IndexOfAny(new[] { '@', '&', '+', '%', '!', '#', '$', '^', '*', ' ', '-' }) >= 0;
+		
+		if (!TestEnvironment.IsWindows || containsSpecialChars)
 		{
 			Assert.IsTrue(DotnetInternal.Run("sln", $"\"{solutionFile}\" remove \"{projectDir}/{name}.WinUI/{name}.WinUI.csproj\""),
 				$"Unable to remove WinUI project from solution. Check test output for errors.");


### PR DESCRIPTION
### Description of Change

The multi-project template did not take into account the `AllPlatforms` variable and therefore when using the command-line to create a new project, the project would not include all platforms. This PR fixes that.

Additionally, this adds a tests for this scenario to check if a platform or all platforms are included when created through the command line depending on the provided parameters.

Also, this PR fixes an issue where the `Info.plist` file was not correctly updated with the `XmlEncodedAppName` value. Right now it was filled with just the project name that you would generate. If the project would contain special characters that are not compatible with XML (which the `Info.plist` file is), then the build would fail. For example, create a .NET MAUI project with the name `MultiProject@Symbol & More`, would result in an `Info.plist` node of that same value, which is not valid XML. With this change, the `MultiProject@Symbol & More` project name value is XML encoded and then replaced in the `Info.plist` file.

The reported issue mentions .NET 10 where this was not working, but this is also not working for .NET 9.

### Issues Fixed

Fixes #28695 