### PR TITLE
[Testing] Fix TapCoordinates method in Catalyst

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue12685.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue12685.cs
@@ -21,12 +21,8 @@ public class Issue12685 : _IssuesUITest
 	{
 		var testLabel = App.WaitForFirstElement(StatusLabelId);
 		Assert.That(testLabel.ReadText(), Is.EqualTo(ResetStatus));
-		var labelRect = App.WaitForFirstElement(StatusLabelId).GetRect(); // Path element not able get via automationid so getting the rect of the label calculated points to tap on the path
-#if MACCATALYST // TapCoordinates is not working on MacCatalyst Issue: https://github.com/dotnet/maui/issues/19754
-        App.ClickCoordinates(labelRect.X + 3, labelRect.Y - 10);
-#else
+		var labelRect = App.WaitForFirstElement(StatusLabelId).GetRect(); // Path element not able get via AutomationId so getting the rect of the label calculated points to tap on the path
 		App.TapCoordinates(labelRect.X + 3, labelRect.Y - 10);
-#endif
 		App.WaitForElement(StatusLabelId);
 		Assert.That(testLabel.ReadText(), Is.EqualTo(ClickedStatus));
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2894.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue2894.cs
@@ -44,11 +44,7 @@ public class Issue2894 : _IssuesUITest
 
 	void PerformGestureAction(float x, float y)
 	{
-#if MACCATALYST // TapCoordinates is not working on MacCatalyst Issue: https://github.com/dotnet/maui/issues/19754
-		App.ClickCoordinates(x, y);
-#else
 		App.TapCoordinates(x, y);
-#endif
 	}
 
 	void PerformGestureActionForFirstSpan(Rectangle target)

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -16,8 +16,6 @@ namespace UITest.Appium
 		/// <summary>
 		/// For desktop, this will perform a mouse click on the target element.
 		/// For mobile, this will tap the element.
-		/// This API works for all platforms whereas TapCoordinates currently doesn't work on Catalyst
-		/// https://github.com/dotnet/maui/issues/19754
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
 		/// <param name="element">Target Element.</param>
@@ -29,8 +27,6 @@ namespace UITest.Appium
 		/// <summary>
 		/// For desktop, this will perform a mouse click on the target element.
 		/// For mobile, this will tap the element.
-		/// This API works for all platforms whereas TapCoordinates currently doesn't work on Catalyst
-		/// https://github.com/dotnet/maui/issues/19754
 		/// </summary>
 		/// <param name="app">Represents the main gateway to interact with an app.</param>
 		/// <param name="query">Represents the query that identify an element by parameters such as type, text it contains or identifier.</param>
@@ -308,8 +304,6 @@ namespace UITest.Appium
 		/// <summary>
 		/// For desktop, this will perform a mouse click on the target element.
 		/// For mobile, this will tap the element.
-		/// This API works for all platforms whereas TapCoordinates currently doesn't work on Catalyst
-		/// https://github.com/dotnet/maui/issues/19754
 		/// </summary>
 		/// <param name="element">Target Element.</param>
 		public static void Tap(this IUIElement element)
@@ -409,11 +403,18 @@ namespace UITest.Appium
 		/// <param name="y">The y coordinate to double tap.</param>
 		public static void DoubleTapCoordinates(this IApp app, float x, float y)
 		{
-			app.CommandExecutor.Execute("doubleTapCoordinates", new Dictionary<string, object>
+			if (app is AppiumCatalystApp)
 			{
-				{ "x", x },
-				{ "y", y }
-			});
+				app.DoubleClickCoordinates(x, y); // Directly invoke coordinate-based double click for AppiumCatalystApp.
+			}
+			else
+			{
+				app.CommandExecutor.Execute("doubleTapCoordinates", new Dictionary<string, object>
+				{
+					{ "x", x },
+					{ "y", y }
+				});
+			}
 		}
 
 		/// <summary>
@@ -1422,11 +1423,18 @@ namespace UITest.Appium
 		/// <param name="y">The y coordinate to tap.</param>
 		public static void TapCoordinates(this IApp app, float x, float y)
 		{
-			app.CommandExecutor.Execute("tapCoordinates", new Dictionary<string, object>
+			if (app is AppiumCatalystApp)
 			{
-				{ "x", x },
-				{ "y", y }
-			});
+				app.ClickCoordinates(x, y); // // Directly invoke coordinate-based click for AppiumCatalystApp.
+			}
+			else
+			{
+				app.CommandExecutor.Execute("tapCoordinates", new Dictionary<string, object>
+				{
+					{ "x", x },
+					{ "y", y }
+				});
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Description of Change

Fix `TapCoordinates` method in Catalyst. No longer requires to use compilation directives in tests, , improving clarity and maintainability.

Fixes #19754