### PR TITLE
[Windows] Fix for ArgumentException thrown when setting a negative padding value for the label

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue6387.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue6387.cs
@@ -1,0 +1,23 @@
+﻿namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 6387, "ArgumentException thrown when a negative value is set for the padding of a label", PlatformAffected.UWP)]
+public class Issue6387 : ContentPage
+{
+	public Issue6387()
+	{
+		Label labelWithNegativePaddingValue = new Label
+		{
+			AutomationId = "LabelWithNegativePaddingValue",
+			Text = "The test passes if the app runs without crashing and fails if the app crashes",
+			Padding = new Thickness(-10)
+		};
+
+		VerticalStackLayout verticalStackLayout = new VerticalStackLayout
+		{
+			Padding = 20,
+			Children = { labelWithNegativePaddingValue }
+		};
+
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue6387.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue6387.cs
@@ -9,7 +9,7 @@ public class Issue6387 : ContentPage
 		{
 			AutomationId = "LabelWithNegativePaddingValue",
 			Text = "The test passes if the app runs without crashing and fails if the app crashes",
-			Padding = new Thickness(-10)
+			Padding = new Thickness(-2)
 		};
 
 		VerticalStackLayout verticalStackLayout = new VerticalStackLayout

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6387.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue6387.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue6387 : _IssuesUITest
+{
+	public Issue6387(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "ArgumentException thrown when a negative value is set for the padding of a label";
+
+	[Test]
+	[Category(UITestCategories.Label)]
+	public void LabelWithNegativePaddingShouldNotThrowException()
+	{
+		App.WaitForElement("LabelWithNegativePaddingValue");
+	}
+}

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdatePadding(this TextBlock platformControl, ILabel label)
 		{
+			// Label padding values do not support negative values; if specified, negative values will be replaced with zero
 			var padding = new WThickness(
 				Math.Max(0, label.Padding.Left),
 				Math.Max(0, label.Padding.Top),

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -34,12 +34,14 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdatePadding(this TextBlock platformControl, ILabel label)
 		{
-			platformControl.UpdateProperty(TextBlock.PaddingProperty, new WThickness(
-				label.Padding.Left < 0 ? 0 : label.Padding.Left,
-				label.Padding.Top < 0 ? 0 : label.Padding.Top,
-				label.Padding.Right < 0 ? 0 : label.Padding.Right,
-				label.Padding.Bottom < 0 ? 0 : label.Padding.Bottom
-			));
+			var padding = new WThickness(
+				Math.Max(0, label.Padding.Left),
+				Math.Max(0, label.Padding.Top),
+				Math.Max(0, label.Padding.Right),
+				Math.Max(0, label.Padding.Bottom)
+			);
+
+			platformControl.UpdateProperty(TextBlock.PaddingProperty, padding);
 		}
 
 		public static void UpdateCharacterSpacing(this TextBlock platformControl, ITextStyle label)

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Resolvers;
 using Microsoft.UI.Xaml.Controls;
+using WThickness = Microsoft.UI.Xaml.Thickness;
 using Microsoft.UI.Xaml.Documents;
 
 namespace Microsoft.Maui.Platform
@@ -31,8 +32,15 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTextColor(this TextBlock platformControl, ITextStyle text) =>
 			platformControl.UpdateProperty(TextBlock.ForegroundProperty, text.TextColor);
 
-		public static void UpdatePadding(this TextBlock platformControl, ILabel label) =>
-			platformControl.UpdateProperty(TextBlock.PaddingProperty, label.Padding.ToPlatform());
+		public static void UpdatePadding(this TextBlock platformControl, ILabel label)
+		{
+			platformControl.UpdateProperty(TextBlock.PaddingProperty, new WThickness(
+				label.Padding.Left < 0 ? 0 : label.Padding.Left,
+				label.Padding.Top < 0 ? 0 : label.Padding.Top,
+				label.Padding.Right < 0 ? 0 : label.Padding.Right,
+				label.Padding.Bottom < 0 ? 0 : label.Padding.Bottom
+			));
+		}
 
 		public static void UpdateCharacterSpacing(this TextBlock platformControl, ITextStyle label)
 		{


### PR DESCRIPTION
### Issue Details

- Argument Exception is thrown when a label's padding is set to a negative value.

### Root Cause

- Since .NET MAUI's Label uses WinUI's TextBlock on Windows, assigning negative padding values is not supported and will result in an exception.

### Description

- Instead of directly creating a WThickness object with the provided padding values, ensured none of the padding values are negative. If any value is negative, then assigned zero; otherwise, assigned the specified padding value.

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Issues Fixed
Fixes #6387 

### Output
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/072ca084-e8c9-4169-ae6a-4cc9aa4b62aa"> | <img src="https://github.com/user-attachments/assets/eae02062-0db4-49ba-afdf-0e08378e8755"> |
