### PR TITLE
Fixed Incorrect Window.Y and Window.Height values when closing a maximized window

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -155,6 +155,25 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		public async Task WindowsBoundsWhenMaximized()
+		{
+			SetupBuilder();
+			var mainPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
+			{
+				var presenter = handler.PlatformView.GetAppWindow()?.Presenter as OverlappedPresenter;
+
+				// maximize window
+				presenter.Maximize();
+				var appwindow= handler.PlatformView.GetAppWindow();
+				var position= appwindow.Position;
+				await AssertEventually(() =>position.X == 0);
+				await AssertEventually(() => position.Y == 0);
+			});
+		}
+
+		[Fact]
 		public async Task ToggleFullscreenTitleBarWorks()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Maui.DeviceTests
 				// maximize window
 				presenter.Maximize();
 				var appWindow = handler.PlatformView.GetWindow();
+				Assert.NotNull(appWindow);
 				await AssertEventually(() => appWindow.X == 0);
 				await AssertEventually(() => appWindow.Y == 0);
 				// Verify width and height are non-zero (regression: Height was reported as 0 when maximized)

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -166,10 +166,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				// maximize window
 				presenter.Maximize();
-				var appwindow= handler.PlatformView.GetAppWindow();
-				var position= appwindow.Position;
-				await AssertEventually(() =>position.X == 0);
-				await AssertEventually(() => position.Y == 0);
+				var appWindow = handler.PlatformView.GetWindow();
+				var position = appWindow.X;
+				await AssertEventually(() => appWindow.X == 0);
+				await AssertEventually(() => appWindow.Y == 0);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -167,7 +167,6 @@ namespace Microsoft.Maui.DeviceTests
 				// maximize window
 				presenter.Maximize();
 				var appWindow = handler.PlatformView.GetWindow();
-				var position = appWindow.X;
 				await AssertEventually(() => appWindow.X == 0);
 				await AssertEventually(() => appWindow.Y == 0);
 			});

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -162,14 +162,57 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
 			{
-				var presenter = handler.PlatformView.GetAppWindow()?.Presenter as OverlappedPresenter;
+				var appWindowPlatform = handler.PlatformView.GetAppWindow();
+				Assert.NotNull(appWindowPlatform?.Presenter);
+				var presenter = Assert.IsType<OverlappedPresenter>(appWindowPlatform.Presenter);
 
 				// maximize window
 				presenter.Maximize();
 				var appWindow = handler.PlatformView.GetWindow();
 				await AssertEventually(() => appWindow.X == 0);
 				await AssertEventually(() => appWindow.Y == 0);
+				// Verify width and height are non-zero (regression: Height was reported as 0 when maximized)
+				await AssertEventually(() => appWindow.Width > 0);
+				await AssertEventually(() => appWindow.Height > 0);
 			});
+		}
+
+		[Fact]
+		public async Task WindowsYAndHeightCorrectWhenClosingMaximizedWindow()
+		{
+			SetupBuilder();
+			var mainPage = new NavigationPage(new ContentPage());
+
+			double destroyingY = double.NaN;
+			double destroyingHeight = double.NaN;
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
+			{
+				var window = handler.VirtualView as Window;
+				Assert.NotNull(window);
+
+				var appWindowPlatform = handler.PlatformView.GetAppWindow();
+				Assert.NotNull(appWindowPlatform?.Presenter);
+				var presenter = Assert.IsType<OverlappedPresenter>(appWindowPlatform.Presenter);
+
+				// Capture the frame values at destroy time so we can verify them after cleanup
+				window.Destroying += (s, e) =>
+	   {
+				 destroyingY = window.Y;
+				 destroyingHeight = window.Height;
+			 };
+
+				// Maximize the window and wait until the frame update reflects the maximized bounds
+				presenter.Maximize();
+				await AssertEventually(() => window.Y == 0);
+				await AssertEventually(() => window.Height > 0);
+			});
+
+			// The window is destroyed during CreateHandlerAndAddToWindow cleanup.
+			// Verify that the Y and Height values at Destroying time were non-negative / non-zero.
+			Assert.False(double.IsNaN(destroyingHeight), "Window.Destroying event was not raised");
+			Assert.True(destroyingHeight > 0, $"Height should be > 0 when closing a maximized window, but was {destroyingHeight}");
+			Assert.True(destroyingY >= 0, $"Y should be >= 0 when closing a maximized window, but was {destroyingY}");
 		}
 
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -170,8 +170,10 @@ namespace Microsoft.Maui.DeviceTests
 				presenter.Maximize();
 				var appWindow = handler.PlatformView.GetWindow();
 				Assert.NotNull(appWindow);
