### PR TITLE
[Windows] FlyoutPage: update CollapseStyle at runtime

### DIFF
--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty), MapPrefersPrefersStatusBarHiddenProperty);
 #endif
 #if WINDOWS
-			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.WindowsSpecific.FlyoutPage.CollapseStyleProperty), MapStyle);
+			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.WindowsSpecific.FlyoutPage.CollapseStyleProperty), MapCollapseStyle);
 #endif
 		}
 
@@ -36,9 +36,10 @@ namespace Microsoft.Maui.Controls
 #endif
 
 #if WINDOWS
-		internal static void MapStyle(IFlyoutViewHandler handler, IFlyoutView view)
+		internal static void MapCollapseStyle(IFlyoutViewHandler handler, IFlyoutView view)
 		{
-			if (view is BindableObject bindable && handler.PlatformView is Microsoft.Maui.Platform.RootNavigationView navigationView && view.FlyoutBehavior == FlyoutBehavior.Flyout)
+			var flyoutLayoutBehavior = (view as FlyoutPage)?.FlyoutLayoutBehavior;
+			if (view is BindableObject bindable && handler.PlatformView is Microsoft.Maui.Platform.RootNavigationView navigationView && flyoutLayoutBehavior == FlyoutLayoutBehavior.Popover)
 			{
 				var collapseStyle = PlatformConfiguration.WindowsSpecific.FlyoutPage.GetCollapseStyle(bindable);
 				switch (collapseStyle)

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Controls
 		internal static void MapCollapseStyle(IFlyoutViewHandler handler, IFlyoutView view)
 		{
 			var flyoutLayoutBehavior = (view as FlyoutPage)?.FlyoutLayoutBehavior;
-			if (view is BindableObject bindable && handler.PlatformView is Microsoft.Maui.Platform.RootNavigationView navigationView && flyoutLayoutBehavior == FlyoutLayoutBehavior.Popover)
+			if (view is BindableObject bindable && handler.PlatformView is Microsoft.Maui.Platform.RootNavigationView navigationView && flyoutLayoutBehavior is FlyoutLayoutBehavior.Popover)
 			{
 				var collapseStyle = PlatformConfiguration.WindowsSpecific.FlyoutPage.GetCollapseStyle(bindable);
 				switch (collapseStyle)

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Maui.Controls
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty), MapPrefersHomeIndicatorAutoHiddenProperty);
 			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty), MapPrefersPrefersStatusBarHiddenProperty);
 #endif
+#if WINDOWS
+			FlyoutViewHandler.Mapper.ReplaceMapping<IFlyoutView, IFlyoutViewHandler>(nameof(PlatformConfiguration.WindowsSpecific.FlyoutPage.CollapseStyleProperty), MapStyle);
+#endif
 		}
 
 		internal static void MapFlyoutLayoutBehavior(IFlyoutViewHandler handler, IFlyoutView view)
