### PR TITLE
[XC] Compile {AppThemeBinding ...}

### DIFF
--- a/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/AppThemeBindingExtension.cs
+++ b/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/AppThemeBindingExtension.cs
@@ -1,0 +1,128 @@
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Xml;
+using Microsoft.Maui.Controls.Xaml;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using static Mono.Cecil.Cil.Instruction;
+using static Mono.Cecil.Cil.OpCodes;
+
+namespace Microsoft.Maui.Controls.Build.Tasks
+{
+	//yes, this is a ICompiledMarkupExtension, but declared as ICompiledValueProvider so it's evaluated later (in SetPropertyValue, not CreateObject)
+	class AppThemeBindingExtension : ICompiledValueProvider
+	{
+		public IEnumerable<Instruction> ProvideValue(VariableDefinitionReference vardefref, ModuleDefinition module, BaseNode node, ILContext context)
+		{
+			ElementNode markupExtensionElementNode = node as ElementNode ?? throw new NotSupportedException();
+			IElementNode? parentElement = node.Parent as IElementNode;
+
+			TypeReference appThemeBindingTypeRef = module.ImportReference(typeof(AppThemeBinding));
+			MethodReference ctor = GetConstructor(appThemeBindingTypeRef);
+
+			List<Instruction> instructions = [Create(Newobj, ctor)];
+
+			SetPropertyValueIfNeeded("Default");
+			SetPropertyValueIfNeeded("Light");
+			SetPropertyValueIfNeeded("Dark");
+
+			var vardef = new VariableDefinition(appThemeBindingTypeRef);
+			instructions.Add(Create(Stloc, vardef));
+			vardefref.VariableDefinition = vardef;
+
+			return instructions;
+
+			void SetPropertyValueIfNeeded(string propertyName)
+			{
+				// Load the property value on the stack
+				if (markupExtensionElementNode.Properties.TryGetValue(new XmlName("", propertyName), out INode? propertyNode))
+				{
+					// Duplicate the AppThemeBinding instance on the stack
+					instructions.Add(Create(Dup));
+
+					if (propertyNode is IElementNode propertyElementNode)
+					{
+						if (!context.Variables.TryGetValue(propertyElementNode, out VariableDefinition? variableDefinition))
+						{
+							throw new InvalidOperationException($"Variable definition for element node '{propertyElementNode}' not found in context.");
+						}
+
+						// Load the variable onto the stack, no need to convert it
+						instructions.Add(Create(Ldloc, variableDefinition));
+					}
+					else if (propertyNode is ValueNode valueNode
+						&& parentElement is not null
+						&& markupExtensionElementNode.TryGetPropertyName(parentElement, out XmlName parentPropertyName))
+					{
+						// Push the value onto the stack
+						instructions.AddRange(
+							TryConvert(valueNode, valueNode, parentElement, parentPropertyName, module, context));
+					}
+					else
+					{
+						throw new InvalidOperationException($"Unsupported property node type: {propertyNode.GetType().Name}");
+					}
+
+					// Store the value to the AppThemeBinding instance property
+					var setMethod = module.ImportReference(typeof(AppThemeBinding).GetProperty(propertyName)?.SetMethod)
+						?? throw new InvalidOperationException($"Property '{propertyName}' not found in 'AppThemeBinding'.");
+					instructions.Add(Create(Call, setMethod));
+				}
+				else
+				{
+					// nothing to do, this property is not used
+				}
+			}
+
+			MethodReference GetConstructor(TypeReference typeRef)
+			{
+				var (ctor, _) = typeRef.GetMethods(context.Cache, m => m.IsConstructor && !m.HasParameters, module).FirstOrDefault()
+					?? throw new InvalidOperationException("AppThemeBinding does not have a parameterless constructor.");
+				return module.ImportReference(ctor);
+			}
+		}
+
+		private static IEnumerable<Instruction> TryConvert(
+			ValueNode valueNode,
+			IXmlLineInfo xmlLine,
+			IElementNode parentElementNode,
+			XmlName parentPropertyName,
+			ModuleDefinition module,
+			ILContext context)
+		{
+			var localName = parentPropertyName.LocalName;
+			var parentType = module.ImportReference(parentElementNode.XmlType.GetTypeReference(context.Cache, module, xmlLine));
+
+			var bpRef = SetPropertiesVisitor.GetBindablePropertyReference(parentType, parentPropertyName.NamespaceURI, ref localName, out _, context, xmlLine);
+			if (bpRef != null)
+			{
+				foreach (var instruction in valueNode.PushConvertedValue(context, bpRef, requiredServices => valueNode.PushServiceProvider(context, requiredServices, bpRef: bpRef), true, false))
+					yield return instruction;
+				yield break;
+			}
+
+			var propertyRef = parentType.GetProperty(context.Cache, pd => pd.Name == localName, out var declaringTypeReference);
+			if (propertyRef != null)
+			{
+				var propertyType = module.ImportReference(propertyRef.PropertyType.ResolveGenericParameters(declaringTypeReference));
+
+				foreach (var instruction in valueNode.PushConvertedValue(
+						context,
+						propertyType,
+						[propertyRef, propertyType.ResolveCached(context.Cache)],
+						requiredServices => valueNode.PushServiceProvider(context, requiredServices, propertyRef: propertyRef),
+						boxValueTypes: true,
+						unboxValueTypes: false))
+					yield return instruction;
+				yield break;
+			}
+
+			throw new InvalidOperationException($"Property '{parentPropertyName}' not found in '{parentType.FullName}'.");
+		}
+	}
+}

