### PR TITLE
Modernize MediaPicker iOS

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Media
 			}
 
 			// Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
-            if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0)) // TODO Mac Catalyst?!
+			if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0))
 			{
 				await Permissions.EnsureGrantedAsync<Permissions.Photos>();
 			}
@@ -94,12 +94,12 @@ namespace Microsoft.Maui.Media
 				}
 
 				var sourceType = pickExisting
-                    ? UIImagePickerControllerSourceType.PhotoLibrary
-                    : UIImagePickerControllerSourceType.Camera;
+					? UIImagePickerControllerSourceType.PhotoLibrary
+					: UIImagePickerControllerSourceType.Camera;
 
 				var mediaType = photo ? UTType.Image : UTType.Movie;
 
-                if (!UIImagePickerController.IsSourceTypeAvailable(sourceType))
+				if (!UIImagePickerController.IsSourceTypeAvailable(sourceType))
 				{
 					throw new FeatureNotSupportedException();
 				}
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Media
 					MediaTypes = [mediaType],
 					AllowsEditing = false
 				};
-				
+
 				if (!photo && !pickExisting)
 				{
 					picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
@@ -124,13 +124,13 @@ namespace Microsoft.Maui.Media
 				pickerRef = picker;
 
 				picker.Delegate = new PhotoPickerDelegate
-                {
+				{
 					CompletedHandler = async info =>
 					{
 						GetFileResult(info, tcs);
 						await vc.DismissViewControllerAsync(true);
 					}
-                };
+				};
 			}
 
 			if (!string.IsNullOrWhiteSpace(options?.Title))
@@ -144,31 +144,31 @@ namespace Microsoft.Maui.Media
 			}
 
 			if (pickerRef.PresentationController is not null)
-            {
-                pickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
-                {
-                    Handler = () => tcs.TrySetResult(null)
-                };
-            }
+			{
+				pickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+				{
+					Handler = () => tcs.TrySetResult(null)
+				};
+			}
 
 			await vc.PresentViewControllerAsync(pickerRef, true);
 
 			var result = await tcs.Task;
 
 			pickerRef?.Dispose();
-            pickerRef = null;
+			pickerRef = null;
 
 			return result;
 		}
 
 		static FileResult PickerResultsToMediaFile(PHPickerResult[] results)
-        {
-            var file = results?.FirstOrDefault();
+		{
+			var file = results?.FirstOrDefault();
 
-            return file == null
-                ? null
-                : new PHPickerFileResult(file.ItemProvider);
-        }
+			return file == null
+				? null
+				: new PHPickerFileResult(file.ItemProvider);
+		}
 
 		static void GetFileResult(NSDictionary info, TaskCompletionSource<FileResult> tcs)
 		{
@@ -291,33 +291,33 @@ namespace Microsoft.Maui.Media
 	}
 
 	class PHPickerFileResult : FileResult
