### PR TITLE
[Android/ iOS] Fix Flyout icon is displayed when flyout is disabled 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
 			var command = backButtonHandler.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
 			bool isEnabled = _shell.Toolbar.BackButtonEnabled;
-			var image = _flyoutBehavior != FlyoutBehavior.Disabled ? 
+			var image = _flyoutBehavior == FlyoutBehavior.Flyout ? 
         GetFlyoutIcon(backButtonHandler, page) : 
         null;
 			var backButtonVisible = _toolbar.BackButtonVisible;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -410,9 +410,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
 			var command = backButtonHandler.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
 			bool isEnabled = _shell.Toolbar.BackButtonEnabled;
-			var image = _flyoutBehavior == FlyoutBehavior.Flyout ? 
-        GetFlyoutIcon(backButtonHandler, page) : 
-        null;
+			//Add the FlyoutIcon only if the FlyoutBehavior is Flyout
+			var image = _flyoutBehavior == FlyoutBehavior.Flyout ? GetFlyoutIcon(backButtonHandler, page) : null;
 			var backButtonVisible = _toolbar.BackButtonVisible;
 
 			DrawerArrowDrawable icon = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -410,7 +410,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
 			var command = backButtonHandler.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
 			bool isEnabled = _shell.Toolbar.BackButtonEnabled;
-			var image = GetFlyoutIcon(backButtonHandler, page);
+			var image = _flyoutBehavior != FlyoutBehavior.Disabled ? 
+        GetFlyoutIcon(backButtonHandler, page) : 
+        null;
 			var backButtonVisible = _toolbar.BackButtonVisible;
 
 			DrawerArrowDrawable icon = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -336,7 +336,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (String.IsNullOrWhiteSpace(text) && image == null)
 			{
-				image = _context.Shell.FlyoutIcon;
+				if (_flyoutBehavior != FlyoutBehavior.Disabled)
+					image = _context.Shell.FlyoutIcon;
 			}
 
 			if (!IsRootPage)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (String.IsNullOrWhiteSpace(text) && image == null)
 			{
-				if (_flyoutBehavior != FlyoutBehavior.Disabled)
+				if (_flyoutBehavior == FlyoutBehavior.Flyout)
 					image = _context.Shell.FlyoutIcon;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -336,8 +336,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (String.IsNullOrWhiteSpace(text) && image == null)
 			{
+				//Add the FlyoutIcon only if the FlyoutBehavior is Flyout
 				if (_flyoutBehavior == FlyoutBehavior.Flyout)
+				{
 					image = _context.Shell.FlyoutIcon;
+				}
 			}
 
 			if (!IsRootPage)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29615.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29615.cs
@@ -1,0 +1,34 @@
+﻿namespace Maui.Controls.Sample.Issues;
+[Issue(IssueTracker.Github, 29615, "Flyout icon is displayed when flyout is disabled on iOS and MacCatalyst", PlatformAffected.iOS)]
+public class Issue29615 : Shell
+{
+	public Issue29615()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Flyout;
+		this.FlyoutIcon = "dotnet_bot.png";
+
+		var disableButton = new Button { Text = "Disable", AutomationId = "DisabledButton" };
+
+		disableButton.Clicked += (s, e) => this.FlyoutBehavior = FlyoutBehavior.Disabled;
+
+		var stack = new StackLayout
+		{
+			Children = { disableButton }
+		};
+
+		var contentPage = new ContentPage
+		{
+			Title = "Home",
+			Content = stack
+		};
+
+		var shellContent = new ShellContent
+		{
+			Title = "Home",
+			Route = "MainPage",
+			Content = contentPage
+		};
+
+		Items.Add(shellContent);
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
@@ -1,0 +1,24 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue29615 : _IssuesUITest
+	{
+		public Issue29615(TestDevice testDevice) : base(testDevice) { }
+
+		public override string Issue => "Flyout icon is displayed when flyout is disabled on iOS and MacCatalyst";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void VerifyFlyoutIconisPresentWhenDisabledFlyout()
+		{
+			App.WaitForElement("DisabledButton");
+			App.WaitForElement(FlyoutIconAutomationId);
+			App.Tap("DisabledButton");
+			App.WaitForNoElement(FlyoutIconAutomationId);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("DisabledButton");
 			App.WaitForFlyoutIcon();
 			App.Tap("DisabledButton");
-			App.WaitForNoElementFlyoutIcon();
+			App.WaitForNoFlyoutIcon();
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.Shell)]
-		public void VerifyFlyoutIconisPresentWhenDisabledFlyout()
+		public void VerifyFlyoutIconIsNotPresentWhenDisabledFlyout()
 		{
 			App.WaitForElement("DisabledButton");
 			App.WaitForFlyoutIcon();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29615.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public void VerifyFlyoutIconisPresentWhenDisabledFlyout()
 		{
 			App.WaitForElement("DisabledButton");
-			App.WaitForElement(FlyoutIconAutomationId);
+			App.WaitForFlyoutIcon();
 			App.Tap("DisabledButton");
-			App.WaitForNoElement(FlyoutIconAutomationId);
+			App.WaitForNoElementFlyoutIcon();
 		}
 	}
 }

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -2160,6 +2160,32 @@ namespace UITest.Appium
 			}
 		}
 
