### PR TITLE
[iOS] Fix for the File.ContentType from MediaPicker not being in valid MIME format

### DIFF
--- a/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Storage
 			// return mimeTypes?.Length > 0 ? mimeTypes[0] : null;
 
 			var uti = UniformTypeIdentifiers.UTType.GetType(extension, UniformTypeIdentifiers.UTTagClass.FilenameExtension, null);
-			extension = uti?.PreferredMimeType;
+			extension = uti?.PreferredMimeType ?? extension;
 
 			return extension;
 		}

--- a/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
@@ -71,6 +71,9 @@ namespace Microsoft.Maui.Storage
 			// var mimeTypes = UTType.CopyAllTags(id, UniformTypeIdentifiers.UTTagClass.MimeType.ToString());
 			// return mimeTypes?.Length > 0 ? mimeTypes[0] : null;
 
+			var uti = UniformTypeIdentifiers.UTType.GetType(extension, UniformTypeIdentifiers.UTTagClass.FilenameExtension, null);
+			extension = uti?.PreferredMimeType;
+
 			return extension;
 		}
 

--- a/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
@@ -67,10 +67,6 @@ namespace Microsoft.Maui.Storage
 			// ios does not like the extensions
 			extension = extension?.TrimStart('.');
 
-			// var id = UTType.CreatePreferredIdentifier(UTType.TagClassFilenameExtension, extension, null);
-			// var mimeTypes = UTType.CopyAllTags(id, UniformTypeIdentifiers.UTTagClass.MimeType.ToString());
-			// return mimeTypes?.Length > 0 ? mimeTypes[0] : null;
-
 			var uti = UniformTypeIdentifiers.UTType.GetType(extension, UniformTypeIdentifiers.UTTagClass.FilenameExtension, null);
 			extension = uti?.PreferredMimeType ?? extension;
 

--- a/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs
@@ -67,8 +67,12 @@ namespace Microsoft.Maui.Storage
 			// ios does not like the extensions
 			extension = extension?.TrimStart('.');
 
-			var uti = UniformTypeIdentifiers.UTType.GetType(extension, UniformTypeIdentifiers.UTTagClass.FilenameExtension, null);
-			extension = uti?.PreferredMimeType ?? extension;
+			// UTType supports only iOS version greater than 14
+			if (OperatingSystem.IsIOSVersionAtLeast(14))
+			{
+				var uti = UniformTypeIdentifiers.UTType.GetType(extension, UniformTypeIdentifiers.UTTagClass.FilenameExtension, null);
+				extension = uti?.PreferredMimeType ?? extension;
+			}
 
 			return extension;
 		}

--- a/src/Essentials/test/DeviceTests/Tests/FileSystem_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/FileSystem_Tests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			await Assert.ThrowsAsync<FileNotFoundException>(() => FileSystem.OpenAppPackageFileAsync("MissingFile.txt")).ConfigureAwait(false);
 		}
 
-#if __MACCATALYST__
+#if MACCATALYST
 		[Fact]
 		public async Task ValidateMIMEFormat()
 		{
@@ -52,7 +52,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			await File.WriteAllTextAsync(filePath, "File Content type is text/plain");
 
 			FileResult fileResult = new FileResult(filePath);
-
 			Assert.Equal("text/plain", fileResult.ContentType);
 
 			File.Delete(filePath);

--- a/src/Essentials/test/DeviceTests/Tests/FileSystem_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/FileSystem_Tests.cs
@@ -43,5 +43,20 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			await Assert.ThrowsAsync<FileNotFoundException>(() => FileSystem.OpenAppPackageFileAsync("MissingFile.txt")).ConfigureAwait(false);
 		}
+
+#if __MACCATALYST__
+		[Fact]
+		public async Task ValidateMIMEFormat()
+		{
+			string filePath = Path.Combine(FileSystem.CacheDirectory, "sample.txt");
+			await File.WriteAllTextAsync(filePath, "File Content type is text/plain");
+
+			FileResult fileResult = new FileResult(filePath);
+
+			Assert.Equal("text/plain", fileResult.ContentType);
+
+			File.Delete(filePath);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
### Issue Details

- ContentType property from the file received after calling MediaPicker.PickPhotoAsync is not in the MIME format.

### Root Cause

- Mapping the file extension to a MIME type is not done. The PlatformGetContentType method currently just returns the extension. 

### Description of Change

- UTType is only supported starting with iOS 14.0. Therefore If the application is running on iOS 14 or later, retrieved the Uniform Type Identifier (UTI) for a given file extension and obtained the associated PreferredMIMEType property of the Uniform Type Identifier. If a valid MIME type is found, assigned the MIME type to the file extension. Otherwise, returned the original file extension.
- `src/Essentials/src/FileSystem/FileSystem.ios.tvos.watchos.macos.cs`: Modified the PlatformGetContentType method to use UniformTypeIdentifiers.UTType.GetType for better MIME type resolution.

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Issues Fixed
Fixes #15562 

### Output

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/351a1a8b-faf0-4df4-857a-c71e7d68d380"> | <video src="https://github.com/user-attachments/assets/4dc655dd-b9b5-45bd-a8ed-9209e04bca8a"> |
