### PR TITLE
Changes to fix Android emulators boot issues on Linux

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -597,7 +597,7 @@ void PrepareDevice(bool waitForBoot)
 	{
 		Information("Waiting for the emulator to finish booting...");
 
-		// wait for it to finish booting
+		// Wait for it to finish booting
 		var waited = 0;
 		var total = EmulatorBootTimeoutSeconds;
 		while (AdbShell("getprop sys.boot_completed", settings).FirstOrDefault() != "1")
@@ -610,8 +610,8 @@ void PrepareDevice(bool waitForBoot)
 				throw new Exception("The emulator did not finish booting in time.");
 			}
 
-			// something may be wrong with ADB, so restart every 30 seconds just in case
-			if (waited % 30 == 0 && IsCIBuild())
+			// Something may be wrong with ADB, so restart every 60 seconds just in case
+			if (waited % 60 == 0 && IsCIBuild())
 			{
                 // Ensure adbkey and adbkey.pub are in place in CI builds
                 Information("Ensuring ADB keys are correctly configured for CI environment...");
@@ -632,6 +632,14 @@ void PrepareDevice(bool waitForBoot)
                     AdbStartServer(settings);
 
                     Information("ADB keys have been successfully regenerated.");
+
+                    // Manually Authorize the Emulator
+                    AdbShell("adb shell settings put global adb_enabled 1", settings);
+
+                    // Ensure the emulator has USB Debugging enabled
+                    AdbShell("adb shell settings put global development_settings_enabled 1", settings);
+
+                    Information("Emulator authorized successfully.");
                 }
                 catch (Exception ex)
                 {

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -631,15 +631,29 @@ void PrepareDevice(bool waitForBoot)
                     AdbKillServer(settings);
                     AdbStartServer(settings);
 
-                    Information("ADB keys have been successfully regenerated.");
+                    bool adbKeyExists = System.IO.File.Exists(adbKeyFile);
 
-                    // Manually Authorize the Emulator
-                    AdbShell("adb shell settings put global adb_enabled 1", settings);
+                    if(adbKeyExists)
+                    {
+                        Information("ADB keys have been successfully regenerated.");
 
-                    // Ensure the emulator has USB Debugging enabled
-                    AdbShell("adb shell settings put global development_settings_enabled 1", settings);
+                        // Ensure that the ~/.android directory has the correct permissions
+                        StartProcess("chmod", $"700 {adbKeyPath}");
+                        StartProcess("chmod", $"600 {adbKeyFile}");
+                        StartProcess("chmod", $"600 {adbKeyPubFile}");
+                        
+                        // Manually Authorize the Emulator
+                        AdbShell("adb shell settings put global adb_enabled 1", settings);
 
-                    Information("Emulator authorized successfully.");
+                        // Ensure the emulator has USB Debugging enabled
+                        AdbShell("adb shell settings put global development_settings_enabled 1", settings);
+
+                        Information("Emulator authorized successfully.");
+                    }
+                    else
+                    {
+                        Information($"ADB keys were not found {adbKeyPath}. Please check the ADB installation.");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -652,7 +652,8 @@ void PrepareDevice(bool waitForBoot)
                     }
                     else
                     {
-                        Information($"ADB keys were not found {adbKeyPath}. Please check the ADB installation.");
+                        Information($"ADB keys were not found {adbKeyPath}. Trying to restart ADB just in case...");
+                        AdbKillServer(adbSettings);
                     }
                 }
                 catch (Exception ex)

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -593,6 +593,33 @@ void PrepareDevice(bool waitForBoot)
 		settings.Serial = DEVICE_UDID;
 	}
 
+    // Ensure adbkey and adbkey.pub are in place in CI builds
+    if (IsCIBuild())
+    {
+        Information("Ensuring ADB keys are correctly configured for CI environment...");
+        try
+        {
+            var adbKeyPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".android");
+            var adbKeyFile = System.IO.Path.Combine(adbKeyPath, "adbkey");
+            var adbKeyPubFile = System.IO.Path.Combine(adbKeyPath, "adbkey.pub");
+
+            // Deletes existing adbkey and adbkey.pub files in the ~/.android directory to ensure no stale keys remain
+            if (System.IO.File.Exists(adbKeyFile)) System.IO.File.Delete(adbKeyFile);
+            if (System.IO.File.Exists(adbKeyPubFile)) System.IO.File.Delete(adbKeyPubFile);
+
+            // Regenerates ADB keys using AdbKillServer and AdbStartServer
+            Information("Regenerating ADB keys...");
+            AdbKillServer(settings);
+            AdbStartServer(settings);
+
+            Information("ADB keys have been successfully regenerated.");
+        }
+        catch (Exception ex)
+        {
+            Warning($"Error ensuring ADB keys: {ex.Message}");
+        }
+    }
+
 	if (waitForBoot)
 	{
 		Information("Waiting for the emulator to finish booting...");


### PR DESCRIPTION
### Description of Change

Changes to try to fix android emulators boot issues on Linux.

Sometimes, when trying to launch the Android emulator on Linux to run UITests we are getting the following error:
```
Executing: /usr/local/lib/android/sdk/platform-tools/adb shell getprop sys.boot_completed
adb: device unauthorized.
This adb server's $ADB_VENDOR_KEYS is not set
Try 'adb kill-server' if that seems wrong.
Otherwise check for a confirmation dialog on your device.
```

This PR include changes to:

- Added code to ensure that adbkey and adbkey.pub files in the ~/.android directory exists.
- Sets appropriate file permissions to ensure secure and proper access to ADB keys (chmod).
- Adds shell commands via AdbShell to ensure proper emulator configuration: ensure ADB debugging enabled