### PR TITLE
[Windows] Fix for CurrentItemChangedEventArgs and PositionChangedEventArgs Not Working Properly in CarouselView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -549,6 +549,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				&& currentItemPosition != -1)
 			{
 				carouselPosition = currentItemPosition;
+				ItemsView.Position = currentItemPosition;
+			}
+
+			if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepLastItemInView)
+			{
+				carouselPosition = count == 0 ? 0 : count - 1;
+			}
+			else if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
+			{
+				carouselPosition = 0;
 			}
 
 			SetCarouselViewCurrentItem(carouselPosition);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29529.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29529.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29529, "CurrentItemChangedEventArgs and PositionChangedEventArgs Not Updating Correctly in CarouselView", PlatformAffected.UWP)]
+public class Issue29529 : ContentPage
+{
+	public Issue29529()
+	{
+		var verticalStackLayout = new VerticalStackLayout();
+		var carouselItems = new ObservableCollection<string>
+		{
+			"Item 1",
+			"Item 2",
+			"Item 3",
+			"Item 4",
+			"Item 5",
+			"Item 6",
+		};
+
+		CarouselView carouselView = new CarouselView
+		{
+			ItemsSource = carouselItems,
+			AutomationId = "carouselview",
+			ItemsUpdatingScrollMode = ItemsUpdatingScrollMode.KeepItemsInView,
+			Loop = false,
+			HeightRequest = 300,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid
+				{
+					Padding = 10
+				};
+
+				var label = new Label
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					FontSize = 18,
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				label.SetBinding(Label.AutomationIdProperty, ".");
+
+				grid.Children.Add(label);
+				return grid;
+			}),
+			HorizontalOptions = LayoutOptions.Fill,
+		};
+
+		var positionLabel = new Label
+		{
+			AutomationId = "positionLabel",
+			Text = $"Current Position{carouselView.Position}",
+			HorizontalOptions = LayoutOptions.Center,
+			Padding = new Thickness(20),
+		};
+
+		var itemLabel = new Label
+		{
+			AutomationId = "itemLabel",
+			Text = $"Current Item{carouselView.CurrentItem}",
+			HorizontalOptions = LayoutOptions.Center,
+			Padding = new Thickness(20),
+		};
+
+		carouselView.PositionChanged += (s, e) =>
+		{
+			positionLabel.Text = $"Current Position: {e.CurrentPosition}, Previous Position: {e.PreviousPosition}";
+		};
+
+		carouselView.CurrentItemChanged += (s, e) =>
+		{
+			itemLabel.Text = $"Current Item: {e.CurrentItem}, Previous Item: {e.PreviousItem}";
+		};
+
+		var insertButton = new Button
+		{
+			Text = "Insert item at index 0",
+			AutomationId = "InsertButton",
+			Margin = new Thickness(20),
+		};
+
+		insertButton.Clicked += (sender, e) =>
+		{
+			carouselItems.Insert(0, "Item 0");
+		};
+
+		verticalStackLayout.Children.Add(carouselView);
+		verticalStackLayout.Children.Add(insertButton);
+		verticalStackLayout.Children.Add(positionLabel);
+		verticalStackLayout.Children.Add(itemLabel);
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29529.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29529.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29529 : _IssuesUITest
+{
+	public override string Issue => "CurrentItemChangedEventArgs and PositionChangedEventArgs Not Updating Correctly in CarouselView";
+
+	public Issue29529(TestDevice device)
+	: base(device)
+	{ }
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void Issue29529VerifyPreviousPositionOnInsert()
+	{
+		App.WaitForElement("carouselview");
+		App.Tap("InsertButton");
+		var text = App.FindElement("positionLabel").GetText();
+		Assert.That(text, Is.EqualTo("Current Position: 0, Previous Position: 1"));
+		text = App.FindElement("itemLabel").GetText();
+		Assert.That(text, Is.EqualTo("Current Item: Item 0, Previous Item: Item 1"));
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### RootCause :
When new item added, the carousel position remains at the last known item, which prevents the item and position from updating correctly.
### Description of Change
The carousel position is updated based on the ItemsUpdatingScrollMode to adjust its behavior and maintain both the current and previous item accordingly. When item added, ItemsView.Position sets the new current item, ensuring both the previous and current positions are updated correctly.

### Issues Fixed

### Tested the behaviour in the following platforms
- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/d89b5c74-34b3-4a0b-ba47-b7deec1f56f3"> | <img src="https://github.com/user-attachments/assets/37683e85-770d-4a07-8427-7e77d8fcc6cc"> |
