### PR TITLE
Fix for Handler not disconnected when removing a non-visible page from the navigation stack

### DIFF
--- a/src/Controls/src/Core/NavigationProxy.cs
+++ b/src/Controls/src/Core/NavigationProxy.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Maui.Controls.Internals
 			{
 				currentInner.RemovePage(page);
 			}
-			page?.Handler?.DisconnectHandler();
+			page?.DisconnectHandlers();
 		}
 
 		Page Pop()

--- a/src/Controls/src/Core/NavigationProxy.cs
+++ b/src/Controls/src/Core/NavigationProxy.cs
@@ -244,6 +244,7 @@ namespace Microsoft.Maui.Controls.Internals
 			{
 				currentInner.RemovePage(page);
 			}
+			page?.Handler?.DisconnectHandler();
 		}
 
 		Page Pop()

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29923.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29923.cs
@@ -22,8 +22,8 @@ public partial class Issue29923 : Shell
 						Command = new Command(async () =>
 						{
 							var navPage = new NavigationPage();
-							var page1 = new HandlerTestPage();
-							var page2 = new HandlerTestPage2();
+							var page1 = new Issue29923TestPage();
+							var page2 = new Issue29923TestPage2();
 
 							await navPage.PushAsync(page1);
 							await navPage.PushAsync(page2);
@@ -37,8 +37,8 @@ public partial class Issue29923 : Shell
 						AutomationId = "NavigateToTestPageButton",
 						Command = new Command(async () =>
 						{
-							var page1 = new HandlerTestPage();
-							var page2 = new HandlerTestPage2();
+							var page1 = new Issue29923TestPage();
+							var page2 = new Issue29923TestPage2();
 
 							await Navigation.PushAsync(page1);
 							await Navigation.PushAsync(page2);
@@ -55,9 +55,9 @@ public partial class Issue29923 : Shell
 		});
 	}
 
-	public class HandlerTestPage : ContentPage
+	public class Issue29923TestPage : ContentPage
 	{
-		public HandlerTestPage()
+		public Issue29923TestPage()
 		{
 			Title = "Test Page";
 
@@ -69,11 +69,11 @@ public partial class Issue29923 : Shell
 		}
 	}
 
-	public class HandlerTestPage2 : ContentPage
+	public class Issue29923TestPage2 : ContentPage
 	{
 		private Label _handlerStatusLabel;
 
-		public HandlerTestPage2()
+		public Issue29923TestPage2()
 		{
 			Title = "Test Page 2";
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29923.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29923.cs
@@ -1,0 +1,140 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+[Issue(IssueTracker.Github, 29923, "Removed page handlers not disconnected when using Navigation.RemovePage()", PlatformAffected.All)]
+public partial class Issue29923 : Shell
+{
+	public Issue29923()
+	{
+		var rootPage = new ContentPage
+		{
+			Title = "Handler Disconnection Test",
+			Content = new VerticalStackLayout
+			{
+				Padding = new Thickness(30, 0),
+				Spacing = 25,
+				Children =
+				{
+					new Button
+					{
+						Text = "Test Page Modal",
+						AutomationId = "NavigateToTestPageModalButton",
+						Command = new Command(async () =>
+						{
+							var navPage = new NavigationPage();
+							var page1 = new HandlerTestPage();
+							var page2 = new HandlerTestPage2();
+
+							await navPage.PushAsync(page1);
+							await navPage.PushAsync(page2);
+
+							await Navigation.PushModalAsync(navPage);
+						})
+					},
+					new Button
+					{
+						Text = "Test Page",
+						AutomationId = "NavigateToTestPageButton",
+						Command = new Command(async () =>
+						{
+							var page1 = new HandlerTestPage();
+							var page2 = new HandlerTestPage2();
+
+							await Navigation.PushAsync(page1);
+							await Navigation.PushAsync(page2);
+						})
+					}
+				}
+			}
+		};
+
+		Items.Add(new ShellContent
+		{
+			Title = "Handler Test",
+			Content = rootPage
+		});
+	}
+
+	public class HandlerTestPage : ContentPage
+	{
+		public HandlerTestPage()
+		{
+			Title = "Test Page";
+
+			Content = new VerticalStackLayout
+			{
+				Padding = new Thickness(20),
+				Spacing = 10,
+			};
+		}
+	}
+
+	public class HandlerTestPage2 : ContentPage
+	{
+		private Label _handlerStatusLabel;
+
+		public HandlerTestPage2()
+		{
+			Title = "Test Page 2";
+
+			_handlerStatusLabel = new Label
+			{
+				Text = "",
+				AutomationId = "HandlerStatusLabel",
+				FontAttributes = FontAttributes.Bold
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Padding = new Thickness(20),
+				Spacing = 10,
+				Children =
+				{
+					new Label
+					{
+						Text = "Test Page Removal Scenarios",
+						FontSize = 18,
+						FontAttributes = FontAttributes.Bold
+					},
+					new Button
+					{
+						Text = "Remove Test Page 1",
+						AutomationId = "RemoveTestPage1Button",
+						Command = new Command(RemoveFirstPage)
+					},
+					new Button
+					{
+						Text = "Pop Modal",
+						AutomationId = "PopModalButton",
+						Command = new Command(() => Navigation.PopModalAsync())
+					},
+					new HorizontalStackLayout
+					{
+						Children =
+						{
+							new Label { Text = "Is Handler still available:", FontAttributes = FontAttributes.Bold },
+							_handlerStatusLabel
+						}
+					}
+				}
+			};
+		}
+
+		private void RemoveFirstPage()
+		{
+			var navigationStack = Navigation.NavigationStack;
+			if (navigationStack.Count == 0)
+				return;
+
+			var pageToRemove = navigationStack.FirstOrDefault();
+			if (pageToRemove == null && navigationStack.Count > 1)
+				pageToRemove = navigationStack[1];
+
+			if (pageToRemove != null)
+			{
+				Navigation.RemovePage(pageToRemove);
+				_handlerStatusLabel.Text = (pageToRemove.Handler != null).ToString();
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29923.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29923.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29923 : _IssuesUITest
+{
+	public Issue29923(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Removed page handlers not disconnected when using Navigation.RemovePage()";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void RemovePageShouldDisconnectHandlers()
+	{
+		App.WaitForElement("NavigateToTestPageModalButton");
+		App.Tap("NavigateToTestPageModalButton");
+		App.WaitForElement("RemoveTestPage1Button");
+		App.Tap("RemoveTestPage1Button");
+		Assert.That(App.WaitForElement("HandlerStatusLabel").GetText(), Is.EqualTo("False"));
+		App.Tap("PopModalButton");
+
+		App.WaitForElement("NavigateToTestPageButton");
+		App.Tap("NavigateToTestPageButton");
+		App.WaitForElement("RemoveTestPage1Button");
+		App.Tap("RemoveTestPage1Button");
+		Assert.That(App.WaitForElement("HandlerStatusLabel").GetText(), Is.EqualTo("False"));
+	}
+}


### PR DESCRIPTION
### Root Cause
When `Navigation.RemovePage()` is used to remove a page from the navigation stack, the handler associated with the removed page is not disconnected. In contrast, methods like `PopAsync()` or `PopModalAsync()` trigger proper cleanup, including handler disconnection.

The `RemovePage()` method modifies the navigation stack without initiating any disposal or disconnection logic for the page's handler. As a result, the Handler property of the removed page remains assigned after removal, which can retain references to platform-specific resources.

Platform implementations do not consistently handle this scenario. On iOS, handler disconnection occur through `ShellSectionRenderer.DisposePage()` for some scenarios only, but this is not invoked as part of `RemovePage()`. On Android and Windows, no corresponding cleanup is performed when removing a page in this way.
 
### Description of Change
This change ensures that when a page is removed from the navigation stack using `RemovePage()`—and the page is not currently visible—its handler is properly disconnected. The fix is implemented in `NavigationProxy.OnRemovePage()`, which provides a centralized and platform-agnostic location for handling page removal. This approach ensures consistent behavior across iOS, Android, and Windows, and correctly manages the page lifecycle by disconnecting the handler at the appropriate time.
 
### Issues Fixed
Fixes #29923 
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/a53bd18c-dfe7-4d2e-ab62-e7d6b3deff96" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/30a86e1a-b15d-4802-bab2-8bd7b45bba1c" /> |