### PR TITLE
[ci] Fix provision profiles

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,26 +1,2 @@
 {
-    "inputs": [
-        {
-            "type": "promptString",
-            "id": "github-key",
-            "password": true, // Encrypted at-rest
-            "description": "GitHub PAT"
-        }
-    ],
-    "servers": {
-       "github": {
-            "command": "docker",
-            "args": [
-                "run",
-                "-i",
-                "--rm",
-                "-e",
-                "GITHUB_PERSONAL_ACCESS_TOKEN",
-                "ghcr.io/github/github-mcp-server"
-            ],
-            "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-key}"
-            }
-        }
-    }
 }

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -21,7 +21,7 @@ parameters:
   provisionatorChannel: 'latest'
   provisionatorExtraArguments: $(provisionator.extraArguments)
   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-  certPass: $(maui-cert-password)
+  certPass: $(maui-cert-password) # This lives on MAUI variable group
   certName: 'MauiCert.p12'
   provisioningProfileName: 'MauiProvisioningProfile.mobileprovision'
   # Enabling internal runtimes / feeds

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -75,7 +75,6 @@ steps:
       echo
       echo selecting latest xcode...
       sudo xcode-select -s /Applications/Xcode_$(REQUIRED_XCODE).app
-      xcode-select -p
       xcrun xcode-select --print-path
       xcodebuild -version
       sudo xcodebuild -license accept
@@ -95,7 +94,7 @@ steps:
       certSecureFile: '${{ parameters.certName }}'
       certPwd: ${{ parameters.certPass }}
       keychain: 'temp'
-      opensslPkcsArgs: '-legacy'
+  #    opensslPkcsArgs: '-legacy'
 
   - task: InstallAppleProvisioningProfile@1
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -21,7 +21,9 @@ parameters:
   provisionatorChannel: 'latest'
   provisionatorExtraArguments: $(provisionator.extraArguments)
   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
-  certPass: $(pass--components-mac-ios-certificate-p12)
+  certPass: $(maui-cert-password)
+  certName: 'MauiCert.p12'
+  provisioningProfileName: 'MauiProvisioningProfile.mobileprovision'
   # Enabling internal runtimes / feeds
   federatedServiceConnection: 'dotnetbuilds-internal-read'
   outputVariableName: 'dotnetbuilds-internal-container-read-token'
@@ -73,6 +75,7 @@ steps:
       echo
       echo selecting latest xcode...
       sudo xcode-select -s /Applications/Xcode_$(REQUIRED_XCODE).app
+      xcode-select -p
       xcrun xcode-select --print-path
       xcodebuild -version
       sudo xcodebuild -license accept
@@ -85,23 +88,36 @@ steps:
 # Provision Additional Software
 - ${{ if ne(parameters.skipProvisionator, true) }}:
   # Prepare macOS
-  - task: xamops.azdevex.provisionator-task.provisionator@3
-    displayName: 'Provision Additional Software'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-    continueOnError: true
+  - task: InstallAppleCertificate@2
     inputs:
-      provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
-      provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-      github_token: ${{ parameters.gitHubToken }}
-    env:
-      PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-      AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
+      certSecureFile: { ? { parameters.certName } }
+      certPwd: '{{ parameters.certPass }}'
+      # Advanced
+      keychain: 'temp'
 
-##################################################
-#              Provisioning Windows              #
-##################################################
+  - task: InstallAppleProvisioningProfile@1
+    inputs:
+      provisioningProfileLocation: 'secureFiles'
+      provProfileSecureFile: '{{ parameters.provisioningProfileName }}'
+  # - task: xamops.azdevex.provisionator-task.provisionator@3
+  #   displayName: 'Provision Additional Software'
+  #   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+  #   continueOnError: true
+  #   inputs:
+  #     provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
+  #     provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
+  #     github_token: ${{ parameters.gitHubToken }}
+  #   env:
+  #     PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
+  #     AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
 
-# Provisioning Windows - Set dump file location
+
+
+  ##################################################
+  #              Provisioning Windows              #
+  ##################################################
+
+  # Provisioning Windows - Set dump file location
 - pwsh: |
     $errorPath = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"
     New-ItemProperty -Path $errorPath -Name DumpFolder -PropertyType String -Value "$(Build.ArtifactStagingDirectory)/crash-dumps" -Force

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -86,7 +86,7 @@ steps:
     timeoutInMinutes: 30
 
 # Provision Additional Software
-- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), ne(parameters.skipProvisionator, true) }}:
+- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), ne(parameters.skipProvisionator, true)) }}:
   # Prepare macOS
   - task: InstallAppleCertificate@2
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -90,28 +90,14 @@ steps:
   # Prepare macOS
   - task: InstallAppleCertificate@2
     inputs:
-      certSecureFile: '{{ parameters.certName }}'
-      certPwd: '{{ parameters.certPass }}'
+      certSecureFile: '${{ parameters.certName }}'
+      certPwd: '${{ parameters.certPass }}'
       keychain: 'temp'
 
   - task: InstallAppleProvisioningProfile@1
     inputs:
       provisioningProfileLocation: 'secureFiles'
-      provProfileSecureFile: '{{ parameters.provisioningProfileName }}'
-  # - task: xamops.azdevex.provisionator-task.provisionator@3
-  #   displayName: 'Provision Additional Software'
-  #   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-  #   continueOnError: true
-  #   inputs:
-  #     provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
-  #     provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-  #     github_token: ${{ parameters.gitHubToken }}
-  #   env:
-  #     PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-  #     AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
-
-
-
+      provProfileSecureFile: '${{ parameters.provisioningProfileName }}'
   ##################################################
   #              Provisioning Windows              #
   ##################################################

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -23,6 +23,7 @@ parameters:
   gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
   certPass: $(maui-cert-password) # This lives on MAUI variable group
   certName: 'MauiCert.p12'
+  openSslArgs: '-legacy'
   provisioningProfileName: 'MauiProvisioningProfile.mobileprovision'
   # Enabling internal runtimes / feeds
   federatedServiceConnection: 'dotnetbuilds-internal-read'
@@ -94,7 +95,7 @@ steps:
       certSecureFile: '${{ parameters.certName }}'
       certPwd: ${{ parameters.certPass }}
       keychain: 'temp'
-  #    opensslPkcsArgs: '-legacy'
+      opensslPkcsArgs: '${{ parameters.openSslArgs }}'
 
   - task: InstallAppleProvisioningProfile@1
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -95,7 +95,7 @@ steps:
       certSecureFile: '${{ parameters.certName }}'
       certPwd: maui
       keychain: 'temp'
-      # opensslPkcsArgs: -legacy
+      opensslPkcsArgs: '-legacy'
 
   - task: InstallAppleProvisioningProfile@1
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -93,9 +93,9 @@ steps:
     displayName: 'Install Apple Certificate ${{ parameters.certName }}'
     inputs:
       certSecureFile: '${{ parameters.certName }}'
-      certPwd: ${{ parameters.certPass }}
+      certPwd: $(maui-cert-password)
       keychain: 'temp'
-      opensslPkcsArgs: -legacy
+      # opensslPkcsArgs: -legacy
 
   - task: InstallAppleProvisioningProfile@1
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -91,6 +91,7 @@ steps:
   - task: InstallAppleCertificate@2
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     displayName: 'Install Apple Certificate ${{ parameters.certName }}'
+    continueOnError: true
     inputs:
       certSecureFile: '${{ parameters.certName }}'
       certPwd: ${{ parameters.certPass }}
@@ -100,6 +101,7 @@ steps:
   - task: InstallAppleProvisioningProfile@1
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     displayName: 'Install Apple Provisioning Profile ${{ parameters.provisioningProfileName }}'
+    continueOnError: true
     inputs:
       provisioningProfileLocation: 'secureFiles'
       provProfileSecureFile: '${{ parameters.provisioningProfileName }}'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -93,7 +93,7 @@ steps:
     displayName: 'Install Apple Certificate ${{ parameters.certName }}'
     inputs:
       certSecureFile: '${{ parameters.certName }}'
-      certPwd: maui
+      certPwd: ${{ parameters.certPass }}
       keychain: 'temp'
       opensslPkcsArgs: '-legacy'
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -93,7 +93,7 @@ steps:
     displayName: 'Install Apple Certificate ${{ parameters.certName }}'
     inputs:
       certSecureFile: '${{ parameters.certName }}'
