### PR TITLE
[Android] Fix the Setting Content of ContentView through style would crash on parent change 

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
@@ -16,12 +16,12 @@ public class Issue11812 : ContentPage
 		{
 			Text = "Add ContentView",
 			HorizontalOptions = LayoutOptions.Center,
-			AutomationId = "TestButton"
+			AutomationId = "ChangeInnerContent"
 		};
 		button.Clicked += OnButtonClicked;
 
 		_mainContentView = new ContentView();
-		_mainContentView.SetBinding(ContentView.ContentProperty, "Content.InnerContentView");
+		_mainContentView.SetBinding(ContentView.ContentProperty, "Content");
 
 		var layout = new VerticalStackLayout
 		{
@@ -39,10 +39,7 @@ public class Issue11812 : ContentPage
 	}
 	private void OnButtonClicked(object sender, EventArgs e)
 	{
-		_viewModel.Content = new Issue11812Model()
-		{
-			InnerContentView = new Issue11812InnerContentView() { BackgroundColor = Colors.Red }
-		};
+		_viewModel.Content = new Issue11812InnerContentView() { BackgroundColor = Colors.Red };
 	}
 }
 
@@ -69,24 +66,15 @@ public class Issue11812InnerContentView : ContentView
 		Style = (Style)Application.Current.Resources["SubContentStyle"];
 	}
 }
