### PR TITLE
Add IsAspireSharedProject prop to ServiceDefaults template

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Maui.ServiceDefaults.csproj
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Maui.ServiceDefaults.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>DOTNET_TFM</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<IsAspireSharedProject>true</IsAspireSharedProject>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Description of Change

Adds the `<IsAspireSharedProject>true</IsAspireSharedProject>` property to the .NET MAUI Service Defaults project. Doesn't have any functionality other than being able to more easily identify this project inside or a solution and let Visual Studio do some magic when enlisting a .NET MAUI app in an Aspire orchestration