### PR TITLE
Implement layout system performance metrics

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -4,15 +4,16 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 
 The following switches are toggled for applications running on Mono for `TrimMode=full` as well as NativeAOT.
 
-| MSBuild Property Name | AppContext Setting | Description |
-|-|-|-|
-| MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types. |
+| MSBuild Property Name | AppContext Setting | Description                                                                                                                                              |
+|-|-|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types.          |
+| IsVisualElementProfilerEnabled | Microsoft.Maui.RuntimeFeature.IsVisualElementProfilerEnabled | When enabled, MAUI ships with `VisualElementProfiler` class to enable profiling of layout pass methods.                                                  |
 | MauiShellSearchResultsRendererDisplayMemberNameSupported | Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported | When disabled, it is necessary to always set `ItemTemplate` of any `SearchHandler`. Displaying search results through `DisplayMemberName` will not work. |
-| MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
-| MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible. |
-| _MauiBindingInterceptorsSupport | Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported | When disabled, MAUI won't intercept any calls to `SetBinding` methods and try to compile them. Enabled by default. |
-| MauiEnableXamlCBindingWithSourceCompilation | Microsoft.Maui.RuntimeFeature.XamlCBindingWithSourceCompilationEnabled | When enabled, MAUI will compile all bindings, including those where the `Source` property is used. |
-| MauiHybridWebViewSupported | Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported | Enables HybridWebView, which makes use of dynamic System.Text.Json serialization features |
+| MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating.                                          |
+| MauiImplicitCastOperatorsUsageViaReflectionSupport | Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported | When disabled, MAUI won't look for implicit cast operators when converting values from one type to another. This feature is not trim-compatible.         |
+| _MauiBindingInterceptorsSupport | Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported | When disabled, MAUI won't intercept any calls to `SetBinding` methods and try to compile them. Enabled by default.                                       |
+| MauiEnableXamlCBindingWithSourceCompilation | Microsoft.Maui.RuntimeFeature.XamlCBindingWithSourceCompilationEnabled | When enabled, MAUI will compile all bindings, including those where the `Source` property is used.                                                       |
+| MauiHybridWebViewSupported | Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported | Enables HybridWebView, which makes use of dynamic System.Text.Json serialization features                                                                |
 
 ## MauiEnableIVisualAssemblyScanning
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -230,6 +230,7 @@
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
     <PropertyGroup>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
+      <MauiEnableVisualElementProfiler Condition="'$(MauiEnableVisualElementProfiler)' == ''">false</MauiEnableVisualElementProfiler>
     </PropertyGroup>
     <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
       <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
@@ -242,6 +243,10 @@
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
                                       Condition="'$(MauiEnableIVisualAssemblyScanning)' != ''"
                                       Value="$(MauiEnableIVisualAssemblyScanning)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsVisualElementProfilerEnabled"
+                                      Condition="'$(MauiEnableVisualElementProfiler)' != ''"
+                                      Value="$(MauiEnableVisualElementProfiler)"
                                       Trim="true" />
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported"
                                       Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' != ''"

--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -261,15 +261,20 @@ namespace Microsoft.Maui.Controls
 
 		public Size CrossPlatformArrange(Graphics.Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
 			var inset = bounds.Inset(StrokeThickness);
 			this.ArrangeContent(inset);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
 			return bounds.Size;
 		}
 
 		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
 			var inset = Padding + StrokeThickness;
-			return this.MeasureContent(inset, widthConstraint, heightConstraint);
+			var size = this.MeasureContent(inset, widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return size;
 		}
 
 		public static void ContentChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>This method is used to pseudo-override the SizeThatFits() on the UIButton since we cannot override the UIButton class.</remarks>
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
+			
 			var button = this;
 
 			var platformButton = Handler?.PlatformView as UIButton;
@@ -146,7 +148,11 @@ namespace Microsoft.Maui.Controls
 							Math.Min(buttonContentHeight, heightConstraint));
 
 			// Rounding the values up to the nearest whole number to match UIView.SizeThatFits
-			return new Size((int)Math.Ceiling(returnSize.Width), (int)Math.Ceiling(returnSize.Height));
+			var size = new Size((int)Math.Ceiling(returnSize.Width), (int)Math.Ceiling(returnSize.Height));
+			
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			
+			return size;
 		}
 
 		/// <summary>