-
-public class Issue11812Model
-{
-	public Issue11812InnerContentView InnerContentView { get; set; }
-}
-
 public class Issue11812ViewModel : INotifyPropertyChanged
 {
 	public Issue11812ViewModel()
 	{
-		Content = new Issue11812Model()
-		{
-			InnerContentView = new Issue11812InnerContentView()
-		};
+		Content = new Issue11812InnerContentView();
 	}
 
-	private Issue11812Model _content;
-	public Issue11812Model Content
+	private Issue11812InnerContentView _content;
+	public Issue11812InnerContentView Content
 	{
 		get => _content;
 		set

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
@@ -7,10 +7,9 @@ namespace Maui.Controls.Sample.Issues;
 public class Issue11812 : ContentPage
 {
 	ContentView _mainContentView;
-	Issue11812ViewModel _viewModel;
 	public Issue11812()
 	{
-		this.BindingContext = _viewModel = new Issue11812ViewModel();
+		this.BindingContext = new Issue11812ViewModel();
 
 		var button = new Button
 		{
@@ -39,7 +38,7 @@ public class Issue11812 : ContentPage
 	}
 	private void OnButtonClicked(object sender, EventArgs e)
 	{
-		_viewModel.Content = new Issue11812InnerContentView() { BackgroundColor = Colors.Red };
+		_mainContentView.Content = new Issue11812InnerContentView() { BackgroundColor = Colors.Red };
 	}
 }
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
@@ -9,8 +9,6 @@ public class Issue11812 : ContentPage
 	ContentView _mainContentView;
 	public Issue11812()
 	{
-		this.BindingContext = new Issue11812ViewModel();
-
 		var button = new Button
 		{
 			Text = "Add ContentView",
@@ -20,7 +18,7 @@ public class Issue11812 : ContentPage
 		button.Clicked += OnButtonClicked;
 
 		_mainContentView = new ContentView();
-		_mainContentView.SetBinding(ContentView.ContentProperty, "Content");
+		_mainContentView.Content = new Issue11812InnerContentView();
 
 		var layout = new VerticalStackLayout
 		{
@@ -63,32 +61,5 @@ public class Issue11812InnerContentView : ContentView
 			};
 		}
 		Style = (Style)Application.Current.Resources["SubContentStyle"];
-	}
-}
-public class Issue11812ViewModel : INotifyPropertyChanged
-{
-	public Issue11812ViewModel()
-	{
-		Content = new Issue11812InnerContentView();
-	}
-
-	private Issue11812InnerContentView _content;
-	public Issue11812InnerContentView Content
-	{
-		get => _content;
-		set
-		{
-			if (_content != value)
-			{
-				_content = value;
-				OnPropertyChanged();
-			}
-		}
-	}
-	public event PropertyChangedEventHandler PropertyChanged;
-
-	protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-	{
-		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
@@ -1,0 +1,127 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 11812, "Setting Content of ContentView through style would crash on parent change", PlatformAffected.Android)]
+public partial class Issue11812 : ContentPage
+{
+	Label _countLabel;
+	ContentView _mainContentView;
+	Issue11812ViewModel _viewModel;
+	public Issue11812()
+	{
+		this.BindingContext = _viewModel = new Issue11812ViewModel();
+
+		var button = new Button
+		{
+			Text = "Add ContentView",
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "TestButton"
+		};
+		button.Clicked += OnButtonClicked;
+
+		_countLabel = new Label();
+		_countLabel.AutomationId = "TestLabel";
+		_countLabel.SetBinding(Label.TextProperty, "Count");
+
+		_mainContentView = new ContentView();
+		_mainContentView.SetBinding(ContentView.ContentProperty, "Content.InnerContentView");
+
+		var layout = new VerticalStackLayout
+		{
+			Spacing = 25,
+			Padding = new Thickness(30, 0),
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				button,
+				_countLabel,
+				_mainContentView
+			}
+		};
+
+		Content = layout;
+	}
+	private void OnButtonClicked(object sender, EventArgs e)
+	{
+		_viewModel.Count++;
+		_viewModel.Content = new Issue11812Model()
+		{
+			InnerContentView = new Issue11812InnerContentView() { BackgroundColor = Colors.Red }
+		};
+	}
+}
+
+public class Issue11812InnerContentView : ContentView
+{
+	public Issue11812InnerContentView()
+	{
+		Application.Current.Resources ??= new ResourceDictionary();
+
+		if (!Application.Current.Resources.ContainsKey("SubContentStyle"))
+		{
+			Application.Current.Resources["SubContentStyle"] = new Style(typeof(ContentView))
+			{
+				Setters =
+			{
+				new Setter
+				{
+					Property = ContentView.ContentProperty,
+					Value = new Label { Text = "SubContent" }
+				}
+			}
+			};
+		}
+		Style = (Style)Application.Current.Resources["SubContentStyle"];
+	}
+}
+
+public class Issue11812Model
+{
+	public Issue11812InnerContentView InnerContentView { get; set; }
+}
+
+public class Issue11812ViewModel : INotifyPropertyChanged
+{
+	public Issue11812ViewModel()
+	{
+		Content = new Issue11812Model()
+		{
+			InnerContentView = new Issue11812InnerContentView()
+		};
+	}
+
+	private Issue11812Model _content;
+	public Issue11812Model Content
+	{
+		get => _content;
+		set
+		{
+			if (_content != value)
+			{
+				_content = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+	private int _count;
+	public int Count
+	{
+		get => _count;
+		set
+		{
+			if (_count != value)
+			{
+				_count = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+	public event PropertyChangedEventHandler PropertyChanged;
+
+	protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
@@ -6,7 +6,6 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 11812, "Setting Content of ContentView through style would crash on parent change", PlatformAffected.Android)]
 public class Issue11812 : ContentPage
 {
-	Label _countLabel;
 	ContentView _mainContentView;
 	Issue11812ViewModel _viewModel;
 	public Issue11812()
@@ -21,10 +20,6 @@ public class Issue11812 : ContentPage
 		};
 		button.Clicked += OnButtonClicked;
 
-		_countLabel = new Label();
-		_countLabel.AutomationId = "TestLabel";
-		_countLabel.SetBinding(Label.TextProperty, "Count");
-
 		_mainContentView = new ContentView();
 		_mainContentView.SetBinding(ContentView.ContentProperty, "Content.InnerContentView");
 
@@ -36,7 +31,6 @@ public class Issue11812 : ContentPage
 			Children =
 			{
 				button,
-				_countLabel,
 				_mainContentView
 			}
 		};
@@ -45,7 +39,6 @@ public class Issue11812 : ContentPage
 	}
 	private void OnButtonClicked(object sender, EventArgs e)
 	{
-		_viewModel.Count++;
 		_viewModel.Content = new Issue11812Model()
 		{
 			InnerContentView = new Issue11812InnerContentView() { BackgroundColor = Colors.Red }
@@ -101,19 +94,6 @@ public class Issue11812ViewModel : INotifyPropertyChanged
 			if (_content != value)
 			{
 				_content = value;
-				OnPropertyChanged();
-			}
-		}
-	}
-	private int _count;
-	public int Count
-	{
-		get => _count;
-		set
-		{
-			if (_count != value)
-			{
-				_count = value;
 				OnPropertyChanged();
 			}
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11812.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 11812, "Setting Content of ContentView through style would crash on parent change", PlatformAffected.Android)]
-public partial class Issue11812 : ContentPage
+public class Issue11812 : ContentPage
 {
 	Label _countLabel;
 	ContentView _mainContentView;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Maui.Controls;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue11812 : _IssuesUITest
+{
+	public Issue11812(TestDevice device) : base(device) { }
+
+	public override string Issue => "Setting Content of ContentView through style would crash on parent change";
+
+	[Test]
+	[Category(UITestCategories.Border)]
+	public void InnerContentViewShouldNotCrash()
+	{
+		App.WaitForElement("TestButton");
+		App.Tap("TestButton");
+		App.WaitForElement("TestLabel");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
@@ -16,6 +16,6 @@ public class Issue11812 : _IssuesUITest
 	{
 		App.WaitForElement("TestButton");
 		App.Tap("TestButton");
-		App.WaitForElement("TestLabel");
+		App.WaitForElement("TestButton");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Maui.Controls;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
@@ -12,10 +12,10 @@ public class Issue11812 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.Border)]
-	public void InnerContentViewShouldNotCrash()
+	public void InnerContentViewShouldNotCrashWhenDynamicallyChange()
 	{
-		App.WaitForElement("TestButton");
-		App.Tap("TestButton");
-		App.WaitForElement("TestButton");
+		App.WaitForElement("ChangeInnerContent");
+		App.Tap("ChangeInnerContent");
+		App.WaitForElement("ChangeInnerContent");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11812.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAILS_ON_WINDOWS // test fails on windows , see https://github.com/dotnet/maui/issues/29930
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -19,3 +20,4 @@ public class Issue11812 : _IssuesUITest
 		App.WaitForElement("ChangeInnerContent");
 	}
 }
+#endif

--- a/src/Core/src/Handlers/Border/BorderHandler.Android.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Android.cs
@@ -45,11 +45,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
 				// Ensure the view is detached from any existing parent before adding it
-				if (platformView.Parent is Android.Views.ViewGroup oldParent)
-				{
-					oldParent.RemoveView(platformView);
-				}
-
+				platformView.RemoveFromParent();
 				handler.PlatformView.AddView(platformView);
 			}
 		}

--- a/src/Core/src/Handlers/Border/BorderHandler.Android.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Android.cs
@@ -44,9 +44,11 @@ namespace Microsoft.Maui.Handlers
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
-				//Ensure the view is detached from any existing parent before adding it
-				var parent = platformView.Parent as Android.Views.ViewGroup;
-				parent?.RemoveView(platformView);
+				// Ensure the view is detached from any existing parent before adding it
+				if (platformView.Parent is Android.Views.ViewGroup oldParent)
+				{
+					oldParent.RemoveView(platformView);
+				}
 
 				handler.PlatformView.AddView(platformView);
 			}

--- a/src/Core/src/Handlers/Border/BorderHandler.Android.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Android.cs
@@ -42,7 +42,14 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView.RemoveAllViews();
 
 			if (handler.VirtualView.PresentedContent is IView view)
-				handler.PlatformView.AddView(view.ToPlatform(handler.MauiContext));
+			{
+				var platformView = view.ToPlatform(handler.MauiContext);
+				//Ensure the view is detached from any existing parent before adding it
+				var parent = platformView.Parent as Android.Views.ViewGroup;
+				parent?.RemoveView(platformView);
+
+				handler.PlatformView.AddView(platformView);
+			}
 		}
 
 		public static partial void MapHeight(IBorderHandler handler, IBorderView border)

--- a/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.VirtualView.PresentedContent is IView content)
 			{
 				var platformContent = content.ToPlatform(handler.MauiContext);
+				platformContent.RemoveFromSuperview();
 
 				// If the content is a UIScrollView, we need a container to handle masks and clip shapes effectively.
 				if (platformContent is UIScrollView)

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
@@ -39,7 +39,14 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView.RemoveAllViews();
 
 			if (handler.VirtualView.PresentedContent is IView view)
-				handler.PlatformView.AddView(view.ToPlatform(handler.MauiContext));
+			{
+				var platformView = view.ToPlatform(handler.MauiContext);
+				//Ensure the view is detached from any existing parent before adding it
+				var parent = platformView.Parent as Android.Views.ViewGroup;
+				parent?.RemoveView(platformView);
+
+				handler.PlatformView.AddView(platformView);
+			}
 		}
 
 		public static partial void MapContent(IContentViewHandler handler, IContentView page)

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
@@ -42,11 +42,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
 				// Ensure the view is detached from any existing parent before adding it