--- a/src/Controls/src/Core/AppThemeBinding.cs
+++ b/src/Controls/src/Core/AppThemeBinding.cs
@@ -1,14 +1,16 @@
 #nullable disable
 using System;
+using System.ComponentModel;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
-	class AppThemeBinding : BindingBase
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class AppThemeBinding : BindingBase
 	{
-		public const string AppThemeResource = "__MAUI_ApplicationTheme__";
+		internal const string AppThemeResource = "__MAUI_ApplicationTheme__";
 		class AppThemeProxy : Element
 		{
 			public AppThemeProxy(Element parent, AppThemeBinding binding)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -397,3 +397,11 @@ Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.Al
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.AllowImplicitXmlnsDeclarationAttribute(bool allow = true) -> void
 ~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.Target.get -> string
 *REMOVED*~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace) -> void
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -597,3 +597,11 @@ Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.Al
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.AllowImplicitXmlnsDeclarationAttribute(bool allow = true) -> void
 ~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.Target.get -> string
 *REMOVED*~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace) -> void
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -597,3 +597,11 @@ Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.Al
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.AllowImplicitXmlnsDeclarationAttribute(bool allow = true) -> void
 ~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.Target.get -> string
 *REMOVED*~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace) -> void
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -345,3 +345,11 @@ Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.Al
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.AllowImplicitXmlnsDeclarationAttribute(bool allow = true) -> void
 ~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.Target.get -> string
 *REMOVED*~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace) -> void
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -393,3 +393,11 @@ Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.Al
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.AllowImplicitXmlnsDeclarationAttribute(bool allow = true) -> void
 ~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.Target.get -> string
 *REMOVED*~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace) -> void
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -379,3 +379,11 @@ Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.GradientBrushPars
 Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css) -> Microsoft.Maui.Controls.GradientBrush?
 static Microsoft.Maui.Controls.Shapes.PathFigureCollectionConverter.ParseStringToPathFigureCollection(Microsoft.Maui.Controls.Shapes.PathFigureCollection! pathFigureCollection, string? pathString) -> void
 ~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.Target.get -> string
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -380,3 +380,11 @@ Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.Allow.get -> bool
 Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute.AllowImplicitXmlnsDeclarationAttribute(bool allow = true) -> void
 *REMOVED*~Microsoft.Maui.Controls.XmlnsDefinitionAttribute.XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace) -> void
+Microsoft.Maui.Controls.AppThemeBinding
+Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
+~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void

--- a/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Maui.Controls.Xaml
 		 typeof(IValueConverterProvider),
 		 typeof(IXmlLineInfoProvider),
 		 typeof(IConverterOptions)])]
-	public class AppThemeBindingExtension : IMarkupExtension<BindingBase>
+	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.AppThemeBindingExtension")]
+	public class AppThemeBindingExtension : IMarkupExtension
 	{
 		object _default;
 		bool _hasdefault;
@@ -46,9 +47,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		}
 		public object Value { get; private set; }
 
-		public object ProvideValue(IServiceProvider serviceProvider) => (this as IMarkupExtension<BindingBase>).ProvideValue(serviceProvider);
-
-		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
+		public object ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (Default == null
 				&& Light == null


### PR DESCRIPTION
### Description of Change

This PR improves compilation of `{AppThemeBinding ...}`. The implementation is based mostly on `StaticResourceExtension` (especially the `TryConvert` method).

This is an example of a Setter with an AppThemeBinding (a common use-case in Styles):

```xml
<Setter Property="BackgroundColor" Value="{AppThemeBinding Light=Yellow, Dark=Orange}" />
```

Before:
```c#
AppThemeBindingExtension val2 = new AppThemeBindingExtension();
Setter val3 = new Setter();
val3.set_Property(VisualElement.BackgroundColorProperty);
val2.set_Light((object)"Yellow");
val2.set_Dark((object)"Orange");
XamlServiceProvider val16 = new XamlServiceProvider();
val16.Add(typeof(IProvideValueTarget), (object)new ValueTargetProvider((object)val3, (object)RuntimeReflectionExtensions.GetRuntimeProperty(typeof(Setter), "Value")));
val16.Add(typeof(IXmlLineInfoProvider), (object)new XmlLineInfoProvider((IXmlLineInfo)new XmlLineInfo(15, 27)));
object value = ((IMarkupExtension)val2).ProvideValue((IServiceProvider)val16);
val3.set_Value(value);
```
After:
```c#
AppThemeBindingExtension val2 = new AppThemeBindingExtension();
Setter val3 = new Setter();
val3.set_Property(VisualElement.BackgroundColorProperty);
val2.set_Light((object)"Yellow");
val2.set_Dark((object)"Orange");
AppThemeBinding val16 = new AppThemeBinding();
val16.set_Light((object)"Yellow");
val16.set_Dark((object)"Orange");
AppThemeBinding value = val16;
val3.set_Value((object)value);
```


So far, the generated code size of the default template app `Styles.xaml`'s InitializeComponent dropped from `61,808` B to `60,542` B, which is a difference of  `1,266` B (2 %). Unfortunately, XamlC will still create an instance of `AppThemeBindingExtension` and set its properties with the expanded values. Hopefully, we'll be able to remove this unused piece of code in some other PR. Ideally, the final code would look like this:
```c#
Setter val3 = new Setter();
val3.set_Property(VisualElement.BackgroundColorProperty);
AppThemeBinding val16 = new AppThemeBinding();
val16.set_Light((object)"Yellow");
val16.set_Dark((object)"Orange");
val3.set_Value((object)val16);
```


/cc @StephaneDelcroix 

### Issues Fixed

Fixes #29356
Contributes to #8865
Contributes to #5574