### PR TITLE
[Catalyst] Fix: CollectionView Crash

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -25,12 +25,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (indexPath is null || indexPath.Handle == IntPtr.Zero)
+			{
+				return;
+			}
+
 			FormsSelectItem(indexPath);
 		}
 
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (indexPath is null || indexPath.Handle == IntPtr.Zero)
+			{
+				return;
+			}
+
 			FormsDeselectItem(indexPath);
 		}
 
@@ -38,6 +48,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void SelectItem(object selectedItem)
 		{
 			var index = GetIndexForItem(selectedItem);
+
+			if (index is null || index.Handle == IntPtr.Zero)
+			{
+				return;
+			}
 
 			if (index.Section > -1 && index.Item > -1)
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -25,12 +25,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (indexPath is null || indexPath.Handle == IntPtr.Zero)
+			{
+				return;
+			}
+
 			FormsSelectItem(indexPath);
 		}
 
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (indexPath is null || indexPath.Handle == IntPtr.Zero)
+			{
+				return;
+			}
+
 			FormsDeselectItem(indexPath);
 		}
 
@@ -38,6 +48,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		internal void SelectItem(object selectedItem)
 		{
 			var index = GetIndexForItem(selectedItem);
+
+			if (index is null || index.Handle == IntPtr.Zero)
+			{
+				return;
+			}
 
 			if (index.Section > -1 && index.Item > -1)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

- A crash was reported on Mac Catalyst with the following exception: `ObjectDisposed_Generic for Foundation.NSIndexPath`, occurring during selection in a CollectionView.

-  Based on the call stack, the crash originates from SelectableItemsViewController.ItemSelected, which attempts to use a disposed NSIndexPath. Although I was unable to reproduce the issue despite testing scenarios such as:
    - Changing the ItemsSource
   - Updating the collection while an item is selected
   - Removing the selected item at runtime
   - Performing rapid updates

- I have provided a defensive fix by adding a null and handle check before invoking FormsSelectItem, FormsDeselectItem and SelectItem.
- This change is expected to prevent the crash by defensively checking for a disposed NSIndexPath, without affecting expected selection behavior.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29791

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
