### PR TITLE
[.NET 10] Implement multi-select for MediaPicker

### DIFF
--- a/src/Essentials/samples/Samples/Platforms/Windows/Package.appxmanifest
+++ b/src/Essentials/samples/Samples/Platforms/Windows/Package.appxmanifest
@@ -46,7 +46,6 @@
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
         <uap:Extension Category="windows.protocol">

--- a/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
+++ b/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
@@ -12,15 +12,32 @@
         <Label Text="Pick or capture a photo or video." FontAttributes="Bold" Margin="12" />
 
         <ScrollView Grid.Row="1">
-            <StackLayout Padding="12,0,12,12" Spacing="6">
+            <VerticalStackLayout Padding="12,0,12,12" Spacing="6">
+                <Label Text="Picker selection limit" HorizontalOptions="Center" />
+                <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
+                    <Stepper Value="{Binding PickerSelectionLimit, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="1" />
+                    <Label Text="{Binding PickerSelectionLimit}" VerticalOptions="Center" />
+                </HorizontalStackLayout>
                 <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
                 <Button Text="Capture photo" Command="{Binding CapturePhotoCommand}" />
                 <Button Text="Pick video" Command="{Binding PickVideoCommand}" />
                 <Button Text="Capture video" Command="{Binding CaptureVideoCommand}" />
 
+                <ScrollView Orientation="Horizontal" IsVisible="{Binding ShowMultiplePhotos}">
+                    <HorizontalStackLayout 
+                        BindableLayout.ItemsSource="{Binding PhotoList}"
+                        IsVisible="{Binding ShowMultiplePhotos}"
+                        HeightRequest="300">
+                        <BindableLayout.ItemTemplate>
+                            <DataTemplate>
+                                <Image Source="{Binding .}" HeightRequest="300" WidthRequest="100" />
+                            </DataTemplate>
+                        </BindableLayout.ItemTemplate>
+                    </HorizontalStackLayout>
+                </ScrollView>
                 <Image Source="{Binding PhotoSource}" IsVisible="{Binding ShowPhoto}" HeightRequest="300"/>
                 <!--<MediaElement VerticalOptions="FillAndExpand" Source="{Binding VideoSource}" IsVisible="{Binding ShowVideo}" />-->
-            </StackLayout>
+            </VerticalStackLayout>
         </ScrollView>
     </Grid>
 

--- a/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
+++ b/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
@@ -4,41 +4,41 @@
                 xmlns:viewmodels="clr-namespace:Samples.ViewModel"
                 x:Class="Samples.View.MediaPickerPage"
                 Title="Media Picker">
-    <views:BasePage.BindingContext>
-        <viewmodels:MediaPickerViewModel />
-    </views:BasePage.BindingContext>
+  <views:BasePage.BindingContext>
+    <viewmodels:MediaPickerViewModel />
+  </views:BasePage.BindingContext>
 
-    <Grid RowDefinitions="Auto,*">
-        <Label Text="Pick or capture a photo or video." FontAttributes="Bold" Margin="12" />
+  <Grid RowDefinitions="Auto,*">
+    <Label Text="Pick or capture a photo or video." FontAttributes="Bold" Margin="12" />
 
-        <ScrollView Grid.Row="1">
-            <VerticalStackLayout Padding="12,0,12,12" Spacing="6">
-                <Label Text="Picker selection limit" HorizontalOptions="Center" />
-                <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
-                    <Stepper Value="{Binding PickerSelectionLimit, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="1" />
-                    <Label Text="{Binding PickerSelectionLimit}" VerticalOptions="Center" />
-                </HorizontalStackLayout>
-                <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
-                <Button Text="Capture photo" Command="{Binding CapturePhotoCommand}" />
-                <Button Text="Pick video" Command="{Binding PickVideoCommand}" />
-                <Button Text="Capture video" Command="{Binding CaptureVideoCommand}" />
+    <ScrollView Grid.Row="1">
+      <VerticalStackLayout Padding="12,0,12,12" Spacing="6">
+        <Label Text="Picker selection limit" HorizontalOptions="Center" />
+        <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
+          <Stepper Value="{Binding PickerSelectionLimit, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="1" />
+          <Label Text="{Binding PickerSelectionLimit}" VerticalOptions="Center" />
+        </HorizontalStackLayout>
+        <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
+        <Button Text="Capture photo" Command="{Binding CapturePhotoCommand}" />
+        <Button Text="Pick video" Command="{Binding PickVideoCommand}" />
+        <Button Text="Capture video" Command="{Binding CaptureVideoCommand}" />
 
