### PR TITLE
Create a workflow that formats PRs

### DIFF
--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -1,4 +1,4 @@
-name: Daily code format check
+name: Format Branch Code
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -28,13 +28,6 @@ jobs:
       - name: Run dotnet format
         run: dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822
     
-      - name: Commit files
-        if: steps.format.outputs.has-changes == 'true'
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -a -m 'Automated dotnet-format update on ${{ matrix.branch }}'
-
       - name: Create Pull Request
         uses: dotnet/actions-create-pull-request@v4
         with:

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -19,14 +19,9 @@ jobs:
           dotnet-version: 8.x
 
       - name: Run dotnet format
-        id: format
         run: |
           dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822
-          if git diff --quiet; then
-            echo "::set-output name=has-changes::false"
-          else
-            echo "::set-output name=has-changes::true"
-          fi
+          git diff
     
       - name: Commit files
         if: steps.format.outputs.has-changes == 'true'

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -27,5 +27,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git show
           git push

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3.2.0

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -19,9 +19,14 @@ jobs:
           dotnet-version: 8.x
 
       - name: Run dotnet format
+        id: format
         run: |
           dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822
-          git diff
+          if git diff --quiet; then
+            echo "::set-output name=has-changes::false"
+          else
+            echo "::set-output name=has-changes::true"
+          fi
     
       - name: Commit files
         if: steps.format.outputs.has-changes == 'true'

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -1,0 +1,39 @@
+name: PR format check
+on:
+  pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dotnet-format:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v3.2.0
+        with:
+          dotnet-version: 8.x
+
+      - name: Run dotnet format
+        run: |
+          dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822
+          git diff
+    
+      - name: Commit files
+        if: steps.format.outputs.has-changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -m 'Automated dotnet-format update'
+
+      - name: Push changes to the PR
+        if: steps.format.outputs.has-changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git show
+          git push

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.pull_request.number }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3.2.0

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -23,15 +23,7 @@ jobs:
           dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822
           git diff
     
-      - name: Commit files
-        if: steps.format.outputs.has-changes == 'true'
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -a -m 'Automated dotnet-format update'
-
       - name: Push changes to the PR
-        if: steps.format.outputs.has-changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -25,7 +25,7 @@ jobs:
           dotnet format .\Microsoft.Maui.sln --no-restore --exclude Templates/src --exclude-diagnostics CA1822
           git diff
     
-      - name: Push changes to the PR
+      - name: Push changes to PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/dotnet-format-pr.yml
+++ b/.github/workflows/dotnet-format-pr.yml
@@ -1,4 +1,4 @@
-name: PR format check
+name: Format PR Code
 on:
   pull_request
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate code formatting for pull requests in the repository. The workflow ensures consistent formatting by running `dotnet format` and committing any changes back to the pull request if necessary.

### New GitHub Actions workflow:
* [`.github/workflows/dotnet-format-pr.yml`](diffhunk://#diff-7ed897a377ce4755697e7b8e864a7e6793194c16c938fd24133a0a79f1686ed0R1-R39): Added a workflow named "PR format check" that runs on pull requests. It uses `dotnet format` to enforce code formatting, commits the changes if formatting updates are made, and pushes them back to the pull request. The workflow is configured to run on `windows-latest` and excludes specific directories and diagnostics during formatting.