### PR TITLE
[Windows] Fixed the flyout content width not being set correctly after updating to WinUI SDK 1.7

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -98,9 +98,6 @@ namespace Microsoft.Maui.Controls.Platform
 			if (ShellView == null)
 				return base.MeasureOverride(availableSize);
 
-			if (!ShellView.IsPaneOpen)
-				return base.MeasureOverride(availableSize);
-
 			if (ShellView.OpenPaneLength < availableSize.Width)
 				return base.MeasureOverride(availableSize);
 

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -124,6 +124,10 @@ namespace Microsoft.Maui.Platform
 			// It causes the content to not be flush up against the title bar
 			PaneContentGrid.Margin = new WThickness(0, 0, 0, 0);
 			UpdateMenuItemsContainerHeight();
+
+			// On WinUI SDK 1.7, it seems that if the PaneContentGrid width is not explicitly set,
+			// it takes on the desired width of its child.
+			PaneContentGrid.Width = OpenPaneLength;
 		}
 
 

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Platform
 			PaneContentGrid.Margin = new WThickness(0, 0, 0, 0);
 			UpdateMenuItemsContainerHeight();
 
-			// On WinUI SDK 1.7, it seems that if the PaneContentGrid width is not explicitly set,
+			// On WinAppSDK 1.7, it seems that if the PaneContentGrid width is not explicitly set,
 			// it takes on the desired width of its child.
 			PaneContentGrid.Width = OpenPaneLength;
 		}

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -249,9 +249,19 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateFlyoutWidth(this MauiNavigationView navigationView, IFlyoutView flyoutView)
 		{
 			if (flyoutView.FlyoutWidth >= 0)
+			{
 				navigationView.OpenPaneLength = flyoutView.FlyoutWidth;
+			}
 			else
+			{
 				navigationView.OpenPaneLength = 320;
+			}
+
+			if (navigationView.PaneContentGrid is not null)
+			{
+				navigationView.PaneContentGrid.Width = navigationView.OpenPaneLength;
+			}
+
 			// At some point this Template Setting is going to show up with a bump to winui
 			//handler.PlatformView.OpenPaneLength = handler.PlatformView.TemplateSettings.OpenPaneWidth;
 		}


### PR DESCRIPTION
### Root Cause of the issue 

-  In WinUI SDK 1.7, it seems that if the PaneContentGrid width is not explicitly set, it takes on the desired width of its child.

### Description of Change

- I set the flyout's OpenPaneLength to the PaneContentGrid width, which resolves the issue. Additionally, due to the current changes, the measure logic is now invoked only once during the initial load and not again when the flyout is opened. To ensure the view is properly arranged during the initial load, I removed the !ShellView.IsPaneOpen condition check in the MeasureOverride method.
 

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28991

### Tested the behaviour in the following platforms

- [x] Windows
- [ ] iOS
- [ ] Android
- [ ] Mac

### Screenshot

| Before Fix | After Fix |
|----------|----------|
| <video  src="https://github.com/user-attachments/assets/b7107ce3-20e7-4d2e-bbf5-8b1c807f69e3"> | <video  src="https://github.com/user-attachments/assets/0e09608d-2d82-4a86-869d-a5bee1b0ba85"> |