### PR TITLE
[Android] Prevent Picker from Gaining Focus on Touch

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2339.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2339.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
-#if TEST_FAILS_ON_ANDROID 
 namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	public class Issue2339 : _IssuesUITest
@@ -28,4 +27,3 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2339.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue2339.cs
@@ -1,7 +1,7 @@
 ﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
-
+#if TEST_FAILS_ON_ANDROID 
 namespace Microsoft.Maui.TestCases.Tests.Issues
 {
 	public class Issue2339 : _IssuesUITest
@@ -28,3 +28,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void ConnectHandler(MauiPicker platformView)
 		{
-			platformView.FocusChange += OnFocusChange;
 			platformView.Click += OnClick;
 
 			base.ConnectHandler(platformView);
@@ -27,7 +26,6 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(MauiPicker platformView)
 		{
-			platformView.FocusChange -= OnFocusChange;
 			platformView.Click -= OnClick;
 
 			base.DisconnectHandler(platformView);
@@ -86,24 +84,6 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateVerticalAlignment(picker.VerticalTextAlignment);
 		}
 
-		void OnFocusChange(object? sender, global::Android.Views.View.FocusChangeEventArgs e)
-		{
-			if (PlatformView == null)
-				return;
-
-			if (e.HasFocus)
-			{
-				if (PlatformView.Clickable)
-					PlatformView.CallOnClick();
-				else
-					OnClick(PlatformView, EventArgs.Empty);
-			}
-			else if (_dialog != null)
-			{
-				_dialog.Hide();
-				_dialog = null;
-			}
-		}
 
 		void OnClick(object? sender, EventArgs e)
 		{

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -88,11 +88,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (handler.IsConnected() && !picker.IsFocused)
 			{
-				if (args is FocusRequest request)
-				{
-					handler.PlatformView.Focus(request);
-				}
-
+				ViewHandler.MapFocus(handler, picker, args);
 				handler.PlatformView.CallOnClick();
 			}
 		}
@@ -102,7 +98,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.IsConnected() && handler is PickerHandler pickerHandler && picker.IsFocused)
 			{
 				pickerHandler.DismissDialog();
-				pickerHandler.PlatformView.ClearFocus();
+				ViewHandler.MapUnfocus(handler,picker,args);
 			}
 		}
 

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Maui.Handlers
 
 		internal static void MapFocus(IPickerHandler handler, IPicker picker, object? args)
 		{
-			if (handler.IsConnected() && !picker.IsFocused)
+			if (handler.IsConnected())
 			{
 				ViewHandler.MapFocus(handler, picker, args);
 				handler.PlatformView.CallOnClick();
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Handlers
 
 		internal static void MapUnfocus(IPickerHandler handler, IPicker picker, object? args)
 		{
-			if (handler.IsConnected() && handler is PickerHandler pickerHandler && picker.IsFocused)
+			if (handler.IsConnected() && handler is PickerHandler pickerHandler)
 			{
 				pickerHandler.DismissDialog();
 				ViewHandler.MapUnfocus(handler,picker,args);

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static CommandMapper<IPicker, IPickerHandler> CommandMapper = new(ViewCommandMapper)
 		{
+#if ANDROID
+			[nameof(IPicker.Focus)] = MapFocus,
+			[nameof(IPicker.Unfocus)] = MapUnfocus
+#endif
 		};
 
 		public PickerHandler() : base(Mapper, CommandMapper)

--- a/src/Core/src/Platform/Android/MauiDatePicker.cs
+++ b/src/Core/src/Platform/Android/MauiDatePicker.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
+		// MovementMethod handles cursor positioning, scrolling, and text selection (per Android docs).
+		// Since text is readonly, we disable it to avoid unnecessary cursor navigation during keyboard input.
 		protected override IMovementMethod? DefaultMovementMethod => null;
 
 		public Action? ShowPicker { get; set; }

--- a/src/Core/src/Platform/Android/MauiDatePicker.cs
+++ b/src/Core/src/Platform/Android/MauiDatePicker.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.Runtime;
 using Android.Text;
+using Android.Text.Method;
 using Android.Util;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
@@ -31,6 +32,8 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
+		protected override IMovementMethod? DefaultMovementMethod => null;
+
 		public Action? ShowPicker { get; set; }
 		public Action? HidePicker { get; set; }
 
@@ -44,10 +47,7 @@ namespace Microsoft.Maui.Platform
 			if (Background != null)
 				DrawableCompat.Wrap(Background);
 
-			Focusable = true;
-			FocusableInTouchMode = false;
-			Clickable = true;
-			InputType = InputTypes.Null;
+			PickerManager.Init(this);
 
 			SetOnClickListener(this);
 		}

--- a/src/Core/src/Platform/Android/MauiPicker.cs
+++ b/src/Core/src/Platform/Android/MauiPicker.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Content;
 using Android.Runtime;
+using Android.Text.Method;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Graphics.Drawable;
@@ -31,5 +32,7 @@ namespace Microsoft.Maui.Platform
 			if (Background != null)
 				DrawableCompat.Wrap(Background);
 		}
+
+		protected override IMovementMethod? DefaultMovementMethod => null;
 	}
 }

