### PR TITLE
[iOS] Fix memory leak in CarouselViewHandler2

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -40,121 +40,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		protected override UICollectionViewLayout SelectLayout()
 		{
 			bool isHorizontal = VirtualView.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+			var peekInsets = VirtualView.PeekAreaInsets;
 
-			NSCollectionLayoutDimension itemWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
-			NSCollectionLayoutDimension itemHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
-			NSCollectionLayoutDimension groupWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
-			NSCollectionLayoutDimension groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
-			nfloat itemSpacing = 0;
-			NSCollectionLayoutGroup group = null;
+			var weakItemsView = new WeakReference<CarouselView>(ItemsView);
+			var weakController = new WeakReference<CarouselViewController2>((CarouselViewController2)Controller);
 
-			var layout = new UICollectionViewCompositionalLayout((sectionIndex, environment) =>
-			{
-				if (VirtualView is null)
-				{
-					return null;
-				}
-				double sectionMargin = 0.0;
-				if (!isHorizontal)
-				{
-					sectionMargin = VirtualView.PeekAreaInsets.VerticalThickness / 2;
-					var newGroupHeight = environment.Container.ContentSize.Height - VirtualView.PeekAreaInsets.VerticalThickness;
-					groupHeight = NSCollectionLayoutDimension.CreateAbsolute((nfloat)newGroupHeight);
-					groupWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
-				}
-				else
-				{
-					sectionMargin = VirtualView.PeekAreaInsets.HorizontalThickness / 2;
-					var newGroupWidth = environment.Container.ContentSize.Width - VirtualView.PeekAreaInsets.HorizontalThickness;
-					groupWidth = NSCollectionLayoutDimension.CreateAbsolute((nfloat)newGroupWidth);
-					groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
-				}
-
-				// Each item has a size
-				var itemSize = NSCollectionLayoutSize.Create(itemWidth, itemHeight);
-				// Create the item itself from the size
-				var item = NSCollectionLayoutItem.Create(layoutSize: itemSize);
-
-				//item.ContentInsets = new NSDirectionalEdgeInsets(0, itemInset, 0, 0);
-
-				var groupSize = NSCollectionLayoutSize.Create(groupWidth, groupHeight);
-
-				if (OperatingSystem.IsIOSVersionAtLeast(16))
-				{
-					group = isHorizontal ? NSCollectionLayoutGroup.GetHorizontalGroup(groupSize, item, 1) :
-										   NSCollectionLayoutGroup.GetVerticalGroup(groupSize, item, 1);
-				}
-				else
-				{
-					group = isHorizontal ? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, 1) :
-										   NSCollectionLayoutGroup.CreateVertical(groupSize, item, 1);
-				}
-
-				// Create our section layout
-				var section = NSCollectionLayoutSection.Create(group: group);
-				section.InterGroupSpacing = itemSpacing;
-				section.OrthogonalScrollingBehavior = isHorizontal ? UICollectionLayoutSectionOrthogonalScrollingBehavior.GroupPagingCentered : UICollectionLayoutSectionOrthogonalScrollingBehavior.None;
-				section.VisibleItemsInvalidationHandler = (items, offset, env) =>
-				{
-					//This will allow us to SetPosition when we are scrolling the items
-					//based on the current page
-					var page = (offset.X + sectionMargin) / env.Container.ContentSize.Width;
-
-					// Check if we not are at the beginning or end of the page and if we have items
-					if (Math.Abs(page % 1) > (double.Epsilon * 100) || Controller.ItemsSource.ItemCount <= 0)
-					{
-						return;
-					}
-
-					var pageIndex = (int)page;
-					var carouselPosition = pageIndex;
-
-					var cv2Controller = (CarouselViewController2)Controller;
-
-					//If we are looping, we need to get the correct position
-					if (ItemsView.Loop)
-					{
-						var maxIndex = (Controller.ItemsSource as ILoopItemsViewSource).LoopCount - 1;
-
-						//To mimic looping, we needed to modify the ItemSource and inserted a new item at the beginning and at the end
-						if (pageIndex == maxIndex)
-						{
-							//When at last item, we need to change to 2nd item, so we can scroll right or left
-							pageIndex = 1;
-						}
-						else if (pageIndex == 0)
-						{
-							//When at first item, need to change to one before last, so we can scroll right or left
-							pageIndex = maxIndex - 1;
-						}
-
-						//since we added one item at the beginning of our ItemSource, we need to subtract one
-						carouselPosition = pageIndex - 1;
-
-						if (ItemsView.Position != carouselPosition)
-						{
-							//If we are updating the ItemsSource, we don't want to scroll the CollectionView
-							if (cv2Controller.IsUpdating())
-							{
-								return;
-							}
-
-							var goToIndexPath = cv2Controller.GetScrollToIndexPath(carouselPosition);
-
-							//This will move the carousel to fake the loop
-							Controller.CollectionView.ScrollToItem(NSIndexPath.FromItemSection(pageIndex, 0), UICollectionViewScrollPosition.Left, false);
-
-						}
-					}
-
-					//Update the CarouselView position
-					cv2Controller?.SetPosition(carouselPosition);
-
-				};
-				return section;
-			});
-
-			return layout;
+			return LayoutFactory2.CreateCarouselLayout(
+				isHorizontal,
+				peekInsets,
+				weakItemsView,
+				weakController);
 		}
 
 		protected override void ScrollToRequested(object sender, ScrollToRequestEventArgs args)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using CoreGraphics;
