### PR TITLE
[Windows]Fixed the PointerGestureRecognizer behaves incorrectly when multiple windows are open.

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -664,10 +664,45 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			// Check if the pointer event is relevant to the current element's window
+			if (!IsPointerEventRelevantToCurrentElement(e))
+			{
+				return;
+			}
 			var pointerGestures = ElementGestureRecognizers.GetGesturesFor<PointerGestureRecognizer>();
 			foreach (var recognizer in pointerGestures)
 			{
 				SendPointerEvent.Invoke(view, recognizer);
+			}
+		}
+
+		bool IsPointerEventRelevantToCurrentElement(PointerRoutedEventArgs e)
+		{
+			if (_container is null)
+			{
+				return false;
+			}
+			// For multi-window scenarios, we need to validate that the pointer event
+			// is actually relevant to the current element's window
+			try
+			{
+				// Check if the container has a valid XamlRoot (indicates it's in a live window)
+				if (_container.XamlRoot is null)
+				{
+					return false;
+				}
+				// Validate that the event source is from the same visual tree as our container
+				if (e.OriginalSource is FrameworkElement sourceElement && sourceElement.XamlRoot != _container.XamlRoot)
+				{
+					return false; // Event is from a different window
+				}
+
+				return true;
+			}
+			catch
+			{
+				// If there's any error, don't process the event
+				return false;
 			}
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -678,16 +678,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		bool IsPointerEventRelevantToCurrentElement(PointerRoutedEventArgs e)
 		{
-			if (_container is null)
-			{
-				return false;
-			}
 			// For multi-window scenarios, we need to validate that the pointer event
 			// is actually relevant to the current element's window
 			try
 			{
 				// Check if the container has a valid XamlRoot (indicates it's in a live window)
-				if (_container.XamlRoot is null)
+				if (_container?.XamlRoot is null || e?.OriginalSource is null)
 				{
 					return false;
 				}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Maui.Controls.Platform
 		readonly IPlatformViewHandler _handler;
 		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
 		readonly List<uint> _fingers = new List<uint>();
+		// Dictionary to track when each pointer last entered, used to work around a bug where
+		// PointerEntered events fire unexpectedly in multi-window scenarios
+		readonly Dictionary<uint, DateTime> _lastPointerEnteredTime = new();
+		// Debounce window in milliseconds - if two PointerEntered events for the same pointer
+		// occur within this timeframe in a multi-window scenario, the second one is likely
+		// the bug manifesting and should be ignored
+		const int POINTER_DEBOUNCE_MS = 1000;
 		FrameworkElement? _container;
 		FrameworkElement? _control;
 		VisualElement? _element;
@@ -611,12 +618,55 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		void OnPgrPointerEntered(object sender, PointerRoutedEventArgs e)
-			=> HandlePgrPointerEvent(e, (view, recognizer)
-				=> recognizer.SendPointerEntered(view, (relativeTo)
-					=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		{
+
+			var pointerId = e.Pointer?.PointerId ?? uint.MaxValue;
+			var now = DateTime.UtcNow;
+			
+			// Periodic cleanup when dictionary gets large - this should never happen since each
+			// PointerEntered should have a matching PointerExited that cleans up the entry,
+			// but we include this as a safety measure to prevent unbounded memory growth.
+			// We clean up entries older than twice the debounce window.
+			if (_lastPointerEnteredTime.Count > 5)
+			{
+				var cutoff = now.AddMilliseconds(-POINTER_DEBOUNCE_MS * 2);
+				var keysToRemove = _lastPointerEnteredTime.Where(kvp => kvp.Value < cutoff).Select(kvp => kvp.Key).ToList();
+				foreach (var key in keysToRemove)
+					_lastPointerEnteredTime.Remove(key);
+			}
+			
+			// Multi-window bug workaround: There's a specific bug where PointerEntered events
+			// fire unexpectedly when multiple windows are open. We work around this by 
+			// debouncing - if the same pointer had an Enter event recently and we have multiple
+			// windows open, we ignore the duplicate event. Only applies in multi-window scenarios
+			// to avoid performance overhead in normal single-window usage.
+			if (_lastPointerEnteredTime.TryGetValue(pointerId, out var lastTime) && 
+				(now - lastTime).TotalMilliseconds < POINTER_DEBOUNCE_MS && HasMultipleWindows())
+			{
+				return;
+			}
+			
+			// Track this pointer's entry time for future debounce checks
+			_lastPointerEnteredTime[pointerId] = now;
+			
+			HandlePgrPointerEvent(e, (view, recognizer)
+						=> recognizer.SendPointerEntered(view, (relativeTo)
+							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
+		}
 
 		void OnPgrPointerExited(object sender, PointerRoutedEventArgs e)
 		{
+			
+			// Clean up debounce tracking when pointer exits, but only for relevant events.
+			// This is part of the multi-window bug workaround. We only clean up tracking
+			// for events that are relevant to our current element's window to avoid clearing
+			// tracking data when spurious events from other windows occur.
+			if (IsPointerEventRelevantToCurrentElement(e))
+			{
+				var pointerId = e.Pointer?.PointerId ?? uint.MaxValue;
+				_lastPointerEnteredTime.Remove(pointerId);
+			}
+			
 			HandlePgrPointerEvent(e, (view, recognizer)
 						=> recognizer.SendPointerExited(view, (relativeTo)
 							=> GetPosition(relativeTo, e), _control is null ? null : new PlatformPointerEventArgs(_control, e)));
@@ -675,6 +725,15 @@ namespace Microsoft.Maui.Controls.Platform
 				SendPointerEvent.Invoke(view, recognizer);
 			}
 		}
+
+		/// <summary>
+		/// Determines if multiple windows are currently open. This is used to decide
+		/// whether to apply pointer event debouncing to work around a specific bug where
+		/// PointerEntered events fire unexpectedly in multi-window scenarios.
+		/// </summary>
+		/// <returns>True if multiple windows are open, false otherwise</returns>
+		bool HasMultipleWindows() => 
+			Application.Current?.Windows?.Count > 1;
 
 		bool IsPointerEventRelevantToCurrentElement(PointerRoutedEventArgs e)
 		{

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -697,7 +697,8 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 			catch
 			{
-				// If there's any error, don't process the event
+				// Log the exception for diagnostics
+				Application.Current?.FindMauiContext()?.CreateLogger<GesturePlatformManager>()?.LogError(ex, "An error occurred while validating pointer event relevance.");
 				return false;
 			}
 		}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -695,7 +695,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				return true;
 			}
-			catch
+			catch (Exception ex)
 			{
 				// Log the exception for diagnostics
 				Application.Current?.FindMauiContext()?.CreateLogger<GesturePlatformManager>()?.LogError(ex, "An error occurred while validating pointer event relevance.");


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- Events from the other (minimized) window are interfering with the active (live) window. 



### Description of Change



- Only allow pointer events to be handled if they originate from the currently active (live) window 

 
This ensures: 

- Minimized or background windows do not interfere with active window interactions. 

- Pointer events are scoped and filtered based on the correct visual root or window handle. 



### Issues Fixed



Fixes #30536 
Fixes #27430



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/7a8cc1fa-aec8-496e-86e0-95d53dcdc883"> | <video src="https://github.com/user-attachments/assets/665b4511-75bc-4eec-bcbe-dd0fed0290a9"> |