### PR TITLE
Fix weird CollectionView1 jumps on iOS with soft keyboard

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29643.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29643.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.Maui.Controls.Shapes;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29643, "iOS soft keyboard causes CollectionView to jump", PlatformAffected.iOS)]
+public class Issue29643 : ContentPage
+{
+	public Issue29643()
+	{
+		var grid = new Grid();
+		var cv = new CollectionView { ItemsSource = new List<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3",
+				"Item 4",
+				"Item 5",
+				"Item 6",
+				"Item 7",
+				"Item 8",
+				"Item 9",
+				"Item 10"
+			},
+			ItemTemplate = new SmallBigTemplateSelector()
+		};
+		grid.Add(cv);
+		Content = grid;
+		Background = Brush.LightSeaGreen;
+	}
+	
+	private class SmallBigTemplateSelector : DataTemplateSelector
+	{
+		private readonly DataTemplate _smallTemplate = new(() => CreateTemplateContent(3));
+		private readonly DataTemplate _bigTemplate = new(() => CreateTemplateContent(15));
+
+		static object CreateTemplateContent(int inputCount)
+		{
+			var border = new Border
+			{
+				StrokeShape = new RoundRectangle { CornerRadius = 16 },
+				Margin = new Thickness(16),
+				Background = Brush.White
+			};
+			var vsl = new VerticalStackLayout
+			{
+				Spacing = 16
+			};
+			border.Content = vsl;
+			
+			var label = new Label
+			{
+				FontSize = 24,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+			
+			label.SetBinding(Label.TextProperty, ".");
+			vsl.Add(label);
+
+			for (int i = 0; i < inputCount; i++)
+			{
+				var entry = new Entry
+				{
+					Placeholder = $"Input {i + 1}",
+					FontSize = 18,
+					HeightRequest = 40,
+					BackgroundColor = Colors.LightGoldenrodYellow,
+					Margin = new Thickness(16, 0)
+				};
+				vsl.Add(entry);
+			}
+			
+			return border;
+		}
+		
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			var str = (string)item;
+			var numericValue = int.Parse(str.Split(' ')[1]);
+			return numericValue % 2 == 0 ? _smallTemplate : _bigTemplate;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29643.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29643.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Maui.Controls.Shapes;
+﻿using System.Text.RegularExpressions;
+using Microsoft.Maui.Controls.Shapes;
 
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29643, "iOS soft keyboard causes CollectionView to jump", PlatformAffected.iOS)]
-public class Issue29643 : ContentPage
+public partial class Issue29643 : ContentPage
 {
 	public Issue29643()
 	{
@@ -16,25 +17,11 @@ public class Issue29643 : ContentPage
 				Margin = new Thickness(16),
 				Background = Brush.White
 			};
-			var vsl = new VerticalStackLayout { Spacing = 16 };
+			var vsl = new VerticalStackLayout { Spacing = 16, Padding = new Thickness(0, 16) };
 			border.Content = vsl;
 
-			vsl.SetBinding(BindableLayout.ItemsSourceProperty, new Binding("Labels"));
-			BindableLayout.SetItemTemplate(vsl, new DataTemplate(() =>
-			{
-				var entry = new Entry
-				{
-					FontSize = 18,
-					HeightRequest = 40,
-					BackgroundColor = Colors.LightGoldenrodYellow,
-					Margin = new Thickness(16, 0)
-				};
-
-				entry.SetBinding(Entry.PlaceholderProperty, new Binding("."));
-				entry.SetBinding(Element.AutomationIdProperty, new Binding("."));
-
-				return entry;
-			}));
+			vsl.SetBinding(BindableLayout.ItemsSourceProperty, new Binding("Inputs"));
+			BindableLayout.SetItemTemplateSelector(vsl, new MyDataTemplateSelector());
 
 			return border;
 		});
@@ -58,18 +45,93 @@ public class Issue29643 : ContentPage
 		Background = Brush.LightSeaGreen;
 	}
 
