### PR TITLE
Run Categories Separately

### DIFF
--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -85,32 +85,26 @@ void ExecuteBuild(string project, string binDir, string config, string rid, stri
 	});
 }
 
+
 void ExecuteTests(string project, string device, string resultsDir, string config, string tfm, string rid, string toolPath)
 {
 	CleanResults(resultsDir);
 
 	var testApp = GetTestApplications(project, device, config, tfm, rid).FirstOrDefault();
-
 	Information($"Testing App: {testApp}");
-	var settings = new DotNetToolSettings
-	{
-		DiagnosticOutput = true,
-		ToolPath = toolPath,
-		ArgumentCustomization = args => args.Append($"run xharness apple test --app=\"{testApp}\" --targets=\"{device}\" --output-directory=\"{resultsDir}\" --verbosity=\"Debug\" ")
-	};
 
-	bool testsFailed = true;
-	try
+	RunMacAndiOSTests(project, device, resultsDir, config, tfm, rid, toolPath, (category) =>
 	{
-		DotNetTool("tool", settings);
-		testsFailed = false;
-	}
-	finally
-	{
-		HandleTestResults(resultsDir, testsFailed, true);
-	}
-
-	Information("Testing completed.");
+		return new DotNetToolSettings
+		{
+			DiagnosticOutput = true,
+			ToolPath = toolPath,
+			ArgumentCustomization = args => 
+				args.Append($"run xharness apple test --app=\"{testApp}\" --targets=\"{device}\" --output-directory=\"{resultsDir}\" " + 
+					" --verbosity=\"Debug\" " + 
+					$"--set-env=\"TestFilter={category}\" ")
+		};
+	});
 }
 
 void ExecuteUITests(string project, string app, string device, string resultsDir, string binDir, string config, string tfm, string rid, string toolPath)

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -93,7 +93,7 @@ void ExecuteTests(string project, string device, string resultsDir, string confi
 	var testApp = GetTestApplications(project, device, config, tfm, rid).FirstOrDefault();
 	Information($"Testing App: {testApp}");
 
-	RunMacAndiOSTests(project, device, resultsDir, config, tfm, rid, toolPath, (category) =>
+	RunMacAndiOSTests(project, device, resultsDir, config, tfm, rid, toolPath, projectPath, (category) =>
 	{
 		return new DotNetToolSettings
 		{

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -283,6 +283,7 @@ void RunMacAndiOSTests(
 	    bool testsFailed = true;
 		Information($"Running tests for category: {category}");
 		var settings = getSettings(category);
+        var suffix = category.Split('=').Skip(1).FirstOrDefault();
 
 		try
 		{
@@ -299,7 +300,20 @@ void RunMacAndiOSTests(
 				{
 					Information($"Test attempt {i} failed: {ex.Message}");
 					if (i == 1)
+                    {
 						throw;
+                    }
+                    else
+                    {
+                        // delete any log files created so it's fresh for the rerun
+			            HandleTestResults(resultsDir, false, true, "-" + suffix);
+                        var logFiles = GetFiles($"{resultsDir}/*-{suffix}*");
+
+                        foreach (var logFile in logFiles)
+                        {
+                            DeleteFile(logFile);
+                        }
+                    }
 				}
 			}
 		}
@@ -309,7 +323,7 @@ void RunMacAndiOSTests(
 		}
 		finally
 		{
-			HandleTestResults(resultsDir, testsFailed, true, "-" + category.Split('=').Skip(1).FirstOrDefault());
+			HandleTestResults(resultsDir, testsFailed, true, "-" + suffix);
 		}
 	}
 

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -274,7 +274,7 @@ DirectoryPath DetermineBinlogDirectory(string projectPath, string binlogArg)
 }
 
 void RunMacAndiOSTests(
-    string project, string device, string resultsDir, string config, string tfm, string rid, string toolPath,
+    string project, string device, string resultsDir, string config, string tfm, string rid, string toolPath, string projectPath,
     Func<string, DotNetToolSettings> getSettings)
 {
     Exception exception = null;

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -133,7 +133,72 @@ void CleanResults(string resultsDir)
     }
 }
 
-void HandleTestResults(string resultsDir, bool testsFailed, bool needsNameFix)
+List<string> GetTestCategoriesToRunSeparately(string projectPath)
+{
+
+    if (!string.IsNullOrEmpty(testFilter))
+    {
+        return new List<string> { testFilter };
+    }
+
+    if (!projectPath.EndsWith("Controls.DeviceTests.csproj") && !projectPath.EndsWith("Core.DeviceTests.csproj"))
+    {
+        return new List<string>
+        {
+            ""
+        };
+    }
+
+	var file = Context.GetCallerInfo().SourceFilePath;
+	var directoryPath = file.GetDirectory().FullPath;
+	Information($"Directory: {directoryPath}");
+	Information(directoryPath);
+
+	// Search for files that match the pattern
+	List<FilePath> dllFilePath = null;
+    
+    if (projectPath.EndsWith("Controls.DeviceTests.csproj"))
+        dllFilePath = GetFiles($"{directoryPath}/../../**/Microsoft.Maui.Controls.DeviceTests.dll").ToList();
+
+    if (projectPath.EndsWith("Core.DeviceTests.csproj"))
+        dllFilePath = GetFiles($"{directoryPath}/../../**/Microsoft.Maui.Core.DeviceTests.dll").ToList();
+
+    System.Reflection.Assembly loadedAssembly = null;
+
+    foreach (var filePath in dllFilePath)
+    {
+        try
+        {
+            loadedAssembly = System.Reflection.Assembly.LoadFrom(filePath.FullPath);
+            Information($"Loaded assembly from {filePath}: {loadedAssembly.FullName}");
+            break; // Exit the loop if the assembly is loaded successfully
+        }
+        catch (Exception ex)
+        {
+            Warning($"Failed to load assembly from {filePath}: {ex.Message}");
+        }
+    }
+
+    if (loadedAssembly == null)
+    {
+        throw new Exception("No test assembly found.");
+    }
+	var testCategoryType = loadedAssembly.GetType("Microsoft.Maui.DeviceTests.TestCategory");
+
+	var values = new List<string>();
+
+	foreach (var field in testCategoryType.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
+	{
+		if (field.FieldType == typeof(string))
+		{
+			values.Add($"Category={(string)field.GetValue(null)}");
+		}
+	}
+	
+	return values.ToList();
+}
+
+void HandleTestResults(string resultsDir, bool testsFailed, bool needsNameFix, string suffix = null)
 {
     Information($"Handling test results: {resultsDir}");
 
@@ -145,10 +210,24 @@ void HandleTestResults(string resultsDir, bool testsFailed, bool needsNameFix)
         {
             throw new Exception("No test results found.");
         }
+        
         if (FileExists(resultsFile))
         {
             Information($"Test results found on {resultsDir}");
-            CopyFile(resultsFile, resultsFile.GetDirectory().CombineWithFilePath("TestResults.xml"));
+            MoveFile(resultsFile, resultsFile.GetDirectory().CombineWithFilePath($"TestResults{suffix}.xml"));
+            var logFiles = GetFiles($"{resultsDir}/*.log");
+
+            foreach (var logFile in logFiles)
+            {
+                if (logFile.GetFilename().ToString().StartsWith("TestResults"))
+                {
+                    // These are log files that have already been renamed
+                    continue;
+                }
+
+                Information($"Log file found: {logFile.GetFilename().ToString()}");
+                MoveFile(logFile, resultsFile.GetDirectory().CombineWithFilePath($"TestResults{suffix}-{logFile.GetFilename()}"));
+            }
         }
     }
 
@@ -158,12 +237,21 @@ void HandleTestResults(string resultsDir, bool testsFailed, bool needsNameFix)
         EnsureDirectoryExists(failurePath);
         // The tasks will retry the tests and overwrite the failed results each retry
         // we want to retain the failed results for diagnostic purposes
-        CopyFiles($"{resultsDir}/*.*", failurePath);
+
+        var searchQuery = "*.*";
+
+        if (!string.IsNullOrWhiteSpace(suffix))
+        {
+            searchQuery = $"*{suffix}*.*";
+        }
+
+        // Only copy files from this suffix set of failures
+        CopyFiles($"{resultsDir}/{searchQuery}", failurePath);
 
         // We don't want these to upload
-        MoveFile($"{failurePath}/TestResults.xml", $"{failurePath}/Results.xml");
+        MoveFile($"{failurePath}/TestResults{suffix}.xml", $"{failurePath}/Results{suffix}.xml");
     }
-    FailRunOnOnlyInconclusiveTests($"{resultsDir}/TestResults.xml");
+    FailRunOnOnlyInconclusiveTests($"{resultsDir}/TestResults{suffix}.xml");
 }
 
 DirectoryPath DetermineBinlogDirectory(string projectPath, string binlogArg)
@@ -183,6 +271,53 @@ DirectoryPath DetermineBinlogDirectory(string projectPath, string binlogArg)
         Warning("No project path or binlog directory specified, using current directory.");
         return null;
     }
+}
+
+void RunMacAndiOSTests(
+    string project, string device, string resultsDir, string config, string tfm, string rid, string toolPath,
+    Func<string, DotNetToolSettings> getSettings)
+{
+    Exception exception = null;
+	foreach (var category in GetTestCategoriesToRunSeparately(projectPath))
+	{
+	    bool testsFailed = true;
+		Information($"Running tests for category: {category}");
+		var settings = getSettings(category);
+
+		try
+		{
+			for(int i = 0; i < 2; i++)
+			{
+				Information($"Running test attempt {i}");
+				try
+				{
+					DotNetTool("tool", settings);
+					testsFailed = false;
+					break;
+				}
+				catch (Exception ex)
+				{
+					Information($"Test attempt {i} failed: {ex.Message}");
+					if (i == 1)
+						throw;
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			exception = ex;
+		}
+		finally
+		{
+			HandleTestResults(resultsDir, testsFailed, true, "-" + category.Split('=').Skip(1).FirstOrDefault());
+		}
+	}
+
+	Information("Testing completed.");
+	if (exception is not null)
+	{
+		throw exception;
+	}
 }
 
 void LogSetupInfo(string toolPath)

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -173,45 +173,38 @@ void ExecuteTests(string project, string device, string resultsDir, string confi
 
 	Information($"Testing App: {testApp}");
 
-	var settings = new DotNetToolSettings
+
+
+	RunMacAndiOSTests(project, device, resultsDir, config, tfm, rid, toolPath, (category) =>
 	{
-		ToolPath = toolPath,
-		DiagnosticOutput = true,
-		ArgumentCustomization = args =>
+		return new DotNetToolSettings
 		{
-			args.Append("run xharness apple test " +
-				$"--app=\"{testApp}\" " +
-				$"--targets=\"{device}\" " +
-				$"--output-directory=\"{resultsDir}\" " +
-				$"--timeout=01:15:00 " +
-				$"--launch-timeout=00:06:00 " +
-				xcode_args +
-				$"--verbosity=\"Debug\" ");
-
-			if (device.Contains("device"))
+			ToolPath = toolPath,
+			DiagnosticOutput = true,
+			ArgumentCustomization = args =>
 			{
-				if (string.IsNullOrEmpty(DEVICE_UDID))
-				{
-					throw new Exception("No device was found to install the app on. See the Setup method for more details.");
-				}
-				args.Append($"--device=\"{DEVICE_UDID}\" ");
-			}
-			return args;
-		}
-	};
+				args.Append("run xharness apple test " +
+					$"--app=\"{testApp}\" " +
+					$"--targets=\"{device}\" " +
+					$"--output-directory=\"{resultsDir}\" " +
+					$"--timeout=01:15:00 " +
+					$"--launch-timeout=00:06:00 " +
+					xcode_args +
+					$"--verbosity=\"Debug\" " +
+					$"--set-env=\"TestFilter={category}\" ");
 
-	bool testsFailed = true;
-	try
-	{
-		DotNetTool("tool", settings);
-		testsFailed = false;
-	}
-	finally
-	{
-		HandleTestResults(resultsDir, testsFailed, true);
-	}
-	
-	Information("Testing completed.");
+				if (device.Contains("device"))
+				{
+					if (string.IsNullOrEmpty(DEVICE_UDID))
+					{
+						throw new Exception("No device was found to install the app on. See the Setup method for more details.");
+					}
+					args.Append($"--device=\"{DEVICE_UDID}\" ");
+				}
+				return args;
+			}
+		};
+	});
 }
 
 void ExecutePrepareUITests(string project, string app, string device, string resultsDir, string binDir, string config, string tfm, string rid, string ver, string toolPath)

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -175,7 +175,7 @@ void ExecuteTests(string project, string device, string resultsDir, string confi
 
 
 
-	RunMacAndiOSTests(project, device, resultsDir, config, tfm, rid, toolPath, (category) =>
+	RunMacAndiOSTests(project, device, resultsDir, config, tfm, rid, toolPath, projectPath, (category) =>
 	{
 		return new DotNetToolSettings
 		{

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -145,7 +145,6 @@ steps:
     displayName: Execute Test Run
     workingDirectory: ${{ parameters.checkoutDirectory }}
     condition: and(succeeded(), ne('${{ parameters.buildType }}', 'buildOnly'))
-    retryCountOnTaskFailure: 1
 
 
   ##################################################

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -145,6 +145,8 @@ steps:
     displayName: Execute Test Run
     workingDirectory: ${{ parameters.checkoutDirectory }}
     condition: and(succeeded(), ne('${{ parameters.buildType }}', 'buildOnly'))
+    ${{ if or(eq(parameters.buildType, 'windows'), eq(parameters.platform, 'android')) }}:
+      retryCountOnTaskFailure: 1
 
 
   ##################################################

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action, IMauiContext mauiContext = null, TimeSpan? timeOut = null)
 			where THandler : class, IElementHandler
 		{
+			var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 			mauiContext ??= MauiContext;
 
 			if (System.Diagnostics.Debugger.IsAttached)
@@ -275,7 +276,11 @@ namespace Microsoft.Maui.DeviceTests
 				finally
 				{
 					_takeOverMainContentSempahore.Release();
-					TestRunnerLogger.LogDebug($"Finished Running Test");
+					stopwatch.Stop();
+					TestRunnerLogger.LogDebug($"Finished Running Test: {stopwatch.Elapsed}");
+
+					if (stopwatch.ElapsedMilliseconds > 15000)
+						TestRunnerLogger.LogError($"Test took longer than 15 seconds to complete.");
 				}
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		Task<string> GetPlatformText(ButtonHandler buttonHandler)
 		{
-			return InvokeOnMainThreadAsync(() => GetPlatformButton(buttonHandler).CurrentTitle);
+			return InvokeOnMainThreadAsync(() => GetPlatformButton(buttonHandler).CurrentTitle!);
 		}
 
 		UILineBreakMode GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -326,7 +326,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Category(TestCategory.Editor)]
-		[Category(TestCategory.TextInput)]
 		[Collection(RunInNewWindowCollection)]
 		public class EditorTextInputTests : TextInputTests<EditorHandler, Editor>
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -239,7 +239,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Category(TestCategory.Entry)]
-		[Category(TestCategory.TextInput)]
 		[Collection(RunInNewWindowCollection)]
 		public class EntryTextInputTests : TextInputTests<EntryHandler, Entry>
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		[Category(TestCategory.Entry)]
 		public class ScrollTests : ControlsHandlerTestBase
 		{
 			[Fact]
@@ -126,6 +127,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		[Category(TestCategory.Entry)]
 		public class NextKeyboardTests : ControlsHandlerTestBase
 		{
 			void SetupNextBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/Page/PageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Page/PageTests.Android.cs
@@ -9,6 +9,7 @@ using AndroidX.Fragment.App;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	[Category(TestCategory.Page)]
 	public partial class PageTests : ControlsHandlerTestBase
 	{
 		//src/Compatibility/Core/tests/Android/EmbeddingTests.cs

--- a/src/Controls/tests/DeviceTests/Elements/Page/PageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Page/PageTests.iOS.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	[Category(TestCategory.Page)]
 	public partial class PageTests : ControlsHandlerTestBase
 	{
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/TextInput/TextInputTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TextInput/TextInputTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	[Category(TestCategory.TextInput)]
 	public abstract partial class TextInputTests<THandler, TView> : ControlsHandlerTestBase
 		where THandler : class, IViewHandler, IPlatformViewHandler, new()
 		where TView : InputView, IView, ITextInput, new()

--- a/src/Controls/tests/DeviceTests/MauiProgram.cs
+++ b/src/Controls/tests/DeviceTests/MauiProgram.cs
@@ -24,9 +24,19 @@ namespace Microsoft.Maui.DeviceTests
 		public static IApplication DefaultTestApp => MauiProgramDefaults.DefaultTestApp;
 
 		public static MauiApp CreateMauiApp() =>
-			MauiProgramDefaults.CreateMauiApp(new List<Assembly>()
+			MauiProgramDefaults.CreateMauiApp((sp) =>
 			{
-				typeof(MauiProgram).Assembly
+				var options = new TestOptions
+				{
+					Assemblies = new List<Assembly>()
+					{
+						typeof(MauiProgram).Assembly
+					},
+					SkipCategories = typeof(TestCategory).GetExcludedTestCategories()
+				};
+
+				return options;
+
 			});
 	}
 }

--- a/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
+++ b/src/Core/tests/DeviceTests.Shared/Core.DeviceTests.Shared.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)"/>
     <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21558.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/tests/DeviceTests.Shared/DeviceTestSharedHelpers.cs
+++ b/src/Core/tests/DeviceTests.Shared/DeviceTestSharedHelpers.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public static class DeviceTestSharedHelpers
+	{
+		public static string[] GetTestCategoryValues(this Type testCategoryType)
+		{
+			var values = new List<string>();
+
+			foreach (var field in testCategoryType.GetFields(BindingFlags.Public | BindingFlags.Static))
+			{
+				if (field.FieldType == typeof(string))
+				{
+					values.Add((string)field.GetValue(null));
+				}
+			}
+
+			return values.ToArray();
+		}
+
+		public static List<String> GetExcludedTestCategories(this Type testCategoryType)
+		{
+#if IOS || MACCATALYST
+			foreach (var en in Foundation.NSProcessInfo.ProcessInfo.Environment)
+			{
+				string filterValue = $"{en.Value}";
+				if ($"{en.Key}" == "TestFilter" && filterValue.StartsWith("Category="))
+				{
+					Console.WriteLine($"TestFilter: {filterValue}");
+					string categoryToRun = $"{filterValue.Split('=')[1]}";
+					var categories = new List<String>(GetTestCategoryValues(testCategoryType));
+					categories.Remove(categoryToRun);
+					return categories.Select(c => $"Category={c}").ToList();
+				}
+			}
+#endif
+			return new List<String>();
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
+++ b/src/Core/tests/DeviceTests.Shared/MauiProgramDefaults.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static MauiApp CreateMauiApp(List<Assembly> testAssemblies)
 		{
+			return CreateMauiApp((_) => new TestOptions
+			{
+				Assemblies = testAssemblies
+			});
+		}
+
+		public static MauiApp CreateMauiApp(Func<IServiceProvider, TestOptions> options)
+		{
 			var appBuilder = MauiApp.CreateBuilder();
 
 #if DEBUG
@@ -45,13 +53,10 @@ namespace Microsoft.Maui.DeviceTests
 					});
 #endif
 				})
-				.ConfigureTests(new TestOptions
-				{
-					Assemblies = testAssemblies,
-				});
+				.ConfigureTests(options);
 
 #if WINDOWS
-			if (testAssemblies.Any(a => a.FullName.Contains("Controls.DeviceTests",
+			if (options(null).Assemblies.Any(a => a.FullName.Contains("Controls.DeviceTests",
 				StringComparison.OrdinalIgnoreCase)))
 			{
 				appBuilder.UseControlsHeadlessRunner(new HeadlessRunnerOptions
@@ -76,10 +81,10 @@ namespace Microsoft.Maui.DeviceTests
 #if IOS || MACCATALYST
 
 			appBuilder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();
-					handlers.AddHandler<Microsoft.Maui.Controls.CarouselView, Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2>();
-				});
+			{
+				handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();
+				handlers.AddHandler<Microsoft.Maui.Controls.CarouselView, Microsoft.Maui.Controls.Handlers.Items2.CarouselViewHandler2>();
+			});
 
 #endif
 			appBuilder.UseVisualRunner();

--- a/src/Core/tests/DeviceTests/Handlers/Element/ElementTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Element/ElementTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	[Category(TestCategory.Element)]
 	public partial class ElementTests : CoreHandlerTestBase
 	{
 		[Fact]

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -279,6 +279,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			await InterruptingLoadCancelsAndStartsOverImplementation();
 		}
+
 		async Task<List<(string Member, object Value)>> InterruptingLoadCancelsAndStartsOverImplementation()
 		{
 			var image = new TStub
@@ -286,10 +287,19 @@ namespace Microsoft.Maui.DeviceTests
 				Background = new SolidPaintStub(Colors.Black)
 			};
 
+			TaskCompletionSource finished = new TaskCompletionSource();
 			var order = new List<string>();
 
 			image.LoadingStarted += () => order.Add($"LoadingStarted");
-			image.LoadingCompleted += successful => order.Add($"LoadingCompleted({successful})");
+			image.LoadingCompleted += successful =>
+			{
+				order.Add($"LoadingCompleted({successful})");
+
+				if (!successful)
+				{
+					finished.SetResult();
+				}
+			};
 			image.LoadingFailed += exception => order.Add($"LoadingFailed({exception})");
 
 			var events = await InvokeOnMainThreadAsync(async () =>
@@ -330,6 +340,8 @@ namespace Microsoft.Maui.DeviceTests
 
 				// make sure it did actually work
 				await handler.PlatformView.AssertContainsColor(Colors.Red, MauiContext);
+
+				await finished.Task.WaitAsync(TimeSpan.FromSeconds(1));
 
 				return handler.ImageEvents;
 			});

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	[Category(TestCategory.NavigationView)]
+	[Category(TestCategory.NavigationPage)]
 	public partial class NavigationViewHandlerTests : CoreHandlerTestBase
 	{
 #if ANDROID || WINDOWS

--- a/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.cs
@@ -7,7 +7,7 @@ using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	[Category("RefreshViewHandler")]
+	[Category(TestCategory.RefreshView)]
 	public partial class RefreshViewHandlerTests : CoreHandlerTestBase<RefreshViewHandler, RefreshViewStub>
 	{
 		[Theory(DisplayName = "Is Refreshing Initializes Correctly")]

--- a/src/Core/tests/DeviceTests/MauiProgram.cs
+++ b/src/Core/tests/DeviceTests/MauiProgram.cs
@@ -17,9 +17,18 @@ namespace Microsoft.Maui.DeviceTests
 		public static IApplication DefaultTestApp { get; private set; }
 
 		public static MauiApp CreateMauiApp() =>
-			MauiProgramDefaults.CreateMauiApp(new List<Assembly>()
+			MauiProgramDefaults.CreateMauiApp((sp) =>
 			{
-				typeof(MauiProgram).Assembly
+				var options = new TestOptions
+				{
+					Assemblies = new List<Assembly>()
+					{
+						typeof(MauiProgram).Assembly
+					},
+					SkipCategories = typeof(TestCategory).GetExcludedTestCategories()
+				};
+
+				return options;
 			});
 	}
 }

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -2,15 +2,22 @@
 {
 	public static class TestCategory
 	{
+		// Because we run the ios/catalyst one category at a time, we only want to compile in
+		// Categories that iOS/Catalyst are actually using
+		#if ANDROID || WINDOWS
 		public const string MauiContext = "MauiContext";
-
 		public const string Application = "Application";
+		public const string BoxView = "BoxView";
+		public const string RadioButton = "RadioButton";
+		public const string WindowOverlay = "WindowOverlay";
+		#endif
+
 		public const string ActivityIndicator = "ActivityIndicator";
 		public const string Border = "Border";
-		public const string BoxView = "BoxView";
 		public const string Button = "Button";
 		public const string CheckBox = "CheckBox";
 		public const string ContentView = "ContentView";
+		public const string Element = "Element";
 		public const string DatePicker = "DatePicker";
 		public const string Dispatcher = "Dispatcher";
 		public const string Editor = "Editor";
@@ -27,11 +34,11 @@
 		public const string Label = "Label";
 		public const string Layout = "Layout";
 		public const string Memory = "Memory";
-		public const string NavigationView = "NavigationView";
+		public const string NavigationPage = "NavigationPage";
 		public const string Page = "Page";
 		public const string Picker = "Picker";
 		public const string ProgressBar = "ProgressBar";
-		public const string RadioButton = "RadioButton";
+		public const string RefreshView = "RefreshView";
 		public const string ScrollView = "ScrollView";
 		public const string SearchBar = "SearchBar";
 		public const string ShapeView = "ShapeView";
@@ -44,6 +51,5 @@
 		public const string View = "View";
 		public const string WebView = "WebView";
 		public const string Window = "Window";
-		public const string WindowOverlay = "WindowOverlay";
 	}
 }

--- a/src/TestUtils/src/DeviceTests.Runners/AppHostBuilderExtensions.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/AppHostBuilderExtensions.cs
@@ -16,6 +16,16 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners
 		public static MauiAppBuilder ConfigureTests(this MauiAppBuilder appHostBuilder, TestOptions options)
 		{
 			appHostBuilder.Services.AddSingleton(options);
+
+			appHostBuilder.Logging.AddConsole();
+			// appHostBuilder.Logging.SetMinimumLevel(LogLevel.Debug);
+			return appHostBuilder;
+		}
+
+		public static MauiAppBuilder ConfigureTests(this MauiAppBuilder appHostBuilder, Func<IServiceProvider, TestOptions> options)
+		{
+			appHostBuilder.Services.AddSingleton(options);
+
 			appHostBuilder.Logging.AddConsole();
 			// appHostBuilder.Logging.SetMinimumLevel(LogLevel.Debug);
 			return appHostBuilder;

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/HeadlessTestRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/HeadlessTestRunner.cs
@@ -42,7 +42,11 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 		{
 			var testRunner = base.GetTestRunner(logWriter);
 			if (_options.SkipCategories?.Count > 0)
+			{
 				testRunner.SkipCategories(_options.SkipCategories);
+				Console.WriteLine($"Skipping categories: {string.Join(", ", _options.SkipCategories)}");
+			}
+			
 			return testRunner;
 		}
 

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/MauiTestApplicationDelegate.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/MauiTestApplicationDelegate.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 
 		protected abstract MauiApp CreateMauiApp();
 
-		public override bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
+		public override bool WillFinishLaunching(UIApplication application, NSDictionary? launchOptions)
 		{
 			Runtime.MarshalManagedException += (object sender, MarshalManagedExceptionEventArgs args) =>
 			{
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 			return true;
 		}
 
-		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+		public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
 		{
 			var tcs = new TaskCompletionSource();
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.DeviceTests
 		
 		public static async Task<T> AttachAndRun<T>(this UIView view, Func<Task<T>> action)
 		{
-			var currentView = FindContentView();
+			var currentView = await FindContentView();
 
 			// MauiView has optimization code that won't fire a remeasure of the child view
 			// Check LayoutSubviews inside MauiView.cs for more details. 
@@ -175,12 +175,22 @@ namespace Microsoft.Maui.DeviceTests
 
 		private static UIView? _contentView;
 		private static readonly object _contentViewLock = new();
-		public static UIView FindContentView()
+
+		public static Task<UIView> FindContentView() => FindContentView(0);
+
+		public static async Task<UIView> FindContentView(int retryCount)
 		{
 			if (_contentView is not null)
 			{
 				return _contentView;
 			}
+
+			if (retryCount > 0)
+				await Task.Delay(1000);
+			else
+				await Task.Yield();
+
+			UIWindow? window = null;
 
 			lock (_contentViewLock)
 			{
@@ -188,21 +198,31 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					return _contentView;
 				}
-				
-				if (GetKeyWindow(UIApplication.SharedApplication) is not UIWindow window)
+
+				window = GetKeyWindow(UIApplication.SharedApplication);
+
+				if (retryCount > 4 || window is not null)
 				{
-					throw new InvalidOperationException("Could not attach view - unable to find UIWindow");
+					if (window is null)
+					{
+						throw new InvalidOperationException($"Could not attach view - unable to find UIWindow.");
+					}
+
+					if (window?.RootViewController is not UIViewController viewController)
+					{
+						throw new InvalidOperationException("Could not attach view - unable to find RootViewController");
+					}
+
+					var rootView = viewController.View ?? throw new InvalidOperationException("Could not attach view - root view is null");
+
+					return _contentView = rootView;
 				}
-
-				if (window.RootViewController is not UIViewController viewController)
-				{
-					throw new InvalidOperationException("Could not attach view - unable to find RootViewController");
-				}
-
-				var rootView = viewController.View ?? throw new InvalidOperationException("Could not attach view - root view is null");
-
-				return _contentView = rootView;
 			}
+
+			// If we don't have a window yet, wait a bit and try again
+			Console.WriteLine($"Retrying to find content view. Retry count: {retryCount}");
+
+			return await FindContentView(retryCount + 1).ConfigureAwait(false);
 		}
 
 		public static Task<UIImage> ToBitmap(this UIView view, IMauiContext mauiContext)


### PR DESCRIPTION
### Description

iOS and Catalyst device tests seem to have hit a critical mass of tests when running on CI. iOS has been problematic for a bit and catalyst just started following suit. This PR splits up the ios/catalyst runs so that it does a run per category

- Split up ios/catalyst  to run per category
- add a property for ios/catalyst runs so you can filter by category `--test-filter="Category=Editor"` this only works on ios/catalyst so don't really want to advertise it too much yet
- Organized the code a bit
- Added a retry in cake so if a category fails it retries just that category