### PR TITLE
[iOS] Fixed OnNavigatedTo not triggered for tabs in More section of TabbedPage

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -43,6 +43,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			this.DisableiOS18ToolbarTabs();
 			_viewHandlerWrapper = new ViewHandlerDelegator<TabbedPage>(Mapper, CommandMapper, this);
+			if (MoreNavigationController is not null)
+			{
+				MoreNavigationController.Delegate = new MoreTabDelegate(this);
+			}
 		}
 
 		public override UIViewController SelectedViewController
@@ -56,6 +60,28 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				if (value == MoreNavigationController)
 					return;
 
+				UpdateCurrentPage();
+			}
+		}
+
+		internal void UpdateCurrentPageForMoreTab()
+		{
+			bool isInMoreTab = false;
+			// Check if the selected tab is in the More tab
+			if (MoreNavigationController is not null && MoreNavigationController.ViewControllers is not null)
+			{
+				foreach (var viewController in MoreNavigationController.ViewControllers)
+				{
+					if (viewController == SelectedViewController)
+					{
+						isInMoreTab = true;
+						break;
+					}
+				}
+			}
+
+			if (isInMoreTab)
+			{
 				UpdateCurrentPage();
 			}
 		}
@@ -190,7 +216,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateTabBarItem(page);
 			}
 		}
