### PR TITLE
[Android, Windows] Fixed App.Current.PageDisappearing not raised when a page is popped

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -783,6 +783,7 @@ namespace Microsoft.Maui.Controls
 				await Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
+						Owner.FireDisappearing(currentPage);
 						Owner.RemoveFromInnerChildren(currentPage);
 						Owner.CurrentPage = newCurrentPage;
 						if (currentPage.TitleView != null)
@@ -793,7 +794,6 @@ namespace Microsoft.Maui.Controls
 					() =>
 					{
 						Owner.SendNavigating(currentPage);
-						Owner.FireDisappearing(currentPage);
 						Owner.FireAppearing(newCurrentPage);
 					},
 					() =>

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -817,6 +817,7 @@ namespace Microsoft.Maui.Controls
 				return Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
+						Owner.FireDisappearing(previousPage);
 						var lastIndex = NavigationStack.Count - 1;
 						while (lastIndex > 0)
 						{
@@ -830,7 +831,6 @@ namespace Microsoft.Maui.Controls
 					() =>
 					{
 						Owner.SendNavigating(previousPage);
-						Owner.FireDisappearing(previousPage);
 						Owner.FireAppearing(newPage);
 					},
 					() =>

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -783,6 +783,7 @@ namespace Microsoft.Maui.Controls
 				await Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
+						Owner.SendNavigating(currentPage);
 						Owner.FireDisappearing(currentPage);
 						Owner.RemoveFromInnerChildren(currentPage);
 						Owner.CurrentPage = newCurrentPage;
@@ -793,7 +794,6 @@ namespace Microsoft.Maui.Controls
 					},
 					() =>
 					{
-						Owner.SendNavigating(currentPage);
 						Owner.FireAppearing(newCurrentPage);
 					},
 					() =>
@@ -817,6 +817,7 @@ namespace Microsoft.Maui.Controls
 				return Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
+						Owner.SendNavigating(previousPage);
 						Owner.FireDisappearing(previousPage);
 						var lastIndex = NavigationStack.Count - 1;
 						while (lastIndex > 0)
@@ -830,7 +831,6 @@ namespace Microsoft.Maui.Controls
 					},
 					() =>
 					{
-						Owner.SendNavigating(previousPage);
 						Owner.FireAppearing(newPage);
 					},
 					() =>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue14092.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue14092.cs
@@ -14,9 +14,14 @@ public class Issue14092 : NavigationPage
 
 	private void Current_PageDisappearing(object sender, Page e)
 	{
-		if (e is Issue14092SecondPage)
+		switch (e)
 		{
-			_firstPage.UpdateStatusLabel("Disappearing triggered when pop");
+			case Issue14092SecondPage:
+				_firstPage.UpdateStatusLabel("Disappearing triggered when pop");
+				break;
+			case Issue14092ThirdPage:
+				_firstPage.UpdateStatusLabel("Disappearing triggered when PopToRoot");
+				break;
 		}
 	}
 }
@@ -36,14 +41,14 @@ public class Issue14092FirstPage : ContentPage
 			VerticalOptions = LayoutOptions.Center
 		};
 
-		var counterBtn = new Button
+		var button = new Button
 		{
-			Text = "Click me",
+			Text = "Go To Page2",
 			AutomationId = "firstPageButton",
 			HorizontalOptions = LayoutOptions.Fill
 		};
 
-		counterBtn.Clicked += OnCounterClicked;
+		button.Clicked += OnCounterClicked;
 
 		Content = new VerticalStackLayout
 		{
@@ -52,7 +57,7 @@ public class Issue14092FirstPage : ContentPage
 			Children =
 			{
 				_label,
-				counterBtn
+				button
 			}
 		};
 	}
