### PR TITLE
Introduce SetterSpecificity.FromUnknown to avoid misuse of FromHandler

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -716,14 +716,14 @@ namespace Microsoft.Maui.Controls
 			binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged, specificity);
 		}
 
-		static bool ShouldOverrideSpecificity(SetterSpecificity previous, SetterSpecificity current)
+		static bool ShouldOverrideSpecificity(SetterSpecificity orginal, SetterSpecificity current)
 		{
 			// FromHandler gets overridden by anything except itself
-			if (previous == SetterSpecificity.FromHandler)
+			if (orginal == SetterSpecificity.FromHandler)
 				return current != SetterSpecificity.FromHandler;
 
 			// FromUnknown gets overridden by anything except itself
-			if (previous == SetterSpecificity.FromUnknown)
+			if (orginal == SetterSpecificity.FromUnknown)
 				return current != SetterSpecificity.FromUnknown;
 
 			// For all other cases, don't override

--- a/src/Controls/src/Core/BindableObjectExtensions.cs
+++ b/src/Controls/src/Core/BindableObjectExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls
 			else
 			{
 				// support normal/code properties
-				self.SetValue(property, value, SetterSpecificity.FromHandler);
+				self.SetValue(property, value, SetterSpecificity.FromUnknown);
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellRenderer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var entryCell = (EntryCell)Cell;
 
 			entryCell
-				.SetValue(EntryCell.TextProperty, text, specificity: SetterSpecificity.FromHandler);
+				.SetValue(EntryCell.TextProperty, text, specificity: SetterSpecificity.FromUnknown);
 		}
 
 		void UpdateHeight()

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/EntryCellRenderer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var model = (EntryCell)cell.Cell;
 
 			model
-				.SetValue(EntryCell.TextProperty, cell.TextField.Text, specificity: SetterSpecificity.FromHandler);
+				.SetValue(EntryCell.TextProperty, cell.TextField.Text, specificity: SetterSpecificity.FromUnknown);
 		}
 
 		static void UpdateHorizontalTextAlignment(EntryCellTableViewCell cell, EntryCell entryCell)

--- a/src/Controls/src/Core/ListView/ListView.cs
+++ b/src/Controls/src/Core/ListView/ListView.cs
@@ -521,7 +521,7 @@ namespace Microsoft.Maui.Controls
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
 			if (SelectionMode != ListViewSelectionMode.None)
-				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0), SetValuePrivateFlags.Default, SetterSpecificity.FromHandler);
+				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0), SetValuePrivateFlags.Default, SetterSpecificity.FromUnknown);
 
 			cell?.OnTapped();
 
@@ -547,7 +547,7 @@ namespace Microsoft.Maui.Controls
 
 			// Set SelectedItem before any events so we don't override any changes they may have made.
 			if (SelectionMode != ListViewSelectionMode.None)
-				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0), SetValuePrivateFlags.Default, SetterSpecificity.FromHandler);
+				SetValueCore(SelectedItemProperty, cell?.BindingContext, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearDynamicResource | (changed ? SetValueFlags.RaiseOnEqual : 0), SetValuePrivateFlags.Default, SetterSpecificity.FromUnknown);
 
 			if (isContextMenuRequested || cell == null)
 			{

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Maui.Controls
 			var oldIndex = SelectedIndex;
 			var newIndex = SelectedIndex.Clamp(-1, Items.Count - 1);
 			//FIXME use the specificity of the caller
-			SetValue(SelectedIndexProperty, newIndex, SetterSpecificity.FromHandler);
+			SetValue(SelectedIndexProperty, newIndex, SetterSpecificity.FromUnknown);
 			// If the index has not changed, still need to change the selected item
 			if (newIndex == oldIndex)
 				UpdateSelectedItem(newIndex);
@@ -384,10 +384,10 @@ namespace Microsoft.Maui.Controls
 
 			if (ItemsSource != null)
 			{
-				SetValue(SelectedIndexProperty, ItemsSource.IndexOf(selectedItem), SetterSpecificity.FromHandler);
+				SetValue(SelectedIndexProperty, ItemsSource.IndexOf(selectedItem), SetterSpecificity.FromUnknown);
 				return;
 			}
-			SetValue(SelectedIndexProperty, Items.IndexOf(selectedItem), SetterSpecificity.FromHandler);
+			SetValue(SelectedIndexProperty, Items.IndexOf(selectedItem), SetterSpecificity.FromUnknown);
 		}
 
 		void UpdateSelectedItem(int index)
