### PR TITLE
[iOS] Allow text selection and copy in readonly Entry

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue605.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue605.cs
@@ -1,0 +1,17 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 605, "Allow text selection and copy in readonly Entry", PlatformAffected.iOS)]
+public class Issue605 : TestContentPage
+{
+	protected override void Init()
+	{
+		Content = new Entry()
+		{
+			Placeholder = "Enter text",
+			Text = "sad",
+			AutomationId = "Entry",
+			TextColor = Colors.Black,
+			IsReadOnly = true
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue605.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue605.cs
@@ -1,4 +1,4 @@
-﻿#if ANDROID
+﻿#if IOS
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue605.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue605.cs
@@ -1,0 +1,23 @@
+﻿#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue605 : _IssuesUITest
+{
+	public Issue605(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "Allow text selection and copy in readonly Entry";
+
+	[Test]
+	[Category(UITestCategories.Entry)]
+	public void TextSelectionShouldBeEnabledInReadonlyEditor()
+	{
+		App.WaitForElement("Entry");
+		App.LongPress("Entry");
+		VerifyScreenshot();
+	}
+}
+#endif

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -205,8 +205,16 @@ namespace Microsoft.Maui.Handlers
 				}
 			}
 
-			bool OnShouldChangeCharacters(UITextField textField, NSRange range, string replacementString) =>
-				(VirtualView?.TextWithinMaxLength(textField.Text, range, replacementString) ?? false) && (!VirtualView?.IsReadOnly ?? true);
+			bool OnShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
+			{
+				if (VirtualView == null || textField?.Text == null)
+					return false;
+
+				bool withinMaxLength = VirtualView.TextWithinMaxLength(textField.Text, range, replacementString);
+				bool isEditable = !VirtualView.IsReadOnly;
+
+				return withinMaxLength && isEditable;
+			}
 
 			void OnSelectionChanged(object? sender, EventArgs e)
 			{

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -70,8 +70,13 @@ namespace Microsoft.Maui.Handlers
 		public static void MapPlaceholderColor(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdatePlaceholder(entry);
 
-		public static void MapIsReadOnly(IEntryHandler handler, IEntry entry) =>
-			handler.PlatformView?.UpdateIsReadOnly(entry);
+		public static void MapIsReadOnly(IEntryHandler handler, IEntry entry)
+		{
+			if (handler.PlatformView is MauiTextField textField)
+			{
+				textField.IsReadOnly = entry.IsReadOnly;
+			}
+		}
 
 		public static void MapKeyboard(IEntryHandler handler, IEntry entry) =>
 			handler.PlatformView?.UpdateKeyboard(entry);
@@ -201,7 +206,7 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			bool OnShouldChangeCharacters(UITextField textField, NSRange range, string replacementString) =>
-				VirtualView?.TextWithinMaxLength(textField.Text, range, replacementString) ?? false;
+				(VirtualView?.TextWithinMaxLength(textField.Text, range, replacementString) ?? false) && (!VirtualView?.IsReadOnly ?? true);
 
 			void OnSelectionChanged(object? sender, EventArgs e)
 			{

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using CoreGraphics;
 using Foundation;
+using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -9,6 +11,9 @@ namespace Microsoft.Maui.Platform
 
 	public class MauiTextField : UITextField, IUIViewLifeCycleEvents
 	{
+		internal bool IsReadOnly;
+
+		readonly HashSet<string> _readOnlyActions = ["copy:", "select:", "selectAll:"];
 
 		public MauiTextField(CGRect frame)
 			: base(frame)
@@ -23,6 +28,9 @@ namespace Microsoft.Maui.Platform
 		{
 			base.WillMoveToWindow(window);
 		}
+
+		public override bool CanPerform(Selector action, NSObject? withSender)
+			=> !IsReadOnly ? base.CanPerform(action, withSender) : _readOnlyActions.Contains(action.Name);
 
 		public override string? Text
 		{

--- a/src/Core/src/Platform/iOS/MauiTextField.cs
+++ b/src/Core/src/Platform/iOS/MauiTextField.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Maui.Platform
 	{
 		internal bool IsReadOnly;
 
-		readonly HashSet<string> _readOnlyActions = ["copy:", "select:", "selectAll:"];
-
 		public MauiTextField(CGRect frame)
 			: base(frame)
 		{
@@ -30,7 +28,12 @@ namespace Microsoft.Maui.Platform
 		}
 
 		public override bool CanPerform(Selector action, NSObject? withSender)
-			=> !IsReadOnly ? base.CanPerform(action, withSender) : _readOnlyActions.Contains(action.Name);
+		{
+			if (!IsReadOnly)
+				return base.CanPerform(action, withSender);
+
+			return action.Name == "copy:" || action.Name == "select:" || action.Name == "selectAll:";
+		}
 
 		public override string? Text
 		{

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -89,11 +89,6 @@ namespace Microsoft.Maui.Platform
 			textField.AttributedPlaceholder.WithCharacterSpacing(entry.CharacterSpacing);
 		}
 
-		public static void UpdateIsReadOnly(this UITextField textField, IEntry entry)
-		{
-			textField.UserInteractionEnabled = !(entry.IsReadOnly || entry.InputTransparent);
-		}
-
 		public static void UpdateFont(this UITextField textField, ITextStyle textStyle, IFontManager fontManager)
 		{
 			var uiFont = fontManager.GetFont(textStyle.Font, UIFont.LabelFontSize);

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -583,22 +583,8 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateInputTransparent(this UIView platformView, IViewHandler handler, IView view)
 		{
-			// Interaction should not be disabled for an editor if it is set as read-only
-			// because this prevents users from scrolling the content inside an editor.
-			if (view is not IEditor && view is ITextInput textInput)
-			{
-				platformView.UpdateInputTransparent(textInput.IsReadOnly, view.InputTransparent);
-				return;
-			}
-
 			platformView.UserInteractionEnabled = !view.InputTransparent;
 		}
-
-		public static void UpdateInputTransparent(this UIView platformView, bool isReadOnly, bool inputTransparent)
-		{
-			platformView.UserInteractionEnabled = !(isReadOnly || inputTransparent);
-		}
-
 
 		internal static UIToolTipInteraction? GetToolTipInteraction(this UIView platformView)
 		{

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -89,3 +89,6 @@ override Microsoft.Maui.Handlers.WindowHandler.DisconnectHandler(UIKit.UIWindow!
 override Microsoft.Maui.Handlers.ImageButtonHandler.SetupContainer() -> void
 *REMOVED*override Microsoft.Maui.Platform.WrapperView.SetNeedsLayout() -> void
 *REMOVED*override Microsoft.Maui.Platform.MauiView.SetNeedsLayout() -> void
+*REMOVED*static Microsoft.Maui.Platform.TextFieldExtensions.UpdateIsReadOnly(this UIKit.UITextField! textField, Microsoft.Maui.IEntry! entry) -> void
+*REMOVED*static Microsoft.Maui.Platform.ViewExtensions.UpdateInputTransparent(this UIKit.UIView! platformView, bool isReadOnly, bool inputTransparent) -> void
+override Microsoft.Maui.Platform.MauiTextField.CanPerform(ObjCRuntime.Selector! action, Foundation.NSObject? withSender) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -90,3 +90,6 @@ override Microsoft.Maui.Handlers.WindowHandler.DisconnectHandler(UIKit.UIWindow!
 override Microsoft.Maui.Handlers.ImageButtonHandler.SetupContainer() -> void
 *REMOVED*override Microsoft.Maui.Platform.WrapperView.SetNeedsLayout() -> void
 *REMOVED*override Microsoft.Maui.Platform.MauiView.SetNeedsLayout() -> void
+*REMOVED*static Microsoft.Maui.Platform.TextFieldExtensions.UpdateIsReadOnly(this UIKit.UITextField! textField, Microsoft.Maui.IEntry! entry) -> void
+*REMOVED*static Microsoft.Maui.Platform.ViewExtensions.UpdateInputTransparent(this UIKit.UIView! platformView, bool isReadOnly, bool inputTransparent) -> void
+override Microsoft.Maui.Platform.MauiTextField.CanPerform(ObjCRuntime.Selector! action, Foundation.NSObject? withSender) -> bool


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The editor is already working as expected, with changes successfully applied on iOS. However, Android support still needs to be fixed.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/605
Fixes https://github.com/dotnet/maui/issues/27111

|Before|After|
|--|--|
<video src="https://github.com/user-attachments/assets/a1127511-8c2a-4191-b7a0-84d43ead1aae" width="300px"/>|<video src="https://github.com/user-attachments/assets/2a36b996-5578-447b-a670-73361b205b2e" width="300px"/>|