### PR TITLE
[net 10.0 Testing] Enabled BuildsWithSpecialCharacters Test

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -87,9 +87,9 @@ public class SimpleTemplateTest : BaseTemplateTests
 	[TestCase("mauilib", "Project Space", "projectspace")]
 	// with invalid characters
 	// @ character issue in MSBuild, to be fixed in: https://github.com/dotnet/msbuild/issues/11237
-	//[TestCase("maui", "Project@Symbol", "projectsymbol")]
-	//[TestCase("maui-blazor", "Project@Symbol", "projectsymbol")]
-	//[TestCase("mauilib", "Project@Symbol", "projectsymbol")]
+	[TestCase("maui", "Project@Symbol", "projectsymbol")]
+	[TestCase("maui-blazor", "Project@Symbol", "projectsymbol")]
+	[TestCase("mauilib", "Project@Symbol", "projectsymbol")]
 	public void BuildsWithSpecialCharacters(string id, string projectName, string expectedId)
 	{
 		var projectDir = Path.Combine(TestDirectory, projectName);

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -85,8 +85,6 @@ public class SimpleTemplateTest : BaseTemplateTests
 	[TestCase("maui", "Project Space", "projectspace")]
 	[TestCase("maui-blazor", "Project Space", "projectspace")]
 	[TestCase("mauilib", "Project Space", "projectspace")]
-	// with invalid characters
-	// @ character issue in MSBuild, to be fixed in: https://github.com/dotnet/msbuild/issues/11237
 	[TestCase("maui", "Project@Symbol", "projectsymbol")]
 	[TestCase("maui-blazor", "Project@Symbol", "projectsymbol")]
 	[TestCase("mauilib", "Project@Symbol", "projectsymbol")]


### PR DESCRIPTION
## Description
This pull request updates the `BuildsWithSpecialCharacters` test in `SimpleTemplateTest.cs` to re-enable test cases that involve special characters in project names. These test cases were previously commented out due to an MSBuild issue, which has now been resolved.

### Issues Fixed:
Fixes #27319

**The screenshot confirms the re-enabled test cases now appear:**
<img width="571" alt="Screenshot 2025-05-13 at 6 13 54 PM" src="https://github.com/user-attachments/assets/02204191-cfc5-4d5f-b198-e1d2429cd77d" />


### Test case updates:

* Re-enabled test cases for projects with the `@` character in their names (`"Project@Symbol"`) for the following templates: `"maui"`, `"maui-blazor"`, and `"mauilib"`. These tests validate that projects with special characters build correctly.