### PR TITLE
[ci] Update internal release pipeline to push nuget 

### DIFF
--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -122,4 +122,135 @@ extends:
                 Write-Host "##vso[task.setvariable variable=WorkloadSetsFeedName;]$workloadSetsFeed"
                 Write-Host "Adding build ID '$barId' to channel '$workloadSetsChannel' and feed '$workloadSetsFeed'"
                 & $darc add-build-to-channel --ci --channel "$workloadSetsChannel" --id "$barId" --skip-assets-publishing --azdev-pat $(System.AccessToken) --verbose
-            
+
+    - stage: stage_push_packs
+      displayName: Release packs
+      dependsOn: []
+      jobs:
+      # Waits for two hours for approval and will fail on timeout. The job can be re-ran to prompt another approval workflow after the initial timeout
+      - job: push_packs_approval
+        displayName: Wait to push packs
+        timeoutInMinutes: 240
+        pool: server
+        steps:
+        - task: ManualValidation@0
+          timeoutInMinutes: 120
+          inputs:
+            instructions: 'Press "Resume" to push workload packs to NuGet.org.'
+            onTimeout: reject
+
+      - job: push_packs
+        displayName: Push packs to NuGet.org
+        timeoutInMinutes: 90
+        dependsOn: push_packs_approval
+        condition: eq(dependencies.push_packs_approval.result, 'Succeeded')
+        workspace:
+          clean: all
+        steps:
+        - checkout: self
+          clean: true
+
+        - ${{ if eq(parameters.commitHash, 'skip') }}:
+          - script: echo parameters.commitHash was not set, skipping...
+            displayName: skip push
+
+        - ${{ else }}:
+          - script: |
+              echo ##vso[task.setvariable variable=COMMIT]${{ parameters.commitHash }}
+            displayName: set COMMIT
+
+          - task: AzureCLI@2
+            displayName: Get build for commit
+            inputs:
+              azureSubscription: "Darc: Maestro Production"
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                Write-Host "Getting BAR ID for commit: $(COMMIT)"
+                . $(Build.SourcesDirectory)\eng\common\tools.ps1
+                $darc = Get-Darc
+                $buildJson = & $darc get-build --ci --repo "${{ parameters.ghRepo }}" --commit "$(COMMIT)" --output-format json --azdev-pat $(System.AccessToken)
+                Write-Host "`n$buildJson`n"
+                $barId = $buildJson | ConvertFrom-Json | Select-Object -ExpandProperty "id" -First 1
+                Write-Host "Got the Bar ID: $barId for commit $(COMMIT) on repo ${{ parameters.ghRepo }}"
+                if ($barId -eq $null) {
+                  Write-Error "Could not find a build for commit $(COMMIT) on repo ${{ parameters.ghRepo }}"
+                  exit 1
+                }
+                Write-Host "Getting drop for Bar ID: $barId"
+                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --verbose  
+
+          - pwsh: Get-ChildItem -Name -Recurse -Path $(Build.StagingDirectory)
+            displayName: list downloaded artifacts
+
+          - powershell: >-
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}"
+            displayName: Push workload packs to NuGet.org
+            env:
+              PUSH_PACKAGES: ${{ parameters.pushPackages }}
+
+    - stage: stage_push_manifests
+      displayName: Release manifests
+      dependsOn: []
+      jobs:
+      # Waits for two hours for approval and will fail on timeout. The job can be re-ran to prompt another approval workflow after the initial timeout
+      - job: push_manifests_approval
+        displayName: Wait to push manifests
+        timeoutInMinutes: 240
+        pool: server
+        steps:
+        - task: ManualValidation@0
+          timeoutInMinutes: 120
+          inputs:
+            instructions: 'Press "Resume" to push workload manifests to NuGet.org.'
+            onTimeout: reject
+
+      - job: push_manifests
+        displayName: Push manifests to NuGet.org
+        timeoutInMinutes: 90
+        dependsOn: push_manifests_approval
+        condition: eq(dependencies.push_manifests_approval.result, 'Succeeded')
+        workspace:
+          clean: all
+        steps:
+        - checkout: self
+          clean: true
+
+        - ${{ if eq(parameters.commitHash, 'skip') }}:
+          - script: echo parameters.commitHash was not set, skipping...
+            displayName: skip push
+
+        - ${{ else }}:
+          - script: |
+              echo ##vso[task.setvariable variable=COMMIT]${{ parameters.commitHash }}
+            displayName: set COMMIT
+
+          - task: AzureCLI@2
+            displayName: Get build for commit
+            inputs:
+              azureSubscription: "Darc: Maestro Production"
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                Write-Host "Getting BAR ID for commit: $(COMMIT)"
+                . $(Build.SourcesDirectory)\eng\common\tools.ps1
+                $darc = Get-Darc
+                $buildJson = & $darc get-build --ci --repo "${{ parameters.ghRepo }}" --commit "$(COMMIT)" --output-format json --azdev-pat $(System.AccessToken)
+                Write-Host "`n$buildJson`n"
+                $barId = $buildJson | ConvertFrom-Json | Select-Object -ExpandProperty "id" -First 1
+                Write-Host "Got the Bar ID: $barId for commit $(COMMIT) on repo ${{ parameters.ghRepo }}"
+                if ($barId -eq $null) {
+                  Write-Error "Could not find a build for commit $(COMMIT) on repo ${{ parameters.ghRepo }}"
+                  exit 1
+                }
+                Write-Host "Getting drop for Bar ID: $barId"
+                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --verbose  
+
+          - pwsh: Get-ChildItem -Name -Recurse -Path $(Build.StagingDirectory)
+            displayName: list downloaded artifacts
+
+          - powershell: >-
+              $(Build.SourcesDirectory)\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"
+            displayName: Push workload manifests to NuGet.org
+            env:
+              PUSH_PACKAGES: ${{ parameters.pushPackages }}

