### PR TITLE
Fix -[iOS] - CarouselView Throws ArgumentOutOfRangeException Immediately on Application Launch in CV2

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsSourceFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsSourceFactory2.cs
@@ -22,7 +22,7 @@ internal static class ItemsSourceFactory2
 			IList _ when itemsSource is INotifyCollectionChanged => new LoopObservableItemsSource2(itemsSource as IList, collectionViewController, loop),
 			IEnumerable _ when itemsSource is INotifyCollectionChanged => new LoopObservableItemsSource2(itemsSource as IEnumerable, collectionViewController, loop),
 			IEnumerable<object> generic => new LoopListSource2(generic, loop),
-			_ => new LoopListSource(itemsSource, loop),
+			_ => new LoopListSource2(itemsSource, loop),
 		};
 	}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewPositionVisibility.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewPositionVisibility.xaml
@@ -11,23 +11,21 @@
             BackgroundColor="Black"
             TextColor="White"
             Text="Swipe the CarouselView to select the item numbered 2. Then, tap the Hide Button to hide the Carousel and the Show Button to show the Carousel again. If the position of the Carousel is the same as before hiding, the test has passed."/>
-        <!-- This functionality failed in CarouselView2. Reference: https://github.com/dotnet/maui/issues/29308 -->  
-        <!-- TODO: Replace CarouselView1 with CarouselView once the issues mentioned in the GitHub issue are resolved. -->
-        <local:CarouselView1
+        <CarouselView
             AutomationId="TestCarouselView"
             x:Name="carousel"
             HorizontalOptions="Center"
             HeightRequest="500"
             ItemsSource="{Binding}">
-            <local:CarouselView1.ItemTemplate>
+            <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <Label
-                      Text="{Binding}"
-                      FontSize="96"
-                      HorizontalTextAlignment="Center"/>
+                        Text="{Binding}"
+                        FontSize="96"
+                        HorizontalTextAlignment="Center"/>
                 </DataTemplate>
-            </local:CarouselView1.ItemTemplate>
-        </local:CarouselView1>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
         <Label
             AutomationId="CarouselPosition"
             Text="{Binding Source={x:Reference carousel}, Path=Position}"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Description:
When using CarouselView2 with ItemsSource set to List<int> and Loop enabled, an ArgumentOutOfRangeException is thrown.

### Root Cause:
When using CarouselView with a List<int> and looping enabled, the SelectLayout method in CarouselViewHandler2 is invoked. In this scenario, the loop count is incorrectly calculated as 9 for an ItemsSource with a count of 3. Ideally, the loop count should be 5 to simulate proper looping behavior. While LoopListSource2 correctly handles this adjustment, the default implementation uses LoopListSource, which works as expected for CarouselView1 but not for CarouselViewHandler2.

### Description of Change:
Reviewed the page count and looping logic in SelectLayout. Since LoopListSource2 provides the correct scroll index, the implementation was updated to use LoopListSource2 for consistent and accurate behavior.

### Issues Fixed
Fixes #29308 

### Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Note: 
As of now, the test cases are running with `CarouselView1` in CI. However, they will be enabled for `CarouselView2` through the upcoming PRs. 
#29283 
#29315

Once those are merged, I will proceed with updating the tests to use `CarouselView2`.

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="250" height="150" alt="Before Fix" src="https://github.com/user-attachments/assets/692b9112-782a-4378-b190-a54619acd750">|<video width="250" height="150" alt="After Fix" src="https://github.com/user-attachments/assets/cf6c70da-f474-4ae8-bef3-ee0a09e98039">|