### PR TITLE
Fix CarouselView PreviousPosition updating when inserting items

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -250,6 +250,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (e.Action == NotifyCollectionChangedAction.Add)
 			{
+				if (currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
+				{
+					SetPosition(currentItemPosition);
+				}
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -251,12 +251,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			if (e.Action == NotifyCollectionChangedAction.Add)
 			{
 				// Updates position to match current item when inserting items, correctly tracking previous position values.
-				if (currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
+				var shouldUpdatePosition = currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView && InitialPositionSet && currentItemPosition > -1;
+				if (shouldUpdatePosition)
 				{
-					if (InitialPositionSet && currentItemPosition > -1)
-					{
-						ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, currentItemPosition);
-					}
+					ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, currentItemPosition);
 				}
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -250,6 +250,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (e.Action == NotifyCollectionChangedAction.Add)
 			{
+				// Updates position to match current item when inserting items, correctly tracking previous position values.
 				if (currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
 				{
 					SetPosition(currentItemPosition);

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -253,7 +253,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				// Updates position to match current item when inserting items, correctly tracking previous position values.
 				if (currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
 				{
-					SetPosition(currentItemPosition);
+					if (InitialPositionSet && currentItemPosition > -1)
+					{
+						ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, currentItemPosition);
+					}
 				}
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -293,15 +293,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)
 		{
+			// Early return for invalid positions - maintain current carousel position
+			if (currentItemPosition == -1)
+				return carouselPosition;
+
 			// Updates position to match current item when inserting items, correctly tracking previous position values.
-			var shouldUpdatePosition = currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView && InitialPositionSet && currentItemPosition > -1;
-			if (shouldUpdatePosition)
+			var shouldUpdatePosition = currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView;
+			if (shouldUpdatePosition && InitialPositionSet)
 			{
 				ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, currentItemPosition);
 			}
 
 			//If we are adding a new item make sure to maintain the CurrentItemPosition
-			return currentItemPosition != -1 ? currentItemPosition : carouselPosition;
+			return currentItemPosition;
 		}
 
 		private int GetTargetPosition()

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -294,8 +294,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)
 		{
 			// Early return for invalid positions - maintain current carousel position
-			if (currentItemPosition == -1)
+			if (currentItemPosition < 0)
+			{
 				return carouselPosition;
+			}
 
 			// Updates position to match current item when inserting items, correctly tracking previous position values.
 			var shouldUpdatePosition = currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -250,12 +250,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (e.Action == NotifyCollectionChangedAction.Add)
 			{
-				// Updates position to match current item when inserting items, correctly tracking previous position values.
-				var shouldUpdatePosition = currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView && InitialPositionSet && currentItemPosition > -1;
-				if (shouldUpdatePosition)
-				{
-					ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, currentItemPosition);
-				}
 				_positionAfterUpdate = GetPositionWhenAddingItems(carouselPosition, currentItemPosition);
 			}
 		}
@@ -299,6 +293,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)
 		{
+			// Updates position to match current item when inserting items, correctly tracking previous position values.
+			var shouldUpdatePosition = currentItemPosition != carouselPosition && ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView && InitialPositionSet && currentItemPosition > -1;
+			if (shouldUpdatePosition)
+			{
+				ItemsView.SetValueFromRenderer(CarouselView.PositionProperty, currentItemPosition);
+			}
+
 			//If we are adding a new item make sure to maintain the CurrentItemPosition
 			return currentItemPosition != -1 ? currentItemPosition : carouselPosition;
 		}

--- a/src/Controls/src/Core/Items/ItemsUpdatingScrollMode.cs
+++ b/src/Controls/src/Core/Items/ItemsUpdatingScrollMode.cs
@@ -8,10 +8,13 @@ namespace Microsoft.Maui.Controls
 	public enum ItemsUpdatingScrollMode
 	{
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsUpdatingScrollMode.xml" path="//Member[@MemberName='KeepItemsInView']/Docs/*" />
+		/// <summary>KeepItemsInView keeps the first item in the list displayed when new items are added.</summary>
 		KeepItemsInView = 0,
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsUpdatingScrollMode.xml" path="//Member[@MemberName='KeepScrollOffset']/Docs/*" />
+		/// <summary>KeepScrollOffset ensures that the current scroll position is maintained when new items are added.</summary>
 		KeepScrollOffset,
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsUpdatingScrollMode.xml" path="//Member[@MemberName='KeepLastItemInView']/Docs/*" />
+		/// <summary>KeepLastItemInView adjusts the scroll offset to keep the last item in the list displayed when new items are added.</summary>
 		KeepLastItemInView
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29524.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29524.cs
@@ -71,8 +71,22 @@ public class Issue29524 : ContentPage
 			carouselItems.Insert(0, "Item 0");
 		};
 
+		var removeButton = new Button
+		{
+			Text = "Remove an item",
+			AutomationId = "RemoveButton",
+			Margin = new Thickness(20),
+		};
+
+		removeButton.Clicked += (sender, e) =>
+		{
+			carouselView.Position = 2;
+			carouselItems.RemoveAt(2);
+		};
+
 		verticalStackLayout.Children.Add(carouselView);
 		verticalStackLayout.Children.Add(insertButton);