--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -17,6 +17,16 @@ parameters:
   type: string
   default: skip
 
+- name: pushWorkloadSet
+  displayName: Push workload set channel
+  type: bool
+  default: true
+
+- name: pushNugetOrg
+  displayName: Push to NuGet.org
+  type: bool
+  default: true
+
 - name: VM_IMAGE_HOST
   type: object
   default:
@@ -62,6 +72,7 @@ extends:
     - stage: publish_maestro
       displayName: Publish to Workload Set channel
       dependsOn: []
+      condition: eq(${{ parameters.pushWorkloadSet }}, true)
       jobs:
       - job: publish_maestro
         displayName: Publish to Workload Set channel
@@ -126,6 +137,7 @@ extends:
     - stage: stage_push_packs
       displayName: Release packs
       dependsOn: []
+      condition: eq(${{ parameters.pushNugetOrg }}, true)
       jobs:
       # Waits for two hours for approval and will fail on timeout. The job can be re-ran to prompt another approval workflow after the initial timeout
       - job: push_packs_approval
@@ -192,6 +204,7 @@ extends:
     - stage: stage_push_manifests
       displayName: Release manifests
       dependsOn: []
+      condition: eq(${{ parameters.pushNugetOrg }}, true)
       jobs:
       # Waits for two hours for approval and will fail on timeout. The job can be re-ran to prompt another approval workflow after the initial timeout
       - job: push_manifests_approval

--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -217,7 +217,7 @@ extends:
             displayName: list downloaded artifacts
 
           - powershell: >-
-              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}"
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\shipping\packages\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}"
             displayName: Push workload packs to NuGet.org
             env:
               PUSH_PACKAGES: ${{ parameters.pushPackages }}
@@ -284,7 +284,7 @@ extends:
             displayName: list downloaded artifacts
 
           - powershell: >-
-              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\shipping\packages\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"
             displayName: Push workload manifests to NuGet.org
             env:
               PUSH_PACKAGES: ${{ parameters.pushPackages }}

--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -18,14 +18,34 @@ parameters:
   default: skip
 
 - name: pushWorkloadSet
-  displayName: Push workload set channel
+  displayName: Push workload set channel stage
   type: boolean
   default: true
 
 - name: pushNugetOrg
-  displayName: Push to NuGet.org
+  displayName: Push to NuGet.org stage
   type: boolean
   default: true
+
+- name: pushPackages
+  displayName: "Controls the script, allows for dry run"
+  type: boolean
+  default: false
+
+- name: nugetIncludeFilters
+  displayName: "[OPTIONAL] Semi-colon (';') separated list of nugets packages to include"
+  type: string
+  default: skip
+
+- name: nugetExcludeFilters
+  displayName: "[OPTIONAL] Semi-colon (';') separated list of nugets packages to exclude"
+  type: string
+  default: skip
+
+- name: feedUrl
+  displayName: "[OPTIONAL] NuGet URL to push to defaults to nuget.org"
+  type: string
+  default: "https://api.nuget.org/v3/index.json"
 
 - name: VM_IMAGE_HOST
   type: object
@@ -196,7 +216,7 @@ extends:
             displayName: list downloaded artifacts
 
           - powershell: >-
-              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}"
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}"
             displayName: Push workload packs to NuGet.org
             env:
               PUSH_PACKAGES: ${{ parameters.pushPackages }}
@@ -263,7 +283,7 @@ extends:
             displayName: list downloaded artifacts
 
           - powershell: >-
-              $(Build.SourcesDirectory)\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"
             displayName: Push workload manifests to NuGet.org
             env:
               PUSH_PACKAGES: ${{ parameters.pushPackages }}

--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -19,12 +19,12 @@ parameters:
 
 - name: pushWorkloadSet
   displayName: Push workload set channel
