### PR TITLE
[Testing] Disable the failed ValidateWebViewScreenshot test in net 10.0

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14825.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14825.cs
@@ -11,7 +11,7 @@ public class Issue14825 : _IssuesUITest
 	public Issue14825(TestDevice device) : base(device)
 	{
 	}
-
+#if TEST_FAILS_ON_ANDROID //For more information see: https://github.com/dotnet/maui/issues/30010
 	[Test]
 	[Category(UITestCategories.WebView)]
 	public void ValidateWebViewScreenshot()
@@ -23,4 +23,5 @@ public class Issue14825 : _IssuesUITest
 		App.WaitForElement("TestInstructions", timeout: TimeSpan.FromSeconds(2));
 		VerifyScreenshot();
 	}
+#endif
 }


### PR DESCRIPTION
This pull request introduces a conditional compilation directive to the `Issue14825` test class to exclude the `ValidateWebViewScreenshot` test fails on Android due to a Image capturing in net10.0 release mode. The most important changes are as follows:

### Test adjustments for platform-specific issues:

* Added `#if TEST_FAILS_ON_ANDROID` and `#endif` directives around the `ValidateWebViewScreenshot` test method to conditionally exclude it on Android. This is related to issue [#30010](https://github.com/dotnet/maui/issues/30010). (`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14825.cs`, [[1]](diffhunk://#diff-5d00bdd22baac43305dc9ed7fdc74baa12da82387bdec0c0e1c2580cf9959a4eL14-R14) [[2]](diffhunk://#diff-5d00bdd22baac43305dc9ed7fdc74baa12da82387bdec0c0e1c2580cf9959a4eR26)