### PR TITLE
Exclude .NET bot for sample content template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -79,7 +79,8 @@
           "condition": "(IncludeSampleContent)",
           "exclude": [
             "MainPage.xaml",
-            "MainPage.xaml.cs"
+            "MainPage.xaml.cs",
+            "Resources/Images/dotnet_bot.png"
           ]
         }]
       }

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -65,8 +65,10 @@
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
+<!--#if (!IncludeSampleContent) -->
 		<MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
-
+		
+<!--#endif -->
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />
 


### PR DESCRIPTION
### Description of Change

Excludes the `dotnet_bot.png` file from the sample content project template as its not being used there and will just result in a unused file that bloats the app.

### Issues Fixed

Contributes to #26484
