### PR TITLE
[iOS]Fix: FlyoutPage memory leak

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		UIView _clickOffView;
 		UIViewController _detailController;
-		WeakReference<VisualElement> element;
-		VisualElement _element => element?.GetTargetOrDefault();
+		WeakReference<VisualElement> _element;
 		bool _disposed;
 
 		UIViewController _flyoutController;
@@ -76,7 +75,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			get { return _presented; }
 		}
 
-		public VisualElement Element => _viewHandlerWrapper.Element ?? _element;
+		public VisualElement Element => _viewHandlerWrapper.Element ?? _element?.GetTargetOrDefault();
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -101,7 +100,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_clickOffView = new UIView();
 			_clickOffView.BackgroundColor = new Color(0, 0, 0, 0).ToPlatform();
 			_viewHandlerWrapper.SetVirtualView(element, OnElementChanged, false);
-			this.element = new(element);
+			_element = new(element);
 
 			if (_intialLayoutFinished)
 			{
@@ -270,7 +269,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 
 				EmptyContainers();
-			    element = null;
+			    _element = null;
 				_disposed = true;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		UIView _clickOffView;
 		UIViewController _detailController;
-		VisualElement _element;
+		WeakReference<VisualElement> element;
+		VisualElement _element => element?.GetTargetOrDefault();
 		bool _disposed;
 
 		UIViewController _flyoutController;
@@ -100,7 +101,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_clickOffView = new UIView();
 			_clickOffView.BackgroundColor = new Color(0, 0, 0, 0).ToPlatform();
 			_viewHandlerWrapper.SetVirtualView(element, OnElementChanged, false);
-			_element = element;
+			this.element = new(element);
 
 			if (_intialLayoutFinished)
 			{
@@ -269,9 +270,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 
 				EmptyContainers();
-
-				Page.SendDisappearing();
-
+			    element = null;
 				_disposed = true;
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -273,17 +273,13 @@ namespace Microsoft.Maui.DeviceTests
 					Detail = new ContentPage { Title = "Detail" }
 				};
 
-				flyoutPage.Appearing += async (_, __) =>
-				{
-					await Task.Delay(100);
-					await flyoutPage.Navigation.PopModalAsync();
-				};
+				await launcherPage.Navigation.PushModalAsync(flyoutPage, true);
 
 				references.Add(new WeakReference(flyoutPage));
 				references.Add(new WeakReference(flyoutPage.Flyout));
 				references.Add(new WeakReference(flyoutPage.Detail));
-				await launcherPage.Navigation.PushModalAsync(flyoutPage, true);
-				await OnUnloadedAsync(flyoutPage);
+
+				await launcherPage.Navigation.PopModalAsync();
 			});
 
 			await AssertionExtensions.WaitForGC(references.ToArray());

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -252,6 +252,43 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "FlyoutPage as Modal Does Not Leak")]
+		public async Task DoesNotLeakAsModal()
+		{
+			SetupBuilder();
+
+			var references = new List<WeakReference>();
+			var launcherPage = new ContentPage();
+			var window = new Window(launcherPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async handler =>
+			{
+				var flyoutPage = new FlyoutPage
+				{
+					Flyout = new ContentPage
+					{
+						Title = "Flyout",
+						IconImageSource = "icon.png"
+					},
+					Detail = new ContentPage { Title = "Detail" }
+				};
+
+				flyoutPage.Appearing += async (_, __) =>
+				{
+					await Task.Delay(100);
+					await flyoutPage.Navigation.PopModalAsync();
+				};
+
+				references.Add(new WeakReference(flyoutPage));
+				references.Add(new WeakReference(flyoutPage.Flyout));
+				references.Add(new WeakReference(flyoutPage.Detail));
+				await launcherPage.Navigation.PushModalAsync(flyoutPage, true);
+				await OnUnloadedAsync(flyoutPage);
+			});
+
+			await AssertionExtensions.WaitForGC(references.ToArray());
+		}	
+
 		bool CanDeviceDoSplitMode(FlyoutPage page)
 		{
 			return ((IFlyoutPageController)page).ShouldShowSplitMode;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla31255.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla31255.cs
@@ -49,8 +49,7 @@
 			{
 				while (true)
 				{
-					((Label)((StackLayout)Content).Children[0]).Text =
-							string.Format("Page1. But Page2 IsAlive = {0}", _page2Tracker.IsAlive);
+					((Label)((StackLayout)Content).Children[0]).Text = _page2Tracker.IsAlive ? "Failed" : "Success";
 					await Task.Delay(1000);
 					GarbageCollectionHelper.Collect();
 				}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla31255.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla31255.cs
@@ -18,7 +18,8 @@
 				{
 					VerticalOptions = LayoutOptions.Center,
 					HorizontalTextAlignment = TextAlignment.Center,
-					Text = "Page 1"
+					Text = "Page 1",
+					AutomationId = "MauiLabel"
 				});
 
 				Content = stack;
@@ -60,12 +61,12 @@
 			{
 				public Page2()
 				{
-					Flyout = new Page()
+					Flyout = new ContentPage
 					{
 						Title = "Flyout",
 						IconImageSource = "Icon.png"
 					};
-					Detail = new Page() { Title = "Detail" };
+					Detail = new ContentPage() { Title = "Detail" };
 				}
 
 				protected override async void OnAppearing()
@@ -74,6 +75,10 @@
 
 					await Task.Delay(1000);
 					await Navigation.PopModalAsync();
+				}
+				protected override void OnDisappearing()
+				{
+					base.OnDisappearing();
 				}
 			}
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla31255.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla31255.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public void Bugzilla31255Test()
 		{
 			App.Screenshot("I am at Bugzilla 31255");
-			Thread.Sleep(5000);
-			var text = App.WaitForElement("MauiLabel").GetText();
-			Assert.That(text, Is.EqualTo("Page1. But Page2 IsAlive = False"));
+			App.AssertMemoryTest();
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla31255.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla31255.cs
@@ -1,5 +1,4 @@
-﻿#if IOS
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -14,15 +13,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public override string Issue => "Flyout's page Icon cause memory leak after FlyoutPage is popped out by holding on page";
 
 		[Test]
-		[Ignore("The sample is crashing. More information: https://github.com/dotnet/maui/issues/21206")]
 		[Category(UITestCategories.Navigation)]
 		[Category(UITestCategories.Compatibility)]
-		public async Task Bugzilla31255Test()
+		public void Bugzilla31255Test()
 		{
 			App.Screenshot("I am at Bugzilla 31255");
-			await Task.Delay(5000);
-			App.WaitForNoElement("Page1. But Page2 IsAlive = False");
+			Thread.Sleep(5000);
+			var text = App.WaitForElement("MauiLabel").GetText();
+			Assert.That(text, Is.EqualTo("Page1. But Page2 IsAlive = False"));
 		}
 	}
 }
