### PR TITLE
[ci] Allows usage of new keys from dotnet

### DIFF
--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -28,9 +28,9 @@ parameters:
   default: true
 
 - name: pushPackages
-  displayName: "Controls the script, allows for dry run"
+  displayName: "Controls the script, allows for dry run if false"
   type: boolean
-  default: false
+  default: true
 
 - name: nugetIncludeFilters
   displayName: "[OPTIONAL] Semi-colon (';') separated list of nugets packages to include"
@@ -59,6 +59,7 @@ variables:
 - group: DotNetBuilds storage account read tokens
 - group: AzureDevOps-Artifact-Feeds-Pats
 - group: DotNet-Maui-Release
+- group: .NET Core Nuget API Keys
 
 resources:
   repositories:
@@ -217,7 +218,7 @@ extends:
             displayName: list downloaded artifacts
 
           - powershell: >-
-              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\shipping\packages\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}"
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(DotNetNugetApiKey-A9)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\shipping\packages\*" -NuGetIncludeFilters "${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "*Manifest*.nupkg;${{ parameters.nugetExcludeFilters }}" -NuGetOrgApiKey2 "$(DotNetNugetApiKey-A8)" -NuGetOrgApiKey3 "$(pat--nuget--xamarinc--push--wildcard)"
             displayName: Push workload packs to NuGet.org
             env:
               PUSH_PACKAGES: ${{ parameters.pushPackages }}
@@ -284,7 +285,7 @@ extends:
             displayName: list downloaded artifacts
 
           - powershell: >-
-              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(pat--nuget--xamarinc--push--wildcard)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\shipping\packages\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"
+              $(Build.SourcesDirectory)\eng\scripts\push_nuget_org.ps1 -ApiKey "$(DotNetNugetApiKey-A9)" -FeedUrl "${{ parameters.feedUrl }}" -NuGetSearchPath "$(Build.StagingDirectory)\nupkgs\shipping\packages\*" -NuGetIncludeFilters "*Manifest*.nupkg;${{ parameters.nugetIncludeFilters }}" -NuGetExcludeFilters "${{ parameters.nugetExcludeFilters }}"  -NuGetOrgApiKey2 "$(DotNetNugetApiKey-A8)" -NuGetOrgApiKey3 "$(pat--nuget--xamarinc--push--wildcard)"
             displayName: Push workload manifests to NuGet.org
             env:
               PUSH_PACKAGES: ${{ parameters.pushPackages }}

--- a/eng/scripts/push_nuget_org.ps1
+++ b/eng/scripts/push_nuget_org.ps1
@@ -90,7 +90,7 @@ $nugetApiKeysExceedingQuota = [System.Collections.Generic.List[string]]::new()
 $nugetApiKeyIndex = 1
 
 foreach ($nupkg in $nupkgs) {
-  if ( $env:PUSH_PACKAGES -ne "True" ) {
+  if ( $env:PUSH_PACKAGES -ne "true" ) {
     Write-Host "`tdry run, not pushing $($nupkg.FullName)"
     continue
   }


### PR DESCRIPTION
### Description of Change

Adds a new variable group to be used on [dnceng internal release](https://dev.azure.com/dnceng/internal/_build?definitionId=1445) , all fixes the script to use those new variables if we have problems with quota