### PR TITLE
[Catalyst] Adding and Removing ContextMenus currently does not work - fix

### DIFF
--- a/src/Core/src/Handlers/MenuFlyoutHandler/MenuFlyoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/MenuFlyoutHandler/MenuFlyoutHandler.iOS.cs
@@ -17,30 +17,18 @@ namespace Microsoft.Maui.Handlers
 
 		public void Add(IMenuElement view)
 		{
-			Rebuild();
 		}
 
 		public void Remove(IMenuElement view)
 		{
-			Rebuild();
 		}
 
 		public void Clear()
 		{
-			Rebuild();
 		}
 
 		public void Insert(int index, IMenuElement view)
 		{
-			Rebuild();
-		}
-
-		internal static void Rebuild()
-		{
-			// TODO: Need to figure out how to rebuild the menu items for the entire context menu. On iOS/MacCat you
-			// can't add/remove individual menu items. You can call UIMenu.GetMenuByReplacingChildren(newChildren) to
-			// rebuild a specific menu, but that needs to be done at the "top" (the menu itself, not individual sub-items).
-			// https://github.com/dotnet/maui/issues/9359
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiUIContextMenuInteraction.cs
+++ b/src/Core/src/Platform/iOS/MauiUIContextMenuInteraction.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.Platform
 			if (contextFlyout == null || mauiContext == null)
 				return null;
 
+			contextFlyout.Handler?.DisconnectHandler();
 			var contextFlyoutHandler = contextFlyout.ToHandler(mauiContext);
 			var contextFlyoutPlatformView = contextFlyoutHandler.PlatformView;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Since context menus with webView don't function anyway (https://github.com/dotnet/maui/issues/30308), I think it's safe to add this line of code that enables runtime changes to menu items

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/9359

``` C#
public MainPage()
{
	var menuFlyout = new MenuFlyout();

	var button = new Button
	{
		Text = "Click me to add new item to me",
		AutomationId = "myButton",
		Command = new Command(() => menuFlyout.Add(new MenuFlyoutItem { Text = $"New Item {menuFlyout.Count + 1}" })),
	};
	
	FlyoutBase.SetContextFlyout(button, menuFlyout);
	Content = new StackLayout { Children = { button } };
}
```

<video src="https://github.com/user-attachments/assets/1c3a1446-51f3-486b-9d36-fdc808156c40"/>
