### PR TITLE
Fix Crash when ItemsSource is set to null in the SelectionChanged handler

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView is null || ItemsView.ItemsSource is null)
+			if (ItemsView?.ItemsSource is null)
 			{
 				return;
 			}
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView is null || ItemsView.ItemsSource is null)
+			if (ItemsView?.ItemsSource is null)
 			{
 				return;
 			}
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void UpdatePlatformSelection()
 		{
-			if (ItemsView is null || ItemsView.ItemsSource is null)
+			if (ItemsView?.ItemsSource is null)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// Called by Forms to mark an item selected 
 		internal void SelectItem(object selectedItem)
 		{
+			if (ItemsView?.ItemsSource is null)
+			{
+				return;
+			}
+
 			var index = GetIndexForItem(selectedItem);
 
 			if (index.Section > -1 && index.Item > -1)
@@ -60,6 +65,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// Called by Forms to clear the native selection
 		internal void ClearSelection()
 		{
+			if (ItemsView?.ItemsSource is null)
+			{
+				return;
+			}
+	
 			var selectedItemIndexes = CollectionView.GetIndexPathsForSelectedItems();
 
 			foreach (var index in selectedItemIndexes)

--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -25,12 +25,20 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (ItemsView is null || ItemsView.ItemsSource is null)
+			{
+				return;
+			}
 			FormsSelectItem(indexPath);
 		}
 
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (ItemsView is null || ItemsView.ItemsSource is null)
+			{
+				return;
+			}
 			FormsDeselectItem(indexPath);
 		}
 
@@ -95,7 +103,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		internal void UpdatePlatformSelection()
 		{
-			if (ItemsView == null)
+			if (ItemsView is null || ItemsView.ItemsSource is null)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -25,12 +25,20 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (ItemsView is null || ItemsView.ItemsSource is null)
+			{
+				return;
+			}
 			FormsSelectItem(indexPath);
 		}
 
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
+			if (ItemsView is null || ItemsView.ItemsSource is null)
+			{
+				return;
+			}
 			FormsDeselectItem(indexPath);
 		}
 
@@ -95,7 +103,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		internal void UpdatePlatformSelection()
 		{
-			if (ItemsView == null)
+			if (ItemsView is null || ItemsView.ItemsSource is null)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// Called by Forms to mark an item selected 
 		internal void SelectItem(object selectedItem)
 		{
+			if (ItemsView?.ItemsSource is null)
+			{
+				return;
+			}
+
 			var index = GetIndexForItem(selectedItem);
 
 			if (index.Section > -1 && index.Item > -1)
@@ -60,6 +65,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// Called by Forms to clear the native selection
 		internal void ClearSelection()
 		{
+			if (ItemsView?.ItemsSource is null)
+			{
+				return;
+			}
+
 			var selectedItemIndexes = CollectionView.GetIndexPathsForSelectedItems();
 
 			foreach (var index in selectedItemIndexes)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView is null || ItemsView.ItemsSource is null)
+			if (ItemsView?.ItemsSource is null)
 			{
 				return;
 			}
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// _Only_ called if the user initiates the selection change; will not be called for programmatic selection
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			if (ItemsView is null || ItemsView.ItemsSource is null)
+			if (ItemsView?.ItemsSource is null)
 			{
 				return;
 			}
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		internal void UpdatePlatformSelection()
 		{
-			if (ItemsView is null || ItemsView.ItemsSource is null)
+			if (ItemsView?.ItemsSource is null)
 			{
 				return;
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Controls.TestCases.HostApp.Issues.Issue29882"
+             x:Class="Maui.Controls.Sample.Issues.Issue29882"
              Title="Issue29882">
     <VerticalStackLayout>
         <Label Text="Issue 29882" AutomationId="MauiLabel" />

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Controls.TestCases.HostApp.Issues.Issue29882"
+             Title="Issue29882">
+    <VerticalStackLayout>
+        <Label Text="Issue 29882" AutomationId="MauiLabel" />
+       <CollectionView
+                    SelectionMode="Single"  ItemsSource="{Binding Items}" 
+                    x:Name="MyCollectionView"  SelectionChanged="MyCollectionView_SelectionChanged"
+                    Margin="10">
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <Border Stroke="LightGray"  Padding="10" Margin="5">
+                  <VerticalStackLayout>
+                      <Label Text="{Binding .}" 
+                           FontSize="18" AutomationId="{Binding .}"
+                           VerticalOptions="Center"
+                           HorizontalOptions="Center"/>
+                  </VerticalStackLayout>
+                </Border>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+
+    </CollectionView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
 
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29882, "[iOS] Crash occurs when ItemsSource is set to null in the SelectionChanged handler",PlatformAffected.iOS)]
 public partial class Issue29882 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29882.xaml.cs
@@ -1,0 +1,33 @@
+using System.Collections.ObjectModel;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 29882, "[iOS] Crash occurs when ItemsSource is set to null in the SelectionChanged handler",PlatformAffected.iOS)]
+public partial class Issue29882 : ContentPage
+{
+	private ObservableCollection<string> items;
+	public ObservableCollection<string> Items
+	{
+		get => items;
+		set
+		{
+			items = value;
+			OnPropertyChanged();
+		}
+	}
+	public Issue29882()
+	{
+		InitializeComponent();
+		Items = new ObservableCollection<string>();
+		for (int i = 1; i <= 10; i++)
+		{
+			Items.Add($"Item{i}");
+		}
+		BindingContext = this;
+	}
+
+	private void MyCollectionView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		Items = null;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29882.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29882.cs
@@ -1,0 +1,24 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+
+public class Issue29882 : _IssuesUITest
+{
+    public Issue29882(TestDevice device) : base(device)
+    {
+    }
+
+    public override string Issue => "[iOS] Crash occurs when ItemsSource is set to null in the SelectionChanged handler";
+
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void SettingItemSourceToNullShouldNotCrash()
+    {
+        App.WaitForElement("Item1");
+        App.Tap("Item1");
+        App.WaitForElement("MauiLabel"); // If app doesn't crash, test passes.
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29882.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29882.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue29882 : _IssuesUITest
 {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Added null checks for ItemsSource in all platform and xplat selection/deselection methods.

This fix is intended as a patch to prevent the crash in SR8.

A follow-up PR will address the root cause.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Contributes to  #29882

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
