### PR TITLE
[iOS] Device tests - html label

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -333,6 +333,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				label.TextType = TextType.Html;
 
+				// We need to delay here because platformLabel.UpdateTextHtml(label) and label.InvalidateMeasure()
+				// are dispatched asynchronously to the main thread and may not complete immediately.
+				// https://github.com/dotnet/maui/pull/26153
+				await Task.Delay(100);
 				await platformView.AssertDoesNotContainColor(Colors.Red, MauiContext);
 			});
 		}
@@ -517,9 +521,13 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "<p>Test</p>"
 			};
 
-			await InvokeOnMainThreadAsync(() =>
+			await InvokeOnMainThreadAsync(async () =>
 			{
 				var handler = CreateHandler<LabelHandler>(label);
+				// We need to delay here because platformLabel.UpdateTextHtml(label) and label.InvalidateMeasure()
+				// are dispatched asynchronously to the main thread and may not complete immediately.
+				// https://github.com/dotnet/maui/pull/26153
+				await Task.Delay(100);
 				AssertEquivalentFont(handler, label.ToFont());
 			});
 		}
@@ -715,9 +723,13 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "<p>Test</p>"
 			};
 
-			await InvokeOnMainThreadAsync(() =>
+			await InvokeOnMainThreadAsync(async () =>
 			{
 				var handler = CreateHandler<LabelHandler>(label);
+				// We need to delay here because platformLabel.UpdateTextHtml(label) and label.InvalidateMeasure()
+				// are dispatched asynchronously to the main thread and may not complete immediately.
+				// https://github.com/dotnet/maui/pull/26153
+				await Task.Delay(100);
 				label.FontFamily = "Baskerville";
 				label.FontSize = 64;
 				AssertEquivalentFont(handler, label.ToFont());


### PR DESCRIPTION
### Description of Change

This Pr fixes these test failures
![Screenshot 2025-06-10 at 17 56 38](https://github.com/user-attachments/assets/7553a260-950a-454d-ba4d-a488161bad09)

We need to delay here because platformLabel.UpdateTextHtml(label) and label.InvalidateMeasure() are dispatched asynchronously to the main thread and may not complete immediately.
The changes were introduced in this PR: https://github.com/dotnet/maui/pull/26153
