### PR TITLE
Make internal types used by MAUI Toolkit public

### DIFF
--- a/src/Controls/src/Core/ICornerElement.cs
+++ b/src/Controls/src/Core/ICornerElement.cs
@@ -1,9 +1,18 @@
-#nullable disable
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls;
+
+/// <summary>
+/// Defines properties for elements that can have rounded corners.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by UI elements that support corner radius customization,
+/// allowing for consistent styling of corners across different controls.
+/// </remarks>
+public interface ICornerElement
 {
-	interface ICornerElement
-	{
-		//note to implementor: implement this property publicly
-		CornerRadius CornerRadius { get; }
-	}
+	/// <summary>
+	/// Gets the radius for the corners of the element.
+	/// </summary>
+	/// <value>A <see cref="CornerRadius"/> value that specifies the radius for each corner of the element. The default value depends on the implementing control.</value>
+	/// <remarks>Implementors should implement this property publicly.</remarks>
+	CornerRadius CornerRadius { get; }
 }

--- a/src/Controls/src/Core/ILineHeightElement.cs
+++ b/src/Controls/src/Core/ILineHeightElement.cs
@@ -1,13 +1,25 @@
-#nullable disable
-using System.ComponentModel;
+namespace Microsoft.Maui.Controls;
 
-namespace Microsoft.Maui.Controls.Internals
+/// <summary>
+/// Defines properties and methods for elements that support line height customization.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by UI elements that need to control the spacing between lines of text,
+/// providing consistent line height behavior across different text-based controls.
+/// </remarks>
+public interface ILineHeightElement
 {
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	interface ILineHeightElement
-	{
-		double LineHeight { get; }
+	/// <summary>
+	/// Gets the line height for text displayed by this element.
+	/// </summary>
+	/// <value>A multiplier that determines the spacing between lines of text. A value of 1.0 represents standard line height.</value>
+	double LineHeight { get; }
 
-		void OnLineHeightChanged(double oldValue, double newValue);
-	}
+	/// <summary>
+	/// Called when the <see cref="LineHeight"/> property changes.
+	/// </summary>
+	/// <param name="oldValue">The old value of the property.</param>
+	/// <param name="newValue">The new value of the property.</param>
+	/// <remarks>Implementors should implement this method explicitly.</remarks>
+	void OnLineHeightChanged(double oldValue, double newValue);
 }

--- a/src/Controls/src/Core/ILineHeightElementInternal.cs
+++ b/src/Controls/src/Core/ILineHeightElementInternal.cs
@@ -1,0 +1,15 @@
+#nullable disable
+using System;
+using System.ComponentModel;
+
+namespace Microsoft.Maui.Controls.Internals
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[Obsolete("This interface is obsolete and will be removed in a future version. Use Microsoft.Maui.Controls.ILineHeightElement instead.")]
+	interface ILineHeightElement
+	{
+		double LineHeight { get; }
+
+		void OnLineHeightChanged(double oldValue, double newValue);
+	}
+}

--- a/src/Controls/src/Core/ITextAlignmentElement.cs
+++ b/src/Controls/src/Core/ITextAlignmentElement.cs
@@ -1,14 +1,33 @@
-#nullable disable
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls;
+
+/// <summary>
+/// Defines properties and methods for elements that support text alignment.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by UI elements that need to control the horizontal and vertical 
+/// alignment of displayed text.
+/// </remarks>
+public interface ITextAlignmentElement
 {
-	interface ITextAlignmentElement
-	{
-		//note to implementor: implement the properties publicly
-		TextAlignment HorizontalTextAlignment { get; }
+	/// <summary>
+	/// Gets the horizontal alignment of the text.
+	/// </summary>
+	/// <value>A <see cref="TextAlignment"/> value that specifies how the text is horizontally aligned. The default value depends on the implementing control.</value>
+	/// <remarks>Implementors should implement this property publicly.</remarks>
+	TextAlignment HorizontalTextAlignment { get; }
 
-		TextAlignment VerticalTextAlignment { get; }
+	/// <summary>
+	/// Gets the vertical alignment of the text.
+	/// </summary>
+	/// <value>A <see cref="TextAlignment"/> value that specifies how the text is vertically aligned. The default value depends on the implementing control.</value>
+	/// <remarks>Implementors should implement this property publicly.</remarks>
+	TextAlignment VerticalTextAlignment { get; }
 
-		//note to implementor: but implement the methods explicitly
-		void OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue);
-	}
+	/// <summary>
+	/// Called when the <see cref="HorizontalTextAlignment"/> property changes.
+	/// </summary>
+	/// <param name="oldValue">The old value of the property.</param>
+	/// <param name="newValue">The new value of the property.</param>
+	/// <remarks>Implementors should implement this method explicitly.</remarks>
+	void OnHorizontalTextAlignmentPropertyChanged(TextAlignment oldValue, TextAlignment newValue);
 }