-                <ScrollView Orientation="Horizontal" IsVisible="{Binding ShowMultiplePhotos}">
-                    <HorizontalStackLayout 
+        <ScrollView Orientation="Horizontal" IsVisible="{Binding ShowMultiplePhotos}">
+          <HorizontalStackLayout 
                         BindableLayout.ItemsSource="{Binding PhotoList}"
                         IsVisible="{Binding ShowMultiplePhotos}"
                         HeightRequest="300">
-                        <BindableLayout.ItemTemplate>
-                            <DataTemplate>
-                                <Image Source="{Binding .}" HeightRequest="300" WidthRequest="100" />
-                            </DataTemplate>
-                        </BindableLayout.ItemTemplate>
-                    </HorizontalStackLayout>
-                </ScrollView>
-                <Image Source="{Binding PhotoSource}" IsVisible="{Binding ShowPhoto}" HeightRequest="300"/>
-                <!--<MediaElement VerticalOptions="FillAndExpand" Source="{Binding VideoSource}" IsVisible="{Binding ShowVideo}" />-->
-            </VerticalStackLayout>
+            <BindableLayout.ItemTemplate>
+              <DataTemplate>
+                <Image Source="{Binding .}" HeightRequest="300" WidthRequest="100" />
+              </DataTemplate>
+            </BindableLayout.ItemTemplate>
+          </HorizontalStackLayout>
         </ScrollView>
-    </Grid>
+
+        <Image Source="{Binding PhotoSource}" IsVisible="{Binding ShowPhoto}" HeightRequest="300"/>
+      </VerticalStackLayout>
+    </ScrollView>
+  </Grid>
 
 </views:BasePage>

--- a/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Maui.Controls;
@@ -13,10 +12,8 @@ namespace Samples.ViewModel
 	public class MediaPickerViewModel : BaseViewModel
 	{
 		ImageSource photoSource;
-		ImageSource videoSource;
 
 		bool showPhoto;
-		bool showVideo;
 		int pickerSelectionLimit = 1;
 		private ObservableCollection<ImageSource> photoList = [];
 		private bool showMultiplePhotos;
@@ -56,12 +53,6 @@ namespace Samples.ViewModel
 			set => SetProperty(ref showMultiplePhotos, value);
 		}
 
