### PR TITLE
Remove .NET 8 specific code for templates

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -84,11 +84,7 @@
 <!--#if (IncludeSampleContent) -->
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-<!--#if (Framework == "net8.0") -->
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.0" />
-<!--#else-->
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.1" />
-<!--#endif-->
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.5" />

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -62,11 +62,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-<!--#if (Framework == "net8.0") -->
-                                        Flags="ValidateOnUnfocusing"
-<!--#else -->
                                         Flags="ValidateOnUnfocused"
-<!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>
@@ -108,11 +104,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-<!--#if (Framework == "net8.0") -->
-                                        Flags="ValidateOnUnfocusing"
-<!--#else -->
                                         Flags="ValidateOnUnfocused"
-<!--#endif -->
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>


### PR DESCRIPTION
### Description of Change

Since .NET 8 is now out of support, this removes the .NET 8 specific code from the templates in the `src/Templates/src/templates/maui-mobile` directory. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #28800 