### PR TITLE
fix some incorrect casting using `as`

### DIFF
--- a/src/Controls/samples/Controls.Sample/Controls/Rate/RateItem.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/RateItem.cs
@@ -104,7 +104,7 @@ namespace Maui.Controls.Sample.Controls
 		{
 			base.OnApplyTemplate();
 
-			_icon = (GetTemplateChild(ElementIcon) as View)!;
+			_icon = (View)GetTemplateChild(ElementIcon);
 			_icon.WidthRequest = Width;
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -62,7 +62,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 			generator.GenerateItems();
 
 			_carouselView.PropertyChanged += CarouselViewPropertyChanged;
-			(_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!.CollectionChanged += IndicatorCodeGalleryCollectionChanged;
+			((ObservableCollection<CollectionViewGalleryTestItem>)_carouselView.ItemsSource).CollectionChanged += IndicatorCodeGalleryCollectionChanged;
 
 			var indicatorView = new IndicatorView
 			{
@@ -205,7 +205,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
-					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!;
+					var items = (ObservableCollection<CollectionViewGalleryTestItem>)_carouselView.ItemsSource;
 					items.Remove(items[0]);
 				})
 			};
@@ -238,7 +238,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 					_carouselView.Position++;
 				}, () =>
 				{
-					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!;
+					var items = (ObservableCollection<CollectionViewGalleryTestItem>)_carouselView.ItemsSource;
 					return _carouselView.Position < items.Count - 1;
 				})
 			};
@@ -252,7 +252,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
-					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!;
+					var items = (ObservableCollection<CollectionViewGalleryTestItem>)_carouselView.ItemsSource;
 					var indexToRemove = items.Count - 1;
 					items.Remove(items[indexToRemove]);
 				})

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemsSourceGenerator.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemsSourceGenerator.cs
@@ -57,7 +57,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			button.Clicked += GenerateItems;
 			WeakReferenceMessenger.Default.Register<ExampleTemplateCarousel, string>(this, "remove", (_, obj) =>
 			{
-				(cv.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>)!.Remove((obj.BindingContext as CollectionViewGalleryTestItem)!);
+				((ObservableCollection<CollectionViewGalleryTestItem>)cv.ItemsSource).Remove((obj.BindingContext as CollectionViewGalleryTestItem)!);
 			});
 
 			Content = layout;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ObservableCodeCollectionViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ObservableCodeCollectionViewGallery.cs
@@ -24,7 +24,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 
 			IItemsLayout itemsLayout = grid
 				? new GridItemsLayout(3, orientation)
-				: new LinearItemsLayout(orientation) as IItemsLayout;
+				: new LinearItemsLayout(orientation);
 
 			var itemTemplate = ExampleTemplates.PhotoTemplate();
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ObservableCollectionResetGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ObservableCollectionResetGallery.cs
@@ -17,7 +17,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				}
 			};
 
-			var itemsLayout = new GridItemsLayout(3, ItemsLayoutOrientation.Vertical) as IItemsLayout;
+			IItemsLayout itemsLayout = new GridItemsLayout(3, ItemsLayoutOrientation.Vertical);
 
 			var itemTemplate = ExampleTemplates.PhotoTemplate();
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ObservableMultiItemCollectionViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ObservableMultiItemCollectionViewGallery.cs
@@ -21,9 +21,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				}
 			};
 
-			var itemsLayout = grid
+			IItemsLayout itemsLayout = grid
 				? new GridItemsLayout(3, orientation)