@@ -29,6 +32,26 @@ namespace Microsoft.Maui.Controls
 		internal static void MapPrefersPrefersStatusBarHiddenProperty(IFlyoutViewHandler handler, IFlyoutView view)
 		{
 			handler.UpdateValue(nameof(PlatformConfiguration.iOSSpecific.Page.PrefersStatusBarHiddenProperty));
+		}
+#endif
+
+#if WINDOWS
+		internal static void MapStyle(IFlyoutViewHandler handler, IFlyoutView view)
+		{
+			if (view is BindableObject bindable && handler.PlatformView is Microsoft.Maui.Platform.RootNavigationView navigationView && view.FlyoutBehavior == FlyoutBehavior.Flyout)
+			{
+				var collapseStyle = PlatformConfiguration.WindowsSpecific.FlyoutPage.GetCollapseStyle(bindable);
+				switch (collapseStyle)
+				{
+					case PlatformConfiguration.WindowsSpecific.CollapseStyle.Partial:
+						navigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftCompact;
+						break;
+					case PlatformConfiguration.WindowsSpecific.CollapseStyle.Full:
+					default:
+						navigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+						break;
+				}
+			}
 		}
 #endif
 	}

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.Mapper.cs
@@ -45,10 +45,12 @@ namespace Microsoft.Maui.Controls
 				switch (collapseStyle)
 				{
 					case PlatformConfiguration.WindowsSpecific.CollapseStyle.Partial:
+						navigationView.FlyoutPaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftCompact;
 						navigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftCompact;
 						break;
 					case PlatformConfiguration.WindowsSpecific.CollapseStyle.Full:
 					default:
+						navigationView.FlyoutPaneDisplayMode = null;
 						navigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
 						break;
 				}

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -13,7 +13,17 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <summary>Bindable property for <see cref="CollapseStyle"/>.</summary>
 		public static readonly BindableProperty CollapseStyleProperty =
 			BindableProperty.CreateAttached("CollapseStyle", typeof(CollapseStyle),
-				typeof(FlyoutPage), CollapseStyle.Full);
+				typeof(FlyoutPage), CollapseStyle.Full, propertyChanged: OnCollapseStylePropertyChanged);
+
+		static void OnCollapseStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+#if WINDOWS
+			if (bindable is Microsoft.Maui.Controls.FlyoutPage flyoutPage)
+			{
+				flyoutPage.Handler.UpdateValue(nameof(CollapseStyleProperty));
+			}
+#endif
+		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle'][1]/Docs/*" />
 		public static CollapseStyle GetCollapseStyle(BindableObject element)

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -17,12 +17,10 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 
 		static void OnCollapseStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-#if WINDOWS
 			if (bindable is Microsoft.Maui.Controls.FlyoutPage flyoutPage && flyoutPage.Handler is not null)
 			{
 				flyoutPage.Handler.UpdateValue(nameof(CollapseStyleProperty));
 			}
-#endif
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle'][1]/Docs/*" />

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		static void OnCollapseStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 #if WINDOWS
-			if (bindable is Microsoft.Maui.Controls.FlyoutPage flyoutPage)
+			if (bindable is Microsoft.Maui.Controls.FlyoutPage flyoutPage && flyoutPage.Handler is not null)
 			{
 				flyoutPage.Handler.UpdateValue(nameof(CollapseStyleProperty));
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
@@ -67,7 +67,7 @@ public class Issue18200 : TestFlyoutPage
         Detail = detailPage;
     }
 
-    private void OnCollapseStyleValueChanged(object sender, EventArgs e)
+    void OnCollapseStyleValueChanged(object sender, EventArgs e)
     {
 		var currentCollapseStyle = this.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetCollapseStyle();
 		var newCollapseStyle = currentCollapseStyle == CollapseStyle.Full 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
@@ -29,16 +29,9 @@ public class Issue18200 : TestFlyoutPage
             VerticalOptions = LayoutOptions.Center
         };
 
-        var page2Button = new Button
-        {
-            Text = "Page2",
-            HorizontalOptions = LayoutOptions.Start,
-            VerticalOptions = LayoutOptions.Center
-        };
-
         flyoutPage.Content = new VerticalStackLayout
         {
-            Children = { page1Button, page2Button }
+            Children = { page1Button }
         };
 
         // Create the detail content
@@ -51,7 +44,7 @@ public class Issue18200 : TestFlyoutPage
         _button = new Button
         {
             Text = "Change Collapse Style",
-            AutomationId = "ToggleFlyoutLayoutBehavior"
+            AutomationId = "CollapseStyleButton",
         };
         _button.Clicked += OnCollapseStyleValueChanged;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
