### PR TITLE
[iOS, Mac] Fix for CursorPosition not updating when typing into Entry control

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20911.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20911.cs
@@ -1,0 +1,41 @@
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 20911, "Updating text in the Entry does not update CursorPosition during the TextChanged event", PlatformAffected.iOS)]
+public class Issue20911 : ContentPage
+{
+	Entry entry;
+	Label cursorPositonStatusLabel;
+
+	public Issue20911()
+	{
+		entry = new Entry
+		{
+			AutomationId = "ValidateEntryCursorPosition",
+		};
+
+		cursorPositonStatusLabel = new Label
+		{
+			AutomationId = "CursorPositionStatusLabel",
+			Text = "Cursor Position: 0",
+			FontSize = 16,
+		};
+
+		Button button = new Button
+		{
+			AutomationId = "ValidateEntryCursorPositionBtn",
+			Text = "Validate Entry Cursor Position",
+		};
+
+		button.Clicked += (sender, e) =>
+		{
+			cursorPositonStatusLabel.Text = $"{entry.CursorPosition}";
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(20),
+			Spacing = 10,
+			Children = { entry, cursorPositonStatusLabel, button }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20911.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20911.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue20911 : _IssuesUITest
+{
+	public Issue20911(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Updating text in the Entry does not update CursorPosition during the TextChanged event";
+
+	[Test]
+	[Category(UITestCategories.Entry)]
+	public void VerifyEntryCursorPositionOnTextChanged()
+	{
+		App.WaitForElement("ValidateEntryCursorPosition");
+
+		App.EnterText("ValidateEntryCursorPosition", "Test");
+
+		App.WaitForElement("ValidateEntryCursorPositionBtn");
+		App.Tap("ValidateEntryCursorPositionBtn");
+
+		var cursorPositionStatus = App.FindElement("CursorPositionStatusLabel").GetText();
+		Assert.That(cursorPositionStatus, Is.EqualTo("4"));
+	}
+}

--- a/src/Core/src/Core/Extensions/ITextInputExtensions.cs
+++ b/src/Core/src/Core/Extensions/ITextInputExtensions.cs
@@ -50,6 +50,14 @@ namespace Microsoft.Maui
 
 			return shouldChange;
 		}
+
+		internal static void UpdateCursorPosition(this ITextInput textInput, int cursorPosition)
+		{
+			if (textInput.CursorPosition != cursorPosition)
+			{
+				textInput.CursorPosition = cursorPosition;
+			}
+		}
 #endif
 
 #if ANDROID

--- a/src/Core/src/Core/Extensions/ITextInputExtensions.cs
+++ b/src/Core/src/Core/Extensions/ITextInputExtensions.cs
@@ -53,13 +53,9 @@ namespace Microsoft.Maui
 
 		internal static void UpdateCursorPosition(this ITextInput textInput, int cursorPosition)
 		{
-			// Validate cursor position bounds
-			var textLength = textInput.Text?.Length ?? 0;
-			var validatedCursorPosition = Math.Clamp(cursorPosition, 0, textLength);
-			
-			if (textInput.CursorPosition != validatedCursorPosition)
+			if (textInput.CursorPosition != cursorPosition)
 			{
-				textInput.CursorPosition = validatedCursorPosition;
+				textInput.CursorPosition = cursorPosition;
 			}
 		}
 #endif

--- a/src/Core/src/Core/Extensions/ITextInputExtensions.cs
+++ b/src/Core/src/Core/Extensions/ITextInputExtensions.cs
@@ -53,9 +53,13 @@ namespace Microsoft.Maui
 
 		internal static void UpdateCursorPosition(this ITextInput textInput, int cursorPosition)
 		{
-			if (textInput.CursorPosition != cursorPosition)
+			// Validate cursor position bounds
+			var textLength = textInput.Text?.Length ?? 0;
+			var validatedCursorPosition = Math.Clamp(cursorPosition, 0, textLength);
+			
+			if (textInput.CursorPosition != validatedCursorPosition)
 			{
-				textInput.CursorPosition = cursorPosition;
+				textInput.CursorPosition = validatedCursorPosition;
 			}
 		}
 #endif

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -193,6 +193,7 @@ namespace Microsoft.Maui.Handlers
 				if (sender is MauiTextField platformView)
 				{
 					VirtualView?.UpdateText(platformView.Text);
+					VirtualView?.UpdateCursorPosition(platformView.GetCursorPosition());
 				}
 			}
 

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -190,13 +190,16 @@ namespace Microsoft.Maui.Handlers
 
 			void OnEditingChanged(object? sender, EventArgs e)
 			{
-				if (sender is MauiTextField platformView)
+				if (sender is MauiTextField platformView && VirtualView is not null)
 				{
-					VirtualView?.UpdateText(platformView.Text);
-					VirtualView?.UpdateCursorPosition(platformView.GetCursorPosition());
-				}
-			}
+					// Update cursor position before updating text so that when TextChanged event fires,
+					// the CursorPosition property reflects the current native cursor position
+					VirtualView.UpdateCursorPosition(platformView.GetCursorPosition());
 
+					VirtualView.UpdateText(platformView.Text);
+				}
+			}	
+				
 			void OnEditingEnded(object? sender, EventArgs e)
 			{
 				if (sender is MauiTextField platformView && VirtualView is IEntry virtualView)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- When typing into Entry control on iOS, the CursorPosition property is not updated.

### Root Cause

- OnEditingChanged was updating the text but not the cursor position, causing the virtual view's cursor position to become out of sync with the platform view during typing.

### Description of Change

- Introduced a new method UpdateCursorPosition in the ITextInputExtensions class to update the cursor position if it differs from the current value.
- Updated EntryHandler.iOS to call UpdateCursorPosition during the OnEditingChanged event, ensuring the cursor position stays in sync with text changes.

### Issues Fixed
Fixes #20911 
Fixes #32483 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/cedc652c-ba03-4c8c-9da1-1cd669edfb53"> | <video src="https://github.com/user-attachments/assets/0ab91254-e8b0-44d5-ac45-1e4c0ceaa1c9"> |