### PR TITLE
[inflight] Change inflight package name

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>70</PatchVersion>
     <SdkBandVersion>9.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>ci.inflight</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,8 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>70</PatchVersion>
     <SdkBandVersion>9.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>ci.inflight</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCHNAME)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -21,7 +21,7 @@ variables:
 - name: signingCondition
   value: $[or(
             eq(variables['Sign'], 'true'),
-            in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main'),
+            in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ),
             startsWith(variables['Build.SourceBranch'], 'refs/tags/'),
             startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
           )]


### PR DESCRIPTION
### Description of Change

By changing the suffix we can understand what nightly package was created from the inflight branch .

Only problem is this would need to be done always, and reverted when merged to main. Open to other ideas? 

Maybe a msbuild condition ? 