@@ -10,7 +10,7 @@ public class Issue18200 : TestFlyoutPage
 	protected override void Init()
     {
 		// Set the platform-specific collapse style (equivalent to your NewPage1.xaml.cs)
-		this.On<Windows>().SetCollapseStyle(CollapseStyle.Partial);
+		this.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetCollapseStyle(CollapseStyle.Partial);
 
         // Set the flyout page properties
         FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover;
@@ -25,6 +25,7 @@ public class Issue18200 : TestFlyoutPage
         var page1Button = new Button
         {
             Text = "Page1",
+			AutomationId = "FlyoutItem",
             HorizontalOptions = LayoutOptions.Start,
             VerticalOptions = LayoutOptions.Center
         };
@@ -69,11 +70,11 @@ public class Issue18200 : TestFlyoutPage
 
     private void OnCollapseStyleValueChanged(object sender, EventArgs e)
     {
-		var currentCollapseStyle = this.On<Windows>().GetCollapseStyle();
+		var currentCollapseStyle = this.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetCollapseStyle();
 		var newCollapseStyle = currentCollapseStyle == CollapseStyle.Full 
 			? CollapseStyle.Partial 
 			: CollapseStyle.Full;
 		
-		this.On<Windows>().SetCollapseStyle(newCollapseStyle);
+		this.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetCollapseStyle(newCollapseStyle);
     }
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.Maui.Controls.PlatformConfiguration;
+using  Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 18200, "Flyout Page SetCollapseStyle doesn't have any change", PlatformAffected.UWP)]
+public class Issue18200 : TestFlyoutPage
+{
+	Button _button;
+	protected override void Init()
+    {
+		// Set the platform-specific collapse style (equivalent to your NewPage1.xaml.cs)
+		this.On<Windows>().SetCollapseStyle(CollapseStyle.Partial);
+
+        // Set the flyout page properties
+        FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover;
+
+        // Create the flyout content
+        var flyoutPage = new ContentPage
+        {
+            Title = "Master",
+            BackgroundColor = Colors.Blue
+        };
+
+        var page1Button = new Button
+        {
+            Text = "Page1",
+            HorizontalOptions = LayoutOptions.Start,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        var page2Button = new Button
+        {
+            Text = "Page2",
+            HorizontalOptions = LayoutOptions.Start,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        flyoutPage.Content = new VerticalStackLayout
+        {
+            Children = { page1Button, page2Button }
+        };
+
+        // Create the detail content
+        var detailPage = new ContentPage
+        {
+            Title = "Detail",
+            BackgroundColor = Colors.LightYellow
+        };
+
+        _button = new Button
+        {
+            Text = "Change Collapse Style",
+            AutomationId = "ToggleFlyoutLayoutBehavior"
+        };
+        _button.Clicked += OnCollapseStyleValueChanged;
+
+        detailPage.Content = new VerticalStackLayout
+        {
+            Children = {
+                new Microsoft.Maui.Controls.Label
+                {
+                    Text = "Welcome to .NET MAUI!",
+                    TextColor = Colors.Black,
+                    HorizontalOptions = LayoutOptions.Center,
+                    VerticalOptions = LayoutOptions.Center
+                },
+                _button
+            }
+        };
+
+        // Set the flyout and detail pages
+        Flyout = flyoutPage;
+        Detail = detailPage;
+    }
+
+    private void OnCollapseStyleValueChanged(object sender, EventArgs e)
+    {
+		var currentCollapseStyle = this.On<Windows>().GetCollapseStyle();
+		var newCollapseStyle = currentCollapseStyle == CollapseStyle.Full 
+			? CollapseStyle.Partial 
+			: CollapseStyle.Full;
+		
+		this.On<Windows>().SetCollapseStyle(newCollapseStyle);
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18200.cs
@@ -9,7 +9,6 @@ public class Issue18200 : TestFlyoutPage
 	Button _button;
 	protected override void Init()
     {
-		// Set the platform-specific collapse style (equivalent to your NewPage1.xaml.cs)
 		this.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetCollapseStyle(CollapseStyle.Partial);
 
         // Set the flyout page properties

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18200.cs
@@ -1,4 +1,4 @@
-# if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS  // It's a Windows specific API issue, so restricting the other platforms
+# if WINDOWS  // It's a Windows specific API issue, so restricting the other platforms
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18200.cs
@@ -1,3 +1,4 @@
+# if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS  // It's a Windows specific API issue, so restricting the other platforms
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -19,5 +20,10 @@ public class Issue18200 : _IssuesUITest
 		App.WaitForElement("CollapseStyleButton");
 		App.Tap("CollapseStyleButton");
 		App.TapFlyoutPageIcon();
+		App.TapFlyoutPageIcon(); // Close the flyout
+		App.WaitForNoElement("FlyoutItem");
+		App.Tap("CollapseStyleButton");
+		App.WaitForElement("FlyoutItem");
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18200.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18200.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue18200 : _IssuesUITest
+{
+	public Issue18200(TestDevice device)
+		: base(device)
+	{ }
+
+	public override string Issue => "Flyout Page SetCollapseStyle doesn't have any change";
+
+	[Test]
+	[Category(UITestCategories.FlyoutPage)]
+	public void VerifyFlyoutCollapseStyleBehaviorChanges()
+	{
+		App.WaitForElement("CollapseStyleButton");
+		App.Tap("CollapseStyleButton");
+		App.TapFlyoutPageIcon();
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -182,13 +182,14 @@ namespace Microsoft.Maui.Platform
 			{
 				case FlyoutBehavior.Flyout:
 					IsPaneToggleButtonVisible = true;
+					var flyoutMode = FlyoutPaneDisplayMode ?? NavigationViewPaneDisplayMode.LeftMinimal;
 					// WinUI bug: Setting PaneDisplayMode to the same value and updating SelectedItem during navigation
 					// causes the selection and selected item indicator to not update correctly.
 					// Workaround: Only set PaneDisplayMode when the value actually changes.
 					// Related: https://github.com/microsoft/microsoft-ui-xaml/issues/9812
-					if (PaneDisplayMode != NavigationViewPaneDisplayMode.LeftMinimal)
+					if (PaneDisplayMode != flyoutMode)
 					{
-						PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
+						PaneDisplayMode = flyoutMode;
 					}
 					break;
 				case FlyoutBehavior.Locked:
@@ -370,6 +371,11 @@ namespace Microsoft.Maui.Platform
 			= DependencyProperty.Register(nameof(PaneToggleButtonWidth), typeof(double), typeof(MauiNavigationView),
 				new PropertyMetadata(DefaultPaneToggleButtonWidth, OnPaneToggleButtonSizeChanged));
 		private NavigationViewPaneDisplayMode? _pinPaneDisplayModeTo;
+
+		// Stores the preferred pane display mode for FlyoutBehavior.Flyout, set by CollapseStyle on Windows.
+		// When null, the default LeftMinimal is used. This ensures CollapseStyle.Partial (LeftCompact) survives
+		// layout-driven FlyoutBehavior re-evaluations (e.g. size/orientation changes).
+		internal NavigationViewPaneDisplayMode? FlyoutPaneDisplayMode { get; set; }
 
 		internal double PaneToggleButtonWidth
 		{


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue details
FlyoutPage on Windows did not update its layout when the CollapseStyle property changed at runtime.


### Description of Change

<!-- Enter description of the fix in this section -->
This update enables dynamic support for the CollapseStyle property in FlyoutPage on Windows. It allows the flyout pane to update at runtime when the property changes,


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #18200 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Windows


| Before  | After  |
|---------|--------|
| **Windows**<br> <video src="https://github.com/user-attachments/assets/9d7844d7-af65-465a-abb3-b611290afe1f" width="400" height="250"> |**Windows**<br> <video src="https://github.com/user-attachments/assets/2edd0934-c369-4dda-8269-e22291769c2e" width="400" height="250"> |

