### PR TITLE
[Android] Switch have different track color in light mode when application started in dark mode - fix

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -308,6 +308,7 @@ public static partial class AppHostBuilderExtensions
 		WebView.RemapForControls();
 		ContentPage.RemapForControls();
 		ImageButton.RemapForControls();
+		Switch.RemapForControls();
 
 		Slider.RemapForControls();
 		return builder;

--- a/src/Controls/src/Core/Switch/Switch.Mapper.cs
+++ b/src/Controls/src/Core/Switch/Switch.Mapper.cs
@@ -1,0 +1,37 @@
+namespace Microsoft.Maui.Controls;
+
+public partial class Switch
+{
+	internal static new void RemapForControls()
+	{
+#if ANDROID
+			SwitchHandler.Mapper.AppendToMapping<Switch, ISwitchHandler>(nameof(ISwitch.TrackColor), MapTrackColor);
+#endif
+	}
+
+#if ANDROID
+	private static void MapTrackColor(ISwitchHandler handler, Switch view)
+	{
+		if (view.IsToggled)
+		{
+			return;
+		}
+
+		if (handler.PlatformView is AndroidX.AppCompat.Widget.SwitchCompat aSwitch)
+		{
+			//https://android.googlesource.com/platform/frameworks/support/+/9d5f84f/v7/appcompat/res/color/abc_tint_switch_track.xml
+			var isDarkTheme = Application.Current?.UserAppTheme != ApplicationModel.AppTheme.Unspecified
+				? Application.Current?.UserAppTheme == ApplicationModel.AppTheme.Dark
+				: Application.Current.PlatformAppTheme == ApplicationModel.AppTheme.Dark;
+
+			var trackMaterial = isDarkTheme ? Resource.Color.foreground_material_dark : Resource.Color.foreground_material_light;
+			var trackColor = new Android.Graphics.Color(AndroidX.Core.Content.ContextCompat.GetColor(handler.PlatformView.Context, trackMaterial));
+
+			var alphaChannel = view.IsEnabled ? 0.3f : 0.1f;
+			var trackColorWithAlpha = new Android.Graphics.Color(trackColor.R, trackColor.G, trackColor.B, (int)(trackColor.A * alphaChannel));
+
+			aSwitch.TrackDrawable?.SetColorFilter(trackColorWithAlpha, FilterMode.SrcIn);
+		}
+	}
+}
+#endif

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -16,10 +16,7 @@ namespace Microsoft.Maui.Platform
 			{
 				aSwitch.TrackDrawable?.SetColorFilter(trackColor, FilterMode.SrcAtop);
 			}
-			else
-			{
-				aSwitch.TrackDrawable?.ClearColorFilter();
-			}
+
 		}
 
 		public static void UpdateThumbColor(this ASwitch aSwitch, ISwitch view)


### PR DESCRIPTION
…ation started in dark mode

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

For fellow developers 🙂

If this PR doesn’t get merged, you can still apply the fix by adding the following code to your custom handlers.

```c#
Microsoft.Maui.Handlers.SwitchHandler.Mapper.AppendToMapping<Switch, ISwitchHandler>(nameof(ISwitch.TrackColor),(handler, view) =>
{
	if (view.IsToggled)
	{
		return;
	}

	if (handler.PlatformView is AndroidX.AppCompat.Widget.SwitchCompat aSwitch)
	{
		//https://android.googlesource.com/platform/frameworks/support/+/9d5f84f/v7/appcompat/res/color/abc_tint_switch_track.xml
		var isDarkTheme = Application.Current?.UserAppTheme != AppTheme.Unspecified
			? Application.Current?.UserAppTheme == AppTheme.Dark
			: Application.Current.PlatformAppTheme == AppTheme.Dark;

		var trackMaterial = isDarkTheme ? Resource.Color.foreground_material_dark : Resource.Color.foreground_material_light;
		var trackColor = new Android.Graphics.Color(AndroidX.Core.Content.ContextCompat.GetColor(handler.PlatformView.Context, trackMaterial));

		var alphaChannel = view.IsEnabled ? 0.3f : 0.1f;
		var trackColorWithAlpha = new Android.Graphics.Color(trackColor.R, trackColor.G, trackColor.B, (int)(trackColor.A * alphaChannel));

		aSwitch.TrackDrawable?.SetColorFilter(trackColorWithAlpha, Android.Graphics.PorterDuff.Mode.SrcIn);
	}
});
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/29687
