### PR TITLE
[ci] Fix Appium provisioning when no global npm exists

### DIFF
--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -165,10 +165,20 @@
 			<_AppiumNpmListOutput>@(_AppiumNpmListOutputLines->'%(Identity)', ' ')</_AppiumNpmListOutput>
 		</PropertyGroup>
 
-		<!-- Peek the appium version info from the json output -->
-		<JsonPeek Content="$(_AppiumNpmListOutput)" Query="$.dependencies.appium.version">
+		<!-- Check if the output contains an error -->
+		<PropertyGroup>
+			<_AppiumNpmListHasError Condition="$(_AppiumNpmListOutput.Contains('error'))">True</_AppiumNpmListHasError>
+		</PropertyGroup>
+
+		<!-- Peek the appium version info from the json output (only if no error) -->
+		<JsonPeek Content="$(_AppiumNpmListOutput)" Query="$.dependencies.appium.version" Condition="'$(_AppiumNpmListHasError)' != 'True'">
 			<Output TaskParameter="Result" PropertyName="_AppiumNpmListVersion" />
 		</JsonPeek>
+
+		<!-- Set the version to empty if there was an error, which will force installation -->
+		<PropertyGroup Condition="'$(_AppiumNpmListHasError)' == 'True'">
+			<_AppiumNpmListVersion></_AppiumNpmListVersion>
+		</PropertyGroup>
 
 		<!-- Install appium at the specified version if necessary -->
 		<Exec Command="npm i --location=global appium@$(AppiumVersion)" Condition=" '$(_AppiumNpmListVersion)' != '$(AppiumVersion)' " />


### PR DESCRIPTION
### Description of Change

This pull request updates the Appium provisioning logic in `Provisioning.csproj` to handle errors more gracefully when checking the installed Appium version. The most important changes include adding error detection for the `npm list` output and ensuring a fallback mechanism to force installation if an error is detected.

When no global file is found it was throwing a error like so :

```
PS C:\repos\dotnet\maui> npm list -g appium --json --depth 1 --loglevel error
npm error code ENOENT
npm error syscall lstat
npm error path Q:\.tools\.npm-global
npm error errno -4058
npm error enoent ENOENT: no such file or directory, lstat 'Q:\.tools\.npm-global'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
{
  "error": {
    "code": "ENOENT",
    "summary": "ENOENT: no such file or directory, lstat 'Q:\\.tools\\.npm-global'",
    "detail": "This is related to npm not being able to find a file."
  }
}
npm error A complete log of this run can be found in: Q:\.tools\.npm\_logs\2025-05-21T11_45_26_019Z-debug-0.log
```

Error handling improvements:

* Added a new property `_AppiumNpmListHasError` to detect if the `npm list` output contains an error. This property is set to `True` when an error is found. (`[src/Provisioning/Provisioning.csprojL168-R182](diffhunk://#diff-7b9d0c8e6acc03936bbba9421e02c53277575ad074bee658e94b87b4011f8c66L168-R182)`)
* Modified the `JsonPeek` task to conditionally extract the Appium version only if no error is detected in the `npm list` output. (`[src/Provisioning/Provisioning.csprojL168-R182](diffhunk://#diff-7b9d0c8e6acc03936bbba9421e02c53277575ad074bee658e94b87b4011f8c66L168-R182)`)
* Introduced a fallback mechanism to set `_AppiumNpmListVersion` to an empty value when an error is detected, ensuring that Appium will be reinstalled. (`[src/Provisioning/Provisioning.csprojL168-R182](diffhunk://#diff-7b9d0c8e6acc03936bbba9421e02c53277575ad074bee658e94b87b4011f8c66L168-R182)`)


### Issues Fixed

Provisioning appium on new windows machine
