### PR TITLE
Fix for exception thrown when disconnecting page handlers in the Unloaded event while navigating on MacCatalyst and iOS

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Maui.Controls
 					// If SendUnloaded caused the unloaded tokens to wire up
 					_loadedUnloadedToken?.Dispose();
 					_loadedUnloadedToken = null;
-					_loadedUnloadedToken = this.OnLoaded(SendLoaded);
+					if (Handler != null)
+						_loadedUnloadedToken = this.OnLoaded(SendLoaded);
 				}
 			}
 			else

--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls
 					// If SendUnloaded caused the unloaded tokens to wire up
 					_loadedUnloadedToken?.Dispose();
 					_loadedUnloadedToken = null;
-					if (Handler != null)
+					if (Handler is not null)
 						_loadedUnloadedToken = this.OnLoaded(SendLoaded);
 				}
 			}

--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls
 					// If SendUnloaded caused the unloaded tokens to wire up
 					_loadedUnloadedToken?.Dispose();
 					_loadedUnloadedToken = null;
-					if (Window?.Handler?.PlatformView is not null)
+					if (Handler is not null)
 					{
 						_loadedUnloadedToken = this.OnLoaded(SendLoaded);
 					}

--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Maui.Controls
 					_loadedUnloadedToken?.Dispose();
 					_loadedUnloadedToken = null;
 					if (Handler is not null)
+					{
 						_loadedUnloadedToken = this.OnLoaded(SendLoaded);
+					}
 				}
 			}
 			else

--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls
 					// If SendUnloaded caused the unloaded tokens to wire up
 					_loadedUnloadedToken?.Dispose();
 					_loadedUnloadedToken = null;
-					if (Handler is not null)
+					if (Window?.Handler?.PlatformView is not null)
 					{
 						_loadedUnloadedToken = this.OnLoaded(SendLoaded);
 					}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29297.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29297.cs
@@ -1,0 +1,87 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29297, "Crash on shell navigation for Mac Catalyst", PlatformAffected.macOS)]
+public class Issue29297 : Shell
+{
+	public Issue29297()
+	{
+		CurrentItem = new Issue29297_MainPage();
+	}
+
+	public class Issue29297_MainPage : ContentPage
+	{
+		Label label;
+		bool isNavigated;
+		public Issue29297_MainPage()
+		{
+			var stack = new StackLayout();
+			label = new Label();
+			var Button = new Button();
+			Button.Text = "Click to navigate new page";
+			Button.AutomationId = "Button";
+			Button.Clicked += Clicked;
+			stack.Children.Add(Button);
+			stack.Children.Add(label);
+			this.Content = stack;
+			this.Loaded += MainPage_Loaded;
+		}
+
+		private async void Clicked(object sender, EventArgs e)
+		{
+			isNavigated = true;
+			await Navigation.PushAsync(new Issue29297_NewPage());
+		}
+
+		private void MainPage_Loaded(object sender, EventArgs e)
+		{
+			if (isNavigated)
+			{
+				label.Text = $"Successfully navigated back";
+			}
+		}
+	}
+
+	public class Issue29297_NewPage : ContentPage
+	{
+		public Issue29297_NewPage()
+		{
+			var stack = new StackLayout();
+			var Button = new Button();
+			Button.Text = "Click to navigate main page";
+			Button.AutomationId = "Button";
+			Button.Clicked += Clicked;
+			stack.Children.Add(Button);
+			this.Unloaded += NewPage_Unloaded;
+			this.Content = stack;
+		}
+
+		private void Clicked(object sender, EventArgs e)
+		{
+			Shell.Current.GoToAsync("..");
+		}
+
+		private void NewPage_Unloaded(object sender, EventArgs e)
+		{
+			if (sender is not VisualElement senderElement)
+				return;
+
+			var visualTreeElement = (IVisualTreeElement)senderElement;
+
+			Disconnect(visualTreeElement);
+
+			return;
+
+			void Disconnect(IVisualTreeElement element)
+			{
+				if (element is VisualElement visualElement)
+				{
+
+					foreach (IVisualTreeElement childElement in element.GetVisualChildren())
+						Disconnect(childElement);
+
+					visualElement.Handler?.DisconnectHandler();
+				}
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29297.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29297.cs
@@ -15,7 +15,7 @@ public class Issue29297 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.Shell)]
-	public void Shell_Issue21916()
+	public void Shell_Issue29297()
 	{
 		App.WaitForElement("Button");
 		App.Click("Button");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29297.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29297.cs
@@ -1,5 +1,4 @@
-#if !ANDROID
-//Skipping the test case to run in android because the loaded event is not triggered when navigating back to previous page.
+#if TEST_FAILS_ON_ANDROID // Loaded event is not triggered when navigating back to previous page - https://github.com/dotnet/maui/issues/29414
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29297.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29297.cs
@@ -1,0 +1,27 @@
+#if !ANDROID
+//Skipping the test case to run in android because the loaded event is not triggered when navigating back to previous page.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue29297 : _IssuesUITest
+{
+	public Issue29297(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Crash on shell navigation for Mac Catalyst";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void Shell_Issue21916()
+	{
+		App.WaitForElement("Button");
+		App.Click("Button");
+		App.WaitForElement("Button");
+		App.Click("Button");
+		App.WaitForElement("Successfully navigated back");
+	}
+}
+#endif


### PR DESCRIPTION
### Issue Details:

When navigating away from the current page, the user disconnects all handlers including those of visual elements and the page itself during the Unloaded event of the current page. This leads to crash with a message " System.InvalidOperationException" is thrown when navigating back to the previous page.
### Root Cause:

When navigating back to the previous page, the Unloaded event of the current page is triggered. As part of this event, the handler for the page is explicitly disconnected by the user. However, after the handler is cleared and the Unloaded event is attempts to save a token for wiring up the Loaded event via the SendLoaded method.
 
At this point, since the handler has already been set to null, calling SendLoaded results in a System.InvalidOperationException, as it requires a valid handler. This is why the exception only occurs during backward navigation.

### Description of Change:

I have applied condition to call the SendLoaded method only if the handler is not null in iOS and Mac platform.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A


### Issues Fixed:

Fixes #29297 

### Screenshots
| Before  | After  |
|---------|--------|
| <Video src="https://github.com/user-attachments/assets/1c647508-17da-49cc-a7bc-0f2491198f31"> |  <Video src="https://github.com/user-attachments/assets/862ee821-7f57-49cc-81dc-e2cef4373d11"> |