### PR TITLE
[.NET 10] Remove MessagingCenter usage for close ListView ContextActions

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -82,8 +82,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			realListView.OnItemClickListener = this;
 			realListView.OnItemLongClickListener = this;
 
-			//TODO: MAUI
-			//MessagingCenter.Subscribe<ListViewAdapter>(this, Platform.CloseContextActionsSignalName, lva => CloseContextActions());
+			var currentWindow = Application.Current?.Windows.FirstOrDefault();
+			var modalNavigationManager = currentWindow?.ModalNavigationManager;
+
+			if (modalNavigationManager is not null)
+			{
+				modalNavigationManager.RequestCloseContextActions += OnCloseContextActions;
+			}
 
 			InvalidateCount();
 		}
@@ -522,8 +527,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				CloseContextActions();
 
-				// TODO: MAUI
-				//MessagingCenter.Unsubscribe<ListViewAdapter>(this, Platform.CloseContextActionsSignalName);
+				var currentWindow = Application.Current?.Windows.FirstOrDefault();
+				var modalNavigationManager = currentWindow?.ModalNavigationManager;
+
+				if (modalNavigationManager is not null)
+				{
+					modalNavigationManager.RequestCloseContextActions -= OnCloseContextActions;
+				}
 
 				_realListView.OnItemClickListener = null;
 				_realListView.OnItemLongClickListener = null;
@@ -543,6 +553,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 
 			base.Dispose(disposing);
+		}
+
+		void OnCloseContextActions(object sender, EventArgs e)
+		{
+			CloseContextActions();
 		}
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
@@ -452,18 +453,20 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (Element.CurrentPage == null)
 				return;
 
-			// TODO MAUI
-			//if (Platform != null)
-			//{
-			//	Platform.NavAnimationInProgress = true;
-			//}
+			var currentWindow = Element.Handler?.MauiContext?.GetPlatformWindow()?.GetWindow() as Window;
+			var modalNavigationManager = currentWindow?.ModalNavigationManager;
+
+			if (modalNavigationManager is not null)
+			{
+				modalNavigationManager.NavAnimationInProgress = true;
+			}
 
 			_viewPager.SetCurrentItem(Element.Children.IndexOf(Element.CurrentPage), Element.OnThisPlatform().IsSmoothScrollEnabled());
 
-			//if (Platform != null)
-			//{
-			//	Platform.NavAnimationInProgress = false;
-			//}
+			if (modalNavigationManager is not null)
+			{
+				modalNavigationManager.NavAnimationInProgress = false;
+			}
 		}
 
 		void UpdateIgnoreContainerAreas()

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -24,11 +24,12 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		ViewGroup? _modalParentView;
 		bool _navAnimationInProgress;
-		internal const string CloseContextActionsSignalName = "Xamarin.CloseContextActions";
 		AAnimation? _dismissAnimation;
 		bool _platformActivated;
 
 		readonly Stack<string> _modals = [];
+
+		internal event EventHandler? RequestCloseContextActions;
 
 		partial void InitializePlatform()
 		{
@@ -106,10 +107,7 @@ namespace Microsoft.Maui.Controls.Platform
 					return;
 				_navAnimationInProgress = value;
 
-#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
-				if (value)
-					MessagingCenter.Send(this, CloseContextActionsSignalName);
-#pragma warning restore CS0618 // Type or member is obsolete
+				RequestCloseContextActions?.Invoke(this, EventArgs.Empty);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Remove MessagingCenter usage for close ListView ContextActions from NavigationManager.
This change is part of an ongoing .NET MAUI threat modeling initiative aimed at identifying potential security risks and implementing proactive improvements to enhance application safety. In this PR we remove the usage of an obsoleted API.

### Issues Fixed

Related  with https://github.com/dotnet/maui/issues/28855