### PR TITLE
Fixes footer position not updated on CV1 when clearing all items

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -924,6 +924,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					!Equals(itemsSource[indexPath], bindingContext))
 				{
 					templatedCell.Unbind();
+
+					if (CollectionView is MauiCollectionView collectionView)
+					{
+						// When removing a cell, we need to trigger a layout update in order to sync the footer position
+						collectionView.NeedsCellLayout = true;
+					}
 				}
 			}
 		}

--- a/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/HeaderFooterGalleries/HeaderFooterView.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/HeaderFooterGalleries/HeaderFooterView.xaml
@@ -7,7 +7,7 @@
              x:Class=" Maui.Controls.Sample.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterView">
     <ContentPage.Content>
 
-        <CollectionView x:Name="CollectionView" ItemsSource="{Binding Items}">
+        <CollectionView x:Name="CollectionView" AutomationId="CV" ItemsSource="{Binding Items}">
             
             <CollectionView.Header>
 

--- a/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/HeaderFooterGalleries/HeaderFooterView.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/CollectionView/HeaderFooterGalleries/HeaderFooterView.xaml.cs
@@ -21,7 +21,7 @@ namespace Maui.Controls.Sample.CollectionViewGalleries.HeaderFooterGalleries
 		{
 		}
 
-		public ICommand AddCommand => new Command(async () => await AddItemsAsync());
+		public ICommand AddCommand => new Command(AddItemsAsync);
 
 		public ICommand ClearCommand => new Command(() => Items.Clear());
 
@@ -29,9 +29,8 @@ namespace Maui.Controls.Sample.CollectionViewGalleries.HeaderFooterGalleries
 
 		public string FooterText => "This Is A Footer";
 
-		async Task AddItemsAsync()
+		void AddItemsAsync()
 		{
-			await Task.Delay(TimeSpan.FromSeconds(1));
 			AddItems(Items, 2);
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
@@ -44,16 +44,14 @@ namespace Microsoft.Maui.TestCases.Tests
             App.WaitForElement("This Is A Footer");
 
 			// Now let's add items until the footer goes out of the screen
-			// and then remove them all and verify the footer is visible again (#29137) 
-            var add2Items = App.WaitForElement("Add 2 Items");
-            for (var i = 6; i >= 0; --i)
-            {
-	            add2Items.Tap();
-            }
+			// and then remove them all and verify the footer is visible again (#29137)
+			var i = 5;
+			while (--i > 0)
+			{
+				App.WaitForElement("Add 2 Items").Tap();
+				App.ScrollDownTo("Add 2 Items", "CV");				
+			}
 
-            await Task.Delay(1500);
-
-            App.ScrollDownTo("Clear All Items", "CV");
             App.WaitForElement("Clear All Items").Tap();
             await Task.Delay(300);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/CollectionView/CollectionViewUITests.HeaderAndFooter.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -31,7 +32,7 @@ namespace Microsoft.Maui.TestCases.Tests
 #if IOS || ANDROID
 		[Test]
         [Category(UITestCategories.CollectionView)]
-        public void HeaderFooterViewWorks()
+        public async Task HeaderFooterViewWorks()
         {
             // Navigate to the selection galleries
             VisitInitialGallery("Header Footer");
@@ -41,6 +42,22 @@ namespace Microsoft.Maui.TestCases.Tests
 
             App.WaitForElement("This Is A Header");
             App.WaitForElement("This Is A Footer");
+
+			// Now let's add items until the footer goes out of the screen
+			// and then remove them all and verify the footer is visible again (#29137) 
+            var add2Items = App.WaitForElement("Add 2 Items");
+            for (var i = 6; i >= 0; --i)
+            {
+	            add2Items.Tap();
+            }
+
+            await Task.Delay(1500);
+
+            App.ScrollDownTo("Clear All Items", "CV");
+            App.WaitForElement("Clear All Items").Tap();
+            await Task.Delay(300);
+
+            ClassicAssert.IsTrue(App.WaitForElement("This Is A Footer").IsDisplayed());
         }
 
 		[Test]


### PR DESCRIPTION
### Description of Change

Now that https://github.com/dotnet/maui/pull/28479 prevents the invalidation to propagate up the collection view when a cell has fixed constraints, there was nothing triggering re-layout of CV1 footer while unbinding cells.

This PR marks the CV to be updated when we unbind a cell.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29137

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
