### PR TITLE
[iOS] CurrentItem does not work when PeekAreaInsets is set - fix

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -339,7 +339,7 @@ internal static class LayoutFactory2
 					return;
 				}
 
-				var page = (offset.X + sectionMargin) / env.Container.ContentSize.Width;
+				var page = (offset.X + sectionMargin) / (env.Container.ContentSize.Width - sectionMargin * 2);
 
 				if (Math.Abs(page % 1) > (double.Epsilon * 100) || cv2Controller.ItemsSource.ItemCount <= 0)
 				{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28524.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28524.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue28524">
+    <Grid RowDefinitions="*,Auto">
+        <CarouselView
+            PeekAreaInsets="25"
+            AutomationId="CarouselView"
+            x:Name="CarouselView">
+            <CarouselView.ItemsLayout>
+                <LinearItemsLayout
+                    Orientation="Horizontal"
+                    SnapPointsType="MandatorySingle"/>
+            </CarouselView.ItemsLayout>
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="{Binding}"/>
+                    </Grid>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+            <CarouselView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Baboon</x:String>
+                    <x:String>Capuchin Monkey</x:String>
+                    <x:String>Blue Monkey</x:String>
+                </x:Array>
+            </CarouselView.ItemsSource>
+        </CarouselView>
+
+        <Label Grid.Row="1"
+               Text="{Binding Source={x:Reference CarouselView}, Path=CurrentItem, StringFormat='CurrentItem={0}'}"/>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28524.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28524.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28524, "[iOS] CurrentItem does not work when PeekAreaInsets is set", PlatformAffected.iOS)]
+public partial class Issue28524 : ContentPage
+{
+	public Issue28524()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28524.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28524.cs
@@ -1,0 +1,24 @@
+﻿#if ANDROID || IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28524 : _IssuesUITest
+{
+	public Issue28524(TestDevice device) : base(device) { }
+
+	public override string Issue => "[iOS] CurrentItem does not work when PeekAreaInsets is set";
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void CurrentItemShouldWork()
+	{
+		App.WaitForElement("CarouselView");
+		App.ScrollRight("CarouselView");
+		App.ScrollRight("CarouselView");
+		App.WaitForElement("Blue Monkey");
+	}
+}
+#endif


### PR DESCRIPTION
…is set

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/28524

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/d214c86c-ca08-4fd8-9afb-6891b6b81bdc" width="300px"/>|<video src="https://github.com/user-attachments/assets/dee6ed32-981d-4239-8701-5088b1c657ae" width="300px"/>|
