### PR TITLE
Apply nullability attributes to TimeChangedEventArgs

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -39,6 +39,9 @@ Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double ol
 Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
 Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
 Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan? oldTime, System.TimeSpan? newTime) -> void
 ~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
 ~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
@@ -155,9 +158,6 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
-Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan oldTime, System.TimeSpan newTime) -> void
 Microsoft.Maui.Controls.TimePicker.TimeSelected -> System.EventHandler<Microsoft.Maui.Controls.TimeChangedEventArgs>
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -15,6 +15,9 @@ Microsoft.Maui.Controls.DateChangedEventArgs.OldDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.Date.get -> System.DateTime?
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan? oldTime, System.TimeSpan? newTime) -> void
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type? sourceType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object!
@@ -317,9 +320,6 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
-Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan oldTime, System.TimeSpan newTime) -> void
 Microsoft.Maui.Controls.TimePicker.TimeSelected -> System.EventHandler<Microsoft.Maui.Controls.TimeChangedEventArgs>
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -15,6 +15,9 @@ Microsoft.Maui.Controls.DateChangedEventArgs.OldDate.get -> System.DateTime?
 Microsoft.Maui.Controls.DatePicker.Date.get -> System.DateTime?
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
 Microsoft.Maui.Controls.Internals.TextTransformUtilities
+Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan? oldTime, System.TimeSpan? newTime) -> void
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type? sourceType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object!
@@ -318,9 +321,6 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
-Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan oldTime, System.TimeSpan newTime) -> void
 Microsoft.Maui.Controls.TimePicker.TimeSelected -> System.EventHandler<Microsoft.Maui.Controls.TimeChangedEventArgs>
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -39,6 +39,9 @@ Microsoft.Maui.Controls.ITextElement.OnCharacterSpacingPropertyChanged(double ol
 Microsoft.Maui.Controls.ITextElement.OnTextTransformChanged(Microsoft.Maui.TextTransform oldValue, Microsoft.Maui.TextTransform newValue) -> void
 Microsoft.Maui.Controls.ITextElement.TextTransform.get -> Microsoft.Maui.TextTransform
 Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
+Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan? oldTime, System.TimeSpan? newTime) -> void
 ~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
 ~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
@@ -154,9 +157,6 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
-Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan oldTime, System.TimeSpan newTime) -> void
 Microsoft.Maui.Controls.TimePicker.TimeSelected -> System.EventHandler<Microsoft.Maui.Controls.TimeChangedEventArgs>
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -34,6 +34,9 @@ Microsoft.Maui.Controls.ITextAlignmentElement.HorizontalTextAlignment.get -> Mic
 Microsoft.Maui.Controls.ITextAlignmentElement.OnHorizontalTextAlignmentPropertyChanged(Microsoft.Maui.TextAlignment oldValue, Microsoft.Maui.TextAlignment newValue) -> void
 Microsoft.Maui.Controls.ITextAlignmentElement.VerticalTextAlignment.get -> Microsoft.Maui.TextAlignment
 Microsoft.Maui.Controls.ITextElement
+Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan? oldTime, System.TimeSpan? newTime) -> void
 ~Microsoft.Maui.Controls.ITextElement.OnTextColorPropertyChanged(Microsoft.Maui.Graphics.Color oldValue, Microsoft.Maui.Graphics.Color newValue) -> void
 ~Microsoft.Maui.Controls.ITextElement.TextColor.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.ITextElement.UpdateFormsText(string original, Microsoft.Maui.TextTransform transform) -> string
@@ -149,9 +152,6 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
-Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan oldTime, System.TimeSpan newTime) -> void
 Microsoft.Maui.Controls.TimePicker.TimeSelected -> System.EventHandler<Microsoft.Maui.Controls.TimeChangedEventArgs>
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -42,6 +42,9 @@ Microsoft.Maui.Controls.ITextElement.TextTransform.set -> void
 Microsoft.Maui.Controls.ShadowTypeConverter
 Microsoft.Maui.Controls.ShadowTypeConverter.ShadowTypeConverter() -> void
 Microsoft.Maui.Controls.StyleableElement.Style.get -> Microsoft.Maui.Controls.Style?
+Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan?
+Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan? oldTime, System.TimeSpan? newTime) -> void
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type? sourceType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.ShadowTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object!
@@ -149,9 +152,6 @@ Microsoft.Maui.Controls.StyleableElement.StyleableElement() -> void
 Microsoft.Maui.Controls.StyleableElement.StyleClass.get -> System.Collections.Generic.IList<string!>!
 Microsoft.Maui.Controls.StyleableElement.StyleClass.set -> void
 Microsoft.Maui.Controls.TimeChangedEventArgs
-Microsoft.Maui.Controls.TimeChangedEventArgs.NewTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.OldTime.get -> System.TimeSpan
-Microsoft.Maui.Controls.TimeChangedEventArgs.TimeChangedEventArgs(System.TimeSpan oldTime, System.TimeSpan newTime) -> void
 Microsoft.Maui.Controls.TimePicker.TimeSelected -> System.EventHandler<Microsoft.Maui.Controls.TimeChangedEventArgs>
 Microsoft.Maui.Controls.TitleBar
 Microsoft.Maui.Controls.TitleBar.Content.get -> Microsoft.Maui.IView?

--- a/src/Controls/src/Core/TimeChangedEventArgs.cs
+++ b/src/Controls/src/Core/TimeChangedEventArgs.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 		/// <param name="oldTime"></param>
 		/// <param name="newTime"></param>
 		/// <remarks>To be added.</remarks>
-		public TimeChangedEventArgs(TimeSpan oldTime, TimeSpan newTime)
+		public TimeChangedEventArgs(TimeSpan? oldTime, TimeSpan? newTime)
 		{
 			OldTime = oldTime;
 			NewTime = newTime;
@@ -20,11 +20,11 @@ namespace Microsoft.Maui.Controls
 		/// <summary>The time that the user entered.</summary>
 		/// <value>To be added.</value>
 		/// <remarks>To be added.</remarks>
-		public TimeSpan NewTime { get; private set; }
+		public TimeSpan? NewTime { get; private set; }
 
 		/// <summary>The time that was on the element at the time that the user selected it.</summary>
 		/// <value>To be added.</value>
 		/// <remarks>To be added.</remarks>
-		public TimeSpan OldTime { get; private set; }
+		public TimeSpan? OldTime { get; private set; }
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/TimePickerUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/TimePickerUnitTest.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			timePicker.Time = initialTime;
 
 			TimePicker pickerFromSender = null;
-			TimeSpan oldTime = new TimeSpan();
-			TimeSpan newTime = new TimeSpan();
+			TimeSpan? oldTime = new TimeSpan();
+			TimeSpan? newTime = new TimeSpan();
 
 			timePicker.TimeSelected += (s, e) =>
 			{


### PR DESCRIPTION
### Description of Change

In .NET 10 we make the Time property of the TimePicker class nullable https://github.com/dotnet/maui/pull/27930 However missed to apply nullability attributes to **TimeChangedEventArgs**. With the changes from this PR we align the behavior with the DatePicker https://github.com/dotnet/maui/blob/net10.0/src/Controls/src/Core/DateChangedEventArgs.cs

### Issues Fixed

Fixes #29513 
Related with https://github.com/dotnet/maui/pull/27930