### PR TITLE
[X] Optionally stop supporting Namescopes

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -13,7 +13,7 @@ The following switches are toggled for applications running on Mono for `TrimMod
 | _MauiBindingInterceptorsSupport | Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported | When disabled, MAUI won't intercept any calls to `SetBinding` methods and try to compile them. Enabled by default. |
 | MauiEnableXamlCBindingWithSourceCompilation | Microsoft.Maui.RuntimeFeature.XamlCBindingWithSourceCompilationEnabled | When enabled, MAUI will compile all bindings, including those where the `Source` property is used. |
 | MauiHybridWebViewSupported | Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported | Enables HybridWebView, which makes use of dynamic System.Text.Json serialization features |
-| MauiNamescopesSupported | Microsoft.Maui.RuntimeFeature.AreNamescopesSupported | Enable supprot for Namescopes, FindByName if the application uses it, or to keep supporting runtime and XamlC XAML inflators |
+| MauiNamescopesSupported | Microsoft.Maui.RuntimeFeature.AreNamescopesSupported | Enable support for Namescopes, FindByName if the application uses it, or to keep supporting runtime and XamlC XAML inflators |
 
 ## MauiEnableIVisualAssemblyScanning
 

--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -13,6 +13,7 @@ The following switches are toggled for applications running on Mono for `TrimMod
 | _MauiBindingInterceptorsSupport | Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported | When disabled, MAUI won't intercept any calls to `SetBinding` methods and try to compile them. Enabled by default. |
 | MauiEnableXamlCBindingWithSourceCompilation | Microsoft.Maui.RuntimeFeature.XamlCBindingWithSourceCompilationEnabled | When enabled, MAUI will compile all bindings, including those where the `Source` property is used. |
 | MauiHybridWebViewSupported | Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported | Enables HybridWebView, which makes use of dynamic System.Text.Json serialization features |
+| MauiNamescopesSupported | Microsoft.Maui.RuntimeFeature.AreNamescopesSupported | Enable supprot for Namescopes, FindByName if the application uses it, or to keep supporting runtime and XamlC XAML inflators |
 
 ## MauiEnableIVisualAssemblyScanning
 
