### PR TITLE
[housekeeping] Dispatch MainPage reset to UI thread to prevent crash in HostApp

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -133,7 +133,7 @@ namespace Maui.Controls.Sample
 				{
 					var realize = page.Realize();
 
-				  Dispatcher.Dispatch(() => Application.Current.MainPage = realize);
+				    Dispatcher.Dispatch(() => Application.Current.MainPage = realize);
 				}
 
 				SelectedItem = null;

--- a/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
+++ b/src/Controls/tests/TestCases.HostApp/CoreViews/CorePageView.cs
@@ -133,7 +133,7 @@ namespace Maui.Controls.Sample
 				{
 					var realize = page.Realize();
 
-					Application.Current.MainPage = realize;
+				  Dispatcher.Dispatch(() => Application.Current.MainPage = realize);
 				}
 
 				SelectedItem = null;


### PR DESCRIPTION
### Description of Change

Fixes a crash caused by setting `MainPage` inside SelectionChanged handler.  I think this is surfaced after this #28830

The reset is now dispatched to the UI thread to allow the selection round-trip to complete and avoid accessing disposed handlers.





https://github.com/user-attachments/assets/6dfe4175-f159-4967-b3ca-ca2e12be4c2d



