### PR TITLE
[android] 20250618 net10.0 ecosystem updates

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -22,6 +22,7 @@
     <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.9.0" />
     <PackageReference Update="Xamarin.AndroidX.Palette" Version="1.0.0.33" />
     <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.4.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.SavedState" Version="1.3.0.1" />
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
     <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.28" />
     <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.6.0" />

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -5,14 +5,16 @@
     <!-- must be kept in sync with the binding library version to it here: -->
     <PackageReference Update="Xamarin.Android.Glide" Version="4.16.0.13" />
     <PackageReference Update="Xamarin.AndroidX.Activity" Version="1.10.1.2" />
-    <PackageReference Update="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.1" />
     <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.8.0.10" />
     <PackageReference Update="Xamarin.AndroidX.DynamicAnimation" Version="1.1.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.7.0.10" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.9.1" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.1" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.1" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.9.1" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.9.1" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.9.1" />
+    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.8.0" />
     <PackageReference Update="Xamarin.AndroidX.Migration" Version="1.0.10" NoWarn="NU1701" />
     <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.9.0" />
     <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.9.0" />
@@ -23,11 +25,11 @@
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
     <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.28" />
     <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.6.0" />
-    <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.3.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.4.0" />
     <PackageReference Update="Xamarin.Build.Download" Version="0.11.4" />
     <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.25" />
     <PackageReference Update="Xamarin.Google.Android.Material" Version="1.12.0.4" />
-    <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.17.0.2" />
+    <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.18.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Maps" Version="119.2.0.2" />
   </ItemGroup>
 </Project>

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -1,25 +1,33 @@
 <Project>
+  <!-- A list of dependencies from https://github.com/dotnet/android-libraries -->
   <ItemGroup>
+    <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
+    <!-- must be kept in sync with the binding library version to it here: -->
+    <PackageReference Update="Xamarin.Android.Glide" Version="4.16.0.13" />
     <PackageReference Update="Xamarin.AndroidX.Activity" Version="1.10.1.2" />
     <PackageReference Update="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.0.7" />
     <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.8.0.10" />
     <PackageReference Update="Xamarin.AndroidX.DynamicAnimation" Version="1.1.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.8.7.4" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.9.0" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.0" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.0" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.9.0" />
     <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.7.0.10" />
     <PackageReference Update="Xamarin.AndroidX.Migration" Version="1.0.10" NoWarn="NU1701" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.8.9.2" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.8.9.2" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Runtime" Version="2.8.9.2" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.8.9.2" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.9.0" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.9.0" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Runtime" Version="2.9.0" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.9.0" />
     <PackageReference Update="Xamarin.AndroidX.Palette" Version="1.0.0.33" />
     <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.4.0.2" />
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
     <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.28" />
-    <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.5.1.6" />
+    <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.6.0" />
     <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.3.0.7" />
     <PackageReference Update="Xamarin.Build.Download" Version="0.11.4" />
     <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.25" />
     <PackageReference Update="Xamarin.Google.Android.Material" Version="1.12.0.4" />
     <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.17.0.2" />
+    <PackageReference Update="Xamarin.GooglePlayServices.Maps" Version="119.2.0.2" />
   </ItemGroup>
 </Project>

--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -155,18 +155,6 @@
         Version="$(MicrosoftGraphicsWin2DPackageVersion)"
     />
     <PackageReference
-        Update="Xamarin.Android.Glide"
-        Version="$(_XamarinAndroidGlideVersion)"
-    />
-    <PackageReference
-        Update="Xamarin.AndroidX.Security.SecurityCrypto"
-        Version="$(_XamarinAndroidXSecurityVersion)"
-    />
-    <PackageReference
-        Update="Xamarin.Google.Crypto.Tink.Android"
-        Version="$(_XamarinGoogleCryptoTinkAndroidVersion)"
-    />
-    <PackageReference
         Update="Microsoft.AspNetCore.Authorization"
         Version="$(MicrosoftAspNetCoreAuthorizationPackageVersion)"
     />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -115,13 +115,6 @@
     <MicrosoftBuildFrameworkPackageVersion>17.9.5</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>17.9.5</MicrosoftBuildUtilitiesCorePackageVersion>
     <MonoApiToolsMSBuildTasksPackageVersion>0.4.0</MonoApiToolsMSBuildTasksPackageVersion>
