### PR TITLE
[XC] Fix detection of x:DataType from outer scope

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					break;
 				}
 
-				if (n.XmlType.Name == nameof(DataTemplate) && n.XmlType.NamespaceUri == XamlParser.MauiUri)
+				if (n.XmlType.Name == nameof(DataTemplate) && (n.XmlType.NamespaceUri == XamlParser.MauiUri || n.XmlType.NamespaceUri == XamlParser.MauiGlobalUri))
 				{
 					xDataTypeIsInOuterScope = true;
 				}

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -532,8 +532,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					break;
 				}
 
-				if (n.XmlType.Name == nameof(Microsoft.Maui.Controls.DataTemplate)
-					&& (n.XmlType.NamespaceUri == XamlParser.MauiUri) || n.XmlType.NamespaceUri == XamlParser.MauiGlobalUri)
+				if (n.XmlType.Name == nameof(DataTemplate) && n.XmlType.NamespaceUri == XamlParser.MauiUri)
 				{
 					xDataTypeIsInOuterScope = true;
 				}


### PR DESCRIPTION
### Description of Change

XamlC reported the following warning for every single binding it compiled:

```
XamlC warning XC0024: Binding might be compiled incorrectly since the x:DataType annotation comes from an outer scope. Make sure you annotate all DataTemplate XAML elements with the correct x:DataType. See https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings for more information.
```

This was caused by an incorrect condition changed #29579. Since this is just a warning and not an error, it wasn't caught in code review.