-		public bool ShowVideo
-		{
-			get => showVideo;
-			set => SetProperty(ref showVideo, value);
-		}
-
 		public ObservableCollection<ImageSource> PhotoList
 		{
 			get => photoList;
@@ -72,12 +63,6 @@ namespace Samples.ViewModel
 		{
 			get => photoSource;
 			set => SetProperty(ref photoSource, value);
-		}
-
-		public ImageSource VideoSource
-		{
-			get => videoSource;
-			set => SetProperty(ref videoSource, value);
 		}
 
 		async void DoPickPhoto()
@@ -120,19 +105,22 @@ namespace Samples.ViewModel
 		{
 			try
 			{
-				var video = await MediaPicker.PickVideoAsync(new MediaPickerOptions
+				var videos = await MediaPicker.PickVideosAsync(new MediaPickerOptions
 				{
 					Title = "Pick a video",
 					SelectionLimit = PickerSelectionLimit,
 				});
 
-				await LoadVideoAsync(video);
+				ShowPhoto = false;
+				ShowMultiplePhotos = false;
 
-				Console.WriteLine($"PickVideoAsync COMPLETED: {VideoSource}");
+				await DisplayAlertAsync($"{videos.Count} videos successfully picked.");
+
+				Console.WriteLine($"PickVideosAsync COMPLETED: {videos.Count} selected");
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"PickVideoAsync THREW: {ex.Message}");
+				Console.WriteLine($"PickVideosAsync THREW: {ex.Message}");
 			}
 		}
 
@@ -140,11 +128,14 @@ namespace Samples.ViewModel
 		{
 			try
 			{
-				var photo = await MediaPicker.CaptureVideoAsync();
+				var video = await MediaPicker.CaptureVideoAsync();
 
-				await LoadVideoAsync(photo);
+				ShowPhoto = false;
+				ShowMultiplePhotos = false;
 
-				Console.WriteLine($"CaptureVideoAsync COMPLETED: {VideoSource}");
+				await DisplayAlertAsync($"Video successfully captured at {video.FullPath}.");
+
+				Console.WriteLine($"CaptureVideoAsync COMPLETED: {video.FullPath}");
 			}
 			catch (Exception ex)
 			{
@@ -163,7 +154,6 @@ namespace Samples.ViewModel
 			var stream = await photo.OpenReadAsync();
 			PhotoSource = ImageSource.FromStream(() => stream);
 
-			ShowVideo = false;
 			ShowMultiplePhotos = false;
 			ShowPhoto = true;
 		}
@@ -185,32 +175,14 @@ namespace Samples.ViewModel
 				PhotoList.Add(ImageSource.FromStream(() => stream));
 			}
 
-			ShowVideo = false;
 			ShowPhoto = false;
 			ShowMultiplePhotos = true;
-		}
-
-		async Task LoadVideoAsync(FileResult video)
-		{
-			// canceled
-			if (video == null)
-			{
-				VideoSource = null;
-				return;
-			}
-
-			var stream = await video.OpenReadAsync();
-			VideoSource = ImageSource.FromStream(() => stream);
-
-			ShowVideo = true;
-			ShowPhoto = false;
 		}
 
 		public override void OnDisappearing()
 		{
 			PhotoList?.Clear();
 			PhotoSource = null;
-			VideoSource = null;
 
 			base.OnDisappearing();
 		}

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
@@ -24,8 +25,14 @@ namespace Microsoft.Maui.Media
 		public Task<FileResult> PickPhotoAsync(MediaPickerOptions options)
 			=> PickAsync(options, true);
 
+		public Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions options)
+			=> throw new FeatureNotSupportedException("Multiple photo selection is not supported on Android. Use PickPhotoAsync instead.");
+
 		public Task<FileResult> PickVideoAsync(MediaPickerOptions options)
 			=> PickAsync(options, false);
+
+		public Task<List<FileResult>> PickVideosAsync(MediaPickerOptions options)
+			=> throw new FeatureNotSupportedException("Multiple video selection is not supported on Android. Use PickVideoAsync instead.");
 
 		public async Task<FileResult> PickAsync(MediaPickerOptions options, bool photo)
 			=> IsPhotoPickerAvailable

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -15,7 +15,7 @@ using AndroidUri = Android.Net.Uri;
 namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
-	{		
+	{
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Media
 			{
 				return null;
 			}
-		}		
+		}
 		
 		async Task<FileResult> PickUsingIntermediateActivity(MediaPickerOptions options, bool photo)
 		{
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Media
 			if (options.SelectionLimit == 1)
 			{
 				var singleResult = await PickUsingPhotoPicker(options, photo);
-				return singleResult is not null ? [singleResult] : null;
+				return singleResult is not null ? [singleResult] : [];
 			}
 			
 			var pickVisualMediaRequestBuilder = new PickVisualMediaRequest.Builder()

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -6,7 +6,6 @@ using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.Provider;
-using Android.Widget;
 using AndroidX.Activity.Result;
 using AndroidX.Activity.Result.Contract;
 using Microsoft.Maui.ApplicationModel;
@@ -132,15 +131,9 @@ namespace Microsoft.Maui.Media
 
 		async Task<FileResult> PickUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
-			var pickVisualMediaRequestBuilder = new PickVisualMediaRequest.Builder()
-				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance);
-
-			if (options.SelectionLimit > 1)
-			{
-				pickVisualMediaRequestBuilder.SetMaxItems(options.SelectionLimit);
-			}
-			
-			var pickVisualMediaRequest = pickVisualMediaRequestBuilder.Build();
+			var pickVisualMediaRequest = new PickVisualMediaRequest.Builder()
+				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance)
+				.Build();
 
 			var androidUri = await PickVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
 
