### PR TITLE
Fixed the span text disappeared in label when setting the font attribute on span and setting an implicit style for Label on content page

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Controls.Platform
 				if (font.IsDefault && defaultFont.HasValue)
 					font = defaultFont.Value;
 				if (!font.IsDefault)
-					spannable.SetSpan(new PlatformFontSpan(context ?? AAplication.Context, font.ToTypeface(fontManager), font.AutoScalingEnabled, (float)font.Size), start, end, SpanTypes.InclusiveInclusive);
+					spannable.SetSpan(new PlatformFontSpan(context ?? AAplication.Context, font.ToTypeface(fontManager), font.AutoScalingEnabled, (float)fontManager.GetFontSize(font).Value), start, end, SpanTypes.InclusiveInclusive);
 
 				// TextDecorations
 				var textDecorations = span.IsSet(Span.TextDecorationsProperty)


### PR DESCRIPTION
### Issue details
When setting the FontAttributes in a Span within a Label, and applying an implicit style to the Label (without specifying the FontSize in the style) from the ContentPage resources, while a global default style for label font size is defined in App.xaml, the default font is not applied correctly. Therefore span text disappeared.

### Root cause
When setting FontAttributes in a Span within a Label, and applying an implicit style to the Label (without specifying the FontSize) from the ContentPage resources, while a global default style for label font size is defined in App.xaml, the default font is not applied because the implicit style does not explicitly define default FontSize.

### Description changes
I retrieved the font size using FontManager.GetFontSize() instead of relying on the default font size from the Label, since font.IsDefault is false when setting FontAttributes in a Span within a Label.

Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference
https://github.com/dotnet/maui/blob/af78f88526422a6d3415fa7d338736ec38345f17/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs#L107

### Test Case
The issue raises when adding the font size style globally in the application's resource file. As a result, I was unable to apply the global style in the host app, and I couldn't find any reference for applying the style globally.

### Issues Fixed

Fixes #19190


### Output images:

| Before  | After  |
|---------|--------|
|<img src="https://github.com/user-attachments/assets/81029427-d9d3-400f-9dc0-a15ab140063c" width="300" height="600"> | <img src="https://github.com/user-attachments/assets/87d4f63a-7888-4ce9-b87c-8e7b43108810" width="300" height="600"> |

