### PR TITLE
[ci] Remove old Mono.ToolChain

### DIFF
--- a/src/DotNet/Dependencies/Workloads.csproj
+++ b/src/DotNet/Dependencies/Workloads.csproj
@@ -5,8 +5,6 @@
   <ItemGroup>
     <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-$(DotNetVersionBand)"   Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net9.Manifest-$(DotNetVersionBand)"   Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(DotNetVersionBand)"   Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.net8.Manifest-$(DotNetVersionBand)"   Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Current.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Emscripten.net9.Manifest-$(DotNetVersionBand)" Version="[$(MicrosoftDotnetSdkInternalPackageVersion)]" />
     <PackageDownload Include="Microsoft.NET.Sdk.Android.Manifest-$(DotNetAndroidManifestVersionBand)"    Version="[$(MicrosoftAndroidSdkWindowsPackageVersion)]" />


### PR DESCRIPTION
### Description of Change

Remove old manifest packs that are not needed .