@@ -176,24 +169,22 @@ namespace Microsoft.Maui.Media
 
 			var androidUris = await PickMultipleVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
 
-			if (androidUris?.IsEmpty ?? true)
+			if (androidUris?.IsEmpty  ?? true)
 			{
 				return null;
 			}
 
 			var resultList = new List<FileResult>();
 
-            var uriArray = androidUris.ToArray();
-            foreach (AndroidUri uri in uriArray.Cast<AndroidUri>())
-            {
-                if (uri?.Equals(AndroidUri.Empty) ?? true)
-                {
-                    continue;
-                }
-
-                var path = FileSystemUtils.EnsurePhysicalPath(uri);
-                resultList.Add(new FileResult(path));
-            }
+            for (var i = 0; i < androidUris.Size(); i++)
+			{
+				var uri = androidUris.Get(i) as AndroidUri;
+				if (!uri?.Equals(AndroidUri.Empty) ?? false)
+				{
+					var path = FileSystemUtils.EnsurePhysicalPath(uri);
+					resultList.Add(new FileResult(path));
+				}
+			}
 
 			return resultList;
 		}

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,12 +16,16 @@ namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
 	{
-		static UIViewController pickerRef;
+		static UIViewController PickerRef;
+		
 		public bool IsCaptureSupported
 			=> UIImagePickerController.IsSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
 
 		public Task<FileResult> PickPhotoAsync(MediaPickerOptions options)
 			=> PhotoAsync(options, true, true);
+
+		public Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions options)
+			=> PhotosAsync(options, true, true);
 
 		public Task<FileResult> CapturePhotoAsync(MediaPickerOptions options)
 		{
@@ -34,6 +39,9 @@ namespace Microsoft.Maui.Media
 
 		public Task<FileResult> PickVideoAsync(MediaPickerOptions options)
 			=> PhotoAsync(options, false, true);
+
+		public Task<List<FileResult>> PickVideosAsync(MediaPickerOptions options)
+			=> PhotosAsync(options, false, true);
 
 		public Task<FileResult> CaptureVideoAsync(MediaPickerOptions options)
 		{
@@ -84,7 +92,7 @@ namespace Microsoft.Maui.Media
 					}
 				};
 
-				pickerRef = picker;
+				PickerRef = picker;
 			}
 			else
 			{
@@ -123,7 +131,7 @@ namespace Microsoft.Maui.Media
 					picker.CameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
 				}
 
