### PR TITLE
Hide MacCatalyst Titlebar separator

### DIFF
--- a/src/Core/src/Platform/iOS/WindowViewController.cs
+++ b/src/Core/src/Platform/iOS/WindowViewController.cs
@@ -130,19 +130,16 @@ internal class WindowViewController : UIViewController
 			_titleBar = newPlatTitleBar;
 			_iTitleBarRef = new WeakReference<IView?>(iTitleBar);
 		}
-		
+
 		_isTitleBarVisible = (iTitleBar?.Visibility == Visibility.Visible);
 
 		var platformTitleBar = platformWindow.WindowScene?.Titlebar;
 
-		if (newTitleBar is not null && platformTitleBar is not null)
+		if (platformTitleBar is not null)
 		{
-			platformTitleBar.TitleVisibility = UITitlebarTitleVisibility.Hidden;
-		}
-
-		else if (newTitleBar is null && platformTitleBar is not null)
-		{
-			platformTitleBar.TitleVisibility = UITitlebarTitleVisibility.Visible;
+			// Hide separator to avoid it cutting through pages (#26650)
+			platformTitleBar.SeparatorStyle = UITitlebarSeparatorStyle.None;
+			platformTitleBar.TitleVisibility = newTitleBar is null ? UITitlebarTitleVisibility.Visible : UITitlebarTitleVisibility.Hidden;
 		}
 
 		IsFirstLayout = true;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

The Titlebar separator does not always appear in the right place on MacCatalyst and it is visible through page transparency and transitions. It being hidden by default seems preferable.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes: #26650

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
