### PR TITLE
[Catalyst] Click-Dragging Behavior in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ReorderableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ReorderableItemsViewController.cs
@@ -162,6 +162,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				if (_longPressGestureRecognizer == null)
 				{
 					_longPressGestureRecognizer = new UILongPressGestureRecognizer(HandleLongPress);
+#if MACCATALYST
+					// On Mac Catalyst, we disable the default drag interaction and instead handle dragging using a long press gesture recognizer.
+					// Since a long press typically takes more time to trigger than the system's default drag interaction, 
+					// we reduce the minimum press duration to 0.1 seconds to better match the previous behavior.
+					_longPressGestureRecognizer.MinimumPressDuration = 0.1;
+#endif
 					CollectionView.AddGestureRecognizer(_longPressGestureRecognizer);
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ReorderableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ReorderableItemsViewController.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		bool _disposed;
 		UILongPressGestureRecognizer _longPressGestureRecognizer;
 
+#if MACCATALYST
+		const double defaultMacCatalystPressDuration = 0.1;
+#endif
+
 		public ReorderableItemsViewController(TItemsView reorderableItemsView, ItemsViewLayout layout)
 			: base(reorderableItemsView, layout)
 		{
@@ -166,7 +170,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					// On Mac Catalyst, we disable the default drag interaction and instead handle dragging using a long press gesture recognizer.
 					// Since a long press typically takes more time to trigger than the system's default drag interaction, 
 					// we reduce the minimum press duration to 0.1 seconds to better match the previous behavior.
-					_longPressGestureRecognizer.MinimumPressDuration = 0.1;
+					_longPressGestureRecognizer.MinimumPressDuration = defaultMacCatalystPressDuration;
 #endif
 					CollectionView.AddGestureRecognizer(_longPressGestureRecognizer);
 				}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ReorderableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ReorderableItemsViewController2.cs
@@ -162,6 +162,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				if (_longPressGestureRecognizer == null)
 				{
 					_longPressGestureRecognizer = new UILongPressGestureRecognizer(HandleLongPress);
+#if MACCATALYST
+					// On Mac Catalyst, we disable the default drag interaction and instead handle dragging using a long press gesture recognizer.
+					// Since a long press typically takes more time to trigger than the system's default drag interaction, 
+					// we reduce the minimum press duration to 0.1 seconds to better match the previous behavior.
+					_longPressGestureRecognizer.MinimumPressDuration = 0.1;
+#endif
 					CollectionView.AddGestureRecognizer(_longPressGestureRecognizer);
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ReorderableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ReorderableItemsViewController2.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		bool _disposed;
 		UILongPressGestureRecognizer _longPressGestureRecognizer;
 
+#if MACCATALYST
+		const double defaultMacCatalystPressDuration = 0.1;
+#endif
+
 		public ReorderableItemsViewController2(TItemsView reorderableItemsView, UICollectionViewLayout layout)
 			: base(reorderableItemsView, layout)
 		{
@@ -166,7 +170,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					// On Mac Catalyst, we disable the default drag interaction and instead handle dragging using a long press gesture recognizer.
 					// Since a long press typically takes more time to trigger than the system's default drag interaction, 
 					// we reduce the minimum press duration to 0.1 seconds to better match the previous behavior.
-					_longPressGestureRecognizer.MinimumPressDuration = 0.1;
+					_longPressGestureRecognizer.MinimumPressDuration = defaultMacCatalystPressDuration;
 #endif
 					CollectionView.AddGestureRecognizer(_longPressGestureRecognizer);
 				}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue 

- On MacCatalyst, the drag event was previously triggered immediately upon clicking an item. PR #28623 restricted this default behavior because the CanMixGroups logic was not functioning correctly. As a result, drag handling was shifted to a long press gesture recognizer. This change altered the default behavior, requiring users to long-press items to initiate a drag operation on Mac Catalyst.

### Description of Change

- To achieve the same behavior, enabling drag and drop without a noticeable long press on Mac Catalyst, the gesture recognizer’s **[MinimumPressDuration](https://developer.apple.com/documentation/uikit/uilongpressgesturerecognizer/minimumpressduration)** was set to 0.1 seconds, reducing the delay and providing a more responsive drag experience that matches the original system behavior.

### Issues Fixed

Fixes #29536

### Tested the behaviour in the following platforms

- [x] iOS
- [x] Mac
- [x] Android
- [ ] Windows

### Screenshot

| Before Fix | After Fix |
|----------|----------|
| <video  src="https://github.com/user-attachments/assets/ca07528e-77d0-4e38-8f10-a3b2d483742a"> | <video  src="https://github.com/user-attachments/assets/507dc73e-655b-4321-9e3e-0a906cf08bb0"> |
