### PR TITLE
[Shell] Implemented BackButtonBehavior Clicked Event

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -165,7 +165,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (isEnabled)
 			{
 				if (backButtonHandler?.Command != null)
+				{
 					backButtonHandler.Command.Execute(backButtonHandler.CommandParameter);
+					backButtonHandler.SendClicked();
+				}
+				else if (backButtonHandler.SendClicked())
+				{
+					// Clicked event handled — do not navigate back or toggle flyout
+				}
 				else if (CanNavigateBack)
 					OnNavigateBack();
 				else

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 							command.Execute(commandParameter);
 						}
 
+						behavior.SendClicked();
+						return false;
+					}
+					else if (behavior.SendClicked())
+					{
 						return false;
 					}
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -44,3 +44,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -47,3 +47,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -47,3 +47,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -44,3 +44,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -44,3 +44,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -44,3 +44,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -35,3 +35,4 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.BackButtonBehavior.Clicked -> System.EventHandler

--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -89,6 +89,20 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(TextOverrideProperty, value); }
 		}
 
+		/// <summary>
+		/// Occurs when the back button is clicked/tapped.
+		/// </summary>
+		public event EventHandler Clicked;
+
+		internal bool SendClicked()
+		{
+			if (Clicked == null)
+				return false;
+
+			Clicked.Invoke(this, EventArgs.Empty);
+			return true;
+		}
+
 		bool IsEnabledCore { set => SetValue(IsEnabledProperty, value); }
 
 		static void OnCommandChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1593,6 +1593,11 @@ namespace Microsoft.Maui.Controls
 				if (command != null)
 				{
 					command.Execute(commandParameter);
+					backButtonBehavior.SendClicked();
+					return true;
+				}
+				else if (backButtonBehavior.SendClicked())
+				{
 					return true;
 				}
 			}

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -83,6 +83,96 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task BackButtonClickedEventFiresWithCommand()
+		{
+			var pushedPage = new ContentPage();
+			TestShell testShell = new TestShell(new ContentPage());
+			var window = new Window()
+			{
+				Page = testShell
+			};
+
+			bool clickedFired = false;
+			bool commandExecuted = false;
+			var command = new Command((p) => commandExecuted = true);
+
+			var backButtonBehavior = new BackButtonBehavior()
+			{
+				Command = command,
+			};
+
+			backButtonBehavior.Clicked += (s, e) => clickedFired = true;
+
+			await testShell.Navigation.PushAsync(pushedPage);
+			Shell.SetBackButtonBehavior(pushedPage, backButtonBehavior);
+
+			(window as IWindow).BackButtonClicked();
+
+			Assert.True(commandExecuted);
+			Assert.True(clickedFired);
+		}
+
+		[Fact]
+		public async Task BackButtonClickedEventFiresWithoutCommand()
+		{
+			var pushedPage = new ContentPage();
+			TestShell testShell = new TestShell(new ContentPage());
+			var window = new Window()
+			{
+				Page = testShell
+			};
+
+			bool clickedFired = false;
+			var backButtonBehavior = new BackButtonBehavior();
+			backButtonBehavior.Clicked += (s, e) => clickedFired = true;
+
+			await testShell.Navigation.PushAsync(pushedPage);
+			Shell.SetBackButtonBehavior(pushedPage, backButtonBehavior);
+
+			(window as IWindow).BackButtonClicked();
+
+			Assert.True(clickedFired);
+			// Should not navigate back when Clicked handler is attached
+			Assert.Equal(pushedPage, testShell.CurrentPage);
+		}
+
+		[Fact]
+		public async Task BackButtonNavigatesBackWhenNoClickedHandler()
+		{
+			var pushedPage = new ContentPage();
+			TestShell testShell = new TestShell(new ContentPage());
+			var window = new Window()
+			{
+				Page = testShell
+			};
+
+			var backButtonBehavior = new BackButtonBehavior();
+
+			await testShell.Navigation.PushAsync(pushedPage);
+			Shell.SetBackButtonBehavior(pushedPage, backButtonBehavior);
+
+			(window as IWindow).BackButtonClicked();
+
+			// With no command and no Clicked handler, should navigate back
+			Assert.NotEqual(pushedPage, testShell.CurrentPage);
+		}
+
+		[Fact]
+		public void SendClickedReturnsFalseWhenNoHandler()
+		{
+			var backButtonBehavior = new BackButtonBehavior();
+			Assert.False(backButtonBehavior.SendClicked());
+		}
+
+		[Fact]
+		public void SendClickedReturnsTrueWhenHandlerAttached()
+		{
+			var backButtonBehavior = new BackButtonBehavior();
+			backButtonBehavior.Clicked += (s, e) => { };
+			Assert.True(backButtonBehavior.SendClicked());
+		}
+
+		[Fact]
 		public async Task BackButtonDisabledWhenCommandDisabled()
 		{
 			var page = new ContentPage();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This PR introduces support for the Clicked event in BackButtonBehavior, allowing developers to handle the back button tap using either an event or a command—similar to how many other controls in .NET MAUI behave.

Usage Example:

**XAML:**
```xaml
<Shell.BackButtonBehavior>
    <BackButtonBehavior 
        TextOverride="Hello"
        Clicked="BackButtonBehavior_Clicked" />
</Shell.BackButtonBehavior>
```

**Code Behind:**
```c#
private void BackButtonBehavior_Clicked(object sender, EventArgs e)
{
    // Custom logic
}
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/29655