### PR TITLE
[ci] Fix issue with duplicate License on msi

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -100,7 +100,7 @@
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(LicenseFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(LicenseFile)'))"
-          Pack="true" />
+          Pack="true" Condition="'$(MSBuildProjectFile)' != 'msi.csproj'" />
     <None Include="$(PackageThirdPartyNoticesFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(PackageThirdPartyNoticesFile)'))"
           Pack="true" />
@@ -118,18 +118,4 @@
                      Pack="true" />
     </ItemGroup>
   </Target>
-
-  <!-- Packaging -->
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <!-- The msi files add the license themselves. -->
-    <None Include="$(LicenseFile)"
-          PackagePath="$([System.IO.Path]::GetFileName('$(LicenseFile)'))"
-          Pack="true"
-          Condition="'$(MSBuildProjectFile)' != 'msi.csproj'" />
-    <None Include="$(PackageThirdPartyNoticesFile)"
-          PackagePath="$([System.IO.Path]::GetFileName('$(PackageThirdPartyNoticesFile)'))"
-          Pack="true" />
-  </ItemGroup>
-
-
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -119,4 +119,17 @@
     </ItemGroup>
   </Target>
 
+  <!-- Packaging -->
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <!-- The msi files add the license themselves. -->
+    <None Include="$(LicenseFile)"
+          PackagePath="$([System.IO.Path]::GetFileName('$(LicenseFile)'))"
+          Pack="true"
+          Condition="'$(MSBuildProjectFile)' != 'msi.csproj'" />
+    <None Include="$(PackageThirdPartyNoticesFile)"
+          PackagePath="$([System.IO.Path]::GetFileName('$(PackageThirdPartyNoticesFile)'))"
+          Pack="true" />
+  </ItemGroup>
+
+
 </Project>


### PR DESCRIPTION
### Description of Change

Another approach to fix duplicate LICENSE.txt on msi projects for workload set when using arcade

inspired on this one https://github.com/dotnet/runtime/commit/57947cbb5cf7f4e01fad7a68c98cd6976d6d9309