### PR TITLE
Add overrides to Help with Obsoleting Compatibility.Layout

### DIFF
--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Maui.Controls
 		}
 	
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
@@ -122,15 +122,15 @@ namespace Microsoft.Maui.Controls
 			return this.MeasureContent(widthConstraint, heightConstraint);
 		}
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override void OnSizeAllocated(double width, double height)
 		{
 			base.OnSizeAllocated(width, height);
 		}
-	
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override Size ArrangeOverride(Rect bounds)

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -107,7 +107,11 @@ namespace Microsoft.Maui.Controls
 				newView.ParentOverride = await TemplateUtilities.FindTemplatedParentAsync((Element)bindable);
 			}
 		}
+	
 
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
@@ -118,6 +122,17 @@ namespace Microsoft.Maui.Controls
 			return this.MeasureContent(widthConstraint, heightConstraint);
 		}
 
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
+		protected override void OnSizeAllocated(double width, double height)
+		{
+			base.OnSizeAllocated(width, height);
+		}
+	
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
 		protected override Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Maui.Controls
 
 		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
-		// and is overriding OnSizeAllocated.
+		// and is overriding MeasureOverride.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls
 
 		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
-		// and is overriding OnSizeAllocated.
+		// and is overriding ArrangeOverride.
 		protected override Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -426,7 +426,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 		void IScrollView.ScrollFinished() => SendScrollFinished();
+	
 
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
@@ -459,13 +463,25 @@ namespace Microsoft.Maui.Controls
 			content.Measure(widthConstraint, heightConstraint);
 			return content.DesiredSize;
 		}
+	
 
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
 		protected override Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);
 			Handler?.PlatformArrange(Frame);
 
 			return Frame.Size;
+		}		
+
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
+		protected override void OnSizeAllocated(double width, double height)
+		{
+			base.OnSizeAllocated(width, height);
 		}
 
 		Size ICrossPlatformLayout.CrossPlatformArrange(Rect bounds)

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Maui.Controls
 
 		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
-		// and is overriding OnSizeAllocated.
+		// and is overriding MeasureOverride.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
@@ -467,7 +467,7 @@ namespace Microsoft.Maui.Controls
 
 		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
-		// and is overriding OnSizeAllocated.
+		// and is overriding ArrangeOverride.
 		protected override Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);

--- a/src/Controls/src/Core/ScrollView/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView/ScrollView.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Maui.Controls
 		void IScrollView.ScrollFinished() => SendScrollFinished();
 	
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
@@ -465,7 +465,7 @@ namespace Microsoft.Maui.Controls
 		}
 	
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override Size ArrangeOverride(Rect bounds)
@@ -476,7 +476,7 @@ namespace Microsoft.Maui.Controls
 			return Frame.Size;
 		}		
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override void OnSizeAllocated(double width, double height)

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Controls
 	
 		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
-		// and is overriding OnSizeAllocated.
+		// and is overriding MeasureOverride.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Controls
 
 		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
-		// and is overriding OnSizeAllocated.
+		// and is overriding ArrangeOverride.
 		protected override Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -126,7 +126,10 @@ namespace Microsoft.Maui.Controls
 		{
 			Handler?.UpdateValue(nameof(IContentView.Content));
 		}
-
+	
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			return this.ComputeDesiredSize(widthConstraint, heightConstraint);
@@ -137,6 +140,18 @@ namespace Microsoft.Maui.Controls
 			return this.MeasureContent(widthConstraint, heightConstraint);
 		}
 
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
+		protected override void OnSizeAllocated(double width, double height)
+		{
+			base.OnSizeAllocated(width, height);
+		}
+	
+
+		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
+		// and is overriding OnSizeAllocated.
 		protected override Size ArrangeOverride(Rect bounds)
 		{
 			Frame = this.ComputeFrame(bounds);

--- a/src/Controls/src/Core/TemplatedView/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView/TemplatedView.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Maui.Controls
 			Handler?.UpdateValue(nameof(IContentView.Content));
 		}
 	
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.Controls
 			return this.MeasureContent(widthConstraint, heightConstraint);
 		}
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override void OnSizeAllocated(double width, double height)
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Controls
 		}
 	
 
-		// Don't delete this override. At somepoint in the future we'd like to delete Compatibility.Layout
+		// Don't delete this override. At some point in the future we'd like to delete Compatibility.Layout
 		// and this is the only way to ensure binary compatibility with code that's already compiled against MAUI
 		// and is overriding OnSizeAllocated.
 		protected override Size ArrangeOverride(Rect bounds)


### PR DESCRIPTION
### Description of Change

We had a few vendors test out the follow PR https://github.com/dotnet/maui/pull/29281 and they reported crashes on `OnSizeAllocated`.

```
An unhandled exception of type 'System.MethodAccessException' occurred in Microsoft.MacCatalyst.dll: 'Method `Microsoft.Maui.Controls.Compatibility.Layout.OnSizeAllocated(double,double)' is inaccessible from method
```

If we add these overrides to the base classes that we are keeping and then 3rd parties recompile, that will better prepare us down the road for hopefully getting to delete `Compatibility.Layout`