+	private partial class MyDataTemplateSelector : DataTemplateSelector
+	{
+		private readonly DataTemplate _entryTemplate = new(() =>
+		{
+			var entry = new Entry
+			{
+				FontSize = 18,
+				HeightRequest = 40,
+				BackgroundColor = Colors.LightGoldenrodYellow,
+				Margin = new Thickness(16, 0)
+			};
+
+			entry.SetBinding(Entry.PlaceholderProperty, new Binding("Label"));
+			entry.SetBinding(Element.AutomationIdProperty, new Binding("Label"));
+			entry.SetBinding(Entry.TextProperty, new Binding("Content", BindingMode.TwoWay));
+			return entry;
+		});
+		
+		private readonly DataTemplate _editorTemplate = new(() =>
+		{
+			var entry = new AutoSizedEditor
+			{
+				FontSize = 18,
+				BackgroundColor = Colors.LightGoldenrodYellow,
+				Margin = new Thickness(16, 0)
+			};
+
+			entry.SetBinding(Editor.PlaceholderProperty, new Binding("Label"));
+			entry.SetBinding(Element.AutomationIdProperty, new Binding("Label"));
+			entry.SetBinding(Editor.TextProperty, new Binding("Content", BindingMode.TwoWay));
+
+			return entry;
+		});
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			var input = (Input)item;
+
+			if (input.Number % 2 == 1)
+			{
+				return _editorTemplate;
+			}
+			
+			return _entryTemplate;
+		}
+
+		[GeneratedRegex(@"(\d+)$")]
+		private static partial Regex GetNumberRegex();
+	}
+
+	private class AutoSizedEditor : Editor
+	{
+		public AutoSizedEditor()
+		{
+			AutoSize = EditorAutoSizeOption.TextChanges;
+		}
+
+		protected override void OnHandlerChanged()
+		{
+			base.OnHandlerChanged();
+#if IOS
+			if (Handler?.PlatformView is UIKit.UITextView textView)
+			{
+				textView.ScrollEnabled = false;
+			}
+#endif
+		}
+	}
+
+	private record Input(
+		string Label,
+		int Number,
+		string Content
+	);
+
 	private class Items
 	{
 		private static int IdCounter;
 
-		public List<string> Labels { get; }
+		public List<Input> Inputs { get; }
 
 		public Items(int count)
 		{
-			Labels = [];
+			Inputs = [];
 			for (int i = 0; i < count; i++)
 			{
-				Labels.Add($"Input{++IdCounter}");
+				Inputs.Add(new Input($"Input{++IdCounter}", IdCounter, string.Empty));
 			}
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29643.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29643.cs
@@ -8,32 +8,7 @@ public class Issue29643 : ContentPage
 	public Issue29643()
 	{
 		var grid = new Grid();
-		var cv = new CollectionView { ItemsSource = new List<string>
-			{
-				"Item 1",
-				"Item 2",
-				"Item 3",
-				"Item 4",
-				"Item 5",
-				"Item 6",
-				"Item 7",
-				"Item 8",
-				"Item 9",
-				"Item 10"
-			},
-			ItemTemplate = new SmallBigTemplateSelector()
-		};
-		grid.Add(cv);
-		Content = grid;
-		Background = Brush.LightSeaGreen;
-	}
-	
-	private class SmallBigTemplateSelector : DataTemplateSelector
-	{
-		private readonly DataTemplate _smallTemplate = new(() => CreateTemplateContent(3));
-		private readonly DataTemplate _bigTemplate = new(() => CreateTemplateContent(15));
-
-		static object CreateTemplateContent(int inputCount)
+		var itemTemplate = new DataTemplate(() =>
 		{
 			var border = new Border
 			{
@@ -41,43 +16,61 @@ public class Issue29643 : ContentPage
 				Margin = new Thickness(16),
 				Background = Brush.White
 			};
-			var vsl = new VerticalStackLayout
-			{
-				Spacing = 16
-			};
+			var vsl = new VerticalStackLayout { Spacing = 16 };
 			border.Content = vsl;
-			
-			var label = new Label
-			{
-				FontSize = 24,
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
-			};
-			
-			label.SetBinding(Label.TextProperty, ".");
-			vsl.Add(label);
 
-			for (int i = 0; i < inputCount; i++)
+			vsl.SetBinding(BindableLayout.ItemsSourceProperty, new Binding("Labels"));
+			BindableLayout.SetItemTemplate(vsl, new DataTemplate(() =>
 			{
 				var entry = new Entry
 				{
-					Placeholder = $"Input {i + 1}",
 					FontSize = 18,
 					HeightRequest = 40,
 					BackgroundColor = Colors.LightGoldenrodYellow,
 					Margin = new Thickness(16, 0)
 				};
-				vsl.Add(entry);
-			}
-			
+
+				entry.SetBinding(Entry.PlaceholderProperty, new Binding("."));
+				entry.SetBinding(Element.AutomationIdProperty, new Binding("."));
+
+				return entry;
+			}));
+
 			return border;
-		}
-		
-		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		});
+		var cv = new CollectionView {
+			AutomationId = "CV",
+			ItemsSource = new List<Items>
+			{
+				new(15),
+				new(3),
+				new(15),
+				new(3),
+				new(15),
+				new(3),
+				new(15),
+				new(3),
+			},
+			ItemTemplate = itemTemplate
+		};
+		grid.Add(cv);
+		Content = grid;
+		Background = Brush.LightSeaGreen;
+	}
+
+	private class Items
+	{
+		private static int IdCounter;
+
+		public List<string> Labels { get; }
+
+		public Items(int count)
 		{
-			var str = (string)item;
-			var numericValue = int.Parse(str.Split(' ')[1]);
-			return numericValue % 2 == 0 ? _smallTemplate : _bigTemplate;
+			Labels = [];
+			for (int i = 0; i < count; i++)
+			{
+				Labels.Add($"Input{++IdCounter}");
+			}
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19214_2.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19214_2.cs
@@ -1,5 +1,6 @@
 #if IOS //This sample is specific to the iOS platform and handles text input behavior by accessing the native UITextView.
 using System.Drawing;
+using System.Globalization;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using OpenQA.Selenium.Appium.Interactions;
@@ -41,7 +42,7 @@ public class Issue19214_2 : _IssuesUITest
 
         var cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
 
-        var cursorHeight1 = Convert.ToDouble(cursorLabel);
+		var cursorHeight1 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
         KeyboardScrolling.HideKeyboard(app, app.Driver, true);
 
         // Click a low spot on the editor
@@ -51,12 +52,12 @@ public class Issue19214_2 : _IssuesUITest
         app.EnterText("IssueEditor", "A");
 
         cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
-        var cursorHeight2 = Convert.ToDouble(cursorLabel);
+		var cursorHeight2 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
 
-        app.EnterText("IssueEditor", sb.ToString());
+        app.EnterText("ssueEditor", sb.ToString());
 
         cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
-        var cursorHeight3 = Convert.ToDouble(cursorLabel);
+		var cursorHeight3 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
 
         if (keyboardLocation is Point keyboardPoint)
         {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19214_3.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19214_3.cs
@@ -1,5 +1,6 @@
 #if IOS //This sample is specific to the iOS platform and handles text input behavior by accessing the native UITextView.
 using System.Drawing;
+using System.Globalization;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using OpenQA.Selenium.Appium.Interactions;
@@ -41,7 +42,7 @@ public class Issue19214_3 : _IssuesUITest
 
         var cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
 
-        var cursorHeight1 = Convert.ToDouble(cursorLabel);
+        var cursorHeight1 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
         KeyboardScrolling.HideKeyboard(app, app.Driver, true);
 
         // Click a low spot on the editor
@@ -51,12 +52,12 @@ public class Issue19214_3 : _IssuesUITest
         app.EnterText("IssueEditor", "A");
 
         cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
-        var cursorHeight2 = Convert.ToDouble(cursorLabel);
+        var cursorHeight2 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
 
         app.EnterText("IssueEditor", sb.ToString());
 
         cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
-        var cursorHeight3 = Convert.ToDouble(cursorLabel);
+        var cursorHeight3 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
 
         if (keyboardLocation is Point keyboardPoint)
         {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24977.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24977.cs
@@ -1,5 +1,6 @@
 #if IOS
 using System.Drawing;
+using System.Globalization;
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -50,7 +51,7 @@ public class Issue24977 : _IssuesUITest
         var keyboardLocation = KeyboardScrolling.FindiOSKeyboardLocation(app.Driver);
 
         var cursorLabel = app.WaitForElement("CursorHeightTracker").GetText();
-        var cursorHeight1 = Convert.ToDouble(cursorLabel);
+        var cursorHeight1 = double.Parse(cursorLabel!, CultureInfo.InvariantCulture);
         try
         {
             if (keyboardLocation is Point keyboardPoint)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29643.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29643.cs
@@ -1,0 +1,63 @@
+#if IOS //This sample is specific to the iOS platform and handles text input behavior by accessing the native UITextView.
+using System.Drawing;
+using System.Globalization;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using OpenQA.Selenium.Appium.Interactions;
+using OpenQA.Selenium.Interactions;
+using UITest.Appium;
+using UITest.Core;
+using System.Text;
+using Microsoft.Maui.Platform;
+using OpenQA.Selenium;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue29643 : _IssuesUITest
+{
+    public Issue29643(TestDevice device) : base(device) { }
+
+    public override string Issue => "iOS soft keyboard causes CollectionView to jump";
+
+    [Test]
+    [Category(UITestCategories.Entry)]
+    public async Task KeepEntryAboveKeyboardInCollectionView ()
+    {
+        var app = App as AppiumApp;
+        if (app is null)
+        {
+            return;
+        }
+        
+        app.ScrollDown("CV", swipePercentage: 0.9, swipeSpeed: 100);
+        app.ScrollDown("CV", swipePercentage: 0.9, swipeSpeed: 100);
+        
+		await AssertVisibleAboveKeyboard(app, "Input72");
+		await AssertVisibleAboveKeyboard(app, "Input69");
+		await AssertVisibleAboveKeyboard(app, "Input68");
+		await AssertVisibleAboveKeyboard(app, "Input67");
+		await AssertVisibleAboveKeyboard(app, "Input66");
+		await AssertVisibleAboveKeyboard(app, "Input65");
+		await AssertVisibleAboveKeyboard(app, "Input62");
+		await AssertVisibleAboveKeyboard(app, "Input61");
+    }
+
+    static async Task AssertVisibleAboveKeyboard(AppiumApp app, string entryId)
+    {
+	    app.ScrollDown("CV", swipePercentage: 0.9, swipeSpeed: 100);
+	    var entry = await TapEntryAsync(app, entryId);
+	    var entryRect = entry.GetRect();
+	    var keyboardLocation = KeyboardScrolling.FindiOSKeyboardLocation(app.Driver)!.Value;
+	    ClassicAssert.GreaterOrEqual(entryRect.Top, 44);
+	    ClassicAssert.LessOrEqual(entryRect.Bottom, keyboardLocation.Y);
+	    KeyboardScrolling.HideKeyboard(app, app.Driver, false);
+    }
+
+    static async Task<IUIElement> TapEntryAsync(AppiumApp app, string entryId)
+    {
+	    var entry = app.WaitForElement(entryId);
+	    entry.Click();
+	    await Task.Delay(100);
+	    return entry;
+    }
+}
+#endif

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -58,17 +58,16 @@ public static class KeyboardAutoManagerScroll
 			return;
 		}
 
-		TextFieldToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UITextFieldTextDidBeginEditingNotification"), DidUITextBeginEditing);
+		TextFieldToken = NSNotificationCenter.DefaultCenter.AddObserver(UITextField.TextDidBeginEditingNotification, DidUITextBeginEditing);
 
-		TextViewToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UITextViewTextDidBeginEditingNotification"), DidUITextBeginEditing);
+		TextViewToken = NSNotificationCenter.DefaultCenter.AddObserver(UITextView.TextDidBeginEditingNotification, DidUITextBeginEditing);
 
-		WillShowToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UIKeyboardWillShowNotification"), WillKeyboardShow);
+		WillShowToken = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, WillKeyboardShow);
 
-		WillHideToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UIKeyboardWillHideNotification"), WillHideKeyboard);
+		WillHideToken = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillHideNotification, WillHideKeyboard);
 
-		DidHideToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UIKeyboardDidHideNotification"), DidHideKeyboard);
+		DidHideToken = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.DidHideNotification, DidHideKeyboard);
 
-		// Add observer for when the keyboard has fully shown
 		DidShowToken = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.DidShowNotification, DidKeyboardShow);
 	}
 
