### PR TITLE
Changes in Android cake to fix emulator boot issues on Linux

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -704,7 +704,7 @@ void EnsureAdbKeys(AdbToolSettings settings)
         Information("Manually authorize the emulator with the generated ADB keys.");
 
         // Push ADB Keys to the device
-        AdbShell($"adb push {adbKeyPubFile} /data/misc/adb/adb_keys"", settings);
+        AdbShell($"adb push {adbKeyPubFile} /data/misc/adb/adb_keys", settings);
 
         // Ensure correct permissions on the device
         AdbShell("adb shell chmod 600 /data/misc/adb/adb_keys", settings);

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -702,8 +702,14 @@ void EnsureAdbKeys(AdbToolSettings settings)
 
         // Manually authorize the emulator
         Information("Manually authorize the emulator with the generated ADB keys.");
+
+        // Push ADB Keys to the device
         AdbShell($"adb push {adbKeyPubFile} /data/misc/adb/adb_keys"", settings);
+
+        // Ensure correct permissions on the device
         AdbShell("adb shell chmod 600 /data/misc/adb/adb_keys", settings);
+
+        // Manually Restart ADB Daemon on the device
         AdbShell("adb shell stop adbd", settings);
         AdbShell("adb shell start adbd", settings);
 

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -682,7 +682,7 @@ void EnsureAdbKeys(AdbToolSettings settings)
         System.Threading.Thread.Sleep(1000);
         AdbStartServer(settings);
 
-        // Wait for ADB key generation (with exponential backoff)
+        // Wait for ADB key generation
         Information("Waiting for ADB keys generation...");
         int keyWaited = 0;
         while ((!System.IO.File.Exists(adbKeyFile) || !System.IO.File.Exists(adbKeyPubFile)) && keyWaited < 30)


### PR DESCRIPTION
### Description of Change

Changes in Android cake to fix emulator boot issues on Linux.

Changes:
- Use `adb keygen `to regenerate the keys instead restart the ADB server.
- Sets `$ADB_VENDOR_KEYS` before restarting ADB to prevents "unauthorized device" issues by defining the variable before restarting the daemon.
- Ensures file permissions are correct before pushing keys.
- Added retry (maximum 3 times) to push the ADB keys to the device.

Also, added more descriptive messages showing what's happening in every step (if something fails, at least detect the step).