### PR TITLE
[Testing] Fix for flaky test(ListViewViewCellBinding) in CI

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ListViewViewCellBinding.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ListViewViewCellBinding.cs
@@ -31,6 +31,7 @@ public class ListViewViewCellBinding : _IssuesUITest
 
 	public void ListViewViewCellBindingTestsAddListItem()
 	{
+		App.WaitForElement("Add");
 		App.Tap("Add");
 		App.WaitForElement("4");
 		App.WaitForElement("400.0");
@@ -40,6 +41,7 @@ public class ListViewViewCellBinding : _IssuesUITest
 
 	public void ListViewViewCellBindingTestsRemoveListItem()
 	{
+		App.WaitForElement("Remove");
 		App.Tap("Remove");
 		App.WaitForNoElement("1");
 		App.WaitForNoElement("100.0");


### PR DESCRIPTION
## Description
This pull request makes minor updates to the test cases in `ListViewViewCellBinding.cs` to improve the reliability of UI interactions by adding explicit waits for elements before performing actions.

### Test case improvements:

* [`ListViewViewCellBindingTestsAddListItem`](diffhunk://#diff-e464e5908b6d265c0d1a9c9c26eea2c1bf6843e69db8f92583be0243362dbf44R34): Added a `WaitForElement` call to ensure the "Add" button is visible before tapping it.
* [`ListViewViewCellBindingTestsRemoveListItem`](diffhunk://#diff-e464e5908b6d265c0d1a9c9c26eea2c1bf6843e69db8f92583be0243362dbf44R44): Added a `WaitForElement` call to ensure the "Remove" button is visible before tapping it.