--- a/src/Core/src/Platform/Android/MauiPicker.cs
+++ b/src/Core/src/Platform/Android/MauiPicker.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Maui.Platform
 				DrawableCompat.Wrap(Background);
 		}
 
+		// MovementMethod handles cursor positioning, scrolling, and text selection (per Android docs).
+		// Since text is readonly, we disable it to avoid unnecessary cursor navigation during keyboard input.
 		protected override IMovementMethod? DefaultMovementMethod => null;
 	}
 }

--- a/src/Core/src/Platform/Android/MauiPicker.cs
+++ b/src/Core/src/Platform/Android/MauiPicker.cs
@@ -9,23 +9,10 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiPicker : MauiPickerBase
 	{
-		public bool ShowPopupOnFocus { get; set; }
 
 		public MauiPicker(Context context) : base(context)
 		{
 			PickerManager.Init(this);
-		}
-
-		public override bool OnTouchEvent(MotionEvent? e)
-		{
-			PickerManager.OnTouchEvent(this, e);
-			return base.OnTouchEvent(e); // Raises the OnClick event if focus is already received
-		}
-
-		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, ARect? previouslyFocusedRect)
-		{
-			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
-			PickerManager.OnFocusChanged(gainFocus, this);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Core/src/Platform/Android/MauiTimePicker.cs
+++ b/src/Core/src/Platform/Android/MauiTimePicker.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
+		// MovementMethod handles cursor positioning, scrolling, and text selection (per Android docs).
+		// Since text is readonly, we disable it to avoid unnecessary cursor navigation during keyboard input.
 		protected override IMovementMethod? DefaultMovementMethod => null;
 
 		public Action? ShowPicker { get; set; }

--- a/src/Core/src/Platform/Android/MauiTimePicker.cs
+++ b/src/Core/src/Platform/Android/MauiTimePicker.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.Runtime;
 using Android.Text;
+using Android.Text.Method;
 using Android.Util;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
@@ -31,6 +32,8 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
+		protected override IMovementMethod? DefaultMovementMethod => null;
+
 		public Action? ShowPicker { get; set; }
 		public Action? HidePicker { get; set; }
 
@@ -44,10 +47,7 @@ namespace Microsoft.Maui.Platform
 			if (Background != null)
 				DrawableCompat.Wrap(Background);
 
-			Focusable = true;
-			FocusableInTouchMode = false;
-			Clickable = true;
-			InputType = InputTypes.Null;
+			PickerManager.Init(this);
 
 			SetOnClickListener(this);
 		}

