### PR TITLE
[Windows] Fix for CarouselView IsSwipeEnabled=False Prevents Visual Navigation

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -235,11 +235,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				case ItemsLayoutOrientation.Horizontal:
 					ScrollViewer.SetHorizontalScrollMode(ListViewBase, ItemsView.IsSwipeEnabled ? WScrollMode.Auto : WScrollMode.Disabled);
-					ScrollViewer.SetHorizontalScrollBarVisibility(ListViewBase, ItemsView.IsSwipeEnabled ? WScrollBarVisibility.Auto : WScrollBarVisibility.Disabled);
+					ScrollViewer.SetHorizontalScrollBarVisibility(ListViewBase, ItemsView.IsSwipeEnabled ? WScrollBarVisibility.Auto : WScrollBarVisibility.Hidden);
 					break;
 				case ItemsLayoutOrientation.Vertical:
 					ScrollViewer.SetVerticalScrollMode(ListViewBase, ItemsView.IsSwipeEnabled ? WScrollMode.Auto : WScrollMode.Disabled);
-					ScrollViewer.SetVerticalScrollBarVisibility(ListViewBase, ItemsView.IsSwipeEnabled ? WScrollBarVisibility.Auto : WScrollBarVisibility.Disabled);
+					ScrollViewer.SetVerticalScrollBarVisibility(ListViewBase, ItemsView.IsSwipeEnabled ? WScrollBarVisibility.Auto : WScrollBarVisibility.Hidden);
 					break;
 			}
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29216.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29216.cs
@@ -1,0 +1,60 @@
+﻿using Maui.Controls.Sample.Issues;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 29216, "Carousel view scrolling on button click", PlatformAffected.UWP)]
+public class Issue29216 : TestContentPage
+{	
+	protected override void Init()
+	{
+		var items = new List<string> { "Page1", "Page2" };
+
+		CarouselView carouselView = new CarouselView
+		{
+			ItemsSource = items,
+			IsSwipeEnabled = false,
+			Loop = false,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					FontSize = 24,
+					TextColor = Colors.Black,
+				};
+
+				label.SetBinding(Label.TextProperty, ".");
+				label.SetBinding(Label.AutomationIdProperty, ".");
+
+				return new StackLayout
+				{
+					Children = { label }
+				};
+			}),
+			HeightRequest = 300
+		};
+
+		var button1 = new Button
+		{
+			Text = "Go to Page 2",
+			AutomationId = "button"
+		};
+
+		button1.Clicked += (s, e) => carouselView.Position = 1;
+
+		Content = new StackLayout
+		{
+			Padding = 20,
+			Children =
+			{
+				new StackLayout
+				{
+					Orientation = StackOrientation.Horizontal,
+					Children = { button1 }
+				},
+				carouselView
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29216.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29216.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29216 : _IssuesUITest
+{
+	public Issue29216(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Carousel view scrolling on button click";
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void Issue29216CarouselViewScrollingIssue()
+	{
+		App.WaitForElement("button");
+		App.Tap("button");
+		App.WaitForElement("Page2");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### RootCause:
Setting IsSwipeEnabled = false disables scrollbar visibility, which prevents the CarouselView from scrolling when position changed programmatically.

### Description of Change:
Using hidden for the scrollbar visibility instead of disabled resolves the issue and enables programmatic scrolling to function correctly.
### Issues Fixed
Fixes #29216 
### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac
### Screenshot

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/8fa17971-419c-44b6-b124-1317062a0a48"> | <video src="https://github.com/user-attachments/assets/c10d80a5-3f20-4aff-8ef2-d9ba33ac5126"> |
