### PR TITLE
[Android] Fix WebView Navigated is fired when source is null

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Controls.TestCases.HostApp.Issues.Issue29233"
+             Title="Issue29233">
+    <VerticalStackLayout VerticalOptions="Center">
+         <Label AutomationId="WaitLabel" x:Name="waitLabel" />
+        <Label IsVisible="false" AutomationId="MauiLabel" x:Name="label" />
+        <WebView Navigated="WebView_Navigated"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml
@@ -4,7 +4,7 @@
              x:Class="Controls.TestCases.HostApp.Issues.Issue29233"
              Title="Issue29233">
     <VerticalStackLayout VerticalOptions="Center">
-         <Label AutomationId="WaitLabel" x:Name="waitLabel" />
+        <Label AutomationId="WaitLabel" x:Name="waitLabel" />
         <Label IsVisible="false" AutomationId="MauiLabel" x:Name="label" />
         <WebView Navigated="WebView_Navigated"/>
     </VerticalStackLayout>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 29233, "Android WebView Navigated is fired without setting source", PlatformAffected.Android)]
+public partial class Issue29233 : ContentPage
+{
+	public Issue29233()
+	{
+		InitializeComponent();
+	}
+
+	private  void WebView_Navigated(object sender, WebNavigatedEventArgs e)
+	{
+		label.IsVisible = true;
+		label.Text= "Naviaged Failed";
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		await Task.Delay(2000);
+		waitLabel.Text = "Hello";
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml.cs
@@ -13,7 +13,7 @@ public partial class Issue29233 : ContentPage
 	private  void WebView_Navigated(object sender, WebNavigatedEventArgs e)
 	{
 		label.IsVisible = true;
-		label.Text= "Naviaged Failed";
+		label.Text= "Failed";
 	}
 
 	protected override async void OnAppearing()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29233.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29233.cs
@@ -1,0 +1,23 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+
+public class Issue29233 : _IssuesUITest
+{
+	public Issue29233(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Android WebView Navigated is fired without setting source";
+
+    [Test]
+	[Category(UITestCategories.WebView)]
+	public void NavigatedShouldNotFireWithNullSource()
+	{
+        App.WaitForElement("WaitLabel",timeout: TimeSpan.FromSeconds(5));
+		App.WaitForNoElement("MauiLabel");
+	}
+}

--- a/src/Core/src/Platform/Android/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Android/WebViewExtensions.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Maui.Platform
 					platformWebView.UpdateCanGoBackForward(webView);
 				}
 			}
-			else
-				platformWebView.LoadUrl("about:blank");
 		}
 
 		public static void UpdateSettings(this AWebView platformWebView, IWebView webView, bool javaScriptEnabled, bool domStorageEnabled)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

`LoadUrl` is being called even when `Source` is not set or `null`

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29233

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
