### PR TITLE
[WIP][Android] Fix for Unable to Programmatically Update SearchHandler Query Value on Second Tab within ShellSection

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -195,7 +195,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_searchView != null)
 				{
 					RemoveSearchView(_searchView);
-					_searchView.Dispose();
 				}
 
 				_drawerLayout.RemoveDrawerListener(_drawerToggle);
@@ -254,7 +253,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (_searchView != null && _searchView.SearchHandler != searchHandler)
 			{
 				RemoveSearchView(_searchView);
-				_searchView.Dispose();
 				_searchView = null;
 			}
 
@@ -288,6 +286,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			searchView.View.RemoveFromParent();
 			searchView.View.ViewAttachedToWindow -= OnSearchViewAttachedToWindow;
 			searchView.SearchConfirmed -= OnSearchConfirmed;
+			searchView.Dispose();
 		}
 
 		void OnShellNavigated(object sender, ShellNavigatedEventArgs e)
@@ -702,7 +701,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_searchView != null)
 				{
 					RemoveSearchView(_searchView);
-					_searchView.Dispose();
 					_searchView = null;
 				}
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			SearchHandler searchHandler = Shell.GetSearchHandler(newPage);
 
-			if (_searchView != null && _searchView.SearchHandler != searchHandler)
+			if (_searchView is not null && _searchView.SearchHandler != searchHandler)
 			{
 				RemoveSearchView(_searchView);
 				_searchView = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -251,6 +251,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				((INotifyCollectionChanged)oldPage.ToolbarItems).CollectionChanged -= OnPageToolbarItemsChanged;
 			}
 
+			if (_searchView != null)
+			{
+				_searchView.View.RemoveFromParent();
+				_searchView.View.ViewAttachedToWindow -= OnSearchViewAttachedToWindow;
+				_searchView.SearchConfirmed -= OnSearchConfirmed;
+				_searchView.Dispose();
+				_searchView = null;
+			}
+
 			if (newPage != null)
 			{
 				newPage.PropertyChanged += OnPagePropertyChanged;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -248,16 +248,16 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				((INotifyCollectionChanged)oldPage.ToolbarItems).CollectionChanged -= OnPageToolbarItemsChanged;
 			}
 
-			SearchHandler searchHandler = Shell.GetSearchHandler(newPage);
-
-			if (_searchView is not null && _searchView.SearchHandler != searchHandler)
-			{
-				RemoveSearchView(_searchView);
-				_searchView = null;
-			}
-
 			if (newPage != null)
 			{
+				SearchHandler searchHandler = Shell.GetSearchHandler(newPage);
+
+				if (_searchView is not null && _searchView.SearchHandler != searchHandler)
+				{
+					RemoveSearchView(_searchView);
+					_searchView = null;
+				}
+
 				newPage.PropertyChanged += OnPagePropertyChanged;
 				_backButtonBehavior = Shell.GetBackButtonBehavior(newPage);
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -194,9 +194,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				if (_searchView != null)
 				{
-					_searchView.View.RemoveFromParent();
-					_searchView.View.ViewAttachedToWindow -= OnSearchViewAttachedToWindow;
-					_searchView.SearchConfirmed -= OnSearchConfirmed;
+					RemoveSearchView(_searchView);
 					_searchView.Dispose();
 				}
 
@@ -251,11 +249,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				((INotifyCollectionChanged)oldPage.ToolbarItems).CollectionChanged -= OnPageToolbarItemsChanged;
 			}
 
-			if (_searchView != null)
+			SearchHandler searchHandler = Shell.GetSearchHandler(newPage);
+
+			if (_searchView != null && _searchView.SearchHandler != searchHandler)
 			{
-				_searchView.View.RemoveFromParent();
-				_searchView.View.ViewAttachedToWindow -= OnSearchViewAttachedToWindow;
-				_searchView.SearchConfirmed -= OnSearchConfirmed;
+				RemoveSearchView(_searchView);
 				_searchView.Dispose();
 				_searchView = null;
 			}
@@ -283,6 +281,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					shellToolbar.ApplyChanges();
 				}
 			}
+		}
+
+		void RemoveSearchView(IShellSearchView searchView)
+		{
+			searchView.View.RemoveFromParent();
+			searchView.View.ViewAttachedToWindow -= OnSearchViewAttachedToWindow;
+			searchView.SearchConfirmed -= OnSearchConfirmed;
 		}
 
 		void OnShellNavigated(object sender, ShellNavigatedEventArgs e)
@@ -696,9 +701,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				if (_searchView != null)
 				{
-					_searchView.View.RemoveFromParent();
-					_searchView.View.ViewAttachedToWindow -= OnSearchViewAttachedToWindow;
-					_searchView.SearchConfirmed -= OnSearchConfirmed;
+					RemoveSearchView(_searchView);
 					_searchView.Dispose();
 					_searchView = null;
 				}

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -77,6 +77,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			if (mauiNavView is not null)
 				mauiNavView.SelectionChanged += OnNavigationTabChanged;
