### PR TITLE
[android] fix `Android` namespace conflicts

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 	class BlazorWebChromeClient : WebChromeClient
 	{
-		public override bool OnCreateWindow(Android.Webkit.WebView? view, bool isDialog, bool isUserGesture, Message? resultMsg)
+		public override bool OnCreateWindow(global::Android.Webkit.WebView? view, bool isDialog, bool isUserGesture, Message? resultMsg)
 		{
 			if (view?.Context is not null)
 			{
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			return false;
 		}
 
-		public override bool OnShowFileChooser(Android.Webkit.WebView? view, IValueCallback? filePathCallback, FileChooserParams? fileChooserParams)
+		public override bool OnShowFileChooser(global::Android.Webkit.WebView? view, IValueCallback? filePathCallback, FileChooserParams? fileChooserParams)
 		{
 			if (filePathCallback is null)
 			{

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Android.Webkit;
+using Android.Widget;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -32,7 +33,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var blazorAndroidWebView = new BlazorAndroidWebView(Context!)
 			{
 #pragma warning disable 618 // This can probably be replaced with LinearLayout(LayoutParams.MatchParent, LayoutParams.MatchParent); just need to test that theory
-				LayoutParameters = new Android.Widget.AbsoluteLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, 0, 0)
+				LayoutParameters = new AbsoluteLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, 0, 0)
 #pragma warning restore 618
 			};
 #pragma warning restore CA1416, CA1412, CA1422 // Validate platform compatibility

--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Maui.Controls
 		// This is used by ListView to pass data to the GetCell call
 		// Ideally we can pass these as arguments to ToHandler
 		// But we'll do that in a different smaller more targeted PR
-		internal Android.Views.View ConvertView { get; set; }
+		internal global::Android.Views.View ConvertView { get; set; }
 #elif IOS
 		internal UIKit.UITableViewCell ReusableCell { get; set; }
 

--- a/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Graphics;
 #if WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif ANDROID
+using Android.Content;
 using PlatformView = Android.Views.View;
 #elif IOS
 using PlatformView = UIKit.UIView;
@@ -64,7 +65,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected bool AutoPackage { get; set; } = true;
 
 #if ANDROID
-		public VisualElementRenderer(Android.Content.Context context) : this(context, VisualElementRendererMapper, VisualElementRendererCommandMapper)
+		public VisualElementRenderer(Context context) : this(context, VisualElementRendererMapper, VisualElementRendererCommandMapper)
 		{
 		}
 #else
@@ -75,7 +76,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 
 #if ANDROID
-		protected VisualElementRenderer(Android.Content.Context context, IPropertyMapper mapper, CommandMapper? commandMapper = null)
+		protected VisualElementRenderer(Context context, IPropertyMapper mapper, CommandMapper? commandMapper = null)
 #else
 		protected VisualElementRenderer(IPropertyMapper mapper, CommandMapper? commandMapper = null)
 #endif

--- a/src/Controls/src/Core/DragAndDrop/PlatformDragEventArgs.cs
+++ b/src/Controls/src/Core/DragAndDrop/PlatformDragEventArgs.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+#if ANDROID
+using Android.Views;
+using AView = Android.Views.View;
+#endif
+
 namespace Microsoft.Maui.Controls;
 
 /// <summary>
@@ -49,14 +54,14 @@ public class PlatformDragEventArgs
 	/// <summary>
 	/// Gets the native view attached to the event.
 	/// </summary>
-	public Android.Views.View Sender { get; }
+	public AView Sender { get; }
 
 	/// <summary>
 	/// Gets the event containing information for drag and drop status.
 	/// </summary>
-	public Android.Views.DragEvent DragEvent { get; }
+	public DragEvent DragEvent { get; }
 
-	internal PlatformDragEventArgs(Android.Views.View sender, Android.Views.DragEvent dragEvent)
+	internal PlatformDragEventArgs(AView sender, DragEvent dragEvent)
 	{
 		Sender = sender;
 		DragEvent = dragEvent;

--- a/src/Controls/src/Core/DragAndDrop/PlatformDragStartingEventArgs.cs
+++ b/src/Controls/src/Core/DragAndDrop/PlatformDragStartingEventArgs.cs
@@ -1,5 +1,12 @@
 ﻿using System;
 
+#if ANDROID
+using Android.Content;
+using Android.Views;
+using DragShadowBuilder = Android.Views.View.DragShadowBuilder;
+using AView = Android.Views.View;
+#endif
+
 namespace Microsoft.Maui.Controls;
 
 /// <summary>
@@ -91,19 +98,19 @@ public class PlatformDragStartingEventArgs
 	/// <summary>
 	/// Gets the native view attached to the event.
 	/// </summary>
-	public Android.Views.View Sender { get; }
+	public AView Sender { get; }
 
 	/// <summary>
 	/// Gets the event containing information for drag and drop status.
 	/// </summary>
-	public Android.Views.MotionEvent MotionEvent { get; }
+	public MotionEvent MotionEvent { get; }
 
-	internal Android.Views.View.DragShadowBuilder? DragShadowBuilder { get; private set; }
-	internal Android.Content.ClipData? ClipData { get; private set; }
+	internal DragShadowBuilder? DragShadowBuilder { get; private set; }
+	internal ClipData? ClipData { get; private set; }
 	internal Java.Lang.Object? LocalData { get; private set; }
-	internal Android.Views.DragFlags? DragFlags { get; private set; }
+	internal DragFlags? DragFlags { get; private set; }
 
-	internal PlatformDragStartingEventArgs(Android.Views.View sender, Android.Views.MotionEvent motionEvent)
+	internal PlatformDragStartingEventArgs(AView sender, MotionEvent motionEvent)
 	{
 		Sender = sender;
 		MotionEvent = motionEvent;
@@ -113,7 +120,7 @@ public class PlatformDragStartingEventArgs
 	/// Sets the drag shadow when dragging begins.
 	/// </summary>
 	/// <param name="dragShadowBuilder">The custom drag shadow builder to use.</param>
-	public void SetDragShadowBuilder(Android.Views.View.DragShadowBuilder dragShadowBuilder)
+	public void SetDragShadowBuilder(DragShadowBuilder dragShadowBuilder)
 	{
 		DragShadowBuilder = dragShadowBuilder;
 	}
@@ -122,7 +129,7 @@ public class PlatformDragStartingEventArgs
 	/// Sets the clip data when dragging begins.
 	/// </summary>
 	/// <param name="clipData">The custom clip data to use.</param>
-	public void SetClipData(Android.Content.ClipData clipData)
+	public void SetClipData(ClipData clipData)
 	{
 		ClipData = clipData;
 	}
@@ -140,7 +147,7 @@ public class PlatformDragStartingEventArgs
 	/// Sets the drag flags when dragging begins.
 	/// </summary>
 	/// <param name="dragFlags">The custom drag flags to use.</param>
-	public void SetDragFlags(Android.Views.DragFlags dragFlags)
+	public void SetDragFlags(DragFlags dragFlags)
 	{
 		DragFlags = dragFlags;
 	}

--- a/src/Controls/src/Core/DragAndDrop/PlatformDropCompletedEventArgs.cs
+++ b/src/Controls/src/Core/DragAndDrop/PlatformDropCompletedEventArgs.cs
@@ -1,4 +1,10 @@
 ﻿using System;
+
+#if ANDROID
+using Android.Views;
+using AView = Android.Views.View;
+#endif
+
 namespace Microsoft.Maui.Controls;
 
 /// <summary>
@@ -73,14 +79,14 @@ public class PlatformDropCompletedEventArgs
 	/// <summary>
 	/// Gets the native view attached to the event.
 	/// </summary>
-	public Android.Views.View Sender { get; }
+	public AView Sender { get; }
 
 	/// <summary>
 	/// Gets the event containing information for drag and drop status.
 	/// </summary>
-	public Android.Views.DragEvent DragEvent { get; }
+	public DragEvent DragEvent { get; }
 
-	internal PlatformDropCompletedEventArgs(Android.Views.View sender, Android.Views.DragEvent dragEvent)
+	internal PlatformDropCompletedEventArgs(AView sender, DragEvent dragEvent)
 	{
 		Sender = sender;
 		DragEvent = dragEvent;

--- a/src/Controls/src/Core/DragAndDrop/PlatformDropEventArgs.cs
+++ b/src/Controls/src/Core/DragAndDrop/PlatformDropEventArgs.cs
@@ -1,5 +1,10 @@
 ﻿using System;
 
+#if ANDROID
+using Android.Views;
+using AView = Android.Views.View;
+#endif
+
 namespace Microsoft.Maui.Controls;
 
 /// <summary>
@@ -35,14 +40,14 @@ public class PlatformDropEventArgs
 	/// <summary>
 	/// Gets the native view attached to the event.
 	/// </summary>
-	public Android.Views.View Sender { get; }
+	public AView Sender { get; }
 
 	/// <summary>
 	/// Gets the event containing information for drag and drop status.
 	/// </summary>
-	public Android.Views.DragEvent DragEvent { get; }
+	public DragEvent DragEvent { get; }
 
-	internal PlatformDropEventArgs(Android.Views.View sender, Android.Views.DragEvent dragEvent)
+	internal PlatformDropEventArgs(AView sender, DragEvent dragEvent)
 	{
 		Sender = sender;
 		DragEvent = dragEvent;

--- a/src/Controls/src/Core/Element/Element.Android.cs
+++ b/src/Controls/src/Core/Element/Element.Android.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.Controls.Platform;
+using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,13 +8,13 @@ namespace Microsoft.Maui.Controls
 		public static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, Element element)
 		{
 			Platform.AutomationPropertiesProvider.SetImportantForAccessibility(
-				handler.PlatformView as Android.Views.View, element);
+				handler.PlatformView as AView, element);
 		}
 
 		public static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, Element element)
 		{
 			Platform.AutomationPropertiesProvider.SetImportantForAccessibility(
-				handler.PlatformView as Android.Views.View, element);
+				handler.PlatformView as AView, element);
 		}
 
 		static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, IElement element)

--- a/src/Controls/src/Core/Embedding/EmbeddingExtensions.cs
+++ b/src/Controls/src/Core/Embedding/EmbeddingExtensions.cs
@@ -37,7 +37,7 @@ public static class EmbeddingExtensions
 	internal static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder)
 	{
 #if ANDROID
-		var platformApplication = (Android.App.Application)Android.App.Application.Context;
+		var platformApplication = (global::Android.App.Application)global::Android.App.Application.Context;
 #elif IOS || MACCATALYST
 		var platformApplication = UIKit.UIApplication.SharedApplication.Delegate;
 #elif WINDOWS

--- a/src/Controls/src/Core/PlatformPointerEventArgs.cs
+++ b/src/Controls/src/Core/PlatformPointerEventArgs.cs
@@ -1,4 +1,10 @@
 ﻿using System;
+
+#if ANDROID
+using Android.Views;
+using AView = Android.Views.View;
+#endif
+
 namespace Microsoft.Maui.Controls;
 
 /// <summary>
@@ -27,14 +33,14 @@ public class PlatformPointerEventArgs
 	/// <summary>
 	/// Gets the native view attached to the event.
 	/// </summary>
-	public Android.Views.View Sender { get; }
+	public AView Sender { get; }
 
 	/// <summary>
 	/// Gets the native event or handler attached to the view.
 	/// </summary>
-	public Android.Views.MotionEvent MotionEvent { get; }
+	public MotionEvent MotionEvent { get; }
 
-	internal PlatformPointerEventArgs(Android.Views.View sender, Android.Views.MotionEvent motionEvent)
+	internal PlatformPointerEventArgs(AView sender, MotionEvent motionEvent)
 	{
 		Sender = sender;
 		MotionEvent = motionEvent;

--- a/src/Controls/src/Core/WebView/PlatformWebViewProcessTerminatedEventArgs.cs
+++ b/src/Controls/src/Core/WebView/PlatformWebViewProcessTerminatedEventArgs.cs
@@ -1,9 +1,14 @@
-﻿namespace Microsoft.Maui.Controls
+﻿#if ANDROID
+using Android.Webkit;
+using AView = Android.Views.View;
+#endif
+
+namespace Microsoft.Maui.Controls
 {
 	public class PlatformWebViewProcessTerminatedEventArgs
 	{
 #if ANDROID
-		internal PlatformWebViewProcessTerminatedEventArgs(Android.Views.View? sender, Android.Webkit.RenderProcessGoneDetail? renderProcessGoneDetail)
+		internal PlatformWebViewProcessTerminatedEventArgs(AView? sender, RenderProcessGoneDetail? renderProcessGoneDetail)
 		{
 			Sender = sender;
 			RenderProcessGoneDetail = renderProcessGoneDetail;
@@ -12,12 +17,12 @@
 		/// <summary>
 		/// Gets the native view attached to the event.
 		/// </summary>
-		public Android.Views.View? Sender { get; }
+		public AView? Sender { get; }
 
 		/// <summary>
 		/// Gets the native event or handler attached to the view.
 		/// </summary>
-		public Android.Webkit.RenderProcessGoneDetail? RenderProcessGoneDetail { get; }
+		public RenderProcessGoneDetail? RenderProcessGoneDetail { get; }
 #elif IOS || MACCATALYST
 		internal PlatformWebViewProcessTerminatedEventArgs(WebKit.WKWebView sender)
 		{

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -7,6 +7,7 @@ using Android.Gms.Common.Apis;
 using Android.Gms.Maps;
 using Android.Gms.Maps.Model;
 using Android.OS;
+using Android.Views;
 using Java.Lang;
 using Java.Util.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -316,7 +317,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			VirtualView.VisibleRegion = new MapSpan(new Devices.Sensors.Location(pos.Latitude, pos.Longitude), dlat, dlong);
 		}
 
-		void MapViewLayoutChange(object? sender, Android.Views.View.LayoutChangeEventArgs e)
+		void MapViewLayoutChange(object? sender, View.LayoutChangeEventArgs e)
 		{
 			InitialUpdate();
 		}

--- a/src/Core/src/ActivationState.cs
+++ b/src/Core/src/ActivationState.cs
@@ -1,12 +1,15 @@
 ﻿#nullable enable
 using System;
+#if ANDROID
+using Android.OS;
+#endif
 
 namespace Microsoft.Maui
 {
 	public class ActivationState : IActivationState
 	{
-#if __ANDROID__
-		public ActivationState(IMauiContext context, Android.OS.Bundle? savedInstance)
+#if ANDROID
+		public ActivationState(IMauiContext context, Bundle? savedInstance)
 			: this(context, GetPersistedState(savedInstance))
 		{
 			SavedInstance = savedInstance;
@@ -46,16 +49,16 @@ namespace Microsoft.Maui
 
 		public IPersistedState State { get; }
 
-#if __ANDROID__
-		public Android.OS.Bundle? SavedInstance { get; }
+#if ANDROID
+		public Bundle? SavedInstance { get; }
 #elif WINDOWS
 		public UI.Xaml.LaunchActivatedEventArgs? LaunchActivatedEventArgs { get; }
 #elif TIZEN
 		public Tizen.Applications.Bundle? SavedInstance { get; }
 #endif
 
-#if __ANDROID__
-		static PersistedState GetPersistedState(Android.OS.Bundle? state)
+#if ANDROID
+		static PersistedState GetPersistedState(Bundle? state)
 		{
 			var dict = new PersistedState();
 

--- a/src/Core/src/Core/Extensions/ITextInputExtensions.cs
+++ b/src/Core/src/Core/Extensions/ITextInputExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+#if ANDROID
+using Android.Text;
+#endif
 
 namespace Microsoft.Maui
 {
@@ -43,8 +46,8 @@ namespace Microsoft.Maui
 		}
 #endif
 
-#if __ANDROID__
-		public static void UpdateText(this ITextInput textInput, Android.Text.TextChangedEventArgs e)
+#if ANDROID
+		public static void UpdateText(this ITextInput textInput, TextChangedEventArgs e)
 		{
 			if (e.Text is Java.Lang.ICharSequence cs)
 				textInput.UpdateText(cs.ToString());

--- a/src/Core/src/Embedding/EmbeddingExtensions.cs
+++ b/src/Core/src/Embedding/EmbeddingExtensions.cs
@@ -31,7 +31,7 @@ internal static class EmbeddingExtensions
 	internal static MauiAppBuilder UseMauiEmbedding(this MauiAppBuilder builder, PlatformApplication? platformApplication = null)
 	{
 #if ANDROID
-		platformApplication ??= (Android.App.Application)Android.App.Application.Context;
+		platformApplication ??= (global::Android.App.Application)global::Android.App.Application.Context;
 #elif IOS || MACCATALYST
 		platformApplication ??= UIKit.UIApplication.SharedApplication.Delegate;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Border/BorderHandler.Android.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Android.Views;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -18,7 +19,7 @@ namespace Microsoft.Maui.Handlers
 
 			// We only want to use a hardware layer for the entering view because its quite likely
 			// the view will invalidate several times the Drawable (Draw).
-			viewGroup.SetLayerType(Android.Views.LayerType.Hardware, null);
+			viewGroup.SetLayerType(LayerType.Hardware, null);
 
 			return viewGroup;
 		}

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Handlers
 			MaterialButton platformButton = new MauiMaterialButton(Context)
 			{
 				IconGravity = MaterialButton.IconGravityTextStart,
-				IconTintMode = Android.Graphics.PorterDuff.Mode.Add,
+				IconTintMode = global::Android.Graphics.PorterDuff.Mode.Add,
 				IconTint = TransparentColorStateList,
 				SoundEffectsEnabled = false
 			};

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Android.Text;
 using Android.Views;
 using Android.Views.InputMethods;
 using Microsoft.Maui.Graphics;
@@ -16,7 +17,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				ImeOptions = ImeAction.Done,
 				Gravity = GravityFlags.Top,
-				TextAlignment = Android.Views.TextAlignment.ViewStart,
+				TextAlignment = global::Android.Views.TextAlignment.ViewStart,
 			};
 
 			editText.SetSingleLine(false);
@@ -113,7 +114,7 @@ namespace Microsoft.Maui.Handlers
 				handler.PlatformView.Focus(request);
 		}
 
-		void OnTextChanged(object? sender, Android.Text.TextChangedEventArgs e)
+		void OnTextChanged(object? sender, TextChangedEventArgs e)
 		{
 			// Let the mapping know that the update is coming from changes to the platform control
 			DataFlowDirection = DataFlowDirection.FromPlatform;

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Handlers
 				// the view size in some dimension. So we need to clip to the view's bounds.
 
 				var (left, top, right, bottom) = PlatformView.Context!.ToPixels(frame);
-				var clipRect = new Android.Graphics.Rect(0, 0, right - left, bottom - top);
+				var clipRect = new global::Android.Graphics.Rect(0, 0, right - left, bottom - top);
 				PlatformView.ClipBounds = clipRect;
 			}
 			else

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
+#if ANDROID
+using Android.App;
+#endif
 
 namespace Microsoft.Maui.Hosting
 {
@@ -26,8 +29,8 @@ namespace Microsoft.Maui.Hosting
 		{
 			builder.ConfigureLifecycleEvents(life =>
 			{
-#if __ANDROID__
-				ApplicationModel.Platform.Init((Android.App.Application)Android.App.Application.Context);
+#if ANDROID
+				ApplicationModel.Platform.Init((Application)Application.Context);
 
 				life.AddAndroid(android => android
 					.OnCreate((activity, savedInstanceState) =>

--- a/src/Core/src/IMauiContext.cs
+++ b/src/Core/src/IMauiContext.cs
@@ -1,4 +1,7 @@
 using System;
+#if ANDROID
+using Android.Content;
+#endif
 
 namespace Microsoft.Maui
 {
@@ -8,8 +11,8 @@ namespace Microsoft.Maui
 
 		IMauiHandlersFactory Handlers { get; }
 
-#if __ANDROID__
-		Android.Content.Context? Context { get; }
+#if ANDROID
+		Context? Context { get; }
 #endif
 	}
 }

--- a/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Android.cs
@@ -5,13 +5,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
+using Android.Widget;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui
 {
 	public partial class FileImageSourceService
 	{
-		public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, Android.Widget.ImageView imageView, CancellationToken cancellationToken = default)
+		public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, ImageView imageView, CancellationToken cancellationToken = default)
 		{
 			var fileImageSource = (IFileImageSource)imageSource;
 

--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Android.cs
@@ -5,13 +5,14 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
 using Android.Util;
+using Android.Widget;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui
 {
 	public partial class FontImageSourceService
 	{
-		public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, Android.Widget.ImageView imageView, CancellationToken cancellationToken = default)
+		public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, ImageView imageView, CancellationToken cancellationToken = default)
 		{
 			var fontImageSource = (IFontImageSource)imageSource;
 			if (!fontImageSource.IsEmpty)

--- a/src/Core/src/ImageSources/IImageSourceService.cs
+++ b/src/Core/src/ImageSources/IImageSourceService.cs
@@ -1,6 +1,10 @@
 ﻿#nullable enable
 using System.Threading;
 using System.Threading.Tasks;
+#if ANDROID
+using Android.Widget;
+using Android.Graphics.Drawables;
+#endif
 
 namespace Microsoft.Maui
 {
@@ -9,12 +13,12 @@ namespace Microsoft.Maui
 #if ANDROID
 		Task<IImageSourceServiceResult?> LoadDrawableAsync(
 			IImageSource imageSource,
-			Android.Widget.ImageView imageView,
+			ImageView imageView,
 			CancellationToken cancellationToken = default);
 
-		Task<IImageSourceServiceResult<Android.Graphics.Drawables.Drawable>?> GetDrawableAsync(
+		Task<IImageSourceServiceResult<Drawable>?> GetDrawableAsync(
 			IImageSource imageSource,
-			Android.Content.Context context,
+			global::Android.Content.Context context,
 			CancellationToken cancellationToken = default);
 #elif IOS
 		Task<IImageSourceServiceResult<UIKit.UIImage>?> GetImageAsync(

--- a/src/Core/src/ImageSources/ImageSourceService.cs
+++ b/src/Core/src/ImageSources/ImageSourceService.cs
@@ -3,6 +3,11 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+#if ANDROID
+using Android.Content;
+using Android.Graphics.Drawables;
+using Android.Widget;
+#endif
 
 namespace Microsoft.Maui
 {
@@ -15,10 +20,10 @@ namespace Microsoft.Maui
 
 		public ILogger? Logger { get; }
 
-#if __ANDROID__
+#if ANDROID
 		public virtual async Task<IImageSourceServiceResult?> LoadDrawableAsync(
 			IImageSource imageSource,
-			Android.Widget.ImageView imageView,
+			ImageView imageView,
 			CancellationToken cancellationToken = default)
 		{
 			var realResult = await GetDrawableAsync(imageSource, imageView.Context!, cancellationToken);
@@ -38,9 +43,9 @@ namespace Microsoft.Maui
 			return result;
 		}
 
-		public abstract Task<IImageSourceServiceResult<Android.Graphics.Drawables.Drawable>?> GetDrawableAsync(
+		public abstract Task<IImageSourceServiceResult<Drawable>?> GetDrawableAsync(
 			IImageSource imageSource,
-			Android.Content.Context context,
+			Context context,
 			CancellationToken cancellationToken = default);
 #elif __IOS__
 		public abstract Task<IImageSourceServiceResult<UIKit.UIImage>?> GetImageAsync(

--- a/src/Core/src/ImageSources/StreamImageSourceService/StreamImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/StreamImageSourceService/StreamImageSourceService.Android.cs
@@ -6,13 +6,14 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
 using Android.Runtime;
+using Android.Widget;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui
 {
 	public partial class StreamImageSourceService
 	{
-		public override async Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, Android.Widget.ImageView imageView, CancellationToken cancellationToken = default)
+		public override async Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, ImageView imageView, CancellationToken cancellationToken = default)
 		{
 			var streamImageSource = (IStreamImageSource)imageSource;
 

--- a/src/Core/src/ImageSources/UriImageSourceService/UriImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/UriImageSourceService/UriImageSourceService.Android.cs
@@ -4,13 +4,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
+using Android.Widget;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui
 {
 	public partial class UriImageSourceService
 	{
-		public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, Android.Widget.ImageView imageView, CancellationToken cancellationToken = default)
+		public override Task<IImageSourceServiceResult?> LoadDrawableAsync(IImageSource imageSource, ImageView imageView, CancellationToken cancellationToken = default)
 		{
 			var uriImageSource = (IUriImageSource)imageSource;
 			if (!uriImageSource.IsEmpty)

--- a/src/Core/src/MauiContext.cs
+++ b/src/Core/src/MauiContext.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
+#if ANDROID
+using Android.Content;
+#endif
 
 namespace Microsoft.Maui
 {
@@ -10,11 +13,11 @@ namespace Microsoft.Maui
 		readonly Lazy<IMauiHandlersFactory> _handlers;
 
 #if ANDROID
-		readonly Lazy<Android.Content.Context?> _context;
+		readonly Lazy<Context?> _context;
 
-		public Android.Content.Context? Context => _context.Value;
+		public Context? Context => _context.Value;
 
-		public MauiContext(IServiceProvider services, Android.Content.Context context)
+		public MauiContext(IServiceProvider services, Context context)
 			: this(services)
 		{
 			AddWeakSpecific(context);
@@ -30,7 +33,7 @@ namespace Microsoft.Maui
 
 			_handlers = new Lazy<IMauiHandlersFactory>(() => _services.GetRequiredService<IMauiHandlersFactory>());
 #if ANDROID
-			_context = new Lazy<Android.Content.Context?>(() => _services.GetService<Android.Content.Context>());
+			_context = new Lazy<Context?>(() => _services.GetService<Context>());
 #endif
 		}
 

--- a/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
+++ b/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using Android.OS;
+using Android.Views;
 using Android.Views.Accessibility;
 using AndroidX.Core.View;
 using AndroidX.Core.View.Accessibility;
@@ -61,7 +62,7 @@ namespace Microsoft.Maui.Platform
 			_originalDelegate.OnInitializeAccessibilityEvent(host, e);
 		}
 
-		public override bool OnRequestSendAccessibilityEvent(Android.Views.ViewGroup host, PlatformView child, AccessibilityEvent e)
+		public override bool OnRequestSendAccessibilityEvent(ViewGroup host, PlatformView child, AccessibilityEvent e)
 		{
 			return _originalDelegate.OnRequestSendAccessibilityEvent(host, child, e);
 		}

--- a/src/Core/src/Platform/Android/ActivityExtensions.cs
+++ b/src/Core/src/Platform/Android/ActivityExtensions.cs
@@ -1,28 +1,29 @@
 using Microsoft.Maui.Graphics;
+using Android.App;
 
 namespace Microsoft.Maui.Platform
 {
 	internal static partial class ActivityExtensions
 	{
-		internal static Rect GetWindowFrame(this Android.App.Activity activity)
+		internal static Rect GetWindowFrame(this Activity activity)
 		{
 			var bounds = PlatformInterop.GetCurrentWindowMetrics(activity);
 			return activity.FromPixels(bounds);
 		}
 
-		internal static void UpdateX(this Android.App.Activity activity, IWindow window) =>
+		internal static void UpdateX(this Activity activity, IWindow window) =>
 			activity.UpdateUnsupportedCoordinate(window);
 
-		internal static void UpdateY(this Android.App.Activity activity, IWindow window) =>
+		internal static void UpdateY(this Activity activity, IWindow window) =>
 			activity.UpdateUnsupportedCoordinate(window);
 
-		internal static void UpdateWidth(this Android.App.Activity activity, IWindow window) =>
+		internal static void UpdateWidth(this Activity activity, IWindow window) =>
 			activity.UpdateUnsupportedCoordinate(window);
 
-		internal static void UpdateHeight(this Android.App.Activity activity, IWindow window) =>
+		internal static void UpdateHeight(this Activity activity, IWindow window) =>
 			activity.UpdateUnsupportedCoordinate(window);
 
-		internal static void UpdateUnsupportedCoordinate(this Android.App.Activity activity, IWindow window) =>
+		internal static void UpdateUnsupportedCoordinate(this Activity activity, IWindow window) =>
 			window.FrameChanged(activity.GetWindowFrame());
 	}
 }

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Platform
 				context.FromPixels(rect.Width),
 				context.FromPixels(rect.Height));
 
-		internal static Rect FromPixels(this Context context, Android.Graphics.Rect rect) =>
+		internal static Rect FromPixels(this Context context, global::Android.Graphics.Rect rect) =>
 			new Rect(
 				context.FromPixels(rect.Left),
 				context.FromPixels(rect.Top),
@@ -248,7 +248,7 @@ namespace Microsoft.Maui.Platform
 			if (s_displayDensity != float.MinValue)
 				return;
 
-			context ??= Android.App.Application.Context;
+			context ??= global::Android.App.Application.Context;
 
 			using (DisplayMetrics? metrics = context.Resources?.DisplayMetrics)
 				s_displayDensity = metrics != null ? metrics.Density : 1;
@@ -333,7 +333,7 @@ namespace Microsoft.Maui.Platform
 			var windows = WindowExtensions.GetWindows();
 			foreach (var window in windows)
 			{
-				if (window.Handler?.PlatformView is Android.App.Activity activity)
+				if (window.Handler?.PlatformView is AActivity activity)
 				{
 					if (activity == platformWindow)
 						return window;

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Android.Content;
 using Android.Content.Res;
+using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Views;
@@ -373,7 +374,7 @@ namespace Microsoft.Maui.Platform
 		// Android.Graphics.Rect has a Containts(x,y) method, but it only takes `int` and the coordinates from
 		// the motion event are `float`. The we use GetX() and GetY() so our coordinates are relative to the
 		// bounds of the EditText.
-		static bool RectContainsMotionEvent(Android.Graphics.Rect rect, MotionEvent motionEvent)
+		static bool RectContainsMotionEvent(Rect rect, MotionEvent motionEvent)
 		{
 			var x = motionEvent.GetX();
 
@@ -393,7 +394,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		// Gets the location of the "Clear" button relative to the bounds of the EditText
-		static Android.Graphics.Rect GetClearButtonLocation(Android.Graphics.Rect buttonRect, EditText platformView)
+		static Rect GetClearButtonLocation(Rect buttonRect, EditText platformView)
 		{
 			// Determine the top and bottom edges of the button
 			// This assumes the button is vertically centered within the padded area of the EditText
@@ -414,14 +415,14 @@ namespace Microsoft.Maui.Platform
 				var rightEdge = platformView.Width - platformView.PaddingRight;
 				var leftEdge = rightEdge - buttonRect.Width();
 
-				return new Android.Graphics.Rect(leftEdge, topEdge, rightEdge, bottomEdge);
+				return new Rect(leftEdge, topEdge, rightEdge, bottomEdge);
 			}
 			else
 			{
 				var leftEdge = platformView.PaddingLeft;
 				var rightEdge = leftEdge + buttonRect.Width();
 
-				return new Android.Graphics.Rect(leftEdge, topEdge, rightEdge, bottomEdge);
+				return new Rect(leftEdge, topEdge, rightEdge, bottomEdge);
 			}
 		}
 	}

--- a/src/Core/src/Platform/Android/ImageSourcePartExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageSourcePartExtensions.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;
 using Android.Views;
+using Android.Widget;
 
 namespace Microsoft.Maui.Platform
 {
@@ -21,7 +22,7 @@ namespace Microsoft.Maui.Platform
 			if (context == null)
 				return null;
 
-			var destinationImageView = destinationContext as Android.Widget.ImageView;
+			var destinationImageView = destinationContext as ImageView;
 
 			if (destinationImageView is null && setImage is null)
 				return null;

--- a/src/Core/src/Platform/Android/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Android/MauiContextExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Platform
 		public static IMauiContext MakeScoped(this IMauiContext mauiContext,
 			LayoutInflater? layoutInflater = null,
 			FragmentManager? fragmentManager = null,
-			Android.Content.Context? context = null,
+			Context? context = null,
 			bool registerNewNavigationRoot = false)
 		{
 			var scopedContext = new MauiContext(mauiContext.Services);
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Platform
 		internal static View ToPlatform(
 			this IView view,
 			IMauiContext fragmentMauiContext,
-			Android.Content.Context context,
+			Context context,
 			LayoutInflater layoutInflater,
 			FragmentManager childFragmentManager)
 		{
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Platform
 			throw new InvalidOperationException("Unable to find Application Services");
 		}
 
-		public static Android.App.Activity GetPlatformWindow(this IMauiContext mauiContext) =>
-			mauiContext.Services.GetRequiredService<Android.App.Activity>();
+		public static global::Android.App.Activity GetPlatformWindow(this IMauiContext mauiContext) =>
+			mauiContext.Services.GetRequiredService<global::Android.App.Activity>();
 	}
 }

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
-		public MauiScrollView(Context context, Android.Util.IAttributeSet attrs) : base(context, attrs)
+		public MauiScrollView(Context context, IAttributeSet attrs) : base(context, attrs)
 		{
 		}
 
-		public MauiScrollView(Context context, Android.Util.IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
+		public MauiScrollView(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
 		{
 		}
 

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Android.App;
 using Android.Content;
+using Android.Content.PM;
 using Android.Views;
 using Android.Webkit;
 using Android.Widget;
@@ -18,7 +19,7 @@ namespace Microsoft.Maui.Platform
 		List<int> _requestCodes;
 		View _customView;
 		ICustomViewCallback _videoViewCallback;
-		Android.Content.PM.ScreenOrientation _originalOrientation;
+		ScreenOrientation _originalOrientation;
 		WindowInsetsControllerCompat _windowInsetsController;
 		bool _isSystemBarVisible;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Maui.Platform
 		{
 			_ = handler ?? throw new ArgumentNullException(nameof(handler));
 
-			_originalOrientation = Android.Content.PM.ScreenOrientation.Unspecified;
+			_originalOrientation = ScreenOrientation.Unspecified;
 
 			SetContext(handler);
 		}
@@ -103,9 +104,9 @@ namespace Microsoft.Maui.Platform
 			_videoViewCallback = callback;
 
 			_customView = view;
-			_customView.SetBackgroundColor(Android.Graphics.Color.White);
+			_customView.SetBackgroundColor(global::Android.Graphics.Color.White);
 
-			context.RequestedOrientation = Android.Content.PM.ScreenOrientation.Landscape;
+			context.RequestedOrientation = ScreenOrientation.Landscape;
 
 			// Handle system UI visibility based on Android version
 			if (OperatingSystem.IsAndroidVersionAtLeast(30))

--- a/src/Core/src/Platform/Android/SliderExtensions.cs
+++ b/src/Core/src/Platform/Android/SliderExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Platform
 				if (slider.ThumbColor is null && context.Theme is not null)
 				{
 					using var value = new TypedValue();
-					context.Theme.ResolveAttribute(Android.Resource.Attribute.ColorAccent, value, true);
+					context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true);
 					var color = new Color(value.Data);
 					seekBar.Thumb?.SetColorFilter(color, FilterMode.SrcIn);
 				}

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -3,6 +3,7 @@ using System.Net;
 using Android.Graphics;
 using Android.Text;
 using Android.Widget;
+using Android.Views;
 using static Android.Widget.TextView;
 using ALayoutDirection = Android.Views.LayoutDirection;
 using ATextDirection = Android.Views.TextDirection;
@@ -63,14 +64,14 @@ namespace Microsoft.Maui.Platform
 			{
 				// But if RTL support is not available for some reason, we have to resort
 				// to gravity, because Android will simply ignore text alignment
-				textView.Gravity = Android.Views.GravityFlags.Top | text.HorizontalTextAlignment.ToHorizontalGravityFlags();
+				textView.Gravity = GravityFlags.Top | text.HorizontalTextAlignment.ToHorizontalGravityFlags();
 			}
 
 			if (OperatingSystem.IsAndroidVersionAtLeast(26))
 			{
 				textView.JustificationMode = text.HorizontalTextAlignment == TextAlignment.Justify
-					? Android.Text.JustificationMode.InterWord
-					: Android.Text.JustificationMode.None;
+					? JustificationMode.InterWord
+					: JustificationMode.None;
 			}
 		}
 

--- a/src/Core/src/Platform/Android/ThemeExtensions.cs
+++ b/src/Core/src/Platform/Android/ThemeExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Android.Content.Res;
+using Android.Util;
 
 namespace Microsoft.Maui.Platform
 {
@@ -9,12 +10,12 @@ namespace Microsoft.Maui.Platform
 	{
 		public static bool TryResolveAttribute(this Resources.Theme? theme, int id)
 		{
-			return theme != null && theme.ResolveAttribute(id, new Android.Util.TypedValue(), resolveRefs: true);
+			return theme != null && theme.ResolveAttribute(id, new TypedValue(), resolveRefs: true);
 		}
 
 		public static bool TryResolveAttribute(this Resources.Theme? theme, int id, out bool? value)
 		{
-			using (var tv = new Android.Util.TypedValue())
+			using (var tv = new TypedValue())
 			{
 				if (theme != null && theme.ResolveAttribute(id, tv, resolveRefs: true))
 				{
@@ -33,7 +34,7 @@ namespace Microsoft.Maui.Platform
 
 		public static bool TryResolveAttribute(this Resources.Theme? theme, int id, out float? value)
 		{
-			using (var tv = new Android.Util.TypedValue())
+			using (var tv = new TypedValue())
 			{
 				if (theme != null && theme.ResolveAttribute(id, tv, resolveRefs: true))
 				{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -524,7 +524,7 @@ namespace Microsoft.Maui.Platform
 				return new Rect();
 
 			var context = platformView.Context;
-			var rect = new Android.Graphics.Rect();
+			var rect = new global::Android.Graphics.Rect();
 			platformView.GetGlobalVisibleRect(rect);
 
 			return new Rect(

--- a/src/Core/src/Primitives/WebProcessTerminatedEventArgs.cs
+++ b/src/Core/src/Primitives/WebProcessTerminatedEventArgs.cs
@@ -1,16 +1,21 @@
-﻿namespace Microsoft.Maui
+﻿#if ANDROID
+using Android.Views;
+using Android.Webkit;
+#endif
+
+namespace Microsoft.Maui
 {
 	public class WebProcessTerminatedEventArgs
 	{
 #if ANDROID
-		internal WebProcessTerminatedEventArgs(Android.Views.View? sender, Android.Webkit.RenderProcessGoneDetail? renderProcessGoneDetail)
+		internal WebProcessTerminatedEventArgs(View? sender, RenderProcessGoneDetail? renderProcessGoneDetail)
 		{
 			Sender = sender;
 			RenderProcessGoneDetail = renderProcessGoneDetail;
 		}
 
-		public Android.Views.View? Sender { get; }
-		public Android.Webkit.RenderProcessGoneDetail? RenderProcessGoneDetail { get; }
+		public View? Sender { get; }
+		public RenderProcessGoneDetail? RenderProcessGoneDetail { get; }
 #elif IOS || MACCATALYST
 		internal WebProcessTerminatedEventArgs(WebKit.WKWebView sender)
 		{

--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui
 				return new Point();
 
 			var decorView = nativeActivity.Window?.DecorView;
-			var rectangle = new Android.Graphics.Rect();
+			var rectangle = new global::Android.Graphics.Rect();
 
 			if (decorView is not null)
 			{

--- a/src/Essentials/src/AppActions/AppActions.shared.cs
+++ b/src/Essentials/src/AppActions/AppActions.shared.cs
@@ -2,6 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+#if ANDROID
+using Android.Content;
+#endif
 
 namespace Microsoft.Maui.ApplicationModel
 {
@@ -58,14 +61,14 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <summary>
 		/// The lifecycle event that is triggered when this app is launched.
 		/// </summary>
-		/// <param name="intent">The provided <see cref="Android.Content.Intent"/> to launch this app with.</param>
-		void OnNewIntent(Android.Content.Intent? intent);
+		/// <param name="intent">The provided <see cref="Intent"/> to launch this app with.</param>
+		void OnNewIntent(Intent? intent);
 
 		/// <summary>
 		/// The lifecycle event that is triggered when this app is launched.
 		/// </summary>
-		/// <param name="intent">The provided <see cref="Android.Content.Intent"/> to resume this app with.</param>
-		void OnResume(Android.Content.Intent? intent);
+		/// <param name="intent">The provided <see cref="Intent"/> to resume this app with.</param>
+		void OnResume(Intent? intent);
 #endif
 	}
 
@@ -161,16 +164,16 @@ namespace Microsoft.Maui.ApplicationModel
 		/// The lifecycle event that is triggered when this app is launched.
 		/// </summary>
 		/// <param name="appActions">Instance of the <see cref="IAppActions"/> object this event is invoked on.</param>
-		/// <param name="intent">The provided <see cref="Android.Content.Intent"/> to launch this app with.</param>
-		public static void OnNewIntent(this IAppActions appActions, Android.Content.Intent? intent) =>
+		/// <param name="intent">The provided <see cref="Intent"/> to launch this app with.</param>
+		public static void OnNewIntent(this IAppActions appActions, Intent? intent) =>
 			appActions.AsPlatform().OnNewIntent(intent);
 
 		/// <summary>
 		/// The lifecycle event that is triggered when this app is launched.
 		/// </summary>
 		/// <param name="appActions">Instance of the <see cref="IAppActions"/> object this event is invoked on.</param>
-		/// <param name="intent">The provided <see cref="Android.Content.Intent"/> to resume this app with.</param>
-		public static void OnResume(this IAppActions appActions, Android.Content.Intent? intent) =>
+		/// <param name="intent">The provided <see cref="Intent"/> to resume this app with.</param>
+		public static void OnResume(this IAppActions appActions, Intent? intent) =>
 			appActions.AsPlatform().OnResume(intent);
 #endif
 	}

--- a/src/Essentials/src/AppInfo/AppInfo.android.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.android.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.ApplicationModel
 			if (config == null)
 				return LayoutDirection.Unknown;
 
-			return (config.LayoutDirection == Android.Views.LayoutDirection.Rtl)
+			return (config.LayoutDirection == global::Android.Views.LayoutDirection.Rtl)
 				? LayoutDirection.RightToLeft
 				: LayoutDirection.LeftToRight;
 		}

--- a/src/Essentials/src/FilePicker/FilePicker.android.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.android.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
+using Environment = Android.OS.Environment;
 
 namespace Microsoft.Maui.Storage
 {
@@ -33,7 +34,7 @@ namespace Microsoft.Maui.Storage
 					// The uri returned is only temporary and only lives as long as the Activity that requested it,
 					// so this means that it will always be cleaned up by the time we need it because we are using
 					// an intermediate activity.
-					bool requireExtendedAccess = !(OperatingSystem.IsAndroidVersionAtLeast(30) && Android.OS.Environment.IsExternalStorageManager);
+					bool requireExtendedAccess = !(OperatingSystem.IsAndroidVersionAtLeast(30) && Environment.IsExternalStorageManager);
 
 					if (intent.ClipData == null)
 					{

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -91,10 +91,10 @@ namespace Microsoft.Maui.Devices.Sensors
 			var allProviders = LocationManager.GetProviders(false);
 
 			var providers = new List<string>();
-			if (allProviders.Contains(Android.Locations.LocationManager.GpsProvider))
-				providers.Add(Android.Locations.LocationManager.GpsProvider);
-			if (allProviders.Contains(Android.Locations.LocationManager.NetworkProvider))
-				providers.Add(Android.Locations.LocationManager.NetworkProvider);
+			if (allProviders.Contains(LocationManager.GpsProvider))
+				providers.Add(LocationManager.GpsProvider);
+			if (allProviders.Contains(LocationManager.NetworkProvider))
+				providers.Add(LocationManager.NetworkProvider);
 
 			if (providers.Count == 0)
 				providers.Add(providerInfo.Provider);
@@ -181,10 +181,10 @@ namespace Microsoft.Maui.Devices.Sensors
 			var allProviders = LocationManager.GetProviders(false);
 
 			listeningProviders = new List<string>();
-			if (allProviders.Contains(Android.Locations.LocationManager.GpsProvider))
-				listeningProviders.Add(Android.Locations.LocationManager.GpsProvider);
-			if (allProviders.Contains(Android.Locations.LocationManager.NetworkProvider))
-				listeningProviders.Add(Android.Locations.LocationManager.NetworkProvider);
+			if (allProviders.Contains(LocationManager.GpsProvider))
+				listeningProviders.Add(LocationManager.GpsProvider);
+			if (allProviders.Contains(LocationManager.NetworkProvider))
+				listeningProviders.Add(LocationManager.NetworkProvider);
 
 			if (listeningProviders.Count == 0)
 				listeningProviders.Add(providerInfo.Provider);

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Maui.ApplicationModel
 	public interface IActivityStateManager
 	{
 		/// <summary>
-		/// Initializes the <see cref="ActivityStateManager"/> for the given <see cref="Android.App.Application"/>.
+		/// Initializes the <see cref="ActivityStateManager"/> for the given <see cref="global::Android.App.Application"/>.
 		/// </summary>
-		/// <param name="application">The <see cref="Android.App.Application"/> to use for initialization.</param>
+		/// <param name="application">The <see cref="global::Android.App.Application"/> to use for initialization.</param>
 		void Init(Application application);
 
 		/// <summary>

--- a/src/Essentials/src/Platform/Platform.shared.cs
+++ b/src/Essentials/src/Platform/Platform.shared.cs
@@ -4,6 +4,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.Authentication;
 using Microsoft.Maui.Devices.Sensors;
+#if ANDROID
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+#endif
 
 namespace Microsoft.Maui.ApplicationModel
 {
@@ -25,14 +30,14 @@ namespace Microsoft.Maui.ApplicationModel
 		}
 
 		/// <summary>
-		/// Gets the <see cref="Android.Content.Context"/> object that represents the current application context.
+		/// Gets the <see cref="Context"/> object that represents the current application context.
 		/// </summary>
-		public static Android.Content.Context AppContext => Android.App.Application.Context;
+		public static Context AppContext => Application.Context;
 
 		// ActivityStateManager
 
 		/// <inheritdoc cref="IActivityStateManager.GetCurrentActivity"/>
-		public static Android.App.Activity? CurrentActivity =>
+		public static Activity? CurrentActivity =>
 			ActivityStateManager.Default.GetCurrentActivity();
 
 
@@ -44,15 +49,15 @@ namespace Microsoft.Maui.ApplicationModel
 		}
 
 		/// <inheritdoc cref="IActivityStateManager.WaitForActivityAsync(CancellationToken)"/>
-		public static Task<Android.App.Activity> WaitForActivityAsync(CancellationToken cancelToken = default) =>
+		public static Task<Activity> WaitForActivityAsync(CancellationToken cancelToken = default) =>
 			ActivityStateManager.Default.WaitForActivityAsync(cancelToken);
 
-		/// <inheritdoc cref="IActivityStateManager.Init(Android.App.Application)"/>
-		public static void Init(Android.App.Application application) =>
+		/// <inheritdoc cref="IActivityStateManager.Init(Application)"/>
+		public static void Init(Application application) =>
 			ActivityStateManager.Default.Init(application);
 
-		/// <inheritdoc cref="IActivityStateManager.Init(Android.App.Activity, Android.OS.Bundle?)"/>
-		public static void Init(Android.App.Activity activity, Android.OS.Bundle? bundle) =>
+		/// <inheritdoc cref="IActivityStateManager.Init(Activity, global::Android.OS.Bundle?)"/>
+		public static void Init(Activity activity, global::Android.OS.Bundle? bundle) =>
 			ActivityStateManager.Default.Init(activity, bundle);
 
 		// Permissions
@@ -63,23 +68,23 @@ namespace Microsoft.Maui.ApplicationModel
 		/// <param name="requestCode">The requestCode from the corresponding overridden method in an activity.</param>
 		/// <param name="permissions">The permissions from the corresponding overridden method in an activity.</param>
 		/// <param name="grantResults">The grantResults from the corresponding overridden method in an activity.</param>
-		public static void OnRequestPermissionsResult(int requestCode, string[] permissions, Android.Content.PM.Permission[] grantResults) =>
+		public static void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults) =>
 			Permissions.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 
 		// AppActions
 
 		/// <summary>
-		/// Called when a new <see cref="Android.Content.Intent"/> was created as part of invoking an app action.
+		/// Called when a new <see cref="Intent"/> was created as part of invoking an app action.
 		/// </summary>
-		/// <param name="intent">The <see cref="Android.Content.Intent"/> that is created.</param>
-		public static void OnNewIntent(Android.Content.Intent? intent) =>
+		/// <param name="intent">The <see cref="Intent"/> that is created.</param>
+		public static void OnNewIntent(global::Android.Content.Intent? intent) =>
 			AppActions.Current.OnNewIntent(intent);
 
 		/// <summary>
-		/// Called when a <see cref="Android.App.Activity"/> is resumed as part of invoking an app action.
+		/// Called when a <see cref="Activity"/> is resumed as part of invoking an app action.
 		/// </summary>
-		/// <param name="activity">The <see cref="Android.App.Activity"/> that is resumed.</param>
-		public static void OnResume(Android.App.Activity? activity = null) =>
+		/// <param name="activity">The <see cref="Activity"/> that is resumed.</param>
+		public static void OnResume(Activity? activity = null) =>
 			AppActions.Current.OnResume(activity?.Intent);
 
 #elif IOS || MACCATALYST

--- a/src/Essentials/src/Screenshot/Screenshot.shared.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.shared.cs
@@ -3,6 +3,10 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
+#if ANDROID
+using Android.App;
+using Android.Views;
+#endif
 
 namespace Microsoft.Maui.Media
 {
@@ -34,14 +38,14 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="activity">The activity to capture.</param>
 		/// <returns>An instance of <see cref="IScreenshotResult"/> with information about the captured screenshot.</returns>
-		Task<IScreenshotResult> CaptureAsync(Android.App.Activity activity);
+		Task<IScreenshotResult> CaptureAsync(Activity activity);
 
 		/// <summary>
 		/// Captures a screenshot of the specified view.
 		/// </summary>
 		/// <param name="view">The view to capture.</param>
 		/// <returns>An instance of <see cref="IScreenshotResult"/> with information about the captured screenshot.</returns>
-		Task<IScreenshotResult?> CaptureAsync(Android.Views.View view);
+		Task<IScreenshotResult?> CaptureAsync(View view);
 #elif IOS || MACCATALYST
 		/// <summary>
 		/// Captures a screenshot of the specified window.
@@ -185,7 +189,7 @@ namespace Microsoft.Maui.Media
 		/// <param name="screenshot">The object this method is invoked on.</param>
 		/// <param name="activity">The activity to capture.</param>
 		/// <returns>An instance of <see cref="IScreenshotResult"/> with information about the captured screenshot.</returns>
-		public static Task<IScreenshotResult> CaptureAsync(this IScreenshot screenshot, Android.App.Activity activity) =>
+		public static Task<IScreenshotResult> CaptureAsync(this IScreenshot screenshot, Activity activity) =>
 			screenshot.AsPlatform().CaptureAsync(activity);
 
 		/// <summary>
@@ -194,7 +198,7 @@ namespace Microsoft.Maui.Media
 		/// <param name="screenshot">The object this method is invoked on.</param>
 		/// <param name="view">The view to capture.</param>
 		/// <returns>An instance of <see cref="IScreenshotResult"/> with information about the captured screenshot.</returns>
-		public static Task<IScreenshotResult?> CaptureAsync(this IScreenshot screenshot, Android.Views.View view) =>
+		public static Task<IScreenshotResult?> CaptureAsync(this IScreenshot screenshot, View view) =>
 			screenshot.AsPlatform().CaptureAsync(view);
 
 #elif IOS || MACCATALYST

--- a/src/Essentials/src/SecureStorage/SecureStorage.android.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.android.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Storage
 				return CreateEncryptedSharedPreferences();
 			}
 			catch (System.Exception ex)
-			when (ex is InvalidProtocolBufferException or Android.Security.KeyStoreException or KeyStoreException or BadPaddingException)
+			when (ex is InvalidProtocolBufferException or global::Android.Security.KeyStoreException or KeyStoreException or BadPaddingException)
 			{
 				// If we encounter any of these exceptions, it's likely due to a corrupt key or bad migration between devices
 				// There isn't much to do at this point except try to delete the shared preferences so we can recreate them

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.android.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.android.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Android.App;
+using Android.Content;
 using Android.Views.Accessibility;
 
 namespace Microsoft.Maui.Accessibility
@@ -7,7 +9,7 @@ namespace Microsoft.Maui.Accessibility
 	{
 		public void Announce(string text)
 		{
-			var manager = Android.App.Application.Context.GetSystemService(Android.Content.Context.AccessibilityService) as AccessibilityManager;
+			var manager = Application.Context.GetSystemService(Context.AccessibilityService) as AccessibilityManager;
 			var announcement = OperatingSystem.IsAndroidVersionAtLeast(33)
 				? new AccessibilityEvent()
 #pragma warning disable 618

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -5,6 +5,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
+#if ANDROID
+using Android.Content;
+#endif
 
 namespace Microsoft.Maui.Authentication
 {
@@ -58,9 +61,9 @@ namespace Microsoft.Maui.Authentication
 		/// <summary>
 		/// The event that is triggered when an authentication flow calls back into the Android application.
 		/// </summary>
-		/// <param name="intent">An <see cref="Android.Content.Intent"/> object containing additional data about this resume operation.</param>
+		/// <param name="intent">An <see cref="Intent"/> object containing additional data about this resume operation.</param>
 		/// <returns><see langword="true"/> when the callback can be processed, otherwise <see langword="false"/>.</returns>
-		bool OnResumeCallback(Android.Content.Intent intent);
+		bool OnResumeCallback(Intent intent);
 #endif
 	}
 
@@ -204,8 +207,8 @@ namespace Microsoft.Maui.Authentication
 		}
 
 #elif ANDROID
-		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnResumeCallback(Android.Content.Intent)"/>
-		public static bool OnResume(this IWebAuthenticator webAuthenticator, Android.Content.Intent intent) =>
+		/// <inheritdoc cref="IPlatformWebAuthenticatorCallback.OnResumeCallback(Intent)"/>
+		public static bool OnResume(this IWebAuthenticator webAuthenticator, Intent intent) =>
 			webAuthenticator.AsPlatformCallback().OnResumeCallback(intent);
 #endif
 	}


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9973

We introduced a new `internal` type in `Mono.Android.dll`:

    namespace Microsoft.Android.Runtime;

    class ManagedValueManager : JniRuntime.JniValueManager

Causes various C# compiler errors in dotnet/maui:

    D:\src\maui\src\Essentials\src\AppActions\AppActions.shared.cs(62,28):
    error CS0234: The type or namespace name 'Content' does not exist in the namespace 'Microsoft.Android' (are you missing an assembly reference?)

At some point in .NET 10 (or future), we will likely introduce a *public* type in `Microsoft.Android` namespace.

This means MAUI's codebase will need to be fixed in a .NET 10 timeframe, so instead of:

    Android.Content.Context content;

This works:

    using Android.Content;
    //...
    Context content;

Because the `using Android.Content;` directive is scoped *outside* of a `Microsoft.*` namespace.

We don't anticipate this to be a problem with customers, because they aren't writing code in `Microsoft.*` namespaces.

I generally took the approach:

* Use `using Android.Content;` if possible.

* Use `global::` if that caused other conflicts.

* Use `using AView = Android.Views.View;` in Microsoft.Maui.Controls or other places this is commonly used.

* Update `#if __ANDROID__` to `#if ANDROID` in a few places.