### PR TITLE
[sample] Allow sample to run with different .net than on machine

### DIFF
--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -22,6 +22,7 @@
     <ApplicationId>com.microsoft.maui.sample</ApplicationId>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
+    <WindowsPackageType>None</WindowsPackageType>
     <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
@@ -82,10 +83,6 @@
     <MauiIcon Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" />
     <MauiFont Include="Resources\Fonts\*" />
     <MauiSplashScreen Include="Resources\Splash\dotnet_splash.svg" Color="#FFFFFF" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Remove="Properties\launchSettings.json" />
   </ItemGroup>
 
   <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\..\BlazorWebView\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.targets" />

--- a/src/Controls/samples/Controls.Sample/Properties/launchSettings.json
+++ b/src/Controls/samples/Controls.Sample/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "Windows Machine": {
-      "commandName": "MsixPackage",
+      "commandName": "Project",
       "nativeDebugging": true
     }
   }


### PR DESCRIPTION
### Description of Change

Sometimes for example on net10.0 branch we want to run the sample with a particular .net version, by using the unpackaged type it allows it and we don t get an error saying the particular runtime is not installed on the machine.