### PR TITLE
[Android] Improve Keyboard Accessibility: Support Spacebar for Android Gesture recognisers

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (info == null)
 				return;
 
-			if (virtualView.TapGestureRecognizerNeedsDelegate())
+			if (virtualView.HasAccessibleTapGesture())
 				info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
 		}
 
@@ -46,5 +46,9 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 			}
 		}
+
+		internal static bool ControlsAccessibilityDelegateNeeded(this View virtualView)
+			=> virtualView.HasAccessibleTapGesture();
+
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Controls.Platform
 		bool _isEnabled;
 		bool _focusableDefaultValue;
 		protected virtual VisualElement? Element => _handler?.VirtualView as VisualElement;
+		IEnumerable<TapGestureRecognizer>? _keyPressGestureRecognizers;
 
 		View? View => Element as View;
 		WeakReference<AView>? _control;
@@ -221,7 +222,13 @@ namespace Microsoft.Maui.Controls.Platform
 			if (shouldAddTouchEvent)
 			{
 				platformView.Touch += OnPlatformViewTouched;
-				platformView.KeyPress += OnKeyPress;
+
+				// If we have a TapGestureRecognizer, we need to handle key presses
+				_keyPressGestureRecognizers = View.GestureRecognizers.OfType<TapGestureRecognizer>().Where(x => x.NumberOfTapsRequired == 1);
+				if (_keyPressGestureRecognizers.Any())
+				{
+					platformView.KeyPress += OnKeyPress;
+				}
 				platformView.Focusable = true;
 			}
 		}
@@ -233,9 +240,9 @@ namespace Microsoft.Maui.Controls.Platform
 			if (View is null)
 				return;
 
-			if (e.KeyCode == Keycode.Space && e.Event?.Action == KeyEventActions.Down)
+			if (e.KeyCode == Keycode.Space && e.Event?.Action == KeyEventActions.Down && _keyPressGestureRecognizers is not null)
 			{
-				foreach (var tapGestureRecognizer in View.GestureRecognizers.OfType<TapGestureRecognizer>())
+				foreach (var tapGestureRecognizer in _keyPressGestureRecognizers)
 				{
 					tapGestureRecognizer.SendTapped(View, (v) => Point.Zero);
 				}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (PlatformView != null &&
 				_handler.VirtualView is View v &&
-				v.TapGestureRecognizerNeedsDelegate() &&
+				v.HasAccessibleTapGesture() &&
 				(PlatformView.AccessibilityTraits & UIAccessibilityTrait.Button) != UIAccessibilityTrait.Button)
 			{
 				PlatformView.AccessibilityTraits |= UIAccessibilityTrait.Button;

--- a/src/Controls/src/Core/Platform/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/SemanticExtensions.cs
@@ -1,20 +1,26 @@
-﻿namespace Microsoft.Maui.Controls.Platform
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Maui.Controls.Platform
 {
 	public static partial class SemanticExtensions
 	{
-		internal static bool ControlsAccessibilityDelegateNeeded(this View virtualView)
-			=> virtualView.TapGestureRecognizerNeedsDelegate();
+		internal static bool HasAccessibleTapGesture(this View virtualView) =>
+			HasAccessibleTapGesture(virtualView, out _);
 
-		internal static bool TapGestureRecognizerNeedsDelegate(this View virtualView)
+		internal static bool HasAccessibleTapGesture(
+			this View virtualView,
+			[NotNullWhen(true)] out TapGestureRecognizer? tapGestureRecognizer)
 		{
 			foreach (var gesture in virtualView.GestureRecognizers)
 			{
 				//Accessibility can't handle Tap Recognizers with > 1 tap
 				if (gesture is TapGestureRecognizer tgr && tgr.NumberOfTapsRequired == 1)
 				{
+					tapGestureRecognizer = tgr;
 					return (tgr.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary;
 				}
 			}
+			tapGestureRecognizer = null;
 			return false;
 		}
 	}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -806,5 +806,18 @@ namespace Microsoft.Maui.Platform
 
 			view.Post(ShowSoftInput);
 		}
-	}
+
+		internal static bool IsConfirmKey(this Keycode keyCode)
+		{
+			switch (keyCode)
+			{
+				case Keycode.DpadCenter:
+				case Keycode.Enter:
+				case Keycode.Space:
+				case Keycode.NumpadEnter:
+					return true;
+				default:
+					return false;
+			}
+		}
 }

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -820,4 +820,5 @@ namespace Microsoft.Maui.Platform
 					return false;
 			}
 		}
+	}
 }


### PR DESCRIPTION
…Recognizers

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Currently, .NET MAUI does not support spacebar key events for gesture recognizers on Android. This lack of support presents a significant accessibility issue, as it prevents keyboard users from activating gesture-based UI elements using the spacebar—something expected under [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/)

This discrepancy also results in inconsistent behavior between platforms, as iOS correctly responds to the spacebar key for gesture recognition.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/29648
Fixes https://github.com/dotnet/maui/issues/30685