-				pickerRef = picker;
+				PickerRef = picker;
 
 				picker.Delegate = new PhotoPickerDelegate
 				{
@@ -137,28 +145,106 @@ namespace Microsoft.Maui.Media
 
 			if (!string.IsNullOrWhiteSpace(options?.Title))
 			{
-				pickerRef.Title = options.Title;
+				PickerRef.Title = options.Title;
 			}
 
 			if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
 			{
-				pickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
+				PickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
 			}
 
-			if (pickerRef.PresentationController is not null)
+			if (PickerRef.PresentationController is not null)
 			{
-				pickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+				PickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
 				{
 					Handler = () => tcs.TrySetResult(null)
 				};
 			}
 
-			await vc.PresentViewControllerAsync(pickerRef, true);
+			await vc.PresentViewControllerAsync(PickerRef, true);
 
 			var result = await tcs.Task;
 
-			pickerRef?.Dispose();
-			pickerRef = null;
+			PickerRef?.Dispose();
+			PickerRef = null;
+
+			return result;
+		}
+
+		async Task<List<FileResult>> PhotosAsync(MediaPickerOptions options, bool photo, bool pickExisting)
+		{
+			// iOS 14+ only supports multiple selection
+			// TODO throw exception?
+			if (!OperatingSystem.IsIOSVersionAtLeast(14, 0))
+			{
+				return null;
+			}
+			
+			if (!photo && !pickExisting)
+			{
+				await Permissions.EnsureGrantedAsync<Permissions.Microphone>();
+			}
+
+			// Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
+			if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0))
+			{
+				await Permissions.EnsureGrantedAsync<Permissions.Photos>();
+			}
+
+			if (!pickExisting)
+			{
+				await Permissions.EnsureGrantedAsync<Permissions.Camera>();
+			}
+
+			var vc = WindowStateManager.Default.GetCurrentUIViewController(true);
+			var tcs = new TaskCompletionSource<List<FileResult>>();
+
+			if (pickExisting)
+			{
+				var config = new PHPickerConfiguration
+				{
+					Filter = photo
+						? PHPickerFilter.ImagesFilter
+						: PHPickerFilter.VideosFilter,
+					SelectionLimit = options?.SelectionLimit ?? 1,
+				};
+
+				var picker = new PHPickerViewController(config)
+				{
+					Delegate = new Media.PhotoPickerDelegate
+					{
+						CompletedHandler = res =>
+							tcs.TrySetResult(PickerResultsToMediaFiles(res))
+					}
+				};
+
+				PickerRef = picker;
+			}
+
+			if (!string.IsNullOrWhiteSpace(options?.Title))
+			{
+				PickerRef.Title = options.Title;
+			}
+
+			if (DeviceInfo.Idiom == DeviceIdiom.Tablet)
+			{
+				PickerRef.ModalPresentationStyle = UIModalPresentationStyle.PageSheet;
+			}
+
+			if (PickerRef.PresentationController is not null)
+			{
+				PickerRef.PresentationController.Delegate = new PhotoPickerPresentationControllerDelegate
+				{
+					Handler = () => tcs.TrySetResult(null)
+				};
+			}
+
+			await vc.PresentViewControllerAsync(PickerRef, true);
+
+			var result = await tcs.Task;
+
+			PickerRef?.Dispose();
+			PickerRef = null;
 
 			return result;
 		}
@@ -170,6 +256,13 @@ namespace Microsoft.Maui.Media
 			return file == null
 				? null
 				: new PHPickerFileResult(file.ItemProvider);
+		}
+
+		static List<FileResult> PickerResultsToMediaFiles(PHPickerResult[] results)
+		{
+			return results?
+				.Select(file => (FileResult)new PHPickerFileResult(file.ItemProvider))
+				.ToList() ?? [];
 		}
 
 		static void GetFileResult(NSDictionary info, TaskCompletionSource<FileResult> tcs)

--- a/src/Essentials/src/MediaPicker/MediaPicker.netstandard.watchos.tvos.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.netstandard.watchos.tvos.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
@@ -21,6 +22,12 @@ namespace Microsoft.Maui.Media
 			throw new NotImplementedInReferenceAssemblyException();
 
 		public Task<FileResult> CaptureVideoAsync(MediaPickerOptions options) =>
+			throw new NotImplementedInReferenceAssemblyException();
+
+		public Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions options = null) =>
+			throw new NotImplementedInReferenceAssemblyException();
+
+		public Task<List<FileResult>> PickVideosAsync(MediaPickerOptions options = null) =>
 			throw new NotImplementedInReferenceAssemblyException();
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -30,7 +30,11 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
-		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
+		/// <remarks>
+		/// <para>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>.</para>
+		/// <para>On Windows, <see cref="MediaPickerOptions.SelectionLimit"/> is not supported.</para>
+		/// <para>Implement your own logic to ensure that the limit is maintained and/or notify the user on these platforms.</para>
+		/// </remarks>
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
 
 		/// <summary>
@@ -54,7 +58,11 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
-		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
+		/// <remarks>
+		/// <para>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>.</para>
+		/// <para>On Windows, <see cref="MediaPickerOptions.SelectionLimit"/> is not supported.</para>
+		/// <para>Implement your own logic to ensure that the limit is maintained and/or notify the user on these platforms.</para>
+		/// </remarks>
 		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
 
 		/// <summary>

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Maui.Storage;
 
@@ -21,6 +22,10 @@ namespace Microsoft.Maui.Media
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked photo. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
 		Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null);
 
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
 		/// <summary>
 		/// Opens the camera to take a photo.
 		/// </summary>