@@ -156,6 +162,8 @@ namespace Microsoft.Maui.Controls
 		/// <returns>Returns a <see cref="Size"/> representing the width and height of the button.</returns>
 		Size ICrossPlatformLayout.CrossPlatformArrange(Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
+
 			bounds = this.ComputeFrame(bounds);
 
 			var platformButton = Handler?.PlatformView as UIButton;
@@ -163,6 +171,8 @@ namespace Microsoft.Maui.Controls
 			// Layout the image and title of the button
 			LayoutButton(platformButton, this, bounds);
 
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
+			
 			return new Size(bounds.Width, bounds.Height);
 		}
 

--- a/src/Controls/src/Core/ContentPage/ContentPage.cs
+++ b/src/Controls/src/Core/ContentPage/ContentPage.cs
@@ -94,14 +94,19 @@ namespace Microsoft.Maui.Controls
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
 			_ = this.MeasureContent(widthConstraint, heightConstraint);
-			return new Size(widthConstraint, heightConstraint);
+			var size = new Size(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return size;
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformArrange(Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
 			Frame = bounds;
 			this.ArrangeContent(bounds);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
 			return bounds.Size;
 		}
 

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -115,7 +115,10 @@ namespace Microsoft.Maui.Controls
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			return this.MeasureContent(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
+			var size = this.MeasureContent(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return size;
 		}
 
 		protected override Size ArrangeOverride(Rect bounds)
@@ -127,7 +130,9 @@ namespace Microsoft.Maui.Controls
 
 		Size ICrossPlatformLayout.CrossPlatformArrange(Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
 			this.ArrangeContent(bounds);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
 			return bounds.Size;
 		}
 	}

--- a/src/Controls/src/Core/Frame/Frame.cs
+++ b/src/Controls/src/Core/Frame/Frame.cs
@@ -111,22 +111,27 @@ namespace Microsoft.Maui.Controls
 		// this code and Border into LayoutExtensions
 		Size ICrossPlatformLayout.CrossPlatformArrange(Graphics.Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
 #if !WINDOWS
 			if (BorderColor is not null)
 				bounds = bounds.Inset(((IBorderElement)this).BorderWidth); // Windows' implementation would cause an incorrect double-counting of the inset
 #endif
 			this.ArrangeContent(bounds);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
 			return bounds.Size;
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
 			var inset = Padding;
 #if !WINDOWS
 			if (BorderColor is not null)
 				inset += ((IBorderElement)this).BorderWidth; // Windows' implementation would cause an incorrect double-counting of the inset
 #endif
-			return this.MeasureContent(inset, widthConstraint, heightConstraint);
+			var size = this.MeasureContent(inset, widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return size;
 		}
 	}
 

--- a/src/Controls/src/Core/ImageButton/ImageButton.iOS.cs
+++ b/src/Controls/src/Core/ImageButton/ImageButton.iOS.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>This method is used to override the SizeThatFitsImage() on wrapper view.</remarks>
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
 			if (Handler?.PlatformView is not UIButton platformButton || platformButton.ImageView is null)
 			{
 				return Size.Zero;
@@ -28,7 +29,9 @@ namespace Microsoft.Maui.Controls
 					.SizeThatFitsImage(constraintSize, Padding.IsNaN ? default : Padding).ToSize();
 			}
 
-			return platformButton.SizeThatFits(constraintSize).ToSize();
+			var crossPlatformMeasure = platformButton.SizeThatFits(constraintSize).ToSize();
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return crossPlatformMeasure;
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -468,11 +468,15 @@ namespace Microsoft.Maui.Controls
 		new public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 #pragma warning restore RS0016 // Add public types and members to the declared API
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
+
 			var layoutManager = _layoutManager ??= CreateLayoutManager();
 
 			InMeasureMode = true;
 			var result = layoutManager.Measure(widthConstraint, heightConstraint);
 			InMeasureMode = false;
+
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
 
 			return result;
 		}

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -348,12 +348,18 @@ namespace Microsoft.Maui.Controls
 
 		public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			return LayoutManager.Measure(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
+			var size = LayoutManager.Measure(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return size;
 		}
 
 		public Graphics.Size CrossPlatformArrange(Graphics.Rect bounds)
 		{
-			return LayoutManager.ArrangeChildren(bounds);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
+			var size = LayoutManager.ArrangeChildren(bounds);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
+			return size;
 		}
 
 		/// <summary>Bindable property for <see cref="CascadeInputTransparent"/>.</summary>
@@ -363,12 +369,12 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>
 		/// Gets or sets a value that controls whether child elements
-		/// inherit the input transparency of this layout when the tranparency is <see langword="true"/>.
+		/// inherit the input transparency of this layout when the transparency is <see langword="true"/>.
 		/// </summary>
 		/// <value>
 		/// <see langword="true" /> to cause child elements to inherit the input transparency of this layout,
 		/// when this layout's <see cref="VisualElement.InputTransparent" /> property is <see langword="true" />.
-		/// <see langword="false" /> to cause child elements to ignore the input tranparency of this layout.
+		/// <see langword="false" /> to cause child elements to ignore the input transparency of this layout.
 		/// </value>
 		public bool CascadeInputTransparent
 		{

--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -682,16 +682,20 @@ namespace Microsoft.Maui.Controls.Compatibility
 		/// <inheritdoc cref="ICrossPlatformLayout.CrossPlatformMeasure(double, double)" />
 		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
 #pragma warning disable CS0618 // Type or member is obsolete
-			return OnMeasure(widthConstraint, heightConstraint).Request;
+			Size crossPlatformMeasure = OnMeasure(widthConstraint, heightConstraint).Request;
 #pragma warning restore CS0618 // Type or member is obsolete
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return crossPlatformMeasure;
 		}
 
 		/// <inheritdoc cref="ICrossPlatformLayout.CrossPlatformArrange(Rect)" />
 		public Size CrossPlatformArrange(Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
 			UpdateChildrenLayout();
-
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -440,6 +440,8 @@ namespace Microsoft.Maui.Controls
 				return ContentSize;
 			}
 
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
+
 			switch (Orientation)
 			{
 				case ScrollOrientation.Horizontal:
@@ -457,6 +459,9 @@ namespace Microsoft.Maui.Controls
 			}
 
 			content.Measure(widthConstraint, heightConstraint);
+
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+
 			return content.DesiredSize;
 		}
 
