### PR TITLE
[iOS] Fixed issue where group Header/Footer template was set to all items when IsGrouped was true for an ObservableCollection

### DIFF
--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net*.0
     - inflight/*
+    - darc-*
   tags:
     include:
     - '*'

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net*.0
     - inflight/*
+    - darc-*
   tags:
     include:
     - '*'

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableGroupedSource.cs
@@ -226,7 +226,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			for (int n = 0; n < _groupSource.Count; n++)
 			{
-				if (_groupSource[n] is IEnumerable list)
+				// Use ICollection (not IEnumerable) so that flat collections whose item type
+				// implements IEnumerable (e.g. string → IEnumerable<char>) are not mistaken
+				// for groups, which would render a header/footer per item.
+				if (_groupSource[n] is ICollection list)
 				{
 					var source = ItemsSourceFactory.Create(list, _groupableItemsView, this);
 					source.HasFooter = _hasGroupFooters;
@@ -287,6 +290,24 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
+			var count = 0;
+
+			foreach (var item in args.NewItems)
+			{
+				// Count only real groups (ICollection); flat items like strings must not
+				// trigger a section insertion — they would cause _groups[groupIndex] to be
+				// out-of-range after UpdateGroupTracking skips non-ICollection items.
+				if (item is ICollection)
+				{
+					count++;
+				}
+			}
+
+			if (count == 0)
+			{
+				return;
+			}
+
 			var groupIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
 			var groupCount = args.NewItems.Count;
 
@@ -307,6 +328,24 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void Remove(NotifyCollectionChangedEventArgs args)
 		{
+			var count = 0;
+
+			foreach (var item in args.OldItems)
+			{
+				// Count only real groups (ICollection); flat items like strings must not
+				// trigger a section removal — they would cause _groups[groupIndex] to be
+				// out-of-range after UpdateGroupTracking skips non-ICollection items.
+				if (item is ICollection)
+				{
+					count++;
+				}
+			}
+
+			if (count == 0)
+			{
+				return;
+			}
+
 			var groupIndex = args.OldStartingIndex;
 
 			if (groupIndex < 0)

--- a/src/Controls/src/Core/Handlers/Items/GroupableItemsViewHandler.cs
+++ b/src/Controls/src/Core/Handlers/Items/GroupableItemsViewHandler.cs
@@ -20,10 +20,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public static PropertyMapper<TItemsView, GroupableItemsViewHandler<TItemsView>> GroupableItemsViewMapper = new(SelectableItemsViewMapper)
 		{
 			[GroupableItemsView.IsGroupedProperty.PropertyName] = MapIsGrouped,
-#if WINDOWS || __ANDROID__ || TIZEN
 			[GroupableItemsView.GroupFooterTemplateProperty.PropertyName] = MapIsGrouped,
 			[GroupableItemsView.GroupHeaderTemplateProperty.PropertyName] = MapIsGrouped,
-#endif
 		};
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/GroupableItemsViewHandler.cs
+++ b/src/Controls/src/Core/Handlers/Items/GroupableItemsViewHandler.cs
@@ -20,8 +20,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public static PropertyMapper<TItemsView, GroupableItemsViewHandler<TItemsView>> GroupableItemsViewMapper = new(SelectableItemsViewMapper)
 		{
 			[GroupableItemsView.IsGroupedProperty.PropertyName] = MapIsGrouped,
+#if WINDOWS || __ANDROID__ || TIZEN
 			[GroupableItemsView.GroupFooterTemplateProperty.PropertyName] = MapIsGrouped,
 			[GroupableItemsView.GroupHeaderTemplateProperty.PropertyName] = MapIsGrouped,
+#endif
 		};
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using Foundation;
 using UIKit;
@@ -19,10 +20,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public ObservableGroupedSource(IEnumerable groupSource, UICollectionViewController collectionViewController)
 		{
 			_collectionViewController = new(collectionViewController);
-			_groupSource = new List<object>();
-			var groupList = groupSource as IList ?? new ListSource(groupSource);
+			_groupSource = groupSource is INotifyCollectionChanged ? new ObservableCollection<object>() : new List<object>();
+			var source = groupSource as IList ?? new ListSource(groupSource);
 
-			foreach (var group in groupList)
+			foreach (var group in source)
 			{
 				if (group is IEnumerable enumerable)
 				{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -12,14 +12,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 	{
 		readonly WeakReference<UICollectionViewController> _collectionViewController;
 		UICollectionView _collectionView => _collectionViewController.TryGetTarget(out var controller) ? controller.CollectionView : null;
-		readonly IList _groupSource;
+		readonly IList _groupSource = new List<object>();
 		bool _disposed;
 		List<ObservableItemsSource> _groups = new List<ObservableItemsSource>();
 
 		public ObservableGroupedSource(IEnumerable groupSource, UICollectionViewController collectionViewController)
 		{
 			_collectionViewController = new(collectionViewController);
-			_groupSource = groupSource as IList ?? new ListSource(groupSource);
+			var groupList = groupSource as IList ?? new ListSource(groupSource);
+
+			foreach (var group in groupList)
+			{
+				if (group is IEnumerable enumerable)
+				{
+					_groupSource.Add(enumerable);
+				}
+			}
 
 			if (_groupSource is INotifyCollectionChanged incc)
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -12,13 +12,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 	{
 		readonly WeakReference<UICollectionViewController> _collectionViewController;
 		UICollectionView _collectionView => _collectionViewController.TryGetTarget(out var controller) ? controller.CollectionView : null;
-		readonly IList _groupSource = new List<object>();
+		readonly IList _groupSource;
 		bool _disposed;
 		List<ObservableItemsSource> _groups = new List<ObservableItemsSource>();
 
 		public ObservableGroupedSource(IEnumerable groupSource, UICollectionViewController collectionViewController)
 		{
 			_collectionViewController = new(collectionViewController);
+			_groupSource = new List<object>();
 			var groupList = groupSource as IList ?? new ListSource(groupSource);
 
 			foreach (var group in groupList)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -20,16 +20,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public ObservableGroupedSource(IEnumerable groupSource, UICollectionViewController collectionViewController)
 		{
 			_collectionViewController = new(collectionViewController);
-			_groupSource = groupSource is INotifyCollectionChanged ? new ObservableCollection<object>() : new List<object>();
-			var source = groupSource as IList ?? new ListSource(groupSource);
-
-			foreach (var group in source)
-			{
-				if (group is IEnumerable enumerable)
-				{
-					_groupSource.Add(enumerable);
-				}
-			}
+			_groupSource = groupSource as IList ?? new ListSource(groupSource);
 
 			if (_groupSource is INotifyCollectionChanged incc)
 			{
@@ -418,12 +409,20 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		int GroupsCount()
 		{
-			if (_groupSource is IList list)
-				return list.Count;
-
 			int count = 0;
-			foreach (var item in _groupSource)
-				count++;
+			if (_groupSource is IList list)
+			{
+				foreach (var group in list)
+				{
+					if (group is IEnumerable enumerable)
+					{
+						count++;
+					}
+				}
+
+				return count;
+			}
+
 			return count;
 		}
 	}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using Foundation;
 using UIKit;

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -240,8 +240,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
+			// Only count items that are actual groups (ICollection); flat items like strings or model objects
+			// must not increment _groupCount or trigger InsertSections on UICollectionView
+			int count = 0;
+
+			foreach (var item in args.NewItems)
+			{
+				// Count only ICollection items — string and plain model objects are not groups
+				if (item is ICollection)
+				{
+					count++;
+				}
+			}
+
+			// None of the new items are groups; no section changes needed
+			if (count == 0)
+			{
+				return;
+			}
+
 			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
-			var count = args.NewItems.Count;
 			_groupCount += count;
 
 			// Adding a group will change the section index for all subsequent groups, so the easiest thing to do
@@ -270,12 +288,30 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
+			// Only count items that are actual groups (ICollection); flat items must not decrement
+			// _groupCount or trigger DeleteSections for sections that were never created
+			int count = 0;
+
+			foreach (var item in args.OldItems)
+			{
+				// Count only ICollection items — string and plain model objects are not groups
+				if (item is ICollection)
+				{
+					count++;
+				}
+			}
+
+			// None of the removed items are groups; no section changes needed
+			if (count == 0)
+			{
+				return;
+			}
+
 			// Removing a group will change the section index for all subsequent groups, so the easiest thing to do
 			// is to reset all the group tracking to get it up-to-date
 			ResetGroupTracking();
 
 			// Since we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
-			var count = args.OldItems.Count;
 			_groupCount -= count;
 
 			// Queue up the updates to the UICollectionView
@@ -413,15 +449,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				foreach (var group in list)
 				{
-					if (group is IEnumerable enumerable)
+					if (group is ICollection)
 					{
 						count++;
 					}
 				}
-
 				return count;
 			}
 
+			foreach (var item in _groupSource)
+			{
+				if (item is ICollection)
+				{
+					count++;
+				}
+			}
 			return count;
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29141.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29141.cs
@@ -1,0 +1,359 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29141, "[iOS] Group Header/Footer Repeated for All Items When IsGrouped is True for ObservableCollection in CollectionView", PlatformAffected.Android)]
+public class Issue29141 : ContentPage
+{
+    Issue29141CollectionViewViewModel _viewModel;
+    CollectionView _collectionView;
+    RadioButton _groupHeaderTemplateNone;
+    RadioButton _groupHeaderTemplateGrid;
+    RadioButton _groupFooterTemplateNone;
+    RadioButton _groupFooterTemplateGrid;
+    RadioButton _isGroupedFalse;
+    RadioButton _isGroupedTrue;
+
+    public Issue29141()
+    {
+        _viewModel = new Issue29141CollectionViewViewModel();
+        BindingContext = _viewModel;
+
+        // Create CollectionView
+        _collectionView = new CollectionView
+        {
+            AutomationId = "collectionView"
+        };
+        _collectionView.SetBinding(CollectionView.ItemsSourceProperty, "ItemsSource");
+        _collectionView.SetBinding(CollectionView.ItemTemplateProperty, "ItemTemplate");
+        _collectionView.SetBinding(CollectionView.IsGroupedProperty, "IsGrouped");
+        _collectionView.SetBinding(CollectionView.GroupHeaderTemplateProperty, "GroupHeaderTemplate");
+        _collectionView.SetBinding(CollectionView.GroupFooterTemplateProperty, "GroupFooterTemplate");
+
+        // Create GroupHeaderTemplate radio buttons
+        _groupHeaderTemplateNone = new RadioButton
+        {
+            IsChecked = true,
+            Content = "None",
+            FontSize = 11,
+            GroupName = "GroupHeaderTemplateGroup",
+            AutomationId = "GroupHeaderTemplateNone"
+        };
+        _groupHeaderTemplateNone.CheckedChanged += OnGroupHeaderTemplateChanged;
+
+        _groupHeaderTemplateGrid = new RadioButton
+        {
+            Content = "View",
+            FontSize = 11,
+            GroupName = "GroupHeaderTemplateGroup",
+            AutomationId = "GroupHeaderTemplateGrid"
+        };
+        _groupHeaderTemplateGrid.CheckedChanged += OnGroupHeaderTemplateChanged;
+
+        // Create GroupFooterTemplate radio buttons
+        _groupFooterTemplateNone = new RadioButton
+        {
+            IsChecked = true,
+            Content = "None",
+            FontSize = 11,
+            GroupName = "GroupFooterTemplateGroup",
+            AutomationId = "GroupFooterTemplateNone"
+        };
+        _groupFooterTemplateNone.CheckedChanged += OnGroupFooterTemplateChanged;
+
+        _groupFooterTemplateGrid = new RadioButton
+        {
+            Content = "View",
+            FontSize = 11,
+            GroupName = "GroupFooterTemplateGroup",
+            AutomationId = "GroupFooterTemplateGrid"
+        };
+        _groupFooterTemplateGrid.CheckedChanged += OnGroupFooterTemplateChanged;
+
+        // Create IsGrouped radio buttons
+        _isGroupedFalse = new RadioButton
+        {
+            Content = "False",
+            IsChecked = true,
+            FontSize = 11,
+            AutomationId = "IsGroupedFalse"
+        };
+        _isGroupedFalse.CheckedChanged += OnIsGroupedChanged;
+
+        _isGroupedTrue = new RadioButton
+        {
+            Content = "True",
+            FontSize = 11,
+            AutomationId = "IsGroupedTrue"
+        };
+        _isGroupedTrue.CheckedChanged += OnIsGroupedChanged;
+
+        // Build the UI
+        var controlsLayout = new StackLayout
+        {
+            Padding = new Thickness(10),
+            Spacing = 10,
+            Children =
+            {
+                new Label
+                {
+                    Text = "GroupHeaderTemplate:",
+                    FontAttributes = FontAttributes.Bold,
+                    FontSize = 12
+                },
+                new StackLayout
+                {
+                    Orientation = StackOrientation.Horizontal,
+                    Children = { _groupHeaderTemplateNone, _groupHeaderTemplateGrid }
+                },
+                new Label
+                {
+                    Text = "GroupFooterTemplate:",
+                    FontAttributes = FontAttributes.Bold,
+                    FontSize = 12
+                },
+                new StackLayout
+                {
+                    Orientation = StackOrientation.Horizontal,
+                    Children = { _groupFooterTemplateNone, _groupFooterTemplateGrid }
+                },
+                new Label
+                {
+                    Text = "IsGrouped:",
+                    FontSize = 12,
+                    FontAttributes = FontAttributes.Bold
+                },
+                new StackLayout
+                {
+                    Orientation = StackOrientation.Horizontal,
+                    Children = { _isGroupedFalse, _isGroupedTrue }
+                }
+            }
+        };
+
+        var scrollView = new ScrollView
+        {
+            Content = controlsLayout
+        };
+
+        Content = new Grid
+        {
+            Padding = new Thickness(10),
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }
+            },
+            Children =
+            {
+                _collectionView,
+                scrollView
+            }
+        };
+
+        Grid.SetRow(_collectionView, 0);
+        Grid.SetRow(scrollView, 1);
+    }
+
+    void OnGroupHeaderTemplateChanged(object sender, CheckedChangedEventArgs e)
+    {
+        if (_groupHeaderTemplateNone.IsChecked)
+        {
+            _viewModel.GroupHeaderTemplate = null;
+        }
+        else if (_groupHeaderTemplateGrid.IsChecked)
+        {
+            _viewModel.GroupHeaderTemplate = new DataTemplate(() =>
+            {
+                return new Grid
+                {
+                    BackgroundColor = Colors.LightGray,
+                    Padding = new Thickness(10),
+                    Children =
+                    {
+                            new Label
+                            {
+                                Text = "Group Header Template (Grid View)",
+                                FontSize = 18,
+                                AutomationId = "GroupHeaderTemplate",
+                                FontAttributes = FontAttributes.Bold,
+                                HorizontalOptions = LayoutOptions.Center,
+                                VerticalOptions = LayoutOptions.Center,
+                                TextColor = Colors.Green
+                            }
+                    }
+                };
+            });
+        }
+    }
+
+    void OnGroupFooterTemplateChanged(object sender, CheckedChangedEventArgs e)
+    {
+        if (_groupFooterTemplateNone.IsChecked)
+        {
+            _viewModel.GroupFooterTemplate = null;
+        }
+        else if (_groupFooterTemplateGrid.IsChecked)
+        {
+            _viewModel.GroupFooterTemplate = new DataTemplate(() =>
+            {
+                return new Grid
+                {
+                    BackgroundColor = Colors.LightGray,
+                    Padding = new Thickness(10),
+                    Children =
+                    {
+                            new Label
+                            {
+                                Text = "Group Footer Template (Grid View)",
+                                FontSize = 18,
+                                AutomationId = "GroupFooterTemplate",
+                                FontAttributes = FontAttributes.Bold,
+                                HorizontalOptions = LayoutOptions.Center,
+                                VerticalOptions = LayoutOptions.Center,
+                                TextColor = Colors.Red
+                            }
+                    }
+                };
+            });
+        }
+    }
+
+    void OnIsGroupedChanged(object sender, CheckedChangedEventArgs e)
+    {
+        if (_isGroupedFalse.IsChecked)
+        {
+            _viewModel.IsGrouped = false;
+        }
+        else if (_isGroupedTrue.IsChecked)
+        {
+            _viewModel.IsGrouped = true;
+        }
+    }
+}
+
+public class Issue29141CollectionViewViewModel : INotifyPropertyChanged
+{
+    DataTemplate _groupHeaderTemplate;
+    DataTemplate _groupFooterTemplate;
+    DataTemplate _itemTemplate;
+    bool _isGrouped = false;
+    ObservableCollection<Issue29141ItemModel> _observableCollection;
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public Issue29141CollectionViewViewModel()
+    {
+        LoadItems();
+        ItemTemplate = new DataTemplate(() =>
+        {
+            var stackLayout = new StackLayout
+            {
+                Padding = new Thickness(10),
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Center
+            };
+
+            var label = new Label
+            {
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Center
+            };
+            label.SetBinding(Label.TextProperty, "Caption");
+            stackLayout.Children.Add(label);
+            return stackLayout;
+        });
+
+        GroupHeaderTemplate = new DataTemplate(() =>
+        {
+            var stackLayout = new StackLayout
+            {
+                BackgroundColor = Colors.LightGray
+            };
+            var label = new Label
+            {
+                FontAttributes = FontAttributes.Bold,
+                FontSize = 18
+            };
+            label.SetBinding(Label.TextProperty, "Key");
+            stackLayout.Children.Add(label);
+            return stackLayout;
+        });
+    }
+
+    void LoadItems()
+    {
+        _observableCollection = new ObservableCollection<Issue29141ItemModel>
+            {
+                new Issue29141ItemModel { Caption = "Item 1" },
+                new Issue29141ItemModel { Caption = "Item 2" },
+                new Issue29141ItemModel { Caption = "Item 3" }
+            };
+    }
+
+    public DataTemplate GroupHeaderTemplate
+    {
+        get => _groupHeaderTemplate;
+        set { _groupHeaderTemplate = value; OnPropertyChanged(); }
+    }
+
+    public DataTemplate GroupFooterTemplate
+    {
+        get => _groupFooterTemplate;
+        set { _groupFooterTemplate = value; OnPropertyChanged(); }
+    }
+
+    public DataTemplate ItemTemplate
+    {
+        get => _itemTemplate;
+        set { _itemTemplate = value; OnPropertyChanged(); }
+    }
+
+    public bool IsGrouped
+    {
+        get => _isGrouped;
+        set { _isGrouped = value; OnPropertyChanged(); }
+    }
+
+    public object ItemsSource
+    {
+        get => _observableCollection;
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        if (propertyName == nameof(IsGrouped))
+        {
+            OnPropertyChanged(nameof(ItemsSource));
+        }
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+internal class Issue29141Grouping<TKey, TItem> : List<TItem>
+{
+    public TKey Key { get; }
+
+    public Issue29141Grouping(TKey key, List<TItem> items) : base(items)
+    {
+        Key = key;
+    }
+
+    public override string ToString()
+    {
+        return Key?.ToString() ?? base.ToString();
+    }
+}
+
+internal class Issue29141ItemModel
+{
+    public string Caption { get; set; }
+
+    public override string ToString()
+    {
+        return !string.IsNullOrEmpty(Caption) ? Caption : base.ToString();
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29141.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29141.cs
@@ -15,6 +15,8 @@ public class Issue29141 : ContentPage
     RadioButton _groupFooterTemplateGrid;
     RadioButton _isGroupedFalse;
     RadioButton _isGroupedTrue;
+    Button _switchToStringCollectionButton;
+    Button _addItemButton;
 
     public Issue29141()
     {
@@ -90,6 +92,20 @@ public class Issue29141 : ContentPage
         };
         _isGroupedTrue.CheckedChanged += OnIsGroupedChanged;
 
+        _switchToStringCollectionButton = new Button
+        {
+            Text = "Use String Collection",
+            AutomationId = "SwitchToStringCollection"
+        };
+        _switchToStringCollectionButton.Clicked += (s, e) => _viewModel.SwitchToStringItems();
+
+        _addItemButton = new Button
+        {
+            Text = "Add Item",
+            AutomationId = "AddItemButton"
+        };
+        _addItemButton.Clicked += (s, e) => _viewModel.AddItem();
+
         // Build the UI
         var controlsLayout = new StackLayout
         {
@@ -129,7 +145,15 @@ public class Issue29141 : ContentPage
                 {
                     Orientation = StackOrientation.Horizontal,
                     Children = { _isGroupedFalse, _isGroupedTrue }
-                }
+                },
+                new Label
+                {
+                    Text = "Scenarios:",
+                    FontSize = 12,
+                    FontAttributes = FontAttributes.Bold
+                },
+                _switchToStringCollectionButton,
+                _addItemButton
             }
         };
 
@@ -241,12 +265,28 @@ public class Issue29141CollectionViewViewModel : INotifyPropertyChanged
     DataTemplate _itemTemplate;
     bool _isGrouped = false;
     ObservableCollection<Issue29141ItemModel> _observableCollection;
+    ObservableCollection<string> _stringCollection;
+    bool _useStringItems;
+    DataTemplate _stringItemTemplate;
 
     public event PropertyChangedEventHandler PropertyChanged;
 
     public Issue29141CollectionViewViewModel()
     {
         LoadItems();
+
+        _stringCollection = new ObservableCollection<string> { "String A", "String B", "String C" };
+        _stringItemTemplate = new DataTemplate(() =>
+        {
+            var label = new Label
+            {
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Center
+            };
+            label.SetBinding(Label.TextProperty, ".");
+            return label;
+        });
+
         ItemTemplate = new DataTemplate(() =>
         {
             var stackLayout = new StackLayout
@@ -293,6 +333,25 @@ public class Issue29141CollectionViewViewModel : INotifyPropertyChanged
             };
     }
 
+    public void SwitchToStringItems()
+    {
+        _useStringItems = true;
+        ItemTemplate = _stringItemTemplate;
+        OnPropertyChanged(nameof(ItemsSource));
+    }
+
+    public void AddItem()
+    {
+        if (_useStringItems)
+        {
+            _stringCollection.Add($"String {_stringCollection.Count + 1}");
+        }
+        else
+        {
+            _observableCollection.Add(new Issue29141ItemModel { Caption = $"Item {_observableCollection.Count + 1}" });
+        }
+    }
+
     public DataTemplate GroupHeaderTemplate
     {
         get => _groupHeaderTemplate;
@@ -319,7 +378,7 @@ public class Issue29141CollectionViewViewModel : INotifyPropertyChanged
 
     public object ItemsSource
     {
-        get => _observableCollection;
+        get => _useStringItems ? (object)_stringCollection : _observableCollection;
     }
 
     protected void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29141.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29141.cs
@@ -1,0 +1,30 @@
+﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // For Windows: Test excluded on Windows due to unrelated NullReferenceException in test infrastructure - see https://github.com/dotnet/maui/issues/28824. 
+// The underlying grouped collection bug (issue #28827) is not Windows-specific; 
+// re-enable this test on Windows once issue #28824 is resolved.
+// For Android: We already have a fix in separate PR #28886, we can re-enable this test once that PR is merged and available in main branch.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29141 : _IssuesUITest
+{
+	public override string Issue => "[iOS] Group Header/Footer Repeated for All Items When IsGrouped is True for ObservableCollection in CollectionView";
+	public Issue29141(TestDevice device)
+	: base(device)
+	{ }
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyCVGroupHFTemplateWithObservableCollection()
+	{
+		App.WaitForElement("collectionView");
+		App.Tap("IsGroupedTrue");
+		App.Tap("GroupHeaderTemplateGrid");
+		App.Tap("GroupFooterTemplateGrid");
+		App.WaitForNoElement("GroupHeaderTemplate");
+		App.WaitForNoElement("GroupFooterTemplate");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29141.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29141.cs
@@ -1,7 +1,6 @@
-﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // For Windows: Test excluded on Windows due to unrelated NullReferenceException in test infrastructure - see https://github.com/dotnet/maui/issues/28824. 
+﻿#if TEST_FAILS_ON_WINDOWS // For Windows: Test excluded on Windows due to unrelated NullReferenceException in test infrastructure - see https://github.com/dotnet/maui/issues/28824. 
 // The underlying grouped collection bug (issue #28827) is not Windows-specific; 
 // re-enable this test on Windows once issue #28824 is resolved.
-// For Android: We already have a fix in separate PR #28886, we can re-enable this test once that PR is merged and available in main branch.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -15,7 +14,7 @@ public class Issue29141 : _IssuesUITest
 	: base(device)
 	{ }
 
-	[Test]
+	[Test, Order(1)]
 	[Category(UITestCategories.CollectionView)]
 	public void VerifyCVGroupHFTemplateWithObservableCollection()
 	{
@@ -25,6 +24,33 @@ public class Issue29141 : _IssuesUITest
 		App.Tap("GroupFooterTemplateGrid");
 		App.WaitForNoElement("GroupHeaderTemplate");
 		App.WaitForNoElement("GroupFooterTemplate");
+	}
+
+	[Test, Order(2)]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyCVGroupHFTemplateWithStringCollection()
+	{
+		App.WaitForElement("collectionView");
+		App.Tap("SwitchToStringCollection");
+		App.Tap("IsGroupedTrue");
+		App.Tap("GroupHeaderTemplateGrid");
+		App.WaitForNoElement("GroupHeaderTemplate");
+	}
+
+	[Test, Order(3)]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyCVNoSectionCrashOnAddFlatItem()
+	{
+		App.WaitForElement("collectionView");
+		App.Tap("IsGroupedTrue");
+		App.Tap("GroupHeaderTemplateGrid");
+		App.WaitForNoElement("GroupHeaderTemplate");
+
+		// Add flat items — should not crash or produce new sections
+		App.Tap("AddItemButton");
+		App.Tap("AddItemButton");
+		App.Tap("AddItemButton");
+		App.WaitForNoElement("GroupHeaderTemplate");
 	}
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Issue 1: Group header and footer templates not updating correctly at runtime on iOS.

### Root Cause

The mapper for `GroupFooterTemplateProperty` and `GroupHeaderTemplateProperty` in `GroupableItemsViewHandler` was conditionally compiled with `#if WINDOWS || __ANDROID__ || TIZEN`, meaning it was excluded from iOS builds. As a result, changing the template at runtime on iOS had no effect and templates were never displayed.

### Description of Change

Removed the `#if WINDOWS || __ANDROID__ || TIZEN` preprocessor guard from `GroupableItemsViewHandler.cs`, making the `GroupFooterTemplateProperty` and `GroupHeaderTemplateProperty` mappers active on all platforms including iOS. Both mappers call `MapIsGrouped`, which triggers `UpdateItemsSource()` and refreshes the grouping state.

---

## Issue 2: Group header/footer templates incorrectly applied to all items in a flat ObservableCollection when `IsGrouped = true`.

### Root Cause

In `ObservableGroupedSource.cs` (iOS), the `GroupsCount()` method iterated over all items in `_groupSource` and counted every item, regardless of whether it was an `IEnumerable` (i.e., an actual group). When `IsGrouped = true` but the source was a flat `ObservableCollection<T>` (non-grouped), each non-grouped item was counted as a section, causing `NumberOfSections` to be inflated. This led to header and footer templates being incorrectly applied to every item.

### Description of Change

Modified `GroupsCount()` to only increment the count for items that implement `IEnumerable`. Non-`IEnumerable` items are no longer counted as sections. As a result, `NumberOfSections` now correctly reflects the number of actual groups, preventing header/footer templates from appearing for non-grouped items.

---

### Issues Fixed

Fixes #29141

### Test Case

Tests for this fix are included in this PR:
- `src/Controls/tests/TestCases.HostApp/Issues/Issue29141.cs` — HostApp page with a `CollectionView` bound to a flat `ObservableCollection`, with radio buttons to toggle `IsGrouped`, `GroupHeaderTemplate`, and `GroupFooterTemplate` at runtime.
- `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29141.cs` — NUnit UI test verifying that group header/footer template views are NOT shown when the source collection is not grouped.

> **Note:** The test is currently excluded from Windows (unrelated NullReferenceException — see #28824) and Android (separate fix in PR #28886). It runs on iOS and MacCatalyst.

### Platforms Tested

- [x] iOS
- [x] Android
- [x] Mac
- [ ] Windows
</details>
