### PR TITLE
[ci] Add a way to open insiders to cake

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -486,7 +486,26 @@ Task("VSCode")
 
         UseLocalNuGetCacheFolder();
 
-        StartVisualStudioCodeForDotNet();
+        StartVisualStudioCodeForDotNet(false);
+    });
+
+Task("Insiders")
+    .Description("Provisions .NET, and launches an instance of Visual Studio Code using it.")
+    .IsDependentOn("Clean")
+    .IsDependentOn("dotnet")
+    .IsDependentOn("dotnet-buildtasks")
+    .IsDependentOn("dotnet-pack") // Run conditionally
+    .Does(() =>
+    {
+        if (pendingException != null)
+        {
+            Error($"{pendingException}");
+            Error("!!!!BUILD TASKS FAILED: !!!!!");
+        }
+
+        UseLocalNuGetCacheFolder();
+
+        StartVisualStudioCodeForDotNet(true);
     });
 
 // Tasks for Local Development
@@ -632,7 +651,7 @@ void UseLocalNuGetCacheFolder(bool reset = false)
     SetEnvironmentVariable("NUGET_PACKAGES", packages.FullPath);
 }
 
-void StartVisualStudioCodeForDotNet()
+void StartVisualStudioCodeForDotNet(bool useInsiders)
 {
     if (IsCIBuild())
     {
@@ -645,7 +664,9 @@ void StartVisualStudioCodeForDotNet()
         SetDotNetEnvironmentVariables();
     }
 
-    StartProcess("code", new ProcessSettings{ EnvironmentVariables = GetDotNetEnvironmentVariables() });
+    string codeProcessName = useInsiders ? "code-insiders" : "code";
+
+    StartProcess(codeProcessName, new ProcessSettings{ EnvironmentVariables = GetDotNetEnvironmentVariables() });
 }
 
 void StartVisualStudioForDotNet()


### PR DESCRIPTION

### Description of Change

This pull request introduces a new `Insiders` task to support launching Visual Studio Code Insiders and updates the existing `VSCode` task to allow conditional selection between standard and Insiders versions. Additionally, the `StartVisualStudioCodeForDotNet` method has been enhanced to handle this functionality.

### Task enhancements:

* [`eng/cake/dotnet.cake`](diffhunk://#diff-f987df2e4d48c04c42bb417e36d0d8b1fa9ddd29f10459c98f16d7b9b10f47c5L489-R508): Added a new `Insiders` task that provisions .NET and launches Visual Studio Code Insiders, with dependencies on several build tasks. It includes error handling for pending exceptions during task execution.

### Method updates:

* [`eng/cake/dotnet.cake`](diffhunk://#diff-f987df2e4d48c04c42bb417e36d0d8b1fa9ddd29f10459c98f16d7b9b10f47c5L635-R654): Updated the `StartVisualStudioCodeForDotNet` method to accept a `bool useInsiders` parameter, enabling conditional selection between launching Visual Studio Code (`code`) or Visual Studio Code Insiders (`code-insiders`). [[1]](diffhunk://#diff-f987df2e4d48c04c42bb417e36d0d8b1fa9ddd29f10459c98f16d7b9b10f47c5L635-R654) [[2]](diffhunk://#diff-f987df2e4d48c04c42bb417e36d0d8b1fa9ddd29f10459c98f16d7b9b10f47c5L648-R669)
<!-- Enter description of the fix in this section -->
