### PR TITLE
[iOS] ScrollView content offset shifts unexpectedly when FlowDirection is changed

### DIFF
--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Maui.Platform
 
 					if (EffectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.RightToLeft)
 					{
+						// Reset the content offset to zero before re-arranging
+						ContentOffset = new CGPoint(0, 0);
+
 						var horizontalOffset = contentSize.Width - crossPlatformBounds.Width;
 						crossPlatformLayout.CrossPlatformArrange(new Rect(new Point(-horizontalOffset, 0), crossPlatformBounds));
 						ContentOffset = new CGPoint(horizontalOffset, 0);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->


### Description of Change

This PR addresses an issue where switching the layout direction from Right-to-Left (RTL) to Left-to-Right (LTR)  could result in incorrect content positioning due to stale or inconsistent scroll offsets.

To ensure layout consistency, we now explicitly reset the ContentOffset to (0,0) before performing layout adjustments. This prevents any residual offset from affecting the new layout direction.

### Issues Fixed

This PR fixes a problem addressed here

![Screenshot 2025-06-18 at 16 41 33](https://github.com/user-attachments/assets/8b0ad619-da45-4b33-bc8a-ca11e80334f0)

https://github.com/dotnet/maui/issues/29458#issuecomment-2983090924

Fixes #31322

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/a1eecb9d-cefe-419b-9ef4-bec5390eb402" width="300px"/>|<video src="https://github.com/user-attachments/assets/9ad0e851-a01d-4ec7-8b6b-1bbb3a5862fc" width="300px"/>|
