### PR TITLE
[iOS] Fixed the ConnectivityChanged event is not triggered when toggling Wifi (turning it on or off)

### DIFF
--- a/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
@@ -169,10 +169,24 @@ namespace Microsoft.Maui.Networking
 
 		async void OnChange(NetworkReachabilityFlags flags)
 		{
-			// Add in artifical delay so the connection status has time to change
-			// else it will return true no matter what.
-			await Task.Delay(400);
+			// This function waits up to 1 second, checking the device’s network status every 100 milliseconds. 
+			// If the network status changes, it immediately triggers the ReachabilityChanged event.
+			var initialAccess = Connectivity.NetworkAccess;
+			const int pollingIntervalMs = 100;
+			const int maxWaitTimeMs = 1000;
+			int elapsedTime = 0;
 
+			while (elapsedTime < maxWaitTimeMs)
+			{
+				await Task.Delay(pollingIntervalMs);
+				elapsedTime += pollingIntervalMs;
+				var currentAccess = Connectivity.NetworkAccess;
+				if (currentAccess != initialAccess)
+				{
+					ReachabilityChanged?.Invoke();
+					return;
+				}
+			}
 			ReachabilityChanged?.Invoke();
 		}
 	}

--- a/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
@@ -109,6 +109,8 @@ namespace Microsoft.Maui.Networking
 		const int ConnectionStatusChangeDelayMs = 100;
 
 		NWPathMonitor pathMonitor;
+		CancellationTokenSource cts = new CancellationTokenSource();
+		int pendingCallbacks;
 
 		internal ReachabilityListener()
 		{
@@ -130,6 +132,10 @@ namespace Microsoft.Maui.Networking
 
 		internal void Dispose()
 		{
+			cts?.Cancel();
+			cts?.Dispose();
+			cts = null;
+
 			if (pathMonitor != null)
 			{
 				pathMonitor.SnapshotHandler = null;
@@ -170,25 +176,45 @@ namespace Microsoft.Maui.Networking
 
 		async void OnChange(NetworkReachabilityFlags flags)
 		{
-			// This function waits up to 1 second, checking the device’s network status every 100 milliseconds. 
+			// Deduplicate: both watchers may fire for the same network change.
+			// Only the first callback runs the polling loop; subsequent ones are no-ops.
+			if (Interlocked.Increment(ref pendingCallbacks) > 1)
+				return;
+
+			var token = cts?.Token ?? default;
+			if (token.IsCancellationRequested)
+				return;
+
+			// This function waits up to 1 second, checking the device's network status every 100 milliseconds.
 			// If the network status changes, it immediately triggers the ReachabilityChanged event.
 			var initialAccess = Connectivity.NetworkAccess;
 			const int pollingIntervalMs = 100;
 			const int maxWaitTimeMs = 1000;
 			int elapsedTime = 0;
 
-			while (elapsedTime < maxWaitTimeMs)
+			try
 			{
-				await Task.Delay(pollingIntervalMs);
-				elapsedTime += pollingIntervalMs;
-				var currentAccess = Connectivity.NetworkAccess;
-				if (currentAccess != initialAccess)
+				while (elapsedTime < maxWaitTimeMs)
 				{
-					ReachabilityChanged?.Invoke();
-					return;
+					await Task.Delay(pollingIntervalMs, token);
+					elapsedTime += pollingIntervalMs;
+					var currentAccess = Connectivity.NetworkAccess;
+					if (currentAccess != initialAccess)
+					{
+						ReachabilityChanged?.Invoke();
+						return;
+					}
 				}
+				ReachabilityChanged?.Invoke();
 			}
-			ReachabilityChanged?.Invoke();
+			catch (OperationCanceledException)
+			{
+				// Listener was disposed during polling, don't fire event
+			}
+			finally
+			{
+				Interlocked.Exchange(ref pendingCallbacks, 0);
+			}
 		}
 	}
 }

--- a/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
@@ -166,5 +166,14 @@ namespace Microsoft.Maui.Networking
 		}
 #pragma warning restore BI1234
 #endif
+
+		async void OnChange(NetworkReachabilityFlags flags)
+		{
+			// Add in artifical delay so the connection status has time to change
+			// else it will return true no matter what.
+			await Task.Delay(400);
+
+			ReachabilityChanged?.Invoke();
+		}
 	}
 }

--- a/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.ios.tvos.macos.reachability.cs
@@ -7,6 +7,7 @@ using CoreTelephony;
 #endif
 using CoreFoundation;
 using Network;
+using SystemConfiguration;
 
 namespace Microsoft.Maui.Networking
 {


### PR DESCRIPTION
### Issue Details:

The Connectivity.ConnectivityChanged event is not triggered for iOS platform when toggling wifi (turning it on or off)
        
### Root Cause:

When toggling Wifi (turning it on or off). The native iOS triggers OnChange() method, Inside this method, a delay of 100 milliseconds was used to allow the system time to update the network state before checking connectivity. The  OnChange()  method when compare the current NetworkAccess with the previous NetworkAccess value after the 100 milli seond delay the current NetworkAccess value is not updated and still it remains previous value. So, here the 100 milli seconds delay is not enough to settle the internal network state transition.

### Description of Change:

To address this, the delay was increased from 100 milliseconds to 400 milliseconds. This adjustment was tested on the iOS simulator and provides sufficient time for the system's network state to fully stabilize. As a result, the NetworkAccess value is updated correctly, and the ConnectivityChanged event is triggered reliably.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A


### Issues Fixed:

Fixes #28961 

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/4223a4bc-3d42-47b4-b710-4ec45cf50869">   |    <Video src="https://github.com/user-attachments/assets/456bbe55-f9f8-411f-9322-394df5ae6a7f">  |