### PR TITLE
Add defensive IsAlive check to Android ViewExtensions.OnUnloaded

### DIFF
--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -556,8 +556,10 @@ namespace Microsoft.Maui.Platform
 			EventHandler<AView.ViewAttachedToWindowEventArgs>? routedEventHandler = null;
 			ActionDisposable? disposable = new ActionDisposable(() =>
 			{
-				if (routedEventHandler != null)
+				if (routedEventHandler is not null && routedEventHandler.IsAlive())
+				
 					view.ViewAttachedToWindow -= routedEventHandler;
+				}
 			});
 
 			routedEventHandler = (_, __) =>

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Maui.Platform
 			EventHandler<AView.ViewAttachedToWindowEventArgs>? routedEventHandler = null;
 			ActionDisposable? disposable = new ActionDisposable(() =>
 			{
-				if (routedEventHandler is not null && routedEventHandler.IsAlive())
+				if (routedEventHandler is not null && view.IsAlive())
 				
 					view.ViewAttachedToWindow -= routedEventHandler;
 				}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -598,16 +598,29 @@ namespace Microsoft.Maui.Platform
 			EventHandler<AView.ViewDetachedFromWindowEventArgs>? routedEventHandler = null;
 			ActionDisposable? disposable = new ActionDisposable(() =>
 			{
-				if (routedEventHandler != null)
+				if (routedEventHandler is not null)
 					view.ViewDetachedFromWindow -= routedEventHandler;
 			});
 
-			routedEventHandler = (_, __) =>
+			routedEventHandler = (sender,args) =>
 			{
 				// This event seems to fire prior to the view actually being
 				// detached from the window
 				if (view.IsLoaded() && Looper.MyLooper() is Looper q)
 				{
+					// We unsubscribe here because if we wait for the looper
+					// to schedule the work the view might get disposed by the time
+					// the unsubscribe code runs
+					if (disposable is not null)
+					{
+						if (args.DetachedView.IsAlive())
+						{
+							args.DetachedView.ViewDetachedFromWindow -= routedEventHandler;
+						}
+						
+						routedEventHandler = null;
+					}
+
 					new Handler(q).Post(() =>
 					{
 						if (disposable is not null)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Maui.Platform
 			ActionDisposable? disposable = new ActionDisposable(() =>
 			{
 				if (routedEventHandler is not null && view.IsAlive())
-				
+				{
 					view.ViewAttachedToWindow -= routedEventHandler;
 				}
 			});


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Adds a defensive `IsAlive()` check to the `OnUnloaded` method in `ViewExtensions.cs` to ensure that the `routedEventHandler` is not null before attempting to remove it from the `ViewAttachedToWindow` event.

### Issues Fixed

Fixes #28051