### PR TITLE
[iOS] Fix CGContext "invalid context 0x0" warnings in .NET 9

### DIFF
--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -136,7 +136,31 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 					Assert.True(stream.Length > 0);
 			});
 		}
+		
+		[Fact]
+		public Task CaptureLayerWithZeroSizeAsync()
+		{
+			return Utils.OnMainThread(async () =>
+			{
+				await Task.Delay(100);
 
+				var window = WindowStateManager.Default.GetCurrentUIWindow();
+				var view = window.RootViewController.View;
+				Assert.NotNull(view);
+				
+				var layer = view.Layer;
+			
+				// Intentionally set the layer bounds to empty (zero width/height)
+				// This simulates an edge case where the drawable area is non-existent
+				layer.Bounds = CoreGraphics.CGRect.Empty;
+				
+				IScreenshotResult mediaFile = await Screenshot.Default.CaptureAsync(layer, false);
+				
+				// Assert that the capture still produces a non-null result
+				// Important: the implementation should gracefully handle null contexts
+				Assert.NotNull(mediaFile);
+			});
+		}
 #endif
 	}
 }

--- a/src/Graphics/src/Graphics/Platforms/Mac/DirectRenderer.cs
+++ b/src/Graphics/src/Graphics/Platforms/Mac/DirectRenderer.cs
@@ -32,6 +32,12 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public void Draw(CGContext coreGraphics, RectF dirtyRect)
 		{
+			// Ensure we have a valid context
+			if (coreGraphics is null)
+			{
+				return;
+			}
+			
 			_canvas.Context = coreGraphics;
 
 			try

--- a/src/Graphics/src/Graphics/Platforms/iOS/DirectRenderer.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/DirectRenderer.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public void Draw(CGContext coreGraphics, RectF dirtyRect)
 		{
+			// Ensure we have a valid context
+			if (coreGraphics is null)
+			{
+				return;
+			}
+
 			_canvas.Context = coreGraphics;
 
 			try

--- a/src/Graphics/src/Graphics/Platforms/iOS/PlatformGraphicsView.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/PlatformGraphicsView.cs
@@ -91,6 +91,12 @@ namespace Microsoft.Maui.Graphics.Platform
 
 			var coreGraphics = UIGraphics.GetCurrentContext();
 
+			// Ensure we have a valid context
+			if (coreGraphics is null)
+			{
+				return;
+			}
+
 			if (_colorSpace == null)
 			{
 				_colorSpace = CGColorSpace.CreateDeviceRGB();


### PR DESCRIPTION
### Description of Change

There are .NET MAUI tools that use screenshots. On iOS, in the `Screenshot.ios.cs` class the `TryRender` method already calls `layer.RenderInContext(ctx) `internally, so the additional call after it was unnecessary and could cause potential CGContext issues. Also, added defensive null checks in all locations where UIGraphics.GetCurrentContext() is called to ensure graceful handling when the graphics context is invalid.

### Issues Fixed

Fixes #29810 