@@ -396,18 +396,18 @@ namespace Microsoft.Maui.Controls
 
 			if (index == -1)
 			{
-				SetValue(SelectedItemProperty, null, SetterSpecificity.FromHandler);
+				SetValue(SelectedItemProperty, null, SetterSpecificity.FromUnknown);
 				return;
 			}
 
 			if (ItemsSource != null)
 			{
 				var item = index < ItemsSource.Count ? ItemsSource[index] : null;
-				SetValue(SelectedItemProperty, item, SetterSpecificity.FromHandler);
+				SetValue(SelectedItemProperty, item, SetterSpecificity.FromUnknown);
 				return;
 			}
 
-			SetValue(SelectedItemProperty, Items[index], SetterSpecificity.FromHandler);
+			SetValue(SelectedItemProperty, Items[index], SetterSpecificity.FromUnknown);
 		}
 
 		/// <inheritdoc/>

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Maui.Controls
 		void SelectRadioButton(object sender, EventArgs e)
 		{
 			if (IsEnabled)
-				SetValue(IsCheckedProperty, true, specificity: SetterSpecificity.FromHandler);
+				SetValue(IsCheckedProperty, true, specificity: SetterSpecificity.FromUnknown);
 		}
 
 		void OnIsCheckedPropertyChanged(bool isChecked)
@@ -428,7 +428,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			SetValue(IsCheckedProperty, false, specificity: SetterSpecificity.FromHandler);
+			SetValue(IsCheckedProperty, false, specificity: SetterSpecificity.FromUnknown);
 		}
 
 		void HandleRadioButtonGroupValueChanged(Element layout, RadioButtonGroupValueChanged args)
@@ -438,7 +438,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			SetValue(IsCheckedProperty, true, specificity: SetterSpecificity.FromHandler);
+			SetValue(IsCheckedProperty, true, specificity: SetterSpecificity.FromUnknown);
 		}
 
 		static View BuildDefaultTemplate()

--- a/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Maui.Controls
 
 			if (object.Equals(radioButton.Value, this.SelectedValue))
 			{
-				radioButton.SetValue(RadioButton.IsCheckedProperty, true, specificity: SetterSpecificity.FromHandler);
+				radioButton.SetValue(RadioButton.IsCheckedProperty, true, specificity: SetterSpecificity.FromUnknown);
 			}
 		}
 

--- a/src/Controls/src/Core/SetterSpecificity.cs
+++ b/src/Controls/src/Core/SetterSpecificity.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls
 
 		public bool IsDefault => _value == 0ul;
 		public bool IsHandler => _value == 0xFFFFFFFFFFFFFFFF;
-		public bool IsUnknown => _value == 0xFEFEFEFEFEFEFEFE;
+		public bool IsUnknown => _value == 0x8000000000000000;
 		public bool IsVsm => (_value & 0x0100000000000000) != 0;
 		public bool IsVsmImplicit => (_value & 0x0000000004000000) != 0;
 		public bool IsManual => ((_value >> 28) & 0xFFFF) == 1;