-		
+
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			if (previousTraitCollection.VerticalSizeClass == TraitCollection.VerticalSizeClass)
@@ -522,6 +548,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateCurrentPage()
 		{
+			if (SelectedViewController?.Title?.Equals("More", StringComparison.Ordinal) == true)
+			{
+				Tabbed.CurrentPage = null;
+				return;
+			}
 			if (Tabbed is TabbedPage tabbed)
 			{
 				var count = tabbed.InternalChildren.Count;
@@ -668,5 +699,25 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_viewHandlerWrapper.DisconnectHandler();
 		}
 		#endregion
+	}
+
+	class MoreTabDelegate : UINavigationControllerDelegate
+	{
+		readonly WeakReference<TabbedRenderer> _renderer;
+
+		public MoreTabDelegate(TabbedRenderer renderer)
+		{
+			_renderer = new WeakReference<TabbedRenderer>(renderer);
+		}
+
+		public override void DidShowViewController(UINavigationController navigationController, UIViewController viewController, bool animated)
+		{
+			if (_renderer is not null
+			&& _renderer.TryGetTarget(out var renderer)
+			&& !renderer.SelectedViewController?.Title?.Equals("More", StringComparison.Ordinal) == true)
+			{
+				renderer.UpdateCurrentPageForMoreTab();
+			}
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16175.cs
@@ -1,0 +1,46 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 16175, "OnNavigatedTo was not triggered when tabs in More section", PlatformAffected.iOS)]
+public class Issue16175 : NavigationPage
+{
+	public Issue16175() : base(new Issue16175MainPage())
+	{
+
+	}
+}
+
+public class Issue16175MainPage : TabbedPage
+{
+	public Issue16175MainPage()
+	{
+		for (var i = 0; i < 10; i++)
+		{
+			Children.Add(new Issue16175Page(i.ToString()));
+		}
+	}
+}
+
+public class Issue16175Page : ContentPage
+{
+	private readonly Label _navigatedToLabel;
+
+	public Issue16175Page(string title)
+	{
+		Title = title;
+		_navigatedToLabel = new Label { Text = "NavigatedTo: Not triggered", AutomationId = "navigatedToLabel" };
+
+		Content = new VerticalStackLayout
+		{
+			Children = { _navigatedToLabel }
+		};
+	}
+
+	protected override void OnNavigatedTo(NavigatedToEventArgs args)
+	{
+		if (Parent is TabbedPage tabbed && tabbed.CurrentPage?.Title.Equals("8", StringComparison.Ordinal) == true)
+		{
+			_navigatedToLabel.Text = "NavigatedTo: Triggered";
+		}
+		base.OnNavigatedTo(args);
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16175.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 16175, "OnNavigatedTo was not triggered when tabs in More section", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 16175, "OnNavigatedTo event triggered in More tabs", PlatformAffected.iOS)]
 
 public class Issue16175 : TabbedPage
 {
@@ -8,18 +8,18 @@ public class Issue16175 : TabbedPage
 	{
 		for (var i = 0; i < 10; i++)
 		{
-			Children.Add(new Issue16175Page(i.ToString()));
+			var page = new Issue16175Page { Title = $"Tab{i + 1}" };
+			Children.Add(page);
 		}
 	}
 }
 
 public class Issue16175Page : ContentPage
 {
-	private readonly Label _navigatedToLabel;
+	Label _navigatedToLabel;
 
-	public Issue16175Page(string title)
+	public Issue16175Page()
 	{
-		Title = title;
 		_navigatedToLabel = new Label { Text = "NavigatedTo: Not triggered", AutomationId = "navigatedToLabel" };
 
 		Content = new VerticalStackLayout
@@ -30,7 +30,7 @@ public class Issue16175Page : ContentPage
 
 	protected override void OnNavigatedTo(NavigatedToEventArgs args)
 	{
-		if (Parent is TabbedPage tabbed && tabbed.CurrentPage?.Title.Equals("8", StringComparison.Ordinal) == true)
+		if (Title is not null && Title == "Tab8" && _navigatedToLabel is not null)
 		{
 			_navigatedToLabel.Text = "NavigatedTo: Triggered";
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue16175.cs
@@ -1,17 +1,10 @@
 ﻿namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 16175, "OnNavigatedTo was not triggered when tabs in More section", PlatformAffected.iOS)]
-public class Issue16175 : NavigationPage
-{
-	public Issue16175() : base(new Issue16175MainPage())
-	{
 
-	}
-}
-
-public class Issue16175MainPage : TabbedPage
+public class Issue16175 : TabbedPage
 {
-	public Issue16175MainPage()
+	public Issue16175()
 	{
 		for (var i = 0; i < 10; i++)
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
@@ -1,0 +1,28 @@
+﻿#if IOS || MACCATALYST // More tab is available in MAC and iOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue16175 : _IssuesUITest
+	{
+		public Issue16175(TestDevice testDevice) : base(testDevice)
+		{
+		}
+		public override string Issue => "OnNavigatedTo was not triggered when tabs in More section";
+
+		[Test]
+		[Category(UITestCategories.TabbedPage)]
+		public void TabbedPageTabEventsTriggeredInMoreSection()
+		{
+			App.WaitForElement("More");
+			App.Tap("More");
+			App.WaitForElement("8");
+			App.Tap("8");
+			var navigatedToLabel = App.WaitForElement("navigatedToLabel");
+			Assert.That(navigatedToLabel.GetText(), Is.EqualTo("NavigatedTo: Triggered"));
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
@@ -3,26 +3,25 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
-{
-	public class Issue16175 : _IssuesUITest
-	{
-		public Issue16175(TestDevice testDevice) : base(testDevice)
-		{
-		}
-		public override string Issue => "OnNavigatedTo was not triggered when tabs in More section";
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
-		[Test]
-		[Category(UITestCategories.TabbedPage)]
-		public void TabbedPageTabEventsTriggeredInMoreSection()
-		{
-			App.WaitForElement("More");
-			App.Tap("More");
-			App.WaitForElement("8");
-			App.Tap("8");
-			var navigatedToLabel = App.WaitForElement("navigatedToLabel");
-			Assert.That(navigatedToLabel.GetText(), Is.EqualTo("NavigatedTo: Triggered"));
-		}
+public class Issue16175 : _IssuesUITest
+{
+	public Issue16175(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "OnNavigatedTo was not triggered when tabs in More section";
+
+	[Test]
+	[Category(UITestCategories.TabbedPage)]
+	public void TabbedPageTabEventsTriggeredInMoreSection()
+	{
+		App.WaitForElement("More");
+		App.Tap("More");
+		App.WaitForElement("8");
+		App.Tap("8");
+		var navigatedToLabel = App.WaitForElement("navigatedToLabel");
+		Assert.That(navigatedToLabel.GetText(), Is.EqualTo("NavigatedTo: Triggered"));
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
@@ -16,6 +16,7 @@ public class Issue16175 : _IssuesUITest
 	[Category(UITestCategories.TabbedPage)]
 	public void TabbedPageTabEventsTriggeredInMoreSection()
 	{
+		App.WaitForElement("navigatedToLabel");
 		App.WaitForElement("More");
 		App.Tap("More");
 		App.WaitForElement("8");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16175.cs
@@ -1,4 +1,4 @@
-﻿#if IOS || MACCATALYST // More tab is available in MAC and iOS
+﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // More tab is available in Mac and iOS
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -7,20 +7,17 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue16175 : _IssuesUITest
 {
-	public Issue16175(TestDevice testDevice) : base(testDevice)
+	public Issue16175(TestDevice device) : base(device)
 	{
 	}
-	public override string Issue => "OnNavigatedTo was not triggered when tabs in More section";
+	public override string Issue => "OnNavigatedTo event triggered in More tabs";
 
 	[Test]
 	[Category(UITestCategories.TabbedPage)]
-	public void TabbedPageTabEventsTriggeredInMoreSection()
+	public void TabEventsTriggeredInMoreTab()
 	{
-		App.WaitForElement("navigatedToLabel");
-		App.WaitForElement("More");
-		App.Tap("More");
-		App.WaitForElement("8");
-		App.Tap("8");
+		App.TapTab("More");
+		App.TapTab("Tab8");
 		var navigatedToLabel = App.WaitForElement("navigatedToLabel");
 		Assert.That(navigatedToLabel.GetText(), Is.EqualTo("NavigatedTo: Triggered"));
 	}


### PR DESCRIPTION
### Issue Detail
OnNavigatedTo not called when navigate to the tabs in more tab in iOS.

### Root cause
On iOS, when a tab is selected from the "More" section of a TabbedPage, the navigation event OnNavigatedTo is not triggered. This is because the CurrentPage property is not updated when selecting tabs from the "More" section, resulting in missing navigation lifecycle events for those tabs.

### Description of change
Updated the CurrentPage using delegate when accessing tabs in More section resolves the issue.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/16175

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/cfd14f8b-f8fc-47cc-b00f-5f99df4d92ba"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/0fcfb8c2-2f0f-4e56-8e4d-0f5f92af81e1">) |