### PR TITLE
Update copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,4 +19,5 @@ jobs:
 
       - name: Run a pre-work build
         shell: pwsh
+        continue-on-error: true
         run: .\build.ps1


### PR DESCRIPTION
This pull request makes a small modification to the `.github/workflows/copilot-setup-steps.yml` file. It updates the "Run a pre-work build" step to include the `continue-on-error: true` property, allowing the workflow to proceed even if this step fails.