+
+			if (VirtualView.Parent is Shell shell)
+			{
+				shell.Navigated += OnShellNavigated;
+			}
 		}
 
 		protected override void DisconnectHandler(FrameworkElement platformView)
@@ -111,6 +116,11 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			if (_shellItem is IShellItemController shellItemController)
 				shellItemController.ItemsCollectionChanged -= OnItemsChanged;
+
+			if (VirtualView.Parent is Shell shell)
+			{
+				shell.Navigated -= OnShellNavigated;
+			}
 		}
 
 		public override void SetVirtualView(Maui.IElement view)
@@ -137,6 +147,11 @@ namespace Microsoft.Maui.Controls.Handlers
 			{
 				base.SetVirtualView(view);
 			}
+		}
+
+		void OnShellNavigated(object? sender, ShellNavigatedEventArgs e)
+		{
+			UpdateSearchHandler();
 		}
 
 		private void OnItemsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -77,11 +77,6 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			if (mauiNavView is not null)
 				mauiNavView.SelectionChanged += OnNavigationTabChanged;
-
-			if (VirtualView.Parent is Shell shell)
-			{
-				shell.Navigated += OnShellNavigated;
-			}
 		}
 
 		protected override void DisconnectHandler(FrameworkElement platformView)
@@ -116,11 +111,6 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			if (_shellItem is IShellItemController shellItemController)
 				shellItemController.ItemsCollectionChanged -= OnItemsChanged;
-
-			if (VirtualView.Parent is Shell shell)
-			{
-				shell.Navigated -= OnShellNavigated;
-			}
 		}
 
 		public override void SetVirtualView(Maui.IElement view)
@@ -147,11 +137,6 @@ namespace Microsoft.Maui.Controls.Handlers
 			{
 				base.SetVirtualView(view);
 			}
-		}
-
-		void OnShellNavigated(object? sender, ShellNavigatedEventArgs e)
-		{
-			UpdateSearchHandler();
 		}
 
 		private void OnItemsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29570.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29570.cs
