### PR TITLE
[iOS, Mac] Fix for CollectionView not triggering Scrolled event when grouped and groups are empty

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -60,11 +60,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
 
-			if (lastVisibleItemIndex == -1)
-			{
-				return;
-			}
-
 			switch (itemsView.RemainingItemsThreshold)
 			{
 				case -1:

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -29,8 +29,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
-			if (!visibleItems)
+			if (!visibleItems && !HasHeaderOrFooter())
+			{
 				return;
+			}
 
 			var contentInset = scrollView.ContentInset;
 			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
@@ -57,6 +59,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
+
+			if (lastVisibleItemIndex == -1)
+			{
+				return;
+			}
 
 			switch (itemsView.RemainingItemsThreshold)
 			{
@@ -145,6 +152,37 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				lastVisibleItemIndex = GetItemIndex(Last, source);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
+		}
+
+		bool HasHeaderOrFooter()
+		{
+			var viewController = ViewController;
+
+			if (viewController?.ItemsView is null)
+			{
+				return false;
+			}
+
+			// Check for structured headers/footers
+			if (viewController.ItemsView is StructuredItemsView structuredItemsView)
+			{
+				if (structuredItemsView.Header is not null || structuredItemsView.HeaderTemplate is not null ||
+					structuredItemsView.Footer is not null || structuredItemsView.FooterTemplate is not null)
+				{
+					return true;
+				}
+			}
+
+			// Check for group headers/footers
+			if (viewController.ItemsView is GroupableItemsView groupableItemsView && groupableItemsView.IsGrouped)
+			{
+				if (groupableItemsView.GroupHeaderTemplate is not null || groupableItemsView.GroupFooterTemplate is not null)
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		static int GetItemIndex(NSIndexPath indexPath, IItemsViewSource itemSource)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -30,8 +30,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
-			if (!visibleItems)
+			if (!visibleItems && !HasHeaderOrFooter())
+			{
 				return;
+			}
 
 			var contentInset = scrollView.ContentInset;
 			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
@@ -58,6 +60,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
+
+			if (lastVisibleItemIndex == -1)
+			{
+				return;
+			}
 
 			switch (itemsView.RemainingItemsThreshold)
 			{
@@ -146,6 +153,37 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				lastVisibleItemIndex = GetItemIndex(Last, source);
 			}
 			return (VisibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex);
+		}
+
+		bool HasHeaderOrFooter()
+		{
+			var viewController = ViewController;
+
+			if (viewController?.ItemsView is null)
+			{
+				return false;
+			}
+
+			// Check for structured headers/footers (overall CollectionView header/footer)
+			if (viewController.ItemsView is StructuredItemsView structuredItemsView)
+			{
+				if (structuredItemsView.Header is not null || structuredItemsView.HeaderTemplate is not null ||
+					structuredItemsView.Footer is not null || structuredItemsView.FooterTemplate is not null)
+				{
+					return true;
+				}
+			}
+
+			// Check for group headers/footers (grouped CollectionView)
+			if (viewController.ItemsView is GroupableItemsView groupableItemsView && groupableItemsView.IsGrouped)
+			{
+				if (groupableItemsView.GroupHeaderTemplate is not null || groupableItemsView.GroupFooterTemplate is not null)
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		static int GetItemIndex(NSIndexPath indexPath, IItemsViewSource itemSource)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -61,11 +61,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
 
-			if (lastVisibleItemIndex == -1)
-			{
-				return;
-			}
-
 			switch (itemsView.RemainingItemsThreshold)
 			{
 				case -1:

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30249.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30249.cs
@@ -1,0 +1,83 @@
+using System.Collections.ObjectModel;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 30249, "Grouped CollectionView does not trigger the Scrolled event for empty groups", PlatformAffected.iOS)]
+public class Issue30249 : ContentPage
+{
+	CollectionView collectionViewWithEmptyGroups;
+	ObservableCollection<Issue30249Group> groupedItems = new ObservableCollection<Issue30249Group>();
+	Label scrolledEventStatusLabel;
+
+	public Issue30249()
+	{
+		Label descriptionLabel = new Label
+		{
+			Text = "Verify CollectionView Scrolled event is triggered for empty groups",
+			Margin = new Thickness(10)
+		};
+
+		scrolledEventStatusLabel = new Label
+		{
+			AutomationId = "ScrolledEventStatusLabel",
+			Text = "Failure",
+			Margin = new Thickness(10)
+		};
+
+		collectionViewWithEmptyGroups = new CollectionView
+		{
+			AutomationId = "CollectionViewWithEmptyGroups",
+			IsGrouped = true
+		};
+		collectionViewWithEmptyGroups.Scrolled += CollectionView_Scrolled;
+
+		collectionViewWithEmptyGroups.GroupHeaderTemplate = new DataTemplate(() =>
+		{
+			Label label = new Label
+			{
+				Padding = new Thickness(10),
+			};
+
+			label.SetBinding(Label.TextProperty, "Title");
+			return label;
+		});
+
+		for (int group = 0; group < 20; group++)
+		{
+			groupedItems.Add(new Issue30249Group($"Group {group}", new List<string>()));
+		}
+
+		collectionViewWithEmptyGroups.ItemsSource = groupedItems;
+
+		Grid grid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		grid.Add(descriptionLabel, 0, 0);
+		grid.Add(scrolledEventStatusLabel, 0, 1);
+		grid.Add(collectionViewWithEmptyGroups, 0, 2);
+
+		Content = grid;
+	}
+
+	private void CollectionView_Scrolled(object sender, ItemsViewScrolledEventArgs e)
+	{
+		scrolledEventStatusLabel.Text = "Success";
+	}
+}
+
+public class Issue30249Group : List<string>
+{
+	public string Title { get; set; }
+
+	public Issue30249Group(string title, List<string> items) : base(items)
+	{
+		Title = title;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30249.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30249.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30249 : _IssuesUITest
+{
+	public Issue30249(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Grouped CollectionView does not trigger the Scrolled event for empty groups";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyScrolledEventForEmptyGroups()
+	{
+		App.WaitForElement("CollectionViewWithEmptyGroups");
+		App.ScrollDown("CollectionViewWithEmptyGroups", ScrollStrategy.Gesture, 0.2, 500);
+
+		var scrolledEventStatus = App.FindElement("ScrolledEventStatusLabel").GetText();
+		Assert.That(scrolledEventStatus, Is.EqualTo("Success"));
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- Grouped CollectionView not triggering the Scrolled event for empty groups on iOS.

### Root Cause

-  The Scrolled method in ItemsViewDelegator and ItemsViewDelegator2 contains an early return that prevents the Scrolled event from firing when there are no visible items. This behavior unintentionally skips scroll notifications for empty groups.

### Description of Change

- Modified the Scrolled method in ItemsViewDelegator and ItemsViewDelegator2 to check for headers or footers before returning early when no visible items are present.
- Added a new helper method HasHeaderOrFooter to determine if headers or footers exist, including structured and group headers/footers.


### Issues Fixed
Fixes #30249 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/7ebdd25a-17d8-4e08-8ffd-264bb176b788"> | <video src="https://github.com/user-attachments/assets/d9d9dc8b-1de9-4dd8-8926-474620602ab1"> |