### PR TITLE
Use the known working version of platform-tools

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -172,6 +172,7 @@
     <JavaJdkVersion>17.0.12</JavaJdkVersion>
     <!-- Android SDK package versions and info -->
     <!-- Build Tools and CmdLine Tools versions -->
+    <AndroidSdkPlatformToolsVersion>35.0.2</AndroidSdkPlatformToolsVersion>
     <AndroidSdkBuildToolsVersion>33.0.0</AndroidSdkBuildToolsVersion>
     <AndroidSdkCmdLineToolsVersion>13.0</AndroidSdkCmdLineToolsVersion>
     <!-- Device Type for creating AVD's -->

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -36,7 +36,7 @@
 
 	<ItemGroup>
 		<!-- Android SDK - construct package names to install -->
-		<AndroidSdkPackages Include="platform-tools" />
+		<AndroidSdkPackages Include="platform-tools%3B$(AndroidSdkPlatformToolsVersion)" />
 		<AndroidSdkPackages Include="build-tools%3B$(AndroidSdkBuildToolsVersion)" />
 		<AndroidSdkPackages Include="cmdline-tools%3B$(AndroidSdkCmdLineToolsVersion)" />
 		<AndroidSdkPackages Include="emulator" />


### PR DESCRIPTION

### Description of Change

After we got the new 36.0 platform-tools, none of the devices are booting or they are not connecting to adb. Or something. Who knows. Adb is ...