-#endif


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

While enabling the UITest `Bugzilla31255Test`, which pushes a `FlyoutPage` modally and then pops it, I encountered a memory leak on iOS. The `FlyoutPage` instance was not being collected even after the modal pop.

Originally, the test case was also causing a crash because `Flyout` and `Detail` were being set to instances of `Page`, which is not supported. I updated them to use `ContentPage`, which resolved the crash.

The memory leak was caused by the renderer holding a strong reference to the virtual view (`_element`), which prevented the `FlyoutPage` from being garbage collected. 

I also added a device test that reproduces the same modal flow and asserts that the page is collected by the GC. While this device test covers the same scenario as the UITest, I’ve kept both for now.

If you'd prefer to remove the UITest and rely only on the device test, let me know.

<table>
  <tr>
<th>Before Fix</th>
<th>After Fix</th>
</tr>
<tr>
<td>

<img width="339" alt="Screenshot 2025-04-02 at 9 17 03 PM" src="https://github.com/user-attachments/assets/1d912974-d196-4cac-a8fb-189fbdce7ec0" />

</td>
<td>

<img width="339" alt="Screenshot 2025-04-02 at 9 19 11 PM" src="https://github.com/user-attachments/assets/b7773d7e-d9a4-4b7f-ae5c-9dcb0a1b438f" />

</td>
</tr>
</table>
<!-- Enter description of the fix in this section -->

### Issues Fixed 

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #21206

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
