### PR TITLE
Obsolete `TextType.Html` for .NET 10

### DIFF
--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Maui.Controls
 			// And we map some of the other property handlers to Controls-specific versions that avoid stepping on HTML text settings
 
 			// these just refresh Text / FormattedText
+#pragma warning disable CS0618 // Type or member is obsolete
 			LabelHandler.Mapper.ReplaceMapping<Label, ILabelHandler>(nameof(TextType), MapTextType);
+#pragma warning restore CS0618 // Type or member is obsolete
 			LabelHandler.Mapper.ReplaceMapping<Label, ILabelHandler>(nameof(TextTransform), MapTextTransform);
 
 			// these are really a single property
@@ -136,7 +138,9 @@ namespace Microsoft.Maui.Controls
 				// then we re-apply the whole formatted text
 				handler.UpdateValue(nameof(FormattedText));
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (label.TextType == TextType.Text || !IsDefaultFont(label))
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				// if this is plain text or if the user specifically wants to override html,
 				// then we fall back to the base implementation
@@ -152,7 +156,9 @@ namespace Microsoft.Maui.Controls
 				// then we re-apply the whole formatted text
 				handler.UpdateValue(nameof(FormattedText));
 			}
+#pragma warning disable CS0618 // Type or member is obsolete
 			else if (label.TextType == TextType.Text || !label.TextColor.IsDefault())
+#pragma warning restore CS0618 // Type or member is obsolete
 			{
 				// if this is plain text or if the user specifically wants to override html,
 				// then we fall back to the base implementation
@@ -167,8 +173,10 @@ namespace Microsoft.Maui.Controls
 			if (label.HasFormattedTextSpans)
 				return false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (label.TextType != TextType.Text)
 				return false;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return true;
 		}

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		/// <summary>Bindable property for <see cref="TextType"/>.</summary>
+		[Obsolete("HTML text formatting is discontinued.")]
 		public static readonly BindableProperty TextTypeProperty = BindableProperty.Create(nameof(TextType), typeof(TextType), typeof(Label), TextType.Text,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Label)bindable).InvalidateMeasureIfLabelSizeable());
 
