### PR TITLE
Local and Copilot dev can generate public apis

### DIFF
--- a/eng/NuGetVersions.targets
+++ b/eng/NuGetVersions.targets
@@ -264,6 +264,10 @@
         Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)"
     />
     <PackageReference
+        Update="Mono.ApiTools.MSBuildTasks"
+        Version="$(MonoApiToolsMSBuildTasksPackageVersion)"
+    />
+    <PackageReference
         Update="Tizen.UIExtensions.NUI"
         Version="$(TizenUIExtensionsVersion)"
     />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -108,6 +108,7 @@
     <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>17.9.5</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>17.9.5</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MonoApiToolsMSBuildTasksPackageVersion>0.4.0</MonoApiToolsMSBuildTasksPackageVersion>
     <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
     <!-- must be kept in sync with the binding library version to it here: -->
     <_XamarinAndroidGlideVersion>4.16.0.12</_XamarinAndroidGlideVersion>

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -504,9 +504,7 @@ namespace Microsoft.Maui.Controls
 
 		//this is only used by XAMLC, not added to public API
 		[EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		public INameScope transientNamescope;
-#pragma warning restore RS0016 // Add public types and members to the declared API
 
 		/// <summary>Returns the element that has the specified name.</summary>
 		/// <param name="name">The name of the element to be found.</param>

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -464,9 +464,7 @@ namespace Microsoft.Maui.Controls
 		// Until we can rewrite the FlexLayout engine to handle measurement properly (without the "in measure mode" hacks)
 		// we need to replace the default implementation of CrossPlatformMeasure.
 		// And we need to disable the public API analyzer briefly, because it doesn't understand hiding.
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		new public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
-#pragma warning restore RS0016 // Add public types and members to the declared API
 		{
 			var layoutManager = _layoutManager ??= CreateLayoutManager();
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
+Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/PublicAPI.targets
+++ b/src/PublicAPI.targets
@@ -8,7 +8,7 @@
     <!-- The Release builds will NEVER generate, only validate -->
     <PublicApiType Condition="'$(PublicApiType)' == '' and '$(Configuration)' != 'Debug'">Validate</PublicApiType>
     <!-- Local Debug workflows will generate -->
-    <PublicApiType Condition="'$(PublicApiType)' == '' and '$(Configuration)' == 'Debug'">Generate</PublicApiType>
+    <!--<PublicApiType Condition="'$(PublicApiType)' == '' and '$(Configuration)' == 'Debug'">Generate</PublicApiType>-->
     <!-- Fall back to validate -->
     <PublicApiType Condition="'$(PublicApiType)' == ''">Validate</PublicApiType>
   </PropertyGroup>

--- a/src/PublicAPI.targets
+++ b/src/PublicAPI.targets
@@ -1,8 +1,22 @@
 <Project>
 
+  <PropertyGroup>
+    <!-- The Copilot SWE always generates instead of trying to fix -->
+    <PublicApiType Condition="'$(PublicApiType)' == '' and '$(GITHUB_WORKFLOW)' == 'Copilot'">Generate</PublicApiType>
+    <!-- The normal CI workflows will NEVER generate, only validate -->
+    <PublicApiType Condition="'$(PublicApiType)' == '' and ('$(CI)' == 'true' or '$(TF_BUILD)' == 'true')">Validate</PublicApiType>
+    <!-- The Release builds will NEVER generate, only validate -->
+    <PublicApiType Condition="'$(PublicApiType)' == '' and '$(Configuration)' != 'Debug'">Validate</PublicApiType>
+    <!-- Local Debug workflows will generate -->
+    <PublicApiType Condition="'$(PublicApiType)' == '' and '$(Configuration)' == 'Debug'">Generate</PublicApiType>
+    <!-- Fall back to validate -->
+    <PublicApiType Condition="'$(PublicApiType)' == ''">Validate</PublicApiType>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Remove="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" Condition="'$(PublicApiType)' != 'Generate'" />
+    <PackageReference Include="Mono.ApiTools.MSBuildTasks" PrivateAssets="all" Condition="'$(PublicApiType)' == 'Generate'" />
   </ItemGroup>
 
   <!-- for explicit TFMs -->
@@ -24,5 +38,20 @@
   <ItemGroup Condition="'$(TargetFramework)' != ''">
     <AdditionalFiles Include="@(PublicAPIFiles)" />
   </ItemGroup>
+
+  <Target Name="_GeneratePublicApiFiles" 
+          AfterTargets="Build"
+          Condition="'$(TargetFramework)' != '' and '$(PublicApiType)' == 'Generate'"
+          Inputs="$(TargetDir)$(AssemblyName).dll"
+          Outputs="$(IntermediateOutputPath)GeneratePublicApiFiles.stamp">
+    <GeneratePublicApiFiles
+      Assembly="$(TargetDir)$(AssemblyName).dll"
+      Files="@(PublicAPIFiles)"
+      ReferenceSearchPaths="@(ReferencePath)" />
+		<Touch Files="$(IntermediateOutputPath)GeneratePublicApiFiles.stamp" AlwaysCreate="True" />
+		<ItemGroup>
+			<FileWrites Include="$(IntermediateOutputPath)GeneratePublicApiFiles.stamp" />
+		</ItemGroup>
+  </Target>
 
 </Project>

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -33,7 +33,7 @@
 
   <!-- A small task to make sure everything depends on the same version of SkiaSharp -->
   <ItemGroup>
-    <PackageReference Include="Mono.ApiTools.MSBuildTasks" Version="0.3.0" PrivateAssets="all" />
+    <PackageReference Include="Mono.ApiTools.MSBuildTasks" PrivateAssets="all" />
   </ItemGroup>
   <PropertyGroup>
     <_AdjustmentsAssembly>$(PkgSvg_Skia)\lib\netstandard2.0\Svg.Skia.dll</_AdjustmentsAssembly>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Currently, the only way is to use the IDE and the lightbulb - or manually. This is often not successful and AI still struggles as well.

The new version of the Mono.ApiTools.MSBuildTasks package now has the ability to generate the files and they can be checked in during development to show the actual API changes.

The rules would be if this is release of CI, then it is set to Validate only, and then only if it is debug AND not CI (ie: local) will it enable generation.


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

The pain of trying to get IDEs to actually generate files in a multi-targeted world.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
