### PR TITLE
[Windows] Upgrade `Microsoft.Graphics.Win2D` from `1.2.0` to `1.3.2` to fix a build warning

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.7.250401001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
-    <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
+    <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.2903.40</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAuthorizationPackageVersion>9.0.4</MicrosoftAspNetCoreAuthorizationPackageVersion>

--- a/src/Core/src/nuget/buildTransitive/WinUI.targets
+++ b/src/Core/src/nuget/buildTransitive/WinUI.targets
@@ -9,6 +9,10 @@
     <Version Condition=" '$(ApplicationDisplayVersion)' != '' ">$(ApplicationDisplayVersion)</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Win2DWarnNoPlatform>false</Win2DWarnNoPlatform>
+  </PropertyGroup>
+
   <Target Name="_AddMauiPriFiles" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <_ReferenceRelatedPaths

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -38,6 +38,7 @@
   <ItemGroup Condition=" $(TargetFramework.Contains('-windows')) ">
     <Compile Include="**\*.uwp.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.uwp.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <PackageReference Include="Microsoft.Web.WebView2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />


### PR DESCRIPTION
### Description of Change

These warnings appear when one builds `Essentials.DeviceTests.csproj` (and other projects):

```
D:\a\1\s\.dotnet\sdk\9.0.100\Microsoft.Common.CurrentVersion.targets(43,3): warning MSB4011: "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\a\1\s\src\Essentials\src\Essentials.csproj]
D:\a\1\s\.dotnet\sdk\9.0.100\Microsoft.Common.CurrentVersion.targets(43,3): warning MSB4011: "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\a\1\s\src\Essentials\src\Essentials.csproj]
D:\a\1\s\.dotnet\sdk\9.0.100\Microsoft.Common.CurrentVersion.targets(43,3): warning MSB4011: "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\a\1\s\src\Graphics\src\Graphics\Graphics.csproj]
D:\a\1\s\.dotnet\sdk\9.0.100\Microsoft.Common.CurrentVersion.targets(43,3): warning MSB4011: "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\a\1\s\src\Graphics\src\Graphics\Graphics.csproj]
D:\a\1\s\.dotnet\sdk\9.0.100\Microsoft.Common.CurrentVersion.targets(43,3): warning MSB4011: "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\a\1\s\src\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj]
D:\a\1\s\.dotnet\sdk\9.0.100\Microsoft.Common.CurrentVersion.targets(43,3): warning MSB4011: "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.5.240227000\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [D:\a\1\s\src\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj]
```

([Full CI output](https://dev.azure.com/xamarin/public/_build/results?buildId=139620&view=logs&j=c55487ff-79f7-53f4-3066-e0d87ace6235&t=c52a47b5-4643-5ee5-27ac-1236ef01f98e))

Notice that the warnings mention WinAppSDK version `1.5` and not `1.6` that is used by MAUI right now.

It appears to be caused by using older version of `Microsoft.Graphics.Win2D` (i.e. 1.2.0 instead of the latest 1.3.2) -- see [dependencies of 1.2.0](https://www.nuget.org/packages/Microsoft.Graphics.Win2D/1.2.0#dependencies-body-tab). Version 1.3.2 [requires WinAppSDK 1.6.](https://www.nuget.org/packages/Microsoft.Graphics.Win2D/1.3.2#dependencies-body-tab).

Changelog for the library is available here: https://github.com/microsoft/Win2D/blob/winappsdk/main/CHANGELOG.md.