### PR TITLE
Fixed the RealParent Warning shown issue

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -368,7 +368,6 @@ namespace Microsoft.Maui.Controls
 			get => TryGetRealParent();
 			private set
 			{
-
 				if (value is null)
 					_realParent = null;
 				else

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -343,12 +343,19 @@ namespace Microsoft.Maui.Controls
 			{
 				return parent;
 			}
-			else if (logWarningIfParentHasBeenCollected)
+			else
 			{
-				Application.Current?
-					.FindMauiContext()?
-					.CreateLogger<Element>()?
-					.LogWarning($"The RealParent on {this} has been Garbage Collected. This should never happen. Please log a bug: https://github.com/dotnet/maui");
+				// Clear the weak reference since the target has been garbage collected
+				// This prevents repeated checks and warnings on subsequent accesses
+				_realParent = null;
+				if (logWarningIfParentHasBeenCollected)
+				{
+					Application.Current?
+										.FindMauiContext()?
+										.CreateLogger<Element>()?
+										.LogWarning($"The RealParent on {this} has been Garbage Collected. This should never happen. Please log a bug: https://github.com/dotnet/maui");
+				}
+
 			}
 
 			return null;

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		WeakReference<Element> _realParent;
-		internal Element GetRealParent(bool logWarningIfParentHasBeenCollected = true)
+		Element GetRealParent(bool logWarningIfParentHasBeenCollected = true)
 		{
 			if (_realParent is null)
 			{

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -333,13 +333,14 @@ namespace Microsoft.Maui.Controls
 		}
 
 		WeakReference<Element> _realParent;
-		Element GetRealParent(bool logWarningIfParentHasBeenCollected = true)
+		Element TryGetRealParent(bool logWarningIfParentHasBeenCollected = true)
 		{
-			if (_realParent is null)
+			var realParent = _realParent;
+			if (realParent is null)
 			{
 				return null;
 			}
-			if (_realParent.TryGetTarget(out var parent))
+			if (realParent.TryGetTarget(out var parent))
 			{
 				return parent;
 			}
@@ -355,7 +356,6 @@ namespace Microsoft.Maui.Controls
 										.CreateLogger<Element>()?
 										.LogWarning($"The RealParent on {this} has been Garbage Collected. This should never happen. Please log a bug: https://github.com/dotnet/maui");
 				}
-
 			}
 
 			return null;
@@ -365,9 +365,10 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Element RealParent
 		{
-			get => GetRealParent();
+			get => TryGetRealParent();
 			private set
 			{
+
 				if (value is null)
 					_realParent = null;
 				else
@@ -395,7 +396,7 @@ namespace Microsoft.Maui.Controls
 
 		void SetParent(Element value)
 		{
-			Element realParent = GetRealParent(false);
+			Element realParent = TryGetRealParent(false);
 
 			if (realParent == value)
 			{

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>Most application authors will not need to set the parent element by hand.</remarks>
 		public Element Parent
 		{
-			get { return ParentOverride ?? GetRealParent(false); }
+			get { return ParentOverride ?? RealParent; }
 			set => SetParent(value);
 		}
 
@@ -399,7 +399,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_parentOverride == null)
 			{
-				OnParentChangingCore(Parent, value);
+				OnParentChangingCore(ParentOverride ?? GetRealParent(false), value);
 			}
 
 			if (realParent is IElementDefinition element)

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -406,7 +406,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_parentOverride == null)
 			{
-				OnParentChangingCore(ParentOverride ?? realParent, value);
+				OnParentChangingCore(Parent, value);
 			}
 
 			if (realParent is IElementDefinition element)

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_parentOverride == null)
 			{
-				OnParentChangingCore(ParentOverride ?? GetRealParent(false), value);
+				OnParentChangingCore(ParentOverride ?? realParent, value);
 			}
 
 			if (realParent is IElementDefinition element)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- When navigating from a first page (with a button) to a second page containing controls like Image, Label, or Border, a warning occurs if properties such as StrokeShape, Image.Source, or Label.FormattedText are bound to values from a ViewModel that was implemented as a static (singleton) instance.

For example, if a StrokeShape is created and stored statically, it is instantiated only once during the first navigation. On subsequent navigations, the same instance is reused. Since elements like StrokeShape maintain a reference to their previous parent, reusing the same instance causes conflicts and triggers warnings due to improper parent-child relationships.



### Description of Change



- Accesses RealParent in a safe way to prevent warnings from occurring when the parent has already been removed or collected. 



### Issues Fixed



Fixes #23050 



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/eaa822b1-0c4c-4eff-bf8d-4e3b6c5227f0"> | <video src="https://github.com/user-attachments/assets/7b7aac0b-d1d5-48e5-ab88-a68cf992e8d7"> |