### PR TITLE
[.NET 10] Use the known working version of platform-tools

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -173,6 +173,7 @@
     <JavaJdkVersion>17.0.12</JavaJdkVersion>
     <!-- Android SDK package versions and info -->
     <!-- Build Tools and CmdLine Tools versions -->
+    <AndroidSdkPlatformToolsVersion>35.0.2</AndroidSdkPlatformToolsVersion>
     <AndroidSdkBuildToolsVersion>33.0.0</AndroidSdkBuildToolsVersion>
     <AndroidSdkCmdLineToolsVersion>13.0</AndroidSdkCmdLineToolsVersion>
     <!-- Device Type for creating AVD's -->

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -36,7 +36,7 @@
 
 	<ItemGroup>
 		<!-- Android SDK - construct package names to install -->
-		<AndroidSdkPackages Include="platform-tools" />
+    <AndroidSdkPackages Include="platform-tools%3B$(AndroidSdkPlatformToolsVersion)" />
 		<AndroidSdkPackages Include="build-tools%3B$(AndroidSdkBuildToolsVersion)" />
 		<AndroidSdkPackages Include="cmdline-tools%3B$(AndroidSdkCmdLineToolsVersion)" />
 		<AndroidSdkPackages Include="emulator" />


### PR DESCRIPTION
### Description of Change

Noticed in several PRs applying changes to .NET 10 failing builds passing the Android UITests. Example: https://dev.azure.com/xamarin/public/_build/results?buildId=145163&view=results
After applying the changes https://github.com/dotnet/maui/pull/30173 from main, that errors passed away. This PR simply backports those changes from main to net10.0 to ensure build stability and test consistency moving forward.