### PR TITLE
Fixed Flyout Not Displayed on Android When FlyoutWidth Is Set Only for Desktop via OnIdiom

### DIFF
--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -65,16 +65,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			{
 				if (bp != null)
 				{
-					object targetObject = valueProvider.TargetObject;
-
-					if (targetObject is Setter)
-					{
-						return null;
-					}
-					else
-					{
-						return bp.GetDefaultValue(targetObject as BindableObject);
-					}
+					return bp.GetDefaultValue(valueProvider.TargetObject as BindableObject);
 				}
 
 				if (propertyType.IsValueType)

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -60,14 +60,12 @@ namespace Microsoft.Maui.Controls.Xaml
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
 			var value = GetValue();
-			// The value returns null when a property value is specified only for Desktop in OnIdiom, and 
-			// the application is run on the Android platform without specifying a default value.
+			// The value returns null when no value is specified for the OnIdiom.
 			if (value == null)
 			{
 				if (bp != null)
 				{
 					object targetObject = valueProvider.TargetObject;
-					// If the target object is a Setter, we don't want to retrieve the default value.
 					if (targetObject is Setter)
 					{
 						return null;

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui.Controls.Xaml
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
 			var value = GetValue();
+
 			if (value == null)
 			{
 				if (bp != null)
@@ -67,12 +68,20 @@ namespace Microsoft.Maui.Controls.Xaml
 					object targetObject = valueProvider.TargetObject;
 
 					if (targetObject is Setter)
+					{
 						return null;
+					}
 					else
+					{
 						return bp.GetDefaultValue(targetObject as BindableObject);
+					}
 				}
+
 				if (propertyType.IsValueType)
+				{
 					return Activator.CreateInstance(propertyType);
+				}
+
 				return null;
 			}
 

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -60,12 +60,23 @@ namespace Microsoft.Maui.Controls.Xaml
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
 			var value = GetValue();
-
+			// The value returns null when a property value is specified only for Desktop in OnIdiom, and 
+			// the application is run on the Android platform without specifying a default value.
 			if (value == null)
 			{
 				if (bp != null)
 				{
-					return bp.GetDefaultValue(valueProvider.TargetObject as BindableObject);
+					object targetObject = valueProvider.TargetObject;
+					// If the target object is a Setter, we don't want to retrieve the default value.
+					if (targetObject is Setter)
+					{
+						return null;
+					}
+					else
+					{
+						// If the target object is a BindableObject, retrieve the default value from it.
+						return bp.GetDefaultValue(targetObject as BindableObject);
+					}
 				}
 
 				if (propertyType.IsValueType)

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -60,8 +60,21 @@ namespace Microsoft.Maui.Controls.Xaml
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
 			var value = GetValue();
-			if (value == null && propertyType.IsValueType)
-				return Activator.CreateInstance(propertyType);
+			if (value == null)
+			{
+				if (bp != null)
+				{
+					object targetObject = valueProvider.TargetObject;
+
+					if (targetObject is Setter)
+						return null;
+					else
+						return bp.GetDefaultValue(targetObject as BindableObject);
+				}
+				if (propertyType.IsValueType)
+					return Activator.CreateInstance(propertyType);
+				return null;
+			}
 
 			if (Converter != null)
 				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue13243.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue13243.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue13243"
+       xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
+       FlyoutWidth="{OnIdiom Desktop=150}">
+
+    <ShellContent Title="Page1"
+                  ContentTemplate="{DataTemplate local:Issue13243Page1}"/>
+    <ShellContent Title="Page2"
+                  ContentTemplate="{DataTemplate local:Issue13243Page2}"/>
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue13243.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue13243.xaml.cs
@@ -1,0 +1,45 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 13243, "Flyout Not Displayed on Android When FlyoutWidth Is Set Only for Desktop via OnIdiom", PlatformAffected.All)]
+public partial class Issue13243 : Shell
+{
+	public Issue13243()
+	{
+		InitializeComponent();
+	}
+}
+
+public class Issue13243Page1 : ContentPage
+{
+	public Issue13243Page1()
+	{
+		Title = "Page 1";
+		var label = new Label
+		{
+			Text = "Hello, World!",
+			AutomationId = "Label",
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+		Content = new StackLayout
+		{
+			Children = { label },
+		};
+	}
+}
+
+public class Issue13243Page2 : ContentPage
+{
+	public Issue13243Page2()
+	{
+		Title = "Page 2";
+		var label = new Label
+		{
+			Text = "Hello, World!",
+		};
+		Content = new StackLayout
+		{
+			Children = { label },
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue13243.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue13243.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue13243 : _IssuesUITest
+{
+	public Issue13243(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "Flyout Not Displayed on Android When FlyoutWidth Is Set Only for Desktop via OnIdiom";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void ShouldDisplayFlyoutWhenOnIdiomHasNoDefaultValue()
+	{
+		App.WaitForElement("Label");
+		App.TapShellFlyoutIcon();
+		App.WaitForElement("Page2");
+	}
+}


### PR DESCRIPTION
### Issue Details

The Shell flyout is not displayed due to the absence of a specified FlyoutWidth value for the current idiom, and no default value is provided in the OnIdiom.

### Root Cause
The FlyoutWidth property returns a value of 0 instead of its default value (-1) from the OnIdiom extension when FlyoutWidth is set only for the Desktop idiom and no default value is provided. As a result, the flyout is not displayed when the application is run on the Android platform.

### Description of Changes
Retrieved the default value using the GetDefaultValue method from the bindable property and handled the target setter case in the OnIdiomExtension when the value is null due to the absence of a specified value for the current idiom.

### Reference

https://github.com/NanthiniMahalingam/maui/blob/35ee660a3219f11cd391fcc838c23c6c5fcad10b/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs#L74

### Issues Fixed
Fixes #13243 

Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output

Android

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/b24347f6-8f56-4fa7-b8c1-d29778711b89" >| <video src="https://github.com/user-attachments/assets/6cc923eb-072c-468d-bf9b-c7dfc74c8a28" >|


iOS

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/dd861cc8-b80f-4af7-b581-cb50889b553d" >| <video src="https://github.com/user-attachments/assets/78966ebb-6f4e-4500-b414-5072c7305813">|