+		public static void WaitForNoElementFlyoutIcon(this IApp app, string automationId = "", bool isShell = true)
+		{
+			if (app is AppiumAndroidApp)
+			{
+				app.WaitForNoElement(AppiumQuery.ByXPath("//android.widget.ImageButton[@content-desc=\"Open navigation drawer\"]"));
+			}
+			else if (app is AppiumIOSApp || app is AppiumCatalystApp || app is AppiumWindowsApp)
+			{
+				if (isShell)
+				{
+					app.WaitForNoElement("OK");
+				}
+				if (!isShell)
+				{
+					if (app is AppiumWindowsApp)
+					{
+						app.WaitForNoElement(AppiumQuery.ByAccessibilityId("TogglePaneButton"));
+					}
+					else
+					{
+						app.WaitForNoElement(automationId);
+					}
+				}
+			}
+		}
+
 		/// <summary>
 		/// Shows the flyout menu in the app.
 		/// </summary>

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -2160,7 +2160,13 @@ namespace UITest.Appium
 			}
 		}
 
-		public static void WaitForNoElementFlyoutIcon(this IApp app, string automationId = "", bool isShell = true)
+		/// <summary>
+		/// Waits for the flyout icon to disappear in the app.
+		/// </summary>
+		/// <param name="app">The IApp instance representing the application.</param>
+		/// <param name="automationId">The automation ID of the flyout icon (default is an empty string).</param>
+		/// <param name="isShell">Indicates whether the app is using Shell navigation (default is true).</param>
+		public static void WaitForNoFlyoutIcon(this IApp app, string automationId = "", bool isShell = true)
 		{
 			if (app is AppiumAndroidApp)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
On iOS and Android, the flyout icon appears even when FlyoutBehavior is set to Disabled, but it does nothing when clicked. This behavior is inconsistent with Windows, where the icon is hidden.


### Description of Change
Only set the FlyoutIcon when FlyoutBehavior is Flyout. This ensures the icon is hidden when the flyout is disabled or locked, matching expected behavior across all platforms.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29615 

**Note: There is no existing Appium method to confirm the absence of the Flyout icon, so I have added a new method.**

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/e6e817d8-0ced-4c01-9a10-f308a17ce0fc" width="260" height="500"> |**iOS**<br> <video src="https://github.com/user-attachments/assets/dfb0aa8f-efd0-4bdf-bd44-f76d9e9e8697" width="260" height="500"> |
| **Android**<br> <video src="https://github.com/user-attachments/assets/66978130-c643-4613-8ea6-76111306c6f7" width="260" height="500"> | **Android**<br> <video src="https://github.com/user-attachments/assets/72bfe30b-8734-47ff-8064-1f29178cb35b" width="260" height="500"> |
