### PR TITLE
[.NET 10] Implement image compression & MaximumWidth/MaximumHeight for MediaPicker

### DIFF
--- a/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
+++ b/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
@@ -18,6 +18,12 @@
           <Stepper Value="{Binding PickerSelectionLimit, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="1" />
           <Label Text="{Binding PickerSelectionLimit}" VerticalOptions="Center" />
         </HorizontalStackLayout>
+        <Label Text="Image compression quality" HorizontalOptions="Center" />
+        <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
+          <Stepper Value="{Binding PickerCompressionQuality, Mode=TwoWay}" Minimum="10" Maximum="100" Increment="10" />
+          <Label Text="{Binding PickerCompressionQuality}" VerticalOptions="Center" />
+        </HorizontalStackLayout>
+        <Label Text="{Binding ImageByteLength, StringFormat='{}{0:N0} bytes'}" HorizontalOptions="Center" />
         <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
         <Button Text="Capture photo" Command="{Binding CapturePhotoCommand}" />
         <Button Text="Pick video" Command="{Binding PickVideoCommand}" />

--- a/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
+++ b/src/Essentials/samples/Samples/View/MediaPickerPage.xaml
@@ -8,43 +8,219 @@
     <viewmodels:MediaPickerViewModel />
   </views:BasePage.BindingContext>
 
-  <Grid RowDefinitions="Auto,*">
-    <Label Text="Pick or capture a photo or video." FontAttributes="Bold" Margin="12" />
+  <ScrollView>
+    <VerticalStackLayout Padding="16" Spacing="20">
+        
+        <!-- Settings Section -->
+        <Border BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#343A40}" 
+                StrokeThickness="0" 
+                Stroke="{AppThemeBinding Light=#DEE2E6, Dark=#495057}"
+                StrokeShape="RoundRectangle 12" 
+                Padding="16">
+          <Border.Shadow>
+            <Shadow Brush="Black" Opacity="0.1" Radius="8" Offset="0,2" />
+          </Border.Shadow>
+          <VerticalStackLayout Spacing="16">
+            <Label Text="⚙️ Settings" 
+                   FontSize="16" 
+                   FontAttributes="Bold" 
+                   TextColor="{AppThemeBinding Light=#495057, Dark=#F8F9FA}" />
+            
+            <!-- Selection Limit -->
+            <Grid ColumnDefinitions="2*,Auto,80">
+              <Label Grid.Column="0" 
+                     Text="Selection Limit" 
+                     VerticalOptions="Center"
+                     TextColor="{AppThemeBinding Light=#6C757D, Dark=#CED4DA}" />
+              <Stepper Grid.Column="1" 
+                       Value="{Binding PickerSelectionLimit, Mode=TwoWay}" 
+                       Minimum="1" Maximum="10" Increment="1" />
+              <Label Grid.Column="2" 
+                     Text="{Binding PickerSelectionLimit}" 
+                     VerticalOptions="Center" 
+                     HorizontalOptions="Center"
+                     FontAttributes="Bold" />
+            </Grid>
+            
+            <!-- Compression Quality -->
+            <Grid ColumnDefinitions="2*,Auto,80">
+              <Label Grid.Column="0" 
+                     Text="Compression Quality %" 
+                     VerticalOptions="Center"
+                     TextColor="{AppThemeBinding Light=#6C757D, Dark=#CED4DA}" />
+              <Stepper Grid.Column="1" 
+                       Value="{Binding PickerCompressionQuality, Mode=TwoWay}" 
+                       Minimum="10" Maximum="100" Increment="10" />
+              <Label Grid.Column="2" 
+                     Text="{Binding PickerCompressionQuality}" 
+                     VerticalOptions="Center" 
+                     HorizontalOptions="Center"
+                     FontAttributes="Bold" />
+            </Grid>
+            
+            <!-- Maximum Width -->
+            <Grid ColumnDefinitions="2*,Auto,80">
+              <Label Grid.Column="0" 
+                     Text="Max Width (0 = original)" 
+                     VerticalOptions="Center"
+                     TextColor="{AppThemeBinding Light=#6C757D, Dark=#CED4DA}" />
+              <Stepper Grid.Column="1" 
+                       Value="{Binding PickerMaximumWidth, Mode=TwoWay}" 
+                       Minimum="0" Maximum="4000" Increment="100" />
+              <Label Grid.Column="2" 
+                     Text="{Binding PickerMaximumWidth}" 
+                     VerticalOptions="Center" 
+                     HorizontalOptions="Center"
+                     FontAttributes="Bold" />
+            </Grid>
+            
+            <!-- Maximum Height -->
+            <Grid ColumnDefinitions="2*,Auto,80">
+              <Label Grid.Column="0" 
+                     Text="Max Height (0 = original)" 
+                     VerticalOptions="Center"
+                     TextColor="{AppThemeBinding Light=#6C757D, Dark=#CED4DA}" />
+              <Stepper Grid.Column="1" 
+                       Value="{Binding PickerMaximumHeight, Mode=TwoWay}" 
+                       Minimum="0" Maximum="4000" Increment="100" />
+              <Label Grid.Column="2" 
+                     Text="{Binding PickerMaximumHeight}" 
+                     VerticalOptions="Center" 
+                     HorizontalOptions="Center"
+                     FontAttributes="Bold" />
+            </Grid>
+          </VerticalStackLayout>
+        </Border>
 
-    <ScrollView Grid.Row="1">
-      <VerticalStackLayout Padding="12,0,12,12" Spacing="6">
-        <Label Text="Picker selection limit" HorizontalOptions="Center" />
-        <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
-          <Stepper Value="{Binding PickerSelectionLimit, Mode=TwoWay}" Minimum="0" Maximum="10" Increment="1" />
-          <Label Text="{Binding PickerSelectionLimit}" VerticalOptions="Center" />
-        </HorizontalStackLayout>
-        <Label Text="Image compression quality" HorizontalOptions="Center" />
-        <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
-          <Stepper Value="{Binding PickerCompressionQuality, Mode=TwoWay}" Minimum="10" Maximum="100" Increment="10" />
-          <Label Text="{Binding PickerCompressionQuality}" VerticalOptions="Center" />
-        </HorizontalStackLayout>
-        <Label Text="{Binding ImageByteLength, StringFormat='{}{0:N0} bytes'}" HorizontalOptions="Center" />
-        <Button Text="Pick photo" Command="{Binding PickPhotoCommand}" />
-        <Button Text="Capture photo" Command="{Binding CapturePhotoCommand}" />
-        <Button Text="Pick video" Command="{Binding PickVideoCommand}" />
-        <Button Text="Capture video" Command="{Binding CaptureVideoCommand}" />
+        <!-- Actions Section -->
+        <Border BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#343A40}" 
+                StrokeThickness="0" 
+                Stroke="{AppThemeBinding Light=#DEE2E6, Dark=#495057}"
+                StrokeShape="RoundRectangle 12" 
+                Padding="16">
+          <Border.Shadow>
+            <Shadow Brush="Black" Opacity="0.1" Radius="8" Offset="0,2" />
+          </Border.Shadow>
+          <VerticalStackLayout Spacing="12">
+            <Label Text="📸 Actions" 
+                   FontSize="16" 
+                   FontAttributes="Bold" 
+                   TextColor="{AppThemeBinding Light=#495057, Dark=#F8F9FA}" />
+            
+            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+              <Button Grid.Row="0" Grid.Column="0"
+                      Text="📷 Pick Photo" 
+                      Command="{Binding PickPhotoCommand}"
+                      BackgroundColor="{AppThemeBinding Light=#007BFF, Dark=#0D6EFD}"
+                      TextColor="White" />
+              <Button Grid.Row="0" Grid.Column="1"
+                      Text="📹 Capture Photo" 
+                      Command="{Binding CapturePhotoCommand}"
+                      BackgroundColor="{AppThemeBinding Light=#28A745, Dark=#198754}"
+                      TextColor="White" />
+              <Button Grid.Row="1" Grid.Column="0"
+                      Text="🎬 Pick Video" 
+                      Command="{Binding PickVideoCommand}"
+                      BackgroundColor="{AppThemeBinding Light=#DC3545, Dark=#DC3545}"
+                      TextColor="White" />
+              <Button Grid.Row="1" Grid.Column="1"
+                      Text="🎥 Capture Video" 
+                      Command="{Binding CaptureVideoCommand}"
+                      BackgroundColor="{AppThemeBinding Light=#FD7E14, Dark=#FD7E14}"
+                      TextColor="White" />
+            </Grid>
+          </VerticalStackLayout>
+        </Border>
 
-        <ScrollView Orientation="Horizontal" IsVisible="{Binding ShowMultiplePhotos}">
-          <HorizontalStackLayout 
-                        BindableLayout.ItemsSource="{Binding PhotoList}"
-                        IsVisible="{Binding ShowMultiplePhotos}"
-                        HeightRequest="300">
-            <BindableLayout.ItemTemplate>
-              <DataTemplate>
-                <Image Source="{Binding .}" HeightRequest="300" WidthRequest="100" />
-              </DataTemplate>
-            </BindableLayout.ItemTemplate>
-          </HorizontalStackLayout>
-        </ScrollView>
+        <!-- Multiple Photos Section -->
+        <Border BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#343A40}" 
+                StrokeThickness="0" 
+                Stroke="{AppThemeBinding Light=#DEE2E6, Dark=#495057}"
+                StrokeShape="RoundRectangle 12" 
+                Padding="16"
+                IsVisible="{Binding ShowMultiplePhotos}">
+          <Border.Shadow>
+            <Shadow Brush="Black" Opacity="0.1" Radius="8" Offset="0,2" />
+          </Border.Shadow>
+          <VerticalStackLayout Spacing="12">
+            <Label Text="🖼️ Selected Photos" 
+                   FontSize="16" 
+                   FontAttributes="Bold" 
+                   TextColor="{AppThemeBinding Light=#495057, Dark=#F8F9FA}" />
+            
+            <ScrollView Orientation="Horizontal" HeightRequest="280">
+              <HorizontalStackLayout BindableLayout.ItemsSource="{Binding PhotoList}" Spacing="12">
+                <BindableLayout.ItemTemplate>
+                  <DataTemplate>
+                    <Border BackgroundColor="{AppThemeBinding Light=#F8F9FA, Dark=#495057}"
+                            StrokeThickness="1"
+                            Stroke="{AppThemeBinding Light=#DEE2E6, Dark=#6C757D}"
+                            StrokeShape="RoundRectangle 8"
+                            Padding="8"
+                            WidthRequest="160">
+                      <VerticalStackLayout Spacing="4">
+                        <Image Source="{Binding Source}" 
+                               HeightRequest="180" 
+                               WidthRequest="144" 
+                               Aspect="AspectFit"
+                               VerticalOptions="Center" />
+                        <Label Text="{Binding Dimensions}" 
+                               FontSize="10" 
+                               HorizontalOptions="Center"
+                               FontAttributes="Bold"
+                               TextColor="{AppThemeBinding Light=#495057, Dark=#F8F9FA}"
+                               LineBreakMode="NoWrap" />
+                        <Label Text="{Binding FileSize}" 
+                               FontSize="9" 
+                               HorizontalOptions="Center"
+                               FontAttributes="Italic"
+                               TextColor="{AppThemeBinding Light=#6C757D, Dark=#CED4DA}"
+                               LineBreakMode="NoWrap" />
+                      </VerticalStackLayout>
+                    </Border>
+                  </DataTemplate>
+                </BindableLayout.ItemTemplate>
+              </HorizontalStackLayout>
+            </ScrollView>
+          </VerticalStackLayout>
+        </Border>
 
