### PR TITLE
[Windows, Mac] Fixed Disappearing event not triggered when closing a window with a modal page

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -434,9 +434,9 @@ namespace Microsoft.Maui.Controls
 			{
 				Page?.SendDisappearing();
 			}
-			else
+			else if (Navigation.ModalStack.Count > 0)
 			{
-				Navigation.ModalStack[Navigation.ModalStack.Count - 1].SendDisappearing();
+				Navigation.ModalStack[Navigation.ModalStack.Count - 1]?.SendDisappearing();
 			}
 
 			IsActivated = false;

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Maui.Controls
 			}
 			else if (Navigation.ModalStack.Count > 0)
 			{
-				Navigation.ModalStack[Navigation.ModalStack.Count - 1]?.SendDisappearing();
+				Navigation.ModalStack[^1]?.SendDisappearing();
 			}
 
 			IsActivated = false;

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -431,7 +431,13 @@ namespace Microsoft.Maui.Controls
 		void SendWindowDisppearing()
 		{
 			if (Navigation.ModalStack.Count == 0)
+			{
 				Page?.SendDisappearing();
+			}
+			else
+			{
+				Navigation.ModalStack[Navigation.ModalStack.Count - 1].SendDisappearing();
+			}
 
 			IsActivated = false;
 		}

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Maui.Controls
 			}
 			else if (Navigation.ModalStack.Count > 0)
 			{
-				Navigation.ModalStack[^1]?.SendDisappearing();
+				Navigation.ModalStack[Navigation.ModalStack.Count - 1]?.SendDisappearing();
 			}
 
 			IsActivated = false;

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -556,6 +556,28 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+#if WINDOWS || MACCATALYST
+		[Fact]
+		public async Task DisappearingEventFiresWhenWindowClosedWithModal()
+		{
+			SetupBuilder();
+			var rootPage = new ContentPage();
+			var modalPage = new ContentPage();
+			bool disappearingTriggered = false;
+			modalPage.Disappearing += (_, _) => disappearingTriggered = true;
+			var window = new Window(rootPage);
+			await rootPage.Navigation.PushModalAsync(modalPage);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async handler =>
+			{
+				await OnLoadedAsync(modalPage);
+				Application.Current?.CloseWindow(window);
+			});
+
+			Assert.True(disappearingTriggered);
+		}
+#endif
+
 		class PageTypes : IEnumerable<object[]>
 		{
 			public IEnumerator<object[]> GetEnumerator()


### PR DESCRIPTION
### Issue Detail
When a page is pushed using PushModalAsync and the window is then closed, the Disappearing event for the pushed page is not triggered.

### Root Cause
The Disappearing event was only triggered when the ModalStack count was zero during window closure. When pushing the page, stack count was greater than zero, which results in restricting the Disappearing event.

### Description of Change
Modified the logic to trigger the Disappearing event for the last page in the stack when closing the window, which resolves the issue.

### Reference:
In PopModalAsync, the [Disappearing](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs#L220) event is triggered for the [LastPage](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs#L205) in the stack. The same logic is now applied when closing the window.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/19675

### Screenshots

Mac:
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/f54d18d2-cae7-4f68-8819-f91fb1e8eb77"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/6d4eaef8-d485-42ec-85af-9832f7f6e660">) |

Windows:
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/ca74cdf6-b60a-4bf1-b322-3efc4c44876c"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/2a42c053-a193-4216-98bc-2e124d52d1cc">) |