-				: new LinearItemsLayout(orientation) as IItemsLayout;
+				: new LinearItemsLayout(orientation);
 
 			var itemTemplate = ExampleTemplates.PhotoTemplate();
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ItemsUpdatingScrollModeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ItemsUpdatingScrollModeGallery.xaml.cs
@@ -50,7 +50,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 
 		void OnItemsUpdatingScrollModeChanged(object sender, EventArgs e)
 		{
-			CollectionView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)(sender! as EnumPicker)!.SelectedItem;
+			CollectionView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)((EnumPicker)sender!).SelectedItem;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DragAndDropBetweenLayouts.xaml.cs
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDragStarting(object sender, DragStartingEventArgs e)
 		{
-			var boxView = (View)(sender as Element)!.Parent;
+			var boxView = (View)((Element)sender)!.Parent;
 			DragStartingTitle.IsVisible = true;
 			DragStartingPositionLabel.Text = $"- Self X:{(int)e.GetPosition(boxView)!.Value.X}, Y:{(int)e.GetPosition(boxView)!.Value.Y}";
 			DragStartingScreenPositionLabel.Text = $"- Screen X:{(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDropCompleted(object sender, DropCompletedEventArgs e)
 		{
-			var sl = (sender as Element)!.Parent as StackLayout;
+			var sl = ((Element)sender).Parent as StackLayout;
 
 			if (sl == SLAllColors)
 				SLRainbow.Background = SolidColorBrush.White;
@@ -65,7 +65,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDragOver(object sender, DragEventArgs e)
 		{
-			var sl = (StackLayout)(sender as Element)!.Parent;
+			var sl = (StackLayout)((Element)sender).Parent;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -86,7 +86,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDragLeave(object sender, DragEventArgs e)
 		{
-			var sl = (StackLayout)(sender as Element)!.Parent;
+			var sl = (StackLayout)((Element)sender).Parent;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -107,7 +107,7 @@ namespace Maui.Controls.Sample.Pages
 
 		private void OnDrop(object sender, DropEventArgs e)
 		{
-			var sl = (sender as Element)!.Parent as StackLayout;
+			var sl = ((Element)sender).Parent as StackLayout;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -122,7 +122,7 @@ namespace Maui.Controls.Sample.Pages
 			DropScreenPositionLabel.Text = $"- Screen: X:{(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
 			DropRelativePositionLabel.Text = $"- This label: X:{(int)e.GetPosition(DropRelativePositionLabel)!.Value.X}, Y:{(int)e.GetPosition(DropRelativePositionLabel)!.Value.Y}";
 
-			var color = (e.Data.Properties["Color"] as SolidColorBrush)!;
+			var color = (SolidColorBrush)e.Data.Properties["Color"];
 
 			if (AllColors.Contains(color))
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
@@ -95,7 +95,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 			else
 			{
-				(Parent as IStackNavigationView)!.RequestNavigation(
+				((IStackNavigationView)Parent).RequestNavigation(
 				   new NavigationRequest(_currentNavStack, true));
 
 				_currentNavStack = null;

--- a/src/Controls/samples/Controls.Sample/Pages/Others/LargeTitlesPageiOS.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/LargeTitlesPageiOS.cs
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Pages
 					{
 						Text = "Tooggle UseLargeTitles on Navigation",
 						Command = new Command( () =>{
-							var navPage = (Parent as NavigationPage)!;
+							var navPage = (NavigationPage)Parent;
 							navPage.On<iOS>().SetPrefersLargeTitles(!navPage.On<iOS>().PrefersLargeTitles());
 						} )
 					},
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Pages
 					{
 						Text = "UseLargeTitles on Navigation with safe Area",
 						Command = new Command( () =>{
-							var navPage = (Parent as NavigationPage)!;
+							var navPage = (NavigationPage)Parent;
 							navPage.On<iOS>().SetPrefersLargeTitles(true);
 							var page = new ContentPage { Title = "New Title", BackgroundColor = Colors.Red };
 							page.On<iOS>().SetUseSafeArea(true);

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSwipeViewTransitionModePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSwipeViewTransitionModePage.xaml.cs
@@ -16,7 +16,7 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnSwipeViewTransitionModeChanged(object sender, EventArgs e)
 		{
-			SwipeTransitionMode transitionMode = (SwipeTransitionMode)(sender as EnumPicker)!.SelectedItem;
+			SwipeTransitionMode transitionMode = (SwipeTransitionMode)((EnumPicker)sender).SelectedItem;
 			swipeView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetSwipeTransitionMode(transitionMode);
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseStyleChangerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseStyleChangerPage.xaml.cs
@@ -40,7 +40,7 @@ namespace Maui.Controls.Sample.Pages
 			if (newValue != null)
 			{
 				var enumType = typeof(CollapseStyle);
-				var instance = (element as WindowsCollapseStyleChangerPage)!;
+				var instance = (WindowsCollapseStyleChangerPage)element;
 				instance.picker.SelectedIndex = Array.IndexOf(Enum.GetNames(enumType), Enum.GetName(enumType, instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetCollapseStyle()));
 			}
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseWidthAdjusterPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseWidthAdjusterPage.xaml.cs
@@ -32,7 +32,7 @@ namespace Maui.Controls.Sample.Pages
 		{
 			if (newValue != null)
 			{
-				var instance = element as WindowsCollapseWidthAdjusterPage;
+				var instance = (WindowsCollapseWidthAdjusterPage)element;
 				instance!.entry.Text = instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().CollapsedPaneWidth().ToString();
 			}
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsToolbarPlacementChangerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsToolbarPlacementChangerPage.xaml.cs
@@ -40,8 +40,8 @@ namespace Maui.Controls.Sample.Pages
 			if (newValue != null)
 			{
 				var enumType = typeof(ToolbarPlacement);
-				var instance = element as WindowsToolbarPlacementChangerPage;
-				instance!.picker.SelectedIndex = Array.IndexOf(Enum.GetNames(enumType), Enum.GetName(enumType, instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetToolbarPlacement()));
+				var instance = (WindowsToolbarPlacementChangerPage)element;
+				instance.picker.SelectedIndex = Array.IndexOf(Enum.GetNames(enumType), Enum.GetName(enumType, instance.ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetToolbarPlacement()));
 			}
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSafeAreaPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSafeAreaPage.xaml.cs
@@ -15,7 +15,7 @@ namespace Maui.Controls.Sample.Pages
 		void OnButtonClicked(object sender, EventArgs e)
 		{
 			On<iOS>().SetUseSafeArea(false);
-			(sender as Button)!.IsEnabled = false;
+			((Button)sender).IsEnabled = false;
 		}
 	}
 }


### PR DESCRIPTION
if the type is known then a direct cast should be used instead of an as. since, in the case where the assumption is wrong, then it is better to get a cast exception  instead of a null ref exception.

basically if code uses `as` and does not check for null when that variable is used, then it is likely problematic code.