-      certPwd: $(maui-cert-password)
+      certPwd: maui
       keychain: 'temp'
       # opensslPkcsArgs: -legacy
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -86,7 +86,7 @@ steps:
     timeoutInMinutes: 30
 
 # Provision Additional Software
-- ${{ if ne(parameters.skipProvisionator, true) }}:
+- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), ne(parameters.skipProvisionator, true) }}:
   # Prepare macOS
   - task: InstallAppleCertificate@2
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -90,9 +90,8 @@ steps:
   # Prepare macOS
   - task: InstallAppleCertificate@2
     inputs:
-      certSecureFile: { ? { parameters.certName } }
+      certSecureFile: '{{ parameters.certName }}'
       certPwd: '{{ parameters.certPass }}'
-      # Advanced
       keychain: 'temp'
 
   - task: InstallAppleProvisioningProfile@1

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -89,12 +89,17 @@ steps:
 - ${{ if ne(parameters.skipProvisionator, true) }}:
   # Prepare macOS
   - task: InstallAppleCertificate@2
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+    displayName: 'Install Apple Certificate ${{ parameters.certName }}'
     inputs:
       certSecureFile: '${{ parameters.certName }}'
-      certPwd: '${{ parameters.certPass }}'
+      certPwd: ${{ parameters.certPass }}
       keychain: 'temp'
+      opensslPkcsArgs: -legacy
 
   - task: InstallAppleProvisioningProfile@1
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+    displayName: 'Install Apple Provisioning Profile ${{ parameters.provisioningProfileName }}'
     inputs:
       provisioningProfileLocation: 'secureFiles'
       provProfileSecureFile: '${{ parameters.provisioningProfileName }}'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -16,7 +16,6 @@ parameters:
   # Provisionator / Xcode
   skipProvisionator: true
   checkoutDirectory: $(System.DefaultWorkingDirectory)
-  provisionatorPath: $(provisionator.path)
   provisionatorXCodePath: $(provisionator.xcode)
   provisionatorChannel: 'latest'
   provisionatorExtraArguments: $(provisionator.extraArguments)
@@ -60,7 +59,7 @@ steps:
         github_token: ${{ parameters.gitHubToken }}
       env:
         PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
-        AUTH_TOKEN_COMPONENTS_MAC_IOS_CERTIFICATE_P12: ${{ parameters.certPass }}
+
   - script: |
       echo Remove old Xamarin Settings
       rm -f ~/Library/Preferences/Xamarin/Settings.plist

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -56,7 +56,6 @@ steps:
 
 - template: provision.yml
   parameters:
-    skipProvisioning: true
     skipJdk: ${{ ne(parameters.platform, 'android') }}
     skipAndroidCommonSdks: ${{ ne(parameters.platform, 'android') }}
     skipAndroidPlatformApis: true
@@ -72,7 +71,7 @@ steps:
       skipProvisionator: false
       gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
     ${{ if eq(parameters.platform, 'catalyst') }}:
-      opensslPkcsArgs: '' # Do not use legacy openssl for Catalyst builds
+      openSslArgs: '' # Do not use legacy openssl for Catalyst builds
 
 - task: PowerShell@2
   condition: and(ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -7,179 +7,181 @@ parameters:
   version: '' #the iOS version'
   provisionatorChannel: 'latest'
   agentPoolAccessToken: ''
-  configuration : "Release"
-  runtimeVariant : "Mono"
+  configuration: "Release"
+  runtimeVariant: "Mono"
   testFilter: ''
   testConfigurationArgs: ''
   skipProvisioning: true
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'))
-    inputs:
-      artifact: ui-tests-samples
-  
-  - task: DownloadPipelineArtifact@2
-    condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'))
-    inputs:
-      artifact: ui-tests-samples-nativeaot
+- task: DownloadPipelineArtifact@2
+  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'))
+  inputs:
+    artifact: ui-tests-samples
 
-  - task: DownloadPipelineArtifact@2
-    condition: eq('${{ parameters.platform }}' , 'windows')
-    inputs:
-      artifact: ui-tests-samples-windows
-  
-  - ${{ if eq(parameters.platform, 'ios')}}:
-    - bash: |
-        chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-        $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
-      displayName: 'Clean bot'
-      continueOnError: true
-      timeoutInMinutes: 60
-  
-  # Enable KVM for Android builds on Linux
-  - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
-    - bash: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
-      displayName: Enable KVM
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))      
+- task: DownloadPipelineArtifact@2
+  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'))
+  inputs:
+    artifact: ui-tests-samples-nativeaot
 
