### PR TITLE
[ci] Rollback can t be pushed

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -30,7 +30,7 @@
         <PublishFlatContainer>true</PublishFlatContainer>
       </Artifact>
   
-      <Artifact Include="@(_MetadataRollbacksToPublish)" Kind="Blob" RelativeBlobPath="$(_UploadPathRoot)/$(VSComponentVersion)/metadata/rollback/%(Filename)%(Extension)">
+      <!-- <Artifact Include="@(_MetadataRollbacksToPublish)" Kind="Blob" RelativeBlobPath="$(_UploadPathRoot)/$(VSComponentVersion)/metadata/rollback/%(Filename)%(Extension)">
         <IsShipping>true</IsShipping>
         <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('NonShipping'))">false</IsShipping>
         <PublishFlatContainer>false</PublishFlatContainer>
@@ -40,8 +40,8 @@
         <IsShipping>true</IsShipping>
         <IsShipping Condition="$([System.String]::Copy('%(RecursiveDir)').StartsWith('NonShipping'))">false</IsShipping>
         <PublishFlatContainer>false</PublishFlatContainer>
-      </Artifact>
-    </ItemGroup>
+      </Artifact>-->
+    </ItemGroup> 
 
   </Target>
 


### PR DESCRIPTION
### Description of Change

The build worked but fails when pushing other packages to darc. 
Skip this for now while we try understand how to workaround this. 

https://dev.azure.com/dnceng/internal/_build/results?buildId=2707150&view=logs&j=c6548b7b-ccee-5c1b-1857-14b2fb22078e&t=676553a9-8408-5a07-0471-8ada94ba615f&l=2745

```
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.25208.6\tools\Publish.proj(219,5): error :    at Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage.ExecuteTask(IFileSystem fileSystem, ISigningInformationModelFactory signingInformationModelFactory, IBlobArtifactModelFactory blobArtifactModelFactory, IPackageArtifactModelFactory packageArtifactModelFactory, IBuildModelFactory buildModelFactory)
##[error].packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.25208.6\tools\Publish.proj(219,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) Invalid package: D:\a\_work\1\s\artifacts\packages\Release\Shipping\metadata\rollbacks\7d2fde697a8b265283befb83ac673d7c2be30563_rollback.json
   at Microsoft.DotNet.VersionTools.Automation.NupkgInfoFactory.CreateNupkgInfo(String path) in /_/src/VersionTools/Microsoft.DotNet.VersionTools/Automation/NupkgInfoFactory.cs:line 52
   at Microsoft.DotNet.Build.Tasks.Feed.PackageArtifactModelFactory.CreatePackageArtifactModel(ITaskItem item, String repoOrigin) in /_/src/Microsoft.DotNet.Build.Tasks.Feed/src/PackageArtifactModelFactory.cs:line 32
   at Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage.<>c__DisplayClass110_0.<ExecuteTask>b__5(ITaskItem i) in /_/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBuildStorage.cs:line 215
   at System.Linq.Enumerable.ArraySelectIterator`2.MoveNext()
   at System.Collections.Generic.List`1.AddRange(IEnumerable`1 collection)
   at Microsoft.DotNet.Build.Tasks.Feed.BuildModelFactory.CreateModel(IEnumerable`1 blobArtifacts, IEnumerable`1 packageArtifacts, String manifestBuildId, String[] manifestBuildData, String manifestRepoName, String manifestBranch, String manifestCommit, Boolean isStableBuild, PublishingInfraVersion publishingVersion, Boolean isReleaseOnlyPackageVersion, SigningInformationModel signingInformationModel) in /_/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs:line 233
   at Microsoft.DotNet.Build.Tasks.Feed.BuildModelFactory.CreateBuildManifest(IEnumerable`1 blobArtifacts, IEnumerable`1 packageArtifacts, String assetManifestPath, String manifestRepoName, String manifestBuildId, String manifestBranch, String manifestCommit, String[] manifestBuildData, Boolean isStableBuild, PublishingInfraVersion publishingVersion, Boolean isReleaseOnlyPackageVersion, SigningInformationModel signingInformationModel) in /_/src/Microsoft.DotNet.Build.Tasks.Feed/src/BuildModelFactory.cs:line 112
   at Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage.ExecuteTask(IFileSystem fileSystem, ISigningInformationModelFactory signingInformationModelFactory, IBlobArtifactModelFactory blobArtifactModelFactory, IPackageArtifactModelFactory packageArtifactModelFactory, IBuildModelFactory buildModelFactory)
```
