### PR TITLE
[Windows] Fixed the Pasted Password Becomes Visible When IsPassword Is Enabled

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
@@ -76,5 +76,41 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(expectedAlignment, nativeAlignment);
 		}
+
+		[Fact]
+		[Description("Password entry should refresh obfuscation when identical text is pasted")]
+		public async Task PasswordEntryObfuscatesIdenticalPastedText()
+		{
+			var entry = new Entry
+			{
+				Text = "password123",
+				IsPassword = true
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<EntryHandler>(entry);
+				var platformControl = GetPlatformControl(handler);
+				var passwordTextBox = platformControl as Microsoft.Maui.Platform.MauiPasswordTextBox;
+
+				Assert.NotNull(passwordTextBox);
+				Assert.True(passwordTextBox.IsPassword);
+
+				// Verify the text is initially obfuscated
+				Assert.Equal(new string('●', entry.Text.Length), passwordTextBox.Text);
+
+				// Simulate pasting the same text by setting the same text value
+				passwordTextBox.Text = "password123";
+
+				// This is equivalent to what happens when a user pastes identical text via Ctrl+V
+				passwordTextBox.GetType().GetMethod("UpdatePasswordIfNeeded",
+					System.Reflection.BindingFlags.NonPublic |
+					System.Reflection.BindingFlags.Instance)?.Invoke(passwordTextBox, null);
+
+
+				// Verify the text is still properly obfuscated after the "paste" operation
+				Assert.Equal(new string('●', entry.Text.Length), passwordTextBox.Text);
+			});
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiPasswordTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiPasswordTextBox.cs
@@ -298,7 +298,15 @@ namespace Microsoft.Maui.Platform
 			var updatedPassword = DetermineTextFromPassword(Password, SelectionStart, Text);
 
 			if (Password != updatedPassword)
+			{
 				Password = updatedPassword;
+			}
+			else
+			{
+				// Ensure the UI properly refreshes when text is pasted with the same value
+				// Without this, pasting identical text via Ctrl+V doesn't trigger obfuscation
+				UpdateVisibleText();
+			}
 		}
 
 		static string Obfuscate(string text, bool leaveLastVisible = false)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- When a user copies text and pastes it into the text box, masking works correctly. However, when the `same text` is pasted a `second time`, the issue occurs.

- When pasting text identical to what's already in the password field, the obfuscation (masking characters with '●') doesn't refresh properly. 

This happens because:  

- The UpdatePasswordIfNeeded() method checks if the calculated password (from the pasted text) differs from the current password value 

- When pasting the same text, this check returns false , As a result, the Password property isn't updated 

- Without updating the Password property, the OnPasswordPropertyChanged callback isn't triggered. So ,the visual obfuscation isn't applied, leaving the pasted text potentially visible 



### Description of Change



- The solution is to explicitly call `UpdateVisibleText()` when the password hasn't changed. This ensures that the UI refresh with the masked text happens even when the underlying password value remains the same. 



### Issues Fixed



Fixes #30263 



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/18d55859-769f-452f-ac6f-cbe66f7d4bce"> | <video src="https://github.com/user-attachments/assets/799f4356-c8ce-4959-a2b2-c1307646a903"> |
| <img src="https://github.com/user-attachments/assets/b39a4c19-ea1e-4151-be07-991c59285580"> | <img src="https://github.com/user-attachments/assets/7ef05813-1aa6-4f88-9de5-5504c3fb1246"> |
