### PR TITLE
[testing] Ignore ConnectivityChanged_Does_Not_Crash while crashing on…

### DIFF
--- a/src/Essentials/test/DeviceTests/Tests/Connectivity_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Connectivity_Tests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal(profiles.Count(), profiles.Distinct().Count());
 		}
 
-		[Fact]
+		[Fact(Skip = "This test is failing on net10 preview 5, needs investigation - https://github.com/dotnet/maui/issues/29678")]
 		public async Task ConnectivityChanged_Does_Not_Crash()
 		{
 			Connectivity.ConnectivityChanged += Connectivity_ConnectivityChanged;


### PR DESCRIPTION
### Description of Change

When moving to net10 preview 5 on this [commit](https://github.com/dotnet/maui/commit/070142f251f93dbcfc053766cd44bb7c9f156d62) the test ConnectivityChanged_Does_Not_Crash started crashing the Device tests on iOS and Android , so ignoring the test for now, and created issue https://github.com/dotnet/maui/issues/29678 to follow up with iOS team 