### PR TITLE
[ci] Add variable group to yaml and not on azdo UI

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -57,6 +57,9 @@ variables:
 - name: _InternalBuildArgs
   value: ''
 
+# Variable groups required for all builds
+- group: xamops-azdev-secrets
+
 # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
   - group: Xamarin-Secrets
@@ -64,7 +67,7 @@ variables:
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - name: internalProvisioning
     value: true
-  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}: 
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     - name: PrivateBuild
       value: false
     - name: _RunAsPublic

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -58,7 +58,8 @@ variables:
   value: ''
 
 # Variable groups required for all builds
-- group: xamops-azdev-secrets
+- ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), eq(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
+  - group: xamops-azdev-secrets
 
 # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:


### PR DESCRIPTION
### Description of Change

Work related to remove usage of secrets on maui builds. 

This variable group is added on AZDO UI and we want to control it from yaml

Work related with https://github.com/dotnet/maui/pull/30146