### PR TITLE
Removed Frame styles from the default project template

### DIFF
--- a/src/Controls/samples/Controls.Sample.Embedding/Resources/Styles/Styles.xaml
+++ b/src/Controls/samples/Controls.Sample.Embedding/Resources/Styles/Styles.xaml
@@ -132,13 +132,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Frame">
-        <Setter Property="HasShadow" Value="False" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-        <Setter Property="CornerRadius" Value="8" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-    </Style>
-
     <Style TargetType="ImageButton">
         <Setter Property="Opacity" Value="1" />
         <Setter Property="BorderColor" Value="Transparent"/>

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -159,13 +159,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Frame">
-        <Setter Property="HasShadow" Value="False" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-        <Setter Property="CornerRadius" Value="8" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-    </Style>
-
     <Style TargetType="ImageButton">
         <Setter Property="Opacity" Value="1" />
         <Setter Property="BorderColor" Value="Transparent"/>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Styles.xaml
@@ -132,13 +132,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Frame">
-        <Setter Property="HasShadow" Value="False" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-        <Setter Property="CornerRadius" Value="8" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
-    </Style>
-
     <Style TargetType="ImageButton">
         <Setter Property="Opacity" Value="1" />
         <Setter Property="BorderColor" Value="Transparent"/>


### PR DESCRIPTION
### Issue Detail
A warning is displayed when opening the Styles.xaml file in a MAUI sample.

Warning:
![image](https://github.com/user-attachments/assets/223640b2-cc0d-4205-9c1f-3a2255f20c9b)

### Root Cause
The Frame control is marked as obsolete in .NET 9, which causes a warning for frame-related styles.

### Description of Change
Removed the frame styles from Styles.xaml to eliminate the warning.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/29218