@@ -99,7 +98,6 @@ public static class KeyboardAutoManagerScroll
 			NSNotificationCenter.DefaultCenter.RemoveObserver(DidHideToken);
 			DidHideToken = null;
 		}
-		// Remove observer for when the keyboard has fully shown
 		if (DidShowToken is not null)
 		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(DidShowToken);
@@ -294,18 +292,23 @@ public static class KeyboardAutoManagerScroll
 			needsCorrection = true;
 		}
 
-		if (needsCorrection)
+		if (!needsCorrection)
 		{
-			// Ensure new offset is within valid bounds
-			newScrollOffsetY = (nfloat)Math.Max(newScrollOffsetY, -LastScrollView.ContentInset.Top);
-			var maxScrollY = LastScrollView.ContentSize.Height - LastScrollView.Bounds.Height + LastScrollView.ContentInset.Bottom;
-			newScrollOffsetY = (nfloat)Math.Min(newScrollOffsetY, maxScrollY);
+			return;
+		}
 
-			// Apply the correction without animation
-			if (Math.Abs(currentScrollOffset.Y - newScrollOffsetY) > 0.1) // Check if change is meaningful
+		// Ensure new offset is within valid bounds
+		newScrollOffsetY = (nfloat)Math.Max(newScrollOffsetY, -LastScrollView.ContentInset.Top);
+		var maxScrollY = LastScrollView.ContentSize.Height - LastScrollView.Bounds.Height + LastScrollView.ContentInset.Bottom;
+		newScrollOffsetY = (nfloat)Math.Min(newScrollOffsetY, maxScrollY);
+
+		// Apply the correction with animation
+		if (Math.Abs(currentScrollOffset.Y - newScrollOffsetY) > 0.1) // Check if change is meaningful
+		{
+			UIView.Animate(0.03, 0, UIViewAnimationOptions.CurveEaseOut, () =>
 			{
 				LastScrollView.SetContentOffset(new CGPoint(currentScrollOffset.X, newScrollOffsetY), animated: false);
-			}
+			}, () => { });
 		}
 	}
 

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -237,15 +237,15 @@ public static class KeyboardAutoManagerScroll
 		var intersectRect = CGRect.Intersect(KeyboardFrame, window.Frame);
 		var kbSize = intersectRect == CGRect.Empty ? new CGSize(KeyboardFrame.Width, 0) : intersectRect.Size;
 