@@ -1,0 +1,139 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 29570, "Unable to Programmatically Update SearchHandler Query Value on Second Tab within ShellSection", PlatformAffected.Android)]
+public class Issue29570 : Shell
+{
+	public Issue29570()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Flyout;
+		this.FlyoutBackgroundImageAspect = Aspect.AspectFill;
+		this.FlyoutHeaderBehavior = FlyoutHeaderBehavior.CollapseOnScroll;
+
+		FlyoutItem flyoutItem = new FlyoutItem
+		{
+			Route = "animals",
+			FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems
+		};
+
+		Tab domesticTab = new Tab
+		{
+			Title = "Domestic",
+			Route = "domestic"
+		};
+
+		domesticTab.Items.Add(new ShellContent
+		{
+			Title = "CatsPage",
+			Route = "cats",
+			ContentTemplate = new DataTemplate(typeof(Issue29570CatsPage))
+		});
+
+		domesticTab.Items.Add(new ShellContent
+		{
+			Title = "DogsPage",
+			Route = "dogs",
+			ContentTemplate = new DataTemplate(typeof(Issue29570DogsPage))
+		});
+
+		flyoutItem.Items.Add(domesticTab);
+		Items.Add(flyoutItem);
+	}
+
+	public class Issue29570CatsPage : ContentPage
+	{
+		Issue29570AnimalSearchHandler searchHandler;
+		public Issue29570CatsPage()
+		{
+			Title = "CatsPage";
+
+			searchHandler = new Issue29570AnimalSearchHandler
+			{
+				Placeholder = "Enter cat's name",
+				ShowsResults = true,
+				Animals = new List<string>() { "Abyssinian", "Arabian Mau" },
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label
+					{
+						FontAttributes = FontAttributes.Bold,
+					};
+
+					nameLabel.SetBinding(Label.TextProperty, ".");
+					return nameLabel;
+				})
+			};
+
+			Shell.SetSearchHandler(this, searchHandler);
+
+			Button button = new Button
+			{
+				Text = "UpdateQuery",
+				AutomationId = "CatsPageUpdateQueryBtn"
+			};
+
+			VerticalStackLayout layout = new VerticalStackLayout
+			{
+				Children = { button }
+			};
+
+			Content = layout;
+		}
+	}
+
+	public class Issue29570DogsPage : ContentPage
+	{
+		Issue29570AnimalSearchHandler searchHandler;
+		public Issue29570DogsPage()
+		{
+			Title = "DogsPage";
+
+			searchHandler = new Issue29570AnimalSearchHandler
+			{
+				Placeholder = "Enter dog's name",
+				ShowsResults = true,
+				Animals = new List<string>() { "Afghan Hound", "Alpine Dachsbracke" },
+				ItemTemplate = new DataTemplate(() =>
+				{
+					Label nameLabel = new Label
+					{
+						FontAttributes = FontAttributes.Bold,
+						VerticalOptions = LayoutOptions.Center
+					};
+
+					nameLabel.SetBinding(Label.TextProperty, ".");
+					return nameLabel;
+				})
+			};
+
+			Shell.SetSearchHandler(this, searchHandler);
+
+			Button button = new Button
+			{
+				Text = "UpdateQuery",
+				AutomationId = "UpdateQueryButton"
+			};
+
+			button.Clicked += (s, e) =>
+			{
+				searchHandler.Query = "Hound";
+			};
+
+			VerticalStackLayout layout = new VerticalStackLayout
+			{
+				Children = { button }
+			};
+
+			Content = layout;
+		}
+	}
+
+	public class Issue29570AnimalSearchHandler : SearchHandler
+	{
+		public IList<string> Animals { get; set; }
+
+		protected override void OnQueryChanged(string oldValue, string newValue)
+		{
+			base.OnQueryChanged(oldValue, newValue);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29570 : _IssuesUITest
+{
+	public Issue29570(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Unable to Programmatically Update SearchHandler Query Value on Second Tab within ShellSection";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void VerifySearchQueryUpdateOnSecondShellTab()
+	{
+#if WINDOWS
+		App.Tap("navViewItem");
+		App.WaitForElement("DogsPage");
+		App.Tap("DogsPage");
+#else
+		App.WaitForElement("CatsPageUpdateQueryBtn");
+		App.TapTab("DogsPage");
+#endif
+		App.WaitForElement("UpdateQueryButton");
+		App.Tap("UpdateQueryButton");
+		var searchHandlerString = App.GetShellSearchHandler().GetText();
+		Assert.That(searchHandlerString, Is.EqualTo("Hound"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_WINDOWS // A fix for this issue is already available for Windows platform in an open PR (https://github.com/dotnet/maui/pull/29441), so the test is restricted on Windows for now.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -17,12 +16,17 @@ public class Issue29570 : _IssuesUITest
 	[Category(UITestCategories.Shell)]
 	public void VerifySearchQueryUpdateOnSecondShellTab()
 	{
+#if WINDOWS
+		App.Tap("navViewItem");
+		App.WaitForElement("DogsPage");
+		App.Tap("DogsPage");
+#else
 		App.WaitForElement("CatsPageUpdateQueryBtn");
 		App.TapTab("DogsPage");
+#endif
 		App.WaitForElement("UpdateQueryButton");
 		App.Tap("UpdateQueryButton");
 		var searchHandlerString = App.GetShellSearchHandler().GetText();
 		Assert.That(searchHandlerString, Is.EqualTo("Hound"));
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
@@ -17,14 +17,8 @@ public class Issue29570 : _IssuesUITest
 	[Category(UITestCategories.Shell)]
 	public void VerifySearchQueryUpdateOnSecondShellTab()
 	{
-#if WINDOWS
-		// App.Tap("navViewItem");
-		// App.WaitForElement("DogsPage");
-		// App.Tap("DogsPage");
-#else
 		App.WaitForElement("CatsPageUpdateQueryBtn");
 		App.TapTab("DogsPage");
-#endif
 		App.WaitForElement("UpdateQueryButton");
 		App.Tap("UpdateQueryButton");
 		var searchHandlerString = App.GetShellSearchHandler().GetText();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29570.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_WINDOWS // A fix for this issue is already available for Windows platform in an open PR (https://github.com/dotnet/maui/pull/29441), so the test is restricted on Windows for now.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -17,9 +18,9 @@ public class Issue29570 : _IssuesUITest
 	public void VerifySearchQueryUpdateOnSecondShellTab()
 	{
 #if WINDOWS
-		App.Tap("navViewItem");
-		App.WaitForElement("DogsPage");
-		App.Tap("DogsPage");
+		// App.Tap("navViewItem");
+		// App.WaitForElement("DogsPage");
+		// App.Tap("DogsPage");
 #else
 		App.WaitForElement("CatsPageUpdateQueryBtn");
 		App.TapTab("DogsPage");
@@ -30,3 +31,4 @@ public class Issue29570 : _IssuesUITest
 		Assert.That(searchHandlerString, Is.EqualTo("Hound"));
 	}
 }
+#endif


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- Unable to Programmatically Update SearchHandler Query Value on Second Tab within ShellSection.

### Root Cause

- When navigating to the second tab, the previous search handler remains attached to the SearchView, and the new handler is not being applied.

### Description of Change

- Introduced a new method RemoveSearchView to encapsulate the logic for cleaning up _searchView, replacing direct inline removal calls in multiple methods (Dispose, OnPageChanged, UpdateToolbarItems). This improves code readability and reduces duplication.
- Also ensured that the old SearchView is properly cleared, and a new one is created with the updated search handler upon page change.


### Issues Fixed
Fixes #29570 
Fixes #8716 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/ad8eb647-d7dd-441e-8966-6efa15aeb0bc"> | <video src="https://github.com/user-attachments/assets/1d65803e-05da-437d-ad39-5375c0383728"> |