-				if (platformView.Parent is Android.Views.ViewGroup oldParent)
-				{
-					oldParent.RemoveView(platformView);
-				}
-
+				platformView.RemoveFromParent();
 				handler.PlatformView.AddView(platformView);
 			}
 		}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
@@ -41,9 +41,11 @@ namespace Microsoft.Maui.Handlers
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
-				//Ensure the view is detached from any existing parent before adding it
-				var parent = platformView.Parent as Android.Views.ViewGroup;
-				parent?.RemoveView(platformView);
+				// Ensure the view is detached from any existing parent before adding it
+				if (platformView.Parent is Android.Views.ViewGroup oldParent)
+				{
+					oldParent.RemoveView(platformView);
+				}
 
 				handler.PlatformView.AddView(platformView);
 			}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
 				var platformView = view.ToPlatform(handler.MauiContext);
+				platformView.RemoveFromSuperview();
 				handler.PlatformView.AddSubview(platformView);
 
 				if (view.FlowDirection == FlowDirection.MatchParent)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- The specific child view retains a reference to its old parent when dynamically added because it is defined as a static resource in style. This leads to an `IllegalStateException` on Android when the view is added to a new parent without being removed from the old one. 



### Description of Change



- Before adding the child view to the new parent, ensure that it is detached from any existing parent to prevent the `IllegalStateException`. 



### Issues Fixed



Fixes #11812 

Windows Fix PR : #30047


### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/af3b8989-c093-4cb0-ad56-88d86aa50457"> | <video src="https://github.com/user-attachments/assets/33eed58c-3a2f-472c-a080-1f585eab27d7"> |