--- a/src/Controls/src/Core/ITextElement.cs
+++ b/src/Controls/src/Core/ITextElement.cs
@@ -1,27 +1,64 @@
 #nullable disable
-using System;
-using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls;
+
+/// <summary>
+/// Defines properties and methods for elements that display text.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by UI elements that can display text and allows consistent 
+/// text styling and formatting across different controls.
+/// </remarks>
+public interface ITextElement
 {
-	interface ITextElement
-	{
-		//note to implementor: implement this property publicly
-		Color TextColor { get; }
+	/// <summary>
+	/// Gets the color of the text.
+	/// </summary>
+	/// <value>The <see cref="Color"/> of the text. The default value depends on the implementing control.</value>
+	/// <remarks>Implementors should implement this property publicly.</remarks>
+	Color TextColor { get; }
 
-		//note to implementor: but implement this method explicitly
-		void OnTextColorPropertyChanged(Color oldValue, Color newValue);
+	/// <summary>
+	/// Called when the <see cref="TextColor"/> property changes.
+	/// </summary>
+	/// <param name="oldValue">The old value of the property.</param>
+	/// <param name="newValue">The new value of the property.</param>
+	/// <remarks>Implementors should implement this method explicitly.</remarks>
+	void OnTextColorPropertyChanged(Color oldValue, Color newValue);
 
-		double CharacterSpacing { get; }
+	/// <summary>
+	/// Gets the character spacing.
+	/// </summary>
+	/// <value>The spacing between characters in the text, in device-independent units. The default is 0.</value>
+	double CharacterSpacing { get; }
 
-		//note to implementor: but implement these methods explicitly
-		void OnCharacterSpacingPropertyChanged(double oldValue, double newValue);
+	/// <summary>
+	/// Called when the <see cref="CharacterSpacing"/> property changes.
+	/// </summary>
+	/// <param name="oldValue">The old value of the property.</param>
+	/// <param name="newValue">The new value of the property.</param>
+	/// <remarks>Implementors should implement this method explicitly.</remarks>
+	void OnCharacterSpacingPropertyChanged(double oldValue, double newValue);
 
-		TextTransform TextTransform { get; set; }
+	/// <summary>
+	/// Gets or sets the text transformation.
+	/// </summary>
+	/// <value>A <see cref="TextTransform"/> value that indicates how the text is transformed. The default is <see cref="TextTransform.None"/>.</value>
+	TextTransform TextTransform { get; set; }
 
-		void OnTextTransformChanged(TextTransform oldValue, TextTransform newValue);
+	/// <summary>
+	/// Called when the <see cref="TextTransform"/> property changes.
+	/// </summary>
+	/// <param name="oldValue">The old value of the property.</param>
+	/// <param name="newValue">The new value of the property.</param>
+	void OnTextTransformChanged(TextTransform oldValue, TextTransform newValue);
 
-		string UpdateFormsText(string original, TextTransform transform);
-	}
+	/// <summary>
+	/// Updates the text according to the specified transformation.
+	/// </summary>
+	/// <param name="original">The original text to transform.</param>
+	/// <param name="transform">The transformation to apply.</param>
+	/// <returns>The transformed text.</returns>
+	string UpdateFormsText(string original, TextTransform transform);
 }

--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -128,7 +128,7 @@ using Compatibility = Microsoft.Maui.Controls.Compatibility;
 [assembly: StyleProperty("visibility", typeof(VisualElement), nameof(VisualElement.IsVisibleProperty), Inherited = true)]
 [assembly: StyleProperty("width", typeof(VisualElement), nameof(VisualElement.WidthRequestProperty))]
 [assembly: StyleProperty("letter-spacing", typeof(ITextElement), nameof(TextElement.CharacterSpacingProperty), Inherited = true)]
