### PR TITLE
[ci] Use new maui release variable group

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -21,182 +21,174 @@ parameters:
 
 steps:
 
-  ##################################################
-  #               Provision Machine                #
-  ##################################################
+##################################################
+#               Provision Machine                #
+##################################################
 
-  # Clean the machine for iOS builds that are running on physical machines
-  - ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines')) }}:
-    - bash: |
-        chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-        chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-simulator-runtime.sh
-        $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-      displayName: 'Clean bot'
-      continueOnError: true
-      timeoutInMinutes: 60
+# Clean the machine for iOS builds that are running on physical machines
+- ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines')) }}:
+  - bash: |
+      chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+      chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-simulator-runtime.sh
+      $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+    displayName: 'Clean bot'
+    continueOnError: true
+    timeoutInMinutes: 60
 
-  # Enable KVM for Android builds on Linux
-  - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
-    - bash: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
-      displayName: Enable KVM
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))      
+# Enable KVM for Android builds on Linux
+- ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
+  - bash: |
+      echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+      sudo udevadm control --reload-rules
+      sudo udevadm trigger --name-match=kvm
+    displayName: Enable KVM
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  # Provision the various SDKs that are needed
-  - template: provision.yml
-    parameters:
-      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
-      skipJdk: ${{ ne(parameters.platform, 'android') }}
-      skipAndroidCommonSdks: ${{ ne(parameters.platform, 'android') }}
-      skipAndroidPlatformApis: ${{ or(eq(parameters.buildType, 'testOnly'), ne(parameters.platform, 'android')) }}
-      onlyAndroidPlatformDefaultApis: true
-      skipAndroidEmulatorImages: ${{ or(eq(parameters.buildType, 'buildOnly'), ne(parameters.platform, 'android')) }}
-      skipAndroidCreateAvds: true
-      androidEmulatorApiLevel: ${{ parameters.apiversion }}
-      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-      ${{ if eq(parameters.skipProvisioning, false) }}:
-        skipProvisionator : false
-        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      skipInternalFeeds: ${{ eq(parameters.buildType, 'testOnly') }}
+# Provision the various SDKs that are needed
+- template: provision.yml
+  parameters:
+    skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
+    skipJdk: ${{ ne(parameters.platform, 'android') }}
+    skipAndroidCommonSdks: ${{ ne(parameters.platform, 'android') }}
+    skipAndroidPlatformApis: ${{ or(eq(parameters.buildType, 'testOnly'), ne(parameters.platform, 'android')) }}
+    onlyAndroidPlatformDefaultApis: true
+    skipAndroidEmulatorImages: ${{ or(eq(parameters.buildType, 'buildOnly'), ne(parameters.platform, 'android')) }}
+    skipAndroidCreateAvds: true
+    androidEmulatorApiLevel: ${{ parameters.apiversion }}
+    provisionatorChannel: ${{ parameters.provisionatorChannel }}
+    ${{ if eq(parameters.skipProvisioning, false) }}:
+      skipProvisionator: false
+    skipInternalFeeds: ${{ eq(parameters.buildType, 'testOnly') }}
 
+##################################################
+#                Provision .NET                  #
+##################################################
 
-  ##################################################
-  #                Provision .NET                  #
-  ##################################################
+# Install a local .NET SDK
+- script: dotnet cake --target=dotnet --configuration="Release" --verbosity=diagnostic
+  displayName: 'Install .NET'
+  condition: and(succeeded(), ne('${{ parameters.skipDotNet }}', 'true'))
+  retryCountOnTaskFailure: 3
+  env:
+    DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+    PRIVATE_BUILD: $(PrivateBuild)
 
-  # Install a local .NET SDK
-  - script: dotnet cake --target=dotnet --configuration="Release" --verbosity=diagnostic
-    displayName: 'Install .NET'
-    condition: and(succeeded(), ne('${{ parameters.skipDotNet }}', 'true'))
-    retryCountOnTaskFailure: 3
-    env:
-      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-      PRIVATE_BUILD: $(PrivateBuild)
+# Add the .NET SDK to the PATH
+- pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+  displayName: 'Add .NET to PATH'
+  condition: and(succeeded(), ne('${{ parameters.skipDotNet }}', 'true'))
 
-  # Add the .NET SDK to the PATH
-  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
-    displayName: 'Add .NET to PATH'
-    condition: and(succeeded(), ne('${{ parameters.skipDotNet }}', 'true'))
+##################################################
+#                 Prepare Build                  #
+##################################################
 
+# Do not prepare the .NET install if we are not going to build anything
+- ${{ if ne(parameters.buildType, 'testOnly') }}:
 
-  ##################################################
-  #                 Prepare Build                  #
-  ##################################################
+  # Download the pre-build .NET MAUI workload and install it to the local .NET SDK
+  - ${{ if eq(parameters.useArtifacts, true) }}:
 
-  # Do not prepare the .NET install if we are not going to build anything
-  - ${{ if ne(parameters.buildType, 'testOnly') }}:
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Packages'
+      inputs:
+        artifactName: ${{ parameters.artifactName }}
+        itemPattern: ${{ parameters.artifactItemPattern }}
+        downloadPath: ${{ parameters.checkoutDirectory }}/artifacts
 
-    # Download the pre-build .NET MAUI workload and install it to the local .NET SDK
-    - ${{ if eq(parameters.useArtifacts, true) }}:
+    - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
+      displayName: Move the downloaded artifacts
 
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download Packages'
-        inputs:
-          artifactName: ${{ parameters.artifactName }}
-          itemPattern: ${{ parameters.artifactItemPattern }}
-          downloadPath: ${{ parameters.checkoutDirectory }}/artifacts
+    - script: dotnet cake --target=dotnet-local-workloads --verbosity=diagnostic
+      displayName: 'Install .NET (Local Workloads)'
+      retryCountOnTaskFailure: 2
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+      env:
+        DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+        PRIVATE_BUILD: $(PrivateBuild)
 
-      - pwsh: Move-Item -Path artifacts\${{ parameters.artifactName }}\*.nupkg -Destination artifacts -Force
-        displayName: Move the downloaded artifacts
+  # Run the build for .NET MAUI on this machine
+  - ${{ else }}:
 
-      - script: dotnet cake --target=dotnet-local-workloads --verbosity=diagnostic
-        displayName: 'Install .NET (Local Workloads)'
-        retryCountOnTaskFailure: 2
-        workingDirectory: ${{ parameters.checkoutDirectory }}
-        env:
-          DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-          PRIVATE_BUILD: $(PrivateBuild)
+    - script: dotnet cake --target=dotnet-buildtasks --configuration="Release"
+      displayName: 'Build the MSBuild Tasks'
 
-    # Run the build for .NET MAUI on this machine
-    - ${{ else }}:
+##################################################
+#                  Prepare Run                   #
+##################################################
 
-      - script: dotnet cake --target=dotnet-buildtasks --configuration="Release"
-        displayName: 'Build the MSBuild Tasks'
+# If this job is a test-only job, download the pre-built artifacts from the build job
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download Build'
+  condition: and(succeeded(), eq('${{ parameters.buildType }}', 'testOnly'))
+  inputs:
+    artifactName: ${{ parameters.appArtifactName }}
+    targetPath: ${{ parameters.checkoutDirectory }}/artifacts/bin
 
+##################################################
+#                  Build / Run                   #
+##################################################
 
