### PR TITLE
[NET10.0][Windows] Add API to Enable/Disable Minimize and Maximize Buttons on Windows

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
@@ -21,6 +21,16 @@
             <Label Text="{Binding Window.Width, StringFormat='W = {0:0.00}'}" />
             <Label Text="{Binding Window.Height, StringFormat='H = {0:0.00}'}" />
 
+            <Grid ColumnDefinitions="*,auto">
+                <Label Text="IsMinimizable: "/>
+                <Switch Grid.Column="1" IsToggled="True" x:Name="isMinimizableSwitch" Toggled="isMinimizableSwitch_Toggled" />
+            </Grid>
+
+            <Grid ColumnDefinitions="*,auto">
+                <Label Text="IsMaximizable: "/>
+                <Switch Grid.Column="1" IsToggled="True" x:Name="isMaximizableSwitch" Toggled="isMaximizableSwitch_Toggled"/>
+            </Grid>
+
             <Label Text="Open/Close Windows:" />
             <Button
                 Clicked="OnNewWindowClicked"

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -83,5 +83,15 @@ namespace Maui.Controls.Sample.Pages
 			Window.X = (disp.Width / disp.Density - Window.Width) / 2;
 			Window.Y = (disp.Height / disp.Density - Window.Height) / 2;
 		}
+
+		void isMinimizableSwitch_Toggled(object sender, ToggledEventArgs e)
+		{
+			Window.IsMinimizable = e.Value;
+		}
+
+		void isMaximizableSwitch_Toggled(object sender, ToggledEventArgs e)
+		{
+			Window.IsMaximizable = e.Value;
+		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -340,6 +340,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.TemplatedView.CascadeInputTransparentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.IsClippedToBoundsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.PaddingProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -342,6 +342,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.TemplatedView.CascadeInputTransparentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.IsClippedToBoundsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.PaddingProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -342,6 +342,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.TemplatedView.CascadeInputTransparentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.IsClippedToBoundsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.PaddingProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -215,6 +215,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.SearchBar.SearchIconColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Shell.NavBarVisibilityAnimationEnabledProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Switch.OffColorProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -337,6 +337,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.TemplatedView.CascadeInputTransparentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.IsClippedToBoundsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.PaddingProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -330,6 +330,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.TemplatedView.CascadeInputTransparentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.IsClippedToBoundsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.PaddingProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -330,6 +330,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 ~static readonly Microsoft.Maui.Controls.TemplatedView.CascadeInputTransparentProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.IsClippedToBoundsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.PaddingProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangedDelegate<TPropertyType>.Invoke(Microsoft.Maui.Controls.BindableObject bindable, TPropertyType oldValue, TPropertyType newValue) -> void
 ~virtual Microsoft.Maui.Controls.BindableProperty.BindingPropertyChangingDelegate.Invoke(Microsoft.Maui.Controls.BindableObject bindable, object oldValue, object newValue) -> void

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -66,11 +66,11 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="IsMinimizable"/>.</summary>
 		public static readonly BindableProperty IsMinimizableProperty = BindableProperty.Create(nameof(IsMinimizable),
-			typeof(bool), typeof(TitleBar), defaultValue: true);
+			typeof(bool), typeof(Window), defaultValue: true);
 
 		/// <summary>Bindable property for <see cref="IsMaximizable"/>.</summary>
 		public static readonly BindableProperty IsMaximizableProperty = BindableProperty.Create(nameof(IsMaximizable),
-			typeof(bool), typeof(TitleBar), defaultValue: true);
+			typeof(bool), typeof(Window), defaultValue: true);
 
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren;

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -64,6 +64,14 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TitleBarProperty = BindableProperty.Create(
 			nameof(TitleBar), typeof(TitleBar), typeof(Window), null, propertyChanged: TitleBarChanged);
 
+		/// <summary>Bindable property for <see cref="IsMinimizable"/>.</summary>
+		public static readonly BindableProperty IsMinimizableProperty = BindableProperty.Create(nameof(IsMinimizable),
+			typeof(bool), typeof(TitleBar), defaultValue: true);
+
+		/// <summary>Bindable property for <see cref="IsMaximizable"/>.</summary>
+		public static readonly BindableProperty IsMaximizableProperty = BindableProperty.Create(nameof(IsMaximizable),
+			typeof(bool), typeof(TitleBar), defaultValue: true);
+
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren;
 		Toolbar? _toolbar;
