### PR TITLE
Fix typo in source-gen error: soruce -> source

### DIFF
--- a/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
+++ b/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
@@ -76,7 +76,7 @@ internal static class DiagnosticsFactory
 			new DiagnosticDescriptor(
 				id: "BSG0006",
 				title: "Lambda result type cannot be resolved",
-				messageFormat: "The lambda result type cannot be resolved. Make sure that soruce generated fields / properties are not used in the path.",
+				messageFormat: "The lambda result type cannot be resolved. Make sure that source generated fields / properties are not used in the path.",
 				category: "Usage",
 				defaultSeverity: DiagnosticSeverity.Error,
 				isEnabledByDefault: true),


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Fix typo in error message from Bindings source code generator.

> Error BSG0006 : The lambda result type cannot be resolved. Make sure that **soruce** generated fields / properties are not used in the path.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes _-none-_

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