-		nfloat statusBarHeight;
 		nfloat navigationBarAreaHeight;
 
-		if (View.FindResponder<UINavigationController>() is UINavigationController navigationController)
+		if (View.FindResponder<UINavigationController>() is { } navigationController)
 		{
 			navigationBarAreaHeight = navigationController.NavigationBar.Frame.GetMaxY();
 		}
 		else
 		{
+			nfloat statusBarHeight;
 			if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
 			{
 				statusBarHeight = window.WindowScene?.StatusBarManager?.StatusBarFrame.Height ?? 0;

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -36,6 +36,7 @@ public static class KeyboardAutoManagerScroll
 	static NSObject? WillShowToken;
 	static NSObject? WillHideToken;
 	static NSObject? DidHideToken;
+	static NSObject? DidShowToken; // Added for UIKeyboardDidShowNotification
 	static NSObject? TextFieldToken;
 	static NSObject? TextViewToken;
 	internal static bool ShouldDisconnectLifecycle;
@@ -66,6 +67,9 @@ public static class KeyboardAutoManagerScroll
 		WillHideToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UIKeyboardWillHideNotification"), WillHideKeyboard);
 
 		DidHideToken = NSNotificationCenter.DefaultCenter.AddObserver(new NSString("UIKeyboardDidHideNotification"), DidHideKeyboard);
+
+		// Add observer for when the keyboard has fully shown
+		DidShowToken = NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.DidShowNotification, DidKeyboardShow);
 	}
 
 	/// <summary>