-				await AssertEventually(() => appWindow.X == 0);
-				await AssertEventually(() => appWindow.Y == 0);
+				// X and Y should be >= 0 (on a multi-monitor setup the maximized window may
+				// land on a non-primary monitor, giving a non-zero but still non-negative position).
+				await AssertEventually(() => appWindow.X >= 0);
+				await AssertEventually(() => appWindow.Y >= 0);
 				// Verify width and height are non-zero (regression: Height was reported as 0 when maximized)
 				await AssertEventually(() => appWindow.Width > 0);
 				await AssertEventually(() => appWindow.Height > 0);

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -170,13 +170,24 @@ namespace Microsoft.Maui.DeviceTests
 				presenter.Maximize();
 				var appWindow = handler.PlatformView.GetWindow();
 				Assert.NotNull(appWindow);
-				// X and Y should be >= 0 (on a multi-monitor setup the maximized window may
-				// land on a non-primary monitor, giving a non-zero but still non-negative position).
-				await AssertEventually(() => appWindow.X >= 0);
-				await AssertEventually(() => appWindow.Y >= 0);
-				// Verify width and height are non-zero (regression: Height was reported as 0 when maximized)
-				await AssertEventually(() => appWindow.Width > 0);
+				// Wait for MAUI frame to be updated with the maximized bounds
+				// (regression guard: Height was reported as 0 when maximized).
 				await AssertEventually(() => appWindow.Height > 0);
+
+				// Compare against the monitor's work area. This correctly handles negative
+				// coordinates when the window is on a monitor positioned left of or above
+				// the primary display, and catches regressions beyond a simple > 0 check.
+				var displayArea = DisplayArea.GetFromWindowId(appWindowPlatform.Id, DisplayAreaFallback.Nearest);
+				var workArea = displayArea.WorkArea;
+				var density = handler.PlatformView.GetDisplayDensity();
+				Assert.True(Math.Abs(appWindow.X - workArea.X / density) < 2,
+					$"X should be near work area X ({workArea.X / density:F2}) but was {appWindow.X}");
+				Assert.True(Math.Abs(appWindow.Y - workArea.Y / density) < 2,
+					$"Y should be near work area Y ({workArea.Y / density:F2}) but was {appWindow.Y}");
+				Assert.True(Math.Abs(appWindow.Width - workArea.Width / density) < 2,
+					$"Width should match work area width ({workArea.Width / density:F2}) but was {appWindow.Width}");
+				Assert.True(Math.Abs(appWindow.Height - workArea.Height / density) < 2,
+					$"Height should match work area height ({workArea.Height / density:F2}) but was {appWindow.Height}");
 			});
 		}
 
@@ -205,17 +216,20 @@ namespace Microsoft.Maui.DeviceTests
 				 destroyingHeight = window.Height;
 			 };
 
-				// Maximize the window and wait until the frame update reflects the maximized bounds
+				// Maximize the window and wait until the frame update reflects the maximized bounds.
+				// Do not assert window.Y == 0: on monitors positioned above the primary display
+				// Y is legitimately negative.
 				presenter.Maximize();
-				await AssertEventually(() => window.Y == 0);
 				await AssertEventually(() => window.Height > 0);
 			});
 
 			// The window is destroyed during CreateHandlerAndAddToWindow cleanup.
-			// Verify that the Y and Height values at Destroying time were non-negative / non-zero.
+			// Verify Height > 0 at Destroying time (regression: it was reported as 0 when closing a maximized window).
+			// Y is not asserted to be non-negative: on monitors positioned above the primary display it is legitimately negative.
 			Assert.False(double.IsNaN(destroyingHeight), "Window.Destroying event was not raised");
 			Assert.True(destroyingHeight > 0, $"Height should be > 0 when closing a maximized window, but was {destroyingHeight}");
-			Assert.True(destroyingY >= 0, $"Y should be >= 0 when closing a maximized window, but was {destroyingY}");
+			Assert.True(!double.IsNaN(destroyingY) && !double.IsInfinity(destroyingY),
+				$"Y should be a valid finite number when closing a maximized window, but was {destroyingY}");
 		}
 
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -170,16 +170,24 @@ namespace Microsoft.Maui.DeviceTests
 				presenter.Maximize();
 				var appWindow = handler.PlatformView.GetWindow();
 				Assert.NotNull(appWindow);
