### PR TITLE
[iOS] CollectionView footer sizing when source is empty in SR5

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -199,6 +199,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public override void ViewWillLayoutSubviews()
 		{
 			ConstrainItemsToBounds();
+			
+			if (CollectionView is Items.MauiCollectionView { NeedsCellLayout: true } collectionView)
+ 			{
+ 				collectionView.NeedsCellLayout = false;
+ 			}
+
 			base.ViewWillLayoutSubviews();
 			InvalidateMeasureIfContentSizeChanged();
 			LayoutEmptyView();

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -10,6 +10,7 @@ internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents, IP
 	bool _invalidateParentWhenMovedToWindow;
 
 	WeakReference<ICustomMauiCollectionViewDelegate>? _customDelegate;
+	internal bool NeedsCellLayout { get; set; }
 	public MauiCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout)
 	{
 	}
@@ -27,10 +28,11 @@ internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents, IP
 
 	void IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
 	{
-		if (!isPropagating)
+		if (isPropagating)
 		{
-			SetNeedsLayout();
+			NeedsCellLayout = true;
 		}
+		SetNeedsLayout();
 	}
 
 	[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]

--- a/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/MauiCollectionView.cs
@@ -10,7 +10,9 @@ internal class MauiCollectionView : UICollectionView, IUIViewLifeCycleEvents, IP
 	bool _invalidateParentWhenMovedToWindow;
 
 	WeakReference<ICustomMauiCollectionViewDelegate>? _customDelegate;
+
 	internal bool NeedsCellLayout { get; set; }
+	
 	public MauiCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout)
 	{
 	}

--- a/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
@@ -86,27 +86,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override void ViewWillLayoutSubviews()
 		{
-			base.ViewWillLayoutSubviews();
-
-			// This update is only relevant if you have a footer view because it's used to place the footer view
-			// based on the ContentSize so we just update the positions if the ContentSize has changed
-			if (_footerUIView != null)
+			var hasHeaderOrFooter = _footerViewFormsElement is not null || _headerViewFormsElement is not null;
+ 			if (hasHeaderOrFooter && CollectionView is MauiCollectionView { NeedsCellLayout: true } collectionView)
 			{
 				var emptyView = CollectionView.ViewWithTag(EmptyTag);
 
-				if (IsHorizontal)
+				if (_headerViewFormsElement is not null)
 				{
-					if (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width ||
-						_footerUIView.Frame.X < emptyView?.Frame.X)
-						UpdateHeaderFooterPosition();
+					RemeasureLayout(_headerViewFormsElement);
 				}
-				else
+				if (_footerViewFormsElement is not null)
 				{
-					if (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height ||
-						_footerUIView.Frame.Y < (emptyView?.Frame.Y + emptyView?.Frame.Height))
-						UpdateHeaderFooterPosition();
+					RemeasureLayout(_footerViewFormsElement);
 				}
+				UpdateHeaderFooterPosition();
 			}
+			base.ViewWillLayoutSubviews();
 		}
 
 		internal void UpdateFooterView()

--- a/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/StructuredItemsViewController.cs
@@ -87,20 +87,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public override void ViewWillLayoutSubviews()
 		{
 			var hasHeaderOrFooter = _footerViewFormsElement is not null || _headerViewFormsElement is not null;
- 			if (hasHeaderOrFooter && CollectionView is MauiCollectionView { NeedsCellLayout: true } collectionView)
+			if (hasHeaderOrFooter && CollectionView is MauiCollectionView { NeedsCellLayout: true } collectionView)
 			{
-				var emptyView = CollectionView.ViewWithTag(EmptyTag);
-
 				if (_headerViewFormsElement is not null)
 				{
 					RemeasureLayout(_headerViewFormsElement);
 				}
+
 				if (_footerViewFormsElement is not null)
 				{
 					RemeasureLayout(_footerViewFormsElement);
 				}
+
 				UpdateHeaderFooterPosition();
 			}
+
 			base.ViewWillLayoutSubviews();
 		}
 


### PR DESCRIPTION
### Description 
Fix for Issue: On iOS, the CollectionView footer width becomes larger than the screen size when the CollectionView's source is empty.
 
This issue has already been resolved in the main branch through a combination of the current changes and the actual fix implemented in [PR #28610](https://github.com/dotnet/maui/pull/28610)
 
To resolve this issue in SR5.1, I have now included the necessary changes from the main branch into the SR5 branch. While the main branch commit contains additional file changes, I have included only the relevant modifications required to address this specific issue in CV1.
 
Reference Commit (from main): [609499c](https://github.com/dotnet/maui/commit/609499c)
#### Before fix: 
<img width="300" alt="Screenshot 2025-04-11 at 10 21 41 AM" src="https://github.com/user-attachments/assets/476a9132-909e-44cb-b827-d2e87654e7a9" />

#### After fix:
<img width="300" alt="Screenshot 2025-04-11 at 10 19 35 AM" src="https://github.com/user-attachments/assets/569447d3-2358-40cb-95e9-0ba8755d6517" />


### Issues Fixed
Fixes #28580