### PR TITLE
[net 10.0 Testing] Enabled CachedFilenameIsCorrectAndValid test 

### DIFF
--- a/src/Core/tests/DeviceTests/Services/ImageSource/UriImageSourceServiceTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/UriImageSourceServiceTests.iOS.cs
@@ -19,33 +19,31 @@ namespace Microsoft.Maui.DeviceTests
 
 			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetImageAsync(imageSource));
 		}
-
-		// Disabled due to https://github.com/dotnet/runtime/issues/111506
 		
-		// [Theory]
-		// [InlineData("https://test.com/file", "{hash}")]
-		// [InlineData("https://test.com/file#test", "{hash}")]
-		// [InlineData("https://test.com/file#test=123", "{hash}")]
-		// [InlineData("https://test.com/file?test", "{hash}")]
-		// [InlineData("https://test.com/file?test=123", "{hash}")]
-		// [InlineData("https://test.com/file.png", "{hash}.png")]
-		// [InlineData("https://test.com/file.jpg", "{hash}.jpg")]
-		// [InlineData("https://test.com/file.gif", "{hash}.gif")]
-		// [InlineData("https://test.com/file.jpg?ids", "{hash}.jpg")]
-		// [InlineData("https://test.com/file.jpg?id=123", "{hash}.jpg")]
-		// [InlineData("https://test.com/file.gif#id=123", "{hash}.gif")]
-		// [InlineData("https://test.com/file.gif#ids", "{hash}.gif")]
-		// public void CachedFilenameIsCorrectAndValid(string uri, string expected)
-		// {
-		// 	using var algorithm = new Crc64HashAlgorithm();
-		// 	var hashed = algorithm.ComputeHashString(uri);
-		// 	expected = expected.Replace("{hash}", hashed, StringComparison.OrdinalIgnoreCase);
+		[Theory]
+		[InlineData("https://test.com/file", "{hash}")]
+		[InlineData("https://test.com/file#test", "{hash}")]
+		[InlineData("https://test.com/file#test=123", "{hash}")]
+		[InlineData("https://test.com/file?test", "{hash}")]
+		[InlineData("https://test.com/file?test=123", "{hash}")]
+		[InlineData("https://test.com/file.png", "{hash}.png")]
+		[InlineData("https://test.com/file.jpg", "{hash}.jpg")]
+		[InlineData("https://test.com/file.gif", "{hash}.gif")]
+		[InlineData("https://test.com/file.jpg?ids", "{hash}.jpg")]
+		[InlineData("https://test.com/file.jpg?id=123", "{hash}.jpg")]
+		[InlineData("https://test.com/file.gif#id=123", "{hash}.gif")]
+		[InlineData("https://test.com/file.gif#ids", "{hash}.gif")]
+		public void CachedFilenameIsCorrectAndValid(string uri, string expected)
+		{
+			using var algorithm = new Crc64HashAlgorithm();
+			var hashed = algorithm.ComputeHashString(uri);
+			expected = expected.Replace("{hash}", hashed, StringComparison.OrdinalIgnoreCase);
 
-		// 	var service = new UriImageSourceService();
+			var service = new UriImageSourceService();
 
-		// 	var filename = service.GetCachedFileName(new UriImageSourceStub { Uri = new Uri(uri) });
+			var filename = service.GetCachedFileName(new UriImageSourceStub { Uri = new Uri(uri) });
 
-		// 	Assert.Equal(expected, filename);
-		// }
+			Assert.Equal(expected, filename);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change
 
This pull request re-enables the CachedFilenameIsCorrectAndValid test in UriImageSourceServiceTests.iOS.cs. The test was previously disabled due to a runtime issue ([dotnet/runtime#111506](https://github.com/dotnet/runtime/issues/111506)), which has now been resolved. I have re-enabled the test and verified that it passes successfully.
 
### Issues Fixed
 
Fixes #27317 

### Output
**iOS:** 
<img width="300" alt="Screenshot 2025-04-23 at 5 25 36 PM" src="https://github.com/user-attachments/assets/10cca614-e2e9-497c-9cfa-39a08cbf8d0d" />


**Mac:**
<img width="1000" alt="Screenshot 2025-04-23 at 1 17 09 PM" src="https://github.com/user-attachments/assets/8f224bad-cc18-4ff6-8de0-6363e41631cc" />

