### PR TITLE
Fix for TapGestureRecognizer ButtonMask always return 0

### DIFF
--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 			if (cmd != null && cmd.CanExecute(CommandParameter))
 				cmd.Execute(CommandParameter);
 
-			Tapped?.Invoke(sender, new TappedEventArgs(CommandParameter, getPosition));
+			Tapped?.Invoke(sender, new TappedEventArgs(CommandParameter, getPosition, Buttons));
 		}
 
 	}

--- a/src/Controls/src/Core/TappedEventArgs.cs
+++ b/src/Controls/src/Core/TappedEventArgs.cs
@@ -14,9 +14,10 @@ namespace Microsoft.Maui.Controls
 			Parameter = parameter;
 		}
 
-		internal TappedEventArgs(object? parameter, Func<IElement?, Point?>? getPosition) : this(parameter)
+		internal TappedEventArgs(object? parameter, Func<IElement?, Point?>? getPosition, ButtonsMask buttons) : this(parameter)
 		{
 			_getPosition = getPosition;
+			Buttons = buttons;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TappedEventArgs.xml" path="//Member[@MemberName='Parameter']/Docs/*" />

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24734.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24734.cs
@@ -14,7 +14,7 @@ public class Issue24734 : ContentPage
 		Label label = new Label
 		{
 			Text = "Failure",
-			AutomationId = "TapLabel",
+			AutomationId = "LabelwithGesture",
 		};
 
 		TapGestureRecognizer tapGestureRecognizer = new TapGestureRecognizer

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24734.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24734.cs
@@ -1,0 +1,37 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 24734, "TapGestureRecognizer ButtonMask always return 0", PlatformAffected.All)]
+public class Issue24734 : ContentPage
+{
+	public Issue24734()
+	{
+		VerticalStackLayout stackLayout = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Padding = new Thickness(20)
+		};
+
+		Label label = new Label
+		{
+			Text = "Tap the label for the TapGestureRecognizer to be triggered.",
+			AutomationId = "TapLabel",
+		};
+
+		TapGestureRecognizer tapGestureRecognizer = new TapGestureRecognizer
+		{
+			Buttons = ButtonsMask.Primary
+		};
+
+		tapGestureRecognizer.Tapped += (sender, e) =>
+		{
+			if (e.Buttons == ButtonsMask.Primary)
+			{
+				label.Text = "Primary button clicked";
+			}
+		};
+
+		label.GestureRecognizers.Add(tapGestureRecognizer);
+		stackLayout.Add(label);
+		Content = stackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24734.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24734.cs
@@ -13,7 +13,7 @@ public class Issue24734 : ContentPage
 
 		Label label = new Label
 		{
-			Text = "Tap the label for the TapGestureRecognizer to be triggered.",
+			Text = "Failure",
 			AutomationId = "TapLabel",
 		};
 
@@ -26,7 +26,7 @@ public class Issue24734 : ContentPage
 		{
 			if (e.Buttons == ButtonsMask.Primary)
 			{
-				label.Text = "Primary button clicked";
+				label.Text = "Success";
 			}
 		};
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24734.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24734.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue24734 : _IssuesUITest
+{
+    public Issue24734(TestDevice device) : base(device)
+    {
+    }
+
+    public override string Issue => "TapGestureRecognizer ButtonMask always return 0";
+
+    [Test]
+    [Category(UITestCategories.Gestures)]
+    public void ButtonMaskShouldNotReturnZero()
+    {
+        App.WaitForElement("TapLabel");
+        App.Tap("TapLabel");
+        App.WaitForElement("Primary button clicked");
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24734.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24734.cs
@@ -18,6 +18,6 @@ public class Issue24734 : _IssuesUITest
     {
         App.WaitForElement("TapLabel");
         App.Tap("TapLabel");
-        App.WaitForElement("Primary button clicked");
+        App.WaitForElement("Success");
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24734.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24734.cs
@@ -16,8 +16,8 @@ public class Issue24734 : _IssuesUITest
     [Category(UITestCategories.Gestures)]
     public void ButtonMaskShouldNotReturnZero()
     {
-        App.WaitForElement("TapLabel");
-        App.Tap("TapLabel");
+        App.WaitForElement("LabelwithGesture");
+        App.Tap("LabelwithGesture");
         App.WaitForElement("Success");
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- TapGestureRecognizer.Buttons always returns 0, regardless of whether the primary or secondary mouse button is used.

### Root Cause of the issue

- In the TappedEventArgs class, the Buttons property has a private setter, meaning it can only be set internally. However, since the class does not assign a value to it—either in its constructor or through any internal method—the property always remains zero.

### Description of Change

- Added internal constructor that accepts ButtonsMask and modified event invocation to pass the button information

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24734 

### Tested the behaviour in the follwing platforms

- [x] - Windows
- [x]  - Android
- [x]  - iOS
- [x]  - Mac

### Output
| Before Fix | After Fix |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/8fd86c5b-6997-48f5-b6b0-3b33dd24de80"> | <img src="https://github.com/user-attachments/assets/3460c653-b5b0-4b2b-b28b-3cdfcb5bb36d"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