-  ##################################################
-  #                  Prepare Run                   #
-  ##################################################
+# First run the build if this is a build-only or build-and-test job
+- script: dotnet cake eng/devices/${{ parameters.platform }}.cake --target="buildOnly" --project="${{ parameters.path }}" --binlog="$(LogDirectory)" --configuration="${{ parameters.deviceTestConfiguration }}" --targetFrameworkVersion="${{ parameters.targetFrameworkVersion }}" ${{ iif(eq(parameters.device, ''), '', format('--device="{0}"', parameters.device)) }} ${{ iif(eq(parameters.apiversion, ''), '', format('--apiversion="{0}"', parameters.apiversion)) }} --create="${{ ne(parameters.buildType, 'buildOnly') }}" --packageid "${{ parameters.packageid }}" --results="$(TestResultsDirectory)" --workloads="${{ iif(eq(parameters.skipDotNet, 'true'), 'global', 'local') }}" --verbosity=diagnostic ${{ parameters.cakeArgs }}
+  displayName: Execute Build
+  workingDirectory: ${{ parameters.checkoutDirectory }}
+  condition: and(succeeded(), ne('${{ parameters.buildType }}', 'testOnly'))
+  retryCountOnTaskFailure: 1
 
-  # If this job is a test-only job, download the pre-built artifacts from the build job
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download Build'
-    condition: and(succeeded(), eq('${{ parameters.buildType }}', 'testOnly'))
-    inputs:
-      artifactName: ${{ parameters.appArtifactName }}
-      targetPath: ${{ parameters.checkoutDirectory }}/artifacts/bin
-
-
-  ##################################################
-  #                  Build / Run                   #
-  ##################################################
-
-  # First run the build if this is a build-only or build-and-test job
-  - script: dotnet cake eng/devices/${{ parameters.platform }}.cake --target="buildOnly" --project="${{ parameters.path }}" --binlog="$(LogDirectory)" --configuration="${{ parameters.deviceTestConfiguration }}" --targetFrameworkVersion="${{ parameters.targetFrameworkVersion }}" ${{ iif(eq(parameters.device, ''), '', format('--device="{0}"', parameters.device)) }} ${{ iif(eq(parameters.apiversion, ''), '', format('--apiversion="{0}"', parameters.apiversion)) }} --create="${{ ne(parameters.buildType, 'buildOnly') }}" --packageid "${{ parameters.packageid }}" --results="$(TestResultsDirectory)" --workloads="${{ iif(eq(parameters.skipDotNet, 'true'), 'global', 'local') }}" --verbosity=diagnostic ${{ parameters.cakeArgs }}
-    displayName: Execute Build
-    workingDirectory: ${{ parameters.checkoutDirectory }}
-    condition: and(succeeded(), ne('${{ parameters.buildType }}', 'testOnly'))
+# Then run the tests if this is a test-only or build-and-test job
+- script: dotnet cake eng/devices/${{ parameters.platform }}.cake --target="testOnly" --project="${{ parameters.path }}" --binlog="$(LogDirectory)" --configuration="${{ parameters.deviceTestConfiguration }}" --targetFrameworkVersion="${{ parameters.targetFrameworkVersion }}" ${{ iif(eq(parameters.device, ''), '', format('--device="{0}"', parameters.device)) }} ${{ iif(eq(parameters.apiversion, ''), '', format('--apiversion="{0}"', parameters.apiversion)) }} --create="${{ ne(parameters.buildType, 'buildOnly') }}" --packageid "${{ parameters.packageid }}" --results="$(TestResultsDirectory)" --workloads="${{ iif(eq(parameters.skipDotNet, 'true'), 'global', 'local') }}" --verbosity=diagnostic ${{ parameters.cakeArgs }}
+  displayName: Execute Test Run
+  workingDirectory: ${{ parameters.checkoutDirectory }}
+  condition: and(succeeded(), ne('${{ parameters.buildType }}', 'buildOnly'))
+  ${{ if or(eq(parameters.buildType, 'windows'), eq(parameters.platform, 'android')) }}:
     retryCountOnTaskFailure: 1
 
-  # Then run the tests if this is a test-only or build-and-test job
-  - script: dotnet cake eng/devices/${{ parameters.platform }}.cake --target="testOnly" --project="${{ parameters.path }}" --binlog="$(LogDirectory)" --configuration="${{ parameters.deviceTestConfiguration }}" --targetFrameworkVersion="${{ parameters.targetFrameworkVersion }}" ${{ iif(eq(parameters.device, ''), '', format('--device="{0}"', parameters.device)) }} ${{ iif(eq(parameters.apiversion, ''), '', format('--apiversion="{0}"', parameters.apiversion)) }} --create="${{ ne(parameters.buildType, 'buildOnly') }}" --packageid "${{ parameters.packageid }}" --results="$(TestResultsDirectory)" --workloads="${{ iif(eq(parameters.skipDotNet, 'true'), 'global', 'local') }}" --verbosity=diagnostic ${{ parameters.cakeArgs }}
-    displayName: Execute Test Run
-    workingDirectory: ${{ parameters.checkoutDirectory }}
-    condition: and(succeeded(), ne('${{ parameters.buildType }}', 'buildOnly'))
-    ${{ if or(eq(parameters.buildType, 'windows'), eq(parameters.platform, 'android')) }}:
-      retryCountOnTaskFailure: 1
+##################################################
+#                    Publish                     #
+##################################################
 
+# Cleanup and create simulator logs for iOS builds
+- ${{ if eq(parameters.platform, 'ios')}}:
+  - script: dotnet cake --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+    displayName: Cleanup and Create Simulator Logs
+    condition: always()
+    continueOnError: true
 
-  ##################################################
-  #                    Publish                     #
-  ##################################################
+# Publish the artifacts directory if this is a build-only job
+- ${{ if eq(parameters.buildType, 'buildOnly') }}:
+  - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
+    displayName: Publish Succeeded Artifacts Directory
+    condition: succeeded()
+    artifact: ${{ parameters.appArtifactName }}
+  - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
+    displayName: Publish Failed Artifacts Directory
+    condition: not(succeeded())
+    artifact: ${{ parameters.appArtifactName }}_failed_$(System.JobAttempt)
 
-  # Cleanup and create simulator logs for iOS builds
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - script: dotnet cake --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
-      displayName: Cleanup and Create Simulator Logs
-      condition: always()
-      continueOnError: true
-
-  # Publish the artifacts directory if this is a build-only job
-  - ${{ if eq(parameters.buildType, 'buildOnly') }}:
-    - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
-      displayName: Publish Succeeded Artifacts Directory
-      condition: succeeded()
-      artifact: ${{ parameters.appArtifactName }}
-    - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
-      displayName: Publish Failed Artifacts Directory
-      condition: not(succeeded())
-      artifact: ${{ parameters.appArtifactName }}_failed_$(System.JobAttempt)
-
-  # Publish the test results
-  - ${{ if ne(parameters.buildType, 'buildOnly') }}:
-    - task: PublishTestResults@2
-      displayName: Publish the $(Agent.JobName) test results
-      condition: always()
-      inputs:
-        testResultsFormat: xUnit
-        testResultsFiles: '$(TestResultsDirectory)/**/TestResults*(-*).xml'
-        testRunTitle: '$(Agent.JobName) (attempt $(System.JobAttempt))'
-
-  # Publish the job artifacts
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Logs
+# Publish the test results
+- ${{ if ne(parameters.buildType, 'buildOnly') }}:
+  - task: PublishTestResults@2
+    displayName: Publish the $(Agent.JobName) test results
     condition: always()
     inputs:
-      artifactName: '$(Agent.JobName) (attempt $(System.JobAttempt))'
+      testResultsFormat: xUnit
+      testResultsFiles: '$(TestResultsDirectory)/**/TestResults*(-*).xml'
+      testRunTitle: '$(Agent.JobName) (attempt $(System.JobAttempt))'
 
+# Publish the job artifacts
+- task: PublishBuildArtifacts@1
+  displayName: Publish Logs
+  condition: always()
+  inputs:
+    artifactName: '$(Agent.JobName) (attempt $(System.JobAttempt))'
+##################################################
+#                    Reboot                      #
+##################################################
 
