### PR TITLE
[Android] Fix for OnSizeAllocated is not reported for Android AppShell Flyout content.

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			_shellContext = shellContext;
 			_shellContext.CurrentDrawerLayout.DrawerStateChanged += OnFlyoutStateChanging;
-			_shellContext.CurrentDrawerLayout.DrawerOpened += OnDrawerOpened;
 			LoadView(shellContext);
 		}
 
@@ -71,15 +70,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				_shellContext.CurrentDrawerLayout.DrawerStateChanged -= OnFlyoutStateChanging;
 			}
-		}
-
-		void OnDrawerOpened(object sender, EventArgs e)
-		{
-			if (FlyoutView.FlyoutBehavior == FlyoutBehavior.Flyout)
-			{
-				UpdateContentPadding();
-			}
-			_shellContext.CurrentDrawerLayout.DrawerOpened -= OnDrawerOpened;
 		}
 		
 		protected virtual void LoadView(IShellContext shellContext)
@@ -429,9 +419,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				// and propagate any margins set
 				if (_contentView?.PlatformView != null)
 				{
-					var dpWidth = _rootView.Context.FromPixels(_contentView.PlatformView.MeasuredWidth);
-					var dpHeight = _rootView.Context.FromPixels(_contentView.PlatformView.MeasuredHeight);
-					_contentView.View.Frame = _contentView.View.ComputeFrame(new Graphics.Rect(0, 0, dpWidth, dpHeight));
+					SetContentViewFrame();
 
 					cl.LeftMargin = (int)_rootView.Context.ToPixels(viewMargin.Left);
 					cl.TopMargin = (int)_rootView.Context.ToPixels(viewMargin.Top);
@@ -442,6 +430,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 
 			return returnValue;
+		}
+
+		void SetContentViewFrame()
+		{
+			var dpWidth = _rootView.Context.FromPixels(_contentView.PlatformView.MeasuredWidth);
+			var dpHeight = _rootView.Context.FromPixels(_contentView.PlatformView.MeasuredHeight);
+			_contentView.View.Frame = _contentView.View.ComputeFrame(new Graphics.Rect(0, 0, dpWidth, dpHeight));
 		}
 
 		void OnFlyoutViewLayoutChanging()
@@ -473,6 +468,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				UpdateFooterLayout();
 				UpdateContentPadding();
+			}
+			else if (_contentView?.PlatformView is not null &&
+				((_contentView.PlatformView.MeasuredHeight > 0 && _contentView.View.Frame.Width == 0) ||
+				 (_contentView.PlatformView.MeasuredWidth > 0 && _contentView.View.Frame.Height == 0)))
+			{
+				SetContentViewFrame();
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			_shellContext = shellContext;
 			_shellContext.CurrentDrawerLayout.DrawerStateChanged += OnFlyoutStateChanging;
+			_shellContext.CurrentDrawerLayout.DrawerOpened += OnDrawerOpened;
 			LoadView(shellContext);
 		}
 
@@ -72,6 +73,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
+		void OnDrawerOpened(object sender, EventArgs e)
+		{
+			if (FlyoutView.FlyoutBehavior == FlyoutBehavior.Flyout)
+			{
+				UpdateContentPadding();
+			}
+			_shellContext.CurrentDrawerLayout.DrawerOpened -= OnDrawerOpened;
+		}
+		
 		protected virtual void LoadView(IShellContext shellContext)
 		{
 			var context = shellContext.AndroidContext;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				_shellContext.CurrentDrawerLayout.DrawerStateChanged -= OnFlyoutStateChanging;
 			}
 		}
-		
+
 		protected virtual void LoadView(IShellContext shellContext)
 		{
 			var context = shellContext.AndroidContext;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22045.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22045.cs
@@ -1,0 +1,86 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 22045, "[Android] OnSizeAllocated not reported for Android AppShell Flyout content", PlatformAffected.Android)]
+public class Issue22045 : Shell
+{
+	public Issue22045()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Flyout;
+
+		var shellContent = new ShellContent
+		{
+			Title = "Home",
+			Route = "MainPage",
+			ContentTemplate = new DataTemplate(typeof(_22045MainPage))
+		};
+
+		Items.Add(shellContent);
+
+		this.FlyoutContent = new _22045NewContent();
+	}
+
+	public class _22045NewContent : ContentView
+	{
+		Label widthLabel;
+		Label heightLabel;
+
+		public _22045NewContent()
+		{
+			widthLabel = new Label
+			{
+				AutomationId= "WidthLabel",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			heightLabel = new Label
+			{
+				AutomationId = "HeightLabel",
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Children =
+				{
+					widthLabel,
+					heightLabel
+				}
+			};
+		}
+		protected override void OnSizeAllocated(double width, double height)
+		{
+			base.OnSizeAllocated(width, height);
+			widthLabel.Text = width.ToString();
+			heightLabel.Text = height.ToString();
+		}
+	}
+
+	public class _22045MainPage : ContentPage
+	{
+		public _22045MainPage()
+		{
+			var button = new Button
+			{
+				Text = "Open Flyout",
+				AutomationId = "OpenFlyoutButton",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			button.Clicked += (s, e) =>
+			{
+				Shell.Current.FlyoutIsPresented = true;
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Children =
+				{
+					button
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22045.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22045.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue22045 : _IssuesUITest
+{
+	public Issue22045(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "[Android] OnSizeAllocated not reported for Android AppShell Flyout content";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void GetValidSizeWhenContentViewInFlyoutContent()
+	{
+		App.WaitForElement("OpenFlyoutButton");
+		App.Click("OpenFlyoutButton");
+		var width = App.WaitForElement("WidthLabel").GetText();
+		var height = App.WaitForElement("HeightLabel").GetText();
+		Assert.That(double.TryParse(width, out double w) && w > 0,
+			Is.True, $"Expected positive width, got {width}");
+		Assert.That(double.TryParse(height, out double h) && h > 0,
+			Is.True, $"Expected positive height, got {height}");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause

The issue arises because, in .NET MAUI on Android, when a ContentView is placed inside Shell.FlyoutContent with FlyoutBehavior values set as Flyout, the Android layout system does not fully measure and lay out the flyout content at the appropriate time. As a result, the OnSizeAllocated method receives zero values for width and height, and OnFlyoutViewLayoutChanging() is triggered before the view is fully measured. This prevents the correct dimensions from being propagated, so the layout system does not update the content size as expected.

### Description of Issue Fix

The fix involves updating the ContentView frame inside the OnFlyoutViewLayoutChanging() method after the view has been measured, ensuring that the correct width and height are applied to the content, allowing the layout system to update the content size properly and display the content as expected.

Tested the behavior in the following platforms.
 
- [x] Windows
- [x] Mac
- [x] iOS
- [x] Android

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/22045

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/ea4d3a7e-2dcb-489c-8202-2218026afbfe"> | <video width="270" height="600"  src="https://github.com/user-attachments/assets/ff3df3ca-5f3a-493e-812f-28fdc1acdb3f"> |