@@ -237,6 +238,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='TextType']/Docs/*" />
+		[Obsolete("HTML text formatting is discontinued.")]
 		public TextType TextType
 		{
 			get => (TextType)GetValue(TextTypeProperty);

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Maui.Controls
 		static void MapFormatting(ILabelHandler handler, Label label)
 		{
 			// we need to re-apply color and font for HTML labels
+#pragma warning disable CS0612 // Type or member is obsolete
 			if (!label.HasFormattedTextSpans && label.TextType == TextType.Html)
+#pragma warning restore CS0612 // Type or member is obsolete
 			{
 				handler.UpdateValue(nameof(ILabel.TextColor));
 				handler.UpdateValue(nameof(ILabel.Font));

--- a/src/Controls/src/Core/Platform/Android/Extensions/TextViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/TextViewExtensions.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Maui.Controls.Platform
 					else
 						textView.Text = TextTransformUtilities.GetTransformedText(label.Text, label.TextTransform);
 					break;
+#pragma warning disable CS0612 // Type or member is obsolete
 				case TextType.Html:
+#pragma warning restore CS0612 // Type or member is obsolete
 					textView.UpdateTextHtml(label);
 					break;
 			}

--- a/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
@@ -24,9 +24,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateText(this TextBlock platformControl, Label label)
 		{
+#pragma warning disable CS0612 // Type or member is obsolete
 			switch (label.TextType)
 			{
 				case TextType.Html:
+#pragma warning restore CS0612 // Type or member is obsolete
 					platformControl.UpdateTextHtml(label);
 					break;
 

--- a/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs
@@ -137,8 +137,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				return;
 			}
-
+#pragma warning disable CS0612 // Type or member is obsolete
 			if (element.TextType == TextType.Html)
+#pragma warning restore CS0612 // Type or member is obsolete			
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			switch (label.TextType)
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				case TextType.Html:
+#pragma warning restore CS0612 // Type or member is obsolete
 					platformLabel.UpdateTextHtml(label);
 					break;
 

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public static void UpdateText(this UILabel platformLabel, Label label)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			switch (label.TextType)
 			{
-#pragma warning disable CS0612 // Type or member is obsolete
 				case TextType.Html:
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 					platformLabel.UpdateTextHtml(label);
 					break;
 
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					break;
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Maui.DeviceTests
 			var label = new Label()
 			{
 				Text = $"&lt;b&gt;{expected}&lt;/b&gt;",
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html
+#pragma warning restore CS0612 // Type or member is obsolete
 			};
 
 			var handler = await CreateHandlerAsync<LabelHandler>(label);

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -330,8 +330,9 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var platformView = handler.ToPlatform();
 				await platformView.AssertContainsColor(Colors.Red, MauiContext);
-
+#pragma warning disable CS0612 // Type or member is obsolete
 				label.TextType = TextType.Html;
+#pragma warning restore CS0612 // Type or member is obsolete
 
 				await platformView.AssertDoesNotContainColor(Colors.Red, MauiContext);
 			});
@@ -490,7 +491,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			var label = new Label
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				TextColor = Colors.Red,
 				Text = "<p>Test</p>"
 			};
@@ -511,7 +514,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			var label = new Label
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				FontSize = 64,
 				FontFamily = "Baskerville",
 				Text = "<p>Test</p>"
@@ -697,7 +702,9 @@ namespace Microsoft.Maui.DeviceTests
 			await InvokeOnMainThreadAsync(() =>
 			{
 				var handler = CreateHandler<LabelHandler>(label);
+#pragma warning disable CS0612 // Type or member is obsolete
 				label.TextType = TextType.Html;
+#pragma warning restore CS0612 // Type or member is obsolete
 				AssertEquivalentFont(handler, label.ToFont());
 			});
 		}
@@ -711,7 +718,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			var label = new Label
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				Text = "<p>Test</p>"
 			};
 

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -114,7 +114,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			var label4 = new Label()
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				Text = "<h1>This is label tests.</h1>",
 				CharacterSpacing = 5d,
 				LineHeight = 1.5d,

--- a/src/Controls/tests/TestCases.HostApp/Elements/LabelCoreGalleryPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Elements/LabelCoreGalleryPage.cs
@@ -262,7 +262,9 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 			var label = new Label
 			{
 				Text = "<h1>Hello world!</h1>",
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html
+#pragma warning restore CS0612 // Type or member is obsolete
 			};
 			var htmlLabelContainer = new ViewContainer<Label>(Test.Label.HtmlTextType, label);
 			Add(htmlLabelContainer);
@@ -272,7 +274,9 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 			var label = new Label
 			{
 				Text = "<h1>Broken Html!<h1>",
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html
+#pragma warning restore CS0612 // Type or member is obsolete
 			};
 			var htmlLabelContainer = new ViewContainer<Label>(Test.Label.BrokenHtmlTextType, label);
 			Add(htmlLabelContainer);
@@ -282,7 +286,9 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 			var label = new Label
 			{
 				Text = "<h1>Hello world!</h1><p>Lorem <strong>ipsum</strong> bla di bla <i>blabla</i> blablabl&nbsp;ablabla & blablablablabl ablabl ablablabl ablablabla blablablablablablab lablablabla blablab lablablabla blablabl ablablablab lablabla blab lablablabla blablab lablabla blablablablab lablabla blablab lablablabl ablablabla blablablablablabla blablabla</p>",
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				MaxLines = 3
 			};
 			var htmlLabelMultipleLinesContainer = new ViewContainer<Label>(Test.Label.HtmlTextTypeMultipleLines, label);
@@ -293,7 +299,9 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 			var label = new Label
 			{
 				Text = "<h1>End aligned. Green. ä</h1>",
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				HorizontalTextAlignment = TextAlignment.Center,
 				TextColor = Colors.Green,
 			};
@@ -304,14 +312,18 @@ internal class LabelCoreGalleryPage : CoreGalleryPage<Label>
 		{
 			var toggleLabel = new Label
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				Text = "<h1 style=\"color: red;\">Hello world!</h1><p>Lorem <strong>ipsum</strong></p>"
 
 			};
 			var gestureRecognizer = new TapGestureRecognizer();
 			gestureRecognizer.Tapped += (s, a) =>
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				toggleLabel.TextType = toggleLabel.TextType == TextType.Html ? TextType.Text : TextType.Html;
+#pragma warning restore CS0612 // Type or member is obsolete
 			};
 			toggleLabel.GestureRecognizers.Add(gestureRecognizer);
 			var toggleHtmlPlainTextLabelContainer = new ViewContainer<Label>(Test.Label.TextTypeToggle, toggleLabel);

--- a/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewSetOrientation.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/CarouselViewSetOrientation.cs
@@ -22,7 +22,9 @@
 			{
 				var label = new Label
 				{
+#pragma warning disable CS0612 // Type or member is obsolete
 					TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 					Text = $"<p style='background-color:red;'>{HTML}</p>",
 					AutomationId = HTML
 				};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21711.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21711.cs
@@ -82,7 +82,9 @@ namespace Maui.Controls.Sample.Issues
 				Text = $"Item{count}",
 				AutomationId = $"Item{count}",
 				Background = Brush.Yellow,
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html
+#pragma warning restore CS0612 // Type or member is obsolete
 			};
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue8870.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue8870.cs
@@ -24,7 +24,9 @@
 			{
 				var label = new Label
 				{
+#pragma warning disable CS0612 // Type or member is obsolete
 					TextType = TextType.Html
+#pragma warning restore CS0612 // Type or member is obsolete
 				};
 
 				label.SetBinding(Label.TextProperty, new Binding(".", stringFormat: "<p style='background-color:red;'>{0}</p>"));

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/LabelTextType.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/LabelTextType.cs
@@ -19,13 +19,16 @@ public class LabelTextType : TestContentPage
 
 		button.Clicked += (s, a) =>
 		{
+#pragma warning disable CS0612 // Type or member is obsolete
 			label.TextType = label.TextType == TextType.Html ? TextType.Text : TextType.Html;
+#pragma warning restore CS0612 // Type or member is obsolete
 		};
 
-
+#pragma warning disable CS0612 // Type or member is obsolete
 		Label htmlLabel = new Label() { TextType = TextType.Html };
 		Label normalLabel = new Label();
 		Label nullLabel = new Label() { TextType = TextType.Html };
+#pragma warning restore CS0612 // Type or member is obsolete
 
 		Button toggle = new Button()
 		{

--- a/src/Core/src/Primitives/TextType.cs
+++ b/src/Core/src/Primitives/TextType.cs
@@ -17,6 +17,6 @@ public enum TextType
 	/// The subset of supported HTML tags varies by platform. Each platform's native text rendering engine
 	/// determines which HTML tags and attributes are supported.
 	/// </remarks>
-	[System.Obsolete]
+	[System.Obsolete("HTML text formatting is discontinued.")]
 	Html
 }

--- a/src/Core/src/Primitives/TextType.cs
+++ b/src/Core/src/Primitives/TextType.cs
@@ -17,5 +17,6 @@ public enum TextType
 	/// The subset of supported HTML tags varies by platform. Each platform's native text rendering engine
 	/// determines which HTML tags and attributes are supported.
 	/// </remarks>
+	[System.Obsolete]
 	Html
 }

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
@@ -303,7 +303,9 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var label = new LabelStub()
 			{
+#pragma warning disable CS0612 // Type or member is obsolete
 				TextType = TextType.Html,
+#pragma warning restore CS0612 // Type or member is obsolete
 				Text = "<h2><strong>Test1&nbsp;</strong>Test2</h2>"
 			};
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

* Adds the `Obsolete` attribute to the `TextType.Html` property in the `Label` class to mark it as obsolete.
* Suppress the build warnings/errors for usages of this in our own codebase

The HTML text type is a headache. Different platforms support different things, and its not very stable across all platforms. If (note: if) we would want to keep this, I would want to move this into its own control and not combine it with the regular `Label`. Or we might just get rid of this entirely. 

Q: Should we then also obsolete the `Label.TextType` property? Since it has no use if we remove the HTML option.

(Mostly a proposal at this point, but might become a real thing...)