-  ##################################################
-  #                    Reboot                      #
-  ##################################################
-
-  # Reboot the physical macs after running iOS tests
-  - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'ios')) }}:
-    - ${{ if and(ne(parameters.poolName, 'Azure Pipelines'), eq(variables['System.TeamProject'], 'devdiv') ) }}:
-      # This must always be placed as the last step in the job
-      - template: agent-rebooter/mac.v1.yml@yaml-templates
-        parameters:
-          AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+# Reboot the physical macs after running iOS tests
+# - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'ios')) }}:
+#   - ${{ if and(ne(parameters.poolName, 'Azure Pipelines'), eq(variables['System.TeamProject'], 'devdiv') ) }}:
+#     # This must always be placed as the last step in the job
+#     - template: agent-rebooter/mac.v1.yml@yaml-templates
+#       parameters:
+#         AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -30,7 +30,7 @@ parameters:
 - name: nugetFolder
   type: string
   default: 'artifacts'
-  
+
 - name: prepareSteps
   type: stepList
   default: []
@@ -38,10 +38,6 @@ parameters:
 - name: postSteps
   type: stepList
   default: []
-
-- name: gitHubToken
-  type: string
-  default: $(github--pat--vs-mobiletools-engineering-service2)
 
 - name: checkoutDirectory
   type: string
@@ -57,8 +53,9 @@ parameters:
 
 - name: buildConfiguration
   type: string
-  default: 
-  
+  default:
+
+
 - name: runAsPublic
   type: boolean
   default: false

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -19,7 +19,8 @@ parameters:
   provisionatorXCodePath: $(provisionator.xcode)
   provisionatorChannel: 'latest'
   provisionatorExtraArguments: $(provisionator.extraArguments)
-  gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+  provisionatorUri: $(provisionator-uri)
+  gitHubToken: $(provisionator--github--pat)
   certPass: $(maui-cert-password) # This lives on MAUI variable group
   certName: 'MauiCert.p12'
   openSslArgs: '-legacy'
@@ -54,6 +55,7 @@ steps:
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
       displayName: 'Provision Xcode'
       inputs:
+        provisionator_uri: ${{ parameters.provisionatorUri }}
         provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorXCodePath }}
         provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
         github_token: ${{ parameters.gitHubToken }}

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -8,90 +8,89 @@ parameters:
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
   skipProvisioning: true
-  configuration : "Release"
+  configuration: "Release"
   testFilter: ''
   runtimeVariant: 'Mono'
 
 steps:
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - bash: |
-        chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-        $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-      displayName: 'Clean bot'
-      continueOnError: true
-      timeoutInMinutes: 60
-
-  - template: provision.yml
-    parameters:
-      # FIXME: 'Build the MSBuild Tasks' step fails for net9.0-android35 without API 35
-      skipAndroidSdks: false
-      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
-      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-      ${{ if parameters.skipProvisioning }}:
-        skipProvisionator: true
-      ${{ else }}:  
-        skipProvisionator: false
-        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-      
-  - task: PowerShell@2
-    condition: ne('${{ parameters.platform }}' , 'windows')
-    inputs:
-      targetType: 'inline'
-      script: |
-        defaults write -g NSAutomaticCapitalizationEnabled -bool false
-        defaults write -g NSAutomaticTextCompletionEnabled -bool false
-        defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
-    displayName: "Modify defaults"
-    continueOnError: true
-
-  - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
-    displayName: 'Install .NET'
-    retryCountOnTaskFailure: 2
-    env:
-      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-      PRIVATE_BUILD: $(PrivateBuild)
-
-  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
-    displayName: 'Add .NET to PATH'
-
-  - pwsh: |
-      Get-Content $PSCommandPath
-      ./build.ps1 --target=uitests-apphost --configuration="${{ parameters.configuration }}" --${{ parameters.platform }} --verbosity=diagnostic --usenuget=false --runtimevariant="${{ parameters.runtimeVariant }}"
-    displayName: 'Build the samples'
-
+- ${{ if eq(parameters.platform, 'ios')}}:
   - bash: |
-      if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
-      if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
-    displayName: Delete Old Simulator Logs
-    condition: ${{ eq(parameters.platform, 'ios') }}
+      chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+      $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+    displayName: 'Clean bot'
     continueOnError: true
+    timeoutInMinutes: 60
 
-  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
-    condition: and(ne('${{ parameters.platform }}' , 'windows'), ne('${{ parameters.runtimeVariant }}' , 'NativeAOT'), succeeded())
-    artifact: ui-tests-samples
-  
-  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
-    condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'), succeeded())
-    artifact: ui-tests-samples-nativeaot
+- template: provision.yml
+  parameters:
+    # FIXME: 'Build the MSBuild Tasks' step fails for net9.0-android35 without API 35
+    skipAndroidSdks: false
+    skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
+    provisionatorChannel: ${{ parameters.provisionatorChannel }}
+    ${{ if parameters.skipProvisioning }}:
+      skipProvisionator: true
+    ${{ else }}:
+      skipProvisionator: false
 
-  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
-    condition: and(eq('${{ parameters.platform }}' , 'windows'), succeeded())
-    artifact: ui-tests-samples-windows
+- task: PowerShell@2
+  condition: ne('${{ parameters.platform }}' , 'windows')
+  inputs:
+    targetType: 'inline'
+    script: |
+      defaults write -g NSAutomaticCapitalizationEnabled -bool false
+      defaults write -g NSAutomaticTextCompletionEnabled -bool false
+      defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
+  displayName: "Modify defaults"
+  continueOnError: true
 
-  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
-    condition: and(ne('${{ parameters.platform }}' , 'windows'), ne('${{ parameters.runtimeVariant }}' , 'NativeAOT'), failed())
-    artifact: ui-tests-samples_failed_$(System.JobAttempt)
+- pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
+  displayName: 'Install .NET'
+  retryCountOnTaskFailure: 2
+  env:
+    DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+    PRIVATE_BUILD: $(PrivateBuild)
 
-  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
-    condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'), failed())
-    artifact: ui-tests-samples-nativeaot_failed_$(System.JobAttempt)
+- pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+  displayName: 'Add .NET to PATH'
 
