### PR TITLE
[Catalyst] WebView does not display ContextFlyout on right-click - fix

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.iOS.cs
@@ -45,16 +45,13 @@ namespace Microsoft.Maui.Handlers
 					{
 						if (uiView is WebKit.WKWebView webView)
 						{
+							var existingMaskView = webView.ViewWithTag(InterceptRightClickWebViewMaskView.MaskViewTag);
+							existingMaskView?.RemoveFromSuperview();
+
 							// If the view is a WKWebView, we need to intercept right-clicks
 							// to show the context menu, so we add a mask view that intercepts
 							// right-clicks and passes them to the context menu interaction.
-							var maskView = new InterceptRightClickWebViewMaskView(uiView.Bounds)
-							{
-								BackgroundColor = UIColor.Clear,
-								AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight,
-								UserInteractionEnabled = true
-							};
-
+							var maskView = new InterceptRightClickWebViewMaskView(uiView.Bounds);
 							webView.AddSubview(maskView);
 							maskView.AddInteraction(new MauiUIContextMenuInteraction(handler));
 						}
@@ -62,19 +59,31 @@ namespace Microsoft.Maui.Handlers
 						{
 							uiView.AddInteraction(new MauiUIContextMenuInteraction(handler));
 						}
-
 					}
 				}
 				else if (currentInteraction != null)
 				{
 					uiView.RemoveInteraction(currentInteraction);
+
+					if (uiView is WebKit.WKWebView webView)
+					{
+						var existingMaskView = webView.ViewWithTag(InterceptRightClickWebViewMaskView.MaskViewTag);
+						existingMaskView?.RemoveFromSuperview();
+					}
 				}
 			}
 		}
 
 		class InterceptRightClickWebViewMaskView : PlatformView
 		{
-			public InterceptRightClickWebViewMaskView(CGRect frame) : base(frame) { }
+			public const int MaskViewTag = 9999;
+			public InterceptRightClickWebViewMaskView(CGRect frame) : base(frame)
+			{
+				Tag = MaskViewTag;
+				BackgroundColor = UIColor.Clear;
+				AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+				UserInteractionEnabled = true;
+			}
 
 			public override PlatformView? HitTest(CGPoint point, UIEvent? uievent)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Note: This approach adds a transparent mask view over the WKWebView to intercept right-click events and display the MAUI ContextFlyout. As a result, this intentionally blocks the default WKWebView context menus on right-click.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/30308

The demo can be found here
```xaml
<WebView x:Name="ContextMenuWebView" Source="https://bing.com" MinimumHeightRequest="400">
    <FlyoutBase.ContextFlyout>
        <MenuFlyout>
            <MenuFlyoutItem Text="Go to MAUI repo" Clicked="OnWebViewGoToSiteClicked"></MenuFlyoutItem>
            <MenuFlyoutSeparator />
            <MenuFlyoutItem Text="Invoke some JS" Clicked="OnWebViewInvokeJSClicked"></MenuFlyoutItem>
        </MenuFlyout>
    </FlyoutBase.ContextFlyout>
</WebView>
```

|Before|After|
|--|--|
<video src="https://github.com/user-attachments/assets/6828be35-ba8d-4b86-be9e-11bbeb592ea7" width="300px"></video>|<video src="https://github.com/user-attachments/assets/2ab34073-fa6b-47d9-980a-9ed9344d05f5" width="300px"></video>|