### PR TITLE
[BlazorWebView] Implement web request interception

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -4,6 +4,8 @@ using Android.Content;
 using Android.Runtime;
 using Android.Webkit;
 using Java.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Platform;
 using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -83,10 +85,40 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 
 			var requestUri = request?.Url?.ToString();
+
+			var logger = _webViewHandler?.Logger;
+
+			logger?.LogDebug("Intercepting request for {Url}.", requestUri);
+
+			if (view is not null && request is not null && !string.IsNullOrEmpty(requestUri))
+			{
+				// 1. Check if the app wants to modify or override the request
+				var response = WebRequestInterceptingWebView.TryInterceptResponseStream(_webViewHandler, view, request, requestUri, logger);
+				if (response is not null)
+				{
+					return response;
+				}
+
+				// 2. Check if the request is for a Blazor resource
+				response = GetResponse(requestUri, _webViewHandler?.Logger);
+				if (response is not null)
+				{
+					return response;
+				}
+			}
+
+			// 3. Otherwise, we let the request go through as is
+			logger?.LogDebug("Request for {Url} was not handled.", requestUri);
+
+			return base.ShouldInterceptRequest(view, request);
+		}
+
+		private WebResourceResponse? GetResponse(string requestUri, ILogger? logger)
+		{
 			var allowFallbackOnHostPage = AppOriginUri.IsBaseOfPage(requestUri);
 			requestUri = QueryStringHelper.RemovePossibleQueryString(requestUri);
 
-			_webViewHandler?.Logger.HandlingWebRequest(requestUri);
+			logger?.HandlingWebRequest(requestUri);
 
 			if (requestUri != null &&
 				_webViewHandler != null &&
@@ -95,16 +127,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			{
 				var contentType = headers["Content-Type"];
 
-				_webViewHandler?.Logger.ResponseContentBeingSent(requestUri, statusCode);
+				logger?.ResponseContentBeingSent(requestUri, statusCode);
 
 				return new WebResourceResponse(contentType, "UTF-8", statusCode, statusMessage, headers, content);
 			}
 			else
 			{
-				_webViewHandler?.Logger.ReponseContentNotFound(requestUri ?? string.Empty);
+				logger?.ReponseContentNotFound(requestUri ?? string.Empty);
 			}
 
-			return base.ShouldInterceptRequest(view, request);
+			return null;
 		}
 
 		public override void OnPageFinished(AWebView? view, string? url)

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
@@ -65,6 +66,18 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// </summary>
 		public event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
 
+		/// <summary>
+		/// Raised when a web resource is requested. This event allows the application to intercept the request and provide a
+		/// custom response.
+		/// The event handler can set the <see cref="WebViewWebResourceRequestedEventArgs.Handled"/> property to true
+		/// to indicate that the request has been handled and no further processing is needed. If the event handler does set this
+		/// property to true, it must also call the
+		/// <see cref="WebViewWebResourceRequestedEventArgs.SetResponse(int, string, System.Collections.Generic.IReadOnlyDictionary{string, string}?, System.IO.Stream?)"/>
+		/// or <see cref="WebViewWebResourceRequestedEventArgs.SetResponse(int, string, System.Collections.Generic.IReadOnlyDictionary{string, string}?, System.Threading.Tasks.Task{System.IO.Stream?})"/>
+		/// method to provide a response to the request.
+		/// </summary>
+		public event EventHandler<WebViewWebResourceRequestedEventArgs>? WebResourceRequested;
+
 		/// <inheritdoc />
 #if ANDROID
 		[System.Runtime.Versioning.SupportedOSPlatform("android23.0")]
@@ -108,5 +121,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc />
 		void IBlazorWebView.BlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
 			BlazorWebViewInitialized?.Invoke(this, args);
+
+		/// <inheritdoc />
+		bool IWebRequestInterceptingWebView.WebResourceRequested(WebResourceRequestedEventArgs args)
+		{
+			var platformArgs = new PlatformWebViewWebResourceRequestedEventArgs(args);
+			var e = new WebViewWebResourceRequestedEventArgs(platformArgs);
+			WebResourceRequested?.Invoke(this, e);
+			return e.Handled;
+		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// <summary>
 	/// Defines a contract for a view that renders Blazor content.
 	/// </summary>
-	public interface IBlazorWebView : IView
+	public interface IBlazorWebView : IView, IWebRequestInterceptingWebView
 	{
 		/// <summary>
 		/// Gets the path to the HTML file to render.

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// </summary>
 	internal class WinUIWebViewManager : WebView2WebViewManager
 	{
+		private readonly BlazorWebViewHandler _handler;
 		private readonly WebView2Control _webview;
 		private readonly string _hostPageRelativePath;
 		private readonly string _contentRootRelativeToAppRoot;
@@ -62,6 +63,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			ILogger logger)
 			: base(webview, services, dispatcher, fileProvider, jsComponents, contentRootRelativeToAppRoot, hostPagePathWithinFileProvider, webViewHandler, logger)
 		{
+			_handler = webViewHandler;
 			_logger = logger;
 			_webview = webview;
 			_hostPageRelativePath = hostPagePathWithinFileProvider;
@@ -71,52 +73,71 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc />
 		protected override async Task HandleWebResourceRequest(CoreWebView2WebResourceRequestedEventArgs eventArgs)
 		{
-			// Unlike server-side code, we get told exactly why the browser is making the request,
-			// so we can be smarter about fallback. We can ensure that 'fetch' requests never result
-			// in fallback, for example.
-			var allowFallbackOnHostPage =
-				eventArgs.ResourceContext == CoreWebView2WebResourceContext.Document ||
-				eventArgs.ResourceContext == CoreWebView2WebResourceContext.Other; // e.g., dev tools requesting page source
+			var url = eventArgs.Request.Uri;
 
-			// Get a deferral object so that WebView2 knows there's some async stuff going on. We call Complete() at the end of this method.
-			using var deferral = eventArgs.GetDeferral();
+			_logger.LogDebug("Intercepting request for {Url}.", url);
 
-			var requestUri = QueryStringHelper.RemovePossibleQueryString(eventArgs.Request.Uri);
-
-			_logger.HandlingWebRequest(requestUri);
-
-			var uri = new Uri(requestUri);
-			var relativePath = AppOriginUri.IsBaseOf(uri) ? AppOriginUri.MakeRelativeUri(uri).ToString() : null;
-
-			// Check if the uri is _framework/blazor.modules.json is a special case as the built-in file provider
-			// brings in a default implementation.
-			if (relativePath != null &&
-				string.Equals(relativePath, "_framework/blazor.modules.json", StringComparison.Ordinal) &&
-				await TryServeFromFolderAsync(eventArgs, allowFallbackOnHostPage: false, requestUri, relativePath))
+			// 1. First check if the app wants to modify or override the request.
+			if (WebRequestInterceptingWebView.TryInterceptResponseStream(_handler, _webview.CoreWebView2, eventArgs, url, _logger))
 			{
-				_logger.ResponseContentBeingSent(requestUri, 200);
-			}
-			else if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers)
-				&& statusCode != 404)
-			{
-				// First, call into WebViewManager to see if it has a framework file for this request. It will
-				// fall back to an IFileProvider, but on WinUI it's always a NullFileProvider, so that will never
-				// return a file.
-				var headerString = GetHeaderString(headers);
-				_logger.ResponseContentBeingSent(requestUri, statusCode);
-				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content.AsRandomAccessStream(), statusCode, statusMessage, headerString);
-			}
-			else if (relativePath != null)
-			{
-				await TryServeFromFolderAsync(
-					eventArgs,
-					allowFallbackOnHostPage,
-					requestUri,
-					relativePath);
+				return;
 			}
 
-			// Notify WebView2 that the deferred (async) operation is complete and we set a response.
-			deferral.Complete();
+			// 2. If this is an app request, then assume the request is for a Blazor resource.
+			var requestUri = QueryStringHelper.RemovePossibleQueryString(url);
+			if (new Uri(requestUri) is Uri uri)
+			{
+				// Unlike server-side code, we get told exactly why the browser is making the request,
+				// so we can be smarter about fallback. We can ensure that 'fetch' requests never result
+				// in fallback, for example.
+				var allowFallbackOnHostPage =
+					eventArgs.ResourceContext == CoreWebView2WebResourceContext.Document ||
+					eventArgs.ResourceContext == CoreWebView2WebResourceContext.Other; // e.g., dev tools requesting page source
+
+				// Get a deferral object so that WebView2 knows there's some async stuff going on. We call Complete() at the end of this method.
+				using var deferral = eventArgs.GetDeferral();
+
+				_logger.HandlingWebRequest(requestUri);
+
+				var relativePath = AppOriginUri.IsBaseOf(uri) ? AppOriginUri.MakeRelativeUri(uri).ToString() : null;
+
+				// Check if the uri is _framework/blazor.modules.json is a special case as the built-in file provider
+				// brings in a default implementation.
+				if (relativePath != null &&
+					string.Equals(relativePath, "_framework/blazor.modules.json", StringComparison.Ordinal) &&
+					await TryServeFromFolderAsync(eventArgs, allowFallbackOnHostPage: false, requestUri, relativePath))
+				{
+					_logger.ResponseContentBeingSent(requestUri, 200);
+				}
+				else if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers)
+					&& statusCode != 404)
+				{
+					// First, call into WebViewManager to see if it has a framework file for this request. It will
+					// fall back to an IFileProvider, but on WinUI it's always a NullFileProvider, so that will never
+					// return a file.
+					var headerString = GetHeaderString(headers);
+					_logger.ResponseContentBeingSent(requestUri, statusCode);
+					eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content.AsRandomAccessStream(), statusCode, statusMessage, headerString);
+				}
+				else if (relativePath != null)
+				{
+					await TryServeFromFolderAsync(
+						eventArgs,
+						allowFallbackOnHostPage,
+						requestUri,
+						relativePath);
+				}
+
+				// Notify WebView2 that the deferred (async) operation is complete and we set a response.
+				deferral.Complete();
+				return;
+			}
+
+			// 3. If the request is not handled by the app nor is it a local source, then we let the WebView2
+			//    handle the request as it would normally do. This means that it will try to load the resource
+			//    from the internet or from the local cache.
+
+			_logger.LogDebug("Request for {Url} was not handled.", url);
 		}
 
 		private async Task<bool> TryServeFromFolderAsync(

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Maui;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using UIKit;
 using WebKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -259,12 +260,29 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			[SupportedOSPlatform("ios11.0")]
 			public void StartUrlSchemeTask(WKWebView webView, IWKUrlSchemeTask urlSchemeTask)
 			{
-				var responseBytes = GetResponseBytes(urlSchemeTask.Request.Url?.AbsoluteString ?? "", out var contentType, statusCode: out var statusCode);
+				var url = urlSchemeTask.Request.Url.AbsoluteString;
+				if (string.IsNullOrEmpty(url))
+				{
+					return;
+				}
+
+				var logger = _webViewHandler.Logger;
+				
+				logger?.LogDebug("Intercepting request for {Url}.", url);
+
+				// 1. First check if the app wants to modify or override the request.
+				if (WebRequestInterceptingWebView.TryInterceptResponseStream(_webViewHandler, webView, urlSchemeTask, url, logger))
+				{
+					return;
+				}
+
+				// 2. If this is an app request, then assume the request is for a Blazor resource.
+				var responseBytes = GetResponseBytes(url, out var contentType, statusCode: out var statusCode);
 				if (statusCode == 200)
 				{
 					using (var dic = new NSMutableDictionary<NSString, NSString>())
 					{
-						dic.Add((NSString)"Content-Length", (NSString)(responseBytes.Length.ToString(CultureInfo.InvariantCulture)));
+						dic.Add((NSString)"Content-Length", (NSString)responseBytes.Length.ToString(CultureInfo.InvariantCulture));
 						dic.Add((NSString)"Content-Type", (NSString)contentType);
 						// Disable local caching. This will prevent user scripts from executing correctly.
 						dic.Add((NSString)"Cache-Control", (NSString)"no-cache, max-age=0, must-revalidate, no-store");
@@ -278,6 +296,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					urlSchemeTask.DidReceiveData(NSData.FromArray(responseBytes));
 					urlSchemeTask.DidFinish();
 				}
+
+				// 3. If the request is not handled by the app nor is it a local source, then we let the WKWebView
+				//    handle the request as it would normally do. This means that it will try to load the resource
+				//    from the internet or from the local cache.
+
+				logger?.LogDebug("Request for {Url} was not handled.", url);
 			}
 
 			private byte[] GetResponseBytes(string? url, out string contentType, out int statusCode)

--- a/src/Controls/src/Core/HybridWebView/HybridWebView.cs
+++ b/src/Controls/src/Core/HybridWebView/HybridWebView.cs
@@ -66,10 +66,11 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		public event EventHandler<HybridWebViewRawMessageReceivedEventArgs>? RawMessageReceived;
 
-		bool IHybridWebView.WebResourceRequested(WebResourceRequestedEventArgs args)
+		/// <inheritdoc/>
+		bool IWebRequestInterceptingWebView.WebResourceRequested(WebResourceRequestedEventArgs args)
 		{
-			var platformArgs = new PlatformHybridWebViewWebResourceRequestedEventArgs(args);
-			var e = new HybridWebViewWebResourceRequestedEventArgs(platformArgs);
+			var platformArgs = new PlatformWebViewWebResourceRequestedEventArgs(args);
+			var e = new WebViewWebResourceRequestedEventArgs(platformArgs);
 			WebResourceRequested?.Invoke(this, e);
 			return e.Handled;
 		}
@@ -77,14 +78,14 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// Raised when a web resource is requested. This event allows the application to intercept the request and provide a
 		/// custom response.
-		/// The event handler can set the <see cref="HybridWebViewWebResourceRequestedEventArgs.Handled"/> property to true
+		/// The event handler can set the <see cref="WebViewWebResourceRequestedEventArgs.Handled"/> property to true
 		/// to indicate that the request has been handled and no further processing is needed. If the event handler does set this
 		/// property to true, it must also call the
-		/// <see cref="HybridWebViewWebResourceRequestedEventArgs.SetResponse(int, string, System.Collections.Generic.IReadOnlyDictionary{string, string}?, System.IO.Stream?)"/>
-		/// or <see cref="HybridWebViewWebResourceRequestedEventArgs.SetResponse(int, string, System.Collections.Generic.IReadOnlyDictionary{string, string}?, System.Threading.Tasks.Task{System.IO.Stream?})"/>
+		/// <see cref="WebViewWebResourceRequestedEventArgs.SetResponse(int, string, System.Collections.Generic.IReadOnlyDictionary{string, string}?, System.IO.Stream?)"/>
+		/// or <see cref="WebViewWebResourceRequestedEventArgs.SetResponse(int, string, System.Collections.Generic.IReadOnlyDictionary{string, string}?, System.Threading.Tasks.Task{System.IO.Stream?})"/>
 		/// method to provide a response to the request.
 		/// </summary>
-		public event EventHandler<HybridWebViewWebResourceRequestedEventArgs>? WebResourceRequested;
+		public event EventHandler<WebViewWebResourceRequestedEventArgs>? WebResourceRequested;
 
 		/// <summary>
 		/// Sends a raw message to the code running in the web view. Raw messages have no additional processing.

--- a/src/Controls/src/Core/WebRequestInterceptingWebView/PlatformWebViewWebResourceRequestedEventArgs.cs
+++ b/src/Controls/src/Core/WebRequestInterceptingWebView/PlatformWebViewWebResourceRequestedEventArgs.cs
@@ -6,15 +6,15 @@ using System.Linq;
 namespace Microsoft.Maui.Controls;
 
 /// <summary>
-/// Provides platform-specific information about the <see cref="HybridWebView.WebResourceRequested"/> event.
+/// Provides platform-specific information about the <see cref="WebViewWebResourceRequestedEventArgs"/> event.
 /// </summary>
-public class PlatformHybridWebViewWebResourceRequestedEventArgs
+public class PlatformWebViewWebResourceRequestedEventArgs
 {
 #if WINDOWS
 
 	IReadOnlyDictionary<string, string>? _headers;
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(
+	internal PlatformWebViewWebResourceRequestedEventArgs(
 		global::Microsoft.Web.WebView2.Core.CoreWebView2 sender,
 		global::Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs eventArgs)
 	{
@@ -22,7 +22,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 		RequestEventArgs = eventArgs;
 	}
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
+	public PlatformWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
 		: this(args.Sender, args.RequestEventArgs)
 	{
 	}
@@ -63,7 +63,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 
 	IReadOnlyDictionary<string, string>? _headers;
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(
+	internal PlatformWebViewWebResourceRequestedEventArgs(
 		global::WebKit.WKWebView sender,
 		global::WebKit.IWKUrlSchemeTask urlSchemeTask)
 	{
@@ -71,7 +71,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 		UrlSchemeTask = urlSchemeTask;
 	}
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
+	public PlatformWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
 		: this(args.Sender, args.UrlSchemeTask)
 	{
 	}
@@ -130,7 +130,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 	global::Android.Webkit.WebResourceResponse? _response;
 	IReadOnlyDictionary<string, string>? _headers;
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(
+	internal PlatformWebViewWebResourceRequestedEventArgs(
 		global::Android.Webkit.WebView sender,
 		global::Android.Webkit.IWebResourceRequest request,
 		Action<global::Android.Webkit.WebResourceResponse?> setResponse)
@@ -140,7 +140,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 		_setResponse = setResponse;
 	}
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
+	public PlatformWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
 		: this(args.Sender, args.Request, (response) => args.Response = response)
 	{
 	}
@@ -164,7 +164,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 	/// <summary>
 	/// Gets or sets the native response to return to the web view.
 	///
-	/// This property must be set to a valid response if the <see cref="HybridWebViewWebResourceRequestedEventArgs.Handled"/> property is set to true.
+	/// This property must be set to a valid response if the <see cref="WebViewWebResourceRequestedEventArgs.Handled"/> property is set to true.
 	///
 	/// This is only available on Android.
 	/// </summary>
@@ -189,11 +189,7 @@ public class PlatformHybridWebViewWebResourceRequestedEventArgs
 
 #else
 
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs()
-	{
-	}
-
-	internal PlatformHybridWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
+	public PlatformWebViewWebResourceRequestedEventArgs(WebResourceRequestedEventArgs args)
 	{
 	}
 

--- a/src/Controls/src/Core/WebRequestInterceptingWebView/WebViewWebResourceRequestedEventArgs.cs
+++ b/src/Controls/src/Core/WebRequestInterceptingWebView/WebViewWebResourceRequestedEventArgs.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Maui.Controls;
 /// <summary>
 /// Event arguments for the <see cref="HybridWebView.WebResourceRequested"/> event.
 /// </summary>
-public class HybridWebViewWebResourceRequestedEventArgs
+public class WebViewWebResourceRequestedEventArgs
 {
 	IReadOnlyDictionary<string, string>? _headers;
 	IReadOnlyDictionary<string, string>? _queryParams;
 
-	internal HybridWebViewWebResourceRequestedEventArgs(PlatformHybridWebViewWebResourceRequestedEventArgs platformArgs)
+	public WebViewWebResourceRequestedEventArgs(PlatformWebViewWebResourceRequestedEventArgs platformArgs)
 	{
 		PlatformArgs = platformArgs;
 		Uri = platformArgs.GetRequestUri() is string uri ? new Uri(uri) : throw new InvalidOperationException("Platform web request did not have a request URI.");
@@ -22,10 +22,10 @@ public class HybridWebViewWebResourceRequestedEventArgs
 	}
 
 	/// <summary>
-	/// Initializes a new instance of the <see cref="HybridWebViewWebResourceRequestedEventArgs"/> class
+	/// Initializes a new instance of the <see cref="WebViewWebResourceRequestedEventArgs"/> class
 	/// with the specified URI and method.
 	/// </summary>
-	public HybridWebViewWebResourceRequestedEventArgs(Uri uri, string method)
+	public WebViewWebResourceRequestedEventArgs(Uri uri, string method)
 	{
 		Uri = uri;
 		Method = method;
@@ -34,7 +34,7 @@ public class HybridWebViewWebResourceRequestedEventArgs
 	/// <summary>
 	/// Gets the platform-specific event arguments.
 	/// </summary>
-	public PlatformHybridWebViewWebResourceRequestedEventArgs? PlatformArgs { get; }
+	public PlatformWebViewWebResourceRequestedEventArgs? PlatformArgs { get; }
 
 	/// <summary>
 	/// Gets the URI of the requested resource.
@@ -264,9 +264,9 @@ public class HybridWebViewWebResourceRequestedEventArgs
 }
 
 /// <summary>
-/// Extension methods for the <see cref="HybridWebViewWebResourceRequestedEventArgs"/> class.
+/// Extension methods for the <see cref="WebViewWebResourceRequestedEventArgs"/> class.
 /// </summary>
-public static class HybridWebViewWebResourceRequestedEventArgsExtensions
+public static class WebViewWebResourceRequestedEventArgsExtensions
 {
 	/// <summary>
 	/// Sets the response for the web resource request with a status code and reason.
@@ -274,7 +274,7 @@ public static class HybridWebViewWebResourceRequestedEventArgsExtensions
 	/// <param name="e">The event arguments.</param>
 	/// <param name="code">The HTTP status code for the response.</param>
 	/// <param name="reason">The reason phrase for the response.</param>
-	public static void SetResponse(this HybridWebViewWebResourceRequestedEventArgs e, int code, string reason) =>
+	public static void SetResponse(this WebViewWebResourceRequestedEventArgs e, int code, string reason) =>
 		e.SetResponse(code, reason, null, (Stream?)null);
 
 	/// <summary>
@@ -285,7 +285,7 @@ public static class HybridWebViewWebResourceRequestedEventArgsExtensions
 	/// <param name="reason">The reason phrase for the response.</param>
 	/// <param name="contentType">The content type of the response.</param>
 	/// <param name="content">The content of the response as a stream.</param>
-	public static void SetResponse(this HybridWebViewWebResourceRequestedEventArgs e, int code, string reason, string contentType, Stream? content) =>
+	public static void SetResponse(this WebViewWebResourceRequestedEventArgs e, int code, string reason, string contentType, Stream? content) =>
 		e.SetResponse(code, reason, new Dictionary<string, string> { ["Content-Type"] = contentType }, content);
 
 	/// <summary>
@@ -296,6 +296,6 @@ public static class HybridWebViewWebResourceRequestedEventArgsExtensions
 	/// <param name="reason">The reason phrase for the response.</param>
 	/// <param name="contentType">The content type of the response.</param>
 	/// <param name="contentTask">A task that represents the asynchronous operation of getting the response content.</param>
-	public static void SetResponse(this HybridWebViewWebResourceRequestedEventArgs e, int code, string reason, string contentType, Task<Stream?> contentTask) =>
+	public static void SetResponse(this WebViewWebResourceRequestedEventArgs e, int code, string reason, string contentType, Task<Stream?> contentTask) =>
 		e.SetResponse(code, reason, new Dictionary<string, string> { ["Content-Type"] = contentType }, contentTask);
 }

--- a/src/Core/src/Core/IHybridWebView.cs
+++ b/src/Core/src/Core/IHybridWebView.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Maui
 {
-	public interface IHybridWebView : IView
+	public interface IHybridWebView : IView, IWebRequestInterceptingWebView
 	{
 		/// <summary>
 		/// Specifies the file within the <see cref="HybridRoot"/> that should be served as the default file. The
@@ -65,16 +65,5 @@ namespace Microsoft.Maui
 			JsonTypeInfo<TReturnType> returnTypeJsonTypeInfo,
 			object?[]? paramValues = null,
 			JsonTypeInfo?[]? paramJsonTypeInfos = null);
-
-		/// <summary>
-		/// Invoked when a web resource is requested. This event can be used to intercept requests and provide custom responses.
-		/// </summary>
-		/// <param name="args">The event arguments containing the request details.</param>
-		/// <returns><c>true</c> if the request was handled; otherwise, <c>false</c>.</returns>
-#if NETSTANDARD
-		bool WebResourceRequested(WebResourceRequestedEventArgs args);
-#else
-		bool WebResourceRequested(WebResourceRequestedEventArgs args) => false;
-#endif
 	}
 }

--- a/src/Core/src/Core/IWebRequestInterceptingWebView.cs
+++ b/src/Core/src/Core/IWebRequestInterceptingWebView.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.Maui;
+
+public interface IWebRequestInterceptingWebView : IView
+{
+	/// <summary>
+	/// Invoked when a web resource is requested. This event can be used to intercept requests and provide custom responses.
+	/// </summary>
+	/// <param name="args">The event arguments containing the request details.</param>
+	/// <returns><c>true</c> if the request was handled; otherwise, <c>false</c>.</returns>
+#if NETSTANDARD
+	bool WebResourceRequested(WebResourceRequestedEventArgs args);
+#else
+	bool WebResourceRequested(WebResourceRequestedEventArgs args) => false;
+#endif
+}

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -109,20 +109,9 @@ namespace Microsoft.Maui.Handlers
 			logger?.LogDebug("Intercepting request for {Url}.", url);
 
 			// 1. First check if the app wants to modify or override the request.
+			if (WebRequestInterceptingWebView.TryInterceptResponseStream(this, sender, eventArgs, url, logger))
 			{
-				// 1.a. First, create the event args
-				var platformArgs = new WebResourceRequestedEventArgs(sender, eventArgs);
-
-				// 1.b. Trigger the event for the app
-				var handled = VirtualView.WebResourceRequested(platformArgs);
-
-				// 1.c. If the app reported that it completed the request, then we do nothing more
-				if (handled)
-				{
-					logger?.LogDebug("Request for {Url} was handled by the user.", url);
-
-					return;
-				}
+				return;
 			}
 
 			// 2. If this is an app request, then assume the request is for a local resource.
@@ -156,6 +145,7 @@ namespace Microsoft.Maui.Handlers
 
 				// 2.e. Notify WebView2 that the deferred (async) operation is complete and we set a response.
 				deferral.Complete();
+				return;
 			}
 
 			// 3. If the request is not handled by the app nor is it a local source, then we let the WebView2

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.Handlers
 			config.DefaultWebpagePreferences!.AllowsContentJavaScript = true;
 
 			config.UserContentController.AddScriptMessageHandler(new WebViewScriptMessageHandler(this), ScriptMessageHandlerName);
+
 			// iOS WKWebView doesn't allow handling 'http'/'https' schemes, so we use the fake 'app' scheme
 			config.SetUrlSchemeHandler(new SchemeHandler(this), urlScheme: "app");
 
@@ -161,20 +162,9 @@ namespace Microsoft.Maui.Handlers
 				logger?.LogDebug("Intercepting request for {Url}.", url);
 
 				// 1. First check if the app wants to modify or override the request.
+				if (WebRequestInterceptingWebView.TryInterceptResponseStream(Handler, webView, urlSchemeTask, url, logger))
 				{
-					// 1.a. First, create the event args
-					var platformArgs = new WebResourceRequestedEventArgs(webView, urlSchemeTask);
-
-					// 1.b. Trigger the event for the app
-					var handled = Handler.VirtualView.WebResourceRequested(platformArgs);
-
-					// 1.c. If the app reported that it completed the request, then we do nothing more
-					if (handled)
-					{
-						logger?.LogDebug("Request for {Url} was handled by the user.", url);
-
-						return;
-					}
+					return;
 				}
 
 				// 2. If this is an app request, then assume the request is for a local resource.

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Maui.Platform
 			if (view is not null && request is not null && !string.IsNullOrEmpty(url))
 			{
 				// 1. Check if the app wants to modify or override the request
-				var response = TryInterceptResponseStream(view, request, url, logger);
+				var response = WebRequestInterceptingWebView.TryInterceptResponseStream(Handler, view, request, url, logger);
 				if (response is not null)
 				{
 					return response;
 				}
 
 				// 2. Check if the request is for a local resource
-				response = GetResponseStream(view, request, url, logger);
+				response = GetResponse(url, logger);
 				if (response is not null)
 				{
 					return response;
@@ -60,31 +60,7 @@ namespace Microsoft.Maui.Platform
 			return base.ShouldInterceptRequest(view, request);
 		}
 
-		private WebResourceResponse? TryInterceptResponseStream(AWebView view, IWebResourceRequest request, string url, ILogger? logger)
-		{
-			if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is null)
-			{
-				return null;
-			}
-
-			// 1. First, create the event args
-			var platformArgs = new WebResourceRequestedEventArgs(view, request);
-
-			// 2. Trigger the event for the app
-			var handled = Handler.VirtualView.WebResourceRequested(platformArgs);
-
-			// 3. If the app reported that it completed the request, then we do nothing more
-			if (handled)
-			{
-				logger?.LogDebug("Request for {Url} was handled by the user.", url);
-
-				return platformArgs.Response;
-			}
-
-			return null;
-		}
-
-		private WebResourceResponse? GetResponseStream(AWebView view, IWebResourceRequest request, string fullUrl, ILogger? logger)
+		private WebResourceResponse? GetResponse(string fullUrl, ILogger? logger)
 		{
 			if (Handler is null || Handler is IViewHandler ivh && ivh.VirtualView is null)
 			{

--- a/src/Core/src/Platform/Android/WebRequestInterceptingWebView.cs
+++ b/src/Core/src/Platform/Android/WebRequestInterceptingWebView.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Android.Webkit;
+using Microsoft.Extensions.Logging;
+using AWebView = Android.Webkit.WebView;
+
+namespace Microsoft.Maui.Platform;
+
+internal static class WebRequestInterceptingWebView
+{
+	internal static WebResourceResponse? TryInterceptResponseStream(IViewHandler? handler, AWebView view, IWebResourceRequest request, string url, ILogger? logger)
+	{
+		if (handler is null || handler.VirtualView is not IWebRequestInterceptingWebView interceptingWebView)
+		{
+			return null;
+		}
+
+		// 1. First, create the event args
+		var platformArgs = new WebResourceRequestedEventArgs(view, request);
+
+		// 2. Trigger the event for the app
+		var handled = interceptingWebView.WebResourceRequested(platformArgs);
+
+		// 3. If the app reported that it completed the request, then we do nothing more
+		if (handled)
+		{
+			logger?.LogDebug("Request for {Url} was handled by the user.", url);
+
+			return platformArgs.Response;
+		}
+
+		return null;
+	}
+}

--- a/src/Core/src/Platform/Windows/WebRequestInterceptingWebView.cs
+++ b/src/Core/src/Platform/Windows/WebRequestInterceptingWebView.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Web.WebView2.Core;
+
+namespace Microsoft.Maui.Platform;
+
+internal static class WebRequestInterceptingWebView
+{
+	internal static bool TryInterceptResponseStream(IViewHandler? handler, CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs eventArgs, string url, ILogger? logger)
+	{
+		if (handler is null || handler.VirtualView is not IWebRequestInterceptingWebView interceptingWebView)
+		{
+			return false;
+		}
+
+		// 1. First, create the event args
+		var platformArgs = new WebResourceRequestedEventArgs(sender, eventArgs);
+
+		// 2. Trigger the event for the app
+		var handled = interceptingWebView.WebResourceRequested(platformArgs);
+
+		// 3. If the app reported that it completed the request, then we do nothing more
+		if (handled)
+		{
+			logger?.LogDebug("Request for {Url} was handled by the user.", url);
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Core/src/Platform/iOS/WebRequestInterceptingWebView.cs
+++ b/src/Core/src/Platform/iOS/WebRequestInterceptingWebView.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+using WebKit;
+
+namespace Microsoft.Maui.Platform;
+
+internal static class WebRequestInterceptingWebView
+{
+	internal static bool TryInterceptResponseStream(IViewHandler? handler, WKWebView webView, IWKUrlSchemeTask urlSchemeTask, string url, ILogger? logger)
+	{
+		if (handler is null || handler.VirtualView is not IWebRequestInterceptingWebView interceptingWebView)
+		{
+			return false;
+		}
+
+		// 1. First, create the event args
+		var platformArgs = new WebResourceRequestedEventArgs(webView, urlSchemeTask);
+
+		// 2. Trigger the event for the app
+		var handled = interceptingWebView.WebResourceRequested(platformArgs);
+
+		// 3. If the app reported that it completed the request, then we do nothing more
+		if (handled)
+		{
+			logger?.LogDebug("Request for {Url} was handled by the user.", url);
+
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Core/src/Primitives/WebResourceRequestedEventArgs.cs
+++ b/src/Core/src/Primitives/WebResourceRequestedEventArgs.cs
@@ -1,13 +1,13 @@
 ﻿namespace Microsoft.Maui;
 
 /// <summary>
-/// Provides platform-specific information for the <see cref="IHybridWebView.WebResourceRequested"/> event.
+/// Provides platform-specific information for the <see cref="IWebRequestInterceptingWebView.WebResourceRequested"/> event.
 /// </summary>
 public class WebResourceRequestedEventArgs
 {
 #if WINDOWS
 
-	internal WebResourceRequestedEventArgs(
+	public WebResourceRequestedEventArgs(
 		global::Microsoft.Web.WebView2.Core.CoreWebView2 sender,
 		global::Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs eventArgs)
 	{
@@ -33,7 +33,7 @@ public class WebResourceRequestedEventArgs
 
 #elif IOS || MACCATALYST
 
-	internal WebResourceRequestedEventArgs(
+	public WebResourceRequestedEventArgs(
 		global::WebKit.WKWebView sender,
 		global::WebKit.IWKUrlSchemeTask urlSchemeTask)
 	{
@@ -59,7 +59,7 @@ public class WebResourceRequestedEventArgs
 
 #elif ANDROID
 
-	internal WebResourceRequestedEventArgs(
+	public WebResourceRequestedEventArgs(
 		global::Android.Webkit.WebView sender,
 		global::Android.Webkit.IWebResourceRequest request)
 	{

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Microsoft.AspNetCore.Components.WebView.Maui")]
+
 [assembly: InternalsVisibleTo("iOSUnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility")]

--- a/src/PublicAPI.targets
+++ b/src/PublicAPI.targets
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Remove="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+    <!-- <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" /> -->
   </ItemGroup>
 
   <!-- for explicit TFMs -->


### PR DESCRIPTION
### Description of Change

> This is the same work as https://github.com/dotnet/maui/pull/28876, but for BlazorWebView. 

This pull request introduces support for intercepting and handling web resource requests across multiple platforms in the Blazor WebView framework. The primary changes include adding new event hooks for request interception, enhancing logging for debugging purposes, and refactoring existing classes to support the new functionality. Below is a summary of the most significant changes, grouped by theme:

### Web Resource Interception and Event Handling

* Added a new `WebResourceRequested` event to the `BlazorWebView` and `HybridWebView` components, allowing applications to intercept web resource requests and provide custom responses. This includes setting the `Handled` property and invoking appropriate methods to define the response. (`src/BlazorWebView/src/Maui/BlazorWebView.cs` [[1]](diffhunk://#diff-686480e837ea6b2efcefbcc3779c37d3137206458b8da550bddb4219e2eff10eR69-R80) [[2]](diffhunk://#diff-686480e837ea6b2efcefbcc3779c37d3137206458b8da550bddb4219e2eff10eR124-R132); `src/Controls/src/Core/HybridWebView/HybridWebView.cs` [[3]](diffhunk://#diff-aadfcda7fa6ce463d6690c416b18822cc49865d2cfff5f6857733ddf228fab88L69-R88)

* Updated the `IBlazorWebView` interface to inherit from `IWebRequestInterceptingWebView`, enabling web resource interception as part of the Blazor WebView contract. (`src/BlazorWebView/src/Maui/IBlazorWebView.cs` [src/BlazorWebView/src/Maui/IBlazorWebView.csL11-R11](diffhunk://#diff-4625d43d1ee4b3e61f89c80d2d8322c243a8ad2c9505a1042d6d7768bbbc2923L11-R11))

### Logging Enhancements

* Introduced detailed logging in the web resource interception flow to aid debugging. Log messages are added to indicate when requests are intercepted, handled, or passed through unmodified. (`src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs` [[1]](diffhunk://#diff-491a4b35962629acb0b5b087bac0135dc974d6f395288b07eae1f8e0de608a00R88-R121) [[2]](diffhunk://#diff-491a4b35962629acb0b5b087bac0135dc974d6f395288b07eae1f8e0de608a00L98-R139); `src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs` [[3]](diffhunk://#diff-8d0044e984fd120fda66bbf1836817b127959ca2097e14b8a81c0bbf24e05348R75-R88) [[4]](diffhunk://#diff-8d0044e984fd120fda66bbf1836817b127959ca2097e14b8a81c0bbf24e05348R133-R140); `src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs` [[5]](diffhunk://#diff-70134b3eb600fca8f30f63350e52df26623afd848728d5e06ea613c6ca032832L262-R285) [[6]](diffhunk://#diff-70134b3eb600fca8f30f63350e52df26623afd848728d5e06ea613c6ca032832R299-R304)

### Platform-Specific Web Resource Handling

* Implemented platform-specific logic for intercepting and handling web resource requests on Android, iOS, and Windows. This includes checking if requests should be overridden, handling Blazor-specific resources, and falling back to default behavior if necessary. (`src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs` [[1]](diffhunk://#diff-491a4b35962629acb0b5b087bac0135dc974d6f395288b07eae1f8e0de608a00R88-R121) [[2]](diffhunk://#diff-491a4b35962629acb0b5b087bac0135dc974d6f395288b07eae1f8e0de608a00L98-R139); `src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs` [[3]](diffhunk://#diff-8d0044e984fd120fda66bbf1836817b127959ca2097e14b8a81c0bbf24e05348R75-R88) [[4]](diffhunk://#diff-8d0044e984fd120fda66bbf1836817b127959ca2097e14b8a81c0bbf24e05348R133-R140); `src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs` [[5]](diffhunk://#diff-70134b3eb600fca8f30f63350e52df26623afd848728d5e06ea613c6ca032832L262-R285) [[6]](diffhunk://#diff-70134b3eb600fca8f30f63350e52df26623afd848728d5e06ea613c6ca032832R299-R304)

### Refactoring and Renaming

* Renamed `PlatformHybridWebViewWebResourceRequestedEventArgs` to `PlatformWebViewWebResourceRequestedEventArgs` to generalize its usage and align with the new `WebResourceRequested` event. Updated all references accordingly. (`src/Controls/src/Core/WebRequestInterceptingWebView/PlatformWebViewWebResourceRequestedEventArgs.cs` [[1]](diffhunk://#diff-f00e3105bc145b4d0fa0a6e8a5392200f1b011022570ca9c7593963dd83984ddL9-R25) [[2]](diffhunk://#diff-f00e3105bc145b4d0fa0a6e8a5392200f1b011022570ca9c7593963dd83984ddL66-R74) [[3]](diffhunk://#diff-f00e3105bc145b4d0fa0a6e8a5392200f1b011022570ca9c7593963dd83984ddL133-R133) [[4]](diffhunk://#diff-f00e3105bc145b4d0fa0a6e8a5392200f1b011022570ca9c7593963dd83984ddL143-R143) [[5]](diffhunk://#diff-f00e3105bc145b4d0fa0a6e8a5392200f1b011022570ca9c7593963dd83984ddL167-R167) [[6]](diffhunk://#diff-f00e3105bc145b4d0fa0a6e8a5392200f1b011022570ca9c7593963dd83984ddL192-R192)

### Miscellaneous

* Added missing namespace imports and minor adjustments to ensure compatibility with the new functionality. (`src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs` [[1]](diffhunk://#diff-491a4b35962629acb0b5b087bac0135dc974d6f395288b07eae1f8e0de608a00R7-R8); `src/BlazorWebView/src/Maui/BlazorWebView.cs` [[2]](diffhunk://#diff-686480e837ea6b2efcefbcc3779c37d3137206458b8da550bddb4219e2eff10eR6); `src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs` [[3]](diffhunk://#diff-70134b3eb600fca8f30f63350e52df26623afd848728d5e06ea613c6ca032832R14)

These changes enhance the flexibility and extensibility of the Blazor WebView framework, enabling developers to customize how web resources are handled across different platforms.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #11382

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