-				// Wait for MAUI frame to be updated with the maximized bounds
-				// (regression guard: Height was reported as 0 when maximized).
-				await AssertEventually(() => appWindow.Height > 0);
 
+				// Compute work-area reference values before polling so the same values
+				// are used for both the wait predicate and the final assertions.
 				// Compare against the monitor's work area. This correctly handles negative
 				// coordinates when the window is on a monitor positioned left of or above
 				// the primary display, and catches regressions beyond a simple > 0 check.
 				var displayArea = DisplayArea.GetFromWindowId(appWindowPlatform.Id, DisplayAreaFallback.Nearest);
 				var workArea = displayArea.WorkArea;
 				var density = handler.PlatformView.GetDisplayDensity();
+
+				// Wait until the MAUI frame reflects the maximized work-area bounds.
+				// Waiting only for Height > 0 is insufficient: that condition is already true
+				// before Maximize() is called, so on slow machines the assertions below would
+				// execute against the pre-maximized frame and become flaky.
+				await AssertEventually(() =>
+					Math.Abs(appWindow.Width - workArea.Width / density) < 2 &&
+					Math.Abs(appWindow.Height - workArea.Height / density) < 2);
+
 				Assert.True(Math.Abs(appWindow.X - workArea.X / density) < 2,
 					$"X should be near work area X ({workArea.X / density:F2}) but was {appWindow.X}");
 				Assert.True(Math.Abs(appWindow.Y - workArea.Y / density) < 2,
@@ -199,6 +207,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			double destroyingY = double.NaN;
 			double destroyingHeight = double.NaN;
+			double expectedY = double.NaN;
+			double expectedHeight = double.NaN;
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
 			{
@@ -211,25 +221,41 @@ namespace Microsoft.Maui.DeviceTests
 
 				// Capture the frame values at destroy time so we can verify them after cleanup
 				window.Destroying += (s, e) =>
-	   {
-				 destroyingY = window.Y;
-				 destroyingHeight = window.Height;
-			 };
+				{
+					destroyingY = window.Y;
+					destroyingHeight = window.Height;
+				};
 
-				// Maximize the window and wait until the frame update reflects the maximized bounds.
+				// Capture the expected work-area bounds before waiting for the maximized frame,
+				// so the same reference values are used for both the wait predicate and the
+				// post-cleanup assertions.
+				var displayArea = DisplayArea.GetFromWindowId(appWindowPlatform.Id, DisplayAreaFallback.Nearest);
+				var workArea = displayArea.WorkArea;
+				var density = handler.PlatformView.GetDisplayDensity();
+				expectedY = workArea.Y / density;
+				expectedHeight = workArea.Height / density;
+
+				// Maximize the window and wait until the MAUI frame reflects the maximized bounds.
+				// Waiting only for Height > 0 is insufficient: that condition is already true
+				// before Maximize() is called, so on slow machines the captured values at
+				// Destroying time could come from the pre-maximized frame.
 				// Do not assert window.Y == 0: on monitors positioned above the primary display
 				// Y is legitimately negative.
 				presenter.Maximize();
-				await AssertEventually(() => window.Height > 0);
+				await AssertEventually(() =>
+					Math.Abs(window.Height - expectedHeight) < 2 &&
+					Math.Abs(window.Y - expectedY) < 2);
 			});
 
 			// The window is destroyed during CreateHandlerAndAddToWindow cleanup.
-			// Verify Height > 0 at Destroying time (regression: it was reported as 0 when closing a maximized window).
-			// Y is not asserted to be non-negative: on monitors positioned above the primary display it is legitimately negative.
+			// Assert that the bounds reported at Destroying time match the monitor work area,
+			// using the same < 2 tolerance as WindowsBoundsWhenMaximized.  This catches
+			// regressions where Y or Height is off by ~8 pixels when closing a maximized window.
 			Assert.False(double.IsNaN(destroyingHeight), "Window.Destroying event was not raised");
