### PR TITLE
BlazorWebView: ignore query‑string dots in IsBaseOfPage 

### DIFF
--- a/src/BlazorWebView/src/Maui/Extensions/UriExtensions.cs
+++ b/src/BlazorWebView/src/Maui/Extensions/UriExtensions.cs
@@ -5,16 +5,21 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 	internal static class UriExtensions
 	{
-		internal static bool IsBaseOfPage(this Uri baseUri, string? uriString)
-		{
-			if (Path.HasExtension(uriString))
-			{
-				// If the path ends in a file extension, it's not referring to a page.
-				return false;
-			}
-
-			var uri = new Uri(uriString!);
-			return baseUri.IsBaseOf(uri);
-		}
+	    internal static bool IsBaseOfPage(this Uri baseUri, string? uriString)
+	    {
+	        if (string.IsNullOrWhiteSpace(uriString))
+	            return false;
+	
+	        if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+	            return false;
+	
+	        if (uri.Scheme is not ("http" or "https"))
+	            return false;
+	
+	        if (Path.HasExtension(uri.AbsolutePath))
+	            return false;
+	
+	        return baseUri.IsBaseOf(uri);
+	    }
 	}
 }

--- a/src/BlazorWebView/src/Maui/Extensions/UriExtensions.cs
+++ b/src/BlazorWebView/src/Maui/Extensions/UriExtensions.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 using System.IO;
 
-namespace Microsoft.AspNetCore.Components.WebView.Maui
+namespace Microsoft.AspNetCore.Components.WebView.Maui;
+
+internal static class UriExtensions      
 {
-	internal static class UriExtensions
+	internal static bool IsBaseOfPage(this Uri baseUri, string? uriString)
 	{
-	    internal static bool IsBaseOfPage(this Uri baseUri, string? uriString)
-	    {
-	        if (string.IsNullOrWhiteSpace(uriString))
-	            return false;
-	
-	        if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
-	            return false;
-	
-	        if (uri.Scheme is not ("http" or "https"))
-	            return false;
-	
-	        if (Path.HasExtension(uri.AbsolutePath))
-	            return false;
-	
-	        return baseUri.IsBaseOf(uri);
-	    }
+		if (string.IsNullOrWhiteSpace(uriString))
+			return false;
+
+		if (!Uri.TryCreate(uriString, UriKind.Absolute, out var uri))
+			return false;
+
+		if (uri.Scheme is not ("http" or "https"))
+			return false;
+
+		if (Path.HasExtension(uri.AbsolutePath))
+			return false;
+
+		return baseUri.IsBaseOf(uri);
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

`BlazorWebView`’s **force reload** logic misidentified query‑string dots (`?weight=62.5`, etc.) as file‑extension dots, so the page was treated as a file and an empty “There is no content at url” screen appeared.
`UriExtensions.IsBaseOfPage` now calls `Path.HasExtension(uri.AbsolutePath)`, evaluating **only the path (AbsolutePath)** segment, so dots in the query or fragment no longer trigger the false file‑extension check.

Fixes #25689