-        <Image Source="{Binding PhotoSource}" IsVisible="{Binding ShowPhoto}" HeightRequest="300"/>
+        <!-- Single Photo Section -->
+        <Border BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#343A40}" 
+                StrokeThickness="0" 
+                Stroke="{AppThemeBinding Light=#DEE2E6, Dark=#495057}"
+                StrokeShape="RoundRectangle 12" 
+                Padding="16"
+                IsVisible="{Binding ShowPhoto}">
+          <Border.Shadow>
+            <Shadow Brush="Black" Opacity="0.1" Radius="8" Offset="0,2" />
+          </Border.Shadow>
+          <VerticalStackLayout Spacing="12" HorizontalOptions="Center">
+            <Label Text="📷 Selected Photo" 
+                   FontSize="16" 
+                   FontAttributes="Bold" 
+                   HorizontalOptions="Center"
+                   TextColor="{AppThemeBinding Light=#495057, Dark=#F8F9FA}" />
+            
+            <Border BackgroundColor="{AppThemeBinding Light=#F8F9FA, Dark=#495057}"
+                    StrokeThickness="1"
+                    Stroke="{AppThemeBinding Light=#DEE2E6, Dark=#6C757D}"
+                    StrokeShape="RoundRectangle 8"
+                    Padding="8">
+              <VerticalStackLayout Spacing="12">
+                <Image Source="{Binding PhotoSource}" 
+                       HeightRequest="300" 
+                       Aspect="AspectFit" />
+                <Label Text="{Binding ImageDimensions}" 
+                       FontSize="16" 
+                       HorizontalOptions="Center" 
+                       FontAttributes="Bold"
+                       TextColor="{AppThemeBinding Light=#495057, Dark=#F8F9FA}" />
+              </VerticalStackLayout>
+            </Border>
+          </VerticalStackLayout>
+        </Border>
       </VerticalStackLayout>
     </ScrollView>
-  </Grid>
 
 </views:BasePage>

--- a/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -104,12 +104,6 @@ namespace Samples.ViewModel
 			set => SetProperty(ref photoList, value);
 		}
 
