### PR TITLE
[iOS] Fix FlyoutPage does not respond to changes in the FlyoutLayoutBehavior property

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -367,25 +367,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.FlyoutPage.ApplyShadowProperty.PropertyName)
 				UpdateApplyShadow(((FlyoutPage)Element).OnThisPlatform().GetApplyShadow());
 			else if (e.PropertyName == Microsoft.Maui.Controls.FlyoutPage.FlyoutLayoutBehaviorProperty.PropertyName) 
-			{
-				var flyoutPage = (FlyoutPage)Element;
-				bool isPresented = flyoutPage.IsPresented;
-
-				LayoutChildren(true);
-
-				bool shouldPresent = FlyoutPageController.ShouldShowSplitMode;
-
-				if (FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover || FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Default)
-				{
-					shouldPresent = false;
-				}
-
-				if (shouldPresent != isPresented)
-				{
-					((IElementController)Element).SetValueFromRenderer(FlyoutPage.IsPresentedProperty, shouldPresent);
-					UpdateLeftBarButton();
-				}
-			}
+				UpdateFlyoutLayoutBehavior();				
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName ||
 					 e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty.PropertyName)
 				UpdatePageSpecifics();
@@ -494,6 +476,27 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (Presented)
 				UpdateClickOffViewFrame();
+		}
+
+		void UpdateFlyoutLayoutBehavior()
+		{
+			var flyoutPage = (FlyoutPage)Element;
+				bool isPresented = flyoutPage.IsPresented;
+
+				LayoutChildren(true);
+
+				bool shouldPresent = FlyoutPageController.ShouldShowSplitMode;
+
+				if (FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover || FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Default)
+				{
+					shouldPresent = false;
+				}
+
+				if (shouldPresent != isPresented)
+				{
+					((IElementController)Element).SetValueFromRenderer(FlyoutPage.IsPresentedProperty, shouldPresent);
+					UpdateLeftBarButton();
+				}
 		}
 
 		void PackContainers()

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.FlyoutPage.ApplyShadowProperty.PropertyName)
 				UpdateApplyShadow(((FlyoutPage)Element).OnThisPlatform().GetApplyShadow());
 			else if (e.PropertyName == Microsoft.Maui.Controls.FlyoutPage.FlyoutLayoutBehaviorProperty.PropertyName) 
-				UpdateFlyoutLayoutBehavior();				
+				UpdateFlyoutLayoutBehaviorChanges();				
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName ||
 					 e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty.PropertyName)
 				UpdatePageSpecifics();
@@ -478,25 +478,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateClickOffViewFrame();
 		}
 
-		void UpdateFlyoutLayoutBehavior()
+		void UpdateFlyoutLayoutBehaviorChanges()
 		{
-			var flyoutPage = (FlyoutPage)Element;
-				bool isPresented = flyoutPage.IsPresented;
-
-				LayoutChildren(true);
-
-				bool shouldPresent = FlyoutPageController.ShouldShowSplitMode;
-
-				if (FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover || FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Default)
-				{
-					shouldPresent = false;
-				}
-
-				if (shouldPresent != isPresented)
-				{
-					((IElementController)Element).SetValueFromRenderer(FlyoutPage.IsPresentedProperty, shouldPresent);
-					UpdateLeftBarButton();
-				}
+			LayoutChildren(true);
+            FlyoutPage flyoutPage = (FlyoutPage)Element;
+            FlyoutLayoutBehavior flyoutBehavior = FlyoutPage.FlyoutLayoutBehavior;
+            bool shouldPresent = FlyoutPageController.ShouldShowSplitMode;
+            if (flyoutBehavior == FlyoutLayoutBehavior.Popover || flyoutBehavior == FlyoutLayoutBehavior.Default)
+            {
+                shouldPresent = false;
+            }
+ 
+            if (shouldPresent != flyoutPage.IsPresented)
+            {
+                ((IElementController)Element).SetValueFromRenderer(FlyoutPage.IsPresentedProperty, shouldPresent);
+                UpdateLeftBarButton();
+            }
 		}
 
 		void PackContainers()

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -481,7 +481,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void UpdateFlyoutLayoutBehaviorChanges()
 		{
 			LayoutChildren(true);
-            FlyoutPage flyoutPage = (FlyoutPage)Element;
+            FlyoutPage flyoutPage = Element as FlyoutPage;
+			if (flyoutPage == null) 
+				return;
             FlyoutLayoutBehavior flyoutBehavior = FlyoutPage.FlyoutLayoutBehavior;
             bool shouldPresent = FlyoutPageController.ShouldShowSplitMode;
             if (flyoutBehavior == FlyoutLayoutBehavior.Popover || flyoutBehavior == FlyoutLayoutBehavior.Default)

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -366,6 +366,26 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateBackground();
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.FlyoutPage.ApplyShadowProperty.PropertyName)
 				UpdateApplyShadow(((FlyoutPage)Element).OnThisPlatform().GetApplyShadow());
