### PR TITLE
[Windows]Fixed the ViewExtensions RotateYTo and RotateXTo with length 0 crashes

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18420.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18420.cs
@@ -1,0 +1,35 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 18420, "[Windows]ViewExtensions RotateYTo and RotateXTo with length 0 crashes on Windows", PlatformAffected.UWP)]
+public class Issue18420 : ContentPage
+{
+	int count = 0;
+	Button rotateButton;
+	public Issue18420()
+	{
+		var layout = new VerticalStackLayout
+		{
+			Spacing = 25,
+			Padding = new Thickness(30, 0),
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		rotateButton = new Button
+		{
+			Text = "Click me to rotate",
+			BackgroundColor= Colors.Red,
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId= "RotateButton"
+		};
+
+		rotateButton.Clicked += OnRotateButtonClicked;
+		layout.Children.Add(rotateButton);
+		this.Content = layout;
+	}
+
+	private void OnRotateButtonClicked(object sender, EventArgs e)
+	{
+		count++;
+		rotateButton.RotateYTo(10 + count, 0);
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18420.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18420.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 18420, "[Windows]ViewExtensions RotateYTo and RotateXTo with length 0 crashes on Windows", PlatformAffected.UWP)]
+[Issue(IssueTracker.Github, 18420, "[Windows] ViewExtensions RotateYTo and RotateXTo with length 0 crashes on Windows", PlatformAffected.UWP)]
 public class Issue18420 : ContentPage
 {
 	int count = 0;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue18420 : _IssuesUITest
+{
+	public Issue18420(TestDevice device) : base(device) { }
+
+	public override string Issue => "[Windows]ViewExtensions RotateYTo and RotateXTo with length 0 crashes on Windows";
+
+	[Test]
+	[Category(UITestCategories.ViewBaseTests)]
+	public void ApplyingRotationWithZeroDurationShouldNotCrash()
+	{
+		App.WaitForElement("RotateButton");
+		App.Tap("RotateButton");
+		App.Tap("RotateButton");
+		App.Tap("RotateButton");
+		App.WaitForElement("RotateButton");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
@@ -8,7 +8,7 @@ public class Issue18420 : _IssuesUITest
 {
 	public Issue18420(TestDevice device) : base(device) { }
 
-	public override string Issue => "[Windows]ViewExtensions RotateYTo and RotateXTo with length 0 crashes on Windows";
+	public override string Issue => "[Windows] ViewExtensions RotateYTo and RotateXTo with length 0 crashes on Windows";
 
 	[Test]
 	[Category(UITestCategories.ViewBaseTests)]

--- a/src/Core/src/Platform/Windows/TransformationExtensions.cs
+++ b/src/Core/src/Platform/Windows/TransformationExtensions.cs
@@ -38,8 +38,12 @@ public static class TransformationExtensions
 			// (i.e. their absolute value is 0), a CompositeTransform is instead used to allow for
 			// rotation of the control on a 2D plane, and the other values are set. Otherwise, the
 			// rotation values are set, but the aforementioned functionality will be lost.
-			if (Math.Abs(view.RotationX) != 0 || Math.Abs(view.RotationY) != 0)
+			if (Math.Abs(rotationX) != 0 || Math.Abs(rotationY) != 0)
 			{
+				if (double.IsNaN(rotationX) || double.IsNaN(rotationY) || double.IsNaN(rotation))
+				{
+					return;
+				}
 				frameworkElement.Projection = new PlaneProjection
 				{
 					CenterOfRotationX = anchorX,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- When RotateYTo is dynamically updated with a duration of 0, it causes the value calculation in Tweener class to result in NaN. This NaN value is then passed to the UpdatedTransformation method on Windows, where the subtraction between the PlaneProjection's Rotation property and the MAUI rotation leads to an ArgumentException.

https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Tweener.cs#L124 





### Description of Change



- If the calculated value is NaN, a defensive check is added to prevent invalid transformations from being applied. This ensures that when any rotation value is NaN (Not a Number), it is skipped. On subsequent updates, a valid value will be used, allowing the transformation to proceed as expected.




### Issues Fixed



Fixes #18420



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/a4cbab59-14a3-4d2e-9a15-1bd547c2fdc7"> | <video src="https://github.com/user-attachments/assets/186e40ba-b79f-4934-a613-1da47c8c82f4"> |
