### PR TITLE
[Testing] Update failing CarouselView2 tests to use CarouselView1 in sample

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Elements/CarouselViewCoreGalleryPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Elements/CarouselViewCoreGalleryPage.xaml
@@ -76,6 +76,7 @@
                     TextColor="Black" />
             </StackLayout>
             <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/28972 -->
+            <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->      
             <local:CarouselView1
                 x:Name="carousel"
                 Grid.Row="5"

--- a/src/Controls/tests/TestCases.HostApp/Elements/CarouselViewCoreGalleryPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Elements/CarouselViewCoreGalleryPage.xaml
@@ -75,7 +75,8 @@
                     BackgroundColor="LightGray"
                     TextColor="Black" />
             </StackLayout>
-            <CarouselView
+            <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/28972 -->
+            <local:CarouselView1
                 x:Name="carousel"
                 Grid.Row="5"
                 Grid.ColumnSpan="2"
@@ -84,7 +85,7 @@
                 ItemsSource="{Binding Items}"
                 Position="{Binding Position}"
                 CurrentItem="{Binding Selected}">
-                <CarouselView.ItemTemplate>
+                <local:CarouselView1.ItemTemplate>
                     <DataTemplate x:DataType="local:CarouselItem">
                         <Border 
                             x:Name="frame"
@@ -115,8 +116,8 @@
                             </Grid>
                         </Border>
                     </DataTemplate>
-                </CarouselView.ItemTemplate>
-            </CarouselView>
+                </local:CarouselView1.ItemTemplate>
+            </local:CarouselView1>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewPositionVisibility.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewPositionVisibility.xaml
@@ -11,7 +11,8 @@
             BackgroundColor="Black"
             TextColor="White"
             Text="Swipe the CarouselView to select the item numbered 2. Then, tap the Hide Button to hide the Carousel and the Show Button to show the Carousel again. If the position of the Carousel is the same as before hiding, the test has passed."/>
-        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29308 -->        
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29308 -->  
+        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->
         <local:CarouselView1
             AutomationId="TestCarouselView"
             x:Name="carousel"

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewPositionVisibility.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewPositionVisibility.xaml
@@ -2,6 +2,7 @@
 <ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Maui.Controls.Sample"
     x:Class="Maui.Controls.Sample.Issues.CarouselViewPositionVisibility"
     Title="Issue 12848">
     <StackLayout>
@@ -10,21 +11,22 @@
             BackgroundColor="Black"
             TextColor="White"
             Text="Swipe the CarouselView to select the item numbered 2. Then, tap the Hide Button to hide the Carousel and the Show Button to show the Carousel again. If the position of the Carousel is the same as before hiding, the test has passed."/>
-        <CarouselView
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29308 -->        
+        <local:CarouselView1
             AutomationId="TestCarouselView"
             x:Name="carousel"
             HorizontalOptions="Center"
             HeightRequest="500"
             ItemsSource="{Binding}">
-            <CarouselView.ItemTemplate>
+            <local:CarouselView1.ItemTemplate>
                 <DataTemplate>
                     <Label
                       Text="{Binding}"
                       FontSize="96"
                       HorizontalTextAlignment="Center"/>
                 </DataTemplate>
-            </CarouselView.ItemTemplate>
-        </CarouselView>
+            </local:CarouselView1.ItemTemplate>
+        </local:CarouselView1>
         <Label
             AutomationId="CarouselPosition"
             Text="{Binding Source={x:Reference carousel}, Path=Position}"

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdateCurrentItem.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdateCurrentItem.xaml
@@ -2,6 +2,7 @@
 <ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Maui.Controls.Sample"
     x:Class="Maui.Controls.Sample.Issues.CarouselViewUpdateCurrentItem"
     BackgroundColor="Blue">
     <ContentPage.Resources>
@@ -59,7 +60,8 @@
             AutomationId="searchBar" Grid.Row="2" x:Name="matchSearch" 
             BindingContext="{Binding CarouselCurrentItem}" Text="{Binding Title, Mode=OneWay}" 
             Placeholder="Title" WidthRequest="300" />
