### PR TITLE
[iOS, Android, Windows] TextTransform Property Does Not Apply at Runtime When TextType="Html" Is Set on Label - fix

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/TextViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/TextViewExtensions.cs
@@ -11,16 +11,17 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public static void UpdateText(this TextView textView, Label label)
 		{
+			string text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
 			switch (label.TextType)
 			{
 				case TextType.Text:
 					if (label.FormattedText != null)
 						textView.TextFormatted = label.ToSpannableString();
 					else
-						textView.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+						textView.Text = text;
 					break;
 				case TextType.Html:
-					textView.UpdateTextHtml(label);
+					textView.UpdateTextHtml(text);
 					break;
 			}
 		}

--- a/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
@@ -24,10 +24,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateText(this TextBlock platformControl, Label label)
 		{
+			string text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+
 			switch (label.TextType)
 			{
 				case TextType.Html:
-					platformControl.UpdateTextHtml(label);
+					platformControl.UpdateTextHtml(label, text);
 					break;
 
 				default:
@@ -39,7 +41,7 @@ namespace Microsoft.Maui.Controls.Platform
 						{
 							platformControl.TextHighlighters.Clear();
 						}
-						platformControl.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+						platformControl.Text = text;
 					}
 					break;
 			}

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public static void UpdateText(this UILabel platformLabel, Label label)
 		{
+			var text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+			
 			switch (label.TextType)
 			{
 				case TextType.Html:
@@ -21,7 +23,7 @@ namespace Microsoft.Maui.Controls.Platform
 					// will be just disappear once we switch.
 					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
 					{
-						platformLabel.UpdateTextHtml(label);
+						platformLabel.UpdateTextHtml(text);
 
 						if (label.Handler is LabelHandler labelHandler)
 							Label.MapFormatting(labelHandler, label);
@@ -42,7 +44,7 @@ namespace Microsoft.Maui.Controls.Platform
 							platformLabel.AttributedText = null;
 						}
 
-						platformLabel.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+						platformLabel.Text = text;
 					}
 					break;
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29700.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29700.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue29700"
+             Title="29700">
+    <VerticalStackLayout>
+        <Label Text="Hello, World"
+               AutomationId="TestLabel"
+               x:Name="TestLabel"
+               TextType="Html"/>
+        <Button Text="Change text transform"
+                AutomationId="ChangeTextTransformButton"
+                Clicked="Button_Clicked"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29700.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29700.xaml.cs
@@ -1,0 +1,21 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29700, "TextTransform Property Does Not Apply at Runtime When TextType='Html'")]
+public partial class Issue29700 : ContentPage
+{
+	public Issue29700()
+	{
+		InitializeComponent();
+	}
+
+	private void Button_Clicked(object sender, EventArgs e)
+	{
+		if (TestLabel.TextTransform == TextTransform.Default)
+			TestLabel.TextTransform = TextTransform.Uppercase;
+		else if (TestLabel.TextTransform == TextTransform.Uppercase)
+			TestLabel.TextTransform = TextTransform.Lowercase;
+		else
+			TestLabel.TextTransform = TextTransform.None;
+	}
+
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29700.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29700.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue29700 : _IssuesUITest
+	{
+		public Issue29700(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "TextTransform Property Does Not Apply at Runtime When TextType='Html'";
+
+		[Test]
+		[Category(UITestCategories.Label)]
+		public void TextTransformPropertyAppliesAtRuntime()
+		{
+			var label = App.WaitForElement("TestLabel");
+			Assert.That(label.GetText(), Is.EqualTo("Hello, World"));
+			App.Tap("ChangeTextTransformButton");
+			Assert.That(label.GetText(), Is.EqualTo("HELLO, WORLD"));
+			App.Tap("ChangeTextTransformButton");
+			Assert.That(label.GetText(), Is.EqualTo("hello, world"));
+			App.Tap("ChangeTextTransformButton");
+			Assert.That(label.GetText(), Is.EqualTo("Hello, World"));
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTextHtml(this TextView textView, ILabel label)
 		{
 			var text = label.Text ?? string.Empty;
+			textView.UpdateTextHtml(text);
+		}
+
+		internal static void UpdateTextHtml(this TextView textView, string text)
+		{
 			var htmlText = WebUtility.HtmlDecode(text);
 
 			if (OperatingSystem.IsAndroidVersionAtLeast(24))

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -85,10 +85,8 @@ namespace Microsoft.Maui.Platform
 			platformControl.VerticalAlignment = label.VerticalTextAlignment.ToPlatformVerticalAlignment();
 		}
 
-		internal static void UpdateTextHtml(this TextBlock platformControl, ILabel label)
+		internal static void UpdateTextHtml(this TextBlock platformControl, ILabel label, string text)
 		{
-			var text = label.Text ?? string.Empty;
-
 			// Just in case we are not given text with elements.
 			var modifiedText = string.Format("<div>{0}</div>", text);
 			modifiedText = Regex.Replace(modifiedText, "<br>", "<br></br>", RegexOptions.IgnoreCase);

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -73,10 +73,8 @@ namespace Microsoft.Maui.Platform
 				platformLabel.AttributedText = modAttrText;
 		}
 
-		internal static void UpdateTextHtml(this UILabel platformLabel, ILabel label)
+		internal static void UpdateTextHtml(this UILabel platformLabel, string text)
 		{
-			string text = label.Text ?? string.Empty;
-
 			var attr = new NSAttributedStringDocumentAttributes
 			{
 				DocumentType = NSDocumentType.HTML,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/29673

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/d6682255-a19c-4acd-9f49-ea6eeb688403" width="300px"/>|<video src="https://github.com/user-attachments/assets/0ccf9e9a-59e0-4c3e-b96b-84d2c3d1dee6" width="300px"/>|

I was curious how the text would behave if we used something like:

`"<b>HTML <span style=\"text-transform:uppercase\">Lorem ipsum dolor sit amet</span>, consectetur adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus</b>";`

It turned out that the label property was overridden by the CSS style, which I believe is the correct and expected behavior. This applies to iOS, where the text-transform: uppercase style works as intended. However, on Android, the <span style="text-transform:uppercase"> has no effect — the text remains unchanged.

<img src="https://github.com/user-attachments/assets/26906b28-5b95-4d91-9681-54700af784ea" width="200px"/>