-  - publish: $(System.DefaultWorkingDirectory)/artifacts/bin
-    condition: and(eq('${{ parameters.platform }}' , 'windows'), failed())
-    artifact: ui-tests-samples-windows_failed_$(System.JobAttempt)
+- pwsh: |
+    Get-Content $PSCommandPath
+    ./build.ps1 --target=uitests-apphost --configuration="${{ parameters.configuration }}" --${{ parameters.platform }} --verbosity=diagnostic --usenuget=false --runtimevariant="${{ parameters.runtimeVariant }}"
+  displayName: 'Build the samples'
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    condition: always()
-    inputs:
-      artifactName: '$(Agent.JobName) (attempt $(System.JobAttempt))'
+- bash: |
+    if [ -f "$HOME/Library/Logs/CoreSimulator/*" ]; then rm -r $HOME/Library/Logs/CoreSimulator/*; fi
+    if [ -f "$HOME/Library/Logs/DiagnosticReports/*" ]; then rm -r $HOME/Library/Logs/DiagnosticReports/*; fi
+  displayName: Delete Old Simulator Logs
+  condition: ${{ eq(parameters.platform, 'ios') }}
+  continueOnError: true
+
+- publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+  condition: and(ne('${{ parameters.platform }}' , 'windows'), ne('${{ parameters.runtimeVariant }}' , 'NativeAOT'), succeeded())
+  artifact: ui-tests-samples
+
+- publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'), succeeded())
+  artifact: ui-tests-samples-nativeaot
+
+- publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+  condition: and(eq('${{ parameters.platform }}' , 'windows'), succeeded())
+  artifact: ui-tests-samples-windows
+
+- publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+  condition: and(ne('${{ parameters.platform }}' , 'windows'), ne('${{ parameters.runtimeVariant }}' , 'NativeAOT'), failed())
+  artifact: ui-tests-samples_failed_$(System.JobAttempt)
+
+- publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'), failed())
+  artifact: ui-tests-samples-nativeaot_failed_$(System.JobAttempt)
+
+- publish: $(System.DefaultWorkingDirectory)/artifacts/bin
+  condition: and(eq('${{ parameters.platform }}' , 'windows'), failed())
+  artifact: ui-tests-samples-windows_failed_$(System.JobAttempt)
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Artifacts
+  condition: always()
+  inputs:
+    artifactName: '$(Agent.JobName) (attempt $(System.JobAttempt))'

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -69,7 +69,6 @@ steps:
       skipProvisionator: true
     ${{ else }}:
       skipProvisionator: false
-      gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
     ${{ if eq(parameters.platform, 'catalyst') }}:
       openSslArgs: '' # Do not use legacy openssl for Catalyst builds
 

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -50,15 +50,11 @@ variables:
 - name: _InternalBuildArgs
   value: ''
 
-# Variable groups required for all builds
-- ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
-  - group: maui-provisionator # This is just needed for the provisionator
-  - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
-
 # Variable groups required for private builds but not prs
 # Variable group for maui release pipelines
-- ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['UseProvisionator'], 'true')) }}:
   - group: maui-provisionator
+  - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
 
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - name: internalProvisioning

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -52,12 +52,13 @@ variables:
 
 # Variable groups required for all builds
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
-  - group: xamops-azdev-secrets
   - group: maui-provisionator # This is just needed for the provisionator
   - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
-  # Variable groups required for private builds but not prs
-- ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
-  - group: Xamarin-Secrets
+
+# Variable groups required for private builds but not prs
+# Variable group for maui release pipelines
+- ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+  - group: maui-provisionator
 
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - name: internalProvisioning
@@ -71,8 +72,6 @@ variables:
       value: true
     - name: _SignType
       value: real
-    # - name: PostBuildSign
-    #   value: true
 
     - group: DotNetBuilds storage account read tokens
     - group: AzureDevOps-Artifact-Feeds-Pats
@@ -86,3 +85,7 @@ variables:
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
+
+- ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui-release') }}:
+  # maui-nuget-release provides: pat--nuget--xamarinc--push--wildcard
+  - group: maui-nuget-release

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -50,10 +50,9 @@ variables:
 - name: _InternalBuildArgs
   value: ''
 
-# Variable groups required for private builds but not prs
-# Variable group for maui release pipelines
-- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['UseProvisionator'], 'true')) }}:
-  - group: maui-provisionator
+# Variable groups required for all builds
+- ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
+  - group: maui-provisionator # This is just needed for the provisionator
   - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
 
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -44,9 +44,7 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
-  - template: /eng/pipelines/common/variables.yml
-  - name: AgentPoolAccessToken
-    value: $(botdeploy--azdo--token)
+- template: /eng/pipelines/common/variables.yml@self
 
 parameters:
 
@@ -114,7 +112,7 @@ stages:
       iosPool: ${{ parameters.iosPool }}
       catalystPool: ${{ parameters.catalystPool }}
       windowsPool: ${{ parameters.windowsPool }}
-      agentPoolAccessToken: $(AgentPoolAccessToken)
+      # agentPoolAccessToken: $(AgentPoolAccessToken)
       targetFrameworkVersion: ${{ targetFrameworkVersion }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -42,323 +42,311 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
-  - template: /eng/pipelines/common/variables.yml
+- template: /eng/pipelines/common/variables.yml
 
 parameters:
 
-  - name: UseProvisionator
-    type: boolean
-    default: false
+- name: UseProvisionator
+  type: boolean
+  default: false
 
-  - name: provisionatorChannel
-    displayName: 'Provisionator channel'
-    type: string
-    default: 'latest'           # Support for launching a build against a Provisionator PR (e.g., pr/[github-account-name]/[pr-number]) as a means to test in-progress Provisionator changes
+- name: provisionatorChannel
+  displayName: 'Provisionator channel'
+  type: string
+  default: 'latest' # Support for launching a build against a Provisionator PR (e.g., pr/[github-account-name]/[pr-number]) as a means to test in-progress Provisionator changes
 
-  - name: BuildEverything
-    type: boolean
-    default: false
+- name: BuildEverything
+  type: boolean
+  default: false
 
-  - name: BuildConfigurations
-    type: object
-    default:
-      - Debug
-      - Release
+- name: BuildConfigurations
+  type: object
+  default:
+  - Debug
+  - Release
 
-  - name: BuildPlatforms
-    type: object
-    default:
-      - name: Windows
-        poolName: $(windowsVmPool)
-        vmImage: $(windowsVmImage)
-        demands:
-           - Agent.OS -equals Windows_NT        
-        artifact: build-windows
-      - name: macOS
-        poolName: $(macOSXVmPool)
-        vmImage: $(macOSXVmImage)
-        demands:
-          - macOS.Name -equals Sequoia
-          - macOS.Architecture -equals x64
-        artifact: build-macos
- 
-  - name: PackPlatforms
-    type: object
-    default:
-      - name: Windows
-        poolName: $(windowsVmPool)
-        vmImage: $(windowsVmImage)
-        demands: 
-          - Agent.OS -equals Windows_NT
-        artifact: nuget
+- name: BuildPlatforms
+  type: object
+  default:
+  - name: Windows
+    poolName: $(windowsVmPool)
+    vmImage: $(windowsVmImage)
+    demands:
+    - Agent.OS -equals Windows_NT
+    artifact: build-windows
+  - name: macOS
+    poolName: $(macOSXVmPool)
+    vmImage: $(macOSXVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
+    - macOS.Architecture -equals x64
+    artifact: build-macos
 
-  - name: BuildTemplatePlatforms
-    type: object
-    default:
-      - name: Windows
-        poolName: $(windowsVmPool)
-        vmImage: $(windowsVmImage)
-        demands: 
-          - Agent.OS -equals Windows_NT
-        artifact: build-windows
-      - name: macOS
-        poolName: $(macOSXVmPool)
-        vmImage: $(macOSXVmImage)
-        demands:
-          - macOS.Name -equals Sequoia
-          - macOS.Architecture -equals x64
-        artifact: build-macos
+- name: PackPlatforms
+  type: object
+  default:
+  - name: Windows
+    poolName: $(windowsVmPool)
+    vmImage: $(windowsVmImage)
+    demands:
+    - Agent.OS -equals Windows_NT
+    artifact: nuget
 
-  - name: RunTemplatePlatforms
-    type: object
-    default:
-    - name: $(androidTestsVmPool)
-      vmImage: $(androidTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
-        - macOS.Architecture -equals x64
-      testName: RunOnAndroid
-      artifact: templates-run-android
-    - name: $(iosTestsVmPool)
-      vmImage: $(iosTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
-        - macOS.Architecture -equals x64
-      testName: RunOniOS
-      artifact: templates-run-ios
+- name: BuildTemplatePlatforms
+  type: object
+  default:
+  - name: Windows
+    poolName: $(windowsVmPool)
+    vmImage: $(windowsVmImage)
+    demands:
+    - Agent.OS -equals Windows_NT
+    artifact: build-windows
+  - name: macOS
+    poolName: $(macOSXVmPool)
+    vmImage: $(macOSXVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
+    - macOS.Architecture -equals x64
+    artifact: build-macos
 
-  - name: MacTemplatePool
-    type: object
-    default:
-      name: $(androidTestsVmPool)
-      vmImage: $(androidTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
-        - macOS.Architecture -equals arm64
+- name: RunTemplatePlatforms
+  type: object
+  default:
+  - name: $(androidTestsVmPool)
+    vmImage: $(androidTestsVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
+    - macOS.Architecture -equals x64
+    testName: RunOnAndroid
+    artifact: templates-run-android
+  - name: $(iosTestsVmPool)
+    vmImage: $(iosTestsVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
+    - macOS.Architecture -equals x64
+    testName: RunOniOS
+    artifact: templates-run-ios
 
-  - name: TestTargetFrameworks
-    type: object
-    default:
-      - name: default
-        tfm: default
-      - name: net9
-        tfm: net9.0
+- name: MacTemplatePool
+  type: object
+  default:
+    name: $(androidTestsVmPool)
+    vmImage: $(androidTestsVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
+    - macOS.Architecture -equals arm64
+
+- name: TestTargetFrameworks
+  type: object
+  default:
+  - name: default
+    tfm: default
+  - name: net9
+    tfm: net9.0
 
 resources:
   repositories:
-    - repository: yaml-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
-      ref: refs/heads/main
+  - repository: yaml-templates
+    type: github
+    name: xamarin/yaml-templates
+    endpoint: xamarin
+    ref: refs/heads/main
 
 stages:
 
-  - stage: build_net
-    displayName: Build .NET MAUI
-    dependsOn: []
-    jobs:
-      - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
-        - ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
-          - job: build_net_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
-            workspace:
-              clean: all
-            displayName: ${{ BuildPlatform.name }} (${{ BuildConfiguration }})
-            timeoutInMinutes: 120
-            condition: or(
-              ${{ parameters.BuildEverything }},
-              ne(variables['Build.Reason'], 'PullRequest'),
-              eq('${{ BuildConfiguration }}', 'Release'))
-            pool:
-              name: ${{ BuildPlatform.poolName }}
-              vmImage: ${{ BuildPlatform.vmImage }}
-              demands: ${{ BuildPlatform.demands }}
-            steps:
-              - template: common/provision.yml
-                parameters:
-                  poolName: ${{ BuildPlatform.poolName }}
-                  skipJdk: false
-                  skipAndroidCommonSdks: false
-                  skipAndroidPlatformApis: false
-                  onlyAndroidPlatformDefaultApis: true
-                  skipAndroidEmulatorImages: true
-                  skipAndroidCreateAvds: true
-                  skipProvisioning: true
-                  skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                  ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
-                    skipProvisionator: false
-                    gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-                  ${{ else }}:
-                    skipProvisionator: true
-            
-              - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Install .NET'
-                retryCountOnTaskFailure: 3
-                env:
-                  DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-                  PRIVATE_BUILD: $(PrivateBuild)
-              - pwsh: ./build.ps1 --target=dotnet-build --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Build .NET Maui'
-              - pwsh: ./build.ps1 --target=dotnet-test --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Run Unit Tests'
-              - task: PublishTestResults@2
-                condition: always()
-                inputs:
-                  testRunner: VSTest
-                  testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
-              - task: PublishBuildArtifacts@1
-                condition: always()
-                displayName: Publish Artifacts (${{ BuildPlatform.artifact }})
-                inputs:
-                  ArtifactName: ${{ BuildPlatform.artifact }}
+- stage: build_net
+  displayName: Build .NET MAUI
+  dependsOn: []
+  jobs:
+  - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
+    - ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
+      - job: build_net_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
+        workspace:
+          clean: all
+        displayName: ${{ BuildPlatform.name }} (${{ BuildConfiguration }})
+        timeoutInMinutes: 120
+        condition: or( ${{ parameters.BuildEverything }}, ne(variables['Build.Reason'], 'PullRequest'), eq('${{ BuildConfiguration }}', 'Release'))
+        pool:
+          name: ${{ BuildPlatform.poolName }}
+          vmImage: ${{ BuildPlatform.vmImage }}
+          demands: ${{ BuildPlatform.demands }}
+        steps:
+        - template: common/provision.yml
+          parameters:
+            poolName: ${{ BuildPlatform.poolName }}
+            skipJdk: false
+            skipAndroidCommonSdks: false
+            skipAndroidPlatformApis: false
+            onlyAndroidPlatformDefaultApis: true
+            skipAndroidEmulatorImages: true
+            skipAndroidCreateAvds: true
+            skipProvisioning: true
+            skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
+            ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
+              skipProvisionator: false
+            ${{ else }}:
+              skipProvisionator: true
 
-  - stage: pack_net
-    displayName: Pack .NET MAUI
-    dependsOn: []
-    jobs:
-      - ${{ each PackPlatform in parameters.PackPlatforms }}:
-        - job: pack_net_${{ PackPlatform.name }}
-          workspace:
-            clean: all
-          displayName: ${{ PackPlatform.name }}
-          timeoutInMinutes: 240
-          pool:
-            name: ${{ PackPlatform.poolName }}
-            vmImage: ${{ PackPlatform.vmImage }}
-            demands: ${{ PackPlatform.demands }}
-          variables:
-            - name: _buildScript
-              value: $(Build.SourcesDirectory)/build.cmd -ci
-            - name: _BuildConfig
-              value: Release
-            - name: _BuildOfficalId
-              value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
+        - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+          displayName: 'Install .NET'
+          retryCountOnTaskFailure: 3
+          env:
+            DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+            PRIVATE_BUILD: $(PrivateBuild)
+        - pwsh: ./build.ps1 --target=dotnet-build --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+          displayName: 'Build .NET Maui'
+        - pwsh: ./build.ps1 --target=dotnet-test --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+          displayName: 'Run Unit Tests'
+        - task: PublishTestResults@2
+          condition: always()
+          inputs:
+            testRunner: VSTest
+            testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
+        - task: PublishBuildArtifacts@1
+          condition: always()
+          displayName: Publish Artifacts (${{ BuildPlatform.artifact }})
+          inputs:
+            ArtifactName: ${{ BuildPlatform.artifact }}
 
-          steps:
-            - template: common/pack.yml
-              parameters:
-                platform: ${{ PackPlatform.name }}
-                provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                artifact:  ${{ PackPlatform.artifact }}
-                artifactsPath: $(Build.ArtifactStagingDirectory)
-                artifactBinaries: 'pack-binaries'
-                buildConfiguration: $(_BuildConfig)
-                dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
-                buildScript: $(_buildScript)
-                repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
-                repoLogPath: $(Build.Arcade.LogsPath)
-                repoTestResultsPath: $(Build.Arcade.TestResultsPath)
-                gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-                officialBuildId: $(_BuildOfficalId)
-                prepareSteps:
-                  - template: common/provision.yml
-                    parameters:
-                      checkoutDirectory: '$(System.DefaultWorkingDirectory)'
-                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      skipJdk: false
-                      skipAndroidCommonSdks: false
-                      skipAndroidPlatformApis: false
-                      onlyAndroidPlatformDefaultApis: true
-                      skipAndroidEmulatorImages: true
-                      skipAndroidCreateAvds: true
-                      skipProvisioning: true
-                      skipXcode: ${{ ne(PackPlatform.name , 'macOS') }}
-                      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
-                        skipProvisionator: false
-                        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-                      ${{ else }}:  
-                        skipProvisionator: true
-                      
-  - stage: samples_net
-    displayName: Test .NET MAUI Samples
-    dependsOn: pack_net
-    jobs:
-      - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
-        - job: build_net_${{ BuildPlatform.name }}_samples
-          workspace:
-            clean: all
-          displayName: ${{ BuildPlatform.name }}
-          timeoutInMinutes: 120
-          pool:
-            name: ${{ BuildPlatform.poolName }}
-            vmImage: ${{ BuildPlatform.vmImage }}
-            demands: ${{ BuildPlatform.demands }}     
-          steps:
-            - template: common/provision.yml
-              parameters:
-                poolName: ${{ BuildPlatform.poolName }}
-                skipJdk: false
-                skipAndroidCommonSdks: false
-                skipAndroidPlatformApis: false
-                onlyAndroidPlatformDefaultApis: true
-                skipAndroidEmulatorImages: true
-                skipAndroidCreateAvds: true
-                skipProvisioning: true
-                skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
-                ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
-                  skipProvisionator: false
-                  gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-                ${{ else }}:  
-                  skipProvisionator: true
-            - task: DownloadBuildArtifacts@0
-              displayName: 'Download Packages'
-              inputs:
-                artifactName: nuget
-                itemPattern: '**/*.nupkg'
-                downloadPath: $(System.DefaultWorkingDirectory)/artifacts
-            - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
-              displayName: Move the downloaded artifacts
-            - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
-              displayName: 'Install .NET (Local Workloads)'
-              retryCountOnTaskFailure: 3
-              env:
-                DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-                PRIVATE_BUILD: $(PrivateBuild)
-            - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
-              displayName: Build Microsoft.Maui.IntegrationTests
-            - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="Category=Samples" --resultsfilename="integration-samples" --verbosity=diagnostic
-              displayName: Run ${{ BuildPlatform.name }} sample build tests
-            - task: PublishTestResults@2
-              displayName: Publish the ${{ BuildPlatform.name }} sample build tests
-              condition: always()
-              inputs:
-                testRunner: VSTest
-                testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
-                testRunTitle: ${{ BuildPlatform.name }} sample build tests
-            - task: PublishBuildArtifacts@1
-              condition: always()
-              displayName: publish artifacts
-              inputs:
-                ArtifactName: build_net_${{ BuildPlatform.name }}_samples
+- stage: pack_net
+  displayName: Pack .NET MAUI
+  dependsOn: []
+  jobs:
+  - ${{ each PackPlatform in parameters.PackPlatforms }}:
+    - job: pack_net_${{ PackPlatform.name }}
+      workspace:
+        clean: all
+      displayName: ${{ PackPlatform.name }}
+      timeoutInMinutes: 240
+      pool:
+        name: ${{ PackPlatform.poolName }}
+        vmImage: ${{ PackPlatform.vmImage }}
+        demands: ${{ PackPlatform.demands }}
+      variables:
+      - name: _buildScript
+        value: $(Build.SourcesDirectory)/build.cmd -ci
+      - name: _BuildConfig
+        value: Release
+      - name: _BuildOfficalId
+        value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 
-  - stage: templates_net
-    displayName: Test Templates
-    dependsOn: pack_net
-    jobs:
-    - template: common/maui-templates.yml
-      parameters:
-        RunPlatforms: ${{ parameters.RunTemplatePlatforms }}
-        BuildPlatforms: ${{ parameters.BuildTemplatePlatforms }}
-        MacBuildPool: ${{ parameters.MacTemplatePool }}
-        conditionMacTemplates: or(
-              ${{ parameters.BuildEverything }},
-              ne(variables['Build.Reason'], 'PullRequest'),
-              eq(variables['System.TeamProject'], 'devdiv'))
-        prepareSteps:
+      steps:
+      - template: common/pack.yml
+        parameters:
+          platform: ${{ PackPlatform.name }}
+          provisionatorChannel: ${{ parameters.provisionatorChannel }}
+          artifact: ${{ PackPlatform.artifact }}
+          artifactsPath: $(Build.ArtifactStagingDirectory)
+          artifactBinaries: 'pack-binaries'
+          buildConfiguration: $(_BuildConfig)
+          dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
+          buildScript: $(_buildScript)
+          repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
+          repoLogPath: $(Build.Arcade.LogsPath)
+          repoTestResultsPath: $(Build.Arcade.TestResultsPath)
+          officialBuildId: $(_BuildOfficalId)
+          prepareSteps:
           - template: common/provision.yml
             parameters:
               checkoutDirectory: '$(System.DefaultWorkingDirectory)'
               provisionatorChannel: ${{ parameters.provisionatorChannel }}
