### PR TITLE
[Windows] Fix for SemanticScreenReader.Default.Announce throws exception when called from MainPage constructor

### DIFF
--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
@@ -12,14 +12,13 @@ namespace Microsoft.Maui.Accessibility
 			if (WindowStateManager.Default.GetActiveWindow() is not Window window)
 				return;
 
-			var peer = FindAutomationPeer(window.Content);
-
-			// If no automation peer is found (e.g., when called early in app lifecycle
-			// before window content is set), returns without error
-			if (peer is null)
+			if(window.Content is null)
 			{
+				// If the window content is null, we can't announce anything yet.
+				// This can happen if the app is still starting up.
 				return;
 			}
+			var peer = FindAutomationPeer(window.Content);
 
 			// This GUID correlates to the internal messages used by UIA to perform an announce
 			// You can extract it  by using accessibility insights to monitor UIA events

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.ApplicationModel;
+﻿using System.Diagnostics;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Media;
@@ -16,6 +17,7 @@ namespace Microsoft.Maui.Accessibility
 			{
 				// If the window content is null, we can't announce anything yet.
 				// This can happen if the app is still starting up.
+				Debug.WriteLine("SemanticScreenReader.Announce() was called too early. The window content is not yet initialized, announcement skipped.");
 				return;
 			}
 			var peer = FindAutomationPeer(window.Content);

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Accessibility
 			if (WindowStateManager.Default.GetActiveWindow() is not Window window)
 				return;
 
-			if(window.Content is null)
+			if (window.Content is null)
 			{
 				// If the window content is null, we can't announce anything yet.
 				// This can happen if the app is still starting up.

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.windows.cs
@@ -14,6 +14,13 @@ namespace Microsoft.Maui.Accessibility
 
 			var peer = FindAutomationPeer(window.Content);
 
+			// If no automation peer is found (e.g., when called early in app lifecycle
+			// before window content is set), returns without error
+			if (peer is null)
+			{
+				return;
+			}
+
 			// This GUID correlates to the internal messages used by UIA to perform an announce
 			// You can extract it  by using accessibility insights to monitor UIA events
 			// If you're curious how this works then do a google search for the GUID


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- When SemanticScreenReader.Default.Announce() is called from the MainPage constructor, it throws a System.NullReferenceException: "Object reference not set to an instance of an object."

### Root Cause of the issue

- During MainPage construction, window.Content is null, which causes FindAutomationPeer to return null. As a result, the call to peer.RaiseNotificationEvent(...) throws a NullReferenceException.

### Description of Change

- Added a null check for window.Content in the Announce method and exited early to prevent a potential exception during early application initialization.

### Issues Fixed
Fixes #21121 

### Tested the behaviour in the follwing platforms
- [x] - Windows
- [x] - macOS
- [x] - Android
- [x] - iOS

### Output
| Before Fix | After Fix |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/e2bb5e30-ea70-4c3c-80a9-09ac4fac4db1"> | <img src="https://github.com/user-attachments/assets/84f09bd7-29ec-4109-a746-1f4f549d24d6"> |