@@ -76,3 +77,11 @@ XamlC skipped compilation of bindings with the `Source` property set to any valu
 ```
 
 This feature is disabled by default, unless `TrimMode=true` or `PublishAot=true`. For fully trimmed and NativeAOT apps, the feature is enabled.
+
+## MauiNamescopesSupported
+
+With (upcoming) sourcegen XAML inflation, the xaml infrastructure no longer need Namescopes. Some apps that want to keep XamlC or Runtime inflation, use FindByName in code, or have MarkupExtensions depending on `IReferenceProvider` will want to turn this back on.
+
+Having this off reduce method body size, making them faster to JIT, and release the pressure on the GC as there are way less allocations.
+
+As of NET10.0, the default is `true` so full compatibility is maintained, but might be changed in the future.

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -269,7 +269,10 @@
                                       Condition="'$(MauiHybridWebViewSupported)' != ''"
                                       Value="$(MauiHybridWebViewSupported)"
                                       Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.AreNamescopesSupported"
+                                      Condition="'$(MauiNamescopesSupported)' != ''"
+                                      Value="$(MauiNamescopesSupported)"
+                                      Trim="true" />      
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -514,6 +514,9 @@ namespace Microsoft.Maui.Controls
 		/// <exception cref="InvalidOperationException">Thrown if the element's namescope couldn't be found.</exception>
 		public object FindByName(string name)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+			
 			var namescope = GetNameScope() ?? transientNamescope;
 			if (namescope == null)
 				throw new InvalidOperationException("this element is not in a namescope");
@@ -523,6 +526,9 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc/>
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			var namescope = GetNameScope() ?? throw new InvalidOperationException("this element is not in a namescope");
 			namescope.RegisterName(name, scopedElement);
 		}
@@ -530,6 +536,9 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc/>
 		void INameScope.UnregisterName(string name)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			var namescope = GetNameScope() ?? throw new InvalidOperationException("this element is not in a namescope");
 			namescope.UnregisterName(name);
 		}
@@ -895,6 +904,9 @@ namespace Microsoft.Maui.Controls
 
 		internal INameScope GetNameScope()
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			var element = this;
 			do
 			{

--- a/src/Controls/src/Core/Internals/NameScope.cs
+++ b/src/Controls/src/Core/Internals/NameScope.cs
@@ -18,10 +18,18 @@ namespace Microsoft.Maui.Controls.Internals
 		readonly Dictionary<object, string> _values = new Dictionary<object, string>();
 
 		object INameScope.FindByName(string name)
-			=> _names.TryGetValue(name, out var element) ? element : null;
+		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
+			return _names.TryGetValue(name, out var element) ? element : null;
+		}
 
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			if (_names.ContainsKey(name))
 				throw new ArgumentException($"An element with the key '{name}' already exists in NameScope", nameof(name));
 
@@ -31,21 +39,37 @@ namespace Microsoft.Maui.Controls.Internals
 
 		//used by VS Live Visual Tree
 		internal string NameOf(object scopedObject)
-			=> _values.TryGetValue(scopedObject, out var name) ? name : null;
+		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
 
+			return _values.TryGetValue(scopedObject, out var name) ? name : null;
+		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NameScope.xml" path="//Member[@MemberName='GetNameScope']/Docs/*" />
-		public static INameScope GetNameScope(BindableObject bindable) => (INameScope)bindable.GetValue(NameScopeProperty);
+		public static INameScope GetNameScope(BindableObject bindable)
+		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
+			return (INameScope)bindable.GetValue(NameScopeProperty);
+		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NameScope.xml" path="//Member[@MemberName='SetNameScope']/Docs/*" />
 		public static void SetNameScope(BindableObject bindable, INameScope value)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			if (bindable.GetValue(NameScopeProperty) == null)
 				bindable.SetValue(NameScopeProperty, value);
 		}
 
 		void INameScope.UnregisterName(string name)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			if (name == null)
 				throw new ArgumentNullException(nameof(name));
 

--- a/src/Controls/src/Core/NameScopeExtensions.cs
+++ b/src/Controls/src/Core/NameScopeExtensions.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Maui.Controls
 	{
 		public static T FindByName<T>(this Element element, string name)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			try
 			{
 				return (T)element.FindByName(name);
@@ -21,6 +24,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 		internal static T FindByName<T>(this INameScope namescope, string name)
-			=> (T)namescope.FindByName(name);
+		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
+			return (T)namescope.FindByName(name);
+		}
 	}
 }

--- a/src/Controls/src/Xaml/XamlServiceProvider.cs
+++ b/src/Controls/src/Xaml/XamlServiceProvider.cs
@@ -174,6 +174,9 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		public object FindByName(string name)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			object value;
 			if (scopes != null)
 				foreach (var scope in scopes)
@@ -278,6 +281,9 @@ namespace Microsoft.Maui.Controls.Xaml.Internals
 
 		public object FindByName(string name)
 		{
+			if (!RuntimeFeature.AreNamescopesSupported)
+				throw new NotSupportedException("Namescopes are not supported. Please enable the feature switch 'Microsoft.Maui.RuntimeFeature.AreNamescopesSupported' to keep using namescopes.");
+
 			var n = _node;
 			while (n != null)
 			{

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -14,20 +14,22 @@ namespace Microsoft.Maui
 	/// </remarks>
 	internal static class RuntimeFeature
 	{
-		private const bool IsIVisualAssemblyScanningEnabledByDefault = false;
-		private const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;
-		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
-		private const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
-		private const bool AreBindingInterceptorsSupportedByDefault = true;
-		private const bool IsXamlCBindingWithSourceCompilationEnabledByDefault = false;
-		private const bool IsHybridWebViewSupportedByDefault = true;
+		const bool IsIVisualAssemblyScanningEnabledByDefault = false;
+		const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;
+		const bool IsQueryPropertyAttributeSupportedByDefault = true;
+		const bool IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault = true;
+		const bool AreBindingInterceptorsSupportedByDefault = true;
+		const bool IsXamlCBindingWithSourceCompilationEnabledByDefault = false;
+		const bool IsHybridWebViewSupportedByDefault = true;
+		const bool SupportNamescopesByDefault = true;
+		const string FeatureSwitchPrefix = "Microsoft.Maui.RuntimeFeature";
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if NET9_0_OR_GREATER
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled")]
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #endif
-		internal static bool IsIVisualAssemblyScanningEnabled =>
+		public static bool IsIVisualAssemblyScanningEnabled =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled", out bool isEnabled)
 				? isEnabled
 				: IsIVisualAssemblyScanningEnabledByDefault;
@@ -36,7 +38,7 @@ namespace Microsoft.Maui
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported")]
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #endif
-		internal static bool IsShellSearchResultsRendererDisplayMemberNameSupported
+		public static bool IsShellSearchResultsRendererDisplayMemberNameSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported", out bool isSupported)
 				? isSupported
 				: IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault;
@@ -45,7 +47,7 @@ namespace Microsoft.Maui
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported")]
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #endif
-		internal static bool IsQueryPropertyAttributeSupported =>
+		public static bool IsQueryPropertyAttributeSupported =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported", out bool isSupported)
 				? isSupported
 				: IsQueryPropertyAttributeSupportedByDefault;
@@ -54,7 +56,7 @@ namespace Microsoft.Maui
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported")]
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #endif
-		internal static bool IsImplicitCastOperatorsUsageViaReflectionSupported =>
+		public static bool IsImplicitCastOperatorsUsageViaReflectionSupported =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsImplicitCastOperatorsUsageViaReflectionSupported", out bool isSupported)
 				? isSupported
 				: IsImplicitCastOperatorsUsageViaReflectionSupportedByDefault;
@@ -62,7 +64,7 @@ namespace Microsoft.Maui
 #if NET9_0_OR_GREATER
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported")]
 #endif
-		internal static bool AreBindingInterceptorsSupported =>
+		public static bool AreBindingInterceptorsSupported =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.AreBindingInterceptorsSupported", out bool areSupported)
 				? areSupported
 				: AreBindingInterceptorsSupportedByDefault;
@@ -70,7 +72,7 @@ namespace Microsoft.Maui
 #if NET9_0_OR_GREATER
 		[FeatureSwitchDefinition("Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled")]
 #endif
-		internal static bool IsXamlCBindingWithSourceCompilationEnabled =>
+		public static bool IsXamlCBindingWithSourceCompilationEnabled =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled", out bool areSupported)
 				? areSupported
 				: IsXamlCBindingWithSourceCompilationEnabledByDefault;
@@ -80,10 +82,22 @@ namespace Microsoft.Maui
 		[FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 		[FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
 #endif
-		internal static bool IsHybridWebViewSupported =>
+		public static bool IsHybridWebViewSupported =>
 			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported", out bool isSupported)
 				? isSupported
 				: IsHybridWebViewSupportedByDefault;
+
+#if NET9_0_OR_GREATER
+		[FeatureSwitchDefinition($"{FeatureSwitchPrefix}.{nameof(AreNamescopesSupported)}")]
+#endif
+		public static bool AreNamescopesSupported
+		{
+			get => AppContext.TryGetSwitch($"{FeatureSwitchPrefix}.{nameof(AreNamescopesSupported)}", out bool isSupported)
+				? isSupported
+				: SupportNamescopesByDefault;
+			//for testing purposes only
+			internal set => AppContext.SetSwitch($"{FeatureSwitchPrefix}.{nameof(AreNamescopesSupported)}", value);
+		}
 #pragma warning restore IL4000
-	}
+    }
 }

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui
 	/// Mapping of MSBuild properties to feature switches and the default values of feature switches
 	/// is defined in Microsoft.Maui.Sdk.Before.targets.
 	/// </remarks>
-	internal static class RuntimeFeature
+	static class RuntimeFeature
 	{
 		const bool IsIVisualAssemblyScanningEnabledByDefault = false;
 		const bool IsShellSearchResultsRendererDisplayMemberNameSupportedByDefault = true;


### PR DESCRIPTION
### Description of Change

With Xaml SourceGen, Namescopes are no longer necessary for the XAML infrastructure. Npt generating them will help the JIT and GC

This is mostly unused right now

### Issues Fixed

- fixes #30434