-		public ObservableCollection<ImageSource> PhotoList
-		{
-			get => photoList;
-			set => SetProperty(ref photoList, value);
-		}
-
 		public ImageSource PhotoSource
 		{
 			get => photoSource;

--- a/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -138,6 +138,7 @@ namespace Samples.ViewModel
 
 				ShowPhoto = false;
 				ShowMultiplePhotos = false;
+				ImageByteLength = 0;
 
 				await DisplayAlertAsync($"{videos.Count} videos successfully picked.");
 
@@ -157,6 +158,7 @@ namespace Samples.ViewModel
 
 				ShowPhoto = false;
 				ShowMultiplePhotos = false;
+				ImageByteLength = 0;
 
 				await DisplayAlertAsync($"Video successfully captured at {video.FullPath}.");
 
@@ -178,6 +180,7 @@ namespace Samples.ViewModel
 
 			var stream = await photo.OpenReadAsync();
 			PhotoSource = ImageSource.FromStream(() => stream);
+			ImageByteLength = stream.Length;
 
 			ShowMultiplePhotos = false;
 			ShowPhoto = true;
@@ -186,6 +189,7 @@ namespace Samples.ViewModel
 		async Task LoadPhotoAsync(List<FileResult> photo)
 		{
 			PhotoList.Clear();
+			ImageByteLength = 0;
 
 			// canceled
 			if (photo is null || photo.Count == 0)

--- a/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -15,6 +15,8 @@ namespace Samples.ViewModel
 
 		bool showPhoto;
 		int pickerSelectionLimit = 1;
+		int pickerCompressionQuality = 100;
+		long imageByteLength = 0;
 		private ObservableCollection<ImageSource> photoList = [];
 		private bool showMultiplePhotos;
 
@@ -39,6 +41,18 @@ namespace Samples.ViewModel
 		{
 			get => pickerSelectionLimit;
 			set => SetProperty(ref pickerSelectionLimit, value);
+		}
+
+		public int PickerCompressionQuality
+		{
+			get => pickerCompressionQuality;
+			set => SetProperty(ref pickerCompressionQuality, value);
+		}
+
+		public long ImageByteLength
+		{
+			get => imageByteLength;
+			set => SetProperty(ref imageByteLength, value);
 		}
 
 		public bool ShowPhoto
@@ -79,6 +93,7 @@ namespace Samples.ViewModel
 				{
 					Title = "Pick a photo",
 					SelectionLimit = PickerSelectionLimit,
+					CompressionQuality = PickerCompressionQuality,
 				});
 
 				await LoadPhotoAsync(photo);
@@ -95,7 +110,11 @@ namespace Samples.ViewModel
 		{
 			try
 			{
-				var photo = await MediaPicker.CapturePhotoAsync();
+				var photo = await MediaPicker.CapturePhotoAsync(new MediaPickerOptions
+				{
+					Title = "Capture a photo",
+					CompressionQuality = PickerCompressionQuality,
+				});
 
 				await LoadPhotoAsync(photo);
 
@@ -179,6 +198,7 @@ namespace Samples.ViewModel
 			{
 				var stream = await item.OpenReadAsync();
 				PhotoList.Add(ImageSource.FromStream(() => stream));
+				ImageByteLength += stream.Length;
 			}
 
 			ShowPhoto = false;

--- a/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -59,6 +59,12 @@ namespace Samples.ViewModel
 			set => SetProperty(ref photoList, value);
 		}
 
+		public ObservableCollection<ImageSource> PhotoList
+		{
+			get => photoList;
+			set => SetProperty(ref photoList, value);
+		}
+
 		public ImageSource PhotoSource
 		{
 			get => photoSource;

--- a/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
+++ b/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-#if IOS || ANDROID
+#if IOS || ANDROID || WINDOWS
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Platform;
 #endif
@@ -25,7 +25,7 @@ internal static class ImageProcessor
     public static async Task<Stream> ProcessImageAsync(Stream inputStream, 
         int? maxWidth, int? maxHeight, int qualityPercent, string originalFileName = null)
     {
-#if !(IOS || ANDROID)
+#if !(IOS || ANDROID || WINDOWS)
         // For platforms without MAUI Graphics support, return null to indicate no processing available
         await Task.CompletedTask; // Avoid async warning
         return null;
@@ -78,7 +78,7 @@ internal static class ImageProcessor
 #endif
     }
 
-#if IOS || ANDROID
+#if IOS || ANDROID || WINDOWS
     /// <summary>
     /// Applies resizing constraints to an image while preserving aspect ratio.
     /// </summary>
@@ -145,7 +145,7 @@ internal static class ImageProcessor
     /// </summary>
     public static bool IsProcessingNeeded(int? maxWidth, int? maxHeight, int qualityPercent)
     {
-#if !(IOS || ANDROID)
+#if !(IOS || ANDROID || WINDOWS)
         // On platforms without MAUI Graphics support, always return false - no processing available
         return false;
 #else
@@ -186,7 +186,7 @@ internal static class ImageProcessor
 #endif
     }
 
-#if IOS || ANDROID
+#if IOS || ANDROID || WINDOWS
     /// <summary>
     /// Detects image format from stream using magic numbers.
     /// </summary>

--- a/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
+++ b/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-#if IOS || ANDROID || WINDOWS
+#if IOS || ANDROID
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Platform;
 #endif
@@ -25,7 +25,7 @@ internal static class ImageProcessor
     public static async Task<Stream> ProcessImageAsync(Stream inputStream, 
         int? maxWidth, int? maxHeight, int qualityPercent, string originalFileName = null)
     {
-#if !(IOS || ANDROID || WINDOWS)
+#if !(IOS || ANDROID)
         // For platforms without MAUI Graphics support, return null to indicate no processing available
         await Task.CompletedTask; // Avoid async warning
         return null;
@@ -78,7 +78,7 @@ internal static class ImageProcessor
 #endif
     }
 
-#if IOS || ANDROID || WINDOWS
+#if IOS || ANDROID
     /// <summary>
     /// Applies resizing constraints to an image while preserving aspect ratio.
     /// </summary>
@@ -145,7 +145,7 @@ internal static class ImageProcessor
     /// </summary>
     public static bool IsProcessingNeeded(int? maxWidth, int? maxHeight, int qualityPercent)
     {
-#if !(IOS || ANDROID || WINDOWS)
+#if !(IOS || ANDROID)
         // On platforms without MAUI Graphics support, always return false - no processing available
         return false;
 #else
@@ -162,7 +162,7 @@ internal static class ImageProcessor
     /// <returns>File extension including the dot (e.g., ".jpg", ".png")</returns>
     public static string DetermineOutputExtension(Stream imageData, int qualityPercent, string originalFileName = null)
     {
-#if !(IOS || ANDROID || WINDOWS)
+#if !(IOS || ANDROID)
         // On platforms without MAUI Graphics support, fall back to simple logic
         bool originalWasPng = !string.IsNullOrEmpty(originalFileName) && 
                               originalFileName.EndsWith(".png", StringComparison.OrdinalIgnoreCase);
@@ -186,7 +186,7 @@ internal static class ImageProcessor
 #endif
     }
 
-#if IOS || ANDROID || WINDOWS
+#if IOS || ANDROID
     /// <summary>
     /// Detects image format from stream using magic numbers.
     /// </summary>

--- a/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
+++ b/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
@@ -1,8 +1,9 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-#if !NETSTANDARD
+#if IOS || ANDROID || WINDOWS
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 #endif
 
 namespace Microsoft.Maui.Essentials;
@@ -24,8 +25,8 @@ internal static class ImageProcessor
     public static async Task<Stream> ProcessImageAsync(Stream inputStream, 
         int? maxWidth, int? maxHeight, int qualityPercent, string originalFileName = null)
     {
-#if NETSTANDARD || NET
-        // For .NET Standard and base .NET (without platform), return null to indicate no processing available
+#if !(IOS || ANDROID || WINDOWS)
+        // For platforms without MAUI Graphics support, return null to indicate no processing available
         await Task.CompletedTask; // Avoid async warning
         return null;
 #else
@@ -77,7 +78,7 @@ internal static class ImageProcessor
 #endif
     }
 
-#if !NETSTANDARD
+#if IOS || ANDROID || WINDOWS
     /// <summary>
     /// Applies resizing constraints to an image while preserving aspect ratio.
     /// </summary>
@@ -144,8 +145,8 @@ internal static class ImageProcessor
     /// </summary>
     public static bool IsProcessingNeeded(int? maxWidth, int? maxHeight, int qualityPercent)
     {
-#if NETSTANDARD || NET
-        // On .NET Standard and base .NET (without platform), always return false - no processing available
+#if !(IOS || ANDROID || WINDOWS)
+        // On platforms without MAUI Graphics support, always return false - no processing available
         return false;
 #else
         return (maxWidth.HasValue || maxHeight.HasValue) || qualityPercent < 100;
@@ -161,10 +162,10 @@ internal static class ImageProcessor
     /// <returns>File extension including the dot (e.g., ".jpg", ".png")</returns>
     public static string DetermineOutputExtension(Stream imageData, int qualityPercent, string originalFileName = null)
     {
-#if NETSTANDARD || NET
-        // On .NET Standard and base .NET (without platform), fall back to simple logic
+#if !(IOS || ANDROID || WINDOWS)
+        // On platforms without MAUI Graphics support, fall back to simple logic
         bool originalWasPng = !string.IsNullOrEmpty(originalFileName) && 
-                                originalFileName.EndsWith(".png", StringComparison.OrdinalIgnoreCase);
+                              originalFileName.EndsWith(".png", StringComparison.OrdinalIgnoreCase);
         return (qualityPercent >= 95 || originalWasPng) ? ".png" : ".jpg";
 #else
         // Try to detect format from the actual processed image data
@@ -185,7 +186,7 @@ internal static class ImageProcessor
 #endif
     }
 
-#if !NETSTANDARD && !NET
+#if IOS || ANDROID || WINDOWS
     /// <summary>
     /// Detects image format from stream using magic numbers.
     /// </summary>

--- a/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
+++ b/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
@@ -1,0 +1,209 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
+
+namespace Microsoft.Maui.Essentials
+{
+	/// <summary>
+	/// Unified image processing helper using MAUI Graphics for cross-platform consistency.
+	/// </summary>
+	internal static class ImageProcessor
+	{
+		/// <summary>
+		/// Processes an image by applying resizing and compression using MAUI Graphics.
+		/// </summary>
+		/// <param name="inputStream">The input image stream.</param>
+		/// <param name="maxWidth">Maximum width constraint (null for no constraint).</param>
+		/// <param name="maxHeight">Maximum height constraint (null for no constraint).</param>
+		/// <param name="qualityPercent">Compression quality percentage (0-100).</param>
+		/// <param name="originalFileName">Original filename to determine format preservation logic.</param>
+		/// <returns>A new stream containing the processed image.</returns>
+		public static async Task<Stream> ProcessImageAsync(Stream inputStream, 
+			int? maxWidth, int? maxHeight, int qualityPercent, string originalFileName = null)
+		{
+            if (inputStream is null)
+            {
+                throw new ArgumentNullException(nameof(inputStream));
+            }
+
+            // Ensure we can read from the beginning of the stream
+            if (inputStream.CanSeek)
+            {
+                inputStream.Position = 0;
+            }
+
+			IImage image = null;
+			try
+			{
+				// Load the image using MAUI Graphics
+				var imageLoadingService = new PlatformImageLoadingService();
+				image = imageLoadingService.FromStream(inputStream);
+
+                if (image is null)
+                {
+                    throw new InvalidOperationException("Failed to load image from stream");
+                }
+
+				// Apply resizing if needed
+                if (maxWidth.HasValue || maxHeight.HasValue)
+                {
+                    image = ApplyResizing(image, maxWidth, maxHeight);
+                }
+
+				// Determine output format and quality
+				var format = ShouldUsePngFormat(originalFileName, qualityPercent) 
+					? ImageFormat.Png : ImageFormat.Jpeg;
+				var quality = Math.Max(0f, Math.Min(1f, qualityPercent / 100.0f));
+
+				// Save to new stream
+				var outputStream = new MemoryStream();
+				await image.SaveAsync(outputStream, format, quality);
+				outputStream.Position = 0;
+
+				return outputStream;
+			}
+			finally
+			{
+				image?.Dispose();
+			}
+		}
+
+		/// <summary>
+		/// Applies resizing constraints to an image while preserving aspect ratio.
+		/// </summary>
+		private static IImage ApplyResizing(IImage image, int? maxWidth, int? maxHeight)
+		{
+			var currentWidth = image.Width;
+			var currentHeight = image.Height;
+
+			// Calculate new dimensions while preserving aspect ratio
+			var newDimensions = CalculateResizedDimensions(currentWidth, currentHeight, maxWidth, maxHeight);
+
+			// Only resize if dimensions actually changed
+			if (Math.Abs(newDimensions.Width - currentWidth) > 0.1f || 
+				Math.Abs(newDimensions.Height - currentHeight) > 0.1f)
+			{
+				return image.Downsize(newDimensions.Width, newDimensions.Height, disposeOriginal: true);
+			}
+
+			return image;
+		}
+
+		/// <summary>
+		/// Calculates new image dimensions while preserving aspect ratio.
+		/// </summary>
+		private static (float Width, float Height) CalculateResizedDimensions(
+			float originalWidth, float originalHeight, int? maxWidth, int? maxHeight)
+		{
+			if (!maxWidth.HasValue && !maxHeight.HasValue)
+			{
+				return (originalWidth, originalHeight);
+			}
+
+			var targetWidth = maxWidth ?? float.MaxValue;
+			var targetHeight = maxHeight ?? float.MaxValue;
+
+			var scaleX = targetWidth / originalWidth;
+			var scaleY = targetHeight / originalHeight;
+			var scale = Math.Min(scaleX, scaleY);
+
+			// Only scale down, never scale up
+			if (scale >= 1.0f)
+				return (originalWidth, originalHeight);
+
+			return (originalWidth * scale, originalHeight * scale);
+		}
+
+		/// <summary>
+		/// Determines whether to use PNG format based on the original filename and quality settings.
+		/// </summary>
+		private static bool ShouldUsePngFormat(string originalFileName, int qualityPercent)
+		{
+			var originalWasPng = !string.IsNullOrEmpty(originalFileName) && 
+								 Path.GetExtension(originalFileName).Equals(".png", StringComparison.OrdinalIgnoreCase);
+
+			// High quality (>=95): Prefer PNG for lossless quality
+			// High quality (>=90) + original was PNG: preserve PNG format
+			// Otherwise: Use JPEG for better compression
+			return qualityPercent >= 95 || (qualityPercent >= 90 && originalWasPng);
+		}
+
+		/// <summary>
+		/// Determines if image processing is needed based on the provided options.
+		/// </summary>
+		public static bool IsProcessingNeeded(int? maxWidth, int? maxHeight, int qualityPercent)
+		{
+			return (maxWidth.HasValue || maxHeight.HasValue) || qualityPercent < 100;
+		}
+
+		/// <summary>
+		/// Determines the output file extension based on processed image data and quality settings.
+		/// </summary>
+		/// <param name="imageData">The processed image stream to analyze</param>
+		/// <param name="qualityPercent">Compression quality percentage</param>
+		/// <param name="originalFileName">Original filename for format hints (optional)</param>
+		/// <returns>File extension including the dot (e.g., ".jpg", ".png")</returns>
+		public static string DetermineOutputExtension(Stream imageData, int qualityPercent, string originalFileName = null)
+		{
+			// Try to detect format from the actual processed image data
+			var detectedFormat = DetectImageFormat(imageData);
+			if (!string.IsNullOrEmpty(detectedFormat))
+			{
+				return detectedFormat;
+			}
+
+			// Fallback: Use quality-based decision with original format consideration
+			var originalWasPng = !string.IsNullOrEmpty(originalFileName) && 
+								 Path.GetExtension(originalFileName).Equals(".png", StringComparison.OrdinalIgnoreCase);
+			
+			// High quality (>=90) and original was PNG: keep PNG
+			// Very high quality (>=95): prefer PNG for maximum quality
+			// Otherwise: use JPEG for better compression
+			return (qualityPercent >= 95 || (qualityPercent >= 90 && originalWasPng)) ? ".png" : ".jpg";
+		}
+
+		/// <summary>
+		/// Detects image format from stream using magic numbers.
+		/// </summary>
+		private static string DetectImageFormat(Stream imageData)
+		{
+			if (imageData?.Length < 4)
+			{
+				return null;
+			}
+
+			var originalPosition = imageData.Position;
+			try
+			{
+				imageData.Position = 0;
+				var bytes = new byte[8];
+				var bytesRead = imageData.Read(bytes, 0, Math.Min(8, (int)imageData.Length));
+				
+				if (bytesRead < 3)
+				{
+					return null;
+				}
+
+				// PNG: 89 50 4E 47
+				if (bytesRead >= 4 && bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47)
+				{
+					return ".png";
+				}
+
+				// JPEG: FF D8 FF
+				if (bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF)
+				{
+					return ".jpg";
+				}
+
+				return null;
+			}
+			finally
+			{
+				imageData.Position = originalPosition;
+			}
+		}
+	}
+}

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -15,7 +15,7 @@ using AndroidUri = Android.Net.Uri;
 namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
-	{		
+	{
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.Provider;
+using Android.Widget;
 using AndroidX.Activity.Result;
 using AndroidX.Activity.Result.Contract;
 using Microsoft.Maui.ApplicationModel;
@@ -15,7 +17,7 @@ using AndroidUri = Android.Net.Uri;
 namespace Microsoft.Maui.Media
 {
 	partial class MediaPickerImplementation : IMediaPicker
-	{
+	{		
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
@@ -132,9 +134,15 @@ namespace Microsoft.Maui.Media
 
 		async Task<FileResult> PickUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
-			var pickVisualMediaRequest = new PickVisualMediaRequest.Builder()
-				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance)
-				.Build();
+			var pickVisualMediaRequestBuilder = new PickVisualMediaRequest.Builder()
+				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance);
+
+			if (options.SelectionLimit > 1)
+			{
+				pickVisualMediaRequestBuilder.SetMaxItems(options.SelectionLimit);
+			}
+			
+			var pickVisualMediaRequest = pickVisualMediaRequestBuilder.Build();
 
 			var androidUri = await PickVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -6,7 +6,6 @@ using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.Provider;
-using Android.Widget;
 using AndroidX.Activity.Result;
 using AndroidX.Activity.Result.Contract;
 using Microsoft.Maui.ApplicationModel;
@@ -134,15 +133,9 @@ namespace Microsoft.Maui.Media
 
 		async Task<FileResult> PickUsingPhotoPicker(MediaPickerOptions options, bool photo)
 		{
-			var pickVisualMediaRequestBuilder = new PickVisualMediaRequest.Builder()
-				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance);
-
-			if (options.SelectionLimit > 1)
-			{
-				pickVisualMediaRequestBuilder.SetMaxItems(options.SelectionLimit);
-			}
-			
-			var pickVisualMediaRequest = pickVisualMediaRequestBuilder.Build();
+			var pickVisualMediaRequest = new PickVisualMediaRequest.Builder()
+				.SetMediaType(photo ? ActivityResultContracts.PickVisualMedia.ImageOnly.Instance : ActivityResultContracts.PickVisualMedia.VideoOnly.Instance)
+				.Build();
 
 			var androidUri = await PickVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
 
@@ -180,7 +173,7 @@ namespace Microsoft.Maui.Media
 
 			var androidUris = await PickMultipleVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
 
-			if (androidUris?.IsEmpty ?? true)
+			if (androidUris?.IsEmpty  ?? true)
 			{
 				return [];
 			}

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -288,6 +288,10 @@ namespace Microsoft.Maui.Media
 					try { originalFile.Delete(); } catch { }
 					return processedPath;
 				}
+				
+				// If ImageProcessor returns null (e.g., on .NET Standard), ImageProcessor.IsProcessingNeeded would have returned false,
+				// so we shouldn't reach this point. Return original path as fallback.
+				return imagePath;
 			}
 			catch
 			{

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
@@ -173,7 +172,7 @@ namespace Microsoft.Maui.Media
 
 			var androidUris = await PickMultipleVisualMediaForResult.Instance.Launch(pickVisualMediaRequest);
 
-			if (androidUris?.IsEmpty  ?? true)
+			if (androidUris?.IsEmpty ?? true)
 			{
 				return [];
 			}

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -268,13 +268,13 @@ namespace Microsoft.Maui.Media
 				.Select(file => (FileResult)new PHPickerFileResult(file.ItemProvider))
 				.ToList() ?? [];
 
-			// Apply compression if specified and dealing with images
-			if (options?.CompressionQuality < 100)
+			// Apply resizing and compression if specified and dealing with images
+			if ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100)
 			{
 				var compressedResults = new List<FileResult>();
 				foreach (var result in fileResults)
 				{
-					var compressedResult = await CompressedUIImageFileResult.CreateCompressedFromFileResult(result, options.CompressionQuality);
+					var compressedResult = await CompressedUIImageFileResult.CreateCompressedFromFileResult(result, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
 					compressedResults.Add(compressedResult);
 				}
 				return compressedResults;
@@ -347,8 +347,7 @@ namespace Microsoft.Maui.Media
 
 				if (img is not null)
 				{
-					var compressionQuality = options?.CompressionQuality ?? 100;
-					return new CompressedUIImageFileResult(img, compressionQuality);
+					return new CompressedUIImageFileResult(img, null, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
 				}
 			}
 
@@ -438,13 +437,16 @@ namespace Microsoft.Maui.Media
 	class CompressedUIImageFileResult : FileResult
 	{
 		readonly UIImage uiImage;
+		readonly int? maximumWidth;
+		readonly int? maximumHeight;
 		readonly int compressionQuality;
+		readonly string originalFileName;
 		NSData data;
 
 		// Static factory method to create compressed result from existing FileResult
-		internal static async Task<FileResult> CreateCompressedFromFileResult(FileResult originalResult, int compressionQuality)
+		internal static async Task<FileResult> CreateCompressedFromFileResult(FileResult originalResult, int? maximumWidth, int? maximumHeight, int compressionQuality = 100)
 		{
-			if (originalResult == null || compressionQuality >= 100)
+			if (originalResult == null || ((!maximumWidth.HasValue && !maximumHeight.HasValue) && compressionQuality >= 100))
 				return originalResult;
 
 			try
@@ -454,7 +456,7 @@ namespace Microsoft.Maui.Media
 				
 				if (image != null)
 				{
-					return new CompressedUIImageFileResult(image, compressionQuality);
+					return new CompressedUIImageFileResult(image, originalResult.FileName, maximumWidth, maximumHeight, compressionQuality);
 				}
 			}
 			catch
@@ -465,17 +467,35 @@ namespace Microsoft.Maui.Media
 			return originalResult;
 		}
 
-		internal CompressedUIImageFileResult(UIImage image, int compressionQuality = 100)
+		internal CompressedUIImageFileResult(UIImage image, string originalFileName = null, int? maximumWidth = null, int? maximumHeight = null, int compressionQuality = 100)
 			: base()
 		{
 			uiImage = image;
+			this.originalFileName = originalFileName;
+			this.maximumWidth = maximumWidth;
+			this.maximumHeight = maximumHeight;
 			this.compressionQuality = Math.Max(0, Math.Min(100, compressionQuality));
 
-			// Use JPEG for compression < 90%, PNG otherwise (to preserve transparency and quality)
-			var useJpeg = this.compressionQuality < 90;
-			var extension = useJpeg ? FileExtensions.Jpg : FileExtensions.Png;
+			// Determine output format: preserve PNG when appropriate, otherwise use JPEG
+			var extension = ShouldUsePngFormat() ? FileExtensions.Png : FileExtensions.Jpg;
 			FullPath = Guid.NewGuid().ToString() + extension;
 			FileName = FullPath;
+		}
+
+		bool ShouldUsePngFormat()
+		{
+			// Use PNG if:
+			// 1. High quality (>=90) and no resizing needed (preserves original format)
+			// 2. Original file was PNG
+			// 3. Image might have transparency (PNG supports alpha channel)
+			
+			bool highQualityNoResize = compressionQuality >= 90 && !maximumWidth.HasValue && !maximumHeight.HasValue;
+			bool originalWasPng = !string.IsNullOrEmpty(originalFileName) && 
+									(originalFileName.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ||
+									 originalFileName.EndsWith(".PNG", StringComparison.OrdinalIgnoreCase));
+			
+			// For very high quality or when original was PNG, preserve PNG format
+			return (compressionQuality >= 95 && !maximumWidth.HasValue && !maximumHeight.HasValue) || originalWasPng;
 		}
 
 		internal override Task<Stream> PlatformOpenReadAsync()
@@ -484,35 +504,65 @@ namespace Microsoft.Maui.Media
 			{
 				var normalizedImage = uiImage.NormalizeOrientation();
 				
-				if (compressionQuality < 90)
+				// First, apply resizing if needed
+				var workingImage = normalizedImage;
+				var originalSize = normalizedImage.Size;
+				var newSize = CalculateResizedDimensions(originalSize.Width, originalSize.Height, maximumWidth, maximumHeight);
+				
+				if (newSize.Width != originalSize.Width || newSize.Height != originalSize.Height)
 				{
-					// Use JPEG compression with quality setting for aggressive compression
-					var qualityFloat = compressionQuality / 100.0f;
-					data = normalizedImage.AsJPEG(qualityFloat);
-				}
-				else if (compressionQuality < 100)
-				{
-					// For PNG with mild compression, scale down the image
-					var scale = Math.Sqrt(compressionQuality / 100.0);
-					var newSize = new CoreGraphics.CGSize(
-						normalizedImage.Size.Width * scale,
-						normalizedImage.Size.Height * scale);
-					
+					// Resize the image
 					UIGraphics.BeginImageContextWithOptions(newSize, false, normalizedImage.CurrentScale);
 					normalizedImage.Draw(new CoreGraphics.CGRect(CoreGraphics.CGPoint.Empty, newSize));
-					var scaledImage = UIGraphics.GetImageFromCurrentImageContext();
+					workingImage = UIGraphics.GetImageFromCurrentImageContext();
 					UIGraphics.EndImageContext();
-					
-					data = scaledImage?.AsPNG() ?? normalizedImage.AsPNG();
+				}
+				
+				// Then determine output format and apply compression
+				bool usePng = ShouldUsePngFormat();
+				
+				if (usePng)
+				{
+					// Use PNG format - lossless compression, supports transparency
+					data = workingImage.AsPNG();
 				}
 				else
 				{
-					// Use PNG for maximum quality
-					data = normalizedImage.AsPNG();
+					// Use JPEG with quality-based compression
+					if (compressionQuality < 90)
+					{
+						// Use JPEG compression with quality setting for aggressive compression
+						var qualityFloat = compressionQuality / 100.0f;
+						data = workingImage.AsJPEG(qualityFloat);
+					}
+					else if (compressionQuality < 100)
+					{
+						// Use JPEG with high quality
+						data = workingImage.AsJPEG(0.9f);
+					}
+					else
+					{
+						// Use JPEG with maximum quality
+						data = workingImage.AsJPEG(0.95f);
+					}
 				}
 			}
 
 			return Task.FromResult(data.AsStream());
+		}
+		
+		static CoreGraphics.CGSize CalculateResizedDimensions(nfloat originalWidth, nfloat originalHeight, int? maxWidth, int? maxHeight)
+		{
+			if (!maxWidth.HasValue && !maxHeight.HasValue)
+				return new CoreGraphics.CGSize(originalWidth, originalHeight);
+
+			nfloat scaleWidth = maxWidth.HasValue ? (nfloat)maxWidth.Value / originalWidth : nfloat.MaxValue;
+			nfloat scaleHeight = maxHeight.HasValue ? (nfloat)maxHeight.Value / originalHeight : nfloat.MaxValue;
+			
+			// Use the smaller scale to ensure both constraints are respected
+			nfloat scale = (nfloat)Math.Min(Math.Min((double)scaleWidth, (double)scaleHeight), 1.0); // Don't scale up
+			
+			return new CoreGraphics.CGSize(originalWidth * scale, originalHeight * scale);
 		}
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Maui.Media
 		// Static factory method to create compressed result from existing FileResult
 		internal static async Task<FileResult> CreateCompressedFromFileResult(FileResult originalResult, int? maximumWidth, int? maximumHeight, int compressionQuality = 100)
 		{
-			if (originalResult == null || !ImageProcessor.IsProcessingNeeded(maximumWidth, maximumHeight, compressionQuality))
+			if (originalResult is null || !ImageProcessor.IsProcessingNeeded(maximumWidth, maximumHeight, compressionQuality))
 				return originalResult;
 
 			try
@@ -455,6 +455,12 @@ namespace Microsoft.Maui.Media
 				using var originalStream = await originalResult.OpenReadAsync();
 				using var processedStream = await ImageProcessor.ProcessImageAsync(
 					originalStream, maximumWidth, maximumHeight, compressionQuality, originalResult.FileName);
+				
+				// If ImageProcessor returns null (e.g., on .NET Standard), return original file
+				if (processedStream is null)
+				{
+					return originalResult;
+				}
 				
 				// Read processed stream into memory
 				var memoryStream = new MemoryStream();

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -25,6 +25,10 @@ namespace Microsoft.Maui.Media
 		[Obsolete("Switch to PickPhotosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null);
 
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
 		/// <summary>
 		/// Opens the media browser to select photos.
 		/// </summary>
@@ -52,6 +56,10 @@ namespace Microsoft.Maui.Media
 		/// <remarks>When using <see cref="MediaPickerOptions.SelectionLimit"/> on this overload, it will <b>not</b> have effect.</remarks>
 		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
+#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the media browser to select videos.

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Maui.Media
 		Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null);
 
 #pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <summary>
+		/// Opens the media browser to select photos.
+		/// </summary>
+		/// <param name="options">Pick options to use.</param>
+		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
+		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
 #pragma warning restore RS0016 // Add public types and members to the declared API
 
@@ -58,6 +64,12 @@ namespace Microsoft.Maui.Media
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
 
 #pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <summary>
+		/// Opens the media browser to select videos.
+		/// </summary>
+		/// <param name="options">Pick options to use.</param>
+		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
+		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
 #pragma warning restore RS0016 // Add public types and members to the declared API
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -38,18 +38,6 @@ namespace Microsoft.Maui.Media
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
 
 		/// <summary>
-		/// Opens the media browser to select photos.
-		/// </summary>
-		/// <param name="options">Pick options to use.</param>
-		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
-		/// <remarks>
-		/// <para>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>.</para>
-		/// <para>On Windows, <see cref="MediaPickerOptions.SelectionLimit"/> is not supported.</para>
-		/// <para>Implement your own logic to ensure that the limit is maintained and/or notify the user on these platforms.</para>
-		/// </remarks>
-		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
-
-		/// <summary>
 		/// Opens the camera to take a photo.
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
@@ -64,18 +52,6 @@ namespace Microsoft.Maui.Media
 		/// <remarks>When using <see cref="MediaPickerOptions.SelectionLimit"/> on this overload, it will <b>not</b> have effect.</remarks>
 		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
-
-		/// <summary>
-		/// Opens the media browser to select videos.
-		/// </summary>
-		/// <param name="options">Pick options to use.</param>
-		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
-		/// <remarks>
-		/// <para>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>.</para>
-		/// <para>On Windows, <see cref="MediaPickerOptions.SelectionLimit"/> is not supported.</para>
-		/// <para>Implement your own logic to ensure that the limit is maintained and/or notify the user on these platforms.</para>
-		/// </remarks>
-		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
 
 		/// <summary>
 		/// Opens the media browser to select videos.

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui.Media
 		[Obsolete("Switch to PickPhotosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null);
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		/// <summary>
 		/// Opens the media browser to select photos.
 		/// </summary>
@@ -33,7 +32,6 @@ namespace Microsoft.Maui.Media
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
 		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the media browser to select photos.
@@ -63,7 +61,6 @@ namespace Microsoft.Maui.Media
 		[Obsolete("Switch to PickVideosAsync which also allows multiple selections.")]
 		Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null);
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		/// <summary>
 		/// Opens the media browser to select videos.
 		/// </summary>
@@ -71,7 +68,6 @@ namespace Microsoft.Maui.Media
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
 		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
 		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>
 		/// Opens the media browser to select videos.

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -30,7 +30,11 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked photos. When the operation was cancelled by the user, this will return an empty list.</returns>
-		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
+		/// <remarks>
+		/// <para>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>.</para>
+		/// <para>On Windows, <see cref="MediaPickerOptions.SelectionLimit"/> is not supported.</para>
+		/// <para>Implement your own logic to ensure that the limit is maintained and/or notify the user on these platforms.</para>
+		/// </remarks>
 		Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null);
 
 		/// <summary>
@@ -66,7 +70,11 @@ namespace Microsoft.Maui.Media
 		/// </summary>
 		/// <param name="options">Pick options to use.</param>
 		/// <returns>A list of <see cref="FileResult"/> objects containing details of the picked videos. When the operation was cancelled by the user, this will return an empty list.</returns>
-		/// <remarks>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>. Implement your own logic to ensure that the limit is maintained and/or notify the user.</remarks>
+		/// <remarks>
+		/// <para>On Android, not all picker user interfaces enforce the <see cref="MediaPickerOptions.SelectionLimit"/>.</para>
+		/// <para>On Windows, <see cref="MediaPickerOptions.SelectionLimit"/> is not supported.</para>
+		/// <para>Implement your own logic to ensure that the limit is maintained and/or notify the user on these platforms.</para>
+		/// </remarks>
 		Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null);
 
 		/// <summary>

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -176,7 +176,9 @@ namespace Microsoft.Maui.Media
 		/// The value should be between 0 and 100, where 0 is the lowest quality (most compression) and 100 is the highest quality (least compression).
 		/// </summary>
 		/// <remarks>
-		/// Please note that performance might be affected by the compression quality, especially on lower-end devices.
+		/// <para>Please note that performance might be affected by the compression quality, especially on lower-end devices.</para>
+		/// <para>For JPEG images, this controls the lossy compression quality directly.</para>
+		/// <para>For PNG images, values below 90 will convert to JPEG format for better compression. Values 90-99 will scale down the PNG image. Value 100 preserves original PNG format and quality.</para>
 		/// </remarks>
 		public int CompressionQuality 
 		{ 

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -170,7 +170,6 @@ namespace Microsoft.Maui.Media
 	{
 		private int compressionQuality = 100;
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		/// <summary>
 		/// Gets or sets the compression quality for picked media.
 		/// The value should be between 0 and 100, where 0 is the lowest quality (most compression) and 100 is the highest quality (least compression).
@@ -185,7 +184,30 @@ namespace Microsoft.Maui.Media
 			get => compressionQuality;
 			set => compressionQuality = Math.Max(0, Math.Min(100, value));
 		}
-#pragma warning restore RS0016 // Add public types and members to the declared API
+
+		/// <summary>
+		/// Gets or sets the maximum width for image resizing.
+		/// When set, images will be resized to fit within this width while preserving aspect ratio.
+		/// A value of 0 or null means no width constraint.
+		/// </summary>
+		/// <remarks>
+		/// The image will be resized to fit within the specified maximum dimensions while maintaining aspect ratio.
+		/// If both MaximumWidth and MaximumHeight are specified, the image will be scaled to fit within both constraints.
+		/// This resizing is applied before any compression quality settings.
+		/// </remarks>
+		public int? MaximumWidth { get; set; }
+
+		/// <summary>
+		/// Gets or sets the maximum height for image resizing.
+		/// When set, images will be resized to fit within this height while preserving aspect ratio.
+		/// A value of 0 or null means no height constraint.
+		/// </summary>
+		/// <remarks>
+		/// The image will be resized to fit within the specified maximum dimensions while maintaining aspect ratio.
+		/// If both MaximumWidth and MaximumHeight are specified, the image will be scaled to fit within both constraints.
+		/// This resizing is applied before any compression quality settings.
+		/// </remarks>
+		public int? MaximumHeight { get; set; }
 
 		/// <summary>
 		/// Gets or sets the title that is displayed when picking media.

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -168,6 +168,23 @@ namespace Microsoft.Maui.Media
 	/// </summary>
 	public class MediaPickerOptions
 	{
+		private int compressionQuality = 100;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		/// <summary>
+		/// Gets or sets the compression quality for picked media.
+		/// The value should be between 0 and 100, where 0 is the lowest quality (most compression) and 100 is the highest quality (least compression).
+		/// </summary>
+		/// <remarks>
+		/// Please note that performance might be affected by the compression quality, especially on lower-end devices.
+		/// </remarks>
+		public int CompressionQuality 
+		{ 
+			get => compressionQuality;
+			set => compressionQuality = Math.Max(0, Math.Min(100, value));
+		}
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
 		/// <summary>
 		/// Gets or sets the title that is displayed when picking media.
 		/// </summary>

--- a/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.shared.cs
@@ -191,9 +191,10 @@ namespace Microsoft.Maui.Media
 		/// A value of 0 or null means no width constraint.
 		/// </summary>
 		/// <remarks>
-		/// The image will be resized to fit within the specified maximum dimensions while maintaining aspect ratio.
+		/// <para>This property only applies to images. It has no effect on video files.</para>
+		/// <para>The image will be resized to fit within the specified maximum dimensions while maintaining aspect ratio.
 		/// If both MaximumWidth and MaximumHeight are specified, the image will be scaled to fit within both constraints.
-		/// This resizing is applied before any compression quality settings.
+		/// This resizing is applied before any compression quality settings.</para>
 		/// </remarks>
 		public int? MaximumWidth { get; set; }
 
@@ -203,9 +204,10 @@ namespace Microsoft.Maui.Media
 		/// A value of 0 or null means no height constraint.
 		/// </summary>
 		/// <remarks>
-		/// The image will be resized to fit within the specified maximum dimensions while maintaining aspect ratio.
+		/// <para>This property only applies to images. It has no effect on video files.</para>
+		/// <para>The image will be resized to fit within the specified maximum dimensions while maintaining aspect ratio.
 		/// If both MaximumWidth and MaximumHeight are specified, the image will be scaled to fit within both constraints.
-		/// This resizing is applied before any compression quality settings.
+		/// This resizing is applied before any compression quality settings.</para>
 		/// </remarks>
 		public int? MaximumHeight { get; set; }
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -62,7 +62,16 @@ namespace Microsoft.Maui.Media
 				return null;
 
 			// picked
-			return new FileResult(result);
+			var fileResult = new FileResult(result);
+
+			// Apply compression if specified for photos
+			if (photo && options?.CompressionQuality < 100)
+			{
+				var compressedResult = await CompressImageAsync(fileResult, options.CompressionQuality);
+				return compressedResult ?? fileResult;
+			}
+
+			return fileResult;
 		}
 
 		public async Task<List<FileResult>> PickMultipleAsync(MediaPickerOptions? options, bool photo)
@@ -99,7 +108,21 @@ namespace Microsoft.Maui.Media
 			}
 
 			// picked
-			return [.. result.Select(file => new FileResult(file))];
+			var fileResults = result.Select(file => new FileResult(file)).ToList();
+
+			// Apply compression if specified for photos
+			if (photo && options?.CompressionQuality < 100)
+			{
+				var compressedResults = new List<FileResult>();
+				foreach (var fileResult in fileResults)
+				{
+					var compressedResult = await CompressImageAsync(fileResult, options.CompressionQuality);
+					compressedResults.Add(compressedResult ?? fileResult);
+				}
+				return compressedResults;
+			}
+
+			return fileResults;
 		}
 
 		public Task<FileResult?> CapturePhotoAsync(MediaPickerOptions? options = null)
@@ -137,8 +160,14 @@ namespace Microsoft.Maui.Media
 		{
 			try
 			{
+				// Determine if we should use PNG or JPEG based on original format and compression level
+				var originalExtension = System.IO.Path.GetExtension(originalFile.Name).ToLowerInvariant();
+				var isPng = originalExtension == ".png";
+				var useJpeg = !isPng || compressionQuality < 90; // Use JPEG for aggressive compression
+
 				// Create compressed file in same directory
-				var compressedFileName = System.IO.Path.GetFileNameWithoutExtension(originalFile.Name) + "_compressed.jpg";
+				var outputExtension = useJpeg ? ".jpg" : ".png";
+				var compressedFileName = System.IO.Path.GetFileNameWithoutExtension(originalFile.Name) + "_compressed" + outputExtension;
 				var compressedFile = await originalFile.GetParentAsync()
 					.AsTask()
 					.ContinueWith(async task => await task.Result.CreateFileAsync(compressedFileName, CreationCollisionOption.GenerateUniqueName))
@@ -149,16 +178,38 @@ namespace Microsoft.Maui.Media
 				{
 					// Use the built-in Windows image compression
 					var decoder = await Windows.Graphics.Imaging.BitmapDecoder.CreateAsync(originalStream);
-					var encoder = await Windows.Graphics.Imaging.BitmapEncoder.CreateForTranscodingAsync(compressedStream, decoder);
 					
-					// Set JPEG quality (0.0 to 1.0)
-					var qualityFloat = compressionQuality / 100.0;
+					Windows.Graphics.Imaging.BitmapEncoder encoder;
+					var propertySet = new Windows.Foundation.Collections.PropertySet();
+
+					if (useJpeg)
+					{
+						encoder = await Windows.Graphics.Imaging.BitmapEncoder.CreateAsync(Windows.Graphics.Imaging.BitmapEncoder.JpegEncoderId, compressedStream);
+						
+						// Set JPEG quality (0.0 to 1.0)
+						var qualityFloat = compressionQuality / 100.0;
+						propertySet.Add("ImageQuality", qualityFloat);
+					}
+					else
+					{
+						encoder = await Windows.Graphics.Imaging.BitmapEncoder.CreateAsync(Windows.Graphics.Imaging.BitmapEncoder.PngEncoderId, compressedStream);
+						
+						// For PNG, we compress by scaling down the image
+						if (compressionQuality < 100)
+						{
+							var scale = Math.Sqrt(compressionQuality / 100.0);
+							var newWidth = (uint)Math.Max(1, decoder.PixelWidth * scale);
+							var newHeight = (uint)Math.Max(1, decoder.PixelHeight * scale);
+							
+							encoder.BitmapTransform.ScaledWidth = newWidth;
+							encoder.BitmapTransform.ScaledHeight = newHeight;
+						}
+					}
+					
 					encoder.BitmapTransform.InterpolationMode = Windows.Graphics.Imaging.BitmapInterpolationMode.Fant;
 					
-					// Configure JPEG compression properties
-					var propertySet = new Windows.Foundation.Collections.PropertySet();
-					propertySet.Add("ImageQuality", qualityFloat);
-					await encoder.SetPropertiesAsync(propertySet);
+					if (propertySet.Count > 0)
+						await encoder.SetPropertiesAsync(propertySet);
 
 					await encoder.FlushAsync();
 				}

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Storage;
 using Windows.Foundation.Collections;
 using Windows.Graphics.Imaging;
@@ -64,7 +65,7 @@ namespace Microsoft.Maui.Media
 			var fileResult = new FileResult(result);
 
 			// Apply compression/resizing if specified for photos
-			if (photo && ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100))
+			if (photo && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 			{
 				var compressedResult = await CompressImageAsync(result, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
 				return compressedResult != null ? new FileResult(compressedResult) : fileResult;
@@ -109,7 +110,7 @@ namespace Microsoft.Maui.Media
 			var fileResults = result.Select(file => new FileResult(file)).ToList();
 
 			// Apply compression/resizing if specified for photos
-			if (photo && ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100))
+			if (photo && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 			{
 				var compressedResults = new List<FileResult>();
 				for (int i = 0; i < result.Count; i++)
@@ -151,7 +152,7 @@ namespace Microsoft.Maui.Media
 				var fileResult = new FileResult(file);
 
 				// Apply compression/resizing if specified for photos
-				if (photo && ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100))
+				if (photo && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 				{
 					var compressedResult = await CompressImageAsync(file, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
 					return compressedResult != null ? new FileResult(compressedResult) : fileResult;
@@ -164,7 +165,7 @@ namespace Microsoft.Maui.Media
 		}
 		static async Task<StorageFile?> CompressImageAsync(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality = 100)
 		{
-			if ((!maximumWidth.HasValue && !maximumHeight.HasValue) && compressionQuality >= 100)
+			if (!ImageProcessor.IsProcessingNeeded(maximumWidth, maximumHeight, compressionQuality))
 			{
 				return null; // No compression or resizing needed
 			}

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -13,6 +13,7 @@ using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Storage;
 using Windows.Foundation.Collections;
+using Windows.Graphics.Imaging;
 using Windows.Media.Capture;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -181,10 +182,11 @@ namespace Microsoft.Maui.Media
 					compressionQuality,
 					originalFile.Name);
 
-				// If ImageProcessor returns null (platforms without MAUI Graphics), return null to use original file
+				// If ImageProcessor returns null (platforms without MAUI Graphics), fall back to Windows-specific processing
+				// MAUI Graphics doesn't support all functionaliy we need on Windows. Until it does, have a fallback.
 				if (processedStream == null)
 				{
-					return null;
+					return await CompressImageWithWindowsApis(originalFile, maximumWidth, maximumHeight, compressionQuality);
 				}
 
 				// Create compressed file in cache directory
@@ -205,6 +207,77 @@ namespace Microsoft.Maui.Media
 				System.Diagnostics.Debug.WriteLine($"Image compression failed: {ex.Message}");
 				return null;
 			}
+		}
+
+		// Fallback method using Windows-specific APIs when MAUI Graphics isn't available
+		static async Task<StorageFile?> CompressImageWithWindowsApis(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality)
+		{
+			try
+			{
+				// Create compressed file in cache directory
+				var tempFolder = await StorageFolder.GetFolderFromPathAsync(FileSystem.CacheDirectory);
+				var compressedFileName = $"processed_{Guid.NewGuid()}.jpg";
+				var compressedFile = await tempFolder.CreateFileAsync(compressedFileName, CreationCollisionOption.ReplaceExisting);
+
+				using (var originalStream = await originalFile.OpenAsync(FileAccessMode.Read))
+				using (var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite))
+				{
+					var decoder = await BitmapDecoder.CreateAsync(originalStream);
+					
+					// Calculate new dimensions if resizing is needed
+					var originalWidth = decoder.PixelWidth;
+					var originalHeight = decoder.PixelHeight;
+					var newDimensions = CalculateResizedDimensions(originalWidth, originalHeight, maximumWidth, maximumHeight);
+					
+					var encoder = await BitmapEncoder.CreateForTranscodingAsync(compressedStream, decoder);
+					
+					// Set the size transform if resizing is needed
+					if (newDimensions.Width != originalWidth || newDimensions.Height != originalHeight)
+					{
+						encoder.BitmapTransform.ScaledWidth = (uint)newDimensions.Width;
+						encoder.BitmapTransform.ScaledHeight = (uint)newDimensions.Height;
+						encoder.BitmapTransform.InterpolationMode = BitmapInterpolationMode.Fant; // High quality scaling
+					}
+
+					// Set JPEG quality based on compression setting
+					var qualityFloat = compressionQuality switch
+					{
+						< 20 => 0.2f,   // Very low quality
+						< 40 => 0.4f,   // Low quality
+						< 60 => 0.6f,   // Medium quality
+						< 80 => 0.75f,  // Good quality
+						_ => 0.85f      // High quality
+					};
+
+					var propertySet = new BitmapPropertySet();
+					var qualityValue = new BitmapTypedValue(qualityFloat, global::Windows.Foundation.PropertyType.Single);
+					propertySet.Add("ImageQuality", qualityValue);
+
+					await encoder.BitmapProperties.SetPropertiesAsync(propertySet);
+					await encoder.FlushAsync();
+				}
+
+				return compressedFile;
+			}
+			catch (Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine($"Windows image compression fallback failed: {ex.Message}");
+				return null;
+			}
+		}
+
+		static (int Width, int Height) CalculateResizedDimensions(uint originalWidth, uint originalHeight, int? maxWidth, int? maxHeight)
+		{
+			if (!maxWidth.HasValue && !maxHeight.HasValue)
+				return ((int)originalWidth, (int)originalHeight);
+
+			float scaleWidth = maxWidth.HasValue ? (float)maxWidth.Value / originalWidth : float.MaxValue;
+			float scaleHeight = maxHeight.HasValue ? (float)maxHeight.Value / originalHeight : float.MaxValue;
+			
+			// Use the smaller scale to ensure both constraints are respected
+			float scale = Math.Min(Math.Min(scaleWidth, scaleHeight), 1.0f); // Don't scale up
+			
+			return ((int)(originalWidth * scale), (int)(originalHeight * scale));
 		}
 
 		class WinUICameraCaptureUI

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Maui.Media
 					compressionQuality,
 					originalFile.Name);
 
-				// If ImageProcessor returns null (e.g., on .NET Standard), return null to use original file
+				// If ImageProcessor returns null (platforms without MAUI Graphics), return null to use original file
 				if (processedStream == null)
 				{
 					return null;

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -12,7 +12,6 @@ using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Storage;
 using Windows.Foundation.Collections;
-using Windows.Graphics.Imaging;
 using Windows.Media.Capture;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -172,48 +171,31 @@ namespace Microsoft.Maui.Media
 
 			try
 			{
+				// Use ImageProcessor for unified image processing
+				using var originalStream = await originalFile.OpenAsync(FileAccessMode.Read);
+				using var processedStream = await ImageProcessor.ProcessImageAsync(
+					originalStream.AsStreamForRead(),
+					maximumWidth,
+					maximumHeight,
+					compressionQuality,
+					originalFile.Name);
+
+				// If ImageProcessor returns null (e.g., on .NET Standard), return null to use original file
+				if (processedStream == null)
+				{
+					return null;
+				}
+
 				// Create compressed file in cache directory
 				var tempFolder = await StorageFolder.GetFolderFromPathAsync(FileSystem.CacheDirectory);
-				var compressedFileName = $"processed_{Guid.NewGuid()}.jpg";
+				var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, compressionQuality, originalFile.Name);
+				var compressedFileName = $"processed_{Guid.NewGuid()}{outputExtension}";
 				var compressedFile = await tempFolder.CreateFileAsync(compressedFileName, CreationCollisionOption.ReplaceExisting);
 
-				using (var originalStream = await originalFile.OpenAsync(FileAccessMode.Read))
-				using (var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite))
-				{
-					var decoder = await BitmapDecoder.CreateAsync(originalStream);
-					
-					// Calculate new dimensions if resizing is needed
-					var originalWidth = decoder.PixelWidth;
-					var originalHeight = decoder.PixelHeight;
-					var newDimensions = CalculateResizedDimensions(originalWidth, originalHeight, maximumWidth, maximumHeight);
-					
-					var encoder = await BitmapEncoder.CreateForTranscodingAsync(compressedStream, decoder);
-					
-					// Set the size transform if resizing is needed
-					if (newDimensions.Width != originalWidth || newDimensions.Height != originalHeight)
-					{
-						encoder.BitmapTransform.ScaledWidth = (uint)newDimensions.Width;
-						encoder.BitmapTransform.ScaledHeight = (uint)newDimensions.Height;
-						encoder.BitmapTransform.InterpolationMode = BitmapInterpolationMode.Fant; // High quality scaling
-					}
-
-					// Set JPEG quality based on compression setting
-					var qualityFloat = compressionQuality switch
-					{
-						< 20 => 0.2f,   // Very low quality
-						< 40 => 0.4f,   // Low quality
-						< 60 => 0.6f,   // Medium quality
-						< 80 => 0.75f,  // Good quality
-						_ => 0.85f      // High quality
-					};
-
-					var propertySet = new BitmapPropertySet();
-					var qualityValue = new BitmapTypedValue(qualityFloat, global::Windows.Foundation.PropertyType.Single);
-					propertySet.Add("ImageQuality", qualityValue);
-
-					await encoder.BitmapProperties.SetPropertiesAsync(propertySet);
-					await encoder.FlushAsync();
-				}
+				// Write processed image to file
+				using var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite);
+				processedStream.Position = 0;
+				await processedStream.CopyToAsync(compressedStream.AsStreamForWrite());
 
 				return compressedFile;
 			}
@@ -222,20 +204,6 @@ namespace Microsoft.Maui.Media
 				System.Diagnostics.Debug.WriteLine($"Image compression failed: {ex.Message}");
 				return null;
 			}
-		}
-
-		static (int Width, int Height) CalculateResizedDimensions(uint originalWidth, uint originalHeight, int? maxWidth, int? maxHeight)
-		{
-			if (!maxWidth.HasValue && !maxHeight.HasValue)
-				return ((int)originalWidth, (int)originalHeight);
-
-			float scaleWidth = maxWidth.HasValue ? (float)maxWidth.Value / originalWidth : float.MaxValue;
-			float scaleHeight = maxHeight.HasValue ? (float)maxHeight.Value / originalHeight : float.MaxValue;
-			
-			// Use the smaller scale to ensure both constraints are respected
-			float scale = Math.Min(Math.Min(scaleWidth, scaleHeight), 1.0f); // Don't scale up
-			
-			return ((int)(originalWidth * scale), (int)(originalHeight * scale));
 		}
 
 		class WinUICameraCaptureUI

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -155,102 +155,29 @@ namespace Microsoft.Maui.Media
 				// Apply compression/resizing if specified for photos
 				if (photo && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 				{
-					var compressedResult = await CompressImageAsync(file, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
-					return compressedResult != null ? new FileResult(compressedResult) : fileResult;
+					using var originalStream = await file.OpenStreamForReadAsync();
+					var processedStream = await ImageProcessor.ProcessImageAsync(
+						originalStream,
+						options?.MaximumWidth,
+						options?.MaximumHeight,
+						options?.CompressionQuality ?? 100,
+						file.Name);
+
+					if (processedStream != null)
+					{
+						// Convert to MemoryStream for ProcessedImageFileResult
+						var memoryStream = new MemoryStream();
+						await processedStream.CopyToAsync(memoryStream);
+						processedStream.Dispose();
+						
+						return new ProcessedImageFileResult(memoryStream, file.Name);
+					}
 				}
 
 				return fileResult;
 			}
 
 			return null;
-		}
-		static async Task<StorageFile?> CompressImageAsync(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality = 100)
-		{
-			if (!ImageProcessor.IsProcessingNeeded(maximumWidth, maximumHeight, compressionQuality))
-			{
-				return null; // No compression or resizing needed
-			}
-
-			try
-			{
-				// Use Windows-specific APIs for image processing
-				return await ProcessImage(originalFile, maximumWidth, maximumHeight, compressionQuality);
-			}
-			catch (Exception ex)
-			{
-				System.Diagnostics.Debug.WriteLine($"Image compression failed: {ex.Message}");
-				return null;
-			}
-		}
-
-		static async Task<StorageFile?> ProcessImage(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality)
-		{
-			try
-			{
-				// Create compressed file in cache directory
-				var tempFolder = await StorageFolder.GetFolderFromPathAsync(FileSystem.CacheDirectory);
-				var compressedFileName = $"processed_{Guid.NewGuid()}.jpg";
-				var compressedFile = await tempFolder.CreateFileAsync(compressedFileName, CreationCollisionOption.ReplaceExisting);
-
-				using (var originalStream = await originalFile.OpenAsync(FileAccessMode.Read))
-				using (var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite))
-				{
-					var decoder = await BitmapDecoder.CreateAsync(originalStream);
-					
-					// Calculate new dimensions if resizing is needed
-					var originalWidth = decoder.PixelWidth;
-					var originalHeight = decoder.PixelHeight;
-					var newDimensions = CalculateResizedDimensions(originalWidth, originalHeight, maximumWidth, maximumHeight);
-					
-					var encoder = await BitmapEncoder.CreateForTranscodingAsync(compressedStream, decoder);
-					
-					// Set the size transform if resizing is needed
-					if (newDimensions.Width != originalWidth || newDimensions.Height != originalHeight)
-					{
-						encoder.BitmapTransform.ScaledWidth = (uint)newDimensions.Width;
-						encoder.BitmapTransform.ScaledHeight = (uint)newDimensions.Height;
-						encoder.BitmapTransform.InterpolationMode = BitmapInterpolationMode.Fant; // High quality scaling
-					}
-
-					// Set JPEG quality based on compression setting
-					var qualityFloat = compressionQuality switch
-					{
-						< 20 => 0.2f,   // Very low quality
-						< 40 => 0.4f,   // Low quality
-						< 60 => 0.6f,   // Medium quality
-						< 80 => 0.75f,  // Good quality
-						_ => 0.85f      // High quality
-					};
-
-					var propertySet = new BitmapPropertySet();
-					var qualityValue = new BitmapTypedValue(qualityFloat, global::Windows.Foundation.PropertyType.Single);
-					propertySet.Add("ImageQuality", qualityValue);
-
-					await encoder.BitmapProperties.SetPropertiesAsync(propertySet);
-					await encoder.FlushAsync();
-				}
-
-				return compressedFile;
-			}
-			catch (Exception ex)
-			{
-				System.Diagnostics.Debug.WriteLine($"Windows image compression fallback failed: {ex.Message}");
-				return null;
-			}
-		}
-
-		static (int Width, int Height) CalculateResizedDimensions(uint originalWidth, uint originalHeight, int? maxWidth, int? maxHeight)
-		{
-			if (!maxWidth.HasValue && !maxHeight.HasValue)
-				return ((int)originalWidth, (int)originalHeight);
-
-			float scaleWidth = maxWidth.HasValue ? (float)maxWidth.Value / originalWidth : float.MaxValue;
-			float scaleHeight = maxHeight.HasValue ? (float)maxHeight.Value / originalHeight : float.MaxValue;
-			
-			// Use the smaller scale to ensure both constraints are respected
-			float scale = Math.Min(Math.Min(scaleWidth, scaleHeight), 1.0f); // Don't scale up
-			
-			return ((int)(originalWidth * scale), (int)(originalHeight * scale));
 		}
 
 		class WinUICameraCaptureUI
@@ -334,6 +261,49 @@ namespace Microsoft.Maui.Media
 					CameraCaptureUIVideoFormat.Wmv => ".wmv",
 					_ => ".mp4",
 				};
+		}
+	}
+
+	/// <summary>
+	/// FileResult implementation for processed images using MAUI Graphics
+	/// </summary>
+	internal class ProcessedImageFileResult : FileResult, IDisposable
+	{
+		readonly MemoryStream imageData;
+		readonly string originalFileName;
+
+		internal ProcessedImageFileResult(MemoryStream imageData, string originalFileName = null)
+			: base()
+		{
+			this.imageData = imageData;
+			this.originalFileName = originalFileName;
+
+			// Determine output format extension using ImageProcessor's improved logic
+			var extension = ImageProcessor.DetermineOutputExtension(imageData, 75, originalFileName);
+			FullPath = Guid.NewGuid().ToString() + extension;
+			FileName = FullPath;
+		}
+
+		internal override Task<Stream> PlatformOpenReadAsync()
+		{
+			// Reset position and return a copy of the stream
+			imageData.Position = 0;
+			var copyStream = new MemoryStream(imageData.ToArray());
+			return Task.FromResult<Stream>(copyStream);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				imageData?.Dispose();
+			}
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -120,9 +120,59 @@ namespace Microsoft.Maui.Media
 			var file = await captureUi.CaptureFileAsync(photo ? CameraCaptureUIMode.Photo : CameraCaptureUIMode.Video);
 
 			if (file is not null)
+			{
+				// Apply compression if needed for photos
+				if (photo && options?.CompressionQuality < 100)
+				{
+					var compressedFile = await CompressImageAsync(file, options.CompressionQuality);
+					return new FileResult(compressedFile ?? file);
+				}
 				return new FileResult(file);
+			}
 
 			return null;
+		}
+
+		async Task<StorageFile?> CompressImageAsync(StorageFile originalFile, int compressionQuality)
+		{
+			try
+			{
+				// Create compressed file in same directory
+				var compressedFileName = System.IO.Path.GetFileNameWithoutExtension(originalFile.Name) + "_compressed.jpg";
+				var compressedFile = await originalFile.GetParentAsync()
+					.AsTask()
+					.ContinueWith(async task => await task.Result.CreateFileAsync(compressedFileName, CreationCollisionOption.GenerateUniqueName))
+					.Unwrap();
+
+				using (var originalStream = await originalFile.OpenAsync(FileAccessMode.Read))
+				using (var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite))
+				{
+					// Use the built-in Windows image compression
+					var decoder = await Windows.Graphics.Imaging.BitmapDecoder.CreateAsync(originalStream);
+					var encoder = await Windows.Graphics.Imaging.BitmapEncoder.CreateForTranscodingAsync(compressedStream, decoder);
+					
+					// Set JPEG quality (0.0 to 1.0)
+					var qualityFloat = compressionQuality / 100.0;
+					encoder.BitmapTransform.InterpolationMode = Windows.Graphics.Imaging.BitmapInterpolationMode.Fant;
+					
+					// Configure JPEG compression properties
+					var propertySet = new Windows.Foundation.Collections.PropertySet();
+					propertySet.Add("ImageQuality", qualityFloat);
+					await encoder.SetPropertiesAsync(propertySet);
+
+					await encoder.FlushAsync();
+				}
+
+				// Delete the original file if compression was successful
+				try { await originalFile.DeleteAsync(); } catch { }
+				
+				return compressedFile;
+			}
+			catch
+			{
+				// If compression fails, return null to use original file
+				return null;
+			}
 		}
 
 		class WinUICameraCaptureUI

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -173,34 +173,8 @@ namespace Microsoft.Maui.Media
 
 			try
 			{
-				// Use ImageProcessor for unified image processing
-				using var originalStream = await originalFile.OpenAsync(FileAccessMode.Read);
-				using var processedStream = await ImageProcessor.ProcessImageAsync(
-					originalStream.AsStreamForRead(),
-					maximumWidth,
-					maximumHeight,
-					compressionQuality,
-					originalFile.Name);
-
-				// If ImageProcessor returns null (platforms without MAUI Graphics), fall back to Windows-specific processing
-				// MAUI Graphics doesn't support all functionaliy we need on Windows. Until it does, have a fallback.
-				if (processedStream == null)
-				{
-					return await CompressImageWithWindowsApis(originalFile, maximumWidth, maximumHeight, compressionQuality);
-				}
-
-				// Create compressed file in cache directory
-				var tempFolder = await StorageFolder.GetFolderFromPathAsync(FileSystem.CacheDirectory);
-				var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, compressionQuality, originalFile.Name);
-				var compressedFileName = $"processed_{Guid.NewGuid()}{outputExtension}";
-				var compressedFile = await tempFolder.CreateFileAsync(compressedFileName, CreationCollisionOption.ReplaceExisting);
-
-				// Write processed image to file
-				using var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite);
-				processedStream.Position = 0;
-				await processedStream.CopyToAsync(compressedStream.AsStreamForWrite());
-
-				return compressedFile;
+				// Use Windows-specific APIs for image processing
+				return await ProcessImage(originalFile, maximumWidth, maximumHeight, compressionQuality);
 			}
 			catch (Exception ex)
 			{
@@ -209,8 +183,7 @@ namespace Microsoft.Maui.Media
 			}
 		}
 
