### PR TITLE
Fixed Query parameters not passed on Shell navigation

### DIFF
--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 
 				if (GetValue(QueryAttributesProperty) is ShellRouteParameters delayedQueryParams)
 				{
-					result.SetValue(QueryAttributesProperty, delayedQueryParams);
+					result?.SetValue(QueryAttributesProperty, delayedQueryParams);
 				}
 
 				ContentCache = result;

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -89,6 +89,12 @@ namespace Microsoft.Maui.Controls
 				}
 
 				result = ContentCache ?? (Page)template.CreateContent(content, this);
+
+				if (GetValue(QueryAttributesProperty) is ShellRouteParameters delayedQueryParams)
+				{
+					result.SetValue(QueryAttributesProperty, delayedQueryParams);
+				}
+
 				ContentCache = result;
 			}
 
@@ -103,9 +109,6 @@ namespace Microsoft.Maui.Controls
 
 			if (result is NavigationPage)
 				throw new NotSupportedException("Shell is currently not compatible with NavigationPage. Shell has Navigation built in and doesn't require a NavigationPage.");
-
-			if (GetValue(QueryAttributesProperty) is ShellRouteParameters delayedQueryParams)
-				result.SetValue(QueryAttributesProperty, delayedQueryParams);
 
 			return result;
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue10509.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue10509.cs
@@ -1,0 +1,82 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 10509, "Query parameter is missing after navigation", PlatformAffected.Android)]
+public class Issue10509 : Shell
+{
+	public Issue10509()
+	{
+		Routing.RegisterRoute(nameof(Issue10509Page1), typeof(Issue10509Page1));
+		Routing.RegisterRoute(nameof(Issue10509Page2), typeof(Issue10509Page2));
+
+		Items.Add(new ShellContent
+		{
+			Title = "First Page",
+			Route = nameof(Issue10509Page1),
+			ContentTemplate = new DataTemplate(typeof(Issue10509Page1))
+		});
+
+		Items.Add(new ShellContent
+		{
+			Title = "Second Page",
+			Route = nameof(Issue10509Page2),
+			ContentTemplate = new DataTemplate(typeof(Issue10509Page2))
+		});
+	}
+}
+
+public class Issue10509Page1 : ContentPage
+{
+	public Issue10509Page1()
+	{
+		var navigateBtn = new Button
+		{
+			Text = "Navigate to Page 2",
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "Page1Button"
+		};
+		navigateBtn.Clicked += NavigateBtn_Clicked;
+
+		Content = new VerticalStackLayout
+		{
+			VerticalOptions = LayoutOptions.Center,
+			Children = { navigateBtn }
+		};
+	}
+
+	private async void NavigateBtn_Clicked(object sender, EventArgs e)
+	{
+		await Shell.Current.GoToAsync($"//{nameof(Issue10509Page2)}?{Issue10509Page2.NavigationDataParam}=Passed");
+	}
+}
+
+[QueryProperty(nameof(NavigationData), NavigationDataParam)]
+public class Issue10509Page2 : ContentPage
+{
+	public const string NavigationDataParam = "NavigationDataParam";
+
+	private Label dataLabel;
+
+	public Issue10509Page2()
+	{
+		dataLabel = new Label
+		{
+			AutomationId = "Page2Label",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		Content = new VerticalStackLayout
+		{
+			VerticalOptions = LayoutOptions.Center,
+			Children = { dataLabel }
+		};
+	}
+
+	public string NavigationData { get; set; }
+
+	protected override void OnNavigatedTo(NavigatedToEventArgs args)
+	{
+		base.OnNavigatedTo(args);
+		dataLabel.Text = $"Navigation data: {NavigationData ?? "Missed"}";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10509.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10509.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue10509 : _IssuesUITest
+{
+	public Issue10509(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "Query parameter is missing after navigation";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void QueryIsPassedOnNavigation()
+	{
+		App.WaitForElement("Page1Button");
+		App.Tap("Page1Button");
+		var label = App.WaitForElement("Page2Label");
+		Assert.That(label.GetText(), Is.EqualTo("Navigation data: Passed"));
+	}
+}


### PR DESCRIPTION
### Issue Detail
When navigating to a page using Shell with query parameters (e.g., via [QueryProperty]), the expected query value was not available during navigation.

### Root Cause
In Shell navigation with query parameters, the query attributes were being set on the page after it was assigned to the Content property. As a result, the query value was not available when the navigation occurred.

### Description of Change
The query parameters (QueryAttributesProperty) are now assigned to the page before it is set to ContentCache in ShellContent. This ensures the query value is available to the page before the Navigated event is triggered.

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed
 
Fixes https://github.com/dotnet/maui/issues/10509
Fixes https://github.com/dotnet/maui/issues/11113
Fixes https://github.com/dotnet/maui/issues/29645
Fixes https://github.com/dotnet/maui/issues/24241

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/23e15d65-0f11-431f-9c2e-6c7fb3a30364"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/e566f8e5-a029-45ea-9172-5369130ee6ab">) |