### PR TITLE
[iOS] - Fixed the performance issue that occurred when updating the Spacing in CollectionView for both Vertical List and Grid layouts

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 using Foundation;
 using Microsoft.Maui.Handlers;
@@ -203,20 +204,29 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			if (itemsLayout is not null)
 			{
-				itemsLayout.PropertyChanged += (sender, args) =>
-				{
-					if (args.PropertyName == nameof(ItemsLayout.SnapPointsAlignment) ||
-						args.PropertyName == nameof(ItemsLayout.SnapPointsType) ||
-						args.PropertyName == nameof(GridItemsLayout.VerticalItemSpacing) ||
-						args.PropertyName == nameof(GridItemsLayout.HorizontalItemSpacing) ||
-						args.PropertyName == nameof(GridItemsLayout.Span) ||
-						args.PropertyName == nameof(LinearItemsLayout.ItemSpacing))
-
-					{
-						UpdateLayout();
-					}
-				};
+				itemsLayout.PropertyChanged -= ItemsLayoutPropertyChanged;
+				itemsLayout.PropertyChanged += ItemsLayoutPropertyChanged;
 			}
+		}
+
+		void ItemsLayoutPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(ItemsLayout.SnapPointsAlignment) ||
+				e.PropertyName == nameof(ItemsLayout.SnapPointsType) ||
+				e.PropertyName == nameof(GridItemsLayout.VerticalItemSpacing) ||
+				e.PropertyName == nameof(GridItemsLayout.HorizontalItemSpacing) ||
+				e.PropertyName == nameof(GridItemsLayout.Span) ||
+				e.PropertyName == nameof(LinearItemsLayout.ItemSpacing))
+
+			{
+				UpdateLayout();
+			}
+		}
+
+		protected override void DisconnectHandler(UIView platformView)
+		{
+			ItemsView.ItemsLayout.PropertyChanged -= ItemsLayoutPropertyChanged;
+			base.DisconnectHandler(platformView);
 		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -15,3 +15,4 @@ virtual Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDec
 ~virtual Microsoft.Maui.Controls.CollectionSynchronizationCallback.Invoke(System.Collections.IEnumerable collection, object context, System.Action accessMethod, bool writeAccess) -> void
 ~virtual Microsoft.Maui.Controls.Internals.EvaluateJavaScriptDelegate.Invoke(string script) -> System.Threading.Tasks.Task<string>
 ~virtual Microsoft.Maui.Controls.PropertyChangingEventHandler.Invoke(object sender, Microsoft.Maui.Controls.PropertyChangingEventArgs e) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -15,3 +15,4 @@ virtual Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDec
 ~virtual Microsoft.Maui.Controls.CollectionSynchronizationCallback.Invoke(System.Collections.IEnumerable collection, object context, System.Action accessMethod, bool writeAccess) -> void
 ~virtual Microsoft.Maui.Controls.Internals.EvaluateJavaScriptDelegate.Invoke(string script) -> System.Threading.Tasks.Task<string>
 ~virtual Microsoft.Maui.Controls.PropertyChangingEventHandler.Invoke(object sender, Microsoft.Maui.Controls.PropertyChangingEventArgs e) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27666.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27666.cs
@@ -1,0 +1,98 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 27666, "Vertical list and Vertical grid pages have different abnormal behaviors when clicking Update after changing the spacing value", PlatformAffected.iOS | PlatformAffected.macOS)]
+
+public class Issue27666_NavigationPage : TestNavigationPage
+{
+	protected override void Init()
+	{
+		var root = CreateRootContentPage();
+		PushAsync(root);
+	}
+
+	ContentPage CreateRootContentPage()
+	{
+		ContentPage ContentPage = new ContentPage();
+
+		VerticalStackLayout rootLayout = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = new Thickness(10),
+		};
+
+		Button collectionViewButton = new Button
+		{
+			Text = "Navigate to VerticalList CollectionView",
+			AutomationId = "NavigationButton"
+		};
+		collectionViewButton.Clicked += (s, e) => Navigation.PushAsync(new Issue27666());
+
+		rootLayout.Add(collectionViewButton);
+		ContentPage.Content = rootLayout;
+		return ContentPage;
+	}
+}
+
+public partial class Issue27666 : TestContentPage
+{
+	ObservableCollection<string> items;
+	CollectionView collectionView;
+	protected override void Init()
+	{
+		items = new ObservableCollection<string>(Enumerable.Range(1, 30).Select(i => $"Item {i}"));
+		Button itemSpacingButton = CreateButton("Update ItemSpacing", "UpdateItemSpacingButton", OnItemSpacingButtonClicked);
+
+		collectionView = new CollectionView
+		{
+			AutomationId = "ItemsLayoutCollectionView",
+			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal),
+			ItemsSource = items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return new Border
+				{
+					Content = label,
+					Padding = 10,
+					Margin = new Thickness(5),
+					BackgroundColor = Colors.LightGray,
+				};
+			})
+		};
+
+		Grid grid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			},
+			RowSpacing = 5
+		};
+		grid.Add(itemSpacingButton, 0, 0);
+		grid.Add(collectionView, 0, 1);
+
+		Content = grid;
+	}
+
+	Button CreateButton(string text, string automationId, EventHandler onClick)
+	{
+		return new Button
+		{
+			Text = text,
+			AutomationId = automationId,
+			Command = new Command(_ => onClick(this, EventArgs.Empty))
+		};
+	}
+
+	void OnItemSpacingButtonClicked(object sender, EventArgs e)
+	{
+		if (collectionView.ItemsLayout is LinearItemsLayout layout)
+		{
+			layout.ItemSpacing = layout.ItemSpacing == 0 ? 50 : 20;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27666.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27666.cs
@@ -35,60 +35,18 @@ public class Issue27666_NavigationPage : TestNavigationPage
 	}
 }
 