-              skipAndroidSdks: true
-              skipAndroidImages: true
-              installDefaultAndroidApi: true
-              skipXcode: false
-              ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') )}}:
+              skipJdk: false
+              skipAndroidCommonSdks: false
+              skipAndroidPlatformApis: false
+              onlyAndroidPlatformDefaultApis: true
+              skipAndroidEmulatorImages: true
+              skipAndroidCreateAvds: true
+              skipProvisioning: true
+              skipXcode: ${{ ne(PackPlatform.name , 'macOS') }}
+              ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
                 skipProvisionator: false
-                gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-              ${{ else }}:  
+              ${{ else }}:
                 skipProvisionator: true
-          
-        
-  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-    - template: common/localization.yml
+
+- stage: samples_net
+  displayName: Test .NET MAUI Samples
+  dependsOn: pack_net
+  jobs:
+  - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
+    - job: build_net_${{ BuildPlatform.name }}_samples
+      workspace:
+        clean: all
+      displayName: ${{ BuildPlatform.name }}
+      timeoutInMinutes: 120
+      pool:
+        name: ${{ BuildPlatform.poolName }}
+        vmImage: ${{ BuildPlatform.vmImage }}
+        demands: ${{ BuildPlatform.demands }}
+      steps:
+      - template: common/provision.yml
+        parameters:
+          poolName: ${{ BuildPlatform.poolName }}
+          skipJdk: false
+          skipAndroidCommonSdks: false
+          skipAndroidPlatformApis: false
+          onlyAndroidPlatformDefaultApis: true
+          skipAndroidEmulatorImages: true
+          skipAndroidCreateAvds: true
+          skipProvisioning: true
+          skipXcode: ${{ ne(BuildPlatform.name , 'macOS') }}
+          ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
+            skipProvisionator: false
+          ${{ else }}:
+            skipProvisionator: true
+      - task: DownloadBuildArtifacts@0
+        displayName: 'Download Packages'
+        inputs:
+          artifactName: nuget
+          itemPattern: '**/*.nupkg'
+          downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+      - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
+        displayName: Move the downloaded artifacts
+      - pwsh: ./build.ps1 --target=dotnet-local-workloads --verbosity=diagnostic
+        displayName: 'Install .NET (Local Workloads)'
+        retryCountOnTaskFailure: 3
+        env:
+          DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+          PRIVATE_BUILD: $(PrivateBuild)
+      - pwsh: ./build.ps1 --target=dotnet-integration-build --verbosity=diagnostic
+        displayName: Build Microsoft.Maui.IntegrationTests
+      - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="Category=Samples" --resultsfilename="integration-samples" --verbosity=diagnostic
+        displayName: Run ${{ BuildPlatform.name }} sample build tests
+      - task: PublishTestResults@2
+        displayName: Publish the ${{ BuildPlatform.name }} sample build tests
+        condition: always()
+        inputs:
+          testRunner: VSTest
+          testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
+          testRunTitle: ${{ BuildPlatform.name }} sample build tests
+      - task: PublishBuildArtifacts@1
+        condition: always()
+        displayName: publish artifacts
+        inputs:
+          ArtifactName: build_net_${{ BuildPlatform.name }}_samples
+
+- stage: templates_net
+  displayName: Test Templates
+  dependsOn: pack_net
+  jobs:
+  - template: common/maui-templates.yml
+    parameters:
+      RunPlatforms: ${{ parameters.RunTemplatePlatforms }}
+      BuildPlatforms: ${{ parameters.BuildTemplatePlatforms }}
+      MacBuildPool: ${{ parameters.MacTemplatePool }}
+      conditionMacTemplates: or( ${{ parameters.BuildEverything }}, ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))
+      prepareSteps:
+      - template: common/provision.yml
+        parameters:
+          checkoutDirectory: '$(System.DefaultWorkingDirectory)'
+          provisionatorChannel: ${{ parameters.provisionatorChannel }}
+          skipAndroidSdks: true
+          skipAndroidImages: true
+          installDefaultAndroidApi: true
+          skipXcode: false
+          ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') )}}:
+            skipProvisionator: false
+          ${{ else }}:
+            skipProvisionator: true
+
+- ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+  - template: common/localization.yml

