### PR TITLE
[Testing] - Enabled Test 29402 to Pass on Both CV1 and CV2 Handlers

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28930.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28930.xaml
@@ -12,7 +12,7 @@
         <Label Text="CAROUSEL"
                TextTransform="Uppercase" />
         <!--https://github.com/dotnet/maui/issues/29402 -->
-        <local:CarouselView1 x:Name="MyCarousel"
+        <CarouselView x:Name="MyCarousel"
                       AutomationId="MyCarousel"
                       HorizontalOptions="Fill"
                       VerticalOptions="Start"
@@ -20,14 +20,14 @@
                       HeightRequest="140"
                       HorizontalScrollBarVisibility="Never"
                       EmptyView="No data">
-          <local:CarouselView1.ItemsSource>
+          <CarouselView.ItemsSource>
             <x:Array Type="{x:Type x:String}">
               <x:String>Item 1</x:String>
               <x:String>Item 2</x:String>
               <x:String>Item 3</x:String>
             </x:Array>
-          </local:CarouselView1.ItemsSource>
-          <local:CarouselView1.ItemTemplate>
+          </CarouselView.ItemsSource>
+          <CarouselView.ItemTemplate>
             <DataTemplate>
               <Grid ColumnDefinitions="*,*,*,*"
                     RowDefinitions="*,Auto">
@@ -140,8 +140,8 @@
                 </Grid>
               </Grid>
             </DataTemplate>
-          </local:CarouselView1.ItemTemplate>
-        </local:CarouselView1>
+          </CarouselView.ItemTemplate>
+        </CarouselView>
       </VerticalStackLayout>
     </Border>
   </VerticalStackLayout>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28523.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28523.cs
@@ -21,5 +21,11 @@ public class Issue28523 : _IssuesUITest
 		App.WaitForElement("Baboon");
 		VerifyScreenshot();
 	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		App.SetOrientationPortrait();
+	}
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Cause

- During the landscape-to-portrait transition, CarouselView fails to retain the expected item position, scrolling to the next item instead. Appium triggers a right-scroll, causing the test to fail in CV2 as Item 3 appears instead of the expected Item 2.

- The test `CarouselViewItemShouldScaleProperly` sets the device to landscape but doesn’t reset it to portrait. As a result, the next test, `CarouselViewInLineBreakMode`, starts in landscape and switches to portrait during execution, causing inconsistent behavior.

- This issue is unrelated to `LineBreakMode` and stems from CarouselView’s item position handling during orientation changes. It has already been reported here: [https://github.com/dotnet/maui/issues/28972]

### Description of Change

- Added a `[TearDown]` method to reset the app's orientation to portrait mode after the `CarouselViewItemShouldScaleProperly` test is completed, ensuring a consistent test environment setup. The test now passes for both CV1 and CV2 handlers.

### Issues Fixed

Fixes #29402 

### Output

| Before| After|
|--|--|
| <video src="https://github.com/user-attachments/assets/0ab4bf1d-0355-46af-a04c-a17916420861"> | <video src="https://github.com/user-attachments/assets/0b8b774e-dec8-4492-b1c2-a30e13f5c546"> |