### PR TITLE
[iOS] Fix: FilePicker.PickAsync hangs on swipe-to-dismiss in older iOS versions

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Maui.Storage
 				{
 					PickHandler = urls => GetFileResults(urls, tcs)
 				};
+			}
 
 #if !MACCATALYST
 				if (documentPicker.PresentationController != null && !(OperatingSystem.IsIOSVersionAtLeast(14, 0) && NSProcessInfo.ProcessInfo.IsiOSApplicationOnMac))
@@ -71,7 +72,6 @@ namespace Microsoft.Maui.Storage
 						new UIPresentationControllerDelegate(() => GetFileResults(null, tcs));
 				}
 #endif
-			}
 
 			var parentController = WindowStateManager.Default.GetCurrentUIViewController(true);
 			parentController.PresentViewController(documentPicker, true, null);


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Follow up to (#29498)

This PR ensures FilePicker.PickAsync completes correctly when the user dismisses the file picker by swiping down on iOS older versions , where WasCancelled is not reliably triggered. ( I can reproduce this on iOS15.5). 

Somehow in older iOS versions dismissing the `UIDocumentPickerViewController` via swipe-down gesture does not invoke the `WasCancelled` event. As a result, the `TaskCompletionSource` is never completed, causing PickAsync to hang.

### Fix

`UIPresentationController.Delegate` was already used in the legacy delegate-based file picker path.
This PR extends that logic to also apply to the modern event-based picker API (DidPickDocumentAtUrls, WasCancelled), ensuring consistent cancellation handling across all code paths.


<!-- Enter description of the fix in this section -->

### Issues Fixed
<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #30282

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
