### PR TITLE
Weak subscription to CanExecuteChange events

### DIFF
--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -616,5 +616,7 @@ namespace Microsoft.Maui.Controls
 			var commandText = DebuggerDisplayHelpers.GetDebugText(nameof(Command), Command, false);
 			return $"{base.GetDebuggerDisplay()}, {textString}, {commandText}";
 		}
+
+		WeakCommandSubscription ICommandElement.CleanupTracker { get; set; }
 	}
 }

--- a/src/Controls/src/Core/Cells/TextCell.cs
+++ b/src/Controls/src/Core/Cells/TextCell.cs
@@ -89,8 +89,13 @@ namespace Microsoft.Maui.Controls
 			Command?.Execute(CommandParameter);
 		}
 
-		void ICommandElement.CanExecuteChanged(object sender, EventArgs eventArgs) =>
+		void ICommandElement.CanExecuteChanged(object sender, EventArgs eventArgs)
+		{
+			if (Command is null)
+				return;
+
 			IsEnabled = Command.CanExecute(CommandParameter);
+		}
 
 		WeakCommandSubscription ICommandElement.CleanupTracker { get; set; }
 	}

--- a/src/Controls/src/Core/Cells/TextCell.cs
+++ b/src/Controls/src/Core/Cells/TextCell.cs
@@ -1,42 +1,27 @@
 #nullable disable
 using System;
 using System.Windows.Input;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/TextCell.xml" path="Type[@FullName='Microsoft.Maui.Controls.TextCell']/Docs/*" />
-	public class TextCell : Cell
+	public class TextCell : Cell, ICommandElement
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
-		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TextCell), default(ICommand),
-			propertyChanging: (bindable, oldvalue, newvalue) =>
-			{
-				var textCell = (TextCell)bindable;
-				var oldcommand = (ICommand)oldvalue;
-				if (oldcommand != null)
-					oldcommand.CanExecuteChanged -= textCell.OnCommandCanExecuteChanged;
-			}, propertyChanged: (bindable, oldvalue, newvalue) =>
-			{
-				var textCell = (TextCell)bindable;
-				var newcommand = (ICommand)newvalue;
-				if (newcommand != null)
-				{
-					textCell.IsEnabled = newcommand.CanExecute(textCell.CommandParameter);
-					newcommand.CanExecuteChanged += textCell.OnCommandCanExecuteChanged;
-				}
-			});
+		public static readonly BindableProperty CommandProperty =
+			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TextCell),
+			propertyChanging: CommandElement.OnCommandChanging,
+			propertyChanged: CommandElement.OnCommandChanged);
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(TextCell), default(object),
-			propertyChanged: (bindable, oldvalue, newvalue) =>
-			{
-				var textCell = (TextCell)bindable;
-				if (textCell.Command != null)
-				{
-					textCell.IsEnabled = textCell.Command.CanExecute(newvalue);
-				}
-			});
+		public static readonly BindableProperty CommandParameterProperty =
+			BindableProperty.Create(nameof(CommandParameter),
+				typeof(object),
+				typeof(TextCell),
+				null,
+				propertyChanged: CommandElement.OnCommandParameterChanged);
 
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(TextCell), default(string));
@@ -104,9 +89,9 @@ namespace Microsoft.Maui.Controls
 			Command?.Execute(CommandParameter);
 		}
 
-		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)
-		{
+		void ICommandElement.CanExecuteChanged(object sender, EventArgs eventArgs) =>
 			IsEnabled = Command.CanExecute(CommandParameter);
-		}
+
+		WeakCommandSubscription ICommandElement.CleanupTracker { get; set; }
 	}
 }

--- a/src/Controls/src/Core/CommandElement.cs
+++ b/src/Controls/src/Core/CommandElement.cs
@@ -10,15 +10,24 @@ namespace Microsoft.Maui.Controls
 		public static void OnCommandChanging(BindableObject bo, object o, object n)
 		{
 			var commandElement = (ICommandElement)bo;
-			if (o is ICommand oldCommand)
-				oldCommand.CanExecuteChanged -= commandElement.CanExecuteChanged;
+			commandElement.CleanupTracker?.Dispose();
+			commandElement.CleanupTracker = null;
 		}
 
 		public static void OnCommandChanged(BindableObject bo, object o, object n)
 		{
 			var commandElement = (ICommandElement)bo;
-			if (n is ICommand newCommand)
-				newCommand.CanExecuteChanged += commandElement.CanExecuteChanged;
+
+			if (n is null)
+			{
+				commandElement.CleanupTracker?.Dispose();
+				commandElement.CleanupTracker = null;
+			}
+			else
+			{
+				commandElement.CleanupTracker = new WeakCommandSubscription(bo, (ICommand)n, commandElement.CanExecuteChanged);
+			}
+
 			commandElement.CanExecuteChanged(bo, EventArgs.Empty);
 		}
 

--- a/src/Controls/src/Core/DepdendentHandle.cs
+++ b/src/Controls/src/Core/DepdendentHandle.cs
@@ -1,0 +1,98 @@
+#nullable enable
+
+#if NETSTANDARD2_0
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace System.Runtime;
+
+/// <summary>
+/// A wrapper around ConditionalWeakTable that replicates DependentHandle behavior.
+/// Creates a dependency between a primary object and a dependent object where
+/// the dependent object becomes eligible for collection when the primary is collected.
+/// </summary>
+internal class DependentHandle : IDisposable
+{
+    private readonly ConditionalWeakTable<object, object> _table;
+    private readonly WeakReference<object> _primaryRef;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of DependentHandle with a primary and dependent object.
+    /// </summary>
+    /// <param name="primary">The primary object that controls the lifetime of the dependent object.</param>
+    /// <param name="dependent">The dependent object that will be collected when primary is collected.</param>
+    public DependentHandle(object primary, object? dependent)
+    {
+        ArgumentNullException.ThrowIfNull(primary);
+
+        _table = new ConditionalWeakTable<object, object>();
+        _primaryRef = new WeakReference<object>(primary);
+
+        // Store the dependent object in the table, keyed by the primary object
+        if (dependent is not null)
+        {
+            _table.Add(primary, dependent);
+        }
+    }
+
+    /// <summary>
+    /// Gets the primary object if it's still alive, otherwise returns null.
+    /// </summary>
+    public object? Target
+    {
+        get
+        {
+            if (_disposed)
+                return null;
+
+            return _primaryRef.TryGetTarget(out var target) ? target : null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the dependent object if the primary object is still alive, otherwise returns null.
+    /// </summary>
+    public object? Dependent
+    {
+        get
+        {
+            if (_disposed)
+                return null;
+
+            if (_primaryRef.TryGetTarget(out var primary) &&
+                _table.TryGetValue(primary, out var dependent))
+            {
+                return dependent;
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Checks if both primary and dependent objects are still alive.
+    /// </summary>
+    public bool IsAllocated => Target is not null && Dependent is not null;
+
+    /// <summary>
+    /// Disposes the DependentHandleCWT, clearing all references.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        // Clear the table - this will allow dependent objects to be collected
+        // even if the primary object is still alive
+        if (_primaryRef.TryGetTarget(out var primary))
+        {
+            _table.Remove(primary);
+        }
+    }
+}
+#endif

--- a/src/Controls/src/Core/DepdendentHandle.cs
+++ b/src/Controls/src/Core/DepdendentHandle.cs
@@ -1,6 +1,6 @@
 #nullable enable
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETSTANDARD2_1
 using System;
 using System.Runtime;
 using System.Runtime.CompilerServices;
@@ -26,8 +26,6 @@ internal class DependentHandle : IDisposable
     /// <param name="dependent">The dependent object that will be collected when primary is collected.</param>
     public DependentHandle(object primary, object? dependent)
     {
-        ArgumentNullException.ThrowIfNull(primary);
-
         _table = new ConditionalWeakTable<object, object>();
         _primaryRef = new WeakReference<object>(primary);
 

--- a/src/Controls/src/Core/ICommandElement.cs
+++ b/src/Controls/src/Core/ICommandElement.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		// implement these explicitly
 		void CanExecuteChanged(object? sender, EventArgs e);
+
+		WeakCommandSubscription? CleanupTracker { get; set; }
 	}
 }

--- a/src/Controls/src/Core/ImageButton/ImageButton.cs
+++ b/src/Controls/src/Core/ImageButton/ImageButton.cs
@@ -288,5 +288,13 @@ namespace Microsoft.Maui.Controls
 		Color IButtonStroke.StrokeColor => (Color)GetValue(BorderColorProperty);
 
 		int IButtonStroke.CornerRadius => (int)GetValue(CornerRadiusProperty);
+
+
+		WeakCommandSubscription ICommandElement.CleanupTracker
+		{
+			get;
+			set;
+		}
+
 	}
 }

--- a/src/Controls/src/Core/Menu/MenuItem.cs
+++ b/src/Controls/src/Core/Menu/MenuItem.cs
@@ -198,5 +198,11 @@ namespace Microsoft.Maui.Controls
 		{
 			OnPropertyChanged(IconImageSourceProperty.PropertyName);
 		}
+
+		WeakCommandSubscription ICommandElement.CleanupTracker
+		{
+			get;
+			set;
+		}
 	}
 }

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -156,5 +156,11 @@ namespace Microsoft.Maui.Controls
 			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(Command), Command, nameof(IsRefreshing), IsRefreshing, false);
 			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
+
+		WeakCommandSubscription ICommandElement.CleanupTracker
+		{
+			get;
+			set;
+		}
 	}
 }

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -160,5 +160,11 @@ namespace Microsoft.Maui.Controls
 			var debugText = DebuggerDisplayHelpers.GetDebugText(nameof(SearchCommand), SearchCommand);
 			return $"{base.GetDebuggerDisplay()}, {debugText}";
 		}
+
+		WeakCommandSubscription ICommandElement.CleanupTracker
+		{
+			get;
+			set;
+		}
 	}
 }

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -666,16 +666,16 @@ namespace Microsoft.Maui.Controls
 			ClearPlaceholderEnabledCore = ClearPlaceholderCommand.CanExecute(ClearPlaceholderCommandParameter);
 		}
 
+		internal WeakCommandSubscription ClearPlaceholderCommandSubscription { get; set; }
+
 		void OnClearPlaceholderCommandChanged(ICommand oldCommand, ICommand newCommand)
 		{
-			if (oldCommand != null)
-			{
-				oldCommand.CanExecuteChanged -= ClearPlaceholderCanExecuteChanged;
-			}
+			ClearPlaceholderCommandSubscription?.Dispose();
+			ClearPlaceholderCommandSubscription = null;
 
 			if (newCommand != null)
 			{
-				newCommand.CanExecuteChanged += ClearPlaceholderCanExecuteChanged;
+				ClearPlaceholderCommandSubscription = new WeakCommandSubscription(this, newCommand, ClearPlaceholderCanExecuteChanged);
 				ClearPlaceholderEnabledCore = ClearPlaceholderCommand.CanExecute(ClearPlaceholderCommandParameter);
 			}
 			else
@@ -690,16 +690,16 @@ namespace Microsoft.Maui.Controls
 				ClearPlaceholderEnabledCore = ClearPlaceholderCommand.CanExecute(CommandParameter);
 		}
 
+		internal WeakCommandSubscription CommandSubscription { get; set; }
+
 		void OnCommandChanged(ICommand oldCommand, ICommand newCommand)
 		{
-			if (oldCommand != null)
-			{
-				oldCommand.CanExecuteChanged -= CanExecuteChanged;
-			}
+			CommandSubscription?.Dispose();
+			CommandSubscription = null;
 
-			if (newCommand != null)
+			if (newCommand is not null)
 			{
-				newCommand.CanExecuteChanged += CanExecuteChanged;
+				CommandSubscription = new WeakCommandSubscription(this, newCommand, CanExecuteChanged);
 				IsSearchEnabledCore = Command.CanExecute(CommandParameter);
 			}
 			else

--- a/src/Controls/src/Core/WeakCommandSubscription.cs
+++ b/src/Controls/src/Core/WeakCommandSubscription.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using System;
+using System.Windows.Input;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Microsoft.Maui.Controls
+{
+	class WeakCommandSubscription : IDisposable
+	{
+		internal CommandCanExecuteSubscription Proxy { get; }
+		public WeakCommandSubscription(
+			BindableObject bindableObject,
+			ICommand command,
+			Action<object, EventArgs> canExecuteChangedHandler)
+		{
+			Proxy = new CommandCanExecuteSubscription(bindableObject, command, canExecuteChangedHandler);
+		}
+
+		~WeakCommandSubscription()
+		{
+			Dispose(false);
+		}
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			Proxy.Dispose();
+		}
+
+		internal class CommandCanExecuteSubscription : IDisposable
+		{
+			WeakReference<BindableObject> _bindableObject;
+			WeakReference<Action<object, EventArgs>> _canExecuteChangedHandler;
+			ICommand? _command;
+
+			public CommandCanExecuteSubscription(
+				BindableObject bindableObject,
+				ICommand command,
+				Action<object, EventArgs> canExecuteChangedHandler)
+			{
+				_command = command;
+				_bindableObject = new WeakReference<BindableObject>(bindableObject);
+				_canExecuteChangedHandler = new WeakReference<Action<object, EventArgs>>(canExecuteChangedHandler);
+				_command.CanExecuteChanged += CanExecuteChanged;
+			}
+
+			public void Dispose()
+			{
+				if (_command is not null)
+				{
+					_command.CanExecuteChanged -= CanExecuteChanged;
+					_command = null;
+				}
+			}
+
+			void CanExecuteChanged(object? arg1, EventArgs args)
+			{
+				if (_bindableObject is not null && _bindableObject.TryGetTarget(out var bindableObject) &&
+					_canExecuteChangedHandler is not null && _canExecuteChangedHandler.TryGetTarget(out var canExecuteChangedHandler))
+				{
+					canExecuteChangedHandler(bindableObject, args);
+				}
+				else
+				{
+					Dispose();
+				}
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/CommandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/CommandTests.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Microsoft.Maui.Controls.Internals;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -250,6 +254,111 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			command.Execute(null); // "null is not a valid value for int"
 			Assert.True(executions == 0, "the command should not have executed");
+		}
+		
+		[Theory]
+		[InlineData(typeof(Button), true)]
+		[InlineData(typeof(Button), false)]
+		[InlineData(typeof(RefreshView), true)]
+		[InlineData(typeof(RefreshView), false)]
+		[InlineData(typeof(TextCell), true)]
+		[InlineData(typeof(TextCell), false)]
+		[InlineData(typeof(ImageButton), true)]
+		[InlineData(typeof(ImageButton), false)]
+		[InlineData(typeof(MenuItem), true)]
+		[InlineData(typeof(MenuItem), false)]
+		[InlineData(typeof(SearchBar), true)]
+		[InlineData(typeof(SearchBar), false)]
+		[InlineData(typeof(SearchHandler), true)]
+		[InlineData(typeof(SearchHandler), false)]
+		public async Task CommandsSubscribedToCanExecuteCollect(Type controlType, bool useWeakEventHandler)
+		{
+			// Create a view model with a Command
+			ICommand command;
+
+			if (!useWeakEventHandler)
+				command = new CommandWithoutWeakEventHandler();
+			else
+				command = new Command(() => { });
+
+			List<WeakReference> weakReferences = new List<WeakReference>();
+
+			// Create a button in a separate scope to ensure no references remain
+			{
+				var control = (BindableObject)Activator.CreateInstance(controlType);
+				switch (control)
+				{
+					case Button b:
+						b.Command = command;
+						break;
+					case RefreshView r:
+						r.Command = command;
+						break;
+						case TextCell t:
+						t.Command = command;
+						break;
+					case ImageButton i:	
+						i.Command = command;
+						break;
+					case MenuItem m:
+						m.Command = command;
+						break;
+					case SearchBar s:
+						s.SearchCommand = command;
+						break;
+					case SearchHandler sh:
+						sh.Command = command;
+						sh.ClearPlaceholderCommand = command;
+						break;
+				}
+
+				// Create a weak reference to the button
+				weakReferences.Add(new WeakReference(control));
+
+				if (control is ICommandElement commandElement)
+				{
+					// Add weak references to the command and its cleanup tracker
+					weakReferences.Add(new WeakReference(commandElement.CleanupTracker));
+					weakReferences.Add(new WeakReference(commandElement.CleanupTracker.Proxy));
+				}
+				else if(control is SearchHandler searchHandler)
+				{
+					// Add weak references to the command and its cleanup tracker
+					weakReferences.Add(new WeakReference(searchHandler.CommandSubscription));
+					weakReferences.Add(new WeakReference(searchHandler.CommandSubscription.Proxy));
+					weakReferences.Add(new WeakReference(searchHandler.ClearPlaceholderCommandSubscription));
+					weakReferences.Add(new WeakReference(searchHandler.ClearPlaceholderCommandSubscription.Proxy));
+				}
+
+				await TestHelpers.Collect();
+				await TestHelpers.Collect();
+
+				// Make sure everything is still alive if the button is still in scope
+				// We need to reference the button here again to keep it alive 
+				// awaiting a Task appears to move us to a new scope and causes the button to be collected
+				Assert.NotNull(control);
+
+				foreach (var weakRef in weakReferences)
+				{
+					Assert.True(weakRef.IsAlive);
+				}
+			}
+	
+			foreach (var weakRef in weakReferences)
+			{
+				Assert.False(await weakRef.WaitForCollect());
+			}
+		}
+
+		class CommandWithoutWeakEventHandler : ICommand
+		{
+			public event EventHandler CanExecuteChanged;
+
+			public bool CanExecute(object parameter) => true;
+
+			public void Execute(object parameter) { }
+
+			public void ChangeCanExecute() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -10,6 +10,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
+			GC.Collect(2, GCCollectionMode.Forced, true);
+			GC.WaitForPendingFinalizers();
+			GC.Collect(2, GCCollectionMode.Forced, true);
+			await Task.Yield();
 		}
 
 
@@ -17,9 +21,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			for (int i = 0; i < 40 && reference.IsAlive; i++)
 			{
-				await Task.Yield();
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
+				await Collect();
 			}
 
 			return reference.IsAlive;


### PR DESCRIPTION
### Description of Change


This pull request introduces a mechanism for managing and cleaning up command event subscriptions when the lifetime of the `ICommand` instance exceeds that of the XAML element it's assigned to.

Example from the Unit Tests

```C#
var command = new CommandWithoutWeakEventHandler();

// The Button subscribes to "command.CanExecuteChanged", creating a strong reference
// from the command to the Button. If the command outlives the Button,
// this prevents the Button from being garbage collected, resulting in a memory leak.
// Our built-in Command implementation avoids this by using WeakEventManager,
// but custom ICommand implementations that do not use weak event patterns are prone to leaks.
{
	var button = new Button();
	button.Command = command;
}			
```

This largerly comes up with scenarios using static viewmodels or if people are using reference bindings. The key changes include the addition of a `WeakCommandSubscription` class, updates to the `ICommandElement` interface, and new unit tests to verify the functionality.

### Memory Management Enhancements:

* **Added `WeakCommandSubscription` class**: Introduced a new class to manage weak references to command subscriptions, ensuring that event handlers do not prevent garbage collection of associated objects. This includes the `CommandCanExecuteSubscription` inner class for handling `CanExecuteChanged` events. (`src/Controls/src/Core/WeakCommandSubscription.cs`)

* **Updated `ICommandElement` interface**: Added a `CleanupTracker` property to manage the lifecycle of command subscriptions. (`src/Controls/src/Core/ICommandElement.cs`)

* **Integrated `WeakCommandSubscription` in controls**: Implemented the `CleanupTracker` property in multiple controls (`Button`, `ImageButton`, `MenuItem`, `RefreshView`, `SearchBar`) to utilize the new subscription management system. [[1]](diffhunk://#diff-dbeeb2751480e86145429d30dd5ba3975839b5add80775a12791474777cbd5e5R619-R624) [[2]](diffhunk://#diff-efc9658e08fe3b783f24e1b9270bdaff4208083a016aad6990d025937841c2adR291-R298) [[3]](diffhunk://#diff-ebcf373c7c4e142e875e0df46cfb3178a88271085ddfb9d30d49ca95ff864f75R201-R206) [[4]](diffhunk://#diff-2d87a80df0a7988d1f249910b23fc95a072e4df4bd0c92c18ec6f03517cf35b7R159-R164) [[5]](diffhunk://#diff-62df0364fa952ab201982cff6814cc4698acb7ad35109ea8488056f2bbcbcf4fR163-R168)

### Command Handling Improvements:

* **Modified `CommandElement` static class**: Updated `OnCommandChanging` and `OnCommandChanged` methods to use the `CleanupTracker` for disposing of old subscriptions and creating new ones. (`src/Controls/src/Core/CommandElement.cs`)

### Unit Testing Enhancements:

* **New tests for garbage collection**: Added tests to ensure that controls with commands can be garbage collected properly and that weak event handlers are not collected prematurely. (`src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs`)

* **Improved garbage collection helper**: Enhanced the `TestHelpers.Collect` method to force multiple garbage collection cycles and ensure deterministic behavior during testing. (`src/Controls/tests/Core.UnitTests/TestHelpers.cs`)

These changes collectively improve the robustness of command handling in the library while addressing potential memory management issues.

### Concerns 

- Calling Managed code from the finalizer typically isn't recommended. The only purpose of the finalizer is to cleanup `CommandCanExecuteSubscription`. The commandelement itself will cleanup without the finalizer. One approach we could take here would be to track these and then just clean them up every so often. 


### Other Notes

- WPF has a much larger solution to this https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CanExecuteChangedEventManager.cs#L321



### Issues Fixed

Fixes #16124