-    <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
-    <!-- must be kept in sync with the binding library version to it here: -->
-    <_XamarinAndroidGlideVersion>4.16.0.13</_XamarinAndroidGlideVersion>
-    <_XamarinAndroidXSecurityVersion>1.1.0.4-alpha07</_XamarinAndroidXSecurityVersion>
-    <_XamarinGoogleCryptoTinkAndroidVersion>1.17.0.2</_XamarinGoogleCryptoTinkAndroidVersion>
-    <!-- Android Maps -->
-    <XamarinGooglePlayServicesMaps>119.2.0.2</XamarinGooglePlayServicesMaps>
     <!--
       SKIASHARP & HARFBUZZSHARP - the various things must be kept in sync with maui graphics:
        - NuGet versions below

--- a/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
+++ b/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Firebase.AppIndexing" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />

--- a/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
+++ b/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
@@ -12,6 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Firebase.AppIndexing" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
+++ b/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
@@ -11,8 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
-    <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="$(XamarinGooglePlayServicesMaps)" />
+    <PackageReference Include="Xamarin.GooglePlayServices.Maps" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
+++ b/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" />
   </ItemGroup>

--- a/src/Controls/Foldable/src/Controls.Foldable.csproj
+++ b/src/Controls/Foldable/src/Controls.Foldable.csproj
@@ -38,6 +38,8 @@
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">

--- a/src/Controls/Foldable/src/Controls.Foldable.csproj
+++ b/src/Controls/Foldable/src/Controls.Foldable.csproj
@@ -35,6 +35,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(UseMaui)' != 'true' and '$(TargetPlatformIdentifier)' == 'android' ">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">

--- a/src/Core/maps/src/Maps.csproj
+++ b/src/Core/maps/src/Maps.csproj
@@ -32,7 +32,7 @@
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-    <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="$(XamarinGooglePlayServicesMaps)" />
+    <PackageReference Include="Xamarin.GooglePlayServices.Maps" />
     <PackageReference Include="Xamarin.AndroidX.Transition" />
   </ItemGroup>
 

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -48,8 +48,11 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
     <AndroidGradleProject Include="../AndroidNative/build.gradle" ModuleName="maui" />
-    <PackageReference Include="Xamarin.Android.Glide" Version="$(_XamarinAndroidGlideVersion)" />
+    <PackageReference Include="Xamarin.Android.Glide" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
+    <PackageReference Include="Xamarin.AndroidX.SavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -53,6 +53,8 @@
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />

--- a/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
+++ b/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
@@ -28,7 +28,7 @@
     <Using Include="BenchmarkDotNet.Order" />
     <Using Include="BenchmarkDotNet.Running" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
-    <PackageReference Include="Xamarin.Android.Glide" Version="$(_XamarinAndroidGlideVersion)" />
+    <PackageReference Include="Xamarin.Android.Glide" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -27,9 +27,6 @@
     <_ValuesToReplace Include="MicrosoftWindowsAppSDKPackageVersion" PropertyName="MicrosoftWindowsAppSDKPackageVersion" />
     <_ValuesToReplace Include="MicrosoftWindowsWebView2PackageVersion" PropertyName="MicrosoftWindowsWebView2PackageVersion" />
     <_ValuesToReplace Include="TizenUIExtensionsVersion" PropertyName="TizenUIExtensionsVersion" />
-    <_ValuesToReplace Include="_XamarinAndroidGlideVersion" PropertyName="_XamarinAndroidGlideVersion" />
-    <_ValuesToReplace Include="_XamarinAndroidXSecurityVersion" PropertyName="_XamarinAndroidXSecurityVersion" />
-    <_ValuesToReplace Include="_XamarinGoogleCryptoTinkAndroidVersion" PropertyName="_XamarinGoogleCryptoTinkAndroidVersion" />
   </ItemGroup>
 
   <Import Project="$(MauiRootDirectory)eng/ReplaceText.targets" />


### PR DESCRIPTION
This mainly updates Xamarin.AndroidX.Navigation.* packages to a new 2.9.0 version from Google.

Going a step further from the recent update in adfe0ec5, I continued to refactor and remove MSBuild properties like
`$(_XamarinAndroidGlideVersion)` that dependabot won't be able to update.

Removed:

* `$(_XamarinAndroidGlideVersion)`
* `$(_XamarinAndroidXSecurityVersion)`
* `$(_XamarinGoogleCryptoTinkAndroidVersion)`
* `$(XamarinGooglePlayServicesMaps)`

The versions of these packages are now tracked in a single location, `AndroidX.targets`, that dependabot can update. Example [here][0].

[0]: https://github.com/jonathanpeppers/boots/commit/c190ed4e5ef8977d5af93877a889919a3f0ade19