--- a/eng/pipelines/maui-release.yml
+++ b/eng/pipelines/maui-release.yml
@@ -30,44 +30,44 @@ schedules:
     - inflight/current
 
 variables:
-  - template: /eng/pipelines/common/variables.yml@self
+- template: /eng/pipelines/common/variables.yml@self
 
 parameters:
-  - name: VM_IMAGE_HOST
-    type: object
-    default:
-      name: MAUI-1ESPT
-      image: 1ESPT-Windows2022
-      os: windows
+- name: VM_IMAGE_HOST
+  type: object
+  default:
+    name: MAUI-1ESPT
+    image: 1ESPT-Windows2022
+    os: windows
 
-  - name: PackPlatform
-    type: object
-    default:
-      name: Windows
-      artifact: nuget
-      binariesArtifact: pack-binaries
-      metadataArtifact: metadata
-      logsArtifact: logs
-      docsArtifact: xml-docs
+- name: PackPlatform
+  type: object
+  default:
+    name: Windows
+    artifact: nuget
+    binariesArtifact: pack-binaries
+    metadataArtifact: metadata
+    logsArtifact: logs
+    docsArtifact: xml-docs
 
-  - name: Skip1ESComplianceTasks
-    type: boolean
-    default: false
+- name: Skip1ESComplianceTasks
+  type: boolean
+  default: false
 
