### PR TITLE
Fixed the crash on iOS when setting HeightRequest on WebView inside a ScrollView with IsVisible set to false

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26795.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26795.cs
@@ -11,7 +11,6 @@ public class Issue26795 : ContentPage
         {
             Source = "https://en.m.wikipedia.org/wiki",
             HeightRequest = 1000,
-            AutomationId = "WebView"
         };
 
         var label = new Label

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26795.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26795.cs
@@ -1,0 +1,32 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 26795, "Specifying HeightRequest in Webview when wrapped by ScrollView set invisible causes crash in iOS", PlatformAffected.iOS)]
+public class Issue26795 : ContentPage
+{
+    public Issue26795()
+    {
+        var layout = new VerticalStackLayout();
+
+        var webView = new WebView
+        {
+            Source = "https://en.m.wikipedia.org/wiki",
+            HeightRequest = 1000,
+            AutomationId = "WebView"
+        };
+
+        var label = new Label
+        {
+            Text = "Test passes if no crash occurs",
+            AutomationId = "Label"
+        };
+
+        var scrollView = new ScrollView
+        {
+            IsVisible = false,
+            Content = webView
+        };
+        layout.Children.Add(label);
+        layout.Children.Add(scrollView);
+        Content = layout;
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26795.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26795.cs
@@ -11,7 +11,7 @@ public class Issue26795 : _IssuesUITest
 
     [Test]
     [Category(UITestCategories.WebView)]
-    public void WebViewShouldNotCrash()
+    public void WebViewShouldNotCrashWithHeightRequest()
     {
         App.WaitForElement("Label");
     }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26795.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue26795.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue26795 : _IssuesUITest
+{
+    public Issue26795(TestDevice device) : base(device) { }
+
+    public override string Issue => "Specifying HeightRequest in Webview when wrapped by ScrollView set invisible causes crash in iOS";
+
+    [Test]
+    [Category(UITestCategories.WebView)]
+    public void WebViewShouldNotCrash()
+    {
+        App.WaitForElement("Label");
+    }
+}

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -104,8 +104,8 @@ namespace Microsoft.Maui.Handlers
 
 			var set = false;
 
-			var width = widthConstraint;
-			var height = heightConstraint;
+			var width = size.Width;
+			var height = size.Height;
 
 			if (size.Width == 0)
 			{

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Handlers
 			var width = size.Width;
 			var height = size.Height;
 
-			if (size.Width == 0)
+			if (width == 0)
 			{
 				if (widthConstraint <= 0 || double.IsInfinity(widthConstraint))
 				{
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Handlers
 				}
 			}
 
-			if (size.Height == 0)
+			if (height == 0)
 			{
 				if (heightConstraint <= 0 || double.IsInfinity(heightConstraint))
 				{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

When WebView is placed inside a ScrollView (especially with `IsVisible=false`), the measurement pass can receive infinite constraints. The previous implementation in `GetDesiredSize` used `widthConstraint` and `heightConstraint` directly to initialize the `width` and `height` variables. When these constraints were infinite, the code could propagate infinite or `NaN` values into subsequent calculations, causing crashes on iOS during layout operations.

The regression was introduced in PR #26629.

### Description of Change

Changed `WebViewHandler.iOS.cs` to use the measured size (`size.Width` and `size.Height` from `PlatformView.SizeThatFits`) instead of the constraint values when initializing the `width` and `height` variables in `GetDesiredSize`.

**Key change:**
```csharp
// Before (could use infinite constraints)
var width = widthConstraint;
var height = heightConstraint;

// After (use measured size, which is always finite)
var width = size.Width;
var height = size.Height;
```

The subsequent validation logic (checking if width/height is 0 and falling back to constraints if valid) remains the same, ensuring backward compatibility while preventing infinite values from being used in calculations.

### What NOT to Do (for future agents)

- ❌ **Don't use constraint values directly without checking for infinity** - Constraints can be infinite in scrollable containers (ScrollView, ListView). Always validate constraints before using them, or prefer using measured size from the native control.
- ❌ **Don't assume constraints are always finite in GetDesiredSize** - Layout containers frequently pass infinite constraints during measurement to determine intrinsic size.

### Regressed PR

- #26629

### Issues Fixed

Fixes #26795

### Platforms Tested

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Screenshot

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/40f039b4-dc76-421f-9161-f4f98e23f621"> | <video src="https://github.com/user-attachments/assets/632c0cf2-243d-489e-8bd2-baa0da7e05d5"> |
</details>

<details>