-			Assert.True(destroyingHeight > 0, $"Height should be > 0 when closing a maximized window, but was {destroyingHeight}");
-			Assert.True(!double.IsNaN(destroyingY) && !double.IsInfinity(destroyingY),
-				$"Y should be a valid finite number when closing a maximized window, but was {destroyingY}");
+			Assert.True(Math.Abs(destroyingY - expectedY) < 2,
+				$"Y should be near work area Y ({expectedY:F2}) when closing a maximized window, but was {destroyingY}");
+			Assert.True(Math.Abs(destroyingHeight - expectedHeight) < 2,
+				$"Height should match work area height ({expectedHeight:F2}) when closing a maximized window, but was {destroyingHeight}");
 		}
 
 		[Fact]

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Graphics;
+using WinRT.Interop;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -201,7 +202,12 @@ namespace Microsoft.Maui.Handlers
 		}
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
-			var hwnd = PlatformView.GetWindowHandle();
+			// Use WindowNative.GetWindowHandle directly (non-throwing) so the
+			// IntPtr.Zero guard below is reachable. GetWindowHandle() extension
+			// throws NullReferenceException when the handle is zero, which would
+			// make the early-return dead code and cause a regression during
+			// ConnectHandler or AppWindow.Changed.
+			var hwnd = WindowNative.GetWindowHandle(PlatformView);
 			if (hwnd == IntPtr.Zero)
 			{
 				return;

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -202,6 +202,11 @@ namespace Microsoft.Maui.Handlers
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
 			var hwnd = PlatformView.GetWindowHandle();
+			if (hwnd == IntPtr.Zero)
+			{
+				return;
+			}
+
 			var bounds = hwnd.GetExtendedFrameBounds();
 
 			var size = appWindow.Size;

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -213,11 +213,14 @@ namespace Microsoft.Maui.Handlers
 			var pos = appWindow.Position;
 
 			if (appWindow.Presenter is OverlappedPresenter presenter &&
-				presenter.IsMaximizable &&
-				presenter.State == OverlappedPresenterState.Maximized)
+			 presenter.IsMaximizable &&
+			 presenter.State == OverlappedPresenterState.Maximized &&
+			 bounds.Width > 0 && bounds.Height > 0)
 			{
 				// If the window is maximized, we need to use the bounds of the window
 				// instead of the size and position of the app window.
+				// Only apply when GetExtendedFrameBounds returned a valid (non-empty) rect;
+				// if DWM failed (returned EmptyRect), keep the AppWindow values as fallback.
 				size = new SizeInt32((int)bounds.Width, (int)bounds.Height);
 				pos = new PointInt32((int)bounds.X, (int)bounds.Y);
 			}

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -199,23 +199,21 @@ namespace Microsoft.Maui.Handlers
 
 			UpdateVirtualViewFrame(sender);
 		}
-
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
 			var hwnd = PlatformView.GetWindowHandle();
 			var bounds = hwnd.GetExtendedFrameBounds();
 
-			(double X, double Y) pos;
-			(double Width, double Height) size;
+			var size = appWindow.Size;
+			var pos = appWindow.Position;
 
-			pos = (bounds.X, bounds.Y);
-			size = (bounds.Width, bounds.Height);
-
-			if (bounds.IsEmpty)
+			bool isMaximized = (appWindow.Presenter as OverlappedPresenter)!.IsMaximizable && (appWindow.Presenter as OverlappedPresenter)!.State == OverlappedPresenterState.Maximized;
+			if (isMaximized)
 			{
-				// If the bounds are empty, we can use the app window's size and position
-				pos = (appWindow.Position.X, appWindow.Position.Y);
-				size = (appWindow.Size.Width, appWindow.Size.Height);
+				// If the window is maximized, we need to use the bounds of the window
+				// instead of the size and position of the app window.
+				size = new SizeInt32((int)bounds.Width, (int)bounds.Height);
+				pos = new PointInt32((int)bounds.X, (int)bounds.Y);
 			}
 
 			var density = PlatformView.GetDisplayDensity();

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 			if (appWindow is not null)
 			{
 				// then pass the actual size back to the user
-				UpdateVirtualViewFrame(appWindow);
+				UpdateVirtualViewFrame();
 
 				// THEN attach the event to reduce churn
 				appWindow.Changed += OnWindowChanged;
@@ -197,16 +197,16 @@ namespace Microsoft.Maui.Handlers
 			if (!args.DidSizeChange && !args.DidPositionChange)
 				return;
 
-			UpdateVirtualViewFrame(sender);
+			UpdateVirtualViewFrame();
 		}
 