-[assembly: StyleProperty("line-height", typeof(ILineHeightElement), nameof(LineHeightElement.LineHeightProperty), Inherited = true)]
+[assembly: StyleProperty("line-height", typeof(Microsoft.Maui.Controls.ILineHeightElement), nameof(LineHeightElement.LineHeightProperty), Inherited = true)]
 
 //flex
 [assembly: StyleProperty("align-content", typeof(FlexLayout), nameof(FlexLayout.AlignContentProperty))]

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -23,7 +23,25 @@ Microsoft.Maui.Controls.DatePicker.MaximumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.MinimumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
 Microsoft.Maui.Controls.ShadowTypeConverter
 Microsoft.Maui.Controls.ShadowTypeConverter.ShadowTypeConverter() -> void
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -105,6 +105,24 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 *REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.WebViewProcessTerminatedEventArgs.PlatformArgs.get -> Microsoft.Maui.Controls.PlatformWebViewProcessTerminatedEventArgs
 ~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -105,6 +105,24 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 *REMOVED*~Microsoft.Maui.Controls.NavigableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
 ~Microsoft.Maui.Controls.ResourceDictionary.SetAndCreateSource<T>(System.Uri value) -> void
 ~Microsoft.Maui.Controls.Internals.TypedBindingBase.UpdateSourceEventName.set -> void
 ~Microsoft.Maui.Controls.Xaml.IXamlTypeResolver.Resolve(string qualifiedTypeName, System.IServiceProvider serviceProvider = null, bool expandToExtension = true) -> System.Type

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -23,7 +23,25 @@ Microsoft.Maui.Controls.DatePicker.MaximumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.MinimumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
 Microsoft.Maui.Controls.ShadowTypeConverter
 Microsoft.Maui.Controls.ShadowTypeConverter.ShadowTypeConverter() -> void
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -23,7 +23,25 @@ Microsoft.Maui.Controls.DatePicker.MaximumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.MinimumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
 override Microsoft.Maui.Controls.Handlers.Items.SelectableItemsViewHandler<TItemsView>.UpdateItemsLayout() -> void
 Microsoft.Maui.Controls.ShadowTypeConverter
 Microsoft.Maui.Controls.ShadowTypeConverter.ShadowTypeConverter() -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -23,7 +23,25 @@ Microsoft.Maui.Controls.DatePicker.MaximumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.MinimumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
 Microsoft.Maui.Controls.ShadowTypeConverter
 Microsoft.Maui.Controls.ShadowTypeConverter.ShadowTypeConverter() -> void
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -23,7 +23,22 @@ Microsoft.Maui.Controls.DatePicker.MaximumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.MinimumDate.get -> System.DateTime?
 Microsoft.Maui.Controls.HybridWebView.InvokeJavaScriptAsync(string! methodName, object?[]? paramValues = null, System.Text.Json.Serialization.Metadata.JsonTypeInfo?[]? paramJsonTypeInfos = null) -> System.Threading.Tasks.Task!
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target) -> void
+Microsoft.Maui.Controls.ICornerElement
+Microsoft.Maui.Controls.ICornerElement.CornerRadius.get -> Microsoft.Maui.CornerRadius
+Microsoft.Maui.Controls.ILineHeightElement
+Microsoft.Maui.Controls.ILineHeightElement.LineHeight.get -> double
+Microsoft.Maui.Controls.ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue) -> void
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.ITextAlignmentElement
+Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
+Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
+Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.ITextElement.CharacterSpacing.get -> double
+Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double oldValue, double newValue) -> void
+Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
+Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
+Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
 Microsoft.Maui.Controls.ShadowTypeConverter
 Microsoft.Maui.Controls.ShadowTypeConverter.ShadowTypeConverter() -> void
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
@@ -31,6 +46,9 @@ override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertFrom(System.Compo
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object!
 override Microsoft.Maui.Controls.ShadowTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type? destinationType) -> object!
+~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
+~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
 ~Microsoft.Maui.Controls.Page.DisplayActionSheetAsync(string title, string cancel, string destruction, Microsoft.Maui.FlowDirection flowDirection, params string[] buttons) -> System.Threading.Tasks.Task<string>
 ~Microsoft.Maui.Controls.Page.DisplayActionSheetAsync(string title, string cancel, string destruction, params string[] buttons) -> System.Threading.Tasks.Task<string>
 ~Microsoft.Maui.Controls.Page.DisplayAlertAsync(string title, string message, string accept, string cancel) -> System.Threading.Tasks.Task<bool>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Earlier attempt: #28994 then reverted in: #29321

We still want this change, but we need to take into account the timing. After the first merge, our tests would break and people were not able to use .NET 10 previews with the .NET MAUI Community Toolkit as there is no compatible Toolkit version yet.

Now I'm breaking up this change:
1. Make the types we need for the Toolkit public, which is this PR
2. Then remove `InternalsVisibleTo` after we have released .NET 10 and there is a compatible Toolkit version, this can be done in a service release since removing `InternalsVisibleTo` is not a breaking change.

### Issues Fixed

Fixes #28981