@@ -472,7 +477,10 @@ namespace Microsoft.Maui.Controls
 		{
 			if (this is IScrollView scrollView)
 			{
-				return scrollView.ArrangeContentUnbounded(bounds);
+				TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
+				var size = scrollView.ArrangeContentUnbounded(bounds);
+				TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
+				return size;
 			}
 
 			return bounds.Size;

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -134,7 +134,10 @@ namespace Microsoft.Maui.Controls
 
 		Size ICrossPlatformLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			return this.MeasureContent(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureStart);
+			var size = this.MeasureContent(widthConstraint, heightConstraint);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformMeasureEnd);
+			return size;
 		}
 
 		protected override Size ArrangeOverride(Rect bounds)
@@ -146,7 +149,9 @@ namespace Microsoft.Maui.Controls
 
 		Size ICrossPlatformLayout.CrossPlatformArrange(Rect bounds)
 		{
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeStart);
 			this.ArrangeContent(bounds);
+			TriggerLayoutPassEvent(Controls.LayoutPassEvent.CrossPlatformArrangeEnd);
 			return bounds.Size;
 		}
 

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1005,6 +1005,11 @@ namespace Microsoft.Maui.Controls
 
 		private protected void TriggerLayoutPassEvent(LayoutPassEvent layoutPassEvent)
 		{
+			if (!RuntimeFeature.IsVisualElementProfilerEnabled)
+			{
+				return;
+			}
+
 			LayoutPassEvent?.Invoke(this, layoutPassEvent);
 		}
 

--- a/src/Controls/src/Core/VisualElementProfiler/ILayoutPassStats.cs
+++ b/src/Controls/src/Core/VisualElementProfiler/ILayoutPassStats.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Maui.Controls;
+
+internal interface ILayoutPassStats
+{
+	ILayoutPassTypeStats this[LayoutPassType type] { get; }
+}

--- a/src/Controls/src/Core/VisualElementProfiler/ILayoutPassTypeStats.cs
+++ b/src/Controls/src/Core/VisualElementProfiler/ILayoutPassTypeStats.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+
+namespace Microsoft.Maui.Controls;
+
+internal interface ILayoutPassTypeStats
+{
+	long StandaloneCount { get; }
+	long Count { get; }
+	long TotalTime { get; }
+}
+
+internal static class LayoutPassTypeStatsExtensions
+{
+	public static double GetAverageTimeNs(this ILayoutPassTypeStats stats)
+	{
+		if (stats.Count == 0)
+		{
+			return 0;
+		}
+
+		return (double)stats.TotalTime / stats.Count / Stopwatch.Frequency * 1000000.0;
+	}
+}

