### PR TITLE
[Proposal] Removed the default span styling from the template

### DIFF
--- a/src/Controls/samples/Controls.Sample.Embedding/Resources/Styles/Styles.xaml
+++ b/src/Controls/samples/Controls.Sample.Embedding/Resources/Styles/Styles.xaml
@@ -173,10 +173,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Span">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-    </Style>
-
     <Style TargetType="Label" x:Key="Headline">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="32" />

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -200,10 +200,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Span">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-    </Style>
-
     <Style TargetType="Label" x:Key="Headline">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="32" />

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Styles.xaml
@@ -173,10 +173,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Span">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-    </Style>
-
     <Style TargetType="Label" x:Key="Headline">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource MidnightBlue}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="32" />


### PR DESCRIPTION
### Description of Change

Some developers prefer to use global styles for their Label controls and expect that properties like `TextColor` will cascade to Span. However, the default `Styles.xaml` file in the MAUI template includes an explicit style targeting Span, which overrides inherited properties—specifically `TextColor`.

This default Span style unnecessarily duplicates the `TextColor`  of Label, causing confusion when global styles don't behave as expected. Removing the Span style resolves the issue by allowing properties such as TextColor to be inherited from the parent Label, as intended.

This change simplifies styling and ensures a more consistent and predictable behavior for developers customizing label appearance via global styles.

