### PR TITLE
Clear Parent on old image source

### DIFF
--- a/src/Controls/src/Core/ImageElement.cs
+++ b/src/Controls/src/Core/ImageElement.cs
@@ -27,8 +27,12 @@ namespace Microsoft.Maui.Controls
 		{
 			var newSource = (ImageSource)newValue;
 			var image = (IImageElement)bindable;
-			if (newSource != null && image != null)
+
+			if (newSource is not null && image is not null)
+			{
 				newSource.SourceChanged += image.OnImageSourceSourceChanged;
+			}
+
 			ImageSourceChanged(bindable, newSource);
 		}
 
@@ -37,8 +41,16 @@ namespace Microsoft.Maui.Controls
 			var oldSource = (ImageSource)oldValue;
 			var image = (IImageElement)bindable;
 
-			if (oldSource != null && image != null)
-				oldSource.SourceChanged -= image.OnImageSourceSourceChanged;
+			if (oldSource is not null)
+			{
+				if (image is not null)
+				{
+					oldSource.SourceChanged -= image.OnImageSourceSourceChanged;
+				}
+
+				oldSource.Parent = null;
+			}
+
 			ImageSourceChanging(oldSource);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/ImageSourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageSourceTests.cs
@@ -167,5 +167,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await ((IStreamImageSource)imageSource).GetStreamAsync();
 			await imageSource.Cancel(); // This should complete!
 		}
+
+		[Fact]
+		public void SettingNewImageeSourceClearsParentOnOldImageSource()
+		{
+			var image = new Image { Source = "File.png" };
+			var imageSource = image.Source;
+			Assert.Equal(image, imageSource.Parent);
+			image.Source = "File2.png";
+			Assert.Null(imageSource.Parent);
+			Assert.Equal(image, image.Source.Parent);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Currently we aren't clearing the parent out on image sources when they are swapped out on images. This is causing old image sources to "leak" via "AddResourcesChangedListener" until the page is popped. 
