### PR TITLE
[Android] Fix RemainingItemsThresholdReachedCommand not firing when CollectionView has Header and Footer both defined

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -61,36 +61,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			var itemsSourceCount = ItemsViewAdapter.ItemCount;
-			bool hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
-			bool hasFooter = ItemsViewAdapter.ItemsSource.HasFooter;
+			var itemsSource = ItemsViewAdapter.ItemsSource;
+			int hasHeader = itemsSource.HasHeader ? 1 : 0;
+			int hasFooter = itemsSource.HasFooter ? 1 : 0;
 
-			int firstDataItemIndex = (hasHeader && hasFooter) ? 1 : 0;
-			int lastDataItemIndex = itemsSourceCount - firstDataItemIndex;
+			int lastDataItemIndex = ItemsViewAdapter.ItemCount - hasFooter - hasHeader;
 
-			if (Last < firstDataItemIndex || Last > lastDataItemIndex)
+			if (Last < hasHeader || Last > lastDataItemIndex)
 			{
 				return;
 			}
 
-			switch (_itemsView.RemainingItemsThreshold)
+			bool isThresholdReached = (Last == lastDataItemIndex - 1) || (lastDataItemIndex - 1 - Last <= _itemsView.RemainingItemsThreshold);
+
+			if (isThresholdReached)
 			{
-				case 0:
-					{
-						if (Last == lastDataItemIndex - 1)
-						{
-							_itemsView.SendRemainingItemsThresholdReached();
-						}
-						break;
-					}
-				default:
-					{
-						if (lastDataItemIndex - 1 - Last <= _itemsView.RemainingItemsThreshold)
-						{
-							_itemsView.SendRemainingItemsThresholdReached();
-						}
-						break;
-					}
+				_itemsView.SendRemainingItemsThresholdReached();
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Don't send RemainingItemsThresholdReached event for non-linear layout managers
 			// This can also happen if a layout pass has not happened yet
-			if (Last == -1 || ItemsViewAdapter == null || _itemsView.RemainingItemsThreshold == -1)
+			if (Last == -1 || ItemsViewAdapter is null || _itemsView.RemainingItemsThreshold == -1)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -57,14 +57,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Early returns for edge cases
 			if (Last == -1 || ItemsViewAdapter == null || _itemsView.RemainingItemsThreshold == -1)
+			{
 				return;
+			}
 
 			var itemsSourceCount = ItemsViewAdapter.ItemCount;
 			bool hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
 			bool hasFooter = ItemsViewAdapter.ItemsSource.HasFooter;
 
-			// Adjust the last visible item index to match the ItemsSource index (excluding header/footer)
-			// Range of actual data item indices in adapter
 			int firstDataItemIndex = (hasHeader && hasFooter) ? 1 : 0;
 			int lastDataItemIndex = itemsSourceCount - firstDataItemIndex;
 
@@ -76,13 +76,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			switch (_itemsView.RemainingItemsThreshold)
 			{
 				case 0:
-					if (Last == lastDataItemIndex - 1)
-						_itemsView.SendRemainingItemsThresholdReached();
-					break;
+					{
+						if (Last == lastDataItemIndex - 1)
+						{
+							_itemsView.SendRemainingItemsThresholdReached();
+						}
+						break;
+					}
 				default:
-					if (lastDataItemIndex - 1 - Last <= _itemsView.RemainingItemsThreshold)
-						_itemsView.SendRemainingItemsThresholdReached();
-					break;
+					{
+						if (lastDataItemIndex - 1 - Last <= _itemsView.RemainingItemsThreshold)
+						{
+							_itemsView.SendRemainingItemsThresholdReached();
+						}
+						break;
+					}
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -55,7 +55,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			_itemsView.SendScrolled(itemsViewScrolledEventArgs);
 
-			// Early returns for edge cases
+
+			// Don't send RemainingItemsThresholdReached event for non-linear layout managers
+			// This can also happen if a layout pass has not happened yet
 			if (Last == -1 || ItemsViewAdapter == null || _itemsView.RemainingItemsThreshold == -1)
 			{
 				return;

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			_itemsView.SendScrolled(itemsViewScrolledEventArgs);
 
-
 			// Don't send RemainingItemsThresholdReached event for non-linear layout managers
 			// This can also happen if a layout pass has not happened yet
 			if (Last == -1 || ItemsViewAdapter == null || _itemsView.RemainingItemsThreshold == -1)

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Adjust the last visible item index to match the ItemsSource index (excluding header/footer)
 			// Range of actual data item indices in adapter
-			int firstDataItemIndex = hasHeader ? 1 : 0;
-			int lastDataItemIndex = itemsSourceCount - (hasFooter ? 1 : 0) - firstDataItemIndex;
+			int firstDataItemIndex = (hasHeader && hasFooter) ? 1 : 0;
+			int lastDataItemIndex = itemsSourceCount - firstDataItemIndex;
 
 			// Don't process if Last is out of bounds
 			if (Last < firstDataItemIndex || Last > lastDataItemIndex)

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -63,17 +63,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var itemsSource = ItemsViewAdapter.ItemsSource;
-			int hasHeader = itemsSource.HasHeader ? 1 : 0;
-			int hasFooter = itemsSource.HasFooter ? 1 : 0;
+			int headerValue = itemsSource.HasHeader ? 1 : 0;
+			int footerValue = itemsSource.HasFooter ? 1 : 0;
 
-			int lastDataItemIndex = ItemsViewAdapter.ItemCount - hasFooter - hasHeader;
+			int modifiedItemCount = ItemsViewAdapter.ItemCount - footerValue - headerValue;
 
-			if (Last < hasHeader || Last > lastDataItemIndex)
+			if (Last < headerValue || Last > modifiedItemCount)
 			{
 				return;
 			}
 
-			bool isThresholdReached = (Last == lastDataItemIndex - 1) || (lastDataItemIndex - 1 - Last <= _itemsView.RemainingItemsThreshold);
+			bool isThresholdReached = (Last == modifiedItemCount - 1) || (modifiedItemCount - 1 - Last <= _itemsView.RemainingItemsThreshold);
 
 			if (isThresholdReached)
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -55,15 +55,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			_itemsView.SendScrolled(itemsViewScrolledEventArgs);
 
-			// Don't send RemainingItemsThresholdReached event for non-linear layout managers
-			// This can also happen if a layout pass has not happened yet
-			if (Last == -1)
+			// Early returns for edge cases
+			if (Last == -1 || ItemsViewAdapter == null || _itemsView.RemainingItemsThreshold == -1)
 				return;
-
-			if (ItemsViewAdapter == null)
-			{
-				return;
-			}
 
 			var itemsSourceCount = ItemsViewAdapter.ItemCount;
 			bool hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
@@ -74,7 +68,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			int firstDataItemIndex = (hasHeader && hasFooter) ? 1 : 0;
 			int lastDataItemIndex = itemsSourceCount - firstDataItemIndex;
 
-			// Don't process if Last is out of bounds
 			if (Last < firstDataItemIndex || Last > lastDataItemIndex)
 			{
 				return;
@@ -82,8 +75,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			switch (_itemsView.RemainingItemsThreshold)
 			{
-				case -1:
-					return;
 				case 0:
 					if (Last == lastDataItemIndex - 1)
 						_itemsView.SendRemainingItemsThresholdReached();

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -60,16 +60,32 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (Last == -1)
 				return;
 
+			if (ItemsViewAdapter == null)
+				return;
+
+			var itemsSourceCount = ItemsViewAdapter.ItemCount;
+			bool hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
+			bool hasFooter = ItemsViewAdapter.ItemsSource.HasFooter;
+
+			// Adjust the last visible item index to match the ItemsSource index (excluding header/footer)
+			// Range of actual data item indices in adapter
+			int firstDataItemIndex = hasHeader ? 1 : 0;
+			int lastDataItemIndex = itemsSourceCount - (hasFooter ? 1 : 0) - firstDataItemIndex;
+
+			// Don't process if Last is out of bounds
+			if (Last < firstDataItemIndex || Last > lastDataItemIndex)
+				return;
+
 			switch (_itemsView.RemainingItemsThreshold)
 			{
 				case -1:
 					return;
 				case 0:
-					if (Last == ItemsViewAdapter.ItemsSource.Count - 1)
+					if (Last == lastDataItemIndex - 1)
 						_itemsView.SendRemainingItemsThresholdReached();
 					break;
 				default:
-					if (ItemsViewAdapter.ItemsSource.Count - 1 - Last <= _itemsView.RemainingItemsThreshold)
+					if (lastDataItemIndex - 1 - Last <= _itemsView.RemainingItemsThreshold)
 						_itemsView.SendRemainingItemsThresholdReached();
 					break;
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 
 			if (ItemsViewAdapter == null)
+			{
 				return;
+			}
 
 			var itemsSourceCount = ItemsViewAdapter.ItemCount;
 			bool hasHeader = ItemsViewAdapter.ItemsSource.HasHeader;
@@ -74,7 +76,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			// Don't process if Last is out of bounds
 			if (Last < firstDataItemIndex || Last > lastDataItemIndex)
+			{
 				return;
+			}
 
 			switch (_itemsView.RemainingItemsThreshold)
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -66,14 +66,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			int headerValue = itemsSource.HasHeader ? 1 : 0;
 			int footerValue = itemsSource.HasFooter ? 1 : 0;
 
-			int modifiedItemCount = ItemsViewAdapter.ItemCount - footerValue - headerValue;
+			// Calculate actual data item count (excluding header and footer positions)
+			int actualItemCount = ItemsViewAdapter.ItemCount - footerValue - headerValue;
 
-			if (Last < headerValue || Last > modifiedItemCount)
+			// Ensure we're within the data items region (not in header/footer)
+			if (Last < headerValue || Last > actualItemCount)
 			{
 				return;
 			}
 
-			bool isThresholdReached = (Last == modifiedItemCount - 1) || (modifiedItemCount - 1 - Last <= _itemsView.RemainingItemsThreshold);
+			// Check if we're at or within threshold distance from the last data item
+			bool isThresholdReached = (Last == actualItemCount - 1) || (actualItemCount - 1 - Last <= _itemsView.RemainingItemsThreshold);
 
 			if (isThresholdReached)
 			{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29588.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29588.cs
@@ -1,0 +1,159 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 29588, "CollectionView RemainingItemsThresholdReachedcommand should trigger on scroll near end", PlatformAffected.Android)]
+	public class Issue29588 : ContentPage
+	{
+		public Issue29588()
+		{
+			BindingContext = new RemainingItemsThresholdViewModel();
+
+			var thresholdLabel = new Label
+			{
+				AutomationId = "29588ThresholdLabel",
+				HorizontalOptions = LayoutOptions.Center,
+				HeightRequest = 50,
+				FontSize = 18
+			};
+			thresholdLabel.SetBinding(Label.TextProperty, nameof(RemainingItemsThresholdViewModel.ThresholdStatus));
+
+			var collectionView = new CollectionView
+			{
+				AutomationId = "29588CollectionView",
+				ItemsSource = ((RemainingItemsThresholdViewModel)BindingContext).Items,
+				RemainingItemsThreshold = 1,
+				RemainingItemsThresholdReachedCommand = ((RemainingItemsThresholdViewModel)BindingContext).RemainingItemReachedCommand,
+				Header = new Grid
+				{
+					BackgroundColor = Colors.Bisque,
+					Children =
+					{
+						new Label
+						{
+							Margin = new Thickness(20,30),
+							FontSize = 22,
+							Text = "CollectionView does not fire RemainingItemsThresholdReachedCommand when Header and Footer both are set."
+						}
+					}
+				},
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label
+					{
+						Margin = new Thickness(20, 30),
+						FontSize = 25
+					};
+					label.SetBinding(Label.TextProperty, ".");
+					return label;
+				}),
+
+			};
+
+			var activityIndicator = new ActivityIndicator
+			{
+				Margin = new Thickness(0, 20)
+			};
+			activityIndicator.SetBinding(ActivityIndicator.IsRunningProperty, "IsLoadingMore");
+			activityIndicator.SetBinding(ActivityIndicator.IsVisibleProperty, "IsLoadingMore");
+			collectionView.Footer = activityIndicator;
+
+
+			var grid = new Grid
+			{
+				Padding = 20,
+				RowDefinitions =
+				{
+					new RowDefinition { Height = 50 }, // Threshold label
+                    new RowDefinition { Height = GridLength.Star }  // CollectionView
+                }
+			};
+
+			grid.Add(thresholdLabel, 0, 0);
+			grid.Add(collectionView, 0, 1);
+
+			Content = grid;
+		}
+	}
+
+	public class RemainingItemsThresholdViewModel : INotifyPropertyChanged
+	{
+		private bool _isLoadingMore;
+		private int _loadCount = 0;
+		private string thresholdStatus;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+		public ObservableCollection<string> Items { get; } = new ObservableCollection<string>();
+
+		public ICommand RemainingItemReachedCommand { get; }
+
+		public bool IsLoadingMore
+		{
+			get => _isLoadingMore;
+			set
+			{
+				if (_isLoadingMore != value)
+				{
+					_isLoadingMore = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+		public string ThresholdStatus
+		{
+			get => thresholdStatus;
+			set
+			{
+				if (thresholdStatus != value)
+				{
+					thresholdStatus = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		public RemainingItemsThresholdViewModel()
+		{
+			ThresholdStatus = "Threshold not reached";
+			RemainingItemReachedCommand = new Command(async () => await LoadMoreItemsAsync());
+			LoadInitialItems();
+		}
+
+		private void LoadInitialItems()
+		{
+			for (int i = 1; i <= 20; i++)
+			{
+				Items.Add($"Item {i}");
+			}
+		}
+
+		private async Task LoadMoreItemsAsync()
+		{
+			if (IsLoadingMore)
+				return;
+
+			IsLoadingMore = true;
+
+			await Task.Delay(1500); // Simulate API call or long operation
+
+			for (int i = 1; i <= 10; i++)
+			{
+				Items.Add($"Loaded Item {_loadCount * 10 + i + 20}");
+			}
+
+			_loadCount++;
+			IsLoadingMore = false;
+			ThresholdStatus = "Threshold reached";
+		}
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}
+

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29588.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29588.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Controls.Issues
 		}
 	}
 
-	public class RemainingItemsThresholdViewModel : INotifyPropertyChanged
+	public class Issue29588ViewModel : INotifyPropertyChanged
 	{
 		private bool _isLoadingMore;
 		private int _loadCount = 0;
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Controls.Issues
 			}
 		}
 
-		public RemainingItemsThresholdViewModel()
+		public Issue29588ViewModel()
 		{
 			ThresholdStatus = "Threshold not reached";
 			RemainingItemReachedCommand = new Command(async () => await LoadMoreItemsAsync());

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29588.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29588.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.Issues
 	{
 		public Issue29588()
 		{
-			BindingContext = new RemainingItemsThresholdViewModel();
+			BindingContext = new Issue29588ViewModel();
 
 			var thresholdLabel = new Label
 			{
@@ -20,14 +20,14 @@ namespace Microsoft.Maui.Controls.Issues
 				HeightRequest = 50,
 				FontSize = 18
 			};
-			thresholdLabel.SetBinding(Label.TextProperty, nameof(RemainingItemsThresholdViewModel.ThresholdStatus));
+			thresholdLabel.SetBinding(Label.TextProperty, nameof(Issue29588ViewModel.ThresholdStatus));
 
 			var collectionView = new CollectionView
 			{
 				AutomationId = "29588CollectionView",
-				ItemsSource = ((RemainingItemsThresholdViewModel)BindingContext).Items,
+				ItemsSource = ((Issue29588ViewModel)BindingContext).Items,
 				RemainingItemsThreshold = 1,
-				RemainingItemsThresholdReachedCommand = ((RemainingItemsThresholdViewModel)BindingContext).RemainingItemReachedCommand,
+				RemainingItemsThresholdReachedCommand = ((Issue29588ViewModel)BindingContext).RemainingItemReachedCommand,
 				Header = new Grid
 				{
 					BackgroundColor = Colors.Bisque,

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29588.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29588.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+
+internal class Issue29588 : _IssuesUITest
+{
+	public override string Issue => "CollectionView RemainingItemsThresholdReachedcommand should trigger on scroll near end";
+
+	public Issue29588(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void RemainingItemsThresholdReachedEventShouldTrigger()
+	{
+		App.WaitForElement("29588CollectionView");
+		for (int i = 0; i < 5; i++)
+		{
+			App.ScrollDown("29588CollectionView", ScrollStrategy.Gesture, 0.8, 500);
+		}
+		App.WaitForElement("29588ThresholdLabel");
+		Assert.That(App.FindElement("29588ThresholdLabel").GetText(), Is.EqualTo("Threshold reached"));
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Description
In Android, the `RemainingThresholdReached` command is not triggered when both a `Header` and a `Footer` are defined for the collection.

### RootCause 
The `SendRemainingThresholdReached` method is triggered based on the `LastVisibleIndex` and the `ItemCount` provided by the ItemAdapter. However, on Android, when both a Header and a Footer are defined, the ItemCount consider it, leading to incorrect triggering logic.
 
### Description of Change
Updated the logic to ensure that the ItemCount correctly includes both the Header and Footer. This change ensures that the Footer becomes visible as expected and that the SendRemainingThresholdReached command is properly executed.

### Issues Fixed
Fixes #29588 

### Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac


### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/919c566b-c5f4-431f-9498-2b7f254e73d9">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/ad7490d5-410c-43a8-b4bd-8702a2bfc48f">|