### PR TITLE
[Android] Removing outdated menu items as Android can delete them after switching activities

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -242,7 +242,10 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					var item = menu.FindItem(previousMenuItem.ItemId);
 					if (item == null)
+					{
+						previousMenuItem.Dispose();
 						previousMenuItems.Remove(previousMenuItem);
+					}
 				}
 			}
 

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -232,8 +232,19 @@ namespace Microsoft.Maui.Controls.Platform
 			if (sortedToolbarItems == null || previousMenuItems == null)
 				return;
 
-			var context = mauiContext.Context;
 			var menu = toolbar.Menu;
+
+			// menu items can be deleted by Android after switching activities, removing outdated menu items first
+			if (menu != null)
+			{
+				var clonedPreviousMenuItems = previousMenuItems.ToArray();
+				foreach (var previousMenuItem in clonedPreviousMenuItems)
+				{
+					var item = menu.FindItem(previousMenuItem.ItemId);
+					if (item == null)
+						previousMenuItems.Remove(previousMenuItem);
+				}
+			}
 
 			foreach (var toolbarItem in previousToolBarItems)
 				toolbarItem.PropertyChanged -= toolbarItemChanged;

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Maui.Controls.Platform
 					if (menu.FindItem(previousMenuItem.ItemId) == null)
 					{
 						previousMenuItem.Dispose();
-						previousMenuItems.Remove(previousMenuItem);
+						previousMenuItems.RemoveAt(j);
 					}
 				}
 			}

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -237,11 +237,10 @@ namespace Microsoft.Maui.Controls.Platform
 			// menu items can be deleted by Android after switching activities, removing outdated menu items first
 			if (menu != null)
 			{
-				var clonedPreviousMenuItems = previousMenuItems.ToArray();
-				foreach (var previousMenuItem in clonedPreviousMenuItems)
+				for (var j = previousMenuItems.Count - 1; j >= 0; j--)
 				{
-					var item = menu.FindItem(previousMenuItem.ItemId);
-					if (item == null)
+					var previousMenuItem = previousMenuItems[j];
+					if (menu.FindItem(previousMenuItem.ItemId) == null)
 					{
 						previousMenuItem.Dispose();
 						previousMenuItems.Remove(previousMenuItem);


### PR DESCRIPTION
### Description of Change

When updating toolbar items first removing outdated menu items as Android can sometimes delete them after switching activities (releasing resources under memory pressure?).

### Issues Fixed

Fixes #24357