### PR TITLE
[Android] Fixed crash when resuming app from background due to null MauiContext

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Platform
 		internal void Subscribe(Window window)
 		{
 			IMauiContext mauiContext = window?.Handler?.MauiContext;
-			if (mauiContext == null)
+			if (mauiContext is null)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Maui.Controls.Platform
 		internal void Subscribe(Window window)
 		{
 			IMauiContext mauiContext = window?.Handler?.MauiContext;
+			if (mauiContext == null)
+			{
+				return;
+			}
+
 			Context context = mauiContext?.Context;
 			Activity activity = context.GetActivity();
 

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal void Subscribe(Window window)
 		{
-			IMauiContext mauiContext = window?.MauiContext;
+			IMauiContext mauiContext = window?.Handler?.MauiContext;
 			Context context = mauiContext?.Context;
 			Activity activity = context.GetActivity();
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue detail
Crash occurs when resuming the app from the background on Android.
System.InvalidOperationException: 'MauiContext is null.'

### Root Cause
In the AlertManager.Subscribe() method, window.MauiContext is accessed directly. However, during certain lifecycle transitions—especially when resuming from background services—the Window.Handler is not yet initialized, and window.MauiContext returns null, leading to a crash.
 
### Description of Change
Updated the AlertManager.Subscribe method to access MauiContext through window.Handler?.MauiContext instead of window.MauiContext. This ensures the context is only accessed if the Handler is initialized, preventing the InvalidOperationException. This change aligns with existing usage in the unsubscribe flow and ensures the app doesn't crash when resuming from background services.

**Reference**
https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs#L42

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/25443
Fixes https://github.com/dotnet/maui/issues/27881

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/f0165988-9d87-42fc-93cc-3aef57cd08bc"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/a5b7c930-a7a7-4508-b2f8-be922e23c078">) |