@@ -94,6 +98,12 @@ public static class KeyboardAutoManagerScroll
 		{
 			NSNotificationCenter.DefaultCenter.RemoveObserver(DidHideToken);
 			DidHideToken = null;
+		}
+		// Remove observer for when the keyboard has fully shown
+		if (DidShowToken is not null)
+		{
+			NSNotificationCenter.DefaultCenter.RemoveObserver(DidShowToken);
+			DidShowToken = null;
 		}
 		if (TextFieldToken is not null)
 		{
@@ -208,6 +218,95 @@ public static class KeyboardAutoManagerScroll
 		IsKeyboardAutoScrollHandling = false;
 		ShouldIgnoreSafeAreaAdjustment = false;
 		ShouldScrollAgain = false;
+	}
+
+	// Handler for UIKeyboardDidShowNotification
+	static void DidKeyboardShow(NSNotification notification)
+	{
+		// Guard conditions
+		if (!IsKeyboardAutoScrollHandling || View is null || ContainerView is null || LastScrollView is null)
+		{
+			return;
+		}
+
+		// Recalculate boundaries
+		var window = ContainerView.Window;
+		if (window is null)
+		{
+			return;
+		}
+
+		var intersectRect = CGRect.Intersect(KeyboardFrame, window.Frame);
+		var kbSize = intersectRect == CGRect.Empty ? new CGSize(KeyboardFrame.Width, 0) : intersectRect.Size;
+
+		nfloat statusBarHeight;
+		nfloat navigationBarAreaHeight;
+
+		if (View.FindResponder<UINavigationController>() is UINavigationController navigationController)
+		{
+			navigationBarAreaHeight = navigationController.NavigationBar.Frame.GetMaxY();
+		}
+		else
+		{
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
+			{
+				statusBarHeight = window.WindowScene?.StatusBarManager?.StatusBarFrame.Height ?? 0;
+			}
+			else
+			{
+				statusBarHeight = UIApplication.SharedApplication.StatusBarFrame.Height;
+			}
+
+			navigationBarAreaHeight = statusBarHeight;
+		}
+
+		var topLayoutGuide = Math.Max(navigationBarAreaHeight, ContainerView.LayoutMargins.Top);
+		var keyboardYPosition = window.Frame.Height - kbSize.Height - TextViewDistanceFromBottom;
+		var bottomBoundary = (double)keyboardYPosition;
+
+		// Get current cursor position
+		var cursorRect = FindCursorPosition();
+
+		if (cursorRect is null)
+		{
+			return;
+		}
+
+		var currentCursorRect = (CGRect)cursorRect;
+
+		// Check for misalignment and apply corrective scroll
+		var currentScrollOffset = LastScrollView.ContentOffset;
+		var newScrollOffsetY = currentScrollOffset.Y;
+		var needsCorrection = false;
+
+		// Check if cursor is below the bottom boundary
+		if (currentCursorRect.Bottom > bottomBoundary)
+		{
+			var deltaY = currentCursorRect.Bottom - (nfloat)bottomBoundary;
+			newScrollOffsetY = currentScrollOffset.Y + deltaY;
+			needsCorrection = true;
+		}
+		// Check if cursor is above the top boundary
+		else if (currentCursorRect.Y < topLayoutGuide)
+		{
+			var deltaY = currentCursorRect.Y - (nfloat)topLayoutGuide;
+			newScrollOffsetY = currentScrollOffset.Y + deltaY;
+			needsCorrection = true;
+		}
+
+		if (needsCorrection)
+		{
+			// Ensure new offset is within valid bounds
+			newScrollOffsetY = (nfloat)Math.Max(newScrollOffsetY, -LastScrollView.ContentInset.Top);
+			var maxScrollY = LastScrollView.ContentSize.Height - LastScrollView.Bounds.Height + LastScrollView.ContentInset.Bottom;
+			newScrollOffsetY = (nfloat)Math.Min(newScrollOffsetY, maxScrollY);
+
+			// Apply the correction without animation
+			if (Math.Abs(currentScrollOffset.Y - newScrollOffsetY) > 0.1) // Check if change is meaningful
+			{
+				LastScrollView.SetContentOffset(new CGPoint(currentScrollOffset.X, newScrollOffsetY), animated: false);
+			}
+		}
 	}
 
 	static NSObject? FindValue(this NSDictionary dict, string key)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

The changes on SR6 introduced a regression with the `KeyboardAutoScrollManager` because the way we recompute header/footer/empty view is now interfering with the keyboard content insets.

This PR fixes the regression and also ensures that if for whatever reason iOS decides to auto-scroll in a bad position we quickly fix the situation.

I know it's not "the best of the best animation" in some cases, but at least it's not blocking the user.

| `main` | PR |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/cea1dd59-018c-4578-9576-8d50739c4a60" /> | <video src="https://github.com/user-attachments/assets/238f13d2-47ec-4dbe-8a9c-0c5c8797dd45" /> | 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29643

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
