### PR TITLE
[Testing] Re-Enabled UI Test - Issue12574Test

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
@@ -11,11 +11,13 @@ namespace Maui.Controls.Sample.Issues
 		readonly string _carouselAutomationId = "carouselView";
 		readonly string _btnRemoveAutomationId = "btnRemove";
 		readonly string _btnRemoveAllAutomationId = "btnRemoveAll";
+		readonly string _btnSwipeAutomationId = "btnSwipe";
 
 		readonly ViewModelIssue12574 _viewModel;
 		readonly CarouselView2 _carouselView;
 		readonly Button _btn;
 		readonly Button _btn2;
+		readonly Button _btn3;
 
 		public CarouselViewLoopNoFreeze()
 		{
@@ -32,6 +34,19 @@ namespace Maui.Controls.Sample.Issues
 				AutomationId = _btnRemoveAllAutomationId
 			};
 			_btn2.SetBinding(Button.CommandProperty, "RemoveAllItemsCommand");
+
+			_btn3 = new Button
+			{
+				Text = "Swipe",
+				AutomationId = _btnSwipeAutomationId
+			};
+			_btn3.Clicked += (s, e) =>
+			{
+				if (_viewModel.Items.Count == 0)
+					return;
+				_viewModel.CurrentPosition = (_viewModel.CurrentPosition + 1) % _viewModel.Items.Count;
+				_carouselView.ScrollTo(_viewModel.CurrentPosition);
+			};
 
 			_carouselView = new CarouselView2
 			{
@@ -62,11 +77,14 @@ namespace Maui.Controls.Sample.Issues
 			var layout = new Grid();
 			layout.RowDefinitions.Add(new RowDefinition { Height = 100 });
 			layout.RowDefinitions.Add(new RowDefinition { Height = 100 });
+			layout.RowDefinitions.Add(new RowDefinition { Height = 100 });
 			layout.RowDefinitions.Add(new RowDefinition());
 			Grid.SetRow(_btn2, 1);
-			Grid.SetRow(_carouselView, 2);
+			Grid.SetRow(_btn3, 2);
+			Grid.SetRow(_carouselView, 3);
 			layout.Children.Add(_btn);
 			layout.Children.Add(_btn2);
+			layout.Children.Add(_btn3);
 			layout.Children.Add(_carouselView);
 
 			BindingContext = _viewModel = new ViewModelIssue12574();
@@ -85,6 +103,16 @@ namespace Maui.Controls.Sample.Issues
 		public Command LoadItemsCommand { get; set; }
 		public Command RemoveAllItemsCommand { get; set; }
 		public Command RemoveLastItemCommand { get; set; }
+		private int _currentPosition = 0;
+		public int CurrentPosition
+		{
+			get => _currentPosition;
+			set
+			{
+				_currentPosition = value;
+				OnPropertyChanged(nameof(CurrentPosition));
+			}
+		}
 
 		public ViewModelIssue12574()
 		{
@@ -110,6 +138,7 @@ namespace Maui.Controls.Sample.Issues
 			Items.Remove(Items.Last());
 			RemoveAllItemsCommand.ChangeCanExecute();
 			RemoveLastItemCommand.ChangeCanExecute();
+			CurrentPosition--;
 		}
 
 		void ExecuteLoadItemsCommand()

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewLoopNoFreeze.cs
@@ -138,7 +138,10 @@ namespace Maui.Controls.Sample.Issues
 			Items.Remove(Items.Last());
 			RemoveAllItemsCommand.ChangeCanExecute();
 			RemoveLastItemCommand.ChangeCanExecute();
-			CurrentPosition--;
+			if (CurrentPosition > 0)
+			{
+				CurrentPosition--;
+			}
 		}
 
 		void ExecuteLoadItemsCommand()

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.LoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.LoopNoFreeze.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		readonly string _carouselAutomationId = "carouselView";
 		readonly string _btnRemoveAutomationId = "btnRemove";
 		readonly string _btnRemoveAllAutomationId = "btnRemoveAll";
+		readonly string _btnSwipeAutomationId = "btnSwipe";
 
 		protected override bool ResetAfterEachTest => true;
 		public CarouselViewLoopNoFreeze(TestDevice device)
@@ -28,10 +29,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("0 item");
 
 			App.WaitForElement(_carouselAutomationId);
-			App.ScrollRight(_carouselAutomationId, ScrollStrategy.Gesture, 0.99);
+			App.WaitForElement(_btnSwipeAutomationId);
+			App.Tap(_btnSwipeAutomationId);
 
 			App.WaitForElement("1 item");
-			App.ScrollRight(_carouselAutomationId, ScrollStrategy.Gesture, 0.99);
+			App.Tap(_btnSwipeAutomationId);
 
 
 			App.WaitForElement("2 item");
@@ -40,7 +42,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			App.WaitForElement("1 item");
 
-			App.ScrollRight(_carouselAutomationId, ScrollStrategy.Gesture, 0.99);
+			App.Tap(_btnSwipeAutomationId);
 
 			App.WaitForElement("0 item");
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.LoopNoFreeze.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/CarouselViewUITests.LoopNoFreeze.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // Related issue for windows: https://github.com/dotnet/maui/issues/24482 and For Android, see : https://github.com/dotnet/maui/issues/28760
+﻿#if TEST_FAILS_ON_WINDOWS // Related issue for windows: https://github.com/dotnet/maui/issues/24482
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
### Description of Change

This pull request addresses improvements to a test case for Issue 12574 by refining the test logic, enhancing user interaction handling, and removing a platform-specific exclusion directive. The changes aim to make the test more robust and platform-independent.

### Issue
Previously, the test was experiencing intermittent failures (flakiness) on Android because scrolling in the carousel view items wasn't working consistently in CI. As a result, the test case was failing continuously on the Android platform.

### Solution
Since this test was added to verify that the CarouselView freezes on iOS, we used programmatic scrolling instead of manual scrolling to preserve the intent of the original test case.

Fixes #28760 (Issue12574Test)