### PR TITLE
Add retries to all tests related to checking for weak references

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -625,17 +625,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				proxyRef = new WeakReference(proxy);
 			}
 
-			// First GC
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			Assert.False(controllerRef.IsAlive, "BindableLayoutController should not be alive!");
-
-			// Second GC
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			Assert.False(proxyRef.IsAlive, "WeakCollectionChangedProxy should not be alive!");
+			Assert.False(await controllerRef.WaitForCollect(), "BindableLayoutController should not be alive!");
+			Assert.False(await proxyRef.WaitForCollect(), "WeakCollectionChangedProxy should not be alive!");
 		}
 
 		[Fact("BindableLayout Still Updates after a GC")]
@@ -648,9 +639,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(2, layout.Children.Count);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			list.Add("Baz");
 			Assert.Equal(3, layout.Children.Count);

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1245,24 +1245,15 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			;
 			create();
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
 			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWay)
-				Assert.False(weakViewModel.IsAlive, "ViewModel wasn't collected");
+				Assert.False(await weakViewModel.WaitForCollect(), "ViewModel wasn't collected");
 
 			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWayToSource)
-				Assert.False(weakBindable.IsAlive, "Bindable wasn't collected");
-
-			// WeakPropertyChangedProxy won't go away until the second GC, BindingExpressionPart unsubscribes in its finalizer
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+				Assert.False(await weakBindable.WaitForCollect(), "Bindable wasn't collected");
 
 			foreach (var proxy in proxies)
 			{
-				Assert.False(proxy.IsAlive, "WeakPropertyChangedProxy wasn't collected");
+				Assert.False(await proxy.WaitForCollect(), "WeakPropertyChangedProxy wasn't collected");
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
@@ -36,42 +36,34 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var list = new SetterSpecificityList<object>();
 			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
 			list[SetterSpecificity.FromHandler] = nameof(SetterSpecificity.FromHandler);
-			WeakReference<object> weakReference;
+			WeakReference weakReference;
 
 			{
 				var o = new object();
-				weakReference = new WeakReference<object>(o);
+				weakReference = new WeakReference(o);
 				list[SetterSpecificity.FromBinding] = o;
 			}
 
 			list.Remove(SetterSpecificity.FromBinding);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(weakReference.TryGetTarget(out _));
+			Assert.False(await weakReference.WaitForCollect());
 		}
 
 		[Fact]
 		public async Task RemovingLastValueDoesNotLeak()
 		{
 			var list = new SetterSpecificityList<object>();
-			WeakReference<object> weakReference;
+			WeakReference weakReference;
 
 			{
 				var o = new object();
-				weakReference = new WeakReference<object>(o);
+				weakReference = new WeakReference(o);
 				list[SetterSpecificity.ManualValueSetter] = o;
 			}
 
 			list.Remove(SetterSpecificity.ManualValueSetter);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(weakReference.TryGetTarget(out _));
+			Assert.False(await weakReference.WaitForCollect());
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/TestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/TestHelpers.cs
@@ -10,6 +10,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await Task.Yield();
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
+			GC.Collect(2, GCCollectionMode.Forced, true);
+			GC.WaitForPendingFinalizers();
+			GC.Collect(2, GCCollectionMode.Forced, true);
+			await Task.Yield();
 		}
 
 
@@ -17,9 +21,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			for (int i = 0; i < 40 && reference.IsAlive; i++)
 			{
-				await Task.Yield();
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
+				await Collect();
 			}
 
 			return reference.IsAlive;

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1437,15 +1437,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewmodel.InvocationListSize());
 
-			await bindingRef.WaitForCollect();
-			await buttonRef.WaitForCollect();
+			Assert.False(await bindingRef.WaitForCollect(), "Binding should not be alive!");
+			Assert.False(await buttonRef.WaitForCollect(), "Button should not be alive!");
 
 			viewmodel.OnPropertyChanged("Foo");
 
 			Assert.Equal(0, viewmodel.InvocationListSize());
-
-			Assert.False(bindingRef.IsAlive, "Binding should not be alive!");
-			Assert.False(buttonRef.IsAlive, "Button should not be alive!");
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1437,9 +1437,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewmodel.InvocationListSize());
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await bindingRef.WaitForCollect();
+			await buttonRef.WaitForCollect();
 
 			viewmodel.OnPropertyChanged("Foo");
 
@@ -1491,18 +1490,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(1, viewModel.InvocationListSize());
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(bindingRef.IsAlive, "Binding should not be alive!");
-			Assert.False(buttonRef.IsAlive, "Button should not be alive!");
+			Assert.False(await bindingRef.WaitForCollect(), "Binding should not be alive!");
+			Assert.False(await buttonRef.WaitForCollect(), "Button should not be alive!");
 
 			// WeakPropertyChangedProxy won't go away until the second GC, PropertyChangedProxy unsubscribes in its finalizer
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			Assert.False(proxyRef.IsAlive, "WeakPropertyChangedProxy should not be alive!");
+			Assert.False(await proxyRef.WaitForCollect(), "WeakPropertyChangedProxy should not be alive!");
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -154,9 +154,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			GC.KeepAlive(visual);
 
 			gradient.GradientStops.Add(new GradientStop(Colors.CornflowerBlue, 1));
@@ -187,9 +185,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			GC.KeepAlive(visual);
 
 			geometry.Rect = new Rect(1, 2, 3, 4);
@@ -209,9 +205,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					fired = true;
 			};
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			GC.KeepAlive(visualElement);
 
 			shadow.Brush = new SolidColorBrush(Colors.Green);
@@ -230,11 +224,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var reference = new WeakReference(new VisualElement { Shadow = shadow });
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(reference.IsAlive, "VisualElement should not be alive!");
+			Assert.False(await reference.WaitForCollect(), "VisualElement should not be alive!");
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WeakEventProxyTests.cs
@@ -22,11 +22,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				reference = new WeakReference(subscriber);
 			}
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-
-			Assert.False(reference.IsAlive, "Subscriber should not be alive!");
+			Assert.False(await reference.WaitForCollect(), "Subscriber should not be alive!");
 		}
 
 		[Fact]
@@ -40,9 +36,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			NotifyCollectionChangedEventHandler handler = (s, e) => fired = true;
 			proxy.Subscribe(list, handler);
 
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 			GC.KeepAlive(handler);
 
 			list.Add("a");

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -756,9 +756,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			// GC collect the original key
-			await Task.Yield();
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
+			await TestHelpers.Collect();
 
 			// Same window, doesn't create a new one
 			var actual = ((IApplication)application).CreateWindow(new ActivationState(new MockMauiContext(), new PersistedState


### PR DESCRIPTION
### Description of Change

While working on https://github.com/dotnet/maui/pull/29837 a number of the tests related to checking for weak references were failing intermittently. This PR adds retries to all tests related to checking for weak references to ensure that the tests are more reliable. With these changes I wasn't able to get it to fail locally.