-    {
-        readonly string _identifier;
-        readonly NSItemProvider _provider;
+	{
+		readonly string _identifier;
+		readonly NSItemProvider _provider;
 
-        internal PHPickerFileResult(NSItemProvider provider)
-        {
-            this._provider = provider;
-            var identifiers = provider?.RegisteredTypeIdentifiers;
+		internal PHPickerFileResult(NSItemProvider provider)
+		{
+			this._provider = provider;
+			var identifiers = provider?.RegisteredTypeIdentifiers;
 
-            _identifier = (identifiers?.Any(i => i.StartsWith(UTType.LivePhoto)) ?? false)
-                && (identifiers?.Contains(UTType.JPEG) ?? false)
-                ? identifiers?.FirstOrDefault(i => i == UTType.JPEG)
-                : identifiers?.FirstOrDefault();
+			_identifier = (identifiers?.Any(i => i.StartsWith(UTType.LivePhoto)) ?? false)
+				&& (identifiers?.Contains(UTType.JPEG) ?? false)
+				? identifiers?.FirstOrDefault(i => i == UTType.JPEG)
+				: identifiers?.FirstOrDefault();
 
-            if (string.IsNullOrWhiteSpace(_identifier))
+			if (string.IsNullOrWhiteSpace(_identifier))
 			{
 				return;
 			}
 
 			FileName = FullPath
-                = $"{provider?.SuggestedName}.{GetTag(_identifier, UTType.TagClassFilenameExtension)}";
-        }
+				= $"{provider?.SuggestedName}.{GetTag(_identifier, UTType.TagClassFilenameExtension)}";
+		}
 
-        internal override async Task<Stream> PlatformOpenReadAsync()
-            => (await _provider?.LoadDataRepresentationAsync(_identifier))?.AsStream();
+		internal override async Task<Stream> PlatformOpenReadAsync()
+			=> (await _provider?.LoadDataRepresentationAsync(_identifier))?.AsStream();
 
 		protected internal static string GetTag(string identifier, string tagClass)
-           	=> UTType.CopyAllTags(identifier, tagClass)?.FirstOrDefault();
-    }
+			   => UTType.CopyAllTags(identifier, tagClass)?.FirstOrDefault();
+	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Maui.Media
 
 		internal PHPickerFileResult(NSItemProvider provider)
 		{
-			this._provider = provider;
+			_provider = provider;
 			var identifiers = provider?.RegisteredTypeIdentifiers;
 
 			_identifier = (identifiers?.Any(i => i.StartsWith(UTType.LivePhoto)) ?? false)

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Foundation;
@@ -7,14 +8,14 @@ using Microsoft.Maui.Devices;
 using Microsoft.Maui.Storage;
 using MobileCoreServices;
 using Photos;
+using PhotosUI;
 using UIKit;
 
 namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
 	{
-		static UIImagePickerController picker;
-
+		static UIViewController pickerRef;
 		public bool IsCaptureSupported
 			=> UIImagePickerController.IsSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
 
@@ -24,7 +25,9 @@ namespace Microsoft.Maui.Media
 		public Task<FileResult> CapturePhotoAsync(MediaPickerOptions options)
 		{
 			if (!IsCaptureSupported)
+			{
 				throw new FeatureNotSupportedException();
+			}
 
 			return PhotoAsync(options, true, false);
 		}
@@ -35,77 +38,137 @@ namespace Microsoft.Maui.Media
 		public Task<FileResult> CaptureVideoAsync(MediaPickerOptions options)
 		{
 			if (!IsCaptureSupported)
+			{
 				throw new FeatureNotSupportedException();
+			}
 
 			return PhotoAsync(options, false, false);
 		}
 
 		public async Task<FileResult> PhotoAsync(MediaPickerOptions options, bool photo, bool pickExisting)
 		{
-#pragma warning disable CA1416 // TODO: UIImagePickerControllerSourceType.PhotoLibrary, UTType.Image, UTType.Movie is supported on ios version 14 and above
-#pragma warning disable CA1422 // Validate platform compatibility
-			var sourceType = pickExisting ? UIImagePickerControllerSourceType.PhotoLibrary : UIImagePickerControllerSourceType.Camera;
-			var mediaType = photo ? UTType.Image : UTType.Movie;
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416
-
-			if (!UIImagePickerController.IsSourceTypeAvailable(sourceType))
-				throw new FeatureNotSupportedException();
-			if (!UIImagePickerController.AvailableMediaTypes(sourceType).Contains(mediaType))
-				throw new FeatureNotSupportedException();
-
 			if (!photo && !pickExisting)
+			{
 				await Permissions.EnsureGrantedAsync<Permissions.Microphone>();
-
-			// Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
-			if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0))
-#pragma warning disable CA1416 // TODO: Permissions.Photos is supported on ios version 14 and above
-				await Permissions.EnsureGrantedAsync<Permissions.Photos>();
-#pragma warning restore CA1416
-
-			if (!pickExisting)
-				await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-
-			var vc = WindowStateManager.Default.GetCurrentUIViewController(true);
-
-			picker = new UIImagePickerController();
-			picker.SourceType = sourceType;
-			picker.MediaTypes = new string[] { mediaType };
-			picker.AllowsEditing = false;
-			if (!photo && !pickExisting)
-				picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
-
-			if (!string.IsNullOrWhiteSpace(options?.Title))
-				picker.Title = options.Title;
-
-			if (DeviceInfo.Current.Idiom == DeviceIdiom.Tablet && picker.PopoverPresentationController != null && vc.View != null)
-				picker.PopoverPresentationController.SourceRect = vc.View.Bounds;
-
-			var tcs = new TaskCompletionSource<FileResult>(picker);
-			picker.Delegate = new PhotoPickerDelegate
-			{
-				CompletedHandler = async info =>
-				{
-					await vc.DismissViewControllerAsync(true);
-					GetFileResult(info, tcs);
-				}
-			};
-
-			if (picker.PresentationController != null)
-			{
-				picker.PresentationController.Delegate =
-					new UIPresentationControllerDelegate(() => GetFileResult(null, tcs));
 			}
 
-			await vc.PresentViewControllerAsync(picker, true);
+			// Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
+            if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0)) // TODO Mac Catalyst?!
+			{
+				await Permissions.EnsureGrantedAsync<Permissions.Photos>();
+			}
+
+			if (!pickExisting)
+			{
+				await Permissions.EnsureGrantedAsync<Permissions.Camera>();
+			}
+
+			var vc = WindowStateManager.Default.GetCurrentUIViewController(true);
+			var tcs = new TaskCompletionSource<FileResult>();
+
+			if (pickExisting && OperatingSystem.IsIOSVersionAtLeast(14, 0))
+			{
+				var config = new PHPickerConfiguration
+				{
+					Filter = photo
+						? PHPickerFilter.ImagesFilter
+						: PHPickerFilter.VideosFilter
+				};
+
+				var picker = new PHPickerViewController(config)
+				{
+					Delegate = new Media.PhotoPickerDelegate
+					{
+						CompletedHandler = res =>
+							tcs.TrySetResult(PickerResultsToMediaFile(res))
+					}
+				};
+
+				pickerRef = picker;
+			}
+			else
+			{
+				if (!pickExisting)
+				{
+					await Permissions.EnsureGrantedAsync<Permissions.PhotosAddOnly>();
+				}
+
+				var sourceType = pickExisting
+                    ? UIImagePickerControllerSourceType.PhotoLibrary
+                    : UIImagePickerControllerSourceType.Camera;
+
+				var mediaType = photo ? UTType.Image : UTType.Movie;
+
+                if (!UIImagePickerController.IsSourceTypeAvailable(sourceType))
+				{
+					throw new FeatureNotSupportedException();
+				}
+
+				if (!UIImagePickerController.AvailableMediaTypes(sourceType).Contains(mediaType))
+				{
+					throw new FeatureNotSupportedException();
+				}
+
+				var picker = new UIImagePickerController
+				{
+					SourceType = sourceType,
+					MediaTypes = [mediaType],
+					AllowsEditing = false
+				};
+				
+				if (!photo && !pickExisting)
+				{
+					picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
+				}
+
+				pickerRef = picker;
+
+				picker.Delegate = new PhotoPickerDelegate
+                {
+					CompletedHandler = async info =>
+					{
+						GetFileResult(info, tcs);
+						await vc.DismissViewControllerAsync(true);
+					}
+                };
+			}
+
+			if (!string.IsNullOrWhiteSpace(options?.Title))
+			{
+				pickerRef.Title = options.Title;
+			}
+
+			if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
+			{
+				pickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
+			}
+
+			if (pickerRef.PresentationController is not null)
+            {
+                pickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+                {
+                    Handler = () => tcs.TrySetResult(null)
+                };
+            }
+
+			await vc.PresentViewControllerAsync(pickerRef, true);
 
 			var result = await tcs.Task;
 
-			picker?.Dispose();
-			picker = null;
+			pickerRef?.Dispose();
+            pickerRef = null;
 
 			return result;
 		}