--- a/src/Core/src/Platform/Android/PickerManager.cs
+++ b/src/Core/src/Platform/Android/PickerManager.cs
@@ -11,49 +11,17 @@ namespace Microsoft.Maui.Platform
 {
 	internal static class PickerManager
 	{
-		readonly static HashSet<Keycode> AvailableKeys = new HashSet<Keycode>(new[] {
-			Keycode.Tab, Keycode.Forward, Keycode.DpadDown, Keycode.DpadLeft, Keycode.DpadRight, Keycode.DpadUp
-		});
-
 		public static void Init(EditText editText)
 		{
 			editText.Focusable = true;
 			editText.FocusableInTouchMode= false;
 			editText.Clickable = true;
 			editText.InputType = InputTypes.Null;
-
-			editText.KeyPress += OnKeyPress;
-		}
-
-
-
-		static void OnKeyPress(object? sender, AView.KeyEventArgs e)
-		{
-			//To prevent user from entering text when focus is received
-			e.Handled = true;
-			if (!AvailableKeys.Contains(e.KeyCode))
-			{
-				return;
-			}
-			(sender as AView)?.CallOnClick();
 		}
 
 		public static void Dispose(EditText editText)
 		{
-			editText.KeyPress -= OnKeyPress;
 			editText.SetOnClickListener(null);
-		}
-
-		public static Java.Lang.ICharSequence GetTitle(Color titleColor, string title)
-		{
-			if (titleColor == null)
-				return new Java.Lang.String(title);
-
-			var spannableTitle = new SpannableString(title ?? string.Empty);
-#pragma warning disable CA1416 // https://github.com/xamarin/xamarin-android/issues/6962
-			spannableTitle.SetSpan(new ForegroundColorSpan(titleColor.ToPlatform()), 0, spannableTitle.Length(), SpanTypes.ExclusiveExclusive);
-#pragma warning restore CA1416
-			return spannableTitle;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/PickerManager.cs
+++ b/src/Core/src/Platform/Android/PickerManager.cs
@@ -18,25 +18,14 @@ namespace Microsoft.Maui.Platform
 		public static void Init(EditText editText)
 		{
 			editText.Focusable = true;
+			editText.FocusableInTouchMode= false;
 			editText.Clickable = true;
 			editText.InputType = InputTypes.Null;
 
 			editText.KeyPress += OnKeyPress;
 		}
 
-		public static void OnTouchEvent(EditText sender, MotionEvent? e)
-		{
-			if (e != null && e.Action == MotionEventActions.Up && !sender.IsFocused)
-			{
-				sender.RequestFocus();
-			}
-		}
 
-		public static void OnFocusChanged(bool gainFocus, EditText sender)
-		{
-			if (gainFocus)
-				sender.CallOnClick();
-		}
 
 		static void OnKeyPress(object? sender, AView.KeyEventArgs e)
 		{

--- a/src/Core/src/Platform/Android/PickerManager.cs
+++ b/src/Core/src/Platform/Android/PickerManager.cs
@@ -14,9 +14,12 @@ namespace Microsoft.Maui.Platform
 		public static void Init(EditText editText)
 		{
 			editText.Focusable = true;
-			editText.FocusableInTouchMode= false;
-			editText.Clickable = true;
-			editText.InputType = InputTypes.Null;
+    		editText.FocusableInTouchMode = false;
+    		editText.Clickable = true;
+
+    		// InputType needs to be set before setting KeyListener
+    		editText.InputType = InputTypes.Null;
+    		editText.KeyListener = null;
 		}
 
 		public static void Dispose(EditText editText)

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.get -> bool
+*REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.set -> void
+*REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
+*REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnTouchEvent(Android.Views.MotionEvent? e) -> bool

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,6 @@
 *REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.set -> void
 *REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
 *REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnTouchEvent(Android.Views.MotionEvent? e) -> bool
+override Microsoft.Maui.Platform.MauiDatePicker.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
+override Microsoft.Maui.Platform.MauiPickerBase.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
+override Microsoft.Maui.Platform.MauiTimePicker.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Description of Change
This PR brings `Picker` behavior on Android in line with `DatePicker` and `TimePicker`, in support of the enhancement described in [#8945](https://github.com/dotnet/maui/issues/8945).

Currently, the `Picker`'s platform control is **focusable on touch**, and a lot of custom logic has been implemented to make it work with this focus behavior. However, even with that logic, the platform control does **not lose focus automatically** when the dialog is dismissed — the `Focus` event fires, but the corresponding `Unfocus` event does **not** trigger when the dialog closes. This has led to some weird bugs.

In contrast, both `DatePicker` and `TimePicker` are **not focusable on touch**, so obviously, their `Focused` and `Unfocused` events do **not** fire.

This PR makes `Picker` behave the same way — by making it **non-focusable on Touch**, we avoid the current awkward focus lifecycle and ensure consistent behavior across all picker types, paving the way for future improvements with [#8945](https://github.com/dotnet/maui/issues/8945).

CC @PureWeen 
<!-- Enter description of the fix in this section -->

Supersedes #25319

Related to #8946 
Related to #6252

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #19739
Fixes #8546
Fixes #13503
Fixes #24862
Fixes #28121
Fixes #21704
Fixes #15394

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