+			else if (e.PropertyName == Microsoft.Maui.Controls.FlyoutPage.FlyoutLayoutBehaviorProperty.PropertyName) 
+			{
+				var flyoutPage = (FlyoutPage)Element;
+				bool isPresented = flyoutPage.IsPresented;
+
+				LayoutChildren(true);
+
+				bool shouldPresent = FlyoutPageController.ShouldShowSplitMode;
+
+				if (FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover || FlyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Default)
+				{
+					shouldPresent = false;
+				}
+
+				if (shouldPresent != isPresented)
+				{
+					((IElementController)Element).SetValueFromRenderer(FlyoutPage.IsPresentedProperty, shouldPresent);
+					UpdateLeftBarButton();
+				}
+			}
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName ||
 					 e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty.PropertyName)
 				UpdatePageSpecifics();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18158.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18158.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 18158, "FlyoutPage does not respond to changes in the FlyoutLayoutBehavior property", PlatformAffected.iOS)]
+public class Issue18158 : TestFlyoutPage
+{
+	Button _button;
+	protected override void Init()
+	{
+		_button = new Button{ Text="Click", AutomationId = "Button"};
+		FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
+		// Define the Flyout page
+		Flyout = new ContentPage
+		{
+			Title = "Menu",
+			
+			Content = new StackLayout
+			{
+				Children =
+				{
+					_button,
+				}
+			}
+		};
+
+		_button.Clicked += (s,e) =>
+		{
+			if (this.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Split)
+			{
+				this.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover;
+			}
+			else
+			{
+				this.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
+			}
+		};
+
+
+		// Define the Detail page
+		Detail = new NavigationPage(new ContentPage
+		{
+			Title = "Detail Page",
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Label { Text = "Welcome to the Detail Page!", AutomationId = "Label" },
+				}
+			}
+		});
+
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18158.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18158.cs
@@ -1,0 +1,26 @@
+#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_IOS    //FlyoutLayoutBehavior changes are not supported on Android and iOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue18158 : _IssuesUITest
+{
+	public Issue18158(TestDevice device)
+		: base(device)
+	{ }
+
+	public override string Issue => "FlyoutPage does not respond to changes in the FlyoutLayoutBehavior property";
+
+	[Test]
+	[Category(UITestCategories.FlyoutPage)]
+	public void VerifyFlyoutLayoutBehaviorChanges()
+	{
+		App.WaitForElement("Button");
+		App.Tap("Button");
+		App.WaitForElement("Label");
+	}
+}
+
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18158.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18158.cs
@@ -20,6 +20,7 @@ public class Issue18158 : _IssuesUITest
 		App.WaitForElement("Button");
 		App.Tap("Button");
 		App.WaitForElement("Label");
+		App.WaitForNoElement("Button");
 	}
 }
 


### PR DESCRIPTION
### Root cause
FlyoutPage did not handle dynamic updates to the FlyoutLayoutBehavior property at runtime on iOS, causing the layout to remain unchanged when the behavior was modified.

### Description of Change

Introduced a new method UpdateFlyoutLayoutBehaviorChanges in PhoneFlyoutPageRenderer to handle runtime changes to FlyoutLayoutBehavior. The HandlePropertyChanged method was updated to invoke this logic when the behavior changes

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #18158 

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **Mac**<br> <video src="https://github.com/user-attachments/assets/c4fe3a13-8190-4512-9d4d-af6bed227f4d" width="260" height="500"> |**Mac**<br> <video src="https://github.com/user-attachments/assets/8d0b7a90-a7df-45c7-8660-dc59e8ea5af0" width="260" height="500"> |
