### PR TITLE
[Testing]Fix some Flaky UI tests that fails on android

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.RemoveAt.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.RemoveAt.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.CarouselView)]
 		public void Issue10300Test()
 		{
+			App.WaitForElement("AddMe");
 			App.Click("AddMe");
+			App.WaitForElement("DeleteMe");
 			App.Click("DeleteMe");
 			App.WaitForElement("CloseMe");
 			App.Click("CloseMe");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue10608.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue10608.cs
@@ -27,7 +27,9 @@ public class Issue10608 : _IssuesUITest
 	[Category(UITestCategories.Shell)]
 	public void ShellWithTopTabsFreezesWhenNavigatingFlyoutItems()
 	{
+		App.WaitForElement(FlyoutItem6);
 		App.Tap(FlyoutItem6);
+		App.WaitForElement("FlyoutItem0");
 		App.Tap("FlyoutItem0");
 		for (int i = 0; i < 5; i++)
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2809.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2809.cs
@@ -16,6 +16,9 @@ public class Issue2809 : _IssuesUITest
 	[Category(UITestCategories.ToolbarItem)]
 	public void TestPageDoesntCrash()
 	{
+#if ANDROID
+		App.WaitForElement(AppiumQuery.ByXPath("//android.widget.ImageView[@content-desc=\"More options\"]"));
+#endif
 		App.TapMoreButton();
 		App.Tap("Item 1");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2809.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2809.cs
@@ -16,7 +16,9 @@ public class Issue2809 : _IssuesUITest
 	[Category(UITestCategories.ToolbarItem)]
 	public void TestPageDoesntCrash()
 	{
+#if ANDROID && WINDOWS // WaitForMoreButton is only supported on Android and Windows
 		App.WaitForMoreButton();
+#endif
 		App.TapMoreButton();
 		App.Tap("Item 1");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2809.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2809.cs
@@ -16,9 +16,7 @@ public class Issue2809 : _IssuesUITest
 	[Category(UITestCategories.ToolbarItem)]
 	public void TestPageDoesntCrash()
 	{
-#if ANDROID
-		App.WaitForElement(AppiumQuery.ByXPath("//android.widget.ImageView[@content-desc=\"More options\"]"));
-#endif
+		App.WaitForMoreButton();
 		App.TapMoreButton();
 		App.Tap("Item 1");
 	}

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -2281,6 +2281,27 @@ namespace UITest.Appium
 		}
 
 		/// <summary>
+		/// Waits for the "More" button in the app, with platform-specific logic for Android and Windows.
+		/// This method does not currently support iOS and macOS platforms, where the "More" button is not shown.
+		/// </summary>
+		/// <param name="app">Represents the main gateway to interact with an app.</param>
+		public static void WaitForMoreButton(this IApp app)
+		{
+			if (app is AppiumAndroidApp)
+			{
+				app.WaitForElement(AppiumQuery.ByXPath("//android.widget.ImageView[@content-desc=\"More options\"]"));
+			}
+			else if (app is AppiumWindowsApp)
+			{
+				app.WaitForElement(AppiumQuery.ByAccessibilityId("MoreButton"));
+			}
+			else
+			{
+				Debug.WriteLine("WaitForMoreButton is not supported on this platform.");
+			}
+		}
+
+		/// <summary>
 		/// Taps the "More" button in the app, with platform-specific logic for Android and Windows.
 		/// This method does not currently support iOS and macOS platforms, where the "More" button is not shown.
 		/// </summary>

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -2297,7 +2297,7 @@ namespace UITest.Appium
 			}
 			else
 			{
-				Debug.WriteLine("WaitForMoreButton is not supported on this platform.");
+				 throw new InvalidOperationException($"WaitForMoreButton is not supported on this platform.");
 			}
 		}
 

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -2297,7 +2297,7 @@ namespace UITest.Appium
 			}
 			else
 			{
-				 throw new InvalidOperationException($"WaitForMoreButton is not supported on this platform.");
+				throw new InvalidOperationException($"WaitForMoreButton is not supported on this platform.");
 			}
 		}
 


### PR DESCRIPTION


### Description of Change

All of these tests sometimes fail at the start because we don't wait for any elements.

<table>
  <tr>
<th >ShellWithTopTabsFreezesWhenNavigatingFlyoutItems </th>
</tr>

<tr>
<td>



<img  width="600" alt="Screenshot 2025-04-13 at 10 16 19 AM" src="https://github.com/user-attachments/assets/d0bd0a25-d619-49ed-8bb2-6a5e74af3785" />



</td>
</tr>
<tr>
<th >TestPageDoesntCrash</th>
</tr>
<tr>
<td>



<img width="600"  alt="Screenshot 2025-04-13 at 10 35 39 AM" src="https://github.com/user-attachments/assets/2ddcea03-be44-4db0-b30b-75826b82d748" />



</td>
</tr>

<tr>
<th >Issue10300Test</th>
</tr>
<tr>
<td>


<img width="600" alt="Screenshot 2025-04-13 at 10 36 47 AM" src="https://github.com/user-attachments/assets/6785dade-b616-4d7a-a42c-d5a8451ace22" />



</td>
</tr>
</table>