-		void UpdateVirtualViewFrame(AppWindow appWindow)
+		void UpdateVirtualViewFrame()
 		{
-			var hwnd = ((MauiWinUIWindow)PlatformView).GetWindowHandle();
+			var hwnd = PlatformView.GetWindowHandle();
 			var bounds = hwnd.GetExtendedFrameBounds();
 
-			var pos = new PointInt32((int)bounds.X, (int)bounds.Y);
-			var size = new SizeInt32((int)bounds.Width, (int)bounds.Height);
+			var pos = (bounds.X, bounds.Y);
+			var size = (bounds.Width, bounds.Height);
 
 			var density = PlatformView.GetDisplayDensity();
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -207,9 +207,14 @@ namespace Microsoft.Maui.Handlers
 			var size = appWindow.Size;
 			var pos = appWindow.Position;
 
-			bool isMaximized = (appWindow.Presenter as OverlappedPresenter)!.IsMaximizable && (appWindow.Presenter as OverlappedPresenter)!.State == OverlappedPresenterState.Maximized;
-			if (isMaximized)
+			bool isMaximized = false;
+			if (appWindow.Presenter is OverlappedPresenter presenter)
 			{
+				isMaximized = presenter.IsMaximizable && presenter.State == OverlappedPresenterState.Maximized;
+			}
+
+			if (isMaximized)
+            {
 				// If the window is maximized, we need to use the bounds of the window
 				// instead of the size and position of the app window.
 				size = new SizeInt32((int)bounds.Width, (int)bounds.Height);

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -202,8 +202,11 @@ namespace Microsoft.Maui.Handlers
 
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
-			var size = appWindow.Size;
-			var pos = appWindow.Position;
+			var hwnd = ((MauiWinUIWindow)PlatformView).GetWindowHandle();
+			var bounds = hwnd.GetExtendedFrameBounds();
+
+			var pos = new PointInt32((int)bounds.X, (int)bounds.Y);
+			var size = new SizeInt32((int)bounds.Width, (int)bounds.Height);
 
 			var density = PlatformView.GetDisplayDensity();
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 			if (appWindow is not null)
 			{
 				// then pass the actual size back to the user
-				UpdateVirtualViewFrame();
+				UpdateVirtualViewFrame(appWindow);
 
 				// THEN attach the event to reduce churn
 				appWindow.Changed += OnWindowChanged;
@@ -197,16 +197,26 @@ namespace Microsoft.Maui.Handlers
 			if (!args.DidSizeChange && !args.DidPositionChange)
 				return;
 
-			UpdateVirtualViewFrame();
+			UpdateVirtualViewFrame(sender);
 		}
 
-		void UpdateVirtualViewFrame()
+		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
 			var hwnd = PlatformView.GetWindowHandle();
 			var bounds = hwnd.GetExtendedFrameBounds();
 
-			var pos = (bounds.X, bounds.Y);
-			var size = (bounds.Width, bounds.Height);
+			(double X, double Y) pos;
+			(double Width, double Height) size;
+
+			pos = (bounds.X, bounds.Y);
+			size = (bounds.Width, bounds.Height);
+
+			if (bounds.IsEmpty)
+			{
+				// If the bounds are empty, we can use the app window's size and position
+				pos = (appWindow.Position.X, appWindow.Position.Y);
+				size = (appWindow.Size.Width, appWindow.Size.Height);
+			}
 
 			var density = PlatformView.GetDisplayDensity();
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -202,33 +202,19 @@ namespace Microsoft.Maui.Handlers
 		}
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
-			// Use WindowNative.GetWindowHandle directly (non-throwing) so the
-			// IntPtr.Zero guard below is reachable. GetWindowHandle() extension
-			// throws NullReferenceException when the handle is zero, which would
-			// make the early-return dead code and cause a regression during
-			// ConnectHandler or AppWindow.Changed.
 			var hwnd = WindowNative.GetWindowHandle(PlatformView);
 			if (hwnd == IntPtr.Zero)
-			{
 				return;
-			}
-
-			var bounds = hwnd.GetExtendedFrameBounds();
 
 			var size = appWindow.Size;
 			var pos = appWindow.Position;
 
 			if (appWindow.Presenter is OverlappedPresenter presenter &&
-			 presenter.IsMaximizable &&
-			 presenter.State == OverlappedPresenterState.Maximized &&
-			 bounds.Width > 0 && bounds.Height > 0)
+				presenter.State == OverlappedPresenterState.Maximized &&
+				PlatformMethods.TryGetExtendedFrameBounds(hwnd, out var dwmRect))
 			{
-				// If the window is maximized, we need to use the bounds of the window
-				// instead of the size and position of the app window.
-				// Only apply when GetExtendedFrameBounds returned a valid (non-empty) rect;
-				// if DWM failed (returned EmptyRect), keep the AppWindow values as fallback.
-				size = new SizeInt32((int)bounds.Width, (int)bounds.Height);
-				pos = new PointInt32((int)bounds.X, (int)bounds.Y);
+				size = new SizeInt32(dwmRect.Right - dwmRect.Left, dwmRect.Bottom - dwmRect.Top);
+				pos = new PointInt32(dwmRect.Left, dwmRect.Top);
 			}
 
 			var density = PlatformView.GetDisplayDensity();

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -207,14 +207,10 @@ namespace Microsoft.Maui.Handlers
 			var size = appWindow.Size;
 			var pos = appWindow.Position;
 
