### PR TITLE
Fixed - On iOS GestureRecognizers don't work on Span in a Label, which doesn't get IsVisible (=true) update from its parent

### DIFF
--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		{
 			var size = base.ArrangeOverride(bounds);
 
-			RecalculateSpanPositions();
+			RecalculateSpanPositions(size);
 
 			return size;
 		}
@@ -51,14 +51,14 @@ namespace Microsoft.Maui.Controls
 			LabelHandler.MapFormatting(handler, label);
 		}
 
-		void RecalculateSpanPositions()
+		void RecalculateSpanPositions(Size size)
 		{
 			if (Handler is LabelHandler labelHandler)
 			{
 				if (labelHandler.PlatformView is not UILabel platformView || labelHandler.VirtualView is not Label virtualView)
 					return;
 
-				platformView.RecalculateSpanPositions(virtualView);
+				platformView.RecalculateSpanPositions(virtualView, size);
 			}
 		}
 	}

--- a/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.Platform
 			return attrString;
 		}
 
-		internal static void RecalculateSpanPositions(this UILabel control, Label element)
+		internal static void RecalculateSpanPositions(this UILabel control, Label element, Size size)
 		{
 			if (element is null)
 			{
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			var finalSize = control.Bounds;
+			var finalSize = size;
 
 			if (finalSize.Width <= 0 || finalSize.Height <= 0)
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28949.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28949.cs
@@ -5,23 +5,6 @@ public class Issue28949 : ContentPage
 {
     public Issue28949()
     {
-        var labelStyle = new Style(typeof(Label))
-        {
-            Setters =
-            {
-                new Setter
-                {
-                    Property = Label.BackgroundColorProperty,
-                    Value = Colors.Transparent
-                }
-            }
-        };
-
-        Resources = new ResourceDictionary
-        {
-            labelStyle
-        };
-
         var toggleButton = new Button
         {
             Text = "Toggle Visibility",
@@ -31,6 +14,7 @@ public class Issue28949 : ContentPage
         var label = new Label
         {
             FormattedText = formattedString,
+            BackgroundColor = Colors.Transparent,
             AutomationId = "Label"
         };
         var grid = new Grid

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28949.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28949.cs
@@ -1,0 +1,72 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28949, "On iOS GestureRecognizers don't work on Span in a Label, which doesn't get IsVisible (=true) update from its parent", PlatformAffected.iOS)]
+public class Issue28949 : ContentPage
+{
+    public Issue28949()
+    {
+        var labelStyle = new Style(typeof(Label))
+        {
+            Setters =
+            {
+                new Setter
+                {
+                    Property = Label.BackgroundColorProperty,
+                    Value = Colors.Transparent
+                }
+            }
+        };
+
+        Resources = new ResourceDictionary
+        {
+            labelStyle
+        };
+
+        var toggleButton = new Button
+        {
+            Text = "Toggle Visibility",
+            AutomationId = "ToggleButton"
+        };
+        var formattedString = new FormattedString();
+        var label = new Label
+        {
+            FormattedText = formattedString,
+            AutomationId = "Label"
+        };
+        var grid = new Grid
+        {
+            BackgroundColor = Colors.Yellow
+        };
+
+        var span = new Span
+        {
+            Text = "Click me",
+            TextColor = Colors.Pink
+        };
+        var tapGesture = new TapGestureRecognizer();
+        tapGesture.Tapped += (s, e) =>
+        {
+            span.Text = "Success";
+            span.TextColor = Colors.Green;
+        };
+        span.GestureRecognizers.Add(tapGesture);
+        formattedString.Spans.Add(span);
+
+        toggleButton.Clicked += (s, e) =>
+        {
+            grid.IsVisible = !grid.IsVisible;
+        };
+        grid.IsVisible = false;
+        grid.Children.Add(label);
+        var stackLayout = new StackLayout
+        {
+            Children =
+            {
+                toggleButton,
+                grid
+            }
+        };
+        Content = stackLayout;
+    }
+
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28949.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28949.cs
@@ -14,7 +14,7 @@ public class Issue28949 : _IssuesUITest
 
     [Test]
     [Category(UITestCategories.Label)]
-    public void GestureRecognizersOnSpan()
+    public void GestureRecognizersOnLabelSpanShouldWork()
     {
         App.WaitForElement("ToggleButton");
         App.Tap("ToggleButton");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28949.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28949.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28949 : _IssuesUITest
+{
+    public Issue28949(TestDevice device) : base(device)
+    {
+    }
+
+    public override string Issue => "On iOS GestureRecognizers don't work on Span in a Label, which doesn't get IsVisible (=true) update from its parent";
+
+    [Test]
+    [Category(UITestCategories.Label)]
+    public void GestureRecognizersOnSpan()
+    {
+        App.WaitForElement("ToggleButton");
+        App.Tap("ToggleButton");
+        var spanRect = App.WaitForElement("Label").GetRect();
+        App.TapCoordinates(spanRect.X + 5, spanRect.Y + 5);
+        App.WaitForElement("Success");
+    }
+}


### PR DESCRIPTION
### Issue Details:

The Tapped event or Command of the TapGestureRecognizer is not triggered for span text when tapped on iOS and Mac platforms.
        
### Root Cause:

In the RecalculateSpanPositions method of the FormattedStringExtension class, span regions are created only when the native bounds are greater than 0. In our scenario, the native bounds of the Label were 0 when its visibility changed from false to true. So, we added an early return in the RecalculateSpanPositions method when the native bounds are 0, preventing the creation of invalid span regions.

### Description of Change:

Since RecalculateSpanPositions is invoked from the ArrangeOverride method in LabelHandler.iOS, where the actual size of the label is available, I modified the logic to pass the correct bounds from the Arrange step. These bounds are then used in RecalculateSpanPositions to create span regions, instead of relying on potentially outdated native label bounds.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A


### Issues Fixed:

Fixes #28949  

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/3a08409b-657a-41af-bf16-e3cb595cdbf3">   |    <Video src="https://github.com/user-attachments/assets/58b16bec-febf-4871-a0a4-a7fd44928290">  |