### PR TITLE
[iOS] Fixed the App crashes when navigating to a page containing a map more than once

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
@@ -54,9 +54,21 @@ public class Issue20612page2 : ContentPage
         };
         goBackButton.Clicked += GoBack;
 
-        var grid = new Grid();
+        var grid = new Grid
+        {
+            RowDefinitions =
+    {
+        new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },  // Row 0: for map
+        new RowDefinition { Height = GridLength.Auto }                         // Row 1: for button
+    }
+        };
+
         grid.Children.Add(_map);
+        Grid.SetRow(_map, 0);
+
         grid.Children.Add(goBackButton);
+        Grid.SetRow(goBackButton, 1);
+
 
         Content = grid;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.Maui.Maps;
+
+namespace Maui.Controls.Sample.Issues;
+
+
+[Issue(IssueTracker.Github, 20612, "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.", PlatformAffected.Android)]
+public class Issue20612 : TestNavigationPage
+{
+    protected override void Init()
+    {
+        PushAsync(new Issue20612page1());
+    }
+}
+
+public class Issue20612page1 : ContentPage
+{
+    public Issue20612page1()
+    {
+        var openMapButton = new Button
+        {
+            Text = "Navigate to Map page",
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            AutomationId = "MapButton"
+        };
+
+        openMapButton.Clicked += (s, e) =>
+        {
+            Navigation.PushAsync(new Issue20612page2());
+        };
+        Content = openMapButton;
+    }
+}
+
+public class Issue20612page2 : ContentPage
+{
+    private Microsoft.Maui.Controls.Maps.Map _map;
+
+    public Issue20612page2()
+    {
+        _map = new Microsoft.Maui.Controls.Maps.Map
+        {
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalOptions = LayoutOptions.Fill,
+            BackgroundColor = Colors.Red
+        };
+
+        var goBackButton = new Button
+        {
+            Text = "Go back",
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            AutomationId = "GoBackButton"
+        };
+        goBackButton.Clicked += GoBack;
+
+        var grid = new Grid();
+        grid.Children.Add(_map);
+        grid.Children.Add(goBackButton);
+
+        Content = grid;
+
+        MoveMap();
+    }
+
+    private async void MoveMap()
+    {
+        await Task.Delay(1000).ConfigureAwait(false);
+
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            var mapSpan = MapSpan.FromCenterAndRadius(
+                new Location(5, 5),
+                Distance.FromMeters(10000));
+
+            _map.MoveToRegion(mapSpan);
+        });
+    }
+
+    void GoBack(object sender, EventArgs e)
+    {
+        _map.Handler?.DisconnectHandler();
+        Navigation.PopAsync();
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
@@ -2,7 +2,6 @@
 
 namespace Maui.Controls.Sample.Issues;
 
-
 [Issue(IssueTracker.Github, 20612, "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue20612 : TestNavigationPage
 {
@@ -68,8 +67,6 @@ public class Issue20612page2 : ContentPage
 
         grid.Children.Add(goBackButton);
         Grid.SetRow(goBackButton, 1);
-
-
         Content = grid;
 
         MoveMap();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20612.cs
@@ -3,7 +3,7 @@
 namespace Maui.Controls.Sample.Issues;
 
 
-[Issue(IssueTracker.Github, 20612, "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.", PlatformAffected.Android)]
+[Issue(IssueTracker.Github, 20612, "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue20612 : TestNavigationPage
 {
     protected override void Init()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			// second Navigation to Map page
 			App.WaitForElement("MapButton");
 			App.Tap("MapButton");
-			//App.WaitForElement("GoBackButton");
+
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue20612 : _IssuesUITest
+	{
+		public Issue20612(TestDevice device) : base(device) { }
+
+		public override string Issue => "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.";
+
+		[Test]
+		[Category(UITestCategories.Maps)]
+		public void MapsShouldNotCrashWhenNavigationOccurs()
+		{
+			App.WaitForElement("MapButton");
+			App.Tap("MapButton");
+			App.WaitForElement("GoBackButton");
+			App.Tap("GoBackButton");
+			// second Navigation to Map page
+			App.WaitForElement("MapButton");
+			App.Tap("MapButton");
+			//App.WaitForElement("GoBackButton");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
@@ -4,26 +4,24 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue20612 : _IssuesUITest
 {
-	public class Issue20612 : _IssuesUITest
+	public Issue20612(TestDevice device) : base(device) { }
+
+	public override string Issue => "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.";
+
+	[Test]
+	[Category(UITestCategories.Maps)]
+	public void MapsShouldNotCrashWhenNavigationOccurs()
 	{
-		public Issue20612(TestDevice device) : base(device) { }
-
-		public override string Issue => "Disconnecting Map Handler causes Map to crash on second page entrance and moving to region.";
-
-		[Test]
-		[Category(UITestCategories.Maps)]
-		public void MapsShouldNotCrashWhenNavigationOccurs()
-		{
-			App.WaitForElement("MapButton");
-			App.Tap("MapButton");
-			App.WaitForElement("GoBackButton");
-			App.Tap("GoBackButton");
-			// second Navigation to Map page
-			App.WaitForElement("MapButton");
-			App.Tap("MapButton");
-		}
+		App.WaitForElement("MapButton");
+		App.Tap("MapButton");
+		App.WaitForElement("GoBackButton");
+		App.Tap("GoBackButton");
+		// second Navigation to Map page
+		App.WaitForElement("MapButton");
+		App.Tap("MapButton");
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			// second Navigation to Map page
 			App.WaitForElement("MapButton");
 			App.Tap("MapButton");
-
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20612.cs
@@ -1,3 +1,5 @@
+#if TEST_FAILS_ON_WINDOWS
+//No Map control support in windows https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/map?view=net-maui-9.0
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -24,3 +26,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		protected override MauiMKMapView CreatePlatformView()
 		{
-			return MapPool.Get() ?? new MauiMKMapView(this);
+			return MapPool.Get(this) ?? new MauiMKMapView(this);
 		}
 
 		protected override void ConnectHandler(MauiMKMapView platformView)

--- a/src/Core/maps/src/Platform/iOS/MapPool.cs
+++ b/src/Core/maps/src/Platform/iOS/MapPool.cs
@@ -14,14 +14,12 @@ namespace Microsoft.Maui.Maps.Platform
 
 		public static MauiMKMapView? Get(IMapHandler mapHandler)
 		{
-			var hasInstance = Instance.Maps.TryDequeue(out MauiMKMapView? mapView);
-
-			if (hasInstance && mapView != null)
+			if (Instance.Maps.TryDequeue(out MauiMKMapView? mapView) && mapView is not null)
 			{
 				mapView.Handler = mapHandler;
+				return mapView;
 			}
-
-			return hasInstance ? mapView : null;
+			return null;
 		}
 	}
 }

--- a/src/Core/maps/src/Platform/iOS/MapPool.cs
+++ b/src/Core/maps/src/Platform/iOS/MapPool.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Microsoft.Maui.Maps.Handlers;
 
 namespace Microsoft.Maui.Maps.Platform
 {
@@ -11,6 +12,16 @@ namespace Microsoft.Maui.Maps.Platform
 
 		public static void Add(MauiMKMapView mapView) => Instance.Maps.Enqueue(mapView);
 
-		public static MauiMKMapView? Get() => Instance.Maps.TryDequeue(out MauiMKMapView? mapView) ? mapView : null;
+		public static MauiMKMapView? Get(IMapHandler mapHandler)
+		{
+			var hasInstance = Instance.Maps.TryDequeue(out MauiMKMapView? mapView);
+
+			if (hasInstance && mapView != null)
+			{
+				mapView.Handler = mapHandler;
+			}
+
+			return hasInstance ? mapView : null;
+		}
 	}
 }

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Maui.Maps.Platform
 {
 	public class MauiMKMapView : MKMapView
 	{
-		WeakReference<IMapHandler> _handlerRef = new WeakReference<IMapHandler>(null!);
+		WeakReference<IMapHandler> _handlerRef;
 		object? _lastTouchedView;
 		UITapGestureRecognizer? _mapClickedGestureRecognizer;
 
 		public MauiMKMapView(IMapHandler handler)
 		{
-			Handler = handler;
+			_handlerRef = new WeakReference<IMapHandler>(handler);
 			OverlayRenderer = GetViewForOverlayDelegate;
 		}
 

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Maps.Platform
 			}
 			set
 			{
-				if (value != null)
+				if (value is not null)
 				{
 					_handlerRef = new WeakReference<IMapHandler>(value);
 				}

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -12,14 +12,30 @@ namespace Microsoft.Maui.Maps.Platform
 {
 	public class MauiMKMapView : MKMapView
 	{
-		WeakReference<IMapHandler> _handlerRef;
+		WeakReference<IMapHandler> _handlerRef = new WeakReference<IMapHandler>(null!);
 		object? _lastTouchedView;
 		UITapGestureRecognizer? _mapClickedGestureRecognizer;
 
 		public MauiMKMapView(IMapHandler handler)
 		{
-			_handlerRef = new WeakReference<IMapHandler>(handler);
+			Handler = handler;
 			OverlayRenderer = GetViewForOverlayDelegate;
+		}
+
+		internal IMapHandler? Handler
+		{
+			get
+			{
+				_handlerRef.TryGetTarget(out var handler);
+				return handler;
+			}
+			set
+			{
+				if (value != null)
+				{
+					_handlerRef = new WeakReference<IMapHandler>(value);
+				}
+			}
 		}
 
 		public override void MovedToWindow()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- The crash occurred because the handler was set inside the constructor, which prevents it from being reused from the map pool.



### Description of Change



- Move the handler assignment outside the constructor so that when it is reused from the `pool`, the handler is not null and does not cause a crash.



### Issues Fixed



Fixes #20612 
Fixes #29346

### Fix Reference

#28795

### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/d4a5321a-6c62-44fd-a7ea-97b68c156bd6"> | <video src="https://github.com/user-attachments/assets/e6bff868-71bd-428d-95ca-9399587f22f3"> |