--- a/src/Controls/src/Core/VisualElementProfiler/LayoutPassEvent.cs
+++ b/src/Controls/src/Core/VisualElementProfiler/LayoutPassEvent.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.Maui.Controls;
+
+internal enum LayoutPassEvent
+{
+	MeasureStart,
+	MeasureEnd,
+	CrossPlatformMeasureStart,
+	CrossPlatformMeasureEnd,
+	ArrangeStart,
+	ArrangeEnd,
+	CrossPlatformArrangeStart,
+	CrossPlatformArrangeEnd
+}

--- a/src/Controls/src/Core/VisualElementProfiler/LayoutPassType.cs
+++ b/src/Controls/src/Core/VisualElementProfiler/LayoutPassType.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.Maui.Controls;
+
+internal enum LayoutPassType
+{
+	Measure,
+	CrossPlatformMeasure,
+	Arrange,
+	CrossPlatformArrange
+}

--- a/src/Controls/src/Core/VisualElementProfiler/VisualElementProfiler.cs
+++ b/src/Controls/src/Core/VisualElementProfiler/VisualElementProfiler.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft.Maui.Controls;
+
+internal class VisualElementProfiler
+{
+	class LayoutPassTypeStats : ILayoutPassTypeStats
+	{
+		public LayoutPassTypeStats(LayoutPassType layoutPassType, long count = 0, long standaloneCount = 0, long totalTime = 0)
+		{
+			LayoutPassType = layoutPassType;
+			Count = count;
+			StandaloneCount = standaloneCount;
+			TotalTime = totalTime;
+		}
+
+		public LayoutPassType LayoutPassType { get; }
+		public long StandaloneCount { get; set; }
+		public long Count { get; set; }
+		public long TotalTime { get; set; }
+	}
+
+	class LayoutPassStats : ILayoutPassStats
+	{
+		private readonly LayoutPassTypeStats[] _layoutPassTypeStats =
+		[
+			new(LayoutPassType.Measure),
+			new(LayoutPassType.CrossPlatformMeasure),
+			new(LayoutPassType.Arrange),
+			new(LayoutPassType.CrossPlatformArrange)
+		];
+
+		public LayoutPassTypeStats this[LayoutPassType type]
+		{
+			get
+			{
+				return _layoutPassTypeStats[(int)type];
+			}
+		}
+
+		ILayoutPassTypeStats ILayoutPassStats.this[LayoutPassType type]
+		{
+			get
+			{
+				return this[type];
+			}
+		}
+
+		public override string ToString()
+		{
+			var sb = new StringBuilder();
+			foreach (var typeStats in _layoutPassTypeStats)
+			{
+				sb.AppendLine($"{typeStats.LayoutPassType}: {typeStats.Count} ({typeStats.TotalTime} ns)");
+			}
+			return sb.ToString();
+		}
+	}
+
+	class LayoutPassTimer
+	{
+		// [ Measure, CrossPlatformMeasure, Arrange, CrossPlatformArrange ]
+		private readonly long[] _startTimes = [0, 0, 0, 0];
+		private readonly long[] _totalTimes = [0, 0, 0, 0];
+		private readonly long[] _counts = [0, 0, 0, 0];
+		private readonly long[] _standaloneCounts = [0, 0, 0, 0];
+
+		public ILayoutPassStats ToStats()
+		{
+			var stats = new LayoutPassStats();
+			for (int i = 0; i < 4; i++)
+			{
+				var typeStats = stats[(LayoutPassType)i];
+				typeStats.Count = _counts[i];
+				typeStats.TotalTime = _totalTimes[i];
+			}
+
+			return stats;
+		}
+
+		public (LayoutPassType Type, bool Standalone, long Duration)? Track(LayoutPassEvent evt)
+		{
+			var index = (int)evt / 2;
+			if ((int)evt % 2 == 0)
+			{
+				_startTimes[index] = Stopwatch.GetTimestamp();
+				return null;
+			}
+
+			var start = _startTimes[index];
+			if (start == 0)
+			{
+				// If we don't have a start time, we ignore this event
+				return null;
+			}
+
+			var stop = Stopwatch.GetTimestamp();
+
+			// If the cross-platform pass is part of a non-platform pass, we need to adjust the start time of the non-platform pass
+			// so that it doesn't count the time of the cross-platform pass.
+			long nonPlatformStartTime;
+			bool isStandalone = true;
+			if (index % 2 == 1 && (nonPlatformStartTime = _startTimes[index - 1]) != 0)
+			{
+				var nonPlatformInitialDuration = start - nonPlatformStartTime;
+				_startTimes[index - 1] = stop - nonPlatformInitialDuration;
+				isStandalone = false;
+			}
+			
+			var totalTime = stop - start;
+			var count = 1L;
+			var standaloneCount = isStandalone ? 1L : 0L;
+
+			_startTimes[index] = 0;
+			_totalTimes[index] += totalTime;
+			_counts[index] += count;
+			_standaloneCounts[index] += standaloneCount;
+
+			return ((LayoutPassType)index, isStandalone, totalTime);
+		}
+	}
+
+	private readonly ConditionalWeakTable<VisualElement, LayoutPassTimer> _elementLayoutPassTimers = new();
+	private readonly Dictionary<Type, LayoutPassStats> _typeStats = new();
+
+	public IEnumerable<Type> TrackedTypes => _typeStats.Keys;
+	public IEnumerable<KeyValuePair<Type, ILayoutPassStats>> TypeStats => _typeStats.Select(kv => new KeyValuePair<Type, ILayoutPassStats>(kv.Key, kv.Value));
+
+	public bool TryGetStats(VisualElement element, [NotNullWhen(true)] out ILayoutPassStats? stats)
+	{
+		var found = _elementLayoutPassTimers.TryGetValue(element, out var timer);
+		stats = found ? timer?.ToStats() : null;
+		return stats != null;
+	}
+
+	public void Attach(VisualElement visualElement)
+	{
+		foreach (var descendant in visualElement.GetVisualTreeDescendants().OfType<VisualElement>())
+		{
+			Observe(descendant);
+		}
+
+		visualElement.DescendantAdded += OnDescendantAdded;
+		visualElement.DescendantRemoved += OnDescendantRemoved;
+	}
+
+	public void Detach(VisualElement visualElement)
+	{
+		visualElement.DescendantAdded -= OnDescendantAdded;
+		visualElement.DescendantRemoved -= OnDescendantRemoved;
+
+		foreach (var descendant in visualElement.GetVisualTreeDescendants().OfType<VisualElement>())
+		{
+			Forget(descendant);
+		}
+	}
+
+	public override string ToString()
+	{
+		var statsTable = new List<string[]>();
+		statsTable.Add(["Type", "M(count)", "M(ns)", "CPM(count)", "CPM(ns)", "A(count)", "A(ns)", "CPA(count)", "CPA(ns)"]);
+		foreach (var ts in _typeStats)
+		{
+			var type = ts.Key;
+			var stats = ts.Value;
+
+			var m = stats[LayoutPassType.Measure];
+			var cpm = stats[LayoutPassType.CrossPlatformMeasure];
+			var a = stats[LayoutPassType.Arrange];
+			var cpa = stats[LayoutPassType.CrossPlatformArrange];
+			statsTable.Add([
+				type.Name,
+				$"{m.StandaloneCount} / {m.Count}",
+				m.GetAverageTimeNs().ToString("N0"),
+				$"{cpm.StandaloneCount} / {cpm.Count}",
+				cpm.GetAverageTimeNs().ToString("N0"),
+				$"{a.StandaloneCount} / {a.Count}",
+				a.GetAverageTimeNs().ToString("N0"),
+				$"{cpa.StandaloneCount} / {cpa.Count}",
+				cpa.GetAverageTimeNs().ToString("N0"),
+			]);
+		}
+
+		var colLengths = new int[9];
+		foreach (var row in statsTable)
+		{
+			for (int i = 0; i < colLengths.Length; i++)
+			{
+				colLengths[i] = Math.Max(colLengths[i], row[i].Length);
+			}
+		}
+
+		var sb = new StringBuilder();
+		var rowIndex = 0;
+		foreach (var row in statsTable)
+		{
+			sb.Append("| ");
+			for (int i = 0; i < colLengths.Length; i++)
+			{
+				sb.Append(i == 0 ? row[i].PadRight(colLengths[i]) : row[i].PadLeft(colLengths[i]));
+				sb.Append(" | ");
+			}
+			sb.Append('\n');
+
+			if (rowIndex++ == 0)
+			{
+				sb.Append("| ");
+				foreach (var l in colLengths)
+				{
+					sb.Append(string.Empty.PadRight(l, '-'));
+					sb.Append(" | ");
+				}
+				sb.Append('\n');
+			}
+		}
+		
+		return sb.ToString();
+	}
+
+	void OnDescendantAdded(object? sender, ElementEventArgs e)
+	{
+		if (e.Element is VisualElement descendant)
+		{
+			Observe(descendant);
+		}
+	}
+
+	void OnDescendantRemoved(object? sender, ElementEventArgs e)
+	{
+		if (e.Element is VisualElement descendant)
+		{
+			Forget(descendant);
+		}
+	}
+
+	void Observe(VisualElement descendant)
+	{
+		descendant.LayoutPassEvent += OnLayoutPass;
+		var elementType = descendant.GetType();
+		if (!_typeStats.ContainsKey(elementType))
+		{
+			_typeStats[elementType] = new LayoutPassStats();
+		}
+	}
+
+	void Forget(VisualElement descendant)
+	{
+		descendant.LayoutPassEvent -= OnLayoutPass;
+		_elementLayoutPassTimers.Remove(descendant);
+	}
+
+	void OnLayoutPass(object? sender, LayoutPassEvent e)
+	{
+		if (sender is not VisualElement visualElement)
+		{
+			return;
+		}
+
+		var timer = _elementLayoutPassTimers.GetValue(visualElement, _ => new LayoutPassTimer());
+		var tracked = timer.Track(e);
+
+		if (tracked is { } value)
+		{
+			var passStats = _typeStats[visualElement.GetType()][value.Type];
+			++passStats.Count;
+			if (value.Standalone)
+			{
+				++passStats.StandaloneCount;
+			}
+
+			passStats.TotalTime += value.Duration;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25671.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25671.xaml
@@ -1,52 +1,55 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
+
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:i="clr-namespace:Maui.Controls.Sample.Issues"
              x:Class="Maui.Controls.Sample.Issues.Issue25671"
              Title="LayoutPassTest">
 
-  <i:Issue25671AbsoluteLayout>
-    <i:Issue25671Grid Padding="0,0,0,100"
-                             BackgroundColor="DarkGray"
-                             RowDefinitions="Auto,*,Auto"
-                             AbsoluteLayout.LayoutFlags="All"
-                             AbsoluteLayout.LayoutBounds="0,0,1,1">
+  <AbsoluteLayout>
+    <Grid Padding="0,0,0,100"
+          BackgroundColor="DarkGray"
+          RowDefinitions="Auto,*,Auto"
+          AbsoluteLayout.LayoutFlags="All"
+          AbsoluteLayout.LayoutBounds="0,0,1,1">
 
-      <i:Issue25671ContentView>
-        <i:Issue25671Label Text="Hello world" Padding="16,8" TextColor="White" x:Name="HeadingLabel" AutomationId="HeadingLabel" />
-      </i:Issue25671ContentView>
+      <ContentView>
+        <Label Text="Hello world" Padding="16,8" TextColor="White" x:Name="HeadingLabel" AutomationId="HeadingLabel" />
+      </ContentView>
 
       <CollectionView x:Name="CV" AutomationId="CV" Grid.Row="1">
         <CollectionView.ItemTemplate>
           <DataTemplate>
-            <i:Issue25671ContentView Padding="16">
-              <i:Issue25671VerticalStackLayout Shadow="{Shadow Radius=16, Brush=Black, Opacity=0.24}"
-                                               BackgroundColor="SlateBlue"
-                                               Padding="16,8"
-                                               Spacing="8">
-                <i:Issue25671Label Text="{Binding Text}" TextColor="White"/>
-                <i:Issue25671Image HorizontalOptions="Center">
-                  <i:Issue25671Image.Source>
-                    <FontImageSource Glyph="{Binding Glyph}" Color="White" FontFamily="FA" Size="24"/>
-                  </i:Issue25671Image.Source>
-                </i:Issue25671Image>
-              </i:Issue25671VerticalStackLayout>
-            </i:Issue25671ContentView>
+            <ContentView Padding="16">
+              <VerticalStackLayout Shadow="{Shadow Radius=16, Brush=Black, Opacity=0.24}"
+                                   BackgroundColor="SlateBlue"
+                                   Padding="16,8"
+                                   Spacing="8">
+                <Label Text="{Binding Text}" TextColor="White" />
+                <Image HorizontalOptions="Center">
+                  <Image.Source>
+                    <FontImageSource Glyph="{Binding Glyph}" Color="White" FontFamily="FA" Size="24" />
+                  </Image.Source>
+                </Image>
+              </VerticalStackLayout>
+            </ContentView>
           </DataTemplate>
         </CollectionView.ItemTemplate>
       </CollectionView>
-      
-      <i:Issue25671VerticalStackLayout Grid.Row="2" BackgroundColor="DarkBlue">
-        <i:Issue25671Button Text="Regenerate items" Padding="16,8" TextColor="White" Clicked="RegenerateItems" AutomationId="RegenerateItems" />
-      </i:Issue25671VerticalStackLayout>
-    </i:Issue25671Grid>
 
-    <i:Issue25671VerticalStackLayout HeightRequest="100"
-                                     BackgroundColor="SlateBlue"
-                                     VerticalOptions="End"
-                                     AbsoluteLayout.LayoutFlags="All"
-                                     AbsoluteLayout.LayoutBounds="0,1,1,1">
+      <VerticalStackLayout Grid.Row="2" BackgroundColor="DarkBlue">
+        <Button Text="Regenerate items" Padding="16,8" TextColor="White" Clicked="RegenerateItems"
+                AutomationId="RegenerateItems" />
+      </VerticalStackLayout>
+    </Grid>
+
+    <VerticalStackLayout HeightRequest="100"
+                         BackgroundColor="SlateBlue"
+                         VerticalOptions="End"
+                         AbsoluteLayout.LayoutFlags="All"
+                         AbsoluteLayout.LayoutBounds="0,1,1,1">
       <Button Text="Press Me" Clicked="OnClick" TextColor="White" AutomationId="PressMe" />
-    </i:Issue25671VerticalStackLayout>
-  </i:Issue25671AbsoluteLayout>
+      <Label AutomationId="Stats" x:Name="Stats" Margin="8" FontSize="8" />
+    </VerticalStackLayout>
+  </AbsoluteLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25671.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25671.cs
@@ -1,4 +1,6 @@
 #if ANDROID || IOS //This test is only valid for Android and iOS as it measures the layout passes.
+using System.Text;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using UITest.Appium;
@@ -34,28 +36,63 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			await ScrollUp();
 
 			App.Tap("PressMe");
+			await Task.Delay(100);
+
 			// Text will be in the format "M: 0, A: 0"
 			var text = App.WaitForElement("PressMe").GetText()!;
-			// Get measure passes and arrange passes value via regex
-			var match = System.Text.RegularExpressions.Regex.Match(text, @"M: (\d+), A: (\d+)");
+			// Get the stats text
+			var statsLabel = App.WaitForElement("Stats");
+			var statsBuilder = new StringBuilder();
+			while (true)
+			{
+				try
+				{
+					var line = statsLabel.GetText();
+					if (string.IsNullOrEmpty(line))
+					{
+						break;
+					}
+
+					statsBuilder.AppendLine(line);
+					statsLabel.Tap();
+					await Task.Delay(10);
+				}
+				catch
+				{
+					break;
+				}
+			}
+
+			// Get standalone measure passes and arrange passes counts via regex
+			var match = Regex.Match(text, @"M: (\d+), A: (\d+), CPM: (\d+), CPA: (\d+)");
 			var measurePasses = int.Parse(match.Groups[1].Value);
 			var arrangePasses = int.Parse(match.Groups[2].Value);
+			var crossPlatformMeasurePasses = int.Parse(match.Groups[3].Value);
+			var crossPlatformArrangePasses = int.Parse(match.Groups[4].Value);
 
 #if IOS
-            var maxMeasurePasses = 225;
+            var maxMeasurePasses = 193;
             var maxArrangePasses = 247;
+            var maxCrossPlatformMeasurePasses = 75;
+            var maxCrossPlatformArrangePasses = 130;
 
             if (App.FindElement("HeadingLabel").GetText() == "CollectionViewHandler2")
             {
-	            maxMeasurePasses = 380;
-	            maxArrangePasses = 295;
+	            maxMeasurePasses = 257;
+	            maxArrangePasses = 235;
+	            maxCrossPlatformMeasurePasses = 103;
+	            maxCrossPlatformArrangePasses = 132;
             }
 #elif ANDROID
-			const int maxMeasurePasses = 353;
-			const int maxArrangePasses = 337;
+			const int maxMeasurePasses = 206;
+			const int maxArrangePasses = 215;
+			const int maxCrossPlatformMeasurePasses = 66;
+			const int maxCrossPlatformArrangePasses = 7;
 #endif
 
 			var logMessage = @$"Measure passes: {measurePasses}, Arrange passes: {arrangePasses}";
+			logMessage += $"\nCrossPlatformMeasure passes: {crossPlatformMeasurePasses}, CrossPlatformArrange passes: {crossPlatformArrangePasses}";
+			logMessage += $"\n\n{statsBuilder}";
 			TestContext.WriteLine(logMessage);
 
 			// Write the log to a file and attach it to the test results for ADO
@@ -67,6 +104,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			// Let's give a 5% margin of error.
 			ClassicAssert.LessOrEqual(measurePasses, maxMeasurePasses * 1.05);
 			ClassicAssert.LessOrEqual(arrangePasses, maxArrangePasses * 1.05);
+			ClassicAssert.LessOrEqual(crossPlatformMeasurePasses, maxCrossPlatformMeasurePasses * 1.05);
+			ClassicAssert.LessOrEqual(crossPlatformArrangePasses, maxCrossPlatformArrangePasses * 1.05);
 		}
 
 		async Task ScrollDown()

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui
 		private const bool AreBindingInterceptorsSupportedByDefault = true;
 		private const bool IsXamlCBindingWithSourceCompilationEnabledByDefault = false;
 		private const bool IsHybridWebViewSupportedByDefault = true;
+		private const bool IsVisualElementProfilerEnabledByDefault = false;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if NET9_0_OR_GREATER
@@ -31,6 +32,15 @@ namespace Microsoft.Maui
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled", out bool isEnabled)
 				? isEnabled
 				: IsIVisualAssemblyScanningEnabledByDefault;
+
+#if NET9_0_OR_GREATER
+		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsVisualElementProfilerEnabled")]
+		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
+#endif
+		internal static bool IsVisualElementProfilerEnabled =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsVisualElementProfilerEnabled", out bool isEnabled)
+				? isEnabled
+				: IsVisualElementProfilerEnabledByDefault;
 
 #if NET9_0_OR_GREATER
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported")]


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This is a proof-of-concept of what we could eventually expose in .NET10 to measure layout system performance.
For now we could merge this in .NET9 as an internal tool to monitor performance.
This is based on the #25671 UITest.

Our huge problem is that `Measure` and `CrossPlatformMeasure` are not the same thing, and they may be called in different ways, same goes for arrange, so I felt it'd be good to have all of them tracked here.

Usage:
```csharp
_profiler = new VisualElementProfiler();
_profiler.Attach(this); // this can be any VisualElement
//.. after a while
_profiler.ToString(); // to print a table with all the information
//or
if (_profiler.TryGetStats(oneOfTheDescendants, out var stats))
{
    stats.ToString(); // to get info about a specific descendant
}
```

Glossary:
```
M: Measure
A: Arrange
CPM: CrossPlatformMeasure
CPA: CrossPlatformArrange
```

Counts are reported as `Standalone Count / Count`

Measure passes: 190, Arrange passes: 245
CrossPlatformMeasure passes: 75, CrossPlatformArrange passes: 130

| Type                | M (count) | M (ns) | CPM (count) | CPM (ns) | A (count) | A (ns) | CPA (count) | CPA (ns) | 
| ------------------- | -------- | ----- | ---------- | ------- | -------- | ----- | ---------- | ------- | 
| Issue25671          |    0 / 0 |     0 |      0 / 0 |       0 |    0 / 0 |     0 |      2 / 2 |     133 | 
| AbsoluteLayout      |    1 / 1 |    15 |      2 / 3 |   9,928 |    2 / 2 |   117 |      3 / 3 |     208 | 
| Grid                |    3 / 3 |    12 |      0 / 3 |   9,357 |    3 / 3 |   107 |      3 / 3 |     566 | 
| ContentView         |    0 / 0 |     0 |    39 / 39 |     236 |  31 / 31 |   312 |    58 / 58 |      70 | 
| Label               |  69 / 69 |    81 |      0 / 0 |       0 |  59 / 59 |   108 |      0 / 0 |       0 | 
| CollectionView      |    3 / 3 | 8,681 |      0 / 0 |       0 |    3 / 3 |    87 |      0 / 0 |       0 | 
| VerticalStackLayout |  42 / 42 |    31 |    30 / 72 |     222 |  87 / 87 |   101 |    60 / 60 |     190 | 
| Button              |    6 / 6 |   127 |     4 / 10 |     341 |    4 / 4 |    81 |      4 / 4 |      24 | 
| Editor              |    0 / 0 |     0 |      0 / 0 |       0 |    0 / 0 |     0 |      0 / 0 |       0 | 
| Image               |  66 / 66 |    90 |      0 / 0 |       0 |  56 / 56 |    85 |      0 / 0 |       0 | 



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29065

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
