### PR TITLE
[net10.0, Testing] Fix Button & RadioFeatureTests Screenshot Issue on Windows

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ButtonFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ButtonFeatureTests.cs
@@ -75,6 +75,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		App.WaitForElement("ClickedEventLabel");
+		App.Tap("ClickedEventLabel");
 		VerifyScreenshot();
 	}
 #endif
@@ -115,6 +117,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		App.WaitForElement("ClickedEventLabel");
+		App.Tap("ClickedEventLabel");
 		VerifyScreenshot();
 	}
 
@@ -249,6 +253,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		App.WaitForElement("ClickedEventLabel");
+		App.Tap("ClickedEventLabel");
 		VerifyScreenshot();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/RadioButtonFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/RadioButtonFeatureTests.cs
@@ -213,8 +213,8 @@ public class RadioButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("RadioButtonControlOne");
-		App.WaitForElement("ClickedEventLabel");
-		App.Tap("ClickedEventLabel");
+		App.WaitForElement("SelectedValueLabelOne");
+		App.Tap("SelectedValueLabelOne");
 		VerifyScreenshot();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/RadioButtonFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/RadioButtonFeatureTests.cs
@@ -213,6 +213,8 @@ public class RadioButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("RadioButtonControlOne");
+		App.WaitForElement("ClickedEventLabel");
+		App.Tap("ClickedEventLabel");
 		VerifyScreenshot();
 	}
 


### PR DESCRIPTION
I have fixed the UI test in the PR [#29281](https://github.com/dotnet/maui/pull/29281) and improved the stability for the test cases.
Build Link: [Azure DevOps - Build #145495](https://dev.azure.com/xamarin/public/_build/results?buildId=145495&view=ms.vss-test-web.build-test-results-tab)

### Enhancements to Button feature tests:

- Added steps to wait for and tap the ClickedEventLabel element in the Button_SetCharacterSpacingAndText_VerifyVisualState test case.
- Added steps to wait for and tap the ClickedEventLabel element in the Button_SetCornerRadiusAndBorderWidth_VerifyVisualState test case.
- Added steps to wait for and tap the ClickedEventLabel element in the Button_setFontSizeAndText_VerifyVisualState test case.

### Enhancements to RadioButton feature tests:

- Added steps to wait for and tap the SelectedValueLabelOne element in the RadioButton_SetContentAndFontSize_VerifyVisualState test case.