### PR TITLE
[workloads] Remove Emscripten references

### DIFF
--- a/src/DotNet/Dependencies/Workloads.csproj
+++ b/src/DotNet/Dependencies/Workloads.csproj
@@ -8,9 +8,6 @@
     <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(DotNetVersionBand)"   Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net8.Manifest-$(DotNetVersionBand)"   Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Current.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net6.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net7.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net8.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" /> 
     <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net9.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)"    Version="[$(MicrosoftAndroidSdkWindowsPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-$(DotNetMaciOSManifestVersionBand)" Version="[$(MicrosoftMacCatalystSdkPackageVersion)]" />

--- a/src/Workload/Microsoft.NET.Sdk.Maui.Manifest/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui.Manifest/Rollback.in.json
@@ -5,8 +5,6 @@
   "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
   "microsoft.net.sdk.maui": "@VERSION@/@DotNetMauiManifestVersionBand@",
   "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
-  "microsoft.net.workload.mono.toolchain.net8": "@MicrosoftDotnetSdkInternalPackageVersion@/@DotNetVersionBand@",
-  "microsoft.net.workload.mono.toolchain.current": "@MicrosoftDotnetSdkInternalPackageVersion@/@DotNetVersionBand@",
-  "microsoft.net.workload.emscripten.net8": "@MicrosoftDotnetSdkInternalPackageVersion@/@DotNetVersionBand@",
-  "microsoft.net.workload.emscripten.current": "@MicrosoftDotnetSdkInternalPackageVersion@/@DotNetVersionBand@"
+  "microsoft.net.workload.mono.toolchain.net9": "@MicrosoftDotnetSdkInternalPackageVersion@/@DotNetVersionBand@",
+  "microsoft.net.workload.mono.toolchain.current": "@MicrosoftDotnetSdkInternalPackageVersion@/@DotNetVersionBand@"
 }


### PR DESCRIPTION
### Description of Change

This was used for rollback when versions were not in sync with mono, but this is not an issue anymore. 