-  - ${{ if eq(parameters.platform, 'catalyst')}}:
-        - bash: |
-              chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
-              $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
-          displayName: 'Disable Notification Center'
-          continueOnError: true
-          timeoutInMinutes: 60
-          
-  - template: provision.yml
-    parameters:
-      skipProvisioning:  true
-      skipJdk: ${{ ne(parameters.platform, 'android') }}
-      skipAndroidCommonSdks: ${{ ne(parameters.platform, 'android') }}
-      skipAndroidPlatformApis: true
-      onlyAndroidPlatformDefaultApis: true
-      skipAndroidEmulatorImages: ${{ ne(parameters.platform, 'android') }}
-      skipAndroidCreateAvds: true
-      androidEmulatorApiLevel: ${{ parameters.version }}
-      skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
-      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-      ${{ if parameters.skipProvisioning }}:
-        skipProvisionator: true
-      ${{ else }}:  
-        skipProvisionator: false
-        gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+- task: DownloadPipelineArtifact@2
+  condition: eq('${{ parameters.platform }}' , 'windows')
+  inputs:
+    artifact: ui-tests-samples-windows
 
-  - task: PowerShell@2
-    condition: and(ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))
-    inputs:
-      targetType: 'inline'
-      script: |
-        defaults write -g NSAutomaticCapitalizationEnabled -bool false
-        defaults write -g NSAutomaticTextCompletionEnabled -bool false
-        defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
-    displayName: "Modify defaults"
-    continueOnError: true
-  
-  - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
-    displayName: 'Install .NET'
-    retryCountOnTaskFailure: 2
-    env:
-      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-      PRIVATE_BUILD: $(PrivateBuild)
-
-  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
-    displayName: 'Add .NET to PATH'
-
-  # AzDO hosted agents default to 1024x768; set something bigger for Windows UI tests
-  - task: ScreenResolutionUtility@1
-    condition: eq('${{ parameters.platform }}' , 'windows')
-    inputs:
-      displaySettings: 'specific'
-      width: '1920'
-      height: '1080'
-    displayName: "Set screen resolution"
-
-  - task: UseNode@1
-    inputs:
-      version: "20.3.1"
-    displayName: "Install node"
-
-  - pwsh: |
-      $skipAppiumDoctor = if ($IsMacOS -or $IsLinux) { "true" } else { "false" }
-      dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -bl:"$(LogDirectory)/provision-appium.binlog"
-    displayName: "Install Appium"
-    continueOnError: false
-    retryCountOnTaskFailure: 2
-    timeoutInMinutes: 10
-    env:
-      APPIUM_HOME: $(APPIUM_HOME)
-
-  - pwsh: |
-      Get-Content $PSCommandPath
-      $command = "./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=uitest --project=""${{ parameters.path }}"""
-      $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
-      $command += " --runtimevariant=""${{ parameters.runtimeVariant }}"""
-      $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
-      
-      $testFilter = ""
-      $testConfigrationArgs = "${{ parameters.testConfigurationArgs }}"
-
-      "${{ parameters.testFilter }}".Split(",") | ForEach {
-        $testFilter += "TestCategory=" + $_ + "|"
-      }
-
-      $testFilter = $testFilter.TrimEnd("|")
-
-      # Cake does not allow empty parameters, so check if our filter is empty before adding it
-      if ($testConfigrationArgs) {
-        $command += " --TEST_CONFIGURATION_ARGS=""$testConfigrationArgs"""
-      }
-      if ($testFilter) {
-        $command += " --test-filter ""$testFilter"""
-      }
-
-      Write-Host "Running command: $command"
-
-      Invoke-Expression $command  
-    displayName: $(Agent.JobName)
-    ${{ if ne(parameters.platform, 'android')}}:
-      retryCountOnTaskFailure: 1
-    env:
-      APPIUM_HOME: $(APPIUM_HOME)
-
+- ${{ if eq(parameters.platform, 'ios')}}:
   - bash: |
