### PR TITLE
Avoid qualified name in x:Type binding for Blazor Hybrid template

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -2,11 +2,12 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MauiApp._1"
+             xmlns:components="clr-namespace:MauiApp._1.Components"
              x:Class="MauiApp._1.MainPage">
 
     <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>
-            <RootComponent Selector="#app" ComponentType="{x:Type local:Components.Routes}" />
+            <RootComponent Selector="#app" ComponentType="{x:Type components:Routes}" />
         </BlazorWebView.RootComponents>
     </BlazorWebView>
 


### PR DESCRIPTION
### Description of Change

Use an explicit XML namespace for Component, avoiding use qualified name syntax in the x:Type binding. Qualified names (like `local:Components.Routes`) aren't currently supported by XAML Hot Reload, producing the error
"Nested types are not supported: Components.Routes" and causing XAML Hot Reload to not work. This support is coming in a future VS update, but for now it's best to avoid using of the qualified name syntax in our templates, to keep things broadly compatible and working for new users. We don't use qualified names in XAML bindings anywhere else in MAUI XAML templates; this is the last occurrence.

### Issues Fixed

Fixes #20669
