### PR TITLE
Fix for Window dimensions not updating after device orientation changes on iOS

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
@@ -1,0 +1,62 @@
+﻿namespace Maui.Controls.Sample.Issues;
+using Microsoft.Maui.Controls;
+using System;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 29236, "Window dimensions not updating after device orientation changes on iOS", PlatformAffected.iOS)]
+public partial class Issue29236 : ContentPage
+{
+	private Label WindowWidth, WindowHeight, PageWidth, PageHeight;
+
+	public Issue29236()
+	{
+		WindowWidth = new Label {AutomationId = "WindowWidth"};
+		WindowHeight = new Label {AutomationId = "WindowHeight"};
+		PageWidth = new Label {AutomationId = "PageWidth"};
+		PageHeight = new Label {AutomationId = "PageHeight"};
+
+		var grid = new Grid
+		{
+			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition(), new ColumnDefinition() },
+			RowDefinitions = { new RowDefinition(), new RowDefinition(), new RowDefinition() }
+		};
+
+		grid.Add(new Label { Text = "Width:" }, 0, 1);
+		grid.Add(new Label { Text = "Height:" }, 0, 2);
+		grid.Add(new Label { Text = "Window" }, 1, 0);
+		grid.Add(new Label { Text = "Page" }, 2, 0);
+
+		grid.Add(WindowWidth, 1, 1);
+		grid.Add(WindowHeight, 1, 2);
+		grid.Add(PageWidth, 2, 1);
+		grid.Add(PageHeight, 2, 2);
+
+		var button = new Button
+		{
+			Text = "Get dimensions",
+			HorizontalOptions = LayoutOptions.Fill,
+			AutomationId = "GetDimensionsButton"
+		};
+		button.Clicked += UpdateDimensions;
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(20),
+			Spacing = 20,
+			Children =
+				{
+					new Label { Text = "Window Dimension Test" , AutomationId = "Label"},
+					grid,
+					button
+				}
+		};
+	}
+
+	private void UpdateDimensions(object sender, EventArgs e)
+	{
+		WindowWidth.Text = Application.Current.Windows[0].Width.ToString();
+		WindowHeight.Text = Application.Current.Windows[0].Height.ToString();
+		PageWidth.Text = Width.ToString();
+		PageHeight.Text = Height.ToString();
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
@@ -24,9 +24,9 @@ public partial class Issue29236 : ContentPage
 
 		var button = new Button
 		{
-			Text = "Get dimensions",
+			Text = "Get Dimensions",
 			HorizontalOptions = LayoutOptions.Fill,
-			AutomationId = "getDimensionsButton"
+			AutomationId = "getDimensions"
 		};
 		button.Clicked += UpdateDimensions;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
@@ -6,30 +6,23 @@ using System;
 [Issue(IssueTracker.Github, 29236, "Window dimensions not updating after device orientation changes on iOS", PlatformAffected.iOS)]
 public partial class Issue29236 : ContentPage
 {
-	private Label WindowWidth, WindowHeight, PageWidth, PageHeight;
+	private Label WindowWidth, WindowHeight;
 
 	public Issue29236()
 	{
-		WindowWidth = new Label {AutomationId = "WindowWidth"};
-		WindowHeight = new Label {AutomationId = "WindowHeight"};
-		PageWidth = new Label {AutomationId = "PageWidth"};
-		PageHeight = new Label {AutomationId = "PageHeight"};
+		WindowWidth = new Label { AutomationId = "WindowWidth" };
+		WindowHeight = new Label { AutomationId = "WindowHeight" };
 
 		var grid = new Grid
 		{
-			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition(), new ColumnDefinition() },
-			RowDefinitions = { new RowDefinition(), new RowDefinition(), new RowDefinition() }
+			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition() },
+			RowDefinitions = { new RowDefinition(), new RowDefinition() }
 		};
 
-		grid.Add(new Label { Text = "Width:" }, 0, 1);
-		grid.Add(new Label { Text = "Height:" }, 0, 2);
-		grid.Add(new Label { Text = "Window" }, 1, 0);
-		grid.Add(new Label { Text = "Page" }, 2, 0);
-
-		grid.Add(WindowWidth, 1, 1);
-		grid.Add(WindowHeight, 1, 2);
-		grid.Add(PageWidth, 2, 1);
-		grid.Add(PageHeight, 2, 2);
+		grid.Add(new Label { Text = "Width:" }, 0, 0);
+		grid.Add(new Label { Text = "Height:" }, 0, 1);
+		grid.Add(WindowWidth, 1, 0);
+		grid.Add(WindowHeight, 1, 1);
 
 		var button = new Button
 		{
@@ -44,11 +37,11 @@ public partial class Issue29236 : ContentPage
 			Padding = new Thickness(20),
 			Spacing = 20,
 			Children =
-				{
-					new Label { Text = "Window Dimension Test" , AutomationId = "Label"},
-					grid,
-					button
-				}
+			{
+				new Label { Text = "Window Dimension Test", AutomationId = "Label" },
+				grid,
+				button
+			}
 		};
 	}
 