@@ -593,6 +601,20 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public float DisplayDensity => ((IWindow)this).RequestDisplayDensity();
+
+		/// <summary>Gets or sets whether the window can be minimized.</summary>
+		public bool IsMinimizable
+		{
+			get { return (bool)GetValue(IsMinimizableProperty); }
+			set { SetValue(IsMinimizableProperty, value); }
+		}
+
+		/// <summary>Gets or sets whether the window can be maximized.</summary>
+		public bool IsMaximizable
+		{
+			get { return (bool)GetValue(IsMaximizableProperty); }
+			set { SetValue(IsMaximizableProperty, value); }
+		}
 
 		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
 		{

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -133,9 +133,9 @@ namespace Microsoft.Maui
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
 		/// <summary>Gets a value indicating whether the window can be minimized.</summary>
-		bool IsMinimizable { get; }
+		bool IsMinimizable => true;
 		/// <summary>Gets a value indicating whether the window can be maximized.</summary>
-		bool IsMaximizable { get; }
+		bool IsMaximizable => true;
 #endif
 
 #if WINDOWS

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -132,6 +132,10 @@ namespace Microsoft.Maui
 
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
+		/// <summary>Gets or sets whether the window can be minimized.</summary>
+		bool IsMinimizable { get; }
+		/// <summary>Gets or sets whether the window can be maximized.</summary>
+		bool IsMaximizable { get; }
 #endif
 
 #if WINDOWS

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -132,9 +132,9 @@ namespace Microsoft.Maui
 
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
-		/// <summary>Gets or sets whether the window can be minimized.</summary>
+		/// <summary>Gets a value indicating whether the window can be minimized.</summary>
 		bool IsMinimizable { get; }
-		/// <summary>Gets or sets whether the window can be maximized.</summary>
+		/// <summary>Gets a value indicating whether the window can be maximized.</summary>
 		bool IsMaximizable { get; }
 #endif
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -108,6 +108,12 @@ namespace Microsoft.Maui.Handlers
 		public static void MapMinimumHeight(IWindowHandler handler, IWindow view) =>
 			handler.PlatformView?.UpdateMinimumHeight(view);
 
+		public static void MapIsMinimizable(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView?.UpdateIsMinimizable(window);
+
+		public static void MapIsMaximizable(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView?.UpdateIsMaximizable(window);
+
 		public static void MapToolbar(IWindowHandler handler, IWindow view)
 		{
 			if (view is IToolbarElement tb)

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.MinimumWidth)] = MapMinimumWidth,
 			[nameof(IWindow.MinimumHeight)] = MapMinimumHeight,
 			[nameof(IWindow.TitleBar)] = MapTitleBar,
-			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
-			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 #if ANDROID || WINDOWS || TIZEN
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,
@@ -40,6 +38,8 @@ namespace Microsoft.Maui.Handlers
 #if WINDOWS
 			[nameof(IWindow.FlowDirection)] = MapFlowDirection,
 			[nameof(IWindow.TitleBarDragRectangles)] = MapTitleBarDragRectangles,
+			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
+			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 		};
 

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.MinimumWidth)] = MapMinimumWidth,
 			[nameof(IWindow.MinimumHeight)] = MapMinimumHeight,
 			[nameof(IWindow.TitleBar)] = MapTitleBar,
+			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
+			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 #if ANDROID || WINDOWS || TIZEN
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AppKit;
 using Foundation;
 using UIKit;
 
@@ -47,6 +48,16 @@ namespace Microsoft.Maui.Handlers
 			{
 				controller.SetUpTitleBar(window, mauiContext);
 			}
+		}
+
+		public static void MapIsMaximizable(IWindowHandler handler, IWindow window)
+		{
+				
+		}
+
+		public static void MapIsMinimizable(IWindowHandler handler, IWindow window)
+		{
+			
 		}
 #endif
 

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using AppKit;
 using Foundation;
 using UIKit;
 

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -49,16 +49,6 @@ namespace Microsoft.Maui.Handlers
 				controller.SetUpTitleBar(window, mauiContext);
 			}
 		}
-
-		public static void MapIsMaximizable(IWindowHandler handler, IWindow window)
-		{
-				
-		}
-
-		public static void MapIsMinimizable(IWindowHandler handler, IWindow window)
-		{
-			
-		}
 #endif
 
 		public static void MapContent(IWindowHandler handler, IWindow window)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		internal static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
 			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
 			{
@@ -226,7 +226,7 @@ namespace Microsoft.Maui.Platform
 			});
 		}
 
-		public static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
+		internal static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
 			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
 			{

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -209,24 +209,29 @@ namespace Microsoft.Maui.Platform
 				appWindow.Resize(temp);
 		}
 
-		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		internal static void UpdateWindowOverlappedPresenter(this UI.Xaml.Window platformWindow, Action<UI.Windowing.OverlappedPresenter> updateAction)
 		{
 			var appWindow = platformWindow.GetAppWindow();
-
 			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
 			{
-				presenter.IsMinimizable = window.IsMinimizable;
+				updateAction(presenter);
 			}
+		}
+
+		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		{
+			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
+			{
+				presenter.IsMinimizable = window.IsMinimizable;
+			});
 		}
 
 		public static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
