### PR TITLE
[Android] Propagate the KeyEvents from Modal pages to MainActivity

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Android.Views.Animations;
 using AndroidX.Activity;
@@ -396,6 +397,54 @@ namespace Microsoft.Maui.Controls.Platform
 				public CustomComponentDialog(Context context, int themeResId) : base(context, themeResId)
 				{
 					this.OnBackPressedDispatcher.AddCallback(new CallBack(true, this));
+				}
+
+				public override bool OnKeyLongPress([GeneratedEnum] Keycode keyCode, KeyEvent e)
+				{
+					var activity = Context?.GetActivity();
+
+					if (activity is null)
+					{
+						return false;
+					}
+
+					return activity.OnKeyLongPress(keyCode, e);
+				}
+
+				public override bool OnKeyDown([GeneratedEnum] Keycode keyCode, KeyEvent e)
+				{
+					var activity = Context?.GetActivity();
+
+					if (activity is null)
+					{
+						return false;
+					}
+
+					return activity.OnKeyDown(keyCode, e);
+				}
+
+				public override bool OnKeyMultiple([GeneratedEnum] Keycode keyCode, int repeatCount, KeyEvent e)
+				{
+					var activity = Context?.GetActivity();
+
+					if (activity is null)
+					{
+						return false;
+					}
+
+					return activity.OnKeyMultiple(keyCode, repeatCount, e);
+				}
+
+				public override bool OnKeyUp([GeneratedEnum] Keycode keyCode, KeyEvent e)
+				{
+					var activity = Context?.GetActivity();
+
+					if (activity is null)
+					{
+						return false;
+					}
+
+					return activity.OnKeyUp(keyCode, e);
 				}
 
 				sealed class CallBack : OnBackPressedCallback


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Calls the MainActivity overrides from the ComponentDialog's overrides, so the previous behavior of KeyEvent handling of Modal pages is restored. 
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #30048 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