@@ -56,7 +49,5 @@ public partial class Issue29236 : ContentPage
 	{
 		WindowWidth.Text = Application.Current.Windows[0].Width.ToString();
 		WindowHeight.Text = Application.Current.Windows[0].Height.ToString();
-		PageWidth.Text = Width.ToString();
-		PageHeight.Text = Height.ToString();
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29236.cs
@@ -1,17 +1,15 @@
 ﻿namespace Maui.Controls.Sample.Issues;
-using Microsoft.Maui.Controls;
-using System;
 
 [XamlCompilation(XamlCompilationOptions.Compile)]
 [Issue(IssueTracker.Github, 29236, "Window dimensions not updating after device orientation changes on iOS", PlatformAffected.iOS)]
 public partial class Issue29236 : ContentPage
 {
-	private Label WindowWidth, WindowHeight;
+	private Label windowWidth, windowHeight;
 
 	public Issue29236()
 	{
-		WindowWidth = new Label { AutomationId = "WindowWidth" };
-		WindowHeight = new Label { AutomationId = "WindowHeight" };
+		windowWidth = new Label { AutomationId = "windowWidth" };
+		windowHeight = new Label { AutomationId = "windowHeight" };
 
 		var grid = new Grid
 		{
@@ -21,14 +19,14 @@ public partial class Issue29236 : ContentPage
 
 		grid.Add(new Label { Text = "Width:" }, 0, 0);
 		grid.Add(new Label { Text = "Height:" }, 0, 1);
-		grid.Add(WindowWidth, 1, 0);
-		grid.Add(WindowHeight, 1, 1);
+		grid.Add(windowWidth, 1, 0);
+		grid.Add(windowHeight, 1, 1);
 
 		var button = new Button
 		{
 			Text = "Get dimensions",
 			HorizontalOptions = LayoutOptions.Fill,
-			AutomationId = "GetDimensionsButton"
+			AutomationId = "getDimensionsButton"
 		};
 		button.Clicked += UpdateDimensions;
 
@@ -38,7 +36,7 @@ public partial class Issue29236 : ContentPage
 			Spacing = 20,
 			Children =
 			{
-				new Label { Text = "Window Dimension Test", AutomationId = "Label" },
+				new Label { Text = "Window Dimension Test", AutomationId = "windowTestTitle" },
 				grid,
 				button
 			}
@@ -47,7 +45,7 @@ public partial class Issue29236 : ContentPage
 
 	private void UpdateDimensions(object sender, EventArgs e)
 	{
-		WindowWidth.Text = Application.Current.Windows[0].Width.ToString();
-		WindowHeight.Text = Application.Current.Windows[0].Height.ToString();
+		windowWidth.Text = Application.Current.Windows[0].Width.ToString();
+		windowHeight.Text = Application.Current.Windows[0].Height.ToString();
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
@@ -16,13 +16,13 @@ internal class Issue29236 : _IssuesUITest
 	public void WindowDimensionsShouldUpdateAfterOrientationChange()
 	{
 		App.WaitForElement("windowTestTitle");
-		App.Tap("GetDimensionsButton");
+		App.Tap("getDimensions");
 		
 		var portraitWindowWidth = App.WaitForElement("windowWidth").GetText();
 		var portraitWindowHeight = App.WaitForElement("windowHeight").GetText();
 		
 		App.SetOrientationLandscape();
-		App.Tap("getDimensionsButton");
+		App.Tap("getDimensions");
 		
 		var previousWindowWidth = Math.Round(double.Parse(portraitWindowWidth ?? "0"));
 		var previousWindowHeight = Math.Round(double.Parse(portraitWindowHeight ?? "0"));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
@@ -1,4 +1,4 @@
-﻿#if IOS //This issue only occurs on iOS - window dimensions not updating after orientation changes
+﻿#if IOS || ANDROID //The test fails on Windows and MacCatalyst because the SetOrientation method, which is intended to change the device orientation, is only supported on mobile platforms iOS and Android.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -16,10 +16,16 @@ internal class Issue29236 : _IssuesUITest
 	public void WindowDimensionsShouldUpdateAfterOrientationChange()
 	{
 		App.WaitForElement("Label");
+		App.WaitForElement("GetDimensionsButton").Tap();
+
+		var portraitWindowWidth = App.WaitForElement("WindowWidth").GetText();
+    	var portraitWindowHeight = App.WaitForElement("WindowHeight").GetText();
+
 		App.SetOrientationLandscape();
 		App.WaitForElement("GetDimensionsButton").Tap();
-		Assert.That(App.WaitForElement("PageWidth").GetText(), Is.EqualTo(App.WaitForElement("WindowWidth").GetText()));
-		Assert.That(App.WaitForElement("PageHeight").GetText(), Is.EqualTo(App.WaitForElement("WindowHeight").GetText()));
+
+		Assert.That(Math.Round(double.Parse(portraitWindowWidth ?? "0")), Is.EqualTo(Math.Round(double.Parse(App.WaitForElement("WindowHeight").GetText() ?? "0"))));
+    	Assert.That(Math.Round(double.Parse(portraitWindowHeight ?? "0")), Is.EqualTo(Math.Round(double.Parse(App.WaitForElement("WindowWidth").GetText() ?? "0"))));
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
@@ -1,0 +1,25 @@
+﻿#if IOS //This issue only occurs on iOS - window dimensions not updating after orientation changes
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+internal class Issue29236 : _IssuesUITest
+{
+	public Issue29236(TestDevice device) : base(device) { }
+
+	public override string Issue => "Window dimensions not updating after device orientation changes on iOS";
+
+	[Test]
+	[Category(UITestCategories.Window)]
+	public void WindowDimensionsShouldUpdateAfterOrientationChange()
+	{
+		App.WaitForElement("Label");
+		App.SetOrientationLandscape();
+		App.WaitForElement("GetDimensionsButton").Tap();
+		Assert.That(App.WaitForElement("PageWidth").GetText(), Is.EqualTo(App.WaitForElement("WindowWidth").GetText()));
+		Assert.That(App.WaitForElement("PageHeight").GetText(), Is.EqualTo(App.WaitForElement("WindowHeight").GetText()));
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
@@ -16,16 +16,21 @@ internal class Issue29236 : _IssuesUITest
 	public void WindowDimensionsShouldUpdateAfterOrientationChange()
 	{
 		App.WaitForElement("Label");
-		App.WaitForElement("GetDimensionsButton").Tap();
-
+		App.Tap("GetDimensionsButton");
+		
 		var portraitWindowWidth = App.WaitForElement("WindowWidth").GetText();
-    	var portraitWindowHeight = App.WaitForElement("WindowHeight").GetText();
-
+		var portraitWindowHeight = App.WaitForElement("WindowHeight").GetText();
+		
 		App.SetOrientationLandscape();
-		App.WaitForElement("GetDimensionsButton").Tap();
-
-		Assert.That(Math.Round(double.Parse(portraitWindowWidth ?? "0")), Is.EqualTo(Math.Round(double.Parse(App.WaitForElement("WindowHeight").GetText() ?? "0"))));
-    	Assert.That(Math.Round(double.Parse(portraitWindowHeight ?? "0")), Is.EqualTo(Math.Round(double.Parse(App.WaitForElement("WindowWidth").GetText() ?? "0"))));
+		App.Tap("GetDimensionsButton");
+		
+		var previousWindowWidth = Math.Round(double.Parse(portraitWindowWidth ?? "0"));
+		var previousWindowHeight = Math.Round(double.Parse(portraitWindowHeight ?? "0"));
+		var currentWindowWidth = Math.Round(double.Parse(App.WaitForElement("WindowWidth").GetText() ?? "0"));
+		var currentWindowHeight = Math.Round(double.Parse(App.WaitForElement("WindowHeight").GetText() ?? "0"));
+		
+		Assert.That(previousWindowWidth, Is.EqualTo(currentWindowHeight));
+		Assert.That(previousWindowHeight, Is.EqualTo(currentWindowWidth));
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29236.cs
@@ -15,19 +15,19 @@ internal class Issue29236 : _IssuesUITest
 	[Category(UITestCategories.Window)]
 	public void WindowDimensionsShouldUpdateAfterOrientationChange()
 	{
-		App.WaitForElement("Label");
+		App.WaitForElement("windowTestTitle");
 		App.Tap("GetDimensionsButton");
 		
-		var portraitWindowWidth = App.WaitForElement("WindowWidth").GetText();
-		var portraitWindowHeight = App.WaitForElement("WindowHeight").GetText();
+		var portraitWindowWidth = App.WaitForElement("windowWidth").GetText();
+		var portraitWindowHeight = App.WaitForElement("windowHeight").GetText();
 		
 		App.SetOrientationLandscape();
-		App.Tap("GetDimensionsButton");
+		App.Tap("getDimensionsButton");
 		
 		var previousWindowWidth = Math.Round(double.Parse(portraitWindowWidth ?? "0"));
 		var previousWindowHeight = Math.Round(double.Parse(portraitWindowHeight ?? "0"));
-		var currentWindowWidth = Math.Round(double.Parse(App.WaitForElement("WindowWidth").GetText() ?? "0"));
-		var currentWindowHeight = Math.Round(double.Parse(App.WaitForElement("WindowHeight").GetText() ?? "0"));
+		var currentWindowWidth = Math.Round(double.Parse(App.WaitForElement("windowWidth").GetText() ?? "0"));
+		var currentWindowHeight = Math.Round(double.Parse(App.WaitForElement("windowHeight").GetText() ?? "0"));
 		
 		Assert.That(previousWindowWidth, Is.EqualTo(currentWindowHeight));
 		Assert.That(previousWindowHeight, Is.EqualTo(currentWindowWidth));

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -62,9 +62,9 @@ namespace Microsoft.Maui.TestCases.Tests
 					config.SetProperty("Udid", Environment.GetEnvironmentVariable("DEVICE_UDID") ?? "");
 					break;
 				case TestDevice.iOS:
-					config.SetProperty("DeviceName", Environment.GetEnvironmentVariable("DEVICE_NAME") ?? "iPhone Xs");
-					config.SetProperty("PlatformVersion", Environment.GetEnvironmentVariable("PLATFORM_VERSION") ?? "18.0");
-					config.SetProperty("Udid", Environment.GetEnvironmentVariable("DEVICE_UDID") ?? "");
+					config.SetProperty("DeviceName", Environment.GetEnvironmentVariable("DEVICE_NAME") ?? "iPhone 16 Pro");
+					config.SetProperty("PlatformVersion", Environment.GetEnvironmentVariable("PLATFORM_VERSION") ?? "18.2");
+					config.SetProperty("Udid", Environment.GetEnvironmentVariable("DEVICE_UDID") ?? "1B1702D1-7308-477A-AAB5-5A7D51A5766A");
 					break;
 				case TestDevice.Windows:
 					var appProjectFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "..\\..\\..\\Controls.TestCases.HostApp");

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -62,9 +62,9 @@ namespace Microsoft.Maui.TestCases.Tests
 					config.SetProperty("Udid", Environment.GetEnvironmentVariable("DEVICE_UDID") ?? "");
 					break;
 				case TestDevice.iOS:
-					config.SetProperty("DeviceName", Environment.GetEnvironmentVariable("DEVICE_NAME") ?? "iPhone 16 Pro");
-					config.SetProperty("PlatformVersion", Environment.GetEnvironmentVariable("PLATFORM_VERSION") ?? "18.2");
-					config.SetProperty("Udid", Environment.GetEnvironmentVariable("DEVICE_UDID") ?? "1B1702D1-7308-477A-AAB5-5A7D51A5766A");
+					config.SetProperty("DeviceName", Environment.GetEnvironmentVariable("DEVICE_NAME") ?? "iPhone Xs");
+					config.SetProperty("PlatformVersion", Environment.GetEnvironmentVariable("PLATFORM_VERSION") ?? "18.0");
+					config.SetProperty("Udid", Environment.GetEnvironmentVariable("DEVICE_UDID") ?? "");
 					break;
 				case TestDevice.Windows:
 					var appProjectFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "..\\..\\..\\Controls.TestCases.HostApp");

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Maui.Handlers
 					_ => {
 						// Using dispatch to defer execution until after the rotation animation completes
 						DispatchQueue.MainQueue.DispatchAsync(() => {
-							if (platformView != null)
+							if (platformView is not null)
 							{
-								//UpdateVirtualViewFrame(platformView);
+								UpdateVirtualViewFrame(platformView);
 							}
 						});
 					});
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				_proxy.Disconnect();
 			}
-			else if (_orientationObserver != null)
+			else if (_orientationObserver is not null)
 			{
 				_orientationObserver.Dispose();
 				_orientationObserver = null;

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -32,11 +32,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				_proxy.Disconnect();
 			}
-			else if (_orientationObserver is not null)
-			{
-				UnregisterOrientationChangeNotification();
-			}
 
+			UnregisterOrientationChangeNotification();
 			base.DisconnectHandler(platformView);
 		}
 
@@ -141,15 +138,19 @@ namespace Microsoft.Maui.Handlers
 
 		private void UnregisterOrientationChangeNotification()
 		{
-			NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver!);
-			_orientationObserver = null;
-			UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
+			if (_orientationObserver is not null)
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(_orientationObserver);
+				_orientationObserver = null;
+				UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
+			}
 		}
 
 		private void HandleOrientationChanged(NSNotification notification)
 		{
-			// Using dispatch to defer execution until after the rotation animation completes
-			DispatchQueue.MainQueue.DispatchAsync(() => {
+			// Using dispatch to defer execution until after the rotation animation completes.
+			DispatchQueue.MainQueue.DispatchAsync(() => 
+			{
 				UpdateVirtualViewFrame(PlatformView);
 			});
 		}

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 						DispatchQueue.MainQueue.DispatchAsync(() => {
 							if (platformView != null)
 							{
-								//UpdateVirtualViewFrame(platformView);
+								UpdateVirtualViewFrame(platformView);
 							}
 						});
 					});

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Handlers
 	public partial class WindowHandler : ElementHandler<IWindow, UIWindow>
 	{
 		readonly WindowProxy _proxy = new();
+		DisplayOrientation _previousOrientation;
 
 		protected override void ConnectHandler(UIWindow platformView)
 		{
@@ -21,6 +22,7 @@ namespace Microsoft.Maui.Handlers
 			else
 			{
 				UpdateVirtualViewFrame(platformView);
+				 _previousOrientation = VirtualView.GetOrientation();
 				DeviceDisplay.Current.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 			}
 		}
@@ -130,10 +132,15 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)
-        {
-			UpdateVirtualViewFrame(PlatformView);
-        }
+		 void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)
+		{
+			// Only update frame when orientation actually changes, not for other display events.
+			if (_previousOrientation != e.DisplayInfo.Orientation)
+			{
+				_previousOrientation = e.DisplayInfo.Orientation;
+				UpdateVirtualViewFrame(PlatformView);
+			}
+		}
 
 		void UpdateVirtualViewFrame(UIWindow window)
 		{

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 						DispatchQueue.MainQueue.DispatchAsync(() => {
 							if (platformView != null)
 							{
-								UpdateVirtualViewFrame(platformView);
+								//UpdateVirtualViewFrame(platformView);
 							}
 						});
 					});


### PR DESCRIPTION
### Root Cause
The root cause of the window dimensions issue on iOS is that the virtual view frame (`VirtualView.FrameChanged`) is only updated once during initialization, and never again during orientation changes.
Unlike Android, iOS lacks a system-level mechanism that automatically updates the window dimensions when orientation changes occur. The `WindowHandler.iOS.cs` only called `UpdateVirtualViewFrame` in the `ConnectHandler` method, with no code to detect and respond to orientation changes. This meant that while the UI correctly rotated visually, programmatic access to `Window.Width` and `Window.Height` continued to return the original (pre-rotation) dimensions.
 
### Description of Change
The implementation uses Apple's recommended `effectiveGeometry` observer pattern for iOS 16+ and MacCatalyst 16+ to properly update window dimensions during orientation changes.
For iOS specifically, the implementation filters for actual orientation changes by comparing InterfaceOrientation values, ensuring window dimensions are only updated when needed and avoiding unnecessary updates from other display events.
This approach ensures Window.Width and Window.Height values correctly reflect the device's current orientation.
 
### Issues Fixed
Fixes #29236 
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [x] iOS
- [ ] Mac
 
 ### Note
 This issue specifically affects iOS and Android because they are mobile platforms where physical device rotation triggers UI orientation changes.


### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/6388edfa-0a24-4264-89b1-5dc5d6d1d455" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/f9ab6180-b191-42d9-9215-bcd02f413328" /> |