### PR TITLE
[iOS] Fix : FilePicker.PickAsync Task Hangs When User Cancels the Picker in iOS

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -35,7 +35,27 @@ namespace Microsoft.Maui.Storage
 
 			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 1))
 			{
-				documentPicker.DidPickDocumentAtUrls += (_, e) => GetFileResults(e.Urls, tcs);
+				EventHandler<UIDocumentPickedAtUrlsEventArgs> pickHandler = null;
+				EventHandler cancelHandler = null;
+
+				pickHandler = (_, e) =>
+				{
+					documentPicker.DidPickDocumentAtUrls -= pickHandler;
+					documentPicker.WasCancelled -= cancelHandler;
+
+					GetFileResults(e.Urls, tcs);
+				};
+
+				cancelHandler = (_, e) =>
+				{
+					documentPicker.DidPickDocumentAtUrls -= pickHandler;
+					documentPicker.WasCancelled -= cancelHandler;
+
+					GetFileResults(null, tcs);
+				};
+
+				documentPicker.DidPickDocumentAtUrls += pickHandler;
+				documentPicker.WasCancelled += cancelHandler;
 			}
 			else
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

###  Root Cause

<!-- Enter description of the fix in this section -->

The modern Picker API doesn't handle cancellations, so when the user dismisses the picker, the task’s result is never set.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29490
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
