### PR TITLE
[Android] Propagate key event from dialog to activity

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Android.Views.Animations;
 using AndroidX.Activity;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR restores the ability to detect KeyEvent actions from modal pages on Android. Previously, modal pages correctly propagated key events to MainActivity overrides (e.g., OnKeyDown, OnKeyUp). However, after the transition to using DialogFragment for modal pages, these key events were no longer reaching the activity-level handlers.

The changes in this PR reintroduce this functionality by ensuring that key events originating from modal dialogs are forwarded appropriately to the MainActivity, enabling consistent behavior and restoring support for hardware key handling scenarios.

```MainPage.cs
public partial class MainPage : ContentPage
{
	public MainPage()
	{
		Content = new Button
		{
			Text = "Navigate to Subpage",
			Command = new Command(() => Navigation.PushModalAsync(new ContentPage()
			{
				Content = new Button
				{
					Text = "Navigate back",
					Command = new Command(() => Navigation.PopModalAsync())
				}
			}))
		};
	}
}
```

```MainActivity.cs
public class MainActivity : MauiAppCompatActivity
{ 
	public override bool OnKeyDown([GeneratedEnum] Keycode keyCode, KeyEvent e)
	{
		Microsoft.Maui.Controls.Application.Current.Windows[0].Page.DisplayAlert("Key Pressed", $"Key: {keyCode}", "OK");
		return base.OnKeyDown(keyCode, e);
	}
}
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/30048