-  - name: PushMauiPackagesToMaestro
-    type: boolean
-    default: true
+- name: PushMauiPackagesToMaestro
+  type: boolean
+  default: true
 
 resources:
   repositories:
-    - repository: yaml-templates
-      type: git
-      name: DevDiv/Xamarin.yaml-templates
-      ref: refs/heads/main
-    - repository: 1ESPipelineTemplates
-      type: git
-      name: 1ESPipelineTemplates/1ESPipelineTemplates
-      ref: refs/tags/release
+  - repository: yaml-templates
+    type: git
+    name: DevDiv/Xamarin.yaml-templates
+    ref: refs/heads/main
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -94,115 +94,115 @@ extends:
         enabled: true
         configFile: '$(Build.SourcesDirectory)\eng\automation\guardian\tsaoptions-v2.json'
     stages:
-      - stage: pack_net
-        displayName: Pack .NET MAUI
-        dependsOn: []
-        jobs:
-          - job: pack_net_${{ parameters.PackPlatform.name }}
-            workspace:
-              clean: all
-            displayName: ${{ parameters.PackPlatform.name }}
-            timeoutInMinutes: 240
-           
-            pool: ${{ parameters.VM_IMAGE_HOST }}
-              
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
-                  displayName: 'Publish the ${{ parameters.PackPlatform.artifact }} artifacts'
-                  artifactName: ${{ parameters.PackPlatform.artifact }}
-                  targetPath: '$(Build.ArtifactStagingDirectory)/nuget'
-                
-                - output: pipelineArtifact
-                  displayName: 'Publish the ${{ parameters.PackPlatform.binariesArtifact }} artifacts'
-                  artifactName: ${{ parameters.PackPlatform.binariesArtifact }}
-                  targetPath: '$(System.DefaultWorkingDirectory)/artifacts/binaries'
+    - stage: pack_net
+      displayName: Pack .NET MAUI
+      dependsOn: []
+      jobs:
+      - job: pack_net_${{ parameters.PackPlatform.name }}
+        workspace:
+          clean: all
+        displayName: ${{ parameters.PackPlatform.name }}
+        timeoutInMinutes: 240
 
-                - output: pipelineArtifact
-                  displayName: 'Publish the ${{ parameters.PackPlatform.docsArtifact }} artifacts'
-                  artifactName: ${{ parameters.PackPlatform.docsArtifact }}
-                  targetPath: '$(System.DefaultWorkingDirectory)/artifacts/docs-packs'
+        pool: ${{ parameters.VM_IMAGE_HOST }}
 
-                - output: pipelineArtifact
-                  displayName: 'Publish the ${{ parameters.PackPlatform.metadataArtifact }} artifacts'
-                  artifactName: ${{ parameters.PackPlatform.metadataArtifact }}
-                  targetPath: '$(Build.ArtifactStagingDirectory)/metadata'
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish the ${{ parameters.PackPlatform.artifact }} artifacts'
+            artifactName: ${{ parameters.PackPlatform.artifact }}
+            targetPath: '$(Build.ArtifactStagingDirectory)/nuget'
 
-                - output: pipelineArtifact
-                  displayName: 'Publish the ${{ parameters.PackPlatform.logsArtifact }} artifacts'
-                  artifactName: ${{ parameters.PackPlatform.logsArtifact }}
-                  targetPath: '$(Build.ArtifactStagingDirectory)/logs'
-            
-            variables:
-              - name: _buildScript
-                value: $(Build.SourcesDirectory)/build.cmd -ci
-              - name: _BuildConfig
-                value: Release
+          - output: pipelineArtifact
+            displayName: 'Publish the ${{ parameters.PackPlatform.binariesArtifact }} artifacts'
+            artifactName: ${{ parameters.PackPlatform.binariesArtifact }}
+            targetPath: '$(System.DefaultWorkingDirectory)/artifacts/binaries'
 
-            steps:
-              - template: /eng/pipelines/common/pack.yml@self
-                parameters:
-                  publishArtifacts: false
-                  platform: ${{ parameters.PackPlatform.name }}
-                  artifact: ${{ parameters.PackPlatform.artifact }}
-                  artifactBinaries: ${{ parameters.PackPlatform.binariesArtifact }}
-                  artifactsPath: '$(Build.ArtifactStagingDirectory)'
-                  buildConfiguration: $(_BuildConfig)
-                  dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
-                  buildScript: $(_buildScript)
-                  repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
-                  repoLogPath: $(Build.Arcade.LogsPath)
-                  repoTestResultsPath: $(Build.Arcade.TestResultsPath)
-                  officialBuildId: $(_BuildOfficalId)
-                  prepareSteps:
-                    - template: /eng/pipelines/common/provision.yml@self
-                      parameters:
-                        checkoutDirectory: '$(System.DefaultWorkingDirectory)'
-                        # gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-                        skipJdk: false
-                        skipAndroidCommonSdks: false
-                        skipAndroidPlatformApis: false
-                        onlyAndroidPlatformDefaultApis: true
-                        skipAndroidEmulatorImages: true
-                        skipAndroidCreateAvds: true
-                        skipProvisioning: true
-                        skipXcode: true
+          - output: pipelineArtifact
+            displayName: 'Publish the ${{ parameters.PackPlatform.docsArtifact }} artifacts'
+            artifactName: ${{ parameters.PackPlatform.docsArtifact }}
+            targetPath: '$(System.DefaultWorkingDirectory)/artifacts/docs-packs'
 
-      - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:                           # Sign only using the private server   
-        - template: /eng/pipelines/common/sign.yml@self                                 
+          - output: pipelineArtifact
+            displayName: 'Publish the ${{ parameters.PackPlatform.metadataArtifact }} artifacts'
+            artifactName: ${{ parameters.PackPlatform.metadataArtifact }}
+            targetPath: '$(Build.ArtifactStagingDirectory)/metadata'
+
+          - output: pipelineArtifact
+            displayName: 'Publish the ${{ parameters.PackPlatform.logsArtifact }} artifacts'
+            artifactName: ${{ parameters.PackPlatform.logsArtifact }}
+            targetPath: '$(Build.ArtifactStagingDirectory)/logs'
+
+        variables:
+        - name: _buildScript
+          value: $(Build.SourcesDirectory)/build.cmd -ci
+        - name: _BuildConfig
+          value: Release
+
+        steps:
+        - template: /eng/pipelines/common/pack.yml@self
           parameters:
