### PR TITLE
[Testing] Re-Enabled UI Test - Issue10222Test

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue10222.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue10222.cs
@@ -58,7 +58,8 @@
 					cv.ItemsSource = items;
 					Content = cv;
 				}
-
+				
+				// Scrolls to last item then pops the page
 				async void LabelTapped()
 				{
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue10222.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue10222.cs
@@ -27,6 +27,7 @@
 			class CarouselViewTestPage : ContentPage
 			{
 				CollectionView cv;
+				List<string> items;
 				public CarouselViewTestPage()
 				{
 					cv = new CollectionView
@@ -42,25 +43,24 @@
 							};
 							label.SetBinding(Label.TextProperty, new Binding("."));
 							label.SetBinding(Label.AutomationIdProperty, new Binding("."));
+							var tapGestureRecognizer = new TapGestureRecognizer();
+							tapGestureRecognizer.Tapped += (sender, e) => LabelTapped();
+							label.GestureRecognizers.Add(tapGestureRecognizer);
 							return label;
 						})
 					};
-					Content = cv;
-					InitCV();
-				}
 
-				async void InitCV()
-				{
-					var items = new List<string>();
+					items = new List<string>();
 					for (int i = 0; i < 10; i++)
 					{
 						items.Add($"items{i}");
 					}
-
 					cv.ItemsSource = items;
+					Content = cv;
+				}
 
-					//give the cv time to draw the items
-					await Task.Delay(1000);
+				async void LabelTapped()
+				{
 
 					cv.ScrollTo(items.Count - 1);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10222.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10222.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_ANDROID // More information: https://github.com/dotnet/maui/issues/28640
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -18,8 +17,8 @@ public class Issue10222 : _IssuesUITest
 	{
 		App.WaitForElement("goTo");
 		App.Tap("goTo");
-		App.WaitForElement("items1", timeout: TimeSpan.FromSeconds(1));
+		App.WaitForElement("items1");
+		App.Tap("items1");
 		App.WaitForElement("goTo", timeout: TimeSpan.FromSeconds(2));
 	}
 }
-#endif


### PR DESCRIPTION
### Description of Change
This pull request addresses improvements to a test case for Issue 10222 by refining the test logic, enhancing user interaction handling, and removing a platform-specific exclusion directive. The changes aim to make the test more robust and platform-independent.

### Issue 
Previously, the test was experiencing intermittent failures (flakiness) on Android due to asynchronous execution. The test was attempting to load items, scroll, and navigate back to the previous page while simultaneously validating item presence and checking page elements, leading to race conditions.

### Solution
Redesigned the test flow to follow a more sequential and predictable pattern with load the items initially and then using tap operation to execute scroll and navigate back execution.
This sequential approach ensures each operation completes before the next begins, eliminating race conditions. Test cases have been updated accordingly to match this new flow pattern.

Fixes #28640

Note : This issue includes two test case problems. One test case has already been fixed by an Open contributor. PR - #28668