### PR TITLE
Obsolete UseMauiCompatibility for .NET 10

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -58,8 +58,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 		}
 
 		[Obsolete("The compatibility functionality is deprecated. This will be removed in the future, please make sure to migrate to handlers. " +
-			"You might already not be using any of the compatibility functionality anymore, in that case please remove this call " +
-			"(and the reference to the Compatibility NuGet package) as it will introduce unnecessary overhead that impacts performance.")]
+		"You might already not be using any of the compatibility functionality anymore, in that case please remove this call, and the reference " +
+		"to the Compatibility NuGet package, as it will introduce unnecessary overhead that negatively impacts performance. " +
+		"Learn how to transition off of the Compatibility packages on Microsoft Learn: https://aka.ms/maui/renderer-to-handler")]
 		public static MauiAppBuilder UseMauiCompatibility(this MauiAppBuilder builder)
 		{
 			Controls.Hosting.CompatibilityCheck.UseCompatibility();

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 			Controls.Hosting.CompatibilityCheck.ResetCompatibilityCheck();
 		}
 
+		[Obsolete("The compatibility functionality is deprecated. This will be removed in the future, please make sure to migrate to handlers. " +
+			"You might already not be using any of the compatibility functionality anymore, in that case please remove this call " +
+			"(and the reference to the Compatibility NuGet package) as it will introduce unnecessary overhead that impacts performance.")]
 		public static MauiAppBuilder UseMauiCompatibility(this MauiAppBuilder builder)
 		{
 			Controls.Hosting.CompatibilityCheck.UseCompatibility();

--- a/src/Compatibility/Core/tests/Compatibility.UnitTests/HostBuilderAppTests.cs
+++ b/src/Compatibility/Core/tests/Compatibility.UnitTests/HostBuilderAppTests.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Maui.Compatibility.Core.UnitTests
 			var builder = MauiApp.CreateBuilder().UseMauiApp<ApplicationStub>();
 
 			if (useCompatibility)
+#pragma warning disable 0618
 				builder = builder.UseMauiCompatibility();
+#pragma warning restore 0618
 
 			var mauiApp =
 				builder.ConfigureMauiHandlers(collection =>


### PR DESCRIPTION
### Description of Change

Add `Obsolete` attribute on the `UseMauiCompatibility` `MauiAppBuilder` extension method. All other compatibility functionality is already deprecated and people might still call this method which might impact performance while they are not even using it anymore.

The message with this obsoletion should hopefully trigger people to look into it and remove it from their projects.

### Issues Fixed

Fixes #29006
