### PR TITLE
[Screenshot] Fix NRE for UIView not being in UIWindow

### DIFF
--- a/src/Essentials/src/Screenshot/Screenshot.ios.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.ios.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Media
 			var renderer = new UIGraphicsImageRenderer(view.Bounds.Size, new UIGraphicsImageRendererFormat()
 			{
 				Opaque = false,
-				Scale = view.Window.Screen.Scale,
+				Scale = view.Window?.Screen?.Scale ?? 1.0f,
 			});
 
 			// renderer will be null if the width/height of the view is zero


### PR DESCRIPTION
The `UIView` Screenshot method uses the `UIWindow` as a reference for the scale it should render with, which causes the method to throw if the `UIView` isn't contained in a window (As you can inflate UIViews without a Window context), leading to an NRE. 