### PR TITLE
Reinstate some iOS13+ guards to support iOS 12.2+

### DIFF
--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
@@ -49,9 +49,16 @@ namespace Microsoft.Maui.LifecycleEvents
 							app.GetWindow()?.Stopped();
 					});
 
+			// Pre iOS 13 doesn't support scenes
+			if (!OperatingSystem.IsIOSVersionAtLeast(13))
+				return;
+
 			iOS
 				.SceneWillEnterForeground(scene =>
 				{
+					if (!OperatingSystem.IsIOSVersionAtLeast(13))
+						return;
+
 					if (scene.Delegate is IUIWindowSceneDelegate windowScene &&
 						scene.ActivationState != UISceneActivationState.Unattached)
 					{
@@ -60,21 +67,33 @@ namespace Microsoft.Maui.LifecycleEvents
 				})
 				.SceneOnActivated(scene =>
 				{
+					if (!OperatingSystem.IsIOSVersionAtLeast(13))
+						return;
+
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Activated();
 				})
 				.SceneOnResignActivation(scene =>
 				{
+					if (!OperatingSystem.IsIOSVersionAtLeast(13))
+						return;
+
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Deactivated();
 				})
 				.SceneDidEnterBackground(scene =>
 				{
+					if (!OperatingSystem.IsIOSVersionAtLeast(13))
+						return;
+
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Stopped();
 				})
 				.SceneDidDisconnect(scene =>
 				{
+					if (!OperatingSystem.IsIOSVersionAtLeast(13))
+						return;
+
 					if (scene.Delegate is IUIWindowSceneDelegate sd)
 						sd.GetWindow().GetWindow()?.Destroying();
 				});
@@ -82,11 +101,17 @@ namespace Microsoft.Maui.LifecycleEvents
 
 		static void OnConfigureWindow(IiOSLifecycleBuilder iOS)
 		{
+			// Pre iOS 13 doesn't support scenes
+			if (!OperatingSystem.IsIOSVersionAtLeast(13))
+			{
+				return;
+			}
+
 			iOS = iOS
 				.WindowSceneDidUpdateCoordinateSpace((windowScene, _, _, _) =>
 				{
 					// Mac Catalyst version 16+ supports effectiveGeometry property on window scenes.
-					if (OperatingSystem.IsMacCatalystVersionAtLeast(16))
+					if (!OperatingSystem.IsIOSVersionAtLeast(13) || (OperatingSystem.IsMacCatalystVersionAtLeast(16)))
 					{
 						return;
 					}

--- a/src/Core/src/Platform/iOS/ColorExtensions.cs
+++ b/src/Core/src/Platform/iOS/ColorExtensions.cs
@@ -14,57 +14,126 @@ namespace Microsoft.Maui.Platform
 
 		internal static UIColor LabelColor
 		{
-			get => UIColor.Label;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.Label;
+
+				return UIColor.Black;
+			}
 		}
 
 		internal static UIColor PlaceholderColor
 		{
-			get => UIColor.PlaceholderText;
+			get
+			{
+
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.PlaceholderText;
+
+				return SeventyPercentGrey;
+			}
 		}
 
 		internal static UIColor SecondaryLabelColor
 		{
-			get => UIColor.SecondaryLabel;
+			get
+			{
+
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.SecondaryLabel;
+
+				return new Color(.32f, .4f, .57f).ToPlatform();
+			}
 		}
 
 		internal static UIColor BackgroundColor
 		{
-			get => UIColor.SystemBackground;
+			get
+			{
+
+				if (OperatingSystem.IsIOSVersionAtLeast(13))
+					return UIColor.SystemBackground;
+
+				return UIColor.White;
+			}
 		}
 
 		internal static UIColor SeparatorColor
 		{
-			get => UIColor.Separator;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.Separator;
+
+				return UIColor.Gray;
+			}
 		}
 
 		internal static UIColor OpaqueSeparatorColor
 		{
-			get => UIColor.OpaqueSeparator;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.OpaqueSeparator;
+
+				return UIColor.Black;
+			}
 		}
 
 		internal static UIColor GroupedBackground
 		{
-			get => UIColor.SystemGroupedBackground;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13))
+					return UIColor.SystemGroupedBackground;
+
+				return new UIColor(247f / 255f, 247f / 255f, 247f / 255f, 1);
+			}
 		}
 
 		internal static UIColor AccentColor
 		{
-			get => UIColor.SystemBlue;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.SystemBlue;
+
+				return Color.FromRgba(50, 79, 133, 255).ToPlatform();
+			}
 		}
 
 		internal static UIColor Red
 		{
-			get => UIColor.SystemRed;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.SystemRed;
+
+				return UIColor.FromRGBA(255, 0, 0, 255);
+			}
 		}
 
 		internal static UIColor Gray
 		{
-			get => UIColor.SystemGray;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+					return UIColor.SystemGray;
+
+				return UIColor.Gray;
+			}
 		}
 
 		internal static UIColor LightGray
 		{
-			get => UIColor.SystemGray2;
+			get
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13))
+					return UIColor.SystemGray2;
+
+				return UIColor.LightGray;
+			}
 		}
 
 		public static CGColor ToCGColor(this Color color)

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -368,7 +368,10 @@ public static class KeyboardAutoManagerScroll
 		}
 		else
 		{
-			statusBarHeight = window.WindowScene?.StatusBarManager?.StatusBarFrame.Height ?? 0;
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
+				statusBarHeight = window.WindowScene?.StatusBarManager?.StatusBarFrame.Height ?? 0;
+			else
+				statusBarHeight = UIApplication.SharedApplication.StatusBarFrame.Height;
 
 			navigationBarAreaHeight = statusBarHeight;
 		}


### PR DESCRIPTION
### Description of Change

Effectively reverts (part of) #26751. In that PR some checks were removed to see if the app was running iOS 13+ and make decisions on which API to use. For .NET 9 we still support iOS 12.2+ and by just using APIs that are only available on iOS 13+ we now suddenly broke some things.

This PR adds that back so we can still keep supporting iOS 12.2+ for a little while longer.

### Issues Fixed

Fixes #30266