### PR TITLE
[iOS] Fix CarouselView proper bounce-back behavior when Loop=false

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LoopObservableItemsSource2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LoopObservableItemsSource2.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			get
 			{
 				var newCount = ItemCount;
-				if (newCount > 0)
+				if (Loop && newCount > 0)
 				{
 					newCount = ItemCount + 2;
 				}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29261.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29261.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29261, "CarouselViewHandler2 for iOS does not properly bounce back when reaching the end with Loop=false", PlatformAffected.iOS)]
+public partial class Issue29261 : ContentPage
+{
+	public Issue29261()
+	{
+		var verticalStackLayout = new VerticalStackLayout();
+
+		var carouselItems = new ObservableCollection<string>
+		{
+			"First Item",
+			"Middle Item",
+			"Last Item",
+		};
+
+		CarouselView2 carousel = new CarouselView2
+		{
+			ItemsSource = carouselItems,
+			AutomationId = "carouselview",
+			HeightRequest = 200,
+			Loop = false,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid
+				{
+					Padding = 10
+				};
+
+				var label = new Label
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					FontSize = 18,
+				};
+				label.SetBinding(Label.TextProperty, ".");
+
+				grid.Children.Add(label);
+				return grid;
+			}),
+			HorizontalOptions = LayoutOptions.Fill,
+		};
+
+		var label = new Label
+		{
+			Text = $"CarouselView Position - {carousel.Position}",
+			AutomationId = "positionLabel",
+			HorizontalOptions = LayoutOptions.Center,
+		};
+
+		carousel.PositionChanged += (s, e) =>
+		{
+			label.Text = $"CarouselView Position - {carousel.Position}";
+		};
+
+		verticalStackLayout.Children.Add(carousel);
+		verticalStackLayout.Children.Add(label);
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29261.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29261.cs
@@ -1,14 +1,12 @@
 using System.Collections.ObjectModel;
 
 namespace Maui.Controls.Sample.Issues;
-
 [Issue(IssueTracker.Github, 29261, "CarouselViewHandler2 for iOS does not properly bounce back when reaching the end with Loop=false", PlatformAffected.iOS)]
-public partial class Issue29261 : ContentPage
+public class Issue29261 : ContentPage
 {
 	public Issue29261()
 	{
 		var verticalStackLayout = new VerticalStackLayout();
-
 		var carouselItems = new ObservableCollection<string>
 		{
 			"First Item",
@@ -36,7 +34,6 @@ public partial class Issue29261 : ContentPage
 					FontSize = 18,
 				};
 				label.SetBinding(Label.TextProperty, ".");
-
 				grid.Children.Add(label);
 				return grid;
 			}),

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29261.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29261.cs
@@ -1,0 +1,28 @@
+#if TEST_FAILS_ON_CATALYST
+// On Catalyst, Swipe actions not supported in Appium.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue29261 : _IssuesUITest
+{
+    public override string Issue => "CarouselViewHandler2 for iOS does not properly bounce back when reaching the end with Loop=false";
+
+    public Issue29261(TestDevice device)
+    : base(device)
+    { }
+
+    [Test]
+    [Category(UITestCategories.CarouselView)]
+    public void VerifyCarouselViewBounceTest()
+    {
+        App.WaitForElement("carouselview");
+        App.SwipeRightToLeft("carouselview");
+        App.SwipeRightToLeft("carouselview");
+        App.SwipeRightToLeft("carouselview");
+        var text = App.FindElement("positionLabel").GetText();
+        Assert.That(text, Is.EqualTo("CarouselView Position - 2"));
+    }
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
In carousel view, when Loop is set to false, scrolling past the last item incorrectly allows scrolling beyond the edge without proper bounce-back behavior.

### Root Cause
The carousel  view was incorrectly calculating its total item count by adding extra positions even when Loop was set to false.

### Description of Change
When Loop is false, the carousel returns the exact Item Count without additional items, preventing over-scrolling.

### Reference

I resolved the issue by referring to the following code. 
https://github.com/dotnet/maui/blob/b498783636495d5224f1abe1866596c706fd141f/src/Controls/src/Core/Handlers/Items2/iOS/LoopListSource2.cs#L27

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #29261   
Fixes #27668 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/ad860f8a-ead2-4e1b-bab3-9b1eb684af8d" >| <video src="https://github.com/user-attachments/assets/69e6ada7-e077-4de1-b503-5e7548cc15ed">|