-            dependsOn: ['pack_net']
-            stageName: 'nuget_signing'
-            poolName: ${{ parameters.VM_IMAGE_HOST.name }}
-            vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
-            os: ${{ parameters.VM_IMAGE_HOST.os }}                                   
-        
-        - template: /eng/pipelines/common/insertion.yml@self                                # Insert on VS and SDK
+            publishArtifacts: false
+            platform: ${{ parameters.PackPlatform.name }}
+            artifact: ${{ parameters.PackPlatform.artifact }}
+            artifactBinaries: ${{ parameters.PackPlatform.binariesArtifact }}
+            artifactsPath: '$(Build.ArtifactStagingDirectory)'
+            buildConfiguration: $(_BuildConfig)
+            dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
+            buildScript: $(_buildScript)
+            repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
+            repoLogPath: $(Build.Arcade.LogsPath)
+            repoTestResultsPath: $(Build.Arcade.TestResultsPath)
+            officialBuildId: $(_BuildOfficalId)
+            prepareSteps:
+            - template: /eng/pipelines/common/provision.yml@self
+              parameters:
+                checkoutDirectory: '$(System.DefaultWorkingDirectory)'
+                skipJdk: false
+                skipAndroidCommonSdks: false
+                skipAndroidPlatformApis: false
+                onlyAndroidPlatformDefaultApis: true
+                skipAndroidEmulatorImages: true
+                skipAndroidCreateAvds: true
+                skipProvisioning: true
+                skipXcode: true
+
+    - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+      # Sign only using the private server   
+      - template: /eng/pipelines/common/sign.yml@self
+        parameters:
+          dependsOn: [ 'pack_net' ]
+          stageName: 'nuget_signing'
+          poolName: ${{ parameters.VM_IMAGE_HOST.name }}
+          vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
+          os: ${{ parameters.VM_IMAGE_HOST.os }}
+
+      - template: /eng/pipelines/common/insertion.yml@self # Insert on VS and SDK
+        parameters:
+          dependsOn: [ 'nuget_signing' ]
+          stageName: 'sdk_insertion'
+          poolName: ${{ parameters.VM_IMAGE_HOST.name }}
+          vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
+          os: ${{ parameters.VM_IMAGE_HOST.os }}
+          pushMauiPackagesToMaestro: ${{ parameters.PushMauiPackagesToMaestro }}
+
+      - template: /eng/pipelines/common/apiscan.yml@self # ApiScan
+        parameters:
+          dependsOn: [ 'pack_net' ]
+          poolName: ${{ parameters.VM_IMAGE_HOST.name }}
+          vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
+          os: ${{ parameters.VM_IMAGE_HOST.os }}
+          tsaUploadEnabled: true
+          tsaConfigFile: '$(Build.SourcesDirectory)\eng\automation\guardian\tsaoptions-v2.json'
+          scanArtifacts: [ '${{ parameters.PackPlatform.binariesArtifact }}' ]
+          softwareVersion: 9.0
+
+      - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+        - template: /eng/pipelines/common/push-nightly.yml@self
           parameters:
-            dependsOn: ['nuget_signing']
-            stageName: 'sdk_insertion'
+            dependsOn: [ 'sdk_insertion' ]
+            stageName: 'nightly'
+            displayName: 'Push Nightly'
             poolName: ${{ parameters.VM_IMAGE_HOST.name }}
             vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
             os: ${{ parameters.VM_IMAGE_HOST.os }}
-            pushMauiPackagesToMaestro: ${{ parameters.PushMauiPackagesToMaestro }}
-
-        - template: /eng/pipelines/common/apiscan.yml@self                                  # ApiScan
-          parameters:
-            dependsOn: ['pack_net']
-            poolName: ${{ parameters.VM_IMAGE_HOST.name }}
-            vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
-            os: ${{ parameters.VM_IMAGE_HOST.os }}     
-            tsaUploadEnabled: true
-            tsaConfigFile: '$(Build.SourcesDirectory)\eng\automation\guardian\tsaoptions-v2.json'
-            scanArtifacts: ['${{ parameters.PackPlatform.binariesArtifact }}']
-            softwareVersion: 9.0
-
-        - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-          - template: /eng/pipelines/common/push-nightly.yml@self
-            parameters:
-              dependsOn: ['sdk_insertion']
-              stageName: 'nightly'
-              displayName: 'Push Nightly'
-              poolName: ${{ parameters.VM_IMAGE_HOST.name }}
-              vmImage: ${{ parameters.VM_IMAGE_HOST.image }}
-              os: ${{ parameters.VM_IMAGE_HOST.os }}  

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -42,7 +42,7 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
-  - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/common/variables.yml@self
   - name: AgentPoolAccessToken
     value: $(botdeploy--azdo--token--register--xamarin-public--untrusted)
 
@@ -160,7 +160,6 @@ stages:
         runCompatibilityTests: true
       ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
         skipProvisioning: false
-        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
       ${{ else }}:  
         skipProvisioning: true
       projects:


### PR DESCRIPTION
### Description of Change

Adds a new variable group for handle push to nuget on dnceng and devdiv, remove usage of other tokens 

`maui-provisionator` : adds variables and secrets to handle with forcing provisionator on devdiv and xamarin public 

`maui-nuget-release`: adds variable to push to nuget.org

these are backed up by keyvault on our azure subscription.

This pull request focuses on removing hardcoded GitHub tokens and improving pipeline configurations across multiple YAML files. The most significant changes include replacing hardcoded tokens with parameterized values, consolidating variable groups, and cleaning up unused or commented-out sections.

### Removal of Hardcoded GitHub Tokens:
* [`eng/pipelines/common/device-tests-steps.yml`](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL61-L64): Removed hardcoded `gitHubToken` references from provisioning steps. [[1]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL61-L64) [[2]](diffhunk://#diff-5d0763fa79fb5e8f8d535acf38d8796d9450d36e0e320f41f99c38f686641840L34) [[3]](diffhunk://#diff-7f18f6022c6d1ed045dfb10263501a775e790161f1ac317c376306110e54461eL73)
* [`eng/pipelines/common/pack.yml`](diffhunk://#diff-b295f649a0c373e6e5bc469fec1fddbd34b6b907a21927be10241829610cb604L42-L45): Removed the `gitHubToken` parameter and its default value.
* [`eng/pipelines/common/provision.yml`](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602L23-R24): Replaced hardcoded `gitHubToken` with `provisionator--github--pat`. [[1]](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602L23-R24) [[2]](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602R56-R63) [[3]](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602R96)
* [`eng/pipelines/handlers.yml`](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L190): Removed hardcoded `gitHubToken` references across multiple stages. [[1]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L190) [[2]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L251) [[3]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L268) [[4]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L300) [[5]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394L358-L362)
* [`eng/pipelines/ui-tests.yml`](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L163): Removed hardcoded `gitHubToken` from provisioning steps.

### Variable Group Updates:
* [`eng/pipelines/common/variables.yml`](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL65-R67): Added new variable groups for `maui-provisionator` and `maui-nuget-release` while removing unused groups like `Xamarin-Secrets`. [[1]](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL65-R67) [[2]](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dR97-R100)

### Cleanup and Consolidation:
* Removed redundant or commented-out sections across multiple files to streamline pipeline configurations:
  - [`eng/pipelines/common/device-tests-steps.yml`](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL83): Removed unused sections and comments. [[1]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL83) [[2]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL118) [[3]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL131) [[4]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL151) [[5]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL190-R194)
  - [`eng/pipelines/common/variables.yml`](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL80-L81): Cleaned up unused variables like `PostBuildSign`.
  - [`eng/pipelines/maui-release.yml`](diffhunk://#diff-dc5b77455b04179371dac6dc60d3a5a38c1efe041364d90722dfd24fbebaafb3L161): Removed commented-out `gitHubToken` parameter.

### Template and Parameter Adjustments:
* Updated template references across pipelines to ensure consistency:
  - [`eng/pipelines/device-tests.yml`](diffhunk://#diff-d2d1c388a0fb3196dbfcdab96421bc88336637a3d44480c96717f92d000facaeL47-R47): Changed template path for variables.
  - [`eng/pipelines/ui-tests.yml`](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L45-R45): Updated template path for variables.
* Adjusted parameters to improve flexibility and readability:
  - [`eng/pipelines/common/provision.yml`](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602R56-R63): Added `provisionatorUri` parameter for provisioning steps. [[1]](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602R56-R63) [[2]](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602R96)
  - [`eng/pipelines/common/pack.yml`](diffhunk://#diff-b295f649a0c373e6e5bc469fec1fddbd34b6b907a21927be10241829610cb604R58): Added `runAsPublic` parameter.