### PR TITLE
[Windows] Bump `Microsoft.Web.WebView2` from `1.0.2903.40` to `1.0.3179.45`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <MicrosoftWindowsAppSDKPackageVersion>1.6.250228001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.2.0</MicrosoftGraphicsWin2DPackageVersion>
-    <MicrosoftWindowsWebView2PackageVersion>1.0.2903.40</MicrosoftWindowsWebView2PackageVersion>
+    <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAuthorizationPackageVersion>9.0.0</MicrosoftAspNetCoreAuthorizationPackageVersion>
     <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>9.0.0</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>


### PR DESCRIPTION
## Description of Change

Current version: https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/?tabs=dotnetcsharp#10290340
New version: https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/?tabs=dotnetcsharp#10317945

Notably, the new version contains the following bugfix:

* Fixed folder uploads in UWP and WinUI. ([Issue #3275](https://github.com/MicrosoftEdge/WebView2Feedback/issues/3275))