### PR TITLE
[iOS/MacCatalyst] Fix: Setting SelectedItem Programmatically and Then Immediately Setting ItemsSource to Null Causes a Crash

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -45,7 +45,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		// Called by Forms to mark an item selected 
 		internal void SelectItem(object selectedItem)
 		{
-			var originalSource = ItemsView.ItemsSource;
+			if(ItemsView?.ItemsSource is not object originalSource)
+			{
+				return;
+			}
+
 			var index = GetIndexForItem(selectedItem);
 
 			if (index.Section > -1 && index.Item > -1)
@@ -77,6 +81,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				});
 			}
 		}
+
 		// Called by Forms to clear the native selection
 		internal void ClearSelection()
 		{

--- a/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/SelectableItemsViewController.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				// Ensure the selected index is updated after the collection view's items generation is completed
 				CollectionView.PerformBatchUpdates(null, _ =>
 				{
+					// Ensure ItemsSource hasn't been disposed
+					if (ItemsSource is EmptySource)
+					{
+						return;
+					}
+
 					// Exit if the ItemsSource reference no longer matches the one captured at invocation.
 					if (!ReferenceEquals(ItemsView.ItemsSource, originalSource))
 					{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -45,11 +45,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// Called by Forms to mark an item selected 
 		internal void SelectItem(object selectedItem)
 		{
-			if (ItemsView?.ItemsSource is null)
-			{
-				return;
-			}
-
+			var originalSource = ItemsView.ItemsSource;
 			var index = GetIndexForItem(selectedItem);
 
 			if (index.Section > -1 && index.Item > -1)
@@ -57,11 +53,30 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				// Ensure the selected index is updated after the collection view's items generation is completed
 				CollectionView.PerformBatchUpdates(null, _ =>
 				{
+					// Exit if the ItemsSource reference no longer matches the one captured at invocation.
+					if (!ReferenceEquals(ItemsView.ItemsSource, originalSource))
+					{
+						return;
+					}
+
+					// Recalculate the index for the selectedItem now that the collection may have changed.(Adding, deleting etc..)
+					var updatedIndex = GetIndexForItem(selectedItem);
+					if (updatedIndex.Section < 0 || updatedIndex.Item < 0)
+					{
+						return;
+					}
+
+					// Retrieve the current item at that index and verify it still equals the intended selection.
+					var liveItem = GetItemAtIndex(updatedIndex);
+					if (!Equals(liveItem, selectedItem))
+					{
+						return;
+					}
+
 					CollectionView.SelectItem(index, true, UICollectionViewScrollPosition.None);
 				});
 			}
 		}
-
 		// Called by Forms to clear the native selection
 		internal void ClearSelection()
 		{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				// Ensure the selected index is updated after the collection view's items generation is completed
 				CollectionView.PerformBatchUpdates(null, _ =>
 				{
+					// Ensure ItemsSource hasn't been disposed
+					if (ItemsSource is Items.EmptySource)
+					{
+						return;
+					}
+
 					// Exit if the ItemsSource reference no longer matches the one captured at invocation.
 					if (!ReferenceEquals(ItemsView.ItemsSource, originalSource))
 					{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/SelectableItemsViewController2.cs
@@ -45,7 +45,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		// Called by Forms to mark an item selected 
 		internal void SelectItem(object selectedItem)
 		{
-			var originalSource = ItemsView.ItemsSource;
+			if(ItemsView?.ItemsSource is not object originalSource)
+			{
+				return;
+			}
+			
 			var index = GetIndexForItem(selectedItem);
 
 			if (index.Section > -1 && index.Item > -1)
@@ -77,6 +81,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				});
 			}
 		}
+
 		// Called by Forms to clear the native selection
 		internal void ClearSelection()
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29937.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29937.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue29937"
+             Title="Issue29937">
+     <VerticalStackLayout
+            Padding="30,0"
+            Spacing="25">
+          <Button AutomationId="MauiButton" Text="Set SelectedItem and make ItemSource = null" Clicked="Button_Clicked" />
+         <CollectionView x:Name="cView" AutomationId="MauiCollectionView"
+                            ItemsSource="{Binding Items}"
+                            SelectionMode="Single">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <VerticalStackLayout Padding="10" Margin="5">
+                            <Label Text="{Binding .}" HeightRequest="40" />
+                        </VerticalStackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29937.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29937.xaml.cs
@@ -1,0 +1,38 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29937, "[iOS/MacCatalyst] Setting SelectedItem Programmatically and Then Immediately Setting ItemsSource to Null Causes a Crash", PlatformAffected.iOS)]
+public partial class Issue29937 : ContentPage
+{
+	private ObservableCollection<string> _items;
+
+	public ObservableCollection<string> Items
+	{
+		get => _items;
+		set
+		{
+			_items = value;
+			OnPropertyChanged(nameof(Items));
+		}
+	}
+	public Issue29937()
+	{
+		InitializeComponent();
+		Items = new ObservableCollection<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3",
+				"Item 4",
+				"Item 5"
+			};
+		BindingContext = this;
+	}
+
+	void Button_Clicked(object sender, EventArgs e)
+	{
+		cView.SelectedItem = "Item 1";
+		cView.ItemsSource = null;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29937.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29937.cs
@@ -19,6 +19,7 @@ public class Issue29937 : _IssuesUITest
     {
         App.WaitForElement("MauiButton");
         App.Tap("MauiButton");
-        App.WaitForElement("MauiCollectionView"); // If app doesn't crash, test passes.
+        App.WaitForNoElement("MauiCollectionView");
+        App.WaitForElement("MauiButton"); // If app doesn't crash, test passes.
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29937.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29937.cs
@@ -1,0 +1,24 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29937 : _IssuesUITest
+{
+    public Issue29937(TestDevice device) : base(device)
+    {
+    }
+
+    public override string Issue => "[iOS/MacCatalyst] Setting SelectedItem Programmatically and Then Immediately Setting ItemsSource to Null Causes a Crash";
+    
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void SettingSelectedItemAndItemSourceShouldNotCrash()
+    {
+        App.WaitForElement("MauiButton");
+        App.Tap("MauiButton");
+        App.WaitForElement("MauiCollectionView"); // If app doesn't crash, test passes.
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
Fixes a crash  in iOS/MacCatalyst when setting `SelectedItem` in a `CollectionView` and then nullifying `ItemsSource`. The issue was due to a race condition.

In `PerformBatchUpdates`, verified ItemsSource reference, recalculated selectedItem index, and validated item before calling `CollectionView.SelectItem`.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29937

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
