### PR TITLE
[NET 10] Fix UseInterpreter being set for non-MAUI projects referencing MAUI class libraries

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
@@ -3,8 +3,13 @@
 	<PropertyGroup>
 		<_IsHotRestartDefined>$([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants.Trim())', '(^|;)HOTRESTART($|;)'))</_IsHotRestartDefined>
 		<DefineConstants Condition="!$(_IsHotRestartDefined) And '$(IsHotRestartBuild)' == 'true'">HOTRESTART;$(DefineConstants)</DefineConstants>
-		<UseInterpreter Condition="'$(UseInterpreter)' == '' and '$(Configuration)' == 'Debug'">True</UseInterpreter>
-	</PropertyGroup>
+    <UseInterpreter Condition="'$(UseInterpreter)' == '' and '$(Configuration)' == 'Debug' and 
+    ('$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' or 
+    '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' or 
+    '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' or 
+    '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' or 
+    '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'tizen')">True</UseInterpreter>
+  </PropertyGroup>
 
 	<!-- FIXME: https://github.com/xamarin/xamarin-macios/pull/21351 -->
 	<PropertyGroup Condition=" '$(_MauiDoNotConfigureTrimAnalyzer)' != 'true' and '$(PublishAot)' != 'true' and '$(TrimMode)' != 'full' ">


### PR DESCRIPTION
### Description of Change

`UseInterpreter=True` is set for any project that references the Microsoft.Maui.Controls NuGet package, including non-MAUI projects like regular .NET class libraries and macOS applications.

This PR includes changes to add a condition to only set `UseInterpreter=True` when the project targets actual MAUI platforms. Examples:

- `net10.0` (.NET library): UseInterpreter NOT set
- `net10.0-macos` (macOS app): UseInterpreter NOT set 
- `net10.0-android` (MAUI Android): UseInterpreter = True

There changes fixes the build failure for non-MAUI projects referencing MAUI libraries while preserves existing functionality for actual MAUI projects.

### Issues Fixed

Fixes #21653 