-      cat ${BASH_SOURCE[0]}
-      pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
-    displayName: Cleanup and Create Simulator Logs if Test Run Failed To
-    condition: ${{ eq(parameters.platform, 'ios') }}
+      chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+      $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
+    displayName: 'Clean bot'
     continueOnError: true
+    timeoutInMinutes: 60
 
-  - task: PublishTestResults@2
-    displayName: Publish the $(System.PhaseName) test results
-    condition: always()
-    inputs:
-      testResultsFormat: VSTest
-      testResultsFiles: '$(TestResultsDirectory)/*.trx'
-      testRunTitle: '${{ parameters.testFilter }}_$(System.PhaseName)'
-      failTaskOnFailedTests: true
+# Enable KVM for Android builds on Linux
+- ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
+  - bash: |
+      echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+      sudo udevadm control --reload-rules
+      sudo udevadm trigger --name-match=kvm
+    displayName: Enable KVM
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  - task: PublishBuildArtifacts@1
-    condition: always()
-    displayName: publish artifacts
+- ${{ if eq(parameters.platform, 'catalyst')}}:
+  - bash: |
+      chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
+      $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
+    displayName: 'Disable Notification Center'
+    continueOnError: true
+    timeoutInMinutes: 60
 
-  - ${{ if eq(parameters.platform, 'catalyst')}}:
-        - bash: |
-              chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/enable-notification-center.sh
-              $(System.DefaultWorkingDirectory)/eng/scripts/enable-notification-center.sh
-          displayName: 'Enable Notification Center'
-          continueOnError: true
-          timeoutInMinutes: 60
+- template: provision.yml
+  parameters:
+    skipProvisioning: true
+    skipJdk: ${{ ne(parameters.platform, 'android') }}
+    skipAndroidCommonSdks: ${{ ne(parameters.platform, 'android') }}
+    skipAndroidPlatformApis: true
+    onlyAndroidPlatformDefaultApis: true
+    skipAndroidEmulatorImages: ${{ ne(parameters.platform, 'android') }}
+    skipAndroidCreateAvds: true
+    androidEmulatorApiLevel: ${{ parameters.version }}
+    skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
+    provisionatorChannel: ${{ parameters.provisionatorChannel }}
+    ${{ if parameters.skipProvisioning }}:
+      skipProvisionator: true
+    ${{ else }}:
+      skipProvisionator: false
+      gitHubToken: $(github--pat--vs-mobiletools-engineering-service2)
+    ${{ if eq(parameters.platform, 'catalyst') }}:
+      opensslPkcsArgs: '' # Do not use legacy openssl for Catalyst builds
 
