### PR TITLE
[Windows] Fixed StackLayout crashes on Windows with HeightRequest as 0

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29919.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29919.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29919, "StackLayout Throws Exception on Windows When Orientation Is Set with HeightRequest of 0, Padding, and Opposing Alignment", PlatformAffected.UWP)]
+public class Issue29919 : ContentPage
+{
+    public Issue29919()
+    {
+		var stack = new StackLayout();
+		var label = new Label
+		{
+			Text = "HorizontalStackLayout with HeightRequest 0 should not crash.",
+			AutomationId = "29919DescriptionLabel",
+		};
+
+        var horizontalStack = new HorizontalStackLayout
+        {
+            Padding = new Thickness(5),
+            HeightRequest = 0,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+		stack.Children.Add(label);
+		stack.Children.Add(horizontalStack);
+		Content = stack;
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29919.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29919.cs
@@ -8,7 +8,7 @@ public class Issue29919 : ContentPage
 		var stack = new StackLayout();
 		var label = new Label
 		{
-			Text = "VerticalStackLayout and HorizontalStackLayout should not crash with HeightRequest set to 0.",
+			Text = "VerticalStackLayout and HorizontalStackLayout should not crash when WidthRequest or HeightRequest is explicitly set to 0, respectively.",
 			AutomationId = "29919DescriptionLabel",
 		};
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29919.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29919.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29919, "StackLayout Throws Exception on Windows When Orientation Is Set with HeightRequest of 0, Padding, and Opposing Alignment", PlatformAffected.UWP)]
@@ -10,7 +8,7 @@ public class Issue29919 : ContentPage
 		var stack = new StackLayout();
 		var label = new Label
 		{
-			Text = "HorizontalStackLayout with HeightRequest 0 should not crash.",
+			Text = "VerticalStackLayout and HorizontalStackLayout should not crash with HeightRequest set to 0.",
 			AutomationId = "29919DescriptionLabel",
 		};
 
@@ -21,8 +19,17 @@ public class Issue29919 : ContentPage
             VerticalOptions = LayoutOptions.Center
         };
 
+		var verticalStack = new VerticalStackLayout
+		{
+			Padding = new Thickness(5),
+			WidthRequest = 0,
+			HeightRequest = 100,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
 		stack.Children.Add(label);
 		stack.Children.Add(horizontalStack);
+		stack.Children.Add(verticalStack);
 		Content = stack;
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29919.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29919.cs
@@ -1,4 +1,3 @@
-
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29919.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29919.cs
@@ -1,0 +1,22 @@
+
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29919 : _IssuesUITest
+{
+    public Issue29919(TestDevice testDevice) : base(testDevice)
+    {
+    }
+
+    public override string Issue => "StackLayout Throws Exception on Windows When Orientation Is Set with HeightRequest of 0, Padding, and Opposing Alignment";
+
+    [Test]
+    [Category(UITestCategories.Layout)]
+    public void StackLayoutWindowsCrashWithZeroHeight()
+    {
+        App.WaitForElement("29919DescriptionLabel");
+    }
+}

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Layouts
 
 			double top = padding.Top + bounds.Top;
 
-			var height = bounds.Height - padding.VerticalThickness;
+			var height = Math.Max(0, bounds.Height - padding.VerticalThickness);
 
 			// Figure out where we're starting from 
 			double xPosition = padding.Left + bounds.Left;

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Layouts
 
 			double stackHeight = padding.Top + bounds.Y;
 			double left = padding.Left + bounds.X;
-			double width = bounds.Width - padding.HorizontalThickness;
+			double width = Math.Max(0, bounds.Width - padding.HorizontalThickness);
 
 			for (int n = 0; n < Stack.Count; n++)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Detail
Setting HeightRequest="0" with padding as some value on stack layouts throws exceptions ,when alignment is set in the opposite direction of the layout.
 
### Root Cause
On Windows in .NET MAUI, setting HeightRequest="0" (or WidthRequest="0") with padding causes a layout exception. This happens because padding is subtracted from bounds.Height/bounds.Width which is explicitly set as 0, resulting in a negative size.
 
### Description of Change
Updated ArrangeChildren methods in both VerticalStackLayoutManager and HorizontalStackLayoutManager to clamp the calculated available size using Math.Max. This ensures the available space is never negative, thereby preventing exceptions during layout on Windows while preserving expected behavior on all platforms.
 
 
### Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed:
Fixes #29919
 
### Screenshots
| Before  | After |
|---------|--------|
|  <img src="https://github.com/user-attachments/assets/3b5833cb-fdef-4ca2-8b2b-67a4041a638e"> |   <img src="https://github.com/user-attachments/assets/7612448c-4b57-4ef9-a449-e0a20e4fca5e">  |