-public partial class Issue27666 : TestContentPage
+public partial class Issue27666 : ContentPage
 {
 	ObservableCollection<string> items;
-	CollectionView collectionView;
-	protected override void Init()
+
+	public Issue27666()
 	{
+		InitializeComponent();
 		items = new ObservableCollection<string>(Enumerable.Range(1, 30).Select(i => $"Item {i}"));
-		Button itemSpacingButton = CreateButton("Update ItemSpacing", "UpdateItemSpacingButton", OnItemSpacingButtonClicked);
-
-		collectionView = new CollectionView
-		{
-			AutomationId = "ItemsLayoutCollectionView",
-			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal),
-			ItemsSource = items,
-			ItemTemplate = new DataTemplate(() =>
-			{
-				var label = new Label();
-				label.SetBinding(Label.TextProperty, ".");
-				return new Border
-				{
-					Content = label,
-					Padding = 10,
-					Margin = new Thickness(5),
-					BackgroundColor = Colors.LightGray,
-				};
-			})
-		};
-
-		Grid grid = new Grid
-		{
-			RowDefinitions =
-			{
-				new RowDefinition { Height = GridLength.Auto },
-				new RowDefinition { Height = GridLength.Star }
-			},
-			RowSpacing = 5
-		};
-		grid.Add(itemSpacingButton, 0, 0);
-		grid.Add(collectionView, 0, 1);
-
-		Content = grid;
+		collectionView.ItemsSource = items;
 	}
 
