### PR TITLE
[Android] Fixed keyboard flickering issue with SearchHandler

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			int cursorPosition = _editText.SelectionStart;
 			bool selectionExists = _editText.HasSelection;
 
-			UpdateTextTransform();
+			_editText.Text = _searchHandler.UpdateFormsText(newText, _searchHandler.TextTransform);
 
 			// If we had a selection, place the cursor at the end of text
 			// Otherwise try to maintain the cursor at its previous position

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -106,10 +106,17 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void UpdateText()
 		{
+			string newText = _searchHandler.Query ?? string.Empty;
+
+			if (_editText.Text == newText)
+			{
+				return;
+			}
+
 			int cursorPosition = _editText.SelectionStart;
 			bool selectionExists = _editText.HasSelection;
 
-			_editText.Text = _searchHandler.Query ?? string.Empty;
+			_editText.Text = newText;
 
 			UpdateTextTransform();
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -106,25 +106,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void UpdateText()
 		{
-			string newText = _searchHandler.Query ?? string.Empty;
+			string newText = _searchHandler.UpdateFormsText(_searchHandler.Query ?? string.Empty, _searchHandler.TextTransform);
 
 			if (_editText.Text == newText)
 			{
 				return;
 			}
 
-			int cursorPosition = _editText.SelectionStart;
-			bool selectionExists = _editText.HasSelection;
-
-			_editText.Text = _searchHandler.UpdateFormsText(newText, _searchHandler.TextTransform);
-
-			// If we had a selection, place the cursor at the end of text
-			// Otherwise try to maintain the cursor at its previous position
-			int textLength = _editText.Text?.Length ?? 0;
-			int newPosition = selectionExists ? textLength : Math.Min(cursorPosition, textLength);
-
-			// Prevents the cursor from resetting to position zero when text is set programmatically
-			_editText.SetSelection(newPosition);
+			_editText.SetTextKeepState(newText);
 		}
 
 		void EditTextFocusChange(object s, AView.FocusChangeEventArgs args)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/SearchHandlerAppearanceTracker.cs
@@ -116,8 +116,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			int cursorPosition = _editText.SelectionStart;
 			bool selectionExists = _editText.HasSelection;
 
-			_editText.Text = newText;
-
 			UpdateTextTransform();
 
 			// If we had a selection, place the cursor at the end of text

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
@@ -12,6 +12,7 @@ using Android.Widget;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CardView.Widget;
 using Java.Lang;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform.Compatibility;
 using AColor = Android.Graphics.Color;
 using AImageButton = Android.Widget.ImageButton;
@@ -66,7 +67,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			UpdateClearButtonState();
 
-			SearchHandler.SetValue(SearchHandler.QueryProperty, text);
+			SearchHandler.SetValue(SearchHandler.QueryProperty, TextTransformUtilites.GetTransformedText(text, SearchHandler.TextTransform));
 
 			if (SearchHandler.ShowsResults)
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			UpdateClearButtonState();
 
-			SearchHandler.SetValue(SearchHandler.QueryProperty, TextTransformUtilites.GetTransformedText(text, SearchHandler.TextTransform));
+			SearchHandler.SetValue(SearchHandler.QueryProperty, text);
 
 			if (SearchHandler.ShowsResults)
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -134,12 +134,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			var newText = _searchHandler.UpdateFormsText(_searchHandler.Query ?? string.Empty, _searchHandler.TextTransform);
 
-			if (uiTextField.Text == newText)
+			if (uiTextField.Text != newText)
 			{
-				return;
+				uiTextField.Text = newText;
 			}
 
-			uiTextField.Text = newText;
 			UpdateCharacterSpacing(uiTextField);
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -127,14 +127,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void UpdateText(UITextField uiTextField)
 		{
-			var newText = _searchHandler.Query ?? string.Empty;
-
-			if (uiTextField is null || uiTextField.Text == newText)
+			if (uiTextField is null)
 			{
 				return;
 			}
 
-			uiTextField.Text = _searchHandler.UpdateFormsText(newText, _searchHandler.TextTransform);
+			var newText = _searchHandler.UpdateFormsText(_searchHandler.Query ?? string.Empty, _searchHandler.TextTransform);
+
+			if (uiTextField.Text == newText)
+			{
+				return;
+			}
+
+			uiTextField.Text = newText;
 			UpdateCharacterSpacing(uiTextField);
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -134,8 +134,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			uiTextField.Text = newText;
-			UpdateTextTransform(uiTextField);
+			uiTextField.Text = _searchHandler.UpdateFormsText(newText, _searchHandler.TextTransform);
 			UpdateCharacterSpacing(uiTextField);
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -127,10 +127,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void UpdateText(UITextField uiTextField)
 		{
-			if (uiTextField is null)
-				return;
+			var newText = _searchHandler.Query ?? string.Empty;
 
-			uiTextField.Text = _searchHandler.Query;
+			if (uiTextField is null || uiTextField.Text == newText)
+			{
+				return;
+			}
+
+			uiTextField.Text = newText;
 			UpdateTextTransform(uiTextField);
 			UpdateCharacterSpacing(uiTextField);
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls.Internals;
 using ObjCRuntime;
 using UIKit;
 using static Microsoft.Maui.Controls.Compatibility.Platform.iOS.AccessibilityExtensions;
@@ -734,7 +735,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_searchController.SetSearchResultsUpdater(sc =>
 			{
-				SearchHandler.SetValue(SearchHandler.QueryProperty, sc.SearchBar.Text);
+				SearchHandler.SetValue(SearchHandler.QueryProperty, TextTransformUtilites.GetTransformedText(sc.SearchBar.Text, SearchHandler.TextTransform));
 			});
 
 			searchBar.BookmarkButtonClicked += BookmarkButtonClicked;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -9,7 +9,6 @@ using System.Windows.Input;
 using CoreGraphics;
 using Foundation;
 using Microsoft.Extensions.Logging;
-using Microsoft.Maui.Controls.Internals;
 using ObjCRuntime;
 using UIKit;
 using static Microsoft.Maui.Controls.Compatibility.Platform.iOS.AccessibilityExtensions;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -735,7 +735,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_searchController.SetSearchResultsUpdater(sc =>
 			{
-				SearchHandler.SetValue(SearchHandler.QueryProperty, TextTransformUtilites.GetTransformedText(sc.SearchBar.Text, SearchHandler.TextTransform));
+				SearchHandler.SetValue(SearchHandler.QueryProperty, sc.SearchBar.Text);
 			});
 
 			searchBar.BookmarkButtonClicked += BookmarkButtonClicked;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Regression PR

- #28400 

### Root Cause of the issue

- The PR [28400](https://github.com/dotnet/maui/pull/28400) addresses a dynamic update issue with SearchHandler.Query by properly handling property changes.
- When typing directly into the SearchHandler, the Query value was being updated using [SetValue](https://github.com/dotnet/maui/blob/d3553b2a0786d4bd2d5887468291fed7067f0158/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSearchView.cs#L69)(SearchHandler.QueryProperty, value). This triggered the Query property changed event, which unnecessarily reassigned the same value. As a result, SearchHandler.Query was updated redundantly, causing flickering in both the keyboard and the SearchHandler itself.

### Description of Change

- Updated the property change logic to set the SearchHandler.Query property only when the new value differs from the current one, preventing redundant updates and resolving both the flickering issue and the dynamic value-setting problem.

### Test Case

- Since this issue is related to animations on older Android versions, reliably automating it does not seem to be feasible.

### Issues Fixed

Fixes #30072

### Tested the behaviour in the following platforms

- [x] Android
- [x] iOS
- [x] Mac
- [x] Windows

### Screenshot

| Before Fix | After Fix |
|----------|----------|
| <video  src="https://github.com/user-attachments/assets/a5f5365f-1f80-45c0-877b-3b117482c653"> | <video  src="https://github.com/user-attachments/assets/26f7f110-75a7-4cb7-8a11-45b0bd48619a"> |
