### PR TITLE
Integrate common ISensor interface (net10.0)

### DIFF
--- a/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
+++ b/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// <summary>
 	/// Accelerometer data of the acceleration of the device in three-dimensional space.
 	/// </summary>
-	public interface IAccelerometer
+	public interface IAccelerometer : ISensor
 	{
 		/// <summary>
 		/// Occurs when the sensor reading changes.
@@ -19,30 +19,6 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// Occurs when the accelerometer detects that the device has been shaken.
 		/// </summary>
 		event EventHandler? ShakeDetected;
-
-		/// <summary>
-		/// Gets a value indicating whether reading the accelerometer is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
-		/// <summary>
-		/// Gets a value indicating whether the accelerometer is being monitored.
-		/// </summary>
-		bool IsMonitoring { get; }
-
-		/// <summary>
-		/// Start monitoring for changes to accelerometer.
-		/// </summary>
-		/// <remarks>
-		/// Will throw <see cref="FeatureNotSupportedException"/> if <see cref="IsSupported"/> is <see langword="false"/>.
-		/// Will throw <see cref="InvalidOperationException"/> if <see cref="IsMonitoring"/> is <see langword="true"/>.</remarks>
-		/// <param name="sensorSpeed">Speed to monitor the sensor.</param>
-		void Start(SensorSpeed sensorSpeed);
-
-		/// <summary>
-		/// Stop monitoring for changes to accelerometer.
-		/// </summary>
-		void Stop();
 	}
 
 	/// <summary>

--- a/src/Essentials/src/AppActions/AppActions.shared.cs
+++ b/src/Essentials/src/AppActions/AppActions.shared.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Maui.Devices;
 #if ANDROID
 using Android.Content;
 #endif
@@ -11,13 +12,8 @@ namespace Microsoft.Maui.ApplicationModel
 	/// <summary>
 	/// The AppActions API lets you create and respond to app shortcuts from the app icon.
 	/// </summary>