+using Foundation;
+using Microsoft.Maui.Controls.Handlers.Items;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items2;
@@ -261,6 +263,134 @@ internal static class LayoutFactory2
 			gridItemsLayout.Span);
 
 
+#nullable disable
+	public static UICollectionViewLayout CreateCarouselLayout(
+		bool isHorizontal,
+		Thickness peekAreaInsets,
+		WeakReference<CarouselView> weakItemsView,
+		WeakReference<CarouselViewController2> weakController)
+	{
+		NSCollectionLayoutDimension itemWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
+		NSCollectionLayoutDimension itemHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
+		NSCollectionLayoutDimension groupWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
+		NSCollectionLayoutDimension groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
+		nfloat itemSpacing = 0;
+		NSCollectionLayoutGroup group = null;
+
+		var layout = new UICollectionViewCompositionalLayout((sectionIndex, environment) =>
+		{
+			if (!weakItemsView.TryGetTarget(out var itemsView) || !weakController.TryGetTarget(out var controller))
+			{
+				return null;
+			}
+
+
+
+			double sectionMargin = 0.0;
+
+			if (!isHorizontal)
+			{
+				sectionMargin = peekAreaInsets.VerticalThickness / 2;
+				var newGroupHeight = environment.Container.ContentSize.Height - peekAreaInsets.VerticalThickness;
+				groupHeight = NSCollectionLayoutDimension.CreateAbsolute((nfloat)newGroupHeight);
+				groupWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
+			}
+			else
+			{
+				sectionMargin = peekAreaInsets.HorizontalThickness / 2;
+				var newGroupWidth = environment.Container.ContentSize.Width - peekAreaInsets.HorizontalThickness;
+				groupWidth = NSCollectionLayoutDimension.CreateAbsolute((nfloat)newGroupWidth);
+				groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
+			}
+
+			// Each item has a size
+			var itemSize = NSCollectionLayoutSize.Create(itemWidth, itemHeight);
+			// Create the item itself from the size
+			var item = NSCollectionLayoutItem.Create(layoutSize: itemSize);
+
+			//item.ContentInsets = new NSDirectionalEdgeInsets(0, itemInset, 0, 0);
+
+			var groupSize = NSCollectionLayoutSize.Create(groupWidth, groupHeight);
+
+			if (OperatingSystem.IsIOSVersionAtLeast(16))
+			{
+				group = isHorizontal
+					? NSCollectionLayoutGroup.GetHorizontalGroup(groupSize, item, 1)
+					: NSCollectionLayoutGroup.GetVerticalGroup(groupSize, item, 1);
+			}
+			else
+			{
+				group = isHorizontal
+					? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, 1)
+					: NSCollectionLayoutGroup.CreateVertical(groupSize, item, 1);
+			}
+
+			var section = NSCollectionLayoutSection.Create(group: group);
+			section.InterGroupSpacing = itemSpacing;
+			section.OrthogonalScrollingBehavior = isHorizontal
+				? UICollectionLayoutSectionOrthogonalScrollingBehavior.GroupPagingCentered
+				: UICollectionLayoutSectionOrthogonalScrollingBehavior.None;
+
+			section.VisibleItemsInvalidationHandler = (items, offset, env) =>
+			{
+				if (!weakItemsView.TryGetTarget(out var itemsView) || !weakController.TryGetTarget(out var cv2Controller))
+					return;
+
+				var page = (offset.X + sectionMargin) / env.Container.ContentSize.Width;
+
+				if (Math.Abs(page % 1) > (double.Epsilon * 100) || cv2Controller.ItemsSource.ItemCount <= 0)
+					return;
+
+				var pageIndex = (int)page;
+				var carouselPosition = pageIndex;
+
+				if (itemsView.Loop && cv2Controller.ItemsSource is ILoopItemsViewSource loopSource)
+				{
+					var maxIndex = loopSource.LoopCount - 1;
+
+					//To mimic looping, we needed to modify the ItemSource and inserted a new item at the beginning and at the end
+					if (pageIndex == maxIndex)
+					{
+						//When at last item, we need to change to 2nd item, so we can scroll right or left
+						pageIndex = 1;
+					}
+					else if (pageIndex == 0)
+					{
+						//When at first item, need to change to one before last, so we can scroll right or left
+						pageIndex = maxIndex - 1;
+					}
+
+					//since we added one item at the beginning of our ItemSource, we need to subtract one
+					carouselPosition = pageIndex - 1;
+
+					if (itemsView.Position != carouselPosition)
+					{
+						//If we are updating the ItemsSource, we don't want to scroll the CollectionView
+						if (cv2Controller.IsUpdating())
+						{
+							return;
+						}
+
+						var goToIndexPath = cv2Controller.GetScrollToIndexPath(carouselPosition);
+
+						//This will move the carousel to fake the loop
+						cv2Controller.CollectionView.ScrollToItem(
+							NSIndexPath.FromItemSection(pageIndex, 0),
+							UICollectionViewScrollPosition.Left,
+							false);
+					}
+				}
+
+				//Update the CarouselView position
+				cv2Controller?.SetPosition(carouselPosition);
+			};
+
+			return section;
+		});
+
+		return layout;
+	}
+#nullable enable
 	class CustomUICollectionViewCompositionalLayout : UICollectionViewCompositionalLayout
 	{
 		LayoutSnapInfo _snapInfo;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -284,8 +284,6 @@ internal static class LayoutFactory2
 				return null;
 			}
 