@@ -74,10 +79,47 @@ public class Issue14092SecondPage : ContentPage
 	{
 		Title = "Second Page";
 
-		var button = new Button
+		var popButton = new Button
 		{
 			Text = "Go Back",
 			AutomationId = "secondPageButton",
+		};
+		popButton.Clicked += OnButtonClicked;
+
+		var pushButton = new Button
+		{
+			Text = "Go To Page3",
+			AutomationId = "secondPagePushButton",
+		};
+		pushButton.Clicked += OnPushButtonClicked;
+
+		Content = new StackLayout
+		{
+			Children = { popButton, pushButton }
+		};
+	}
+
+	private void OnPushButtonClicked(object sender, EventArgs e)
+	{
+		Navigation.PushAsync(new Issue14092ThirdPage());
+	}
+
+	private void OnButtonClicked(object sender, EventArgs e)
+	{
+		Navigation.PopAsync();
+	}
+}
+
+public class Issue14092ThirdPage : ContentPage
+{
+	public Issue14092ThirdPage()
+	{
+		Title = "Third Page";
+
+		var button = new Button
+		{
+			Text = "PopToRoot",
+			AutomationId = "thirdPageButton",
 		};
 		button.Clicked += OnButtonClicked;
 
@@ -89,6 +131,6 @@ public class Issue14092SecondPage : ContentPage
 
 	private void OnButtonClicked(object sender, EventArgs e)
 	{
-		Navigation.PopAsync();
+		Navigation.PopToRootAsync();
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue14092.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue14092.cs
@@ -1,0 +1,94 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 14092, "Disappeared was not triggered when popping a page", PlatformAffected.Android)]
+
+public class Issue14092 : NavigationPage
+{
+	Issue14092FirstPage _firstPage;
+
+	public Issue14092() : base(new Issue14092FirstPage())
+	{
+		_firstPage = (Issue14092FirstPage)CurrentPage;
+		Application.Current.PageDisappearing += Current_PageDisappearing;
+	}
+
+	private void Current_PageDisappearing(object sender, Page e)
+	{
+		if (e is Issue14092SecondPage)
+		{
+			_firstPage.UpdateStatusLabel("Disappearing triggered when pop");
+		}
+	}
+}
+
+public class Issue14092FirstPage : ContentPage
+{
+	Label _label;
+	public Issue14092FirstPage()
+	{
+		Title = "Main Page";
+
+		_label = new Label
+		{
+			Text = "Status: Ready",
+			AutomationId = "StatusLabel",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var counterBtn = new Button
+		{
+			Text = "Click me",
+			AutomationId = "firstPageButton",
+			HorizontalOptions = LayoutOptions.Fill
+		};
+
+		counterBtn.Clicked += OnCounterClicked;
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(30, 0),
+			Spacing = 25,
+			Children =
+			{
+				_label,
+				counterBtn
+			}
+		};
+	}
+
+	public void UpdateStatusLabel(string text)
+	{
+		_label.Text = text;
+	}
+
+	private void OnCounterClicked(object sender, EventArgs e)
+	{
+		Navigation.PushAsync(new Issue14092SecondPage());
+	}
+}
+
+public class Issue14092SecondPage : ContentPage
+{
+	public Issue14092SecondPage()
+	{
+		Title = "Second Page";
+
+		var button = new Button
+		{
+			Text = "Go Back",
+			AutomationId = "secondPageButton",
+		};
+		button.Clicked += OnButtonClicked;
+
+		Content = new StackLayout
+		{
+			Children = { button }
+		};
+	}
+
+	private void OnButtonClicked(object sender, EventArgs e)
+	{
+		Navigation.PopAsync();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14092.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14092.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue14092 : _IssuesUITest
+{
+	public Issue14092(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "Disappeared was not triggered when popping a page";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void PageDisAppearingTriggeredWhenPop()
+	{
+		App.WaitForElement("firstPageButton");
+		App.Tap("firstPageButton");
+		App.WaitForElement("secondPageButton");
+		App.Tap("secondPageButton");
+		var label = App.WaitForElement("StatusLabel");
+		Assert.That(label.GetText(), Is.EqualTo("Disappearing triggered when pop"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14092.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14092.cs
@@ -13,7 +13,7 @@ public class Issue14092 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.Navigation)]
-	public void PageDisAppearingTriggeredWhenPop()
+	public void PageDisappearingTriggeredOnPop()
 	{
 		App.WaitForElement("firstPageButton");
 		App.Tap("firstPageButton");
@@ -21,5 +21,19 @@ public class Issue14092 : _IssuesUITest
 		App.Tap("secondPageButton");
 		var label = App.WaitForElement("StatusLabel");
 		Assert.That(label.GetText(), Is.EqualTo("Disappearing triggered when pop"));
+	}
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void PageDisappearingTriggeredOnPopToRoot()
+	{
+		App.WaitForElement("firstPageButton");
+		App.Tap("firstPageButton");
+		App.WaitForElement("secondPagePushButton");
+		App.Tap("secondPagePushButton");
+		App.WaitForElement("thirdPageButton");
+		App.Tap("thirdPageButton");
+		var label = App.WaitForElement("StatusLabel");
+		Assert.That(label.GetText(), Is.EqualTo("Disappearing triggered when PopToRoot"));
 	}
 }


### PR DESCRIPTION
### Issue Detail
App.Current.PageDisappearing is not raised when a page is popped using PopAsync/PopToRootAsync

### Root Cause
The navigation stack was not updated correctly when the Disappearing event was invoked. The page was removed from the stack before the event was triggered. Since the page was already removed, its parent was set to null, and as a result, the Disappearing event was not invoked.

### Description of change
Modified the logic to trigger the Disappearing event before removing the page from the stack, which resolves the issue.

### Reference
On iOS, [Disappearing](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs#L44) event is invoked first then the page is [removed](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs#L65) from the stack.
In PopModalAsync also, [Disappearing](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs#L220) invoked first then [Removed](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs#L241) from stack.

Attached is a reference showing the order of events before and after the fix.
![image](https://github.com/user-attachments/assets/c194be4f-a6a4-4893-b0d0-5cc24c8a02da)

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/14092

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/2be733d1-729e-4cc4-96e4-7f4a3f160345"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/99f4db25-8e41-4cb8-a0c8-d227b07c4bee">) |