-	Button CreateButton(string text, string automationId, EventHandler onClick)
-	{
-		return new Button
-		{
-			Text = text,
-			AutomationId = automationId,
-			Command = new Command(_ => onClick(this, EventArgs.Empty))
-		};
-	}
-
-	void OnItemSpacingButtonClicked(object sender, EventArgs e)
+	private void OnItemSpacingButtonClicked(object sender, EventArgs e)
 	{
 		if (collectionView.ItemsLayout is LinearItemsLayout layout)
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27666.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27666.xaml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue27666">
+
+  <Grid RowSpacing="5">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+
+    <Button Grid.Row="0"
+            Text="Update ItemSpacing"
+            AutomationId="UpdateItemSpacingButton"
+            Clicked="OnItemSpacingButtonClicked"/>
+
+    <CollectionView x:Name="collectionView"
+                    Grid.Row="1"
+                    AutomationId="ItemsLayoutCollectionView"
+                    ItemsLayout="HorizontalList">
+      <CollectionView.ItemTemplate>
+        <DataTemplate>
+          <Border Padding="10"
+              Margin="5"
+              BackgroundColor="LightGray">
+            <Label Text="{Binding .}"/>
+          </Border>
+        </DataTemplate>
+      </CollectionView.ItemTemplate>
+    </CollectionView>
+  </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27666.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27666.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue27666 : _IssuesUITest
+{
+	public override string Issue => "Vertical list and Vertical grid pages have different abnormal behaviors when clicking Update after changing the spacing value";
+
+	public Issue27666(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifySpacingUpdateInItemsLayout()
+	{
+		App.WaitForElement("NavigationButton");
+		App.Tap("NavigationButton");
+		App.WaitForElement("ItemsLayoutCollectionView");
+		App.Tap("UpdateItemSpacingButton");
+		App.TapBackArrow();
+		App.WaitForElement("NavigationButton");
+		App.Tap("NavigationButton");
+		App.WaitForElement("ItemsLayoutCollectionView");
+		App.Tap("UpdateItemSpacingButton");
+		App.WaitForElement("ItemsLayoutCollectionView");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27666.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27666.cs
@@ -7,22 +7,24 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 public class Issue27666 : _IssuesUITest
 {
 	public override string Issue => "Vertical list and Vertical grid pages have different abnormal behaviors when clicking Update after changing the spacing value";
-
+	const string UpdateItemSpacingButton = "UpdateItemSpacingButton";
+	const string ItemsLayoutCollectionView = "ItemsLayoutCollectionView";
+	const string NavigationButton = "NavigationButton";
 	public Issue27666(TestDevice device) : base(device) { }
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]
 	public void VerifySpacingUpdateInItemsLayout()
 	{
-		App.WaitForElement("NavigationButton");
-		App.Tap("NavigationButton");
-		App.WaitForElement("ItemsLayoutCollectionView");
-		App.Tap("UpdateItemSpacingButton");
+		App.WaitForElement(NavigationButton);
+		App.Tap(NavigationButton);
+		App.WaitForElement(ItemsLayoutCollectionView);
+		App.Tap(UpdateItemSpacingButton);
 		App.TapBackArrow();
-		App.WaitForElement("NavigationButton");
-		App.Tap("NavigationButton");
-		App.WaitForElement("ItemsLayoutCollectionView");
-		App.Tap("UpdateItemSpacingButton");
-		App.WaitForElement("ItemsLayoutCollectionView");
+		App.WaitForElement(NavigationButton);
+		App.Tap(NavigationButton);
+		App.WaitForElement(ItemsLayoutCollectionView);
+		App.Tap(UpdateItemSpacingButton);
+		App.WaitForElement(ItemsLayoutCollectionView);
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause

- `SubscribeToItemsLayoutPropertyChanged` subscribes to the `PropertyChanged` event to track changes in the layout.
- However, when the ItemsLayout is updated, new `PropertyChanged` event handlers are added without removing the previously registered handlers.
- This causes the number of event handlers to accumulate exponentially with each update.
- As a result, each layout change triggers multiple redundant calls to `UpdateLayout()`, causing cascading layout recalculations and severe performance degradation.

### Description of Change

- Properly unsubscribed from `ItemsLayout.PropertyChanged` by invoking a dedicated cleanup method in DisconnectHandler() before the base disposal logic.
- Ensured existing event handlers are unsubscribed before assigning new ones in `SubscribeToItemsLayoutPropertyChanged()`.

**Tested the behaviour in the following platforms**

- [x] Android
- [x]  Windows
- [x]  iOS
- [x] Mac

### Issues Fixed

Fixes #27666 
Fixes #27667
Fixes #29619 

### Output


| Before| After|
|--|--|
| <video src="https://github.com/user-attachments/assets/c2d43412-20af-44ec-9ef7-c2b79fd09cef"> | <video src="https://github.com/user-attachments/assets/d0da726a-6978-405c-beb2-eb6ab5c77bc4"> |