+		verticalStackLayout.Children.Add(removeButton);
 		verticalStackLayout.Children.Add(positionLabel);
 		Content = verticalStackLayout;
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29524.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29524.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29524, "Previous Position in PositionChangedEventArgs Not Updating Correctly in CarouselView", PlatformAffected.iOS)]
+public class Issue29524 : ContentPage
+{
+	public Issue29524()
+	{
+		var verticalStackLayout = new VerticalStackLayout();
+		var carouselItems = new ObservableCollection<string>
+		{
+			"Item 1",
+			"Item 2",
+			"Item 3",
+			"Item 4",
+			"Item 5",
+			"Item 6",
+		};
+
+		CarouselView2 carouselView = new CarouselView2
+		{
+			ItemsSource = carouselItems,
+			AutomationId = "carouselview",
+			ItemsUpdatingScrollMode = ItemsUpdatingScrollMode.KeepItemsInView,
+			HeightRequest = 300,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid
+				{
+					Padding = 10
+				};
+
+				var label = new Label
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					FontSize = 18,
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				label.SetBinding(Label.AutomationIdProperty, ".");
+
+				grid.Children.Add(label);
+				return grid;
+			}),
+			HorizontalOptions = LayoutOptions.Fill,
+		};
+
+		var positionLabel = new Label
+		{
+			AutomationId = "positionLabel",
+			Text = $"Current Position{carouselView.Position}",
+			HorizontalOptions = LayoutOptions.Center,
+			Padding = new Thickness(20),
+		};
+
+		carouselView.PositionChanged += (s, e) =>
+		{
+			positionLabel.Text = $"Current Position: {e.CurrentPosition}, Previous Position: {e.PreviousPosition}";
+		};
+
+		var insertButton = new Button
+		{
+			Text = "Insert item at index 0",
+			AutomationId = "InsertButton",
+			Margin = new Thickness(20),
+		};
+
+		insertButton.Clicked += (sender, e) =>
+		{
+			carouselItems.Insert(0, "Item 0");
+		};
+
+		verticalStackLayout.Children.Add(carouselView);
+		verticalStackLayout.Children.Add(insertButton);
+		verticalStackLayout.Children.Add(positionLabel);
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29524.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29524.cs
@@ -23,16 +23,16 @@ public class Issue29524 : _IssuesUITest
 		Assert.That(text, Is.EqualTo("Current Position: 0, Previous Position: 1"));
 	}
 
+#if TEST_FAILS_ON_ANDROID  // Related issue for android: https://github.com/dotnet/maui/issues/29415
 	[Test]
 	[Category(UITestCategories.CarouselView)]
 	public void VerifyPreviousPositionUpdatesCorrectlyWhenRemovingItems()
 	{
 		App.WaitForElement("carouselview");
 		App.Tap("RemoveButton");
-#if TEST_FAILS_ON_ANDROID  // Related issue for android: https://github.com/dotnet/maui/issues/29415
 		var text = App.FindElement("positionLabel").GetText();
 		Assert.That(text, Is.EqualTo("Current Position: 0, Previous Position: 2"));
-#endif
 	}
+#endif
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29524.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29524.cs
@@ -1,0 +1,26 @@
+#if TEST_FAILS_ON_WINDOWS // Related issue for windows: https://github.com/dotnet/maui/issues/29245
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29524 : _IssuesUITest
+{
+	public override string Issue => "Previous Position in PositionChangedEventArgs Not Updating Correctly in CarouselView";
+
+	public Issue29524(TestDevice device)
+	: base(device)
+	{ }
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void VerifyPreviousPositionUpdatesCorrectlyWhenInsertingItems()
+	{
+		App.WaitForElement("carouselview");
+		App.Tap("InsertButton");
+		var text = App.FindElement("positionLabel").GetText();
+		Assert.That(text, Is.EqualTo("Current Position: 0, Previous Position: 1"));
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29524.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29524.cs
@@ -22,5 +22,17 @@ public class Issue29524 : _IssuesUITest
 		var text = App.FindElement("positionLabel").GetText();
 		Assert.That(text, Is.EqualTo("Current Position: 0, Previous Position: 1"));
 	}
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void VerifyPreviousPositionUpdatesCorrectlyWhenRemovingItems()
+	{
+		App.WaitForElement("carouselview");
+		App.Tap("RemoveButton");
+#if TEST_FAILS_ON_ANDROID  // Related issue for android: https://github.com/dotnet/maui/issues/29415
+		var text = App.FindElement("positionLabel").GetText();
+		Assert.That(text, Is.EqualTo("Current Position: 0, Previous Position: 2"));
+#endif
+	}
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
In the CarouselView control, when items are added at index 0, the PreviousPosition property in the PositionChangedEventArgs does not update correctly.

### Root Cause
When items are inserted at index 0, explicitly setting the position to the current item position (currentItemPosition) prevents the actual position from changing. As a result, the PositionChanged event is not triggered, and PreviousPosition remains incorrect.

### Description of Change
To correctly update the position and trigger the PositionChanged event, it update the PreviousPosition value correctly.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #29524   

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/589086d5-cc80-4a85-8761-756fc506cbbd" >| <video src="https://github.com/user-attachments/assets/fd548b02-00d5-4c66-90b4-d11b7662ddb5">|