### PR TITLE
[ai] Update github mcp

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,19 +8,9 @@
         }
     ],
     "servers": {
-       "github": {
-            "command": "docker",
-            "args": [
-                "run",
-                "-i",
-                "--rm",
-                "-e",
-                "GITHUB_PERSONAL_ACCESS_TOKEN",
-                "ghcr.io/github/github-mcp-server"
-            ],
-            "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-key}"
-            }
+        "github": {
+            "type": "http",
+            "url": "https://api.githubcopilot.com/mcp/"
         }
     }
 }


### PR DESCRIPTION
### Description of Change

Use the latest version of GitHub mcp server with new auth (no need of PAT)

https://github.com/github/github-mcp-server?tab=readme-ov-file