### PR TITLE
[testing] Enable multiproject back

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
@@ -6,9 +6,8 @@ public class MultiProjectTemplateTest : BaseTemplateTests
 	[Test]
 	[TestCase("Debug", "simplemulti")]
 	[TestCase("Release", "simplemulti")]
-	//TODO: Reenable when we have a fix for the issue https://github.com/dotnet/maui/issues/30351
-	// [TestCase("Debug", "MultiProject@Symbol & More")]
-	// [TestCase("Release", "MultiProject@Symbol & More")]
+	[TestCase("Debug", "MultiProject@Symbol & More")]
+	[TestCase("Release", "MultiProject@Symbol & More")]
 	public void BuildMultiProject(string config, string projectName)
 	{
 		var projectDir = Path.Combine(TestDirectory, projectName);


### PR DESCRIPTION
### Description of Change

Enable back the tests for multi project.

This reverts commit 27fada9ff3b9a6555e2c06d44e38f2ff934a3450, reversing changes made to 85e17c4f82fcbf8afdb2ac1035cedcf6c0ee9794.


### Issues Fixed

Fixes #30351 