-		// Fallback method using Windows-specific APIs when MAUI Graphics isn't available
-		static async Task<StorageFile?> CompressImageWithWindowsApis(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality)
+		static async Task<StorageFile?> ProcessImage(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality)
 		{
 			try
 			{

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Media
 			// Apply compression/resizing if specified for photos
 			if (photo && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 			{
-				var compressedResult = await CompressImageAsync(result, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
+				var compressedResult = await CompressImageAsync(result, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
 				return compressedResult != null ? new FileResult(compressedResult) : fileResult;
 			}
 
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Media
 				{
 					var originalFile = result[i];
 					var fileResult = fileResults[i];
-					var compressedResult = await CompressImageAsync(originalFile, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
+					var compressedResult = await CompressImageAsync(originalFile, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
 					compressedResults.Add(compressedResult != null ? new FileResult(compressedResult) : fileResult);
 				}
 				return compressedResults;
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Media
 				// Apply compression/resizing if specified for photos
 				if (photo && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 				{
-					var compressedResult = await CompressImageAsync(file, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
+					var compressedResult = await CompressImageAsync(file, options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100);
 					return compressedResult != null ? new FileResult(compressedResult) : fileResult;
 				}
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -6,6 +6,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;

--- a/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.windows.cs
@@ -63,10 +63,10 @@ namespace Microsoft.Maui.Media
 				return null;            // picked
 			var fileResult = new FileResult(result);
 
-			// Apply compression if specified for photos
-			if (photo && options?.CompressionQuality < 100)
+			// Apply compression/resizing if specified for photos
+			if (photo && ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100))
 			{
-				var compressedResult = await CompressImageAsync(result, options.CompressionQuality);
+				var compressedResult = await CompressImageAsync(result, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
 				return compressedResult != null ? new FileResult(compressedResult) : fileResult;
 			}
 
@@ -108,15 +108,15 @@ namespace Microsoft.Maui.Media
 			// picked
 			var fileResults = result.Select(file => new FileResult(file)).ToList();
 
-			// Apply compression if specified for photos
-			if (photo && options?.CompressionQuality < 100)
+			// Apply compression/resizing if specified for photos
+			if (photo && ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100))
 			{
 				var compressedResults = new List<FileResult>();
 				for (int i = 0; i < result.Count; i++)
 				{
 					var originalFile = result[i];
 					var fileResult = fileResults[i];
-					var compressedResult = await CompressImageAsync(originalFile, options.CompressionQuality);
+					var compressedResult = await CompressImageAsync(originalFile, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
 					compressedResults.Add(compressedResult != null ? new FileResult(compressedResult) : fileResult);
 				}
 				return compressedResults;
@@ -150,10 +150,10 @@ namespace Microsoft.Maui.Media
 			{
 				var fileResult = new FileResult(file);
 
-				// Apply compression if specified for photos
-				if (photo && options?.CompressionQuality < 100)
+				// Apply compression/resizing if specified for photos
+				if (photo && ((options?.MaximumWidth.HasValue == true || options?.MaximumHeight.HasValue == true) || options?.CompressionQuality < 100))
 				{
-					var compressedResult = await CompressImageAsync(file, options.CompressionQuality);
+					var compressedResult = await CompressImageAsync(file, options.MaximumWidth, options.MaximumHeight, options?.CompressionQuality ?? 100);
 					return compressedResult != null ? new FileResult(compressedResult) : fileResult;
 				}
 
@@ -162,33 +162,48 @@ namespace Microsoft.Maui.Media
 
 			return null;
 		}
-		static async Task<StorageFile?> CompressImageAsync(StorageFile originalFile, int compressionQuality)
+		static async Task<StorageFile?> CompressImageAsync(StorageFile originalFile, int? maximumWidth, int? maximumHeight, int compressionQuality = 100)
 		{
-			if (compressionQuality >= 100)
+			if ((!maximumWidth.HasValue && !maximumHeight.HasValue) && compressionQuality >= 100)
 			{
-				return null; // No compression needed
+				return null; // No compression or resizing needed
 			}
 
 			try
 			{
 				// Create compressed file in cache directory
 				var tempFolder = await StorageFolder.GetFolderFromPathAsync(FileSystem.CacheDirectory);
-				var compressedFileName = $"compressed_{Guid.NewGuid()}.jpg";
+				var compressedFileName = $"processed_{Guid.NewGuid()}.jpg";
 				var compressedFile = await tempFolder.CreateFileAsync(compressedFileName, CreationCollisionOption.ReplaceExisting);
 
 				using (var originalStream = await originalFile.OpenAsync(FileAccessMode.Read))
 				using (var compressedStream = await compressedFile.OpenAsync(FileAccessMode.ReadWrite))
 				{
 					var decoder = await BitmapDecoder.CreateAsync(originalStream);
+					
+					// Calculate new dimensions if resizing is needed
+					var originalWidth = decoder.PixelWidth;
+					var originalHeight = decoder.PixelHeight;
+					var newDimensions = CalculateResizedDimensions(originalWidth, originalHeight, maximumWidth, maximumHeight);
+					
 					var encoder = await BitmapEncoder.CreateForTranscodingAsync(compressedStream, decoder);
+					
+					// Set the size transform if resizing is needed
+					if (newDimensions.Width != originalWidth || newDimensions.Height != originalHeight)
+					{
+						encoder.BitmapTransform.ScaledWidth = (uint)newDimensions.Width;
+						encoder.BitmapTransform.ScaledHeight = (uint)newDimensions.Height;
+						encoder.BitmapTransform.InterpolationMode = BitmapInterpolationMode.Fant; // High quality scaling
+					}
 
+					// Set JPEG quality based on compression setting
 					var qualityFloat = compressionQuality switch
 					{
-						< 20 => 0.2,   // Very low quality
-						< 40 => 0.4,   // Low quality
-						< 60 => 0.6,   // Medium quality
-						< 80 => 0.75,  // Good quality
-						_ => 0.85      // High quality
+						< 20 => 0.2f,   // Very low quality
+						< 40 => 0.4f,   // Low quality
+						< 60 => 0.6f,   // Medium quality
+						< 80 => 0.75f,  // Good quality
+						_ => 0.85f      // High quality
 					};
 
 					var propertySet = new BitmapPropertySet();
@@ -206,6 +221,20 @@ namespace Microsoft.Maui.Media
 				System.Diagnostics.Debug.WriteLine($"Image compression failed: {ex.Message}");
 				return null;
 			}
+		}
+
+		static (int Width, int Height) CalculateResizedDimensions(uint originalWidth, uint originalHeight, int? maxWidth, int? maxHeight)
+		{
+			if (!maxWidth.HasValue && !maxHeight.HasValue)
+				return ((int)originalWidth, (int)originalHeight);
+
+			float scaleWidth = maxWidth.HasValue ? (float)maxWidth.Value / originalWidth : float.MaxValue;
+			float scaleHeight = maxHeight.HasValue ? (float)maxHeight.Value / originalHeight : float.MaxValue;
+			
+			// Use the smaller scale to ensure both constraints are respected
+			float scale = Math.Min(Math.Min(scaleWidth, scaleHeight), 1.0f); // Don't scale up
+			
+			return ((int)(originalWidth * scale), (int)(originalHeight * scale));
 		}
 
 		class WinUICameraCaptureUI

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.set -> void
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.set -> void
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.set -> void
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.set -> void
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.set -> void
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Media.IMediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.get -> int
+Microsoft.Maui.Media.MediaPickerOptions.CompressionQuality.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumHeight.set -> void
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.get -> int?
+Microsoft.Maui.Media.MediaPickerOptions.MaximumWidth.set -> void
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.get -> int
 Microsoft.Maui.Media.MediaPickerOptions.SelectionLimit.set -> void
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformImage.cs
@@ -5,7 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas;
 using Microsoft.IO;
+using Windows.Foundation;
 using Windows.Storage.Streams;
+using WinRect = Windows.Foundation.Rect;
 
 #if MAUI_GRAPHICS_WIN2D
 namespace Microsoft.Maui.Graphics.Win2D
@@ -91,15 +93,16 @@ namespace Microsoft.Maui.Graphics.Platform
 
 			// Create a new render target with the scaled dimensions
 			var newRenderTarget = new CanvasRenderTarget(_creator, newWidth, newHeight, 96);
-			
 			using (var session = newRenderTarget.CreateDrawingSession())
 			{
 				// Draw the original bitmap scaled to the new size
-				session.DrawImage(_bitmap, new Windows.Foundation.Rect(0, 0, newWidth, newHeight));
+				session.DrawImage(_bitmap, new WinRect(0, 0, newWidth, newHeight));
 			}
 
 			if (disposeOriginal)
+			{
 				Dispose();
+			}
 
 #if MAUI_GRAPHICS_WIN2D
 			return new W2DImage(_creator, newRenderTarget);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This PR introduces image compression for MediaPicker. This works for images only when picked from the gallery as well as when captured through the camera. The quality of the image can be controlled by setting the newly introduced `CompressionQuality` property in the `MediaPickerOptions` object.

Additionally, this PR introduces a way to limit the size of the image that is returned by influencing the dimensions. On the `MediaPickerOptions` object, two properties were added to control the size of the image: `MaximumWidth` and `MaximumHeight`. Based on the values, the picked/captured image will be resized to fit within the specified dimensions while maintaining the aspect ratio.

As a bonus the Essentials Sample looks a bit nicer and is updated to play with all these new features.

### Issues Fixed

Fixes #29080
Fixes #29081
