### PR TITLE
Fix Stepper control fails to reach maximum value when increment exceeds remaining threshold

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29740.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29740.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 29740, "[Windows]Stepper control fails to reach maximum value when increment exceeds remaining threshold",
+[Issue(IssueTracker.Github, 29740, "[Windows] Stepper control fails to reach maximum value when increment exceeds remaining threshold",
 	PlatformAffected.UWP)]
 public class Issue29740 : ContentPage
 {

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29740.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29740.cs
@@ -1,0 +1,64 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29740, "[Windows]Stepper control fails to reach maximum value when increment exceeds remaining threshold",
+	PlatformAffected.UWP)]
+public class Issue29740 : ContentPage
+{
+	Label stepperValueLabel;
+	Stepper myStepper;
+
+	public Issue29740()
+	{
+		// Initialize the label
+		stepperValueLabel = new Label
+		{
+			AutomationId = "29740StepperValueLabel",
+			Text = "Stepper Value: 0",
+			FontSize = 18,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		// Initialize the stepper
+		myStepper = new Stepper
+		{
+			AutomationId = "29740Stepper",
+			Minimum = 0,
+			Maximum = 10,
+			Increment = 3,
+			HorizontalOptions = LayoutOptions.Center
+		};
+		myStepper.ValueChanged += OnStepperValueChanged;
+
+		// Create the layout
+		var verticalStack = new VerticalStackLayout
+		{
+			Padding = new Thickness(30, 0),
+			Spacing = 25,
+			Children =
+				{
+					stepperValueLabel,
+					myStepper
+				}
+		};
+
+		// Embed in a ScrollView
+		Content = new ScrollView
+		{
+			Content = verticalStack
+		};
+
+		// Optionally update initial value display
+		UpdateLabel(myStepper.Value);
+	}
+
+	private void OnStepperValueChanged(object sender, ValueChangedEventArgs e)
+	{
+		UpdateLabel(e.NewValue);
+	}
+
+	private void UpdateLabel(double value)
+	{
+		stepperValueLabel.Text = $"Stepper Value: {value}";
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29740.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29740.cs
@@ -16,7 +16,6 @@ public class Issue29740 : _IssuesUITest
 	[Category(UITestCategories.Stepper)]
 	public void GestureRecognizersOnLabelSpanShouldWork()
 	{
-		App.WaitForElement("29740Stepper");
 		var initialvalue = App.WaitForElement("29740StepperValueLabel").GetText();
 		Assert.That(initialvalue, Is.EqualTo("Stepper Value: 0"));
 		for (int i = 0; i < 4; i++)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29740.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29740.cs
@@ -10,7 +10,7 @@ public class Issue29740 : _IssuesUITest
 	{
 	}
 
-	public override string Issue => "[Windows]Stepper control fails to reach maximum value when increment exceeds remaining threshold";
+	public override string Issue => "[Windows] Stepper control fails to reach maximum value when increment exceeds remaining threshold";
 
 	[Test]
 	[Category(UITestCategories.Stepper)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29740.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29740.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29740 : _IssuesUITest
+{
+	public Issue29740(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "[Windows]Stepper control fails to reach maximum value when increment exceeds remaining threshold";
+
+	[Test]
+	[Category(UITestCategories.Stepper)]
+	public void GestureRecognizersOnLabelSpanShouldWork()
+	{
+		App.WaitForElement("29740Stepper");
+		var initialvalue = App.WaitForElement("29740StepperValueLabel").GetText();
+		Assert.That(initialvalue, Is.EqualTo("Stepper Value: 0"));
+		for (int i = 0; i < 4; i++)
+		{
+			App.IncreaseStepper("29740Stepper");
+		}
+		var finalvalue = App.WaitForElement("29740StepperValueLabel").GetText();
+		Assert.That(finalvalue, Is.EqualTo("Stepper Value: 10"));
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiStepper.cs
+++ b/src/Core/src/Platform/Windows/MauiStepper.cs
@@ -258,9 +258,6 @@ namespace Microsoft.Maui.Platform
 		void UpdateValue(double delta)
 		{
 			double newValue = Value + delta;
-			if (newValue > Maximum || newValue < Minimum)
-				return;
-
 			Value = newValue;
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Description: 

On the Windows platform, the stepper control does not update to the defined maximum value if the increment step is larger than the remaining threshold to reach that maximum. 
 
### RootCause:

On the Windows platform, the MauiStepper native control uses a method called UpdateValue, which stops updating the value if it tries to go beyond the defined minimum or maximum limits.
However, on other platforms, the value is updated directly through the Value property, regardless of the min/max limits. The actual limit enforcement happens later through coerceValue  logic. 

### Description of Change:

In order to achieve same behavior, we should directly set the value and rely on CoerceValue to enforce the min/max boundaries.

### Issues Fixed
Fixes #29740 

### Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac


### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/584b8379-50ea-45fb-8a78-44081dfab3fd">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/99d5aa72-6951-40f4-869c-8d61bab5607d">|