+
+		static FileResult PickerResultsToMediaFile(PHPickerResult[] results)
+        {
+            var file = results?.FirstOrDefault();
+
+            return file == null
+                ? null
+                : new PHPickerFileResult(file.ItemProvider);
+        }
 
 		static void GetFileResult(NSDictionary info, TaskCompletionSource<FileResult> tcs)
 		{
@@ -121,8 +184,16 @@ namespace Microsoft.Maui.Media
 
 		static FileResult DictionaryToMediaFile(NSDictionary info)
 		{
-			if (info == null)
+			// This method should only be called for iOS < 14
+			if (!OperatingSystem.IsIOSVersionAtLeast(14))
+			{
 				return null;
+			}
+
+			if (info is null)
+			{
+				return null;
+			}
 
 			PHAsset phAsset = null;
 			NSUrl assetUrl = null;
@@ -132,50 +203,47 @@ namespace Microsoft.Maui.Media
 				assetUrl = info[UIImagePickerController.ImageUrl] as NSUrl;
 
 				// Try the MediaURL sometimes used for videos
-				if (assetUrl == null)
-					assetUrl = info[UIImagePickerController.MediaURL] as NSUrl;
+				assetUrl ??= info[UIImagePickerController.MediaURL] as NSUrl;
 
-				if (assetUrl != null)
+				if (assetUrl is not null)
 				{
 					if (!assetUrl.Scheme.Equals("assets-library", StringComparison.OrdinalIgnoreCase))
+					{
 						return new UIDocumentFileResult(assetUrl);
-#pragma warning disable CA1416 // TODO: 'UIImagePickerController.PHAsset' is only supported on: 'ios' from version 11.0 to 14.0
-#pragma warning disable CA1422 // Validate platform compatibility
+					}
+
 					phAsset = info.ValueForKey(UIImagePickerController.PHAsset) as PHAsset;
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416
 				}
 			}
 
 #if !MACCATALYST
-#pragma warning disable CA1416 // TODO: 'UIImagePickerController.ReferenceUrl' is unsupported on 'ios' 11.0 and later
-#pragma warning disable CA1422 // Validate platform compatibility
-			if (phAsset == null)
+			if (phAsset is null)
 			{
 				assetUrl = info[UIImagePickerController.ReferenceUrl] as NSUrl;
 
-				if (assetUrl != null)
-					phAsset = PHAsset.FetchAssets(new NSUrl[] { assetUrl }, null)?.LastObject as PHAsset;
+				if (assetUrl is not null)
+				{
+					phAsset = PHAsset.FetchAssets([assetUrl], null)?.LastObject as PHAsset;
+				}
 			}
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416 // 'PHAsset.FetchAssets(NSUrl[], PHFetchOptions?)' is unsupported on 'ios' 11.0 and later
 #endif
 
-			if (phAsset == null || assetUrl == null)
+			if (phAsset is null || assetUrl is null)
 			{
 				var img = info.ValueForKey(UIImagePickerController.OriginalImage) as UIImage;
 
-				if (img != null)
+				if (img is not null)
+				{
 					return new UIImageFileResult(img);
+				}
 			}
 
-			if (phAsset == null || assetUrl == null)
+			if (phAsset is null || assetUrl is null)
+			{
 				return null;
-#pragma warning disable CA1416 // https://github.com/xamarin/xamarin-macios/issues/14619
-#pragma warning disable CA1422 // Validate platform compatibility
+			}
+
 			string originalFilename = PHAssetResource.GetAssetResources(phAsset).FirstOrDefault()?.OriginalFilename;
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416
 			return new PHAssetFileResult(assetUrl, phAsset, originalFilename);
 		}
 