@@ -34,6 +39,10 @@ namespace Microsoft.Maui.Media
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked video. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the camera to take a video.
@@ -62,6 +71,11 @@ namespace Microsoft.Maui.Media
 		public static Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null) =>
 			Default.PickPhotoAsync(options);
 
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public static Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null) =>
+			Default.PickPhotosAsync(options);
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
 		/// <summary>
 		/// Opens the camera to take a photo.
 		/// </summary>
@@ -77,6 +91,11 @@ namespace Microsoft.Maui.Media
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked video. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
 		public static Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null) =>
 			Default.PickVideoAsync(options);
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public static Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null) =>
+			Default.PickVideosAsync(options);
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the camera to take a video.
@@ -108,5 +127,12 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <remarks>This title is not guaranteed to be shown on all operating systems.</remarks>
 		public string? Title { get; set; }
+
+		/// <summary>
+		/// Gets or sets the maximum number of items that can be selected. Default value is 1.
+		/// </summary>
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public int SelectionLimit { get; set; } = 1;
+#pragma warning restore RS0016 // Add public types and members to the declared API
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -116,7 +116,6 @@ namespace Microsoft.Maui.Media
 		internal static void SetDefault(IMediaPicker? implementation) =>
 			defaultImplementation = implementation;
 	}
-
 	/// <summary>
 	/// Pick options for picking media from the device.
 	/// </summary>
@@ -131,6 +130,9 @@ namespace Microsoft.Maui.Media
 		/// <summary>
 		/// Gets or sets the maximum number of items that can be selected. Default value is 1.
 		/// </summary>
+		/// <remarks>
+		/// A value of 0 means no limit.
+		/// </remarks>
 #pragma warning disable RS0016 // Add public types and members to the declared API
 		public int SelectionLimit { get; set; } = 1;
 #pragma warning restore RS0016 // Add public types and members to the declared API

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -23,6 +23,12 @@ namespace Microsoft.Maui.Media
 		Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null);
 
 #pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <summary>
+		/// Opens the media browser to select photos.
+		/// </summary>
+		/// <param name="options">Pick options to use.</param>
+		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
+		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
 #pragma warning restore RS0016 // Add public types and members to the declared API
 
@@ -41,6 +47,12 @@ namespace Microsoft.Maui.Media
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
 
 #pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <summary>
+		/// Opens the media browser to select videos.
+		/// </summary>
+		/// <param name="options">Pick options to use.</param>
+		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
+		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
 #pragma warning restore RS0016 // Add public types and members to the declared API
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Maui.Storage;
@@ -20,9 +21,10 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked photo. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
+		/// <remarks>When using <see cref="MediaPickerOptions.SelectionLimit"/> on this overload, it will <b>not</b> have effect.</remarks>
+		[Obsolete("Switch to PickPhotosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null);
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		/// <summary>
 		/// Opens the media browser to select photos.
 		/// </summary>
@@ -30,7 +32,6 @@ namespace Microsoft.Maui.Media
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
 		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the camera to take a photo.
@@ -44,9 +45,10 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked video. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
+		/// <remarks>When using <see cref="MediaPickerOptions.SelectionLimit"/> on this overload, it will <b>not</b> have effect.</remarks>
+		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		/// <summary>
 		/// Opens the media browser to select videos.
 		/// </summary>
@@ -54,7 +56,6 @@ namespace Microsoft.Maui.Media
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
 		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the camera to take a video.
@@ -80,13 +81,14 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked photo. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
+		/// <remarks>When using <see cref="MediaPickerOptions.SelectionLimit"/> on this overload, it will <b>not</b> have effect.</remarks>
+		[Obsolete("Switch to PickPhotosAsync which also allows multiple selections.")]
 		public static Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null) =>
 			Default.PickPhotoAsync(options);
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <inheritdoc cref="IMediaPicker.PickPhotosAsync(MediaPickerOptions?)"/>
 		public static Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null) =>
 			Default.PickPhotosAsync(options);
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the camera to take a photo.
@@ -101,13 +103,14 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A <see cref="FileResult"/> object containing details of the picked video. When the operation was cancelled by the user, this will return <see langword="null"/>.</returns>
+		/// <remarks>When using <see cref="MediaPickerOptions.SelectionLimit"/> on this overload, it will <b>not</b> have effect.</remarks>
+		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
 		public static Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null) =>
 			Default.PickVideoAsync(options);
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <inheritdoc cref="IMediaPicker.PickVideosAsync(MediaPickerOptions?)"/>
 		public static Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null) =>
 			Default.PickVideosAsync(options);
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the camera to take a video.
@@ -145,8 +148,6 @@ namespace Microsoft.Maui.Media
 		/// <remarks>
 		/// A value of 0 means no limit.
 		/// </remarks>
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		public int SelectionLimit { get; set; } = 1;
-#pragma warning restore RS0016 // Add public types and members to the declared API
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -3,7 +3,9 @@
 //  - https://github.com/GiampaoloGabba
 //  - https://github.com/richardrigutins
 
