### PR TITLE
[Android] Fix for disabled Picker prevents the parent container's GestureRecognizer from being triggered

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22565.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22565.cs
@@ -1,0 +1,50 @@
+﻿namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 22565, "A disabled Picker prevents the parent container's GestureRecognizer from being triggered", PlatformAffected.Android)]
+public class Issue22565 : ContentPage
+{
+	Label descriptionLabel;
+	public Issue22565()
+	{
+		VerticalStackLayout verticalStackLayout = new VerticalStackLayout
+		{
+			Padding = new Thickness(30, 0),
+			Spacing = 25
+		};
+
+		Grid grid = new Grid
+		{
+			Padding = 20,
+			BackgroundColor = Colors.DarkRed
+		};
+
+		Picker picker = new Picker
+		{
+			AutomationId = "DisabledPicker",
+			BackgroundColor = Colors.Gray,
+			IsEnabled = false
+		};
+
+		TapGestureRecognizer tapGesture = new TapGestureRecognizer();
+		tapGesture.Tapped += OnCounterClicked;
+
+		grid.GestureRecognizers.Add(tapGesture);
+		grid.Children.Add(picker);
+
+		descriptionLabel = new Label
+		{
+			AutomationId = "22565DescriptionLabel",
+			Text = "The test passes if the disabled Picker does not intercept the parent container's GestureRecognizer; otherwise, it fails.",
+		};
+
+		verticalStackLayout.Children.Add(grid);
+		verticalStackLayout.Children.Add(descriptionLabel);
+
+		Content = verticalStackLayout;
+	}
+
+	private void OnCounterClicked(object sender, EventArgs e)
+	{
+		descriptionLabel.Text = "Parent Gesture recognizer triggered";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22565.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22565.cs
@@ -18,6 +18,7 @@ public class Issue22565 : _IssuesUITest
 	{
 		App.WaitForElement("22565DescriptionLabel");
 		App.Tap("DisabledPicker");
-		Assert.That(App.FindElement("22565DescriptionLabel").GetText(), Is.EqualTo("Parent Gesture recognizer triggered"));
+		var labelText = App.FindElement("22565DescriptionLabel").GetText();
+		Assert.That(labelText, Is.EqualTo("Parent Gesture recognizer triggered"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22565.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22565.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue22565 : _IssuesUITest
+{
+	public Issue22565(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "A disabled Picker prevents the parent container's GestureRecognizer from being triggered";
+
+	[Test]
+	[Category(UITestCategories.Picker)]
+	public void VerifyGesturePropagationWithDisabledPicker()
+	{
+		App.WaitForElement("22565DescriptionLabel");
+		App.Tap("DisabledPicker");
+		Assert.That(App.FindElement("22565DescriptionLabel").GetText(), Is.EqualTo("Parent Gesture recognizer triggered"));
+	}
+}

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -104,6 +104,20 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		internal static void MapIsEnabled(IPickerHandler handler, IPicker picker)
+		{
+			var platformView = handler.PlatformView;
+			if (platformView == null)
+				return;
+
+			// Set native enabled state
+			platformView.Enabled = picker.IsEnabled;
+
+			// Ensure touch events propagate to parent views when disabled
+			platformView.Clickable = picker.IsEnabled;
+			platformView.Focusable = picker.IsEnabled;
+		}
+
 		internal static void MapFocus(IPickerHandler handler, IPicker picker, object? args)
 		{
 			if (handler.IsConnected() && handler is PickerHandler pickerHandler)

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Maui.Handlers
 #if __ANDROID__ || WINDOWS
 			[nameof(IPicker.Background)] = MapBackground,
 #endif
+#if __ANDROID__
+			[nameof(IView.IsEnabled)] = MapIsEnabled,
+#endif
 			[nameof(IPicker.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IPicker.Font)] = MapFont,
 			[nameof(IPicker.SelectedIndex)] = MapSelectedIndex,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- Disabled Picker view intercepts GestureRecognizer of parent container.

### Root Cause

- The touch event is triggered regardless of whether the picker is enabled or disabled. As a result, the base class OnTouchEvent is called and returns true, indicating that the touch event has been handled. This behavior prevents the parent tap gesture recognizer from being triggered.


### Description of Change

- Updated the OnTouchEvent method to return false if the Picker is disabled, ensuring that touch events are not intercepted by the Picker in this state.

### Reference :
https://github.com/dotnet/maui/blob/9894e0f8c1fb39a2f71a2ad642ff7c83bbe9031e/src/Core/src/Platform/Android/MauiScrollView.cs#L156-L165

### Issues Fixed
Fixes #22565 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/518eadce-55a6-4a42-9238-054de8ab4fb5"> | <video src="https://github.com/user-attachments/assets/fc06a418-e175-443e-b7aa-632e9c46f12f"> |
