### PR TITLE
[Windows] Fixed Setting a ContentView with a content of StaticResource Style Causes a System.Runtime.InteropServices.COMException.

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29930.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29930.cs
@@ -1,0 +1,62 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29930, "[Windows] Setting a ContentView with a content of StaticResource Style Causes a System.Runtime.InteropServices.COMException.", PlatformAffected.UWP)]
+public class Issue29930 : ContentPage
+{
+	ContentView _mainContentView;
+	public Issue29930()
+	{
+		var button = new Button
+		{
+			Text = "Add ContentView",
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "ChangeInnerContent"
+		};
+		button.Clicked += OnButtonClicked;
+
+		_mainContentView = new ContentView();
+		_mainContentView.Content = new Issue29930InnerContentView();
+
+		var layout = new VerticalStackLayout
+		{
+			Spacing = 25,
+			Padding = new Thickness(30, 0),
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				button,
+				_mainContentView
+			}
+		};
+
+		Content = layout;
+	}
+	private void OnButtonClicked(object sender, EventArgs e)
+	{
+		_mainContentView.Content = new Issue29930InnerContentView() { BackgroundColor = Colors.Red };
+	}
+}
+
+public class Issue29930InnerContentView : ContentView
+{
+	public Issue29930InnerContentView()
+	{
+		Application.Current.Resources ??= new ResourceDictionary();
+
+		if (!Application.Current.Resources.ContainsKey("SubContentStyle"))
+		{
+			Application.Current.Resources["SubContentStyle"] = new Style(typeof(ContentView))
+			{
+				Setters =
+			{
+				new Setter
+				{
+					Property = ContentView.ContentProperty,
+					Value = new Label { Text = "SubContent" }
+				}
+			}
+			};
+		}
+		Style = (Style)Application.Current.Resources["SubContentStyle"];
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29930.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29930.cs
@@ -1,0 +1,23 @@
+﻿#if TEST_FAILS_ON_ANDROID // Test fails on Android , see https://github.com/dotnet/maui/issues/11812
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29930 : _IssuesUITest
+{
+	public Issue29930(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows] Setting a ContentView with a content of StaticResource Style Causes a System.Runtime.InteropServices.COMException.";
+
+	[Test]
+	[Category(UITestCategories.Border)]
+	public void InnerContentViewShouldNotCrashWhenDynamicallyChange()
+	{
+		App.WaitForElement("ChangeInnerContent");
+		App.Tap("ChangeInnerContent");
+		App.WaitForElement("ChangeInnerContent");
+	}
+}
+#endif

--- a/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Windows.cs
@@ -24,7 +24,12 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView.EnsureBorderPath();
 
 			if (handler.VirtualView.PresentedContent is IView view)
+			{
+				// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
+				view.Handler?.DisconnectHandler(); 
 				handler.PlatformView.Content = view.ToPlatform(handler.MauiContext);
+			}
+				
 		}
 
 		protected override ContentPanel CreatePlatformView()

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Maui.Handlers
 
 			if (handler.VirtualView.PresentedContent is IView view)
 			{
+				// Detach the old handler if it exists (prevents WinUI COM exception on reuse)
+				view.Handler?.DisconnectHandler();
 				handler.PlatformView.CachedChildren.Add(view.ToPlatform(handler.MauiContext));
 			}
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- The specific view retains a reference to its `existing `handler when it is dynamically added as content, especially when the view is defined as a static resource in a style.

- when the same view instance is added to a new parent (without being fully removed from the old one), cause WinUI throws a `COMException`





### Description of Change



- Before reusing the view, `detach `its old handler if it exists. This ensures that MAUI disposes of the existing platform-specific native view, and allows it to be safely recreated and added to the new parent.





### Issues Fixed



Fixes #29930 

Android & iOS Fix PR : #29931


### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/25fd7b6b-fb5c-499e-aa79-c11fa78d5e7f"> | <video src="https://github.com/user-attachments/assets/28d93a5e-3117-45b3-98cd-2f3ecef1dbd5"> |