### PR TITLE
[.Net10][Proposal]TabbedPage - TabActiveTapped event

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -131,6 +131,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				view.Arrange(View.Bounds.ToRectangle());
 		}
 
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+			ShouldSelectViewController = (tabController, viewController) =>
+			{
+				if (viewController == tabController.SelectedViewController)
+				{
+					Tabbed?.SendTabActiveTapped();
+				}
+				return true;
+			};
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -965,6 +965,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			TabLayoutMediator.ITabConfigurationStrategy
 		{
 			readonly TabbedPageManager _tabbedPageManager;
+			bool _initialBottomNavigation;
 
 			public Listeners(TabbedPageManager tabbedPageManager)
 			{
@@ -1024,6 +1025,12 @@ namespace Microsoft.Maui.Controls.Handlers
 				{
 					if (_tabbedPageManager._bottomNavigationView.SelectedItemId != item.ItemId && _tabbedPageManager.Element.Children.Count > item.ItemId)
 						_tabbedPageManager.Element.CurrentPage = _tabbedPageManager.Element.Children[item.ItemId];
+					// The _initialBottomNavigation flag prevents TabActiveTapped from firing during initial setup.
+					// We only want this event when users actually tap an already-selected tab, not during framework initialization.
+					else if (_tabbedPageManager._bottomNavigationView.SelectedItemId == item.ItemId && _initialBottomNavigation)
+						_tabbedPageManager.Element?.SendTabActiveTapped();
+
+					_initialBottomNavigation = true;
 				}
 
 				return true;
@@ -1032,6 +1039,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			void TabLayout.IOnTabSelectedListener.OnTabReselected(TabLayout.Tab tab)
 			{
+				_tabbedPageManager?.Element?.SendTabActiveTapped();
 			}
 
 			void TabLayout.IOnTabSelectedListener.OnTabSelected(TabLayout.Tab tab)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.TabbedPage.TabActiveTapped -> System.EventHandler
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.TabbedPage.TabActiveTapped -> System.EventHandler
+override Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer.ViewDidLoad() -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.TabbedPage.TabActiveTapped -> System.EventHandler
+override Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer.ViewDidLoad() -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Microsoft.Maui.Controls.TabbedPage.TabActiveTapped -> System.EventHandler
 const Microsoft.Maui.Controls.BrushTypeConverter.Hsl = "hsl" -> string!
 const Microsoft.Maui.Controls.BrushTypeConverter.Hsla = "hsla" -> string!
 const Microsoft.Maui.Controls.BrushTypeConverter.LinearGradient = "linear-gradient" -> string!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.TabbedPage.TabActiveTapped -> System.EventHandler
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.TabbedPage.TabActiveTapped -> System.EventHandler
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SelectedTabColorProperty, value);
 		}
 
+		public event EventHandler TabActiveTapped;
+
 		protected override Page CreateDefault(object item)
 		{
 			var page = new Page();
@@ -85,6 +87,11 @@ namespace Microsoft.Maui.Controls
 		{
 			// We don't want forcelayout to call the legacy
 			// Page.LayoutChildren code
+		}
+
+		internal void SendTabActiveTapped()
+		{
+			TabActiveTapped?.Invoke(this, EventArgs.Empty);
 		}
 
 		partial void OnHandlerChangingPartial(HandlerChangingEventArgs args);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15301TabbedPage.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15301TabbedPage.cs
@@ -1,0 +1,47 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, "15301TabbedPage", "TabbedPage.TabActiveTapped", PlatformAffected.Android | PlatformAffected.iOS)]
+public class Issue15301TabbedPage : TabbedPage
+{
+	public Issue15301TabbedPage()
+	{
+		Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.SetToolbarPlacement(this, Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Bottom);
+
+		var rootPage = new ContentPage
+		{
+			Title = "Root Page"
+		};
+
+		var button = new Button
+		{
+			Text = "Deep 0",
+			AutomationId = "Deep0Button",
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var navPage = new NavigationPage(rootPage) { Title = "Tab 1" };
+		
+		TabActiveTapped += (s, e) =>
+		{
+			navPage.PopAsync();
+		};
+
+		button.Command = new Command(() =>
+		{
+			navPage.PushAsync(new ContentPage()
+			{
+				Title = "Deep 1",
+				Content = new Button()
+				{
+					Text = "Hello, World!",
+					AutomationId = "Deep1Label",
+					VerticalOptions = LayoutOptions.Center,
+				}
+			});
+		});
+
+		rootPage.Content = button;
+		Children.Add(navPage);
+		Children.Add(new ContentPage { Title = "Ignore Me" });
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15301TabbedPage.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15301TabbedPage.cs
@@ -1,0 +1,28 @@
+﻿#if ANDROID || IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue15301TabbedPage : _IssuesUITest
+{
+	public Issue15301TabbedPage(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "TabbedPage.TabActiveTapped";
+
+	[Test]
+	[Category(UITestCategories.TabbedPage)]
+	public void ClickingCurrentTabShouldCallTabActiveTappedEvent()
+	{
+		App.WaitForElement("Deep0Button");
+		App.Click("Deep0Button");
+		App.WaitForElement("Deep1Label");
+		App.Click("Tab 1");
+		App.WaitForElement("Deep0Button");
+	}
+}
+
+#endif


### PR DESCRIPTION
Description of Change
This proposal introduces a new TabReselected event to the .NET MAUI TabbedPage. This event is raised when a user taps on the currently active tab. It provides developers with a clean and consistent way to handle tab reselection scenarios across platforms.

Motivation
In many tab-based applications, it's a common user expectation that tapping an already selected tab performs an action, such as popping the navigation stack to the root or refreshing the content. Currently, developers must implement workarounds to detect tab reselection, which adds complexity and platform-specific code. 

Fixes https://github.com/dotnet/maui/issues/27401
Fixes https://github.com/dotnet/maui/issues/15301
Fixes https://github.com/dotnet/maui/issues/29395