### PR TITLE
Prevent the BlazorWebView bounce on iOS

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -112,6 +112,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				WebView = webview
 			});
 
+			// Disable bounce scrolling to make Blazor apps feel more native
+			if (webview.ScrollView != null)
+			{
+				webview.ScrollView.Bounces = false;
+				webview.ScrollView.AlwaysBounceVertical = false;
+				webview.ScrollView.AlwaysBounceHorizontal = false;
+			}
+
 			Logger.CreatedWebKitWKWebView();
 
 			return webview;

--- a/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.Behaviors.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.MauiBlazorWebView.DeviceTests.Components;
+using Xunit;
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
+
+public partial class BlazorWebViewTests
+{
+#if IOS || MACCATALYST
+	[Fact]
+	public async Task BlazorWebViewScrollBounceDisabledByDefault()
+	{
+		EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+		{
+			appBuilder.Services.AddMauiBlazorWebView();
+		});
+
+		var bwv = new BlazorWebViewWithCustomFiles
+		{
+			HostPage = "wwwroot/index.html",
+			CustomFiles = new Dictionary<string, string>
+			{
+				{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+			},
+		};
+		bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(NoOpComponent), Selector = "#app", });
+
+		await InvokeOnMainThreadAsync(async () =>
+		{
+			var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+			var platformWebView = bwvHandler.PlatformView;
+			await WebViewHelpers.WaitForWebViewReady(platformWebView);
+
+			// Verify that bounce scrolling is disabled by default to make apps feel more native
+			Assert.False(platformWebView.ScrollView.Bounces);
+			Assert.False(platformWebView.ScrollView.AlwaysBounceVertical);
+			Assert.False(platformWebView.ScrollView.AlwaysBounceHorizontal);
+		});
+	}
+#endif
+}


### PR DESCRIPTION

### Description of Change

Disbale the buiny/overscroll by default on iOS since this is a hybrid app. No need for overscroll on titlebars. It is weird.

Better than #30169

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6689 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