+#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
@@ -23,13 +25,21 @@ namespace Microsoft.Maui.Media
 		public bool IsCaptureSupported
 			=> true;
 
-		public Task<FileResult> PickPhotoAsync(MediaPickerOptions options)
+		[Obsolete("Switch to PickPhotoAsync which also allows multiple selections.")]
+		public Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null)
 			=> PickAsync(options, true);
 
-		public Task<FileResult> PickVideoAsync(MediaPickerOptions options)
+		public Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null)
+			=> PickMultipleAsync(options, false);
+
+		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
+		public Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null)
 			=> PickAsync(options, false);
 
-		public async Task<FileResult> PickAsync(MediaPickerOptions options, bool photo)
+		public Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null)
+			=> PickMultipleAsync(options, false);
+
+		public async Task<FileResult?> PickAsync(MediaPickerOptions? options, bool photo)
 		{
 			var picker = new FileOpenPicker();
 
@@ -55,13 +65,44 @@ namespace Microsoft.Maui.Media
 			return new FileResult(result);
 		}
 
-		public Task<FileResult> CapturePhotoAsync(MediaPickerOptions options)
+		public async Task<List<FileResult>> PickMultipleAsync(MediaPickerOptions? options, bool photo)
+		{
+			var picker = new FileOpenPicker();
+
+			var hwnd = WindowStateManager.Default.GetActiveWindowHandle(true);
+			InitializeWithWindow.Initialize(picker, hwnd);
+
+			var defaultTypes = photo ? FilePickerFileType.Images.Value : FilePickerFileType.Videos.Value;
+
+			// set picker properties
+			foreach (var filter in defaultTypes.Select(t => t.TrimStart('*')))
+			{
+				picker.FileTypeFilter.Add(filter);
+			}
+
+			picker.SuggestedStartLocation = photo ? PickerLocationId.PicturesLibrary : PickerLocationId.VideosLibrary;
+			picker.ViewMode = PickerViewMode.Thumbnail;
+
+			// show the picker
+			var result = await picker.PickMultipleFilesAsync();
+
+			// cancelled
+			if (result is null)
+			{
+				return [];
+			}
+
+			// picked
+			return [.. result.Select(file => new FileResult(file))];
+		}
+
+		public Task<FileResult?> CapturePhotoAsync(MediaPickerOptions? options = null)
 			=> CaptureAsync(options, true);
 
-		public Task<FileResult> CaptureVideoAsync(MediaPickerOptions options)
+		public Task<FileResult?> CaptureVideoAsync(MediaPickerOptions? options = null)
 			=> CaptureAsync(options, false);
 
-		public async Task<FileResult> CaptureAsync(MediaPickerOptions options, bool photo)
+		public async Task<FileResult?> CaptureAsync(MediaPickerOptions? options, bool photo)
 		{
 			var captureUi = new WinUICameraCaptureUI();
 
@@ -90,7 +131,7 @@ namespace Microsoft.Maui.Media
 
 			public WinUICameraCaptureUIVideoCaptureSettings VideoSettings { get; } = new();
 
-			public async Task<StorageFile> CaptureFileAsync(CameraCaptureUIMode mode)
+			public async Task<StorageFile?> CaptureFileAsync(CameraCaptureUIMode mode)
 			{
 				var hwnd = WindowStateManager.Default.GetActiveWindowHandle(true);
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Media
 			=> PickAsync(options, true);
 
 		public Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null)
-			=> PickMultipleAsync(options, false);
+			=> PickMultipleAsync(options, true);
 
 		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
 		public Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null)
@@ -67,6 +67,12 @@ namespace Microsoft.Maui.Media
 
 		public async Task<List<FileResult>> PickMultipleAsync(MediaPickerOptions? options, bool photo)
 		{
+			if (options?.SelectionLimit == 1)
+			{
+				var singleResult = await PickAsync(options, photo);
+				return singleResult is null ? [] : [singleResult];
+			}
+
 			var picker = new FileOpenPicker();
 
 			var hwnd = WindowStateManager.Default.GetActiveWindowHandle(true);

--- a/src/Essentials/src/Platform/ActivityStateManager.android.cs
+++ b/src/Essentials/src/Platform/ActivityStateManager.android.cs
@@ -83,7 +83,10 @@ namespace Microsoft.Maui.ApplicationModel
 				throw new InvalidOperationException("Activity was not attached to an application.");
 
 			if (activity is ComponentActivity componentActivity && MediaPickerImplementation.IsPhotoPickerAvailable)
+			{
 				PickVisualMediaForResult.Instance.Register(componentActivity);
+				PickMultipleVisualMediaForResult.Instance.Register(componentActivity);
+			}
 
 			Init(application);
 			lifecycleListener!.Activity = activity;

--- a/src/Essentials/src/Platform/PickMultipleVisualMediaForResult.android.cs
+++ b/src/Essentials/src/Platform/PickMultipleVisualMediaForResult.android.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Android.Util;
+using static AndroidX.Activity.Result.Contract.ActivityResultContracts;
+
+namespace Microsoft.Maui.ApplicationModel;
+
+internal class PickMultipleVisualMediaForResult : ActivityForResultRequest<PickMultipleVisualMedia, ArraySet>
+{
+	static readonly Lazy<PickMultipleVisualMediaForResult> LazyInstance = new(new PickMultipleVisualMediaForResult());
+
+	public static PickMultipleVisualMediaForResult Instance => LazyInstance.Value;
+}

--- a/src/Essentials/src/Platform/PickMultipleVisualMediaForResult.android.cs
+++ b/src/Essentials/src/Platform/PickMultipleVisualMediaForResult.android.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Android.Util;
+using Android.Runtime;
 using static AndroidX.Activity.Result.Contract.ActivityResultContracts;
 
 namespace Microsoft.Maui.ApplicationModel;
 
-internal class PickMultipleVisualMediaForResult : ActivityForResultRequest<PickMultipleVisualMedia, ArraySet>
+internal class PickMultipleVisualMediaForResult : ActivityForResultRequest<PickMultipleVisualMedia, JavaList>
 {
 	static readonly Lazy<PickMultipleVisualMediaForResult> LazyInstance = new(new PickMultipleVisualMediaForResult());
 

--- a/src/Essentials/src/Platform/PickVisualMediaForResult.android.cs
+++ b/src/Essentials/src/Platform/PickVisualMediaForResult.android.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AndroidX.Collection;
 using static AndroidX.Activity.Result.Contract.ActivityResultContracts;
 using AndroidUri = Android.Net.Uri;
 

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
+Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
+Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
+Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
+Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
+Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
+Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue, string? sharedName) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Get(string! key, System.DateTimeOffset defaultValue) -> System.DateTimeOffset
 static Microsoft.Maui.Storage.Preferences.Set(string! key, System.DateTimeOffset value, string? sharedName) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This PR adds the ability to pick multiple files at once through MediaPicker. The single pick methods are obsoleted in favor of the multi pick ones. This prevents the need to have a separate options objects or parameter etc. Now the `MediaPickerOptions` object has a new field `SelectionLimit` with a default value of 1. So default is still a single pick action. Then 0 means unlimited and any other number is the actual limit.

There are a few notes:
* iOS, works as expected, just set the limit and the UI will block the user from picking more than configured
* Android, the default UI blocks the user, but on Android people have the option to use their own custom picker. Those pickers are not guaranteed to honor the maximum selection limit, so be aware.
* Windows, does not have any selection limit implemented at all. This is not available through the Windows APIs. Make sure to implement your own code to detect this.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29079
