### PR TITLE
Tabs on TabbedPage gone after popping Modal in background - fix

### DIFF
--- a/src/Core/src/Platform/Android/FragmentManagerExtensions.cs
+++ b/src/Core/src/Platform/Android/FragmentManagerExtensions.cs
@@ -118,7 +118,9 @@ namespace Microsoft.Maui.Platform
 			public override void OnFragmentDestroyed(FragmentManager fm, Fragment f)
 			{
 				base.OnFragmentDestroyed(fm, f);
+				var resume = _onResume;
 				Disconnect();
+				resume?.Invoke(fm);
 			}
 
 			public override void OnFragmentResumed(FragmentManager fm, Fragment f)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This is an extension of PR https://github.com/dotnet/maui/pull/19532

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/22444

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/9d5371e8-1908-4942-b831-009bbeaf130e" width="300px"></video>|<video src="https://github.com/user-attachments/assets/90c38f8e-fc47-4ed7-b3a3-122f6bc4ed42" width="300px"></video>|

```c#
public partial class MainPage : TabbedPage
{
	public MainPage()
	{
		Children.Add(new ContentPage
		{
			Title = "Tab 1",
			Content = new StackLayout
			{
				Children =
			{
				new Button
				{
					Text = "Open Modal Page",
					Command = new Command(() => {
						Navigation.PushModalAsync(new ContentPage
						{
							Title = "Modal Page",
							Content = new StackLayout
							{
								Children =
								{
									new Label { Text = "This is a modal page." },
									new Button
									{
										Text = "Close",
										Command = new Command(async() =>
										{
											await Task.Delay(2000);
											await Navigation.PopModalAsync();
										})
									}
								}
							}
						});
					})
				}
			}
			}
		});

		Children.Add(new ContentPage { Title = "Tab 2" });
	}
}
```
