### PR TITLE
[maui-release] Use DevDiv/Xamarin.yaml-templates

### DIFF
--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -61,9 +61,8 @@ parameters:
 resources:
   repositories:
     - repository: yaml-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
+      type: git
+      name: DevDiv/Xamarin.yaml-templates
       ref: refs/heads/main
     - repository: 1ESPipelineTemplates
       type: git


### PR DESCRIPTION
Updates maui-release.yml to use common yaml templates from https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates