### PR TITLE
[Android, iOS, macOS] Fixed Shell SearchHandler Command Not Executed on Item Selection

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
@@ -355,6 +355,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_textBlock.Text = "";
 			SearchConfirmed?.Invoke(this, EventArgs.Empty);
 			Controller.ItemSelected(item);
+			Controller.QueryConfirmed();
 		}
 
 		void UpdateClearButtonState()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
@@ -355,7 +355,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_textBlock.Text = "";
 			SearchConfirmed?.Invoke(this, EventArgs.Empty);
 			Controller.ItemSelected(item);
-			Controller.QueryConfirmed();
 		}
 
 		void UpdateClearButtonState()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1058,9 +1058,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			(SearchHandler as ISearchHandlerController)?.ItemSelected(e);
-			(SearchHandler as ISearchHandlerController)?.QueryConfirmed();
 			_searchController.Active = false;
+			if (SearchHandler is ISearchHandlerController controller)
+			{
+				controller.ItemSelected(e);
+				controller.QueryConfirmed();
+			}
 		}
 
 		void SearchButtonClicked(object? sender, EventArgs e)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				ViewController.AutomaticallyAdjustsScrollViewInsets = false;
 			}
 		}
-		
+
 		internal void UpdateTitleViewInternal()
 		{
 			UpdateTitleView();
@@ -1059,6 +1059,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 
 			(SearchHandler as ISearchHandlerController)?.ItemSelected(e);
+			(SearchHandler as ISearchHandlerController)?.QueryConfirmed();
 			_searchController.Active = false;
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1058,12 +1058,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
+			(SearchHandler as ISearchHandlerController)?.ItemSelected(e);
 			_searchController.Active = false;
-			if (SearchHandler is ISearchHandlerController controller)
-			{
-				controller.ItemSelected(e);
-				controller.QueryConfirmed();
-			}
 		}
 
 		void SearchButtonClicked(object? sender, EventArgs e)

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Devices;
 using static Microsoft.Maui.Controls.VisualElement;
 
 namespace Microsoft.Maui.Controls
@@ -314,6 +315,12 @@ namespace Microsoft.Maui.Controls
 		{
 			OnItemSelected(obj);
 			SetValue(SelectedItemPropertyKey, obj, specificity: SetterSpecificity.FromHandler);
+			if (!(DeviceInfo.Platform == DevicePlatform.WinUI))
+			{
+				// For WinUI the query is confirmed in the QuerySubmitted event, 
+				// so we don't want to call OnQueryConfirmed here as it would cause the command to execute twice
+				OnQueryConfirmed();
+			}
 		}
 
 		void ISearchHandlerController.QueryConfirmed()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
@@ -23,6 +23,12 @@ public class Issue19219Shell : Shell
 	{
 		public Issue19219()
 		{
+			Label label = new Label
+			{
+				Text = "SearchHandler command will execute when tap on item",
+				AutomationId = "SearchHandlerLabel"
+			};
+
 			var fruits = new List<string> { "New York", "London", "Sydney", "Toronto", "Los Angeles", "Chicago", "Melbourne", "Vancouver",
   			"Manchester", "Birmingham", "San Francisco", "Dublin", "Auckland", "Glasgow", "Perth", "Houston",
   			"Seattle", "Cape Town", "Ottawa", "Brisbane", "Boston", "Phoenix", "Washington", "Edinburgh" };
@@ -30,7 +36,10 @@ public class Issue19219Shell : Shell
 			{
 				AutomationId = "searchBar",
 				Placeholder = "SearchHandler",
-				Command = CreateRelayCommand(),
+				Command = (new Command(() =>
+				{
+					label.Text = "SearchHandler Command Executed when tap on item";
+				})),
 				ShowsResults = true,
 			};
 			searchHandler.SetBinding(SearchHandler.ItemsSourceProperty, new Binding
@@ -53,18 +62,10 @@ public class Issue19219Shell : Shell
 
 			StackLayout stackLayout = new StackLayout
 			{
-				Children = { button }
+				Children = { button, label }
 			};
 
 			Content = stackLayout;
-		}
-
-		private ICommand CreateRelayCommand()
-		{
-			return new Command(() =>
-			{
-				DisplayAlert("Command triggered when select on item", "", "OK");
-			});
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
@@ -1,0 +1,70 @@
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 19219, "[Android, iOS, macOS] Shell SearchHandler Command Not Executed on Item Selection", PlatformAffected.iOS)]
+public class Issue19219Shell : Shell
+{
+	public Issue19219Shell()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Flyout;
+
+		var shellContent = new ShellContent
+		{
+			Title = "Home",
+			Route = "MainPage",
+			Content = new Issue19219() { Title = "Home" }
+		};
+
+		Items.Add(shellContent);
+	}
+
+	class Issue19219 : ContentPage
+	{
+		public Issue19219()
+		{
+			var fruits = new List<string> { "New York", "London", "Sydney", "Toronto", "Los Angeles", "Chicago", "Melbourne", "Vancouver",
+  			"Manchester", "Birmingham", "San Francisco", "Dublin", "Auckland", "Glasgow", "Perth", "Houston",
+  			"Seattle", "Cape Town", "Ottawa", "Brisbane", "Boston", "Phoenix", "Washington", "Edinburgh" };
+			var searchHandler = new SearchHandler
+			{
+				AutomationId = "searchBar",
+				Placeholder = "SearchHandler",
+				Command = CreateRelayCommand(),
+				ShowsResults = true,
+			};
+			searchHandler.SetBinding(SearchHandler.ItemsSourceProperty, new Binding
+			{
+				Source = fruits,
+				Mode = BindingMode.OneWay
+			});
+
+			Shell.SetSearchHandler(this, searchHandler);
+			Button button = new Button
+			{
+				Text = "Set query in SearchHandler",
+				Command = new Command(() =>
+				{
+					searchHandler.Query = "a";
+
+				}),
+				AutomationId = "SetQueryButton"
+			};
+
+			StackLayout stackLayout = new StackLayout
+			{
+				Children = { button }
+			};
+
+			Content = stackLayout;
+		}
+
+		private ICommand CreateRelayCommand()
+		{
+			return new Command(() =>
+			{
+				DisplayAlert("Command triggered when select on item", "", "OK");
+			});
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
@@ -29,7 +29,7 @@ public class Issue19219Shell : Shell
 				AutomationId = "SearchHandlerLabel"
 			};
 
-			var fruits = new List<string> { "New York", "London", "Sydney", "Toronto", "Los Angeles", "Chicago", "Melbourne", "Vancouver",
+			var fruits = new List<string> { "Los Angeles", "New York", "London", "Sydney", "Toronto", "Chicago", "Melbourne", "Vancouver",
   			"Manchester", "Birmingham", "San Francisco", "Dublin", "Auckland", "Glasgow", "Perth", "Houston",
   			"Seattle", "Cape Town", "Ottawa", "Brisbane", "Boston", "Phoenix", "Washington", "Edinburgh" };
 			var searchHandler = new SearchHandler
@@ -49,23 +49,13 @@ public class Issue19219Shell : Shell
 			});
 
 			Shell.SetSearchHandler(this, searchHandler);
-			Button button = new Button
-			{
-				Text = "Set query in SearchHandler",
-				Command = new Command(() =>
-				{
-					searchHandler.Query = "a";
 
-				}),
-				AutomationId = "SetQueryButton"
+			Grid grid = new Grid
+			{
+				Children = { label }
 			};
 
-			StackLayout stackLayout = new StackLayout
-			{
-				Children = { button, label }
-			};
-
-			Content = stackLayout;
+			Content = grid;
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19219.cs
@@ -2,7 +2,7 @@ using System.Windows.Input;
 
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 19219, "[Android, iOS, macOS] Shell SearchHandler Command Not Executed on Item Selection", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 19219, "[Android, iOS, macOS] Shell SearchHandler Command Not Executed on Item Selection", PlatformAffected.All)]
 public class Issue19219Shell : Shell
 {
 	public Issue19219Shell()
@@ -29,7 +29,7 @@ public class Issue19219Shell : Shell
 				AutomationId = "SearchHandlerLabel"
 			};
 
-			var fruits = new List<string> { "Los Angeles", "New York", "London", "Sydney", "Toronto", "Chicago", "Melbourne", "Vancouver",
+			var cities = new List<string> { "Los Angeles", "New York", "London", "Sydney", "Toronto", "Chicago", "Melbourne", "Vancouver",
   			"Manchester", "Birmingham", "San Francisco", "Dublin", "Auckland", "Glasgow", "Perth", "Houston",
   			"Seattle", "Cape Town", "Ottawa", "Brisbane", "Boston", "Phoenix", "Washington", "Edinburgh" };
 			var searchHandler = new SearchHandler
@@ -44,7 +44,7 @@ public class Issue19219Shell : Shell
 			};
 			searchHandler.SetBinding(SearchHandler.ItemsSourceProperty, new Binding
 			{
-				Source = fruits,
+				Source = cities,
 				Mode = BindingMode.OneWay
 			});
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
@@ -27,7 +27,7 @@ public class Issue19219 : _IssuesUITest
 		App.WaitForElement("Los Angeles");
 		App.Tap("Los Angeles");
 #endif
-		VerifyScreenshot();
-
+		var text = App.WaitForElement("SearchHandlerLabel").GetText();
+		Assert.That(text, Is.EqualTo("SearchHandler Command Executed when tap on item"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
@@ -17,14 +17,14 @@ public class Issue19219 : _IssuesUITest
 	[Category(UITestCategories.SearchBar)]
 	public void ShouldExecuteCommandWhenTappingShellSearchItem()
 	{
-		App.WaitForElement("SetQueryButton");
-		var searchHandler = App.GetShellSearchHandler().GetRect();
-		App.Tap("SetQueryButton");
-		App.TapCoordinates(searchHandler.X + 100, searchHandler.Y + 10);
-#if ANDROID
-		App.TapCoordinates(searchHandler.X + 100, searchHandler.Height + 100);
+		App.WaitForElement("SearchHandlerLabel");
+		var searchHandler = App.GetShellSearchHandler();
+		searchHandler.Tap();
+		searchHandler.SendKeys("Los Angeles");
+#if ANDROID // Android does not support selecting elements in SearchHandler's results so used tap coordinates
+		var y = searchHandler.GetRect().Y + searchHandler.GetRect().Height;
+		App.TapCoordinates(searchHandler.GetRect().X + 10, y + 10);
 #else
-		App.WaitForElement("Los Angeles");
 		App.Tap("Los Angeles");
 #endif
 		var text = App.WaitForElement("SearchHandlerLabel").GetText();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue19219 : _IssuesUITest
+{
+	public override string Issue => "[Android, iOS, macOS] Shell SearchHandler Command Not Executed on Item Selection";
+
+	public Issue19219(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	[Category(UITestCategories.SearchBar)]
+	public void ShouldExecuteCommandWhenTappingShellSearchItem()
+	{
+		App.WaitForElement("SetQueryButton");
+		var searchHandler = App.GetShellSearchHandler().GetRect();
+		App.Tap("SetQueryButton");
+		App.TapCoordinates(searchHandler.X + 100, searchHandler.Y + 10);
+#if ANDROID
+		App.TapCoordinates(searchHandler.X + 100, searchHandler.Height + 100);
+#else
+		App.WaitForElement("Los Angeles");
+		App.Tap("Los Angeles");
+#endif
+		VerifyScreenshot();
+
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19219.cs
@@ -14,7 +14,6 @@ public class Issue19219 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.Shell)]
-	[Category(UITestCategories.SearchBar)]
 	public void ShouldExecuteCommandWhenTappingShellSearchItem()
 	{
 		App.WaitForElement("SearchHandlerLabel");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- The SearchHandler.Command is not executed when selecting an item from the SearchHandler.ItemsSource in Shell.

### Root Cause

- The Command was not triggered on item tap because the relevant execution logic was missing in the platform-specific methods:
OnSearchItemSelected (iOS)
OnTextBlockItemClicked (Android)

### Description of Changes
- Invoked QueryConfirmed, which contains the command execution logic, inside OnSearchItemSelected for iOS.
- Invoked QueryConfirmed inside OnTextBlockItemClicked for Android to ensure the command is executed as expected when an item is selected.

Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes #19219 

### Output images
**Android**
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/1771e7fd-caa1-4168-9ddc-0e8fa063392a" >| <video src="https://github.com/user-attachments/assets/11876b67-47c5-4420-9f9a-f61feae8d364">|

**iOS**
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/ddecb2a7-ea21-4b45-9838-60af193b3f53" >| <video src="https://github.com/user-attachments/assets/743cd5ae-4d26-4bca-82fe-5ff4c4aaf6ef">|

**MacOS**

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/1029db27-685a-4598-a5bd-47c9e709bc81" >| <video src="https://github.com/user-attachments/assets/b641f13d-2f54-49f5-a091-64f8676e38e0">|

