### PR TITLE
[ci] Don't add license file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,6 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageOutputPath>$(MauiRootDirectory)artifacts</PackageOutputPath>
-    <LicenseFile>$(MauiRootDirectory)LICENSE.TXT</LicenseFile>
     <PackageIconFullPath>$(MauiRootDirectory)Assets\icon.png</PackageIconFullPath>
     <PackageThirdPartyNoticesFile>$(MauiRootDirectory)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
     <DefaultPackageTags>dotnet-maui;dotnet;maui;cross-platform;ios;android;macos;maccatalyst;windows;winui;tizen</DefaultPackageTags>


### PR DESCRIPTION
### Description of Change

Some packages have 2 license files because they are evaluated using PackageLicenseExpression
