### PR TITLE
[housekeeping] Update namespaces in HostApp and Shared tests projects

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Controls.TestCases.HostApp.Issues.Issue15649"
-             xmlns:local="clr-namespace:Controls.TestCases.HostApp.Issues"
+             x:Class="Maui.Controls.Sample.Issues.Issue15649"
+             xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
              x:Name="HomePage"
              Title="Issue15649">
     <ContentPage.Resources>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15649.xaml.cs
@@ -1,4 +1,4 @@
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 15649, "Updating a ControlTemplate at runtime for a Content Page is not working.", PlatformAffected.All)]
 public partial class Issue15649 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20419.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20419.cs
@@ -1,4 +1,4 @@
-﻿namespace Controls.TestCases.HostApp.Issues;
+﻿namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 20419, "Argument Exception raised when the GetStringSize method of ICanvas called with default font", PlatformAffected.UWP)]
 public class Issue20419 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20443.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20443.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Controls.TestCases.HostApp.Issues.Issue20443"
-              xmlns:local="clr-namespace:Controls.TestCases.HostApp.Issues"
+             x:Class="Maui.Controls.Sample.Issues.Issue20443"
+              xmlns:local="clr-namespace:Maui.Controls.Sample.Issues"
               x:DataType="local:Issue20443ViewModel"
              Title="Issue20443">
   <ContentPage.BindingContext>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20443.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20443.xaml.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 
-namespace Controls.TestCases.HostApp.Issues
+namespace Maui.Controls.Sample.Issues
 {
 	[Issue(IssueTracker.Github, 20443, "CollectionView item sizing wrong after refresh", PlatformAffected.iOS)]
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27169.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27169.cs
@@ -1,4 +1,4 @@
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 27169, "Grid inside ScrollView should measure with infinite constraints", PlatformAffected.iOS)]
 public class Issue27169 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27803.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27803.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Controls.TestCases.HostApp.Issues.Issue27803"
+             x:Class="Maui.Controls.Sample.Issues.Issue27803"
              Title="Issue27803">
     <VerticalStackLayout VerticalOptions="Center"
                          HorizontalOptions="Center"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27803.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27803.xaml.cs
@@ -1,4 +1,4 @@
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 27803, "DatePicker default format on iOS", PlatformAffected.iOS)]
 public partial class Issue27803 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Controls.TestCases.HostApp.Issues.Issue27992"
+             x:Class="Maui.Controls.Sample.Issues.Issue27992"
              Title="Issue27992">
      <VerticalStackLayout Margin="10,30,10,0">
               <Entry AutomationId="MauiEntry" Completed="Entry_Completed"

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27992.xaml.cs
@@ -1,4 +1,4 @@
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 27992, "Entry Completed Event Triggered Twice", PlatformAffected.Android)]
 public partial class Issue27992 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28153.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28153.cs
@@ -1,4 +1,4 @@
-﻿namespace Controls.TestCases.HostApp.Issues;
+﻿namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 28153, "The border color of the RadioButton is visible in Windows only", PlatformAffected.UWP)]
 class Issue28153 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28657.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28657.cs
@@ -1,4 +1,4 @@
-﻿namespace Controls.TestCases.HostApp.Issues;
+﻿namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 28657, "iOS - Rotating the simulator would cause clipping on the description text", PlatformAffected.iOS)]
 class Issue28657 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29216.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29216.cs
@@ -1,6 +1,6 @@
 ﻿using Maui.Controls.Sample.Issues;
 
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29216, "Carousel view scrolling on button click", PlatformAffected.UWP)]
 public class Issue29216 : TestContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Controls.TestCases.HostApp.Issues.Issue29233"
+             x:Class="Maui.Controls.Sample.Issues.Issue29233"
              Title="Issue29233">
     <VerticalStackLayout VerticalOptions="Center">
         <Label AutomationId="WaitLabel" x:Name="waitLabel" />

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29233.xaml.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29233, "Android WebView Navigated is fired without setting source", PlatformAffected.Android)]
 public partial class Issue29233 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29472.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29472.cs
@@ -1,4 +1,4 @@
-﻿namespace Controls.TestCases.HostApp.Issues;
+﻿namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29472, "ItemsSource is not dynamically cleared in the CarouselView", PlatformAffected.UWP)]
 public class Issue29472 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue6387.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue6387.cs
@@ -1,4 +1,4 @@
-﻿namespace Controls.TestCases.HostApp.Issues;
+﻿namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 6387, "ArgumentException thrown when a negative value is set for the padding of a label", PlatformAffected.UWP)]
 public class Issue6387 : ContentPage

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue7144.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue7144.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 7144, "IndicatorView using templated icons not working", PlatformAffected.UWP)]
 public class Issue7144 : ContentPage

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27803.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27803.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue27803 : _IssuesUITest
 {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27992.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27992.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue27992 : _IssuesUITest
 {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29233.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29233.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Tests.Issues;
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue29233 : _IssuesUITest
 {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Update namespaces to follow standard naming convention:

Changes in hostapp:
- `Controls.TestCases.HostApp.Issues` -> `Maui.Controls.Sample.Issues`
- Update corresponding XAML class references

Changes in Shared Tests project:
- ` Microsoft.Maui.TestCases.Tests.Tests.Issues` -> `Microsoft.Maui.TestCases.Tests.Issues`

