### PR TITLE
[Android] Add defensive not null check to SearchHandlerAppearanceTracker.FocusChange

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -270,6 +270,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (_searchHandler != null)
 				{
 					_searchHandler.PropertyChanged -= SearchHandlerPropertyChanged;
+				}
+				if (_editText != null)
+				{
 					_editText.FocusChange -= EditTextFocusChange;
 				}
 				_searchHandler = null;


### PR DESCRIPTION
Check if _editText is null before detaching the event.