-			bool isMaximized = false;
-			if (appWindow.Presenter is OverlappedPresenter presenter)
+			if (appWindow.Presenter is OverlappedPresenter presenter &&
+				presenter.IsMaximizable &&
+				presenter.State == OverlappedPresenterState.Maximized)
 			{
-				isMaximized = presenter.IsMaximizable && presenter.State == OverlappedPresenterState.Maximized;
-			}
-
-			if (isMaximized)
-            {
 				// If the window is maximized, we need to use the bounds of the window
 				// instead of the size and position of the app window.
 				size = new SizeInt32((int)bounds.Width, (int)bounds.Height);

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -203,6 +203,9 @@ namespace Microsoft.Maui.Handlers
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
 			var hwnd = WindowNative.GetWindowHandle(PlatformView);
+			// GetWindowHandle returns IntPtr.Zero only when the underlying HWND has not yet been
+			// created. In practice ConnectHandler only calls this after GetAppWindow() succeeds,
+			// which requires a valid HWND, so this guard is a safety net for unexpected edge cases.
 			if (hwnd == IntPtr.Zero)
 				return;
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -10,6 +10,10 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class WindowHandler : ElementHandler<IWindow, UI.Xaml.Window>
 	{
+		// The HWND never changes after the window is created; cache it once to avoid
+		// a COM/marshalling round-trip on every OnWindowChanged (move/resize) event.
+		IntPtr _hwnd = IntPtr.Zero;
+
 		protected override void ConnectHandler(UI.Xaml.Window platformView)
 		{
 			base.ConnectHandler(platformView);
@@ -20,6 +24,8 @@ namespace Microsoft.Maui.Handlers
 			// update the platform window with the user size/position
 			platformView.UpdatePosition(VirtualView);
 			platformView.UpdateSize(VirtualView);
+
+			_hwnd = platformView.GetWindowHandle();
 
 			var appWindow = platformView.GetAppWindow();
 			if (appWindow is not null)
@@ -68,6 +74,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				appWindow.Changed -= OnWindowChanged;
 			}
+
+			_hwnd = IntPtr.Zero;
 
 			base.DisconnectHandler(platformView);
 		}
@@ -200,21 +208,22 @@ namespace Microsoft.Maui.Handlers
 
 			UpdateVirtualViewFrame(sender);
 		}