-
-
 			double sectionMargin = 0.0;
 
 			if (!isHorizontal)
@@ -334,12 +332,16 @@ internal static class LayoutFactory2
 			section.VisibleItemsInvalidationHandler = (items, offset, env) =>
 			{
 				if (!weakItemsView.TryGetTarget(out var itemsView) || !weakController.TryGetTarget(out var cv2Controller))
+				{
 					return;
+				}
 
 				var page = (offset.X + sectionMargin) / env.Container.ContentSize.Width;
 
 				if (Math.Abs(page % 1) > (double.Epsilon * 100) || cv2Controller.ItemsSource.ItemCount <= 0)
+				{
 					return;
+				}
 
 				var pageIndex = (int)page;
 				var carouselPosition = pageIndex;

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -11,6 +11,9 @@ using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.DeviceTests.Stubs;
+#if IOS || MACCATALYST
+using Microsoft.Maui.Controls.Handlers.Items2;
+#endif
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
@@ -20,6 +23,11 @@ namespace Microsoft.Maui.DeviceTests.Memory;
 [Category(TestCategory.Memory)]
 public class MemoryTests : ControlsHandlerTestBase
 {
+	// Subclasses used to enable memory tests for CV2 handlers
+	public class CollectionView2 : CollectionView { }
+	public class CarouselView2 : CarouselView { }
+
+
 	void SetupBuilder()
 	{
 		EnsureHandlerCreated(builder =>
@@ -31,6 +39,10 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<BoxView, BoxViewHandler>();
 				handlers.AddHandler<CarouselView, CarouselViewHandler>();
 				handlers.AddHandler<CollectionView, CollectionViewHandler>();
+#if IOS || MACCATALYST
+				handlers.AddHandler<CollectionView2,CollectionViewHandler2>();
+				handlers.AddHandler<CarouselView2,CarouselViewHandler2>();
+#endif
 				handlers.AddHandler<CheckBox, CheckBoxHandler>();
 				handlers.AddHandler<DatePicker, DatePickerHandler>();
 				handlers.AddHandler<Shape, ShapeViewHandler>();
@@ -170,6 +182,10 @@ public class MemoryTests : ControlsHandlerTestBase
 	[InlineData(typeof(TableView))]
 	//[InlineData(typeof(WebView))] - This test was moved to MemoryTests.cs inside Appium
 	[InlineData(typeof(CollectionView))]
+#if IOS || MACCATALYST
+	//[InlineData(typeof(CollectionView2))] - Fails, Check https://github.com/dotnet/maui/issues/29619
+	[InlineData(typeof(CarouselView2))]
+#endif
 	public async Task HandlerDoesNotLeak(Type type)
 	{
 		SetupBuilder();
@@ -177,7 +193,7 @@ public class MemoryTests : ControlsHandlerTestBase
 #if ANDROID
 		// NOTE: skip certain controls on older Android devices
 		if ((type == typeof(DatePicker) || type == typeof(ListView)) && !OperatingSystem.IsAndroidVersionAtLeast(30))
-				return;
+			return;
 
 		if (type == typeof(HybridWebView) && !OperatingSystem.IsAndroidVersionAtLeast(24))
 		{
@@ -259,8 +275,12 @@ public class MemoryTests : ControlsHandlerTestBase
 		await AssertionExtensions.WaitForGC(viewReference, handlerReference, platformViewReference);
 	}
 
-	[Fact("CollectionView Header/Footer Doesn't Leak")]
-	public async Task CollectionViewHeaderFooterDoesntLeak()
+	[Theory("CollectionView Header/Footer Doesn't Leak")]
+	[InlineData(typeof(CollectionView))]
+#if IOS || MACCATALYST
+	//[InlineData(typeof(CollectionView2))] Fails, Check https://github.com/dotnet/maui/issues/29619
+#endif
+	public async Task CollectionViewHeaderFooterDoesntLeak(Type type)
 	{
 		SetupBuilder();
 
@@ -273,20 +293,19 @@ public class MemoryTests : ControlsHandlerTestBase
 
 		await CreateHandlerAndAddToWindow(new Window(navPage), async () =>
 		{
-			var cv = new CollectionView
+			var cv = (CollectionView)Activator.CreateInstance(type);
+			cv.Footer = new VerticalStackLayout();
+			cv.Header = new VerticalStackLayout();
+			cv.ItemTemplate = new DataTemplate(() =>
 			{
-				Footer = new VerticalStackLayout(),
-				Header = new VerticalStackLayout(),
-				ItemTemplate = new DataTemplate(() =>
+				var view = new Label
 				{
-					var view = new Label
-					{
-					};
-					view.SetBinding(Label.TextProperty, ".");
-					return view;
-				}),
-				ItemsSource = observable
-			};
+				};
+				view.SetBinding(Label.TextProperty, ".");
+				return view;
+			});
+			cv.ItemsSource = observable;
+
 
 			viewReference = new WeakReference(cv);
 			handlerReference = new WeakReference(cv.Handler);
@@ -298,10 +317,20 @@ public class MemoryTests : ControlsHandlerTestBase
 			});
 
 
-#if IOS
-			var controller = (cv.Handler as CollectionViewHandler).Controller;
-			controllerReference = new WeakReference(controller);
-			controller = null;
+#if IOS || MACCATALYST
+			var cv1handler = cv.Handler as CollectionViewHandler;
+			var cv2handler = cv.Handler as CollectionViewHandler2;
+
+			if (cv1handler is not null)
+			{
+				controllerReference = new WeakReference(cv1handler.Controller);
+			}
+			else if (cv2handler is not null)
+			{
+				controllerReference = new WeakReference(cv2handler.Controller);
+			}
+			cv1handler = null;
+			cv2handler = null;
 #else
 			controllerReference = new WeakReference(new object());
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

`CarouselViewHandler2` sets a `VisibleItemsInvalidationHandler` on the `NSCollectionLayoutSection` during layout construction. This handler captures strong references to `VirtualView` and `Controller`, causing a memory leak.

Updated the handler to use WeakReference's. Moved Layout creation to `LayoutFacotry`

<!-- Enter description of the fix in this section -->

<table>
  <tr>
<th>Befor fix</th>
<th>After fix</th>
</tr>
<tr>
<td>


<img  height="500" alt="Image" src="https://github.com/user-attachments/assets/bb6062d1-34d8-43bd-a28e-3b80e42884ae" />




</td>
<td>




<img  height="500" alt="Screenshot 2025-05-29 at 12 56 59 AM" src="https://github.com/user-attachments/assets/6e178fa5-4d98-4ad1-8f3d-9d51d4371e5a" />





</td>
</tr>
</table>

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29677

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