@@ -183,11 +251,73 @@ namespace Microsoft.Maui.Media
 		{
 			public Action<NSDictionary> CompletedHandler { get; set; }
 
-			public override void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info) =>
+			public override void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
+			{
+				picker.DismissViewController(true, null);
 				CompletedHandler?.Invoke(info);
+			}
 
-			public override void Canceled(UIImagePickerController picker) =>
+			public override void Canceled(UIImagePickerController picker)
+			{
+				picker.DismissViewController(true, null);
 				CompletedHandler?.Invoke(null);
+			}
 		}
 	}
+
+	class PhotoPickerDelegate : PHPickerViewControllerDelegate
+	{
+		public Action<PHPickerResult[]> CompletedHandler { get; set; }
+
+		public override void DidFinishPicking(PHPickerViewController picker, PHPickerResult[] results)
+		{
+			picker.DismissViewController(true, null);
+			CompletedHandler?.Invoke(results?.Length > 0 ? results : null);
+		}
+	}
+
+	class PhotoPickerPresentationControllerDelegate : UIAdaptivePresentationControllerDelegate
+	{
+		public Action Handler { get; set; }
+
+		public override void DidDismiss(UIPresentationController presentationController) =>
+			Handler?.Invoke();
+
+		protected override void Dispose(bool disposing)
+		{
+			Handler?.Invoke();
+			base.Dispose(disposing);
+		}
+	}
+
+	class PHPickerFileResult : FileResult
+    {
+        readonly string _identifier;
+        readonly NSItemProvider _provider;
+
+        internal PHPickerFileResult(NSItemProvider provider)
+        {
+            this._provider = provider;
+            var identifiers = provider?.RegisteredTypeIdentifiers;
+
+            _identifier = (identifiers?.Any(i => i.StartsWith(UTType.LivePhoto)) ?? false)
+                && (identifiers?.Contains(UTType.JPEG) ?? false)
+                ? identifiers?.FirstOrDefault(i => i == UTType.JPEG)
+                : identifiers?.FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(_identifier))
+			{
+				return;
+			}
+
+			FileName = FullPath
+                = $"{provider?.SuggestedName}.{GetTag(_identifier, UTType.TagClassFilenameExtension)}";
+        }
+
+        internal override async Task<Stream> PlatformOpenReadAsync()
+            => (await _provider?.LoadDataRepresentationAsync(_identifier))?.AsStream();
+
+		protected internal static string GetTag(string identifier, string tagClass)
+           	=> UTType.CopyAllTags(identifier, tagClass)?.FirstOrDefault();
+    }
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -101,11 +101,13 @@ namespace Microsoft.Maui.Media
 
 				if (!UIImagePickerController.IsSourceTypeAvailable(sourceType))
 				{
+					tcs.TrySetCanceled();
 					throw new FeatureNotSupportedException();
 				}
 
 				if (!UIImagePickerController.AvailableMediaTypes(sourceType).Contains(mediaType))
 				{
+					tcs.TrySetCanceled();
 					throw new FeatureNotSupportedException();
 				}
 


### PR DESCRIPTION
### Description of Change

Modernize the API usage for MediaPicker on iOS and Mac Catalyst.

Code lifted from https://github.com/xamarin/Essentials/pull/1475 and https://github.com/xamarin/Essentials/pull/1750

### Issues Fixed

Fixes #20311
Fixes #29077