### PR TITLE
[Testing] Add Validation Test For Issue28051 On Android

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28051.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28051.cs
@@ -1,0 +1,112 @@
+#if ANDROID
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 28051, "ObjectDisposedException Occurs During View Recycling When PlatformBehavior Is Attached on Android", PlatformAffected.Android)]
+public class Issue28051 : TestContentPage, INotifyPropertyChanged
+{
+	ObservableCollection<string> items;
+
+	public ObservableCollection<string> Items
+	{
+		get => items;
+		set
+		{
+			if (items != value)
+			{
+				items = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+
+	protected override void Init()
+	{
+		BindingContext = this;
+		LoadItems();
+
+		Button refreshItemsButton = new Button
+		{
+			AutomationId = "RefreshItemsButton",
+			Text = "Refresh"
+		};
+		refreshItemsButton.Clicked += OnReproClicked;
+
+		StackLayout contentLayout = new StackLayout() { Spacing = 10 };
+
+		StackLayout itemContainer = new StackLayout();
+		itemContainer.SetBinding(BindableLayout.ItemsSourceProperty, new Binding("Items"));
+
+		BindableLayout.SetItemTemplate(itemContainer, CreateItemTemplate());
+
+		RefreshView refreshView = new RefreshView
+		{
+			Content = itemContainer
+		};
+
+		contentLayout.Children.Add(refreshItemsButton);
+		contentLayout.Children.Add(refreshView);
+
+		this.Content = contentLayout;
+	}
+
+	DataTemplate CreateItemTemplate()
+	{
+		DataTemplate itemTemplate = new DataTemplate(() =>
+		{
+			Button button = new Button
+			{
+				BackgroundColor = Colors.DarkGreen,
+				TextColor = Colors.White
+			};
+			button.SetBinding(Button.TextProperty, new Binding("."));
+			LongPressBehavior longPressBehavior = new LongPressBehavior();
+			button.Behaviors.Add(longPressBehavior);
+			return button;
+		});
+
+		return itemTemplate;
+	}
+
+	void OnReproClicked(object sender, EventArgs e)
+	{
+		Items = null;
+		Items = new ObservableCollection<string>
+			{
+				"Item A",
+				"Item B",
+				"Item C"
+			};
+	}
+
+	void LoadItems()
+	{
+		Items = new ObservableCollection<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3"
+			};
+	}
+
+	public new event PropertyChangedEventHandler PropertyChanged;
+	protected new void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+
+public partial class LongPressBehavior : PlatformBehavior<Element, Android.Views.View>
+{
+	protected override void OnAttachedTo(Element bindable, Android.Views.View platformView)
+	{
+		BindingContext = bindable.BindingContext;
+	}
+
+	protected override void OnDetachedFrom(Element bindable, Android.Views.View platformView)
+	{
+		BindingContext = null;
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28051.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28051.cs
@@ -1,4 +1,3 @@
-#if ANDROID
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -97,16 +96,57 @@ public class Issue28051 : TestContentPage, INotifyPropertyChanged
 		=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }
 
+#if ANDROID
 public class LongPressBehavior : PlatformBehavior<Element, Android.Views.View>
 {
-	protected override void OnAttachedTo(Element bindable, Android.Views.View platformView)
+    protected override void OnAttachedTo(Element bindable, Android.Views.View platformView)
+    {
+        BindingContext = bindable.BindingContext;
+    }
+ 
+    protected override void OnDetachedFrom(Element bindable, Android.Views.View platformView)
+    {
+        BindingContext = null;
+    }
+}
+#elif IOS || MACCATALYST
+public class LongPressBehavior : PlatformBehavior<Element, UIKit.UIView>
+{
+	protected override void OnAttachedTo(Element bindable, UIKit.UIView platformView)
 	{
 		BindingContext = bindable.BindingContext;
 	}
 
-	protected override void OnDetachedFrom(Element bindable, Android.Views.View platformView)
+	protected override void OnDetachedFrom(Element bindable, UIKit.UIView platformView)
 	{
 		BindingContext = null;
+
 	}
+}
+#elif WINDOWS
+public class LongPressBehavior : PlatformBehavior<Element, Microsoft.UI.Xaml.FrameworkElement>
+{
+    protected override void OnAttachedTo(Element bindable, Microsoft.UI.Xaml.FrameworkElement platformView)
+    {
+        BindingContext = bindable.BindingContext;
+    }
+ 
+    protected override void OnDetachedFrom(Element bindable, Microsoft.UI.Xaml.FrameworkElement platformView)
+    {
+        BindingContext = null;
+    }
+}
+#else
+public class LongPressBehavior : PlatformBehavior<Element, object>
+{
+    protected override void OnAttachedTo(Element bindable, object platformView)
+    {
+        BindingContext = bindable.BindingContext;
+    }
+ 
+    protected override void OnDetachedFrom(Element bindable, object platformView)
+    {
+        BindingContext = null;
+    }
 }
 #endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28051.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28051.cs
@@ -97,7 +97,7 @@ public class Issue28051 : TestContentPage, INotifyPropertyChanged
 		=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }
 
-public partial class LongPressBehavior : PlatformBehavior<Element, Android.Views.View>
+public class LongPressBehavior : PlatformBehavior<Element, Android.Views.View>
 {
 	protected override void OnAttachedTo(Element bindable, Android.Views.View platformView)
 	{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28051.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28051.cs
@@ -1,5 +1,4 @@
-﻿#if ANDROID
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -25,4 +24,3 @@ public class Issue28051 : _IssuesUITest
 		App.WaitForElement(Refresh);
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28051.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28051.cs
@@ -1,0 +1,28 @@
+﻿#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue28051 : _IssuesUITest
+{
+	public Issue28051(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "ObjectDisposedException Occurs During View Recycling When PlatformBehavior Is Attached on Android";
+
+	const string Refresh = "Refresh";
+
+	[Test]
+	[Category(UITestCategories.Performance)]
+	public void RefreshItemsShouldNotCrash()
+	{
+		App.WaitForElement(Refresh);
+		for (int i = 0; i < 10; i++)
+		{
+			App.Tap("RefreshItemsButton");
+		}
+		App.WaitForElement(Refresh);
+	}
+}
+#endif


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

The following [Issue](https://github.com/dotnet/maui/issues/28051#issue-2880225028) was previously resolved via a [PR](https://github.com/dotnet/maui/pull/29934) merged into inflight, but no Test was included to validate the scenario.  This PR adds a test to reliably reproduce the original crash scenario,  ensuring that no `ObjectDisposedException` occurs when refreshing the items repeatedly.

### Output 

| Before| After|
|--|--|
| <video src="https://github.com/user-attachments/assets/778481aa-6122-408a-a5e9-695c143fe1da"> | <video src="https://github.com/user-attachments/assets/2f6e2b13-dc34-4fff-9388-9a8b3ee843be"> |