### PR TITLE
[net10.0] Update sdk version for arcade

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.3.25201.16"
+    "dotnet": "10.0.100-preview.4.25220.1"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",


### PR DESCRIPTION
### Description of Change

Fixes dnceng builds for net10.0 by installing the correct sdk version that is on Version.props
