### PR TITLE
Add Circle, Polygon, and Polyline click events for Map control

### DIFF
--- a/src/Controls/Maps/src/Circle.cs
+++ b/src/Controls/Maps/src/Circle.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Maps;
@@ -56,5 +57,16 @@ namespace Microsoft.Maui.Controls.Maps
 			get => (Color)GetValue(FillColorProperty);
 			set => SetValue(FillColorProperty, value);
 		}
+
+		/// <summary>
+		/// Occurs when the user clicks/taps on the circle element
+		/// </summary>
+		public event EventHandler? CircleClicked;
+
+		void IMapElement.Clicked()
+		{
+			CircleClicked?.Invoke(this, EventArgs.Empty);
+		}
+
 	}
 }

--- a/src/Controls/Maps/src/HandlerImpl/MapElement.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/MapElement.Impl.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Maui.Controls.Maps
 		float IStroke.StrokeDashOffset => throw new NotImplementedException();
 
 		float IStroke.StrokeMiterLimit => throw new NotImplementedException();
+
+		void IMapElement.Clicked() => throw new NotImplementedException();
 	}
 }

--- a/src/Controls/Maps/src/Polygon.cs
+++ b/src/Controls/Maps/src/Polygon.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Maps;
 
 namespace Microsoft.Maui.Controls.Maps
 {
@@ -30,6 +32,16 @@ namespace Microsoft.Maui.Controls.Maps
 		/// Gets a list of locations on the map which forms the outline of this polygon on the map.
 		/// </summary>
 		public IList<Location> Geopath { get; }
+
+		/// <summary>
+		/// Occurs when the user clicks/taps on the polygon element
+		/// </summary>
+		public event EventHandler? PolygonClicked;
+
+		void IMapElement.Clicked()
+		{
+			PolygonClicked?.Invoke(this, EventArgs.Empty);
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Polygon"/> class.

--- a/src/Controls/Maps/src/Polyline.cs
+++ b/src/Controls/Maps/src/Polyline.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.Maui.Devices.Sensors;
+using Microsoft.Maui.Maps;
 
 namespace Microsoft.Maui.Controls.Maps
 {
@@ -13,6 +15,16 @@ namespace Microsoft.Maui.Controls.Maps
 		/// Gets a list of locations on the map which forms the polyline on the map.
 		/// </summary>
 		public IList<Location> Geopath { get; }
+
+		/// <summary>
+		/// Occurs when the user clicks/taps on the polyline element
+		/// </summary>
+		public event EventHandler? PolylineClicked;
+
+		void IMapElement.Clicked()
+		{
+			PolylineClicked?.Invoke(this, EventArgs.Empty);
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Polyline"/> class.

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,11 +1,14 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
+Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
-static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
-Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
-Microsoft.Maui.Controls.Maps.Map.Region.set -> void

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapElementClickGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapElementClickGallery.xaml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapElementClickGallery"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+    xmlns:sensors="clr-namespace:Microsoft.Maui.Devices.Sensors;assembly=Microsoft.Maui.Essentials"
+    Title="MapElement Click Events">
+    <Grid RowDefinitions="Auto,*">
+        <Label x:Name="StatusLabel" 
+               Text="Tap on a circle, polygon, or polyline"
+               Padding="10"
+               FontSize="16"
+               HorizontalTextAlignment="Center" />
+        <maps:Map x:Name="map" Grid.Row="1">
+            <x:Arguments>
+                <maps:MapSpan>
+                    <x:Arguments>
+                        <sensors:Location>
+                            <x:Arguments>
+                                <x:Double>37.79752</x:Double>
+                                <x:Double>-122.40183</x:Double>
+                            </x:Arguments>
+                        </sensors:Location>
+                        <x:Double>0.02</x:Double>
+                        <x:Double>0.02</x:Double>
+                    </x:Arguments>
+                </maps:MapSpan>
+            </x:Arguments>
+        </maps:Map>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapElementClickGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapElementClickGallery.xaml.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Maps;
+using Position = Microsoft.Maui.Devices.Sensors.Location;
+
+namespace Maui.Controls.Sample.Pages.MapsGalleries
+{
+	public partial class MapElementClickGallery : ContentPage
+	{
+		public MapElementClickGallery()
+		{
+			InitializeComponent();
+			AddMapElements();
+		}
+
+		void AddMapElements()
+		{
+			// Add a circle
+			var circle = new Circle
+			{
+				Center = new Position(37.79752, -122.40183),
+				Radius = new Distance(200),
+				StrokeColor = Color.FromArgb("#88FF0000"),
+				StrokeWidth = 8,
+				FillColor = Color.FromArgb("#88FFC0CB")
+			};
+			circle.CircleClicked += OnCircleClicked;
+			map.MapElements.Add(circle);
+
+			// Add a polygon (triangle)
+			var polygon = new Polygon
+			{
+				StrokeColor = Color.FromArgb("#880000FF"),
+				StrokeWidth = 8,
+				FillColor = Color.FromArgb("#8800FF00")
+			};
+			polygon.Geopath.Add(new Position(37.7997, -122.4050));
+			polygon.Geopath.Add(new Position(37.7997, -122.3980));
+			polygon.Geopath.Add(new Position(37.7950, -122.4015));
+			polygon.PolygonClicked += OnPolygonClicked;
+			map.MapElements.Add(polygon);
+
+			// Add a polyline
+			var polyline = new Polyline
+			{
+				StrokeColor = Color.FromArgb("#FF6600"),
+				StrokeWidth = 10
+			};
+			polyline.Geopath.Add(new Position(37.7930, -122.4100));
+			polyline.Geopath.Add(new Position(37.7940, -122.4050));
+			polyline.Geopath.Add(new Position(37.7935, -122.4000));
+			polyline.Geopath.Add(new Position(37.7950, -122.3950));
+			polyline.PolylineClicked += OnPolylineClicked;
+			map.MapElements.Add(polyline);
+		}
+
+		void OnCircleClicked(object? sender, EventArgs e)
+		{
+			StatusLabel.Text = "Circle clicked!";
+			StatusLabel.TextColor = Colors.Red;
+		}
+
+		void OnPolygonClicked(object? sender, EventArgs e)
+		{
+			StatusLabel.Text = "Polygon clicked!";
+			StatusLabel.TextColor = Colors.Green;
+		}
+
+		void OnPolylineClicked(object? sender, EventArgs e)
+		{
+			StatusLabel.Text = "Polyline clicked!";
+			StatusLabel.TextColor = Colors.Orange;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -20,6 +20,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Circle", () => new CircleGallery(), Navigation),
 						GalleryBuilder.NavButton("Polygon", () => new PolygonsGallery(), Navigation),
 						GalleryBuilder.NavButton("Element Visibility & ZIndex", () => new MapElementVisibilityGallery(), Navigation),
+						GalleryBuilder.NavButton("MapElement Click Events", () => new MapElementClickGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -528,5 +528,96 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Items = itemsSource;
 			}
 		}
+
+		[Fact]
+		public void CircleClickedEventFires()
+		{
+			var circle = new Circle
+			{
+				Center = new Location(37.79752, -122.40183),
+				Radius = new Distance(200),
+			};
+
+			bool eventFired = false;
+			circle.CircleClicked += (s, e) => eventFired = true;
+
+			((IMapElement)circle).Clicked();
+
+			Assert.True(eventFired);
+		}
+
+		[Fact]
+		public void PolygonClickedEventFires()
+		{
+			var polygon = new Polygon();
+			polygon.Geopath.Add(new Location(37.7997, -122.4050));
+			polygon.Geopath.Add(new Location(37.7997, -122.3980));
+			polygon.Geopath.Add(new Location(37.7950, -122.4015));
+
+			bool eventFired = false;
+			polygon.PolygonClicked += (s, e) => eventFired = true;
+
+			((IMapElement)polygon).Clicked();
+
+			Assert.True(eventFired);
+		}
+
+		[Fact]
+		public void PolylineClickedEventFires()
+		{
+			var polyline = new Polyline();
+			polyline.Geopath.Add(new Location(37.7930, -122.4100));
+			polyline.Geopath.Add(new Location(37.7940, -122.4050));
+
+			bool eventFired = false;
+			polyline.PolylineClicked += (s, e) => eventFired = true;
+
+			((IMapElement)polyline).Clicked();
+
+			Assert.True(eventFired);
+		}
+
+		[Fact]
+		public void CircleClickedEventSenderIsCircle()
+		{
+			var circle = new Circle
+			{
+				Center = new Location(37.79752, -122.40183),
+				Radius = new Distance(200),
+			};
+
+			object sender = null;
+			circle.CircleClicked += (s, e) => sender = s;
+
+			((IMapElement)circle).Clicked();
+
+			Assert.Same(circle, sender);
+		}
+
+		[Fact]
+		public void PolygonClickedEventSenderIsPolygon()
+		{
+			var polygon = new Polygon();
+
+			object sender = null;
+			polygon.PolygonClicked += (s, e) => sender = s;
+
+			((IMapElement)polygon).Clicked();
+
+			Assert.Same(polygon, sender);
+		}
+
+		[Fact]
+		public void PolylineClickedEventSenderIsPolyline()
+		{
+			var polyline = new Polyline();
+
+			object sender = null;
+			polyline.PolylineClicked += (s, e) => sender = s;
+
+			((IMapElement)polyline).Clicked();
+
+			Assert.Same(polyline, sender);
+		}
 	}
 }

--- a/src/Core/maps/src/Core/IMapElement.cs
+++ b/src/Core/maps/src/Core/IMapElement.cs
@@ -20,5 +20,10 @@
 		/// Higher values are drawn on top of lower values.
 		/// </summary>
 		int ZIndex { get; }
+
+		/// <summary>
+		/// Method called by the handler when user clicks on the element.
+		/// </summary>
+		void Clicked();
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (Map != null)
 			{
 				Map.SetOnCameraMoveListener(null);
+				Map.SetOnPolygonClickListener(null);
+				Map.SetOnCircleClickListener(null);
+				Map.SetOnPolylineClickListener(null);
 				Map.MarkerClick -= OnMarkerClick;
 				Map.InfoWindowClick -= OnInfoWindowClick;
 				Map.MapClick -= OnMapClick;
@@ -300,6 +303,9 @@ namespace Microsoft.Maui.Maps.Handlers
 			Map = map;
 
 			map.SetOnCameraMoveListener(_mapReady);
+			map.SetOnPolygonClickListener(_mapReady);
+			map.SetOnCircleClickListener(_mapReady);
+			map.SetOnPolylineClickListener(_mapReady);
 
 			map.MarkerClick += OnMarkerClick;
 			map.InfoWindowClick += OnInfoWindowClick;
@@ -546,6 +552,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				var nativePolyline = map.AddPolyline(options);
 
 				polyline.MapElementId = nativePolyline.Id;
+				nativePolyline.Clickable = true;
 
 				if (polyline is IMapElement mapElement)
 				{
@@ -574,6 +581,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			var nativePolygon = map.AddPolygon(options);
 
 			polygon.MapElementId = nativePolygon.Id;
+			nativePolygon.Clickable = true;
 
 			if (polygon is IMapElement mapElement)
 			{
@@ -601,6 +609,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			var nativeCircle = map.AddCircle(options);
 
 			circle.MapElementId = nativeCircle.Id;
+			nativeCircle.Clickable = true;
 
 			if (circle is IMapElement mapElement)
 			{
@@ -612,7 +621,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		}
 	}
 
-	class MapCallbackHandler : Java.Lang.Object, GoogleMap.IOnCameraMoveListener, IOnMapReadyCallback
+	class MapCallbackHandler : Java.Lang.Object, GoogleMap.IOnCameraMoveListener, IOnMapReadyCallback, GoogleMap.IOnPolygonClickListener, GoogleMap.IOnCircleClickListener, GoogleMap.IOnPolylineClickListener
 	{
 		MapHandler? _handler;
 		GoogleMap? _googleMap;
@@ -645,6 +654,18 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 
 			base.Dispose(disposing);
+		}
+
+		public void OnCircleClick(ACircle circle) => SendElementClickEvent(circle.Id);
+
+		public void OnPolygonClick(APolygon polygon) => SendElementClickEvent(polygon.Id);
+
+		public void OnPolylineClick(APolyline polyline) => SendElementClickEvent(polyline.Id);
+
+		void SendElementClickEvent(string elementId)
+		{
+			var element = _handler?.VirtualView.Elements.FirstOrDefault(x => x.MapElementId?.ToString() == elementId);
+			element?.Clicked();
 		}
 	}
 

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -342,6 +342,7 @@ namespace Microsoft.Maui.Maps.Platform
 				.Clicked();
 			}
 
+			// Hit-test overlays in order: Circle > Polygon > Polyline (first match wins)
 			foreach (var overlay in mauiMkMapView.Overlays)
 			{
 				if (overlay is MKCircle circle)
@@ -383,8 +384,9 @@ namespace Microsoft.Maui.Maps.Platform
 						var mapPoint = MKMapPoint.FromCoordinate(tapCoord);
 						var pointInRenderer = renderer.PointForMapPoint(mapPoint);
 
-						// Check if tap is within stroke width of the polyline path
-						using var strokedPath = renderer.Path.CopyByStrokingPath(renderer.StrokeColor is not null ? renderer.LineWidth : 44, CoreGraphics.CGLineCap.Round, CoreGraphics.CGLineJoin.Round, 1);
+						// Use a minimum tap target width for easier polyline interaction
+						var hitTestWidth = renderer.LineWidth < 44 ? (nfloat)44 : renderer.LineWidth;
+						using var strokedPath = renderer.Path.CopyByStrokingPath(hitTestWidth, CoreGraphics.CGLineCap.Round, CoreGraphics.CGLineJoin.Round, 1);
 						if (strokedPath?.ContainsPoint(pointInRenderer, true) == true)
 						{
 							SendClickEvent(overlay);

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,12 +1,13 @@
-#nullable enable
 
+#nullable enable
+Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
-static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This PR adds support for detecting click interactions on Circle, Polygon, and Polyline elements within the .NET MAUI Map control.

**Enhancements over original proposal:**
- Added `PolylineClicked` event (in addition to Circle and Polygon)
- Rebased onto net11.0 branch
- Added proper PublicAPI.Unshipped.txt entries
- Added sample gallery page (`MapElementClickGallery`)
- Added unit tests for click events

### Platforms Affected
- Android: Uses `IOnCircleClickListener`, `IOnPolygonClickListener`, `IOnPolylineClickListener`
- iOS/MacCatalyst: Uses hit testing in tap gesture recognizer

### Public API Changes

```csharp
// Circle
circle.CircleClicked += (s, e) =>
{
    DisplayAlert("Circle Clicked", "You clicked the circle!", "OK");
};

// Polygon
polygon.PolygonClicked += (s, e) =>
{
    DisplayAlert("Polygon Clicked", "You clicked the polygon!", "OK");
};

// Polyline (NEW)
polyline.PolylineClicked += (s, e) =>
{
    DisplayAlert("Polyline Clicked", "You clicked the polyline!", "OK");
};
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28825

---

### Original Proposal

> This PR proposes support for detecting click interactions on Polygon, and Circle elements within the .NET MAUI Map control.

### Demo

|Android|iOS|
|--|--|
|<video src="https://github.com/user-attachments/assets/900920c0-580c-4b62-afd7-d452b4013d90" width="300px"/>|<video src="https://github.com/user-attachments/assets/d53c9c29-5060-417e-b3f8-9c7b8278b8a1" width="300px"/>|

Co-authored-by: Jakub Florkowski <kubaflo123@gmail.com>