### PR TITLE
[Testing] Fix PaddingWithoutSafeArea

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellInsets.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellInsets.cs
@@ -129,6 +129,7 @@ public class ShellInsets : _IssuesUITest
 		Assert.That(zeroPadding, Is.EqualTo(1));
 		App.WaitForElement(ResetButton);
 		App.Tap(ResetButton);
+	    App.WaitForElement(PaddingEntry);
 		App.EnterText(PaddingEntry, "100");
 		App.WaitForElement(PaddingTest);
 		App.Tap(PaddingTest);


### PR DESCRIPTION

### Description of Change

The `PaddingWithoutSafeArea` test fails intermittently.
<img width="696" alt="Screenshot 2025-04-11 at 12 12 49 AM" src="https://github.com/user-attachments/assets/a7a2cbd9-fc09-4f8b-a8c4-245fe8daba2b" />


The reason is that the text 100 is not reliably entered into the entry field during the second attempt.
![image](https://github.com/user-attachments/assets/400a249e-2bb4-4a1c-811e-9efd8129619e)
