### PR TITLE
Fixed the RealParent warning issue

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -619,7 +619,10 @@ namespace Microsoft.Maui.Controls
 
 			OnDescendantRemoved(child);
 			foreach (Element element in child.Descendants())
+			{
+				element.SetParent(null);
 				OnDescendantRemoved(element);
+			}
 		}
 
 		/// <summary>Raises the (internal) <c>ParentSet</c> event. Implement this method in order to add behavior when the element is added to a parent.</summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



When navigating from a first page (with a button) to a second page containing controls like Image, Label, or Border, a warning occurs if properties such as StrokeShape, Image.Source, or Label.FormattedText are bound to values from a ViewModel that was implemented as a static (singleton) instance. 

- For example, if a StrokeShape is created and stored statically, it is instantiated only once during the first navigation. On subsequent navigations, the same instance is reused. Since elements like StrokeShape maintain a reference to their previous parent, reusing the same instance causes conflicts and triggers warnings due to improper parent-child relationships.

#### Example Code snippet
<img width="661" src="https://github.com/user-attachments/assets/3bcf90b7-e681-40e9-bcdb-9c188335a9ce" />

<img width="518" src="https://github.com/user-attachments/assets/4062ad6c-aba6-4914-bb13-9ecd6f48ccdb" />

<img width="358" src="https://github.com/user-attachments/assets/39a27c36-4c4f-4d5e-bb1c-4f20dec3e7c3" />



### Description of Change



- To resolve this, I cleared the parent reference for each element in OnChildRemoved by setting element.SetParent(null). This also resets the inherited binding context. 

As a result, when the page is popped, the PropertyChanging event is triggered, and the old parent reference is correctly removed, preventing warnings and ensuring a clean reattachment on subsequent navigations. 

### For example : 

| StrokeShape PropertyChanging | Label FormattedText PropertyChanging |
|----------|----------|
| <img width="585" src="https://github.com/user-attachments/assets/8bc6e0b8-3ab0-4b4e-b06b-3c18980f63ed" /> | <img width="550" src="https://github.com/user-attachments/assets/42c18b6d-2fe6-41a3-8d86-4ab8d51add03" /> |



### Issues Fixed



Fixes #23050 



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/2f63e523-140d-4a54-9cc3-d44a80187375"> | <video src="https://github.com/user-attachments/assets/f657125e-9f81-478a-b548-c95541b80097"> |