--- a/src/Controls/src/Core/SetterSpecificity.cs
+++ b/src/Controls/src/Core/SetterSpecificity.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.Controls
 	{
 		const byte ExtrasVsm = 0x01;
 		const byte ExtrasHandler = 0xFF;
+		const byte ExtrasUnknown = 0xFE;
 
 		public const ushort ManualTriggerBaseline = 2;
 
@@ -38,12 +39,16 @@ namespace Microsoft.Maui.Controls
 		// handler always apply, but are removed when anything else comes in. see SetValueActual
 		public static readonly SetterSpecificity FromHandler = new SetterSpecificity(0xFF, 0, 0, 0, 0, 0, 0, 0);
 
+		// Similar to FromHandler, with slightly lower priority
+		public static readonly SetterSpecificity FromUnknown = new SetterSpecificity(ExtrasUnknown, 0, 0, 0, 0, 0, 0, 0);
+
 		// We store all information in one single UInt64 value to have the fastest comparison possible
 		readonly ulong _value;
 
 
 		public bool IsDefault => _value == 0ul;
 		public bool IsHandler => _value == 0xFFFFFFFFFFFFFFFF;
+		public bool IsUnknown => _value == 0xFEFEFEFEFEFEFEFE;
 		public bool IsVsm => (_value & 0x0100000000000000) != 0;
 		public bool IsVsmImplicit => (_value & 0x0000000004000000) != 0;
 		public bool IsManual => ((_value >> 28) & 0xFFFF) == 1;
@@ -112,6 +117,12 @@ namespace Microsoft.Maui.Controls
 			if (extras == ExtrasHandler)
 			{
 				_value = 0xFFFFFFFFFFFFFFFF;
+				return;
+			}
+
+			if (extras == ExtrasUnknown)
+			{
+				_value = 0x8000000000000000;
 				return;
 			}
 

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetIsFocused(bool value)
 		{
-			SetValue(IsFocusedPropertyKey, value, specificity: SetterSpecificity.FromHandler);
+			SetValue(IsFocusedPropertyKey, value, specificity: SetterSpecificity.FromUnknown);
 		}
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler<FocusRequestArgs> FocusChangeRequested;
@@ -297,7 +297,7 @@ namespace Microsoft.Maui.Controls
 		void ISearchHandlerController.ItemSelected(object obj)
 		{
 			OnItemSelected(obj);
-			SetValue(SelectedItemPropertyKey, obj, specificity: SetterSpecificity.FromHandler);
+			SetValue(SelectedItemPropertyKey, obj, specificity: SetterSpecificity.FromUnknown);
 		}
 
 		void ISearchHandlerController.QueryConfirmed()

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.Controls
 			if (CurrentItem == child)
 			{
 				if (ShellItemController.GetItems().Count == 0)
-					ClearValue(CurrentItemProperty, specificity: SetterSpecificity.FromHandler);
+					ClearValue(CurrentItemProperty, specificity: SetterSpecificity.FromUnknown);
 				else
 					SetValueFromRenderer(CurrentItemProperty, ShellItemController.GetItems()[0]);
 			}

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -721,7 +721,7 @@ namespace Microsoft.Maui.Controls
 				var contentItems = ShellSectionController.GetItems();
 				if (contentItems.Count == 0)
 				{
-					ClearValue(CurrentItemProperty, specificity: SetterSpecificity.FromHandler);
+					ClearValue(CurrentItemProperty, specificity: SetterSpecificity.FromUnknown);
 				}
 				else
 				{

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -220,10 +220,10 @@ namespace Microsoft.Maui.Controls
 
 			var shouldTriggerSizeChanged = (Width != frame.Width) || (Height != frame.Height);
 
-			SetValue(XProperty, frame.X, SetterSpecificity.FromHandler);
-			SetValue(YProperty, frame.Y, SetterSpecificity.FromHandler);
-			SetValue(WidthProperty, frame.Width, SetterSpecificity.FromHandler);
-			SetValue(HeightProperty, frame.Height, SetterSpecificity.FromHandler);
+			SetValue(XProperty, frame.X, SetterSpecificity.FromUnknown);
+			SetValue(YProperty, frame.Y, SetterSpecificity.FromUnknown);
+			SetValue(WidthProperty, frame.Width, SetterSpecificity.FromUnknown);
+			SetValue(HeightProperty, frame.Height, SetterSpecificity.FromUnknown);
 
 			_batchFrameUpdate--;
 			if (_batchFrameUpdate < 0)

--- a/src/Controls/src/Core/Xaml/Diagnostics/BindablePropertyDiagnostics.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/BindablePropertyDiagnostics.cs
@@ -28,7 +28,7 @@ internal static class BindablePropertyDiagnostics
 			return new ValueSource(BaseValueSource.Style);
 		if (specificity == SetterSpecificity.Trigger)
 			return new ValueSource(BaseValueSource.StyleTrigger);
-		if (specificity == SetterSpecificity.FromHandler)
+		if (specificity == SetterSpecificity.FromHandler || specificity == SetterSpecificity.FromUnknown)
 			return new ValueSource(BaseValueSource.Unknown, isCurrent: true);
 
 		if (specificity.IsVsm)

--- a/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
@@ -193,5 +193,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(nameof(SetterSpecificity.DefaultValue), list.GetClearedValue(SetterSpecificity.ManualValueSetter));
 			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), list.GetClearedValue(SetterSpecificity.FromHandler));
 		}
+
+		[Fact]
+		public void GetClearedValueForFromUnknown()
+		{
+			var list = new SetterSpecificityList<object>();
+
+			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
+			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list[SetterSpecificity.FromUnknown] = nameof(SetterSpecificity.FromUnknown);
+
+			// Should fall back to ManualValueSetter
+			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), list.GetClearedValue(SetterSpecificity.FromUnknown));
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
Adds a new `SetterSpecificity.FromUnknown` for cases where a value needs to be applied with higher priority but should still be overridable by everything else, including `FromHandler`.

This addresses current misuse of `SetterSpecificity.FromHandler` in scenarios that are *not* actually coming from the platform/handler.
These usages are not handler-driven updates. Overloading FromHandler here undermines its intent and blocks necessary changes (like in #29970) to prevent round-trips in handler-property mappings.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Contributes to #29970
Contributes to #22585

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