+
 		void UpdateVirtualViewFrame(AppWindow appWindow)
 		{
-			var hwnd = WindowNative.GetWindowHandle(PlatformView);
-			// GetWindowHandle returns IntPtr.Zero only when the underlying HWND has not yet been
-			// created. In practice ConnectHandler only calls this after GetAppWindow() succeeds,
-			// which requires a valid HWND, so this guard is a safety net for unexpected edge cases.
-			if (hwnd == IntPtr.Zero)
+			// Use the HWND cached at ConnectHandler — it never changes and this method
+			// runs on every move/resize event, so avoid the COM round-trip each time.
+			if (_hwnd == IntPtr.Zero)
+			{
 				return;
+			}
 
 			var size = appWindow.Size;
 			var pos = appWindow.Position;
 
 			if (appWindow.Presenter is OverlappedPresenter presenter &&
 				presenter.State == OverlappedPresenterState.Maximized &&
-				PlatformMethods.TryGetExtendedFrameBounds(hwnd, out var dwmRect))
+				PlatformMethods.TryGetExtendedFrameBounds(_hwnd, out var dwmRect))
 			{
 				size = new SizeInt32(dwmRect.Right - dwmRect.Left, dwmRect.Bottom - dwmRect.Top);
 				pos = new PointInt32(dwmRect.Left, dwmRect.Top);

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -10,7 +10,6 @@ using Microsoft.UI.Xaml;
 using Windows.Graphics;
 using Windows.Graphics.Display;
 using WinRT.Interop;
-using static Microsoft.Maui.ApplicationModel.PlatformMethods;
 
 namespace Microsoft.Maui.Platform
 {
@@ -22,12 +21,12 @@ namespace Microsoft.Maui.Platform
 		 static extern int DwmGetWindowAttribute(
 			IntPtr hwnd,
 			int dwAttribute,
-			out RECT pvAttribute,
+			out PlatformMethods.RECT pvAttribute,
 			int cbAttribute);
 	
 		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
 		{
-			if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out RECT rect, Marshal.SizeOf<RECT>()) == 0)
+			if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out PlatformMethods.RECT rect, Marshal.SizeOf<PlatformMethods.RECT>()) == 0)
 			{
 				return new Rect(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
 			}

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -10,29 +10,21 @@ using Microsoft.UI.Xaml;
 using Windows.Graphics;
 using Windows.Graphics.Display;
 using WinRT.Interop;
+using static Microsoft.Maui.ApplicationModel.PlatformMethods;
 
 namespace Microsoft.Maui.Platform
 {
 	public static partial class WindowExtensions
 	{
-		private const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+		const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
 
 		[DllImport("dwmapi.dll", PreserveSig = true)]
-		private static extern int DwmGetWindowAttribute(
+		 static extern int DwmGetWindowAttribute(
 			IntPtr hwnd,
 			int dwAttribute,
 			out RECT pvAttribute,
 			int cbAttribute);
-
-		[StructLayout(LayoutKind.Sequential)]
-		private struct RECT
-		{
-			public int Left;
-			public int Top;
-			public int Right;
-			public int Bottom;
-		}
-
+	
 		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
 		{
 			if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out RECT rect, Marshal.SizeOf<RECT>()) == 0)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Platform
 			out PlatformMethods.RECT pvAttribute,
 			int cbAttribute);
 
-		private static readonly Rect EmptyRect = new(0, 0, 0, 0);
+		static readonly Rect EmptyRect = new(0, 0, 0, 0);
 
 		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
 		{

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -26,11 +26,13 @@ namespace Microsoft.Maui.Platform
 	
 		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
 		{
+			Rect emptyRect = new();
+
 			try
 			{
 				if (hwnd == IntPtr.Zero)
 				{
-					return new Rect();
+					return emptyRect;
 				}
 
 				if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out PlatformMethods.RECT rect, Marshal.SizeOf<PlatformMethods.RECT>()) == 0)
@@ -40,10 +42,10 @@ namespace Microsoft.Maui.Platform
 			}
 			catch
 			{
-				return new Rect();
+				return emptyRect;
 			}
 
-			return new Rect();
+			return emptyRect;
 		}
 
 		internal static Rect[]? GetDefaultTitleBarDragRectangles(this UI.Xaml.Window platformWindow, IWindow window)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -26,14 +26,26 @@ namespace Microsoft.Maui.Platform
 	
 		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
 		{
-			if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out PlatformMethods.RECT rect, Marshal.SizeOf<PlatformMethods.RECT>()) == 0)
+			try
 			{
-				return new Rect(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
+				if (hwnd == IntPtr.Zero)
+				{
+					return new Rect();
+				}
+
+				if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out PlatformMethods.RECT rect, Marshal.SizeOf<PlatformMethods.RECT>()) == 0)
+				{
+					return new Rect(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
+				}
+			}
+			catch
+			{
+				return new Rect();
 			}
 
-			return new Rect(); // fallback if DWM fails
+			return new Rect();
 		}
-    
+
 		internal static Rect[]? GetDefaultTitleBarDragRectangles(this UI.Xaml.Window platformWindow, IWindow window)
 		{
 			if (window?.Handler?.MauiContext is IMauiContext mauiContext)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -23,29 +23,33 @@ namespace Microsoft.Maui.Platform
 			int dwAttribute,
 			out PlatformMethods.RECT pvAttribute,
 			int cbAttribute);
-	
+
+		private static readonly Rect EmptyRect = new(0, 0, 0, 0);
+
 		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
 		{
-			Rect emptyRect = new();
+			if (hwnd == IntPtr.Zero)
+			{
+				return EmptyRect;
+			}
 
 			try
 			{
-				if (hwnd == IntPtr.Zero)
-				{
-					return emptyRect;
-				}
+				PlatformMethods.RECT rect = default;
+				int result = DwmGetWindowAttribute(
+				hwnd,
+				DWMWA_EXTENDED_FRAME_BOUNDS,
+				out rect,
+				Marshal.SizeOf<PlatformMethods.RECT>());
 
-				if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, out PlatformMethods.RECT rect, Marshal.SizeOf<PlatformMethods.RECT>()) == 0)
-				{
-					return new Rect(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
-				}
+				return result == 0
+				? new Rect(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top)
+				: EmptyRect;
 			}
 			catch
 			{
-				return emptyRect;
+				return EmptyRect;
 			}