-  type: bool
+  type: boolean
   default: true
 
 - name: pushNugetOrg
   displayName: Push to NuGet.org
-  type: bool
+  type: boolean
   default: true
 
 - name: VM_IMAGE_HOST

--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -58,6 +58,7 @@ variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self
 - group: DotNetBuilds storage account read tokens
 - group: AzureDevOps-Artifact-Feeds-Pats
+- group: DotNet-Maui-Release
 
 resources:
   repositories:

--- a/eng/scripts/push_nuget_org.ps1
+++ b/eng/scripts/push_nuget_org.ps1
@@ -1,0 +1,127 @@
+param (
+    [Parameter(Mandatory)]
+    [String]
+    $ApiKey,
+
+    [Parameter(Mandatory)]
+    [String]
+    $NuGetSearchPath,
+
+    [String]
+    $NuGetIncludeFilters,
+
+    [String]
+    $NuGetExcludeFilters,
+
+    [String]
+    $FeedUrl,
+
+    [String]
+    $NuGetOrgApiKey2,
+
+    [String]
+    $NuGetOrgApiKey3
+)
+
+function CheckQuotaExceeded {
+  param (
+    [String] $pushOutput
+  )
+  return ($pushOutput -like "*Quota exceeded*" -or $pushOutput -like "*Rate limit is exceeded*")
+}
+
+function TryPushNuGetWithRetry {
+  param (
+    [System.IO.FileInfo] $nupkg,
+    [String] $feedUrl,
+    [String] $apiKey,
+    [Int32] $maxAttempts
+  )
+
+  $nupkgFile = $nupkg.FullName
+  for ($i = 1; $i -le $maxAttempts; $i++) {
+    try {
+      Write-Host "Pushing $nupkgFile to $feedUrl (attempt $i of $maxAttempts)"
+      $output = & dotnet nuget push --source $feedUrl --api-key $apiKey --skip-duplicate $nupkgFile
+      $exitCode = $LASTEXITCODE
+      if ($exitCode -eq 0) {
+        return "`tSuccessfully pushed $nupkgFile to $FeedUrl. Output:`n`t$output"
+      } else {
+        throw "Process failed with exit code '$exitCode'. Output:`n`t$output"
+      }
+    } catch {
+      if ($i -eq $maxAttempts -or $(CheckQuotaExceeded -pushOutput $_.Exception.Message) -eq $true) {
+        return "`t$($_.Exception.Message)"
+      }
+    }
+  }
+}
+
+# If no feed was provided, then push to NuGet.org
+$nugetOrgFeedUrl = "https://api.nuget.org/v3/index.json"
+if (!$FeedUrl) {
+  $FeedUrl = $nugetOrgFeedUrl
+}
+
+# Get the Filter from the list of included packages
+if ([string]::IsNullOrEmpty($NuGetIncludeFilters) -or "$NuGetIncludeFilters" -eq "skip") {
+  $includeFilters = @()
+} else {
+  $includeFilters = "$NuGetIncludeFilters" -split ";" | Where-Object { $_ } | % { $_.Trim() }
+}
+if ([string]::IsNullOrEmpty($NuGetExcludeFilters) -or "$NuGetExcludeFilters" -eq "skip") {
+  $excludeFilters = @()
+} else {
+  $excludeFilters = "$NuGetExcludeFilters" -split ";" | Where-Object { $_ } | % { $_.Trim() }
+}
+
+$nupkgs = (Get-ChildItem -Path "$NuGetSearchPath" -Filter *.nupkg -Recurse -Include $includeFilters -Exclude $excludeFilters)
+Write-Output "Publishing the following packages:"
+foreach ($nupkg in $nupkgs) {
+  Write-Output $nupkg.FullName
+}
+
+$nugetApiKeys = [System.Collections.Generic.List[string]]::new()
+$initialKeys = @($ApiKey, $NuGetOrgApiKey2, $NuGetOrgApiKey3) | Where-Object { -not [string]::IsNullOrEmpty($_) }
+foreach ($key in $initialKeys) {
+    $nugetApiKeys.Add($key)
+}
+$nugetApiKeysExceedingQuota = [System.Collections.Generic.List[string]]::new()
+$nugetApiKeyIndex = 1
+
+foreach ($nupkg in $nupkgs) {
+  if ( $env:PUSH_PACKAGES -ne "True" ) {
+    Write-Host "`tdry run, not pushing $($nupkg.FullName)"
+    continue
+  }
+
+  if ($FeedUrl -eq $nugetOrgFeedUrl) {
+    if ($nugetApiKeys.Count -eq 0) {
+      throw "Unable to push to NuGet.org, all API keys have exceeded quota or none were provided."
+    }
+    foreach ($key in $nugetApiKeys) {
+      if (!$key) {
+        continue
+      }
+      $pushTryOutput = TryPushNuGetWithRetry -nupkg $nupkg -feedUrl $FeedUrl -apiKey $key -maxAttempts 3
+      Write-Host $pushTryOutput
+      if ($pushTryOutput -like "*Successfully pushed*") {
+        break
+      }
+      if ($(CheckQuotaExceeded -pushOutput $pushTryOutput) -eq $true) {
+        Write-Host "`tQuota exceeded, future push attempts will not try to use key $nugetApiKeyIndex."
+        $nugetApiKeysExceedingQuota.Add($key)
+        $nugetApiKeyIndex++
+      } else {
+        break
+      }
+    }
+    foreach ($keyToRemove in $nugetApiKeysExceedingQuota) {
+      $nugetApiKeys.Remove($keyToRemove)
+    }
+    $nugetApiKeysExceedingQuota.Clear()
+  } else {
+    $pushTryOutput = TryPushNuGetWithRetry -nupkg $nupkg -feedUrl $FeedUrl -apiKey $ApiKey -maxAttempts 3
+    Write-Host $pushTryOutput
+  }
+}


