### PR TITLE
Clean up .NET versions in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,7 +70,7 @@ body:
         - 9.0.0-preview.3.10457
         - 9.0.0-preview.2.10293
         - 9.0.0-preview.1.9973
-        - .NET 8 (Our of support, please specify exact version)
+        - .NET 8 (Out of support, please specify exact version)
         - Nightly / CI build (Please specify exact version)
         - Unknown/Other
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,26 +70,7 @@ body:
         - 9.0.0-preview.3.10457
         - 9.0.0-preview.2.10293
         - 9.0.0-preview.1.9973
-        - 8.0.100 SR10
-        - 8.0.93 SR9.3
-        - 8.0.92 SR9.2
-        - 8.0.91 SR9.1
-        - 8.0.90 SR9
-        - 8.0.83 SR8.3
-        - 8.0.82 SR8.2
-        - 8.0.80 SR8
-        - 8.0.71 SR7.1
-        - 8.0.70 SR7
-        - 8.0.61 SR6.1
-        - 8.0.60 SR6
-        - 8.0.40 SR5
-        - 8.0.21 SR4.1
-        - 8.0.20 SR4
-        - 8.0.14 SR3.1
-        - 8.0.10 SR3
-        - 8.0.7 SR2
-        - 8.0.6 SR1
-        - 8.0.3 GA
+        - .NET 8 (Our of support, please specify exact version)
         - Nightly / CI build (Please specify exact version)
         - Unknown/Other
     validations:
@@ -115,47 +96,9 @@ body:
       options:
         - 
         - Unknown/Other
-        - 6.0
-        - 7.0.49
-        - 7.0.52
-        - 7.0.58
-        - 7.0.59
-        - 7.0.81
-        - 7.0.86
-        - 7.0.92
-        - 7.0.96
-        - 7.0.100
-        - 7.0.101
-        - 8.0.0-preview.1.7762
-        - 8.0.0-preview.2.7871
-        - 8.0.0-preview.3.8149
-        - 8.0.0-preview.4.8333
-        - 8.0.0-preview.5.8529
-        - 8.0.0-preview.6.8686
-        - 8.0.0-preview.7.8842
-        - 8.0.0-rc.1.9171
-        - 8.0.0-rc.2.9373
-        - 8.0.0-rc.2.9511
-        - 8.0.3 GA
-        - 8.0.6 SR1
-        - 8.0.7 SR2        
-        - 8.0.10 SR3
-        - 8.0.14 SR3.1
-        - 8.0.20 SR4
-        - 8.0.21 SR4.1
-        - 8.0.40 SR5
-        - 8.0.60 SR6
-        - 8.0.61 SR6.1
-        - 8.0.70 SR7
-        - 8.0.71 SR7.1
-        - 8.0.80 SR8
-        - 8.0.82 SR8.2
-        - 8.0.83 SR8.3
-        - 8.0.90 SR9
-        - 8.0.91 SR9.1
-        - 8.0.92 SR9.2
-        - 8.0.93 SR9.3
-        - 8.0.100 SR10
+        - .NET 6  (Please specify exact version)
+        - .NET 7  (Please specify exact version)
+        - .NET 8  (Please specify exact version)
         - 9.0.0-preview.1.9973
         - 9.0.0-preview.2.10293
         - 9.0.0-preview.3.10457


### PR DESCRIPTION
Cleans up the version lists in the bug report template.

All out of support versions are now folded into their main version with the ask to specify the exact version.