-			var appWindow = platformWindow.GetAppWindow();
-
-			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
 			{
 				presenter.IsMaximizable = window.IsMaximizable;
-			}
+			});
 		}
 
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -209,29 +209,24 @@ namespace Microsoft.Maui.Platform
 				appWindow.Resize(temp);
 		}
 
-		internal static void UpdateWindowOverlappedPresenter(this UI.Xaml.Window platformWindow, Action<UI.Windowing.OverlappedPresenter> updateAction)
-		{
-			var appWindow = platformWindow.GetAppWindow();
-			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
-			{
-				updateAction(presenter);
-			}
-		}
-
 		internal static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
-			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
 			{
 				presenter.IsMinimizable = window.IsMinimizable;
-			});
+			}
 		}
 
 		internal static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
-			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
 			{
 				presenter.IsMaximizable = window.IsMaximizable;
-			});
+			}
 		}
 
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -209,6 +209,26 @@ namespace Microsoft.Maui.Platform
 				appWindow.Resize(temp);
 		}
 
+		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		{
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+			{
+				presenter.IsMinimizable = window.IsMinimizable;
+			}
+		}
+
+		public static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
+		{
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+			{
+				presenter.IsMaximizable = window.IsMaximizable;
+			}
+		}
+
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)
 		{
 			foreach (var window in WindowExtensions.GetWindows())

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -48,6 +48,8 @@ Microsoft.Maui.Platform.MauiTimePicker.UpdateTime(System.TimeSpan? time) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFinishNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation) -> void
 Microsoft.Maui.Platform.TextInputExtensions
 Microsoft.Maui.Platform.UIApplicationExtensions
+Microsoft.Maui.IWindow.IsMaximizable.get -> bool
+Microsoft.Maui.IWindow.IsMinimizable.get -> bool
 Microsoft.Maui.ScrollToRequest.Deconstruct(out double HorizontalOffset, out double VerticalOffset, out bool Instant) -> void
 Microsoft.Maui.ScrollToRequest.ScrollToRequest(Microsoft.Maui.ScrollToRequest! original) -> void
 Microsoft.Maui.SwipeViewCloseRequest.Deconstruct(out bool Animated) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -39,6 +39,8 @@ Microsoft.Maui.ITimePicker.Time.get -> System.TimeSpan?
 Microsoft.Maui.IWebRequestInterceptingWebView
 Microsoft.Maui.IWebRequestInterceptingWebView.WebResourceRequested(Microsoft.Maui.WebResourceRequestedEventArgs! args) -> bool
 Microsoft.Maui.Platform.CalendarDatePickerExtensions
+Microsoft.Maui.IWindow.IsMaximizable.get -> bool
+Microsoft.Maui.IWindow.IsMinimizable.get -> bool
 Microsoft.Maui.ScrollToRequest.Deconstruct(out double HorizontalOffset, out double VerticalOffset, out bool Instant) -> void
 Microsoft.Maui.ScrollToRequest.ScrollToRequest(Microsoft.Maui.ScrollToRequest! original) -> void
 Microsoft.Maui.SwipeViewCloseRequest.Deconstruct(out bool Animated) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -41,6 +41,8 @@ Microsoft.Maui.IWebRequestInterceptingWebView.WebResourceRequested(Microsoft.Mau
 Microsoft.Maui.Platform.CalendarDatePickerExtensions
 Microsoft.Maui.IWindow.IsMaximizable.get -> bool
 Microsoft.Maui.IWindow.IsMinimizable.get -> bool
+static Microsoft.Maui.Handlers.WindowHandler.MapIsMaximizable(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
+static Microsoft.Maui.Handlers.WindowHandler.MapIsMinimizable(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 Microsoft.Maui.ScrollToRequest.Deconstruct(out double HorizontalOffset, out double VerticalOffset, out bool Instant) -> void
 Microsoft.Maui.ScrollToRequest.ScrollToRequest(Microsoft.Maui.ScrollToRequest! original) -> void
 Microsoft.Maui.SwipeViewCloseRequest.Deconstruct(out bool Animated) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This is a follow-up to PR #27363. All feedback and suggested changes from that pull request have been addressed in this.

#### New Properties

- `IsMinimizable` and `IsMaximizable` have been added to the `Window` class.

#### Platform Support

- Implemented on Windows.
- Not implemented on Mac due to the lack of a reliable API to support this functionality.

#### Mac Catalyst Notes
While this implementation supports Windows, Mac Catalyst lacks a clean and officially supported API for controlling window minimization or maximization. There are some community discussions and AppKit-based workarounds.

Related links for reference:

- https://stackoverflow.com/questions/59749105/how-to-disabled-fullscreen-button-on-maccatalyst

- https://stackoverflow.com/questions/77525693/disable-close-button-and-miniaturize-window-in-maui-maccatalyst-application

- https://crunchybagel.com/disabling-the-mac-zoom-maximise-button-in-catalyst

The properties are still available on IWindow, so platform-specific extensions or mapper overrides can be implemented by developers if needed.



Contributes to #10297.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