-        <CarouselView 
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29312 -->        
+        <local:CarouselView1
             Grid.Row="3" x:Name="cv"
             ItemsSource="{Binding Items}" 
             CurrentItem="{Binding CarouselCurrentItem}" 

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdateCurrentItem.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdateCurrentItem.xaml
@@ -60,7 +60,8 @@
             AutomationId="searchBar" Grid.Row="2" x:Name="matchSearch" 
             BindingContext="{Binding CarouselCurrentItem}" Text="{Binding Title, Mode=OneWay}" 
             Placeholder="Title" WidthRequest="300" />
-        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29312 -->        
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29312 -->  
+        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->      
         <local:CarouselView1
             Grid.Row="3" x:Name="cv"
             ItemsSource="{Binding Items}" 

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdatePosition.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdatePosition.xaml
@@ -2,6 +2,7 @@
 <ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Maui.Controls.Sample"
     x:Class="Maui.Controls.Sample.Issues.CarouselViewUpdatePosition">
     <ContentPage.Content>
         <StackLayout
@@ -11,20 +12,21 @@
                 BackgroundColor="Black"
                 TextColor="White"
                 Text="Tap the Button. If the item selected in the CarouselView is Item 4, the test has passed."/>
-            <CarouselView
+            <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29309 -->        
+            <local:CarouselView1
                 x:Name="carousel"
                 IsSwipeEnabled="True"
                 Position="3"
                 IsVisible="False">
-                <CarouselView.ItemTemplate>
+                <local:CarouselView1.ItemTemplate>
                     <DataTemplate>
                         <Label
                             Text="{Binding}"
                             FontSize="Large"
                             HorizontalOptions="CenterAndExpand"/>
                     </DataTemplate>
-                </CarouselView.ItemTemplate>
-                <CarouselView.ItemsSource>
+                </local:CarouselView1.ItemTemplate>
+                <local:CarouselView1.ItemsSource>
                     <x:Array Type="{x:Type x:String}">
                         <x:String>Item 1</x:String>
                         <x:String>Item 2</x:String>
@@ -32,8 +34,8 @@
                         <x:String>Item 4</x:String>
                         <x:String>Item 5</x:String>
                     </x:Array>
-                </CarouselView.ItemsSource>
-            </CarouselView>
+                </local:CarouselView1.ItemsSource>
+            </local:CarouselView1>
             <Button
                 AutomationId="AppearButton"
                 Text="Appear"

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdatePosition.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewUpdatePosition.xaml
@@ -12,7 +12,8 @@
                 BackgroundColor="Black"
                 TextColor="White"
                 Text="Tap the Button. If the item selected in the CarouselView is Item 4, the test has passed."/>
-            <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29309 -->        
+            <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29309 -->     
+            <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->  
             <local:CarouselView1
                 x:Name="carousel"
                 IsSwipeEnabled="True"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
@@ -4,7 +4,8 @@
              xmlns:local="clr-namespace:Maui.Controls.Sample"
              x:Class="Maui.Controls.Sample.Issues.Issue25192">
     <Grid>
-        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/27025 -->        
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/27025 -->    
+        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->    
         <local:CarouselView1 Margin="2,9,2,20"
                       HeightRequest="180"
                       Loop="False"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25192.xaml
@@ -1,28 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Maui.Controls.Sample"
              x:Class="Maui.Controls.Sample.Issues.Issue25192">
     <Grid>
-        <CarouselView Margin="2,9,2,20"
+        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/27025 -->        
+        <local:CarouselView1 Margin="2,9,2,20"
                       HeightRequest="180"
                       Loop="False"
                       PeekAreaInsets="20"
                       VerticalOptions="End"
                       HorizontalScrollBarVisibility="Never">
-            <CarouselView.ItemsSource>
+            <local:CarouselView1.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
                     <x:String>Item1</x:String>
                     <x:String>Item2</x:String>
                     <x:String>Item3</x:String>
                 </x:Array>
