### PR TITLE
[iOS] - Enabled MultipleTouch Support for Handling Multi-Touch Points in GraphicsView

### DIFF
--- a/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Platform
 			_proxy = new(this);
 			Opaque = false;
 			BackgroundColor = null;
+			MultipleTouchEnabled = true;
 		}
 
 		public override void LayoutSubviews()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

On iOS, `UIView` has `MultipleTouchEnabled` set to `false` by default, which causes `PlatformTouchGraphicsView` to receive only a single touch point. As a result, multi-touch gestures like pinch and zoom do not function correctly.
 
### Description of Change

Added multi-touch support to the iOS implementation of `PlatformTouchGraphicsView` by enabling the `MultipleTouchEnabled` property.

**Documentation Reference:**

- As per [Apple's documentation](https://developer.apple.com/documentation/uikit/uiview/ismultipletouchenabled):  This property defaults to `false` and must be explicitly set to `true` to receive multiple touches.

### Issues Fixed

Fixes #29461

**Tested the behaviour in the following platforms**

- [x] Android
- [ ]  Windows
- [x]  iOS
- [ ] Mac

### Test Case

**Note :** Appium currently does not support multi-finger touch actions, which makes it technically infeasible to automate a test case for this scenario. Therefore, a test case could not be added to validate this fix through automated UI testing.

### Output

| Before| After|
|--|--|
| <video src="https://github.com/user-attachments/assets/420413f4-e251-4e55-892e-2c3378b98ac9"> | <video src="https://github.com/user-attachments/assets/bd609251-320a-4188-ab04-6146767708dd"> |
