### PR TITLE
[Windows] Upgrade Windows App SDK from 1.6.6 to 1.6.7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.6.250228001</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.6.250402001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.2903.40</MicrosoftWindowsWebView2PackageVersion>


### PR DESCRIPTION
### Description of Change

This PR upgrades Windows App SDK from [1.6.6](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/release-notes-archive/stable-channel-1.6#version-166-16250228001) to [1.6.7](https://learn.microsoft.com/en-gb/windows/apps/windows-app-sdk/release-notes-archive/stable-channel-1.6#version-167-16250402001). It might be a good first step before #28499 because 1.7 appears to bring a [genuine test failure](https://github.com/dotnet/maui/pull/28499#issuecomment-2779658989).