### PR TITLE
Use a newer Linux

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -69,7 +69,7 @@ parameters:
       name: $(1ESPTPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - ImageOverride -equals 1ESPT-Ubuntu22.04
+        - ImageOverride -equals 1ESPT-Ubuntu24.04
 
   - name: iosPool
     type: object

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -80,7 +80,7 @@ parameters:
       name: $(1ESPTPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - ImageOverride -equals 1ESPT-Ubuntu22.04
+        - ImageOverride -equals 1ESPT-Ubuntu24.04
 
   - name: iosPool
     type: object


### PR DESCRIPTION

### Description of Change

After we got the new 36.0 platform-tools, none of the devices are booting or they are not connecting to adb. Or something. Who knows. Adb is ...

Alternate is https://github.com/dotnet/maui/pull/30173