### PR TITLE
[Mac] Fix Button sizing broken by .NET9 when using the Mac UI Idiom

### DIFF
--- a/src/Controls/src/Core/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/Button/Button.iOS.cs
@@ -38,7 +38,25 @@ namespace Microsoft.Maui.Controls
 			{
 				return Size.Zero;
 			}
+#if MACCATALYST		
+			// For buttons with UIButtonConfiguration, use native sizing
+			if (OperatingSystem.IsIOSVersionAtLeast(15) && platformButton.Configuration is not null)
+			{
+				platformButton.LayoutIfNeeded();
+				
+				// Calculates the optimal size the button should occupy based on its current configuration.
+				// This includes text, icons, spacing, and intrinsic content size.
+				var nativeSize = platformButton.SizeThatFits(new CGSize(widthConstraint, heightConstraint));
 
+				if (nativeSize.Width > 0 && nativeSize.Height > 0 && 
+				    !double.IsInfinity(nativeSize.Width) && !double.IsInfinity(nativeSize.Height))
+				{
+					// Round up to the nearest whole number to avoid clipping.
+					return new Size((int)Math.Ceiling(nativeSize.Width), (int)Math.Ceiling(nativeSize.Height));
+				}
+			}
+#endif
+			
 			var layout = button.ContentLayout;
 			var spacing = (nfloat)layout.Spacing;
 			var borderWidth = button.BorderWidth < 0 ? 0 : button.BorderWidth;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26154.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26154.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue26154"
+             Title="Issue 26154">
+  <VerticalStackLayout
+    Padding="12">
+    <Label
+      Text="Add Mac Idiom (edit Platforms/MacCatalyst/Info.plist key of UIDeviceFamily to value 6)" />
+    <HorizontalStackLayout Spacing="10" Padding="20" >
+      <Button Text="Button 1" />
+      <Button Text="Button 2" />
+    </HorizontalStackLayout>
+  </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue26154.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue26154.xaml.cs
@@ -1,0 +1,10 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 26154, "Button sizing broken by .NET9 when using the Mac UI Idiom", PlatformAffected.macOS)]
+public partial class Issue26154 : ContentPage
+{
+	public Issue26154()
+	{
+		InitializeComponent();
+	}
+}


### PR DESCRIPTION
### Description of Change

Button sizing was broken in .NET 9 when using Mac Catalyst with Mac UI Idiom, causing button text to be truncated. This affected buttons without explicitly set sizes.
This PR apply changes when using `UIButtonConfiguration`, with the Mac UI Idiom, to trust native sizing (`SizeThatFits`) and fix the Button size.

Before
![image](https://github.com/user-attachments/assets/34ab4352-bd87-4340-957f-0266117c3ade)

After
![image](https://github.com/user-attachments/assets/6b6b82e4-8080-47ff-86cc-c69a3571a6fb)

### Issues Fixed

Fixes #26154 