### PR TITLE
[Android] - Fix inconsistent footer scrolling when EmptyView is a string in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			// No template, Footer is not a Forms View, so just display Footer.ToString
-			return SimpleViewHolder.FromText(content?.ToString(), context, false);
+			return SimpleViewHolder.FromText(content?.ToString(), context, fill: false);
 		}
 
 		protected RecyclerView.ViewHolder CreateEmptyViewHolder(object content, DataTemplate template, ViewGroup parent)
@@ -235,7 +235,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				if (content is not View formsView)
 				{
 					// No template, EmptyView is not a Forms View, so just display EmptyView.ToString
-					return SimpleViewHolder.FromText(content?.ToString(), context);
+					return SimpleViewHolder.FromText(content?.ToString(), context, () => GetWidth(parent), () => GetHeight(parent), ItemsView);
 				}
 
 				// EmptyView is a Forms View; display that
@@ -317,6 +317,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				var content = dataTemplate.CreateContent() as IView;
 				size = content.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			}
+
+			if (item is string text)
+			{
+				Label label = new Label { Text = text };
+				TemplateHelpers.GetHandler(label, ItemsView.FindMauiContext());
+
+				size = label.Measure(double.PositiveInfinity, double.PositiveInfinity);
 			}
 
 			var itemHeight = size.Height;

--- a/src/Controls/src/Core/Handlers/Items/Android/SimpleViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SimpleViewHolder.cs
@@ -27,19 +27,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			itemsView.RemoveLogicalChild(View);
 		}
 
-		public static SimpleViewHolder FromText(string text, Context context, bool fill = true)
+		public static SimpleViewHolder FromText(string text, Context context, Func<double> width = null, Func<double> height = null, ItemsView container = null, bool fill = true)
 		{
-			var textView = new TextView(context) { Text = text };
-
 			if (fill)
 			{
-				var layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent,
-					ViewGroup.LayoutParams.MatchParent);
-				textView.LayoutParameters = layoutParams;
+				// When displaying an EmptyView with Header and Footer, we need to account for the Header and Footer sizes in layout calculations.
+				// This prevents the EmptyView from occupying the full remaining space. 
+				Label label = new Label() { Text = text, VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center };
+				SizedItemContentView itemContentControl = new SizedItemContentView(context, width, height);
+				itemContentControl.RealizeContent(label, container);
+				return new SimpleViewHolder(itemContentControl, null);
 			}
 
-			textView.Gravity = GravityFlags.Center;
-
+			TextView textView = new TextView(context) { Text = text, Gravity = GravityFlags.Center };
 			return new SimpleViewHolder(textView, null);
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28765.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28765.cs
@@ -1,0 +1,43 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28765, "[Android] Inconsistent footer scrolling in CollectionView when EmptyView as string", PlatformAffected.Android)]
+public class Issue28765 : TestContentPage
+{
+	override protected void Init()
+	{
+		Grid grid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Star },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		CollectionView headerFooterView = new CollectionView
+		{
+			EmptyView = "No items to display",
+			Header = new Label
+			{
+				Text = "Header View",
+			},
+			Footer = new Label
+			{
+				Text = "Footer View"
+			}
+		};
+
+		CollectionView headerFooterStringView = new CollectionView
+		{
+			EmptyView = "No items to display",
+			Header = "Header String",
+			Footer = "Footer String"
+		};
+		Grid.SetRow(headerFooterStringView, 1);
+
+		grid.Children.Add(headerFooterView);
+		grid.Children.Add(headerFooterStringView);
+
+		Content = grid;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28765.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28765.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28765 : _IssuesUITest
+{
+    public override string Issue => "[Android] Inconsistent footer scrolling in CollectionView when EmptyView as string";
+    public Issue28765(TestDevice device) : base(device)
+    {
+    }
+
+    [Test, Order(1)]
+    [Category(UITestCategories.CollectionView)]
+    public void EmptyViewStringWithHeaderAndFooterAsView()
+    {
+        App.WaitForElement("Footer View");
+    }
+
+    [Test, Order(2)]
+    [Category(UITestCategories.CollectionView)]
+    public void EmptyViewStringWithHeaderAndFooterString()
+    {
+        App.WaitForElement("Footer String");
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

- When the `EmptyView` is defined as a string, it occupies the entire parent space without considering header and footer dimensions, causing overlaps or forcing the footer into a scrollable area.

### Description of Change

- Enhanced layout logic to account for `Header` and `Footer` measurements when the `EmptyView` is specified as a string. This ensures the `EmptyView` no longer occupies the entire available space indiscriminately and allows the `Footer` to remain properly anchored, preserving the correct layout.
- Enhanced `UpdateHeaderFooterHeight` to handle string-based content by creating a `Label` for measurement, ensuring accurate height calculations for header and footer items.

### Issues Fixed

Fixes #28765

**Tested the behaviour in the following platforms**

- [x] Android
- [x]  Windows
- [x]  iOS
- [x] Mac

### Output

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/b50ed50f-ad65-44ca-8a18-7eefe90e4e4b">| <video src="https://github.com/user-attachments/assets/46ca66bd-e53f-4a5e-b7c9-72d36f2a2fc6">|
