### PR TITLE
Add testing note to GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!-- Please let the below note in for people that find this PR -->
+> [!NOTE]
+> Are you waiting for the changes in this PR to be merged?
+> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
+
 <!--
 !!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
 -->


### PR DESCRIPTION
### Description of Change

Adds a testing note to the PR template to encourage users to test the resulting artifacts from the PR and provide feedback.

Preview:

![image](https://github.com/user-attachments/assets/f0674b92-ee7c-4ef7-8ed5-01f5de70bf4a)