-
-			return emptyRect;
 		}
 
 		internal static Rect[]? GetDefaultTitleBarDragRectangles(this UI.Xaml.Window platformWindow, IWindow window)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Graphics;
@@ -15,43 +14,6 @@ namespace Microsoft.Maui.Platform
 {
 	public static partial class WindowExtensions
 	{
-		const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
-
-		[DllImport("dwmapi.dll", PreserveSig = true)]
-		 static extern int DwmGetWindowAttribute(
-			IntPtr hwnd,
-			int dwAttribute,
-			out PlatformMethods.RECT pvAttribute,
-			int cbAttribute);
-
-		static readonly Rect EmptyRect = new(0, 0, 0, 0);
-
-		internal static Rect GetExtendedFrameBounds(this IntPtr hwnd)
-		{
-			if (hwnd == IntPtr.Zero)
-			{
-				return EmptyRect;
-			}
-
-			try
-			{
-				PlatformMethods.RECT rect = default;
-				int result = DwmGetWindowAttribute(
-				hwnd,
-				DWMWA_EXTENDED_FRAME_BOUNDS,
-				out rect,
-				Marshal.SizeOf<PlatformMethods.RECT>());
-
-				return result == 0
-				? new Rect(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top)
-				: EmptyRect;
-			}
-			catch
-			{
-				return EmptyRect;
-			}
-		}
-
 		internal static Rect[]? GetDefaultTitleBarDragRectangles(this UI.Xaml.Window platformWindow, IWindow window)
 		{
 			if (window?.Handler?.MauiContext is IMauiContext mauiContext)

--- a/src/Essentials/src/Platform/PlatformMethods.windows.cs
+++ b/src/Essentials/src/Platform/PlatformMethods.windows.cs
@@ -74,6 +74,19 @@ namespace Microsoft.Maui.ApplicationModel
 			static extern long GetWindowLongPtr64(IntPtr hWnd, WindowLongFlags nIndex);
 		}
 
+		internal static bool TryGetExtendedFrameBounds(IntPtr hWnd, out RECT bounds)
+		{
+			bounds = default;
+			if (hWnd == IntPtr.Zero)
+			{
+				return false;
+			}
+
+			int hr = DwmGetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_EXTENDED_FRAME_BOUNDS,
+				out bounds, Marshal.SizeOf<RECT>());
+			return hr == 0 && (bounds.Right - bounds.Left) > 0 && (bounds.Bottom - bounds.Top) > 0;
+		}
+
 		[DllImport("user32.dll")]
 		public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 


### PR DESCRIPTION
### Issue Detail:
 
On the Windows platform, if the application window is maximized, the main window X,Y  values are in negative (-7, -7). For a non-maximized window, values are correct.
 
### Root Cause
On Windows, when the application window is maximized, the values of Window.Y and Window.Height reported during Window_Destroying are offset by 8 pixels. This occurs because the default window bounds include the non-client area (e.g., title bar and borders), which is excluded by the OS when maximizing the window. As a result, the bounds do not accurately reflect the actual client area used by the application, leading to incorrect frame values being reported to the virtual view.
 
### Description of Change
To resolve this, the implementation now uses the Windows Desktop Window Manager (DWM) API to retrieve the extended frame bounds via DwmGetWindowAttribute with the DWMWA_EXTENDED_FRAME_BOUNDS attribute. These bounds reflect the full screen-space dimensions of the window, even when maximized.

In the UpdateVirtualViewFrame method, when the window is in a normal state, the position and size reported by AppWindow are used directly. When the window is maximized, the logic switches to use the bounds provided by the DWM API. This ensures that the virtual view receives accurate and consistent frame data (X, Y, Width, and Height) regardless of the window state.

### Validated the behaviour in the following platforms
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac
### Issues Fixed:
Fixes #29066
 
### Screenshots

| Before  | After |
|---------|--------|
|  <img src="https://github.com/user-attachments/assets/3d5c192f-b681-491f-971a-6d6c0822ad12"> |   <img src="https://github.com/user-attachments/assets/255b3ea5-c147-414d-9bce-6dbe119b4b2b">  |