-            </CarouselView.ItemsSource>
-            <CarouselView.ItemsLayout>
+            </local:CarouselView1.ItemsSource>
+            <local:CarouselView1.ItemsLayout>
                 <LinearItemsLayout ItemSpacing="5"
                                    Orientation="Horizontal"
                                    SnapPointsAlignment="Center"
                                    SnapPointsType="MandatorySingle"/>
-            </CarouselView.ItemsLayout>
-            <CarouselView.ItemTemplate>
+            </local:CarouselView1.ItemsLayout>
+            <local:CarouselView1.ItemTemplate>
                 <DataTemplate
                     x:DataType="{x:Null}">
                     <Border BackgroundColor="Red"
@@ -100,7 +102,7 @@
                         </Grid>
                     </Border>
                 </DataTemplate>
-            </CarouselView.ItemTemplate>
-        </CarouselView>
+            </local:CarouselView1.ItemTemplate>
+        </local:CarouselView1>
     </Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678.cs
@@ -28,7 +28,8 @@ public class Issue7678 : TestContentPage
 				SnapPointsType = SnapPointsType.MandatorySingle,
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
-		//This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310      
+		// This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310
+		// TODO: Replace CarouselView1 with CarouselView2 once the issues are resolved.
 		var carouselView = new CarouselView1
 		{
 			AutomationId = "carouselView",

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678.cs
@@ -28,8 +28,8 @@ public class Issue7678 : TestContentPage
 				SnapPointsType = SnapPointsType.MandatorySingle,
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
-
-		var carouselView = new CarouselView
+		//This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310      
+		var carouselView = new CarouselView1
 		{
 			AutomationId = "carouselView",
 			ItemsLayout = itemsLayout,

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678.cs
@@ -29,7 +29,7 @@ public class Issue7678 : TestContentPage
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
 		// This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310
-		// TODO: Replace CarouselView1 with CarouselView2 once the issues are resolved.
+		// TODO: Replace CarouselView1 with CarouselView once the issues are resolved.
 		var carouselView = new CarouselView1
 		{
 			AutomationId = "carouselView",

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678_1.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678_1.cs
@@ -28,8 +28,9 @@ public class Issue7678_2 : TestContentPage
 				SnapPointsType = SnapPointsType.MandatorySingle,
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
-
-		var carouselView = new CarouselView
+			
+		//This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310      
+		var carouselView = new CarouselView1
 		{
 			AutomationId = "carouselView",
 			ItemsLayout = itemsLayout,

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678_1.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678_1.cs
@@ -30,7 +30,7 @@ public class Issue7678_2 : TestContentPage
 			};
 			
 		// This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310      
-		// TODO: Replace CarouselView1 with CarouselView2 once the issues mentioned in the GitHub issue are resolved.
+		// TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved.
 		var carouselView = new CarouselView1
 		{
 			AutomationId = "carouselView",

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678_1.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7678_1.cs
@@ -29,7 +29,8 @@ public class Issue7678_2 : TestContentPage
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
 			
-		//This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310      
+		// This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29310      
+		// TODO: Replace CarouselView1 with CarouselView2 once the issues mentioned in the GitHub issue are resolved.
 		var carouselView = new CarouselView1
 		{
 			AutomationId = "carouselView",


### PR DESCRIPTION
## Description
As we plan to integrate CarouselView2 into the CI pipeline ([PR #29283](https://github.com/dotnet/maui/pull/29283)), this PR modifies the UI tests that are currently failing with CarouselView2 to use CarouselView1 instead. This approach ensures the test suite continues to run successfully while we track and resolve the issues related to CarouselView2 separately.
 
### Changes
- Modified failing tests to explicitly instantiate CarouselView1 instead of defaulting to CarouselView2
- Created separate tracking issues for each test that needs fixing for CarouselView2
 
### New Issues Created
- [#29308](https://github.com/dotnet/maui/issues/29308)
- [#29309](https://github.com/dotnet/maui/issues/29309)
- [#29310](https://github.com/dotnet/maui/issues/29310)
- [#29312](https://github.com/dotnet/maui/issues/29312)
 
All issues have been linked to the CarouselView2 epic: https://github.com/dotnet/maui/issues/28978