-  - ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines'), eq(variables['System.TeamProject'], 'devdiv') ) }}:
-      # This must always be placed as the last step in the job
-      - template: agent-rebooter/mac.v1.yml@yaml-templates
-        parameters:
-          AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+- task: PowerShell@2
+  condition: and(ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))
+  inputs:
+    targetType: 'inline'
+    script: |
+      defaults write -g NSAutomaticCapitalizationEnabled -bool false
+      defaults write -g NSAutomaticTextCompletionEnabled -bool false
+      defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
+  displayName: "Modify defaults"
+  continueOnError: true
+
+- pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
+  displayName: 'Install .NET'
+  retryCountOnTaskFailure: 2
+  env:
+    DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+    PRIVATE_BUILD: $(PrivateBuild)
+
+- pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+  displayName: 'Add .NET to PATH'
+
+# AzDO hosted agents default to 1024x768; set something bigger for Windows UI tests
+- task: ScreenResolutionUtility@1
+  condition: eq('${{ parameters.platform }}' , 'windows')
+  inputs:
+    displaySettings: 'specific'
+    width: '1920'
+    height: '1080'
+  displayName: "Set screen resolution"
+
+- task: UseNode@1
+  inputs:
+    version: "20.3.1"
+  displayName: "Install node"
+
+- pwsh: |
+    $skipAppiumDoctor = if ($IsMacOS -or $IsLinux) { "true" } else { "false" }
+    dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -bl:"$(LogDirectory)/provision-appium.binlog"
+  displayName: "Install Appium"
+  continueOnError: false
+  retryCountOnTaskFailure: 2
+  timeoutInMinutes: 10
+  env:
+    APPIUM_HOME: $(APPIUM_HOME)
+
+- pwsh: |
+    Get-Content $PSCommandPath
+    $command = "./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --target=uitest --project=""${{ parameters.path }}"""
+    $command += " --appproject=""${{ parameters.app }}"" --device=""${{ parameters.device }}"" --apiversion=""${{ parameters.version }}"" --configuration=""${{ parameters.configuration }}"""
+    $command += " --runtimevariant=""${{ parameters.runtimeVariant }}"""
+    $command += " --results=""$(TestResultsDirectory)"" --binlog=""$(LogDirectory)"" ${{ parameters.cakeArgs }} --verbosity=diagnostic"
+
+    $testFilter = ""
+    $testConfigrationArgs = "${{ parameters.testConfigurationArgs }}"
+
+    "${{ parameters.testFilter }}".Split(",") | ForEach {
+      $testFilter += "TestCategory=" + $_ + "|"
+    }
+
+    $testFilter = $testFilter.TrimEnd("|")
+
+    # Cake does not allow empty parameters, so check if our filter is empty before adding it
+    if ($testConfigrationArgs) {
+      $command += " --TEST_CONFIGURATION_ARGS=""$testConfigrationArgs"""
+    }
+    if ($testFilter) {
+      $command += " --test-filter ""$testFilter"""
+    }
+
+    Write-Host "Running command: $command"
+
+    Invoke-Expression $command  
+  displayName: $(Agent.JobName)
+  ${{ if ne(parameters.platform, 'android')}}:
+    retryCountOnTaskFailure: 1
+  env:
+    APPIUM_HOME: $(APPIUM_HOME)
+
+- bash: |
+    cat ${BASH_SOURCE[0]}
+    pwsh ./build.ps1 --target=Cleanup -Script eng/devices/${{ parameters.platform }}.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}
+  displayName: Cleanup and Create Simulator Logs if Test Run Failed To
+  condition: ${{ eq(parameters.platform, 'ios') }}
+  continueOnError: true
+
+- task: PublishTestResults@2
+  displayName: Publish the $(System.PhaseName) test results
+  condition: always()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(TestResultsDirectory)/*.trx'
+    testRunTitle: '${{ parameters.testFilter }}_$(System.PhaseName)'
+    failTaskOnFailedTests: true
+
+- task: PublishBuildArtifacts@1
+  condition: always()
+  displayName: publish artifacts
+
+- ${{ if eq(parameters.platform, 'catalyst')}}:
+  - bash: |
+      chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/enable-notification-center.sh
+      $(System.DefaultWorkingDirectory)/eng/scripts/enable-notification-center.sh
+    displayName: 'Enable Notification Center'
+    continueOnError: true
+    timeoutInMinutes: 60
+
+- ${{ if and(eq(parameters.platform, 'ios'), ne(parameters.poolName, 'Azure Pipelines'), eq(variables['System.TeamProject'], 'devdiv') ) }}:
+  # This must always be placed as the last step in the job
+  - template: agent-rebooter/mac.v1.yml@yaml-templates
+    parameters:
+      AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,9 +56,9 @@ variables:
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - group: xamops-azdev-secrets
   - group: maui-provisionator
-  - group: MAUI
+  #- group: MAUI
 
-# Variable groups required for private builds but not prs
+  # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
   - group: Xamarin-Secrets
 

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -31,8 +31,6 @@ variables:
   value: $(Build.ArtifactStagingDirectory)/test-results
 - name: provisionator.xcode
   value: 'eng/provisioning/xcode.csx'
-- name: provisionator.path
-  value: 'eng/provisioning/provisioning.csx'
 - name: internalProvisioning
   value: false
 - name: provisionator.extraArguments

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -19,12 +19,7 @@ variables:
 - name: isLocHandoffBranch
   value: $[in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main')]
 - name: signingCondition
-  value: $[or(
-            eq(variables['Sign'], 'true'),
-            in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ),
-            startsWith(variables['Build.SourceBranch'], 'refs/tags/'),
-            startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
-          )]
+  value: $[or( eq(variables['Sign'], 'true'), in(variables['Build.SourceBranch'], 'refs/heads/net9.0', 'refs/heads/net10.0', 'refs/heads/main', 'refs/heads/inflight/current' ), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') )]
 # Common Agent Pools in use
 - name: HostedMacImage
   value: macOS-15
@@ -60,6 +55,7 @@ variables:
 # Variable groups required for all builds
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - group: xamops-azdev-secrets
+  - group: maui-provisionator
 
 # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
@@ -83,10 +79,7 @@ variables:
     - group: DotNetBuilds storage account read tokens
     - group: AzureDevOps-Artifact-Feeds-Pats
     - name: _InternalBuildArgs
-      value: /p:DotNetSignType=$(_SignType)
-        /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
-        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
 - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,8 +56,6 @@ variables:
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - group: xamops-azdev-secrets
   - group: maui-provisionator
-  #- group: MAUI
-
   # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
   - group: Xamarin-Secrets

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,6 +56,7 @@ variables:
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - group: xamops-azdev-secrets
   - group: maui-provisionator
+  - group: MAUI
 
 # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,6 +56,7 @@ variables:
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - group: xamops-azdev-secrets
   - group: maui-provisionator
+  - group: MAUI
   # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
   - group: Xamarin-Secrets

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -55,8 +55,8 @@ variables:
 # Variable groups required for all builds
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui')) }}:
   - group: xamops-azdev-secrets
-  - group: maui-provisionator
-  - group: MAUI
+  - group: maui-provisionator # This is just needed for the provisionator
+  - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
   # Variable groups required for private builds but not prs
 - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr') }}:
   - group: Xamarin-Secrets

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -1,7 +1,0 @@
-if (IsMac)
-{	
-	AppleCodesignIdentity("Apple Development: Jonathan Dick (FJL7285DY2)", "https://dl.internalx.com/qa/code-signing-entitlements/components-mac-ios-certificate.p12");
-	AppleCodesignProfile("https://dl.internalx.com/qa/code-signing-entitlements/components-ios-provisioning.mobileprovision");
-	AppleCodesignProfile("https://dl.internalx.com/qa/code-signing-entitlements/components-mac-provisioning.mobileprovision");
-	AppleCodesignProfile("https://dl.internalx.com/qa/code-signing-entitlements/components-tvos-provisioning.mobileprovision");
-}


### PR DESCRIPTION
### Description of Change

Stop using provisionator for Apple cert and provision profile, these are secure files on AZDO UI , and the password lives on MAUI variable group.

Also removing the AI GitHub mcp


This pull request introduces several changes focused on improving provisioning processes, simplifying configurations, and removing unused code. Key updates include the removal of legacy GitHub token handling, the addition of new Apple provisioning tasks, and updates to variable groups for better organization.

### Provisioning updates:
* [`eng/pipelines/common/provision.yml`](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602L86-R105): Replaced the legacy Provisionator task with `InstallAppleCertificate@2` and `InstallAppleProvisioningProfile@1` tasks for handling Apple certificates and provisioning profiles. This change simplifies macOS provisioning and aligns with updated workflows.

### Configuration simplifications:
* [`.vscode/mcp.json`](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaL2-L25): Removed GitHub token-related inputs and server configurations, as they are no longer used.
* [`eng/pipelines/common/variables.yml`](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL63-R59): Streamlined variable definitions by consolidating multiline values into single lines and added new variable groups (`maui-provisionator` and `MAUI`) for better organization of secrets related to Apple certificates. [[1]](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL63-R59) [[2]](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL86-R82)

### Minor enhancements:
* [`eng/pipelines/common/provision.yml`](diffhunk://#diff-c41e74c2211fe6eddc2f3a29c9407dc5549e936bb02fba9b28c0181f94add602R78): Added a command (`xcode-select -p`) to verify the selected Xcode path during macOS provisioning steps.