### PR DESCRIPTION
### Description of Change

This pull request introduces updates to the `eng/pipelines/maui-release-internal.yml` pipeline and adds a new script, `push_nuget_org.ps1`, to enhance the release process for NuGet packages and workload manifests based on maestro and darc. Key changes include the addition of new pipeline parameters, conditional stages for pushing artifacts, and a robust PowerShell script for handling NuGet uploads with retry logic and quota management.

Test with dry run
https://dev.azure.com/dnceng/internal/_build/results?buildId=2699308&view=results

### Pipeline Enhancements:
* **New Parameters Added**: Introduced parameters such as `pushWorkloadSet`, `pushNugetOrg`, `pushPackages`, `nugetIncludeFilters`, `nugetExcludeFilters`, and `feedUrl` to control stages and provide flexibility for dry runs, filtering packages, and specifying custom feed URLs. (`eng/pipelines/maui-release-internal.yml`, [eng/pipelines/maui-release-internal.ymlR20-R49](diffhunk://#diff-380314a872c5f32bf6ee23d225452a3235fee606a3b4d87cb29092244abc1a74R20-R49))
* **New Variable Group**: Added the `DotNet-Maui-Release` variable group for managing release-related secrets and configurations. (`eng/pipelines/maui-release-internal.yml`, [eng/pipelines/maui-release-internal.ymlR61](diffhunk://#diff-380314a872c5f32bf6ee23d225452a3235fee606a3b4d87cb29092244abc1a74R61))

### Conditional Pipeline Stages:
* **Workload Set Publishing**: Added a condition to the `publish_maestro` stage to execute only if the `pushWorkloadSet` parameter is set to `true`. (`eng/pipelines/maui-release-internal.yml`, [eng/pipelines/maui-release-internal.ymlR96](diffhunk://#diff-380314a872c5f32bf6ee23d225452a3235fee606a3b4d87cb29092244abc1a74R96))
* **NuGet.org Release Stages**: Introduced two new stages, `stage_push_packs` and `stage_push_manifests`, with approval workflows and conditional execution based on the `pushNugetOrg` parameter. These stages handle the release of workload packs and manifests to NuGet.org. (`eng/pipelines/maui-release-internal.yml`, [eng/pipelines/maui-release-internal.ymlR158-R290](diffhunk://#diff-380314a872c5f32bf6ee23d225452a3235fee606a3b4d87cb29092244abc1a74R158-R290))

### New PowerShell Script for NuGet Publishing:
* **Script Addition**: Added `push_nuget_org.ps1` to handle NuGet package uploads with features such as retry logic, quota management, and support for include/exclude filters. (`eng/scripts/push_nuget_org.ps1`, [eng/scripts/push_nuget_org.ps1R1-R127](diffhunk://#diff-1b0cc5f4a01ee10dff464619c9fd297d3632fad84b40f891cabe23ab4847071bR1-R127))
* **Quota Management**: Implemented logic to detect and handle quota or rate-limit errors, switching between multiple API keys if necessary. (`eng/scripts/push_nuget_org.ps1`, [eng/scripts/push_nuget_org.ps1R1-R127](diffhunk://#diff-1b0cc5f4a01ee10dff464619c9fd297d3632fad84b40f891cabe23ab4847071bR1-R127))
* **Dry Run Support**: Enabled a dry run mode controlled by the `PUSH_PACKAGES` environment variable to simulate uploads without pushing packages. (`eng/scripts/push_nuget_org.ps1`, [eng/scripts/push_nuget_org.ps1R1-R127](diffhunk://#diff-1b0cc5f4a01ee10dff464619c9fd297d3632fad84b40f891cabe23ab4847071bR1-R127))