### PR TITLE
[Testing] Fix for flaky UITests in CI that occasionally fail - 9

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28930.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28930.xaml
@@ -31,7 +31,7 @@
                     RowDefinitions="*,Auto">
                 <Label Grid.ColumnSpan="4"
                        Grid.Row="1"
-                       AutomationId="ItemLabel"
+                       AutomationId="{Binding .}"
                        Text="{Binding .}"
                        VerticalTextAlignment="Center"
                        HorizontalTextAlignment="Center" />

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42832.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla42832.cs
@@ -18,6 +18,7 @@ public class Bugzilla42832 : _IssuesUITest
 	[Category(UITestCategories.ListView)]
 	public void ContextActionsScrollNRE()
 	{
+		App.WaitForElement("Item #0");
 		App.ActivateContextMenu("Item #0");
 		App.WaitForElement("Test Item");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28930.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28930.cs
@@ -22,11 +22,8 @@ public class Issue28930 : _IssuesUITest
 		App.WaitForElement("dotnetbot4");
 		
 		App.ScrollRight("MyCarousel", swipePercentage: 0.9, swipeSpeed: 200);
-
-		if (!App.WaitForTextToBePresentInElement("ItemLabel", "Item 2"))
-		{
-			Assert.Fail("Item 2 not found");
-		}
+		
+		Assert.That(App.WaitForElementTillPageNavigationSettled("Item 2").GetText(), Is.EqualTo("Item 2"));
 	}
 }
 


### PR DESCRIPTION
### Description
This pull request includes updates to improve test reliability and enhance the binding logic in the UI definitions. The most significant changes involve adjusting automation IDs in XAML for better binding, refining test assertions for carousel view behavior, and adding a step to ensure elements are fully loaded before interacting with them in tests.

### Test Case Updates:
**Issue28930:**
* Changed the Label’s AutomationId to use data binding ({Binding .})
* Improved the test in LineBreakModeInCarouselViewShouldWork() by using a more reliable check with WaitForElementTillPageNavigationSettled and GetText to validate the carousel content accurately.

**Bugzilla42832**
* [Added WaitForElement in ContextActionsScrollNRE() to make sure the element is fully loaded before using the context menu, helping prevent test failures.