-	public interface IAppActions
+	public interface IAppActions : IDeviceCapabilities
 	{
-		/// <summary>
-		/// Gets if app actions are supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
 		/// <summary>
 		/// Retrieves all the currently available <see cref="AppAction"/> instances.
 		/// </summary>

--- a/src/Essentials/src/Barometer/Barometer.shared.cs
+++ b/src/Essentials/src/Barometer/Barometer.shared.cs
@@ -7,33 +7,12 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// <summary>
 	/// Monitor changes to the atmospheric pressure.
 	/// </summary>
-	public interface IBarometer
+	public interface IBarometer : ISensor
 	{
-		/// <summary>
-		/// Gets a value indicating whether reading the barometer is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
-		/// <summary>
-		/// Gets a value indicating whether the barometer is actively being monitored.
-		/// </summary>
-		bool IsMonitoring { get; }
-
-		/// <summary>
-		/// Start monitoring for changes to the barometer.
-		/// </summary>
-		/// <param name="sensorSpeed">The speed to listen for changes.</param>
-		void Start(SensorSpeed sensorSpeed);
-
 		/// <summary>
 		/// Occurs when the barometer reading changes.
 		/// </summary>
 		event EventHandler<BarometerChangedEventArgs>? ReadingChanged;
-
-		/// <summary>
-		/// Stop monitoring for changes to the barometer.
-		/// </summary>
-		void Stop();
 	}
 
 	/// <summary>

--- a/src/Essentials/src/Compass/Compass.shared.cs
+++ b/src/Essentials/src/Compass/Compass.shared.cs
@@ -7,35 +7,14 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// <summary>
 	/// Monitor changes to the orientation of the user's device.
 	/// </summary>
-	public interface ICompass
+	public interface ICompass : ISensor
 	{
-		/// <summary>
-		/// Gets a value indicating whether reading the compass is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
-		/// <summary>
-		/// Gets if compass is actively being monitored.
-		/// </summary>
-		bool IsMonitoring { get; }
-
-		/// <summary>
-		/// Start monitoring for changes to the compass.
-		/// </summary>
-		/// <param name="sensorSpeed">The speed to monitor for changes.</param>
-		void Start(SensorSpeed sensorSpeed);
-
 		/// <summary>
 		/// Start monitoring for changes to the compass.
 		/// </summary>
 		/// <param name="sensorSpeed">The speed to monitor for changes.</param>
 		/// <param name="applyLowPassFilter">Whether or not to apply a moving average filter (only used on Android).</param>
 		void Start(SensorSpeed sensorSpeed, bool applyLowPassFilter);
-
-		/// <summary>
-		/// Stop monitoring for changes to the compass.
-		/// </summary>
-		void Stop();
 
 		/// <summary>
 		/// Occurs when compass reading changes.

--- a/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
+++ b/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
@@ -8,29 +8,8 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// <summary>
 	/// The Gyroscope API lets you monitor the device's gyroscope sensor which is the rotation around the device's three primary axes.
 	/// </summary>
-	public interface IGyroscope
+	public interface IGyroscope : ISensor
 	{
-		/// <summary>
-		/// Gets a value indicating whether reading the gyroscope is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
-		/// <summary>
-		/// Gets a value indicating whether the gyroscope is actively being monitored.
-		/// </summary>
-		bool IsMonitoring { get; }
-
-		/// <summary>
-		/// Start monitoring for changes to the gyroscope.
-		/// </summary>
-		/// <param name="sensorSpeed">The speed to listen for changes.</param>
-		void Start(SensorSpeed sensorSpeed);
-
-		/// <summary>
-		/// Stop monitoring for changes to the gyroscope.
-		/// </summary>
-		void Stop();
-
 		/// <summary>
 		/// Occurs when the gyroscope reading changes.
 		/// </summary>

--- a/src/Essentials/src/HapticFeedback/HapticFeedback.shared.cs
+++ b/src/Essentials/src/HapticFeedback/HapticFeedback.shared.cs
@@ -5,13 +5,8 @@ namespace Microsoft.Maui.Devices
 	/// <summary>
 	/// The HapticFeedback API lets you control haptic feedback on the device.
 	/// </summary>
-	public interface IHapticFeedback
+	public interface IHapticFeedback : IDeviceCapabilities
 	{
-		/// <summary>
-		/// Gets a value indicating whether haptic feedback is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
 		/// <summary>
 		/// Perform a type of haptic feedback on the device.
 		/// </summary>

--- a/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
+++ b/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
@@ -6,31 +6,10 @@ using Microsoft.Maui.ApplicationModel;
 namespace Microsoft.Maui.Devices.Sensors
 {
 	/// <summary>
-	/// Detect device's orentation relative to Earth's magnetic field in microteslas (µ).
+	/// Detect device's orentation relative to Earth's magnetic field in microteslas (ï¿½).
 	/// </summary>
-	public interface IMagnetometer
+	public interface IMagnetometer : ISensor
 	{
-		/// <summary>
-		/// Gets a value indicating whether reading the magnetometer is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
-		/// <summary>
-		/// Gets a value indicating whether the magnetometer is actively being monitored.
-		/// </summary>
-		bool IsMonitoring { get; }
-
-		/// <summary>
-		/// Start monitoring for changes to the magnetometer.
-		/// </summary>
-		/// <param name="sensorSpeed">The speed to listen for changes.</param>
-		void Start(SensorSpeed sensorSpeed);
-
-		/// <summary>
-		/// Stop monitoring for changes to the magnetometer.
-		/// </summary>
-		void Stop();
-
 		/// <summary>
 		/// Occurs when the magnetometer reading changes.
 		/// </summary>
@@ -38,7 +17,7 @@ namespace Microsoft.Maui.Devices.Sensors
 	}
 
 	/// <summary>
-	/// Detect device's orentation relative to Earth's magnetic field in microteslas (µ).
+	/// Detect device's orentation relative to Earth's magnetic field in microteslas (ï¿½).
 	/// </summary>
 	public static partial class Magnetometer
 	{
@@ -138,7 +117,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			MagneticField = new Vector3(x, y, z);
 
 		/// <summary>
-		/// Gets the magnetic field vector in microteslas (µ).
+		/// Gets the magnetic field vector in microteslas (ï¿½).
 		/// </summary>
 		public Vector3 MagneticField { get; }
 

--- a/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
+++ b/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
@@ -8,29 +8,8 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// <summary>
 	/// The OrientationSensor API lets you monitor the orientation of a device in three dimensional space.
 	/// </summary>
-	public interface IOrientationSensor
+	public interface IOrientationSensor : ISensor
 	{
-		/// <summary>
-		/// Gets a value indicating whether reading the orientation sensor is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
-		/// <summary>
-		/// Gets a value indicating whether the orientation sensor is actively being monitored.
-		/// </summary>
-		bool IsMonitoring { get; }
-
-		/// <summary>
-		/// Start monitoring for changes to the orientation.
-		/// </summary>
-		/// <param name="sensorSpeed">The speed to listen for changes.</param>
-		void Start(SensorSpeed sensorSpeed);
-
-		/// <summary>
-		/// Stop monitoring for changes to the orientation.
-		/// </summary>
-		void Stop();
-
 		/// <summary>
 		/// Occurs when the orientation reading changes.
 		/// </summary>

--- a/src/Essentials/src/PhoneDialer/PhoneDialer.shared.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.shared.cs
@@ -1,18 +1,14 @@
 #nullable enable
 using System;
+using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.ApplicationModel.Communication
 {
 	/// <summary>
 	/// The PhoneDialer API enables an application to open a phone number in the dialer.
 	/// </summary>
-	public interface IPhoneDialer
+	public interface IPhoneDialer : IDeviceCapabilities
 	{
-		/// <summary>
-		/// Gets a value indicating whether using the phone dialer is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
 		/// <summary>
 		/// Open the phone dialer to a specific phone number.
 		/// </summary>

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -18,9 +18,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
@@ -23,5 +23,41 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
 static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -18,9 +18,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
@@ -23,5 +23,41 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
 static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,9 +18,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
@@ -23,5 +23,41 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
 static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -14,9 +14,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 Microsoft.Maui.Devices.Sensors.ISensor

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3,6 +3,12 @@ Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.SpeechOptions.Rate.get -> float?
 Microsoft.Maui.Media.SpeechOptions.Rate.set -> void
+static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
+static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
+static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
+static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
@@ -13,3 +19,37 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
 static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -18,9 +18,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
@@ -23,5 +23,41 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
 static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
@@ -25,3 +25,39 @@ static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.Med
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -18,9 +18,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -18,9 +18,7 @@ Microsoft.Maui.Storage.IFilePicker.PickMultipleAsync(Microsoft.Maui.Storage.Pick
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticator.AuthenticateAsync(System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 static Microsoft.Maui.Authentication.WebAuthenticatorExtensions.AuthenticateAsync(this Microsoft.Maui.Authentication.IWebAuthenticator! webAuthenticator, System.Uri! url, System.Uri! callbackUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
-static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
 static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
-static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.Maui.Authentication.IWebAuthenticator.AuthenticateAsync(Microsoft.Maui.Authentication.WebAuthenticatorOptions! webAuthenticatorOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Maui.Authentication.WebAuthenticatorResult!>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsEnabled.get -> bool
 Microsoft.Maui.Media.IMediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
@@ -23,5 +23,41 @@ static Microsoft.Maui.Devices.Sensors.Geolocation.IsEnabled.get -> bool
 static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 static Microsoft.Maui.Media.MediaPicker.PickPhotosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Media.MediaPicker.PickVideosAsync(Microsoft.Maui.Media.MediaPickerOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.List<Microsoft.Maui.Storage.FileResult!>!>!
+static Microsoft.Maui.Devices.HapticFeedback.IsSupported.get -> bool
+static Microsoft.Maui.Devices.Vibration.IsSupported.get -> bool
 *REMOVED*static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult!>!>!
 static Microsoft.Maui.Storage.FilePicker.PickMultipleAsync(Microsoft.Maui.Storage.PickOptions? options = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Maui.Storage.FileResult?>!>!
+Microsoft.Maui.Devices.Sensors.ISensor
+Microsoft.Maui.Devices.Sensors.ISensor.IsMonitoring.get -> bool
+Microsoft.Maui.Devices.Sensors.ISensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+Microsoft.Maui.Devices.Sensors.ISensor.Stop() -> void
+Microsoft.Maui.Devices.IDeviceCapabilities
+Microsoft.Maui.Devices.IDeviceCapabilities.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.ApplicationModel.IAppActions.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IHapticFeedback.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.IVibration.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IAccelerometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IBarometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.ICompass.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IGyroscope.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IMagnetometer.Stop() -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsMonitoring.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.IsSupported.get -> bool
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Start(Microsoft.Maui.Devices.Sensors.SensorSpeed sensorSpeed) -> void
+*REMOVED*Microsoft.Maui.Devices.Sensors.IOrientationSensor.Stop() -> void

--- a/src/Essentials/src/Sensors/IDeviceCapabilities.shared.cs
+++ b/src/Essentials/src/Sensors/IDeviceCapabilities.shared.cs
@@ -1,0 +1,15 @@
+#nullable enable
+namespace Microsoft.Maui.Devices
+{
+	/// <summary>
+	/// Base interface for all interfaces related to device capabilities.
+	/// </summary>
+	public interface IDeviceCapabilities
+	{
+		/// <summary>
+		/// Gets a value indicating whether the device supports the specific capability.
+		/// </summary>
+		bool IsSupported { get; }
+
+	}
+}

--- a/src/Essentials/src/Sensors/ISensors.shared.cs
+++ b/src/Essentials/src/Sensors/ISensors.shared.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System;
+using System.Numerics;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.ApplicationModel;
+
+namespace Microsoft.Maui.Devices.Sensors
+{
+	/// <summary>
+	/// Base interface for all sensors.
+	/// </summary>
+	public interface ISensor : IDeviceCapabilities
+	{
+		/// <summary>
+		/// Gets a value indicating whether the sensor is actively being monitored.
+		/// </summary>
+		bool IsMonitoring { get; }
+
+		/// <summary>
+		/// Start monitoring for changes to the sensor.
+		/// </summary>
+		/// <remarks>
+		/// Will throw <see cref="FeatureNotSupportedException"/> if <see cref="IDeviceCapabilities.IsSupported"/> is <see langword="false"/>.
+		/// Will throw <see cref="InvalidOperationException"/> if <see cref="IsMonitoring"/> is <see langword="true"/>.</remarks>
+		/// <param name="sensorSpeed">Speed to monitor the sensor.</param>
+		void Start(SensorSpeed sensorSpeed);
+
+		/// <summary>
+		/// Stop monitoring for changes to the sensor.
+		/// </summary>
+		void Stop();
+	}
+}

--- a/src/Essentials/src/Vibration/Vibration.shared.cs
+++ b/src/Essentials/src/Vibration/Vibration.shared.cs
@@ -7,13 +7,8 @@ namespace Microsoft.Maui.Devices
 	/// <summary>
 	/// The Vibration API provides an easy way to make the device vibrate.
 	/// </summary>
-	public interface IVibration
+	public interface IVibration : IDeviceCapabilities
 	{
-		/// <summary>
-		/// Gets a value indicating whether vibration is supported on this device.
-		/// </summary>
-		bool IsSupported { get; }
-
 		/// <summary>
 		/// Vibrates the device for 500ms.
 		/// </summary>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Extends sensor interfaces such as IAccelerometer, IBarometer, ICompass, IGyroscope, IMagnetometer, and IOrientationSensor with a common ISensor interface to unify capabilities. Eliminates redundant IsSupported and IsMonitoring properties and Start/Stop methods from individual sensor interfaces. Updates IAppActions, IHapticFeedback, IPhoneDialer, and IVibration to extend from IDeviceCapabilities for uniformity. Improves code maintainability by reducing duplicate functionality.

Relates to codebase cleanup and standardization.

(net9 PR : https://github.com/dotnet/maui/pull/30121)