### PR TITLE
[net10.0, Testing] Fix LabelFeatureTests Screenshot Issue on Windows

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/LabelFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/LabelFeatureTests.cs
@@ -524,6 +524,8 @@ public class LabelFeatureTests : UITest
 		App.EnterText(FontSizeEntry, "24");
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		App.WaitForElement(MainLabel);
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -573,6 +575,8 @@ public class LabelFeatureTests : UITest
 		App.EnterText(CharacterSpacingEntry, "3");
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		App.WaitForElement(MainLabel);
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -713,6 +717,8 @@ public class LabelFeatureTests : UITest
 		App.EnterText(MaxLinesEntry, "1");
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		App.WaitForElement(MainLabel);
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -730,6 +736,8 @@ public class LabelFeatureTests : UITest
 		App.EnterText(LineHeightEntry, "2");
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		App.WaitForElement(MainLabel);
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 


### PR DESCRIPTION
 This pull request enhances the test cases for verifying label features in LabelFeatureTests.cs by ensuring that the main label is explicitly tapped before taking a screenshot. This interaction removes the keyboard navigation focus indicator (black box) that may appear if a control is previously focused via keyboard. By tapping another region (the label), the black box disappears, resulting in more reliable and cleaner screenshots for verification.
Enhancements to label feature test cases:

* [`VerifyLabelWithTextAndFontSize`](diffhunk://#diff-b2437c826a2d886630a2dea353292dab5c18c9ccf00fe84418d9ed12a28f0827R527-R528): Added steps to wait for and tap on `MainLabel` before verifying the screenshot.
* [`VerifyLabelWithTextAndCharacterSpacing`](diffhunk://#diff-b2437c826a2d886630a2dea353292dab5c18c9ccf00fe84418d9ed12a28f0827R578-R579): Added steps to wait for and tap on `MainLabel` before verifying the screenshot.
* [`VerifyLabelWithTextAndMaxlines`](diffhunk://#diff-b2437c826a2d886630a2dea353292dab5c18c9ccf00fe84418d9ed12a28f0827R720-R721): Added steps to wait for and tap on `MainLabel` before verifying the screenshot.
* [`VerifyLabelWithTextWhenLineHeight`](diffhunk://#diff-b2437c826a2d886630a2dea353292dab5c18c9ccf00fe84418d9ed12a28f0827R739-R740): Added steps to wait for and tap on `MainLabel` before verifying the screenshot.