### PR TITLE
Improve TFM condition for sample content template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -84,8 +84,7 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
 <!--#if (Framework == "net8.0") -->
 		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
-<!--#endif-->
-<!--#if (Framework == "net9.0") -->
+<!--#else-->
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.1" />
 <!--#endif-->
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -64,8 +64,7 @@
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
 <!--#if (Framework == "net8.0") -->
                                         Flags="ValidateOnUnfocusing"
-<!--#endif -->
-<!--#if (Framework == "net9.0") -->
+<!--#else -->
                                         Flags="ValidateOnUnfocused"
 <!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
@@ -111,8 +110,7 @@
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
 <!--#if (Framework == "net8.0") -->
                                         Flags="ValidateOnUnfocusing"
-<!--#endif -->
-<!--#if (Framework == "net9.0") -->
+<!--#else -->
                                         Flags="ValidateOnUnfocused"
 <!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />


### PR DESCRIPTION
### Description of Change

This PR improves the TFM condition for the sample content template to not only include the reference for the .NET MAUI Community Toolkit when targeting .NET 9, but also include it for anything else.

Before there would be an if statement checking for .NET 8 and .NET 9 specifically. Now the check looks for .NET 8 and the alternative path is now just al "else" so that it also works with .NET 10 (or 11, or 12, etc.)

In either case this should be temporary anyway: #28800 