### PR TITLE
Fixed Early casting in Entry bound to double for negative decimal input

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,20 +200,6 @@ git commit -m "Fix: Description of the change"
 - `.github/instructions/android.instructions.md` - Android handler implementation
 - `.github/instructions/xaml-unittests.instructions.md` - XAML unit test guidelines
 
-### Opening PRs
-
-All PRs are required to have this at the top of the description:
-
-```
-<!-- Please let the below note in for people that find this PR -->
-> [!NOTE]
-> Are you waiting for the changes in this PR to be merged?
-> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
-```
-
-Always put that at the top, without the block quotes. Without it, users will NOT be able to try the PR and your work will have been in vain!
-
-
 
 ## Custom Agents and Skills
 

--- a/.github/skills/pr-finalize/SKILL.md
+++ b/.github/skills/pr-finalize/SKILL.md
@@ -127,16 +127,10 @@ Examples:
 ## Description Requirements
 
 PR description should:
-1. Start with the required NOTE block (so users can test PR artifacts)
-2. Include the base sections from `.github/PULL_REQUEST_TEMPLATE.md` ("Description of Change" and "Issues Fixed"). The skill adds additional structured fields (Root cause, Fix, Key insight, etc.) as recommended enhancements for better agent context.
-3. Match the actual implementation
+1. Include the base sections from `.github/PULL_REQUEST_TEMPLATE.md` ("Description of Change" and "Issues Fixed"). The skill adds additional structured fields (Root cause, Fix, Key insight, etc.) as recommended enhancements for better agent context.
+2. Match the actual implementation
 
 ```markdown
-<!-- Please let the below note in for people that find this PR -->
-> [!NOTE]
-> Are you waiting for the changes in this PR to be merged?
-> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
-
 ### Description of Change
 [Must match actual implementation]
 
@@ -229,11 +223,6 @@ Example: "Before: Safe area applied by default (opt-out). After: Only views impl
 Use structured template only when existing description is inadequate:
 
 ```markdown
-<!-- Please let the below note in for people that find this PR -->
-> [!NOTE]
-> Are you waiting for the changes in this PR to be merged?
-> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
-
 ### Root Cause
 
 [Why the bug occurred - be specific about the code path]

--- a/.github/skills/pr-finalize/references/complete-example.md
+++ b/.github/skills/pr-finalize/references/complete-example.md
@@ -9,10 +9,6 @@ This example shows a PR description optimized for future agent success.
 
 ## Description
 ```markdown
-> [!NOTE]
-> Are you waiting for the changes in this PR to be merged?
-> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
-
 ### Root Cause
 
 In `MauiView.GetAdjustedSafeAreaInsets()` on iOS, views that don't implement `ISafeAreaView` or `ISafeAreaView2` (such as `ContentPresenter`, `Border`) were falling through to return `baseSafeArea`. This applied full device safe area insets to views that never opted into safe area handling, causing double-padding when used inside ControlTemplates.

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -186,6 +186,8 @@ steps:
 - task: PublishBuildArtifacts@1
   condition: always()
   displayName: publish artifacts
+  inputs:
+    artifactName: drop-$(System.StageName)-$(System.JobName)-$(System.JobAttempt)
 
 # Enable Notification Center re-enabled only for catalyst
 - ${{ if eq(parameters.platform, 'catalyst')}}:

--- a/src/Controls/src/Core/BindingExpressionHelper.cs
+++ b/src/Controls/src/Core/BindingExpressionHelper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls
 				}
 
 				// do not canonicalize "-0"; user will likely enter a period after "-0"
-				if (stringValue == "-0" && DecimalTypes.Contains(convertTo))
+				if ((stringValue.StartsWith("0") || stringValue.StartsWith("-0")) && DecimalTypes.Contains(convertTo))
 				{
 					value = original;
 					return false;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30181.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30181.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 30181, "Entry bound to a double casts values too early, preventing small negative decimal entries", PlatformAffected.All)]
+public class Issue30181 : ContentPage
+{
+    public Issue30181()
+    {
+        var viewModel = new Issue30181_ViewModel();
+        BindingContext = viewModel;
+
+        var numericEntry = new Entry
+        {
+            Keyboard = Keyboard.Numeric,
+            AutomationId = "Issue30181Entry"
+        };
+        numericEntry.SetBinding(Entry.TextProperty, nameof(viewModel.NumericValue));
+
+        var stackLayout = new StackLayout
+        {
+            Padding = 20,
+            Children = { numericEntry }
+        };
+
+        Content = stackLayout;
+    }
+}
+
+public partial class Issue30181_ViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    double? _numericValue;
+    public double? NumericValue
+    {
+        get => _numericValue;
+        set
+        {
+            if (_numericValue != value)
+            {
+                _numericValue = value;
+                OnPropertyChanged(nameof(NumericValue));
+            }
+        }
+    }
+
+    protected void OnPropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30181.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30181.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-namespace Controls.TestCases.HostApp.Issues;
+namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 30181, "Entry bound to a double casts values too early, preventing small negative decimal entries", PlatformAffected.All)]
 public class Issue30181 : ContentPage

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30181.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30181.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30181 : _IssuesUITest
+{
+    public Issue30181(TestDevice testDevice) : base(testDevice)
+    {
+    }
+    public override string Issue => "Entry bound to a double casts values too early, preventing small negative decimal entries";
+
+    [Test]
+    [Category(UITestCategories.Entry)]
+    public void EntryBoundToDouble_AllowsTypingSmallNegativeDecimal()
+    {
+        App.WaitForElement("Issue30181Entry");
+        App.EnterText("Issue30181Entry", "-0.01");
+        var result = App.WaitForElement("Issue30181Entry").GetText();
+        Assert.That(result, Is.EqualTo("-0.01"), "The Entry should allow typing a small negative decimal value.");
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30181.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30181.cs
@@ -11,13 +11,30 @@ public class Issue30181 : _IssuesUITest
     }
     public override string Issue => "Entry bound to a double casts values too early, preventing small negative decimal entries";
 
+    const string Issue30181Entry = "Issue30181Entry";
+
     [Test]
     [Category(UITestCategories.Entry)]
     public void EntryBoundToDouble_AllowsTypingSmallNegativeDecimal()
     {
-        App.WaitForElement("Issue30181Entry");
-        App.EnterText("Issue30181Entry", "-0.01");
-        var result = App.WaitForElement("Issue30181Entry").GetText();
-        Assert.That(result, Is.EqualTo("-0.01"), "The Entry should allow typing a small negative decimal value.");
+        App.WaitForElement(Issue30181Entry);
+        App.EnterText(Issue30181Entry, "-0.01");
+        var result = App.WaitForElement(Issue30181Entry).GetText();
+        Assert.That(result, Is.EqualTo("-0.01"));
+        App.ClearText(Issue30181Entry);
+
+        App.EnterText(Issue30181Entry, "0.01");
+        result = App.WaitForElement(Issue30181Entry).GetText();
+        Assert.That(result, Is.EqualTo("0.01"));
+        App.ClearText(Issue30181Entry);
+
+        App.EnterText(Issue30181Entry, "-1");
+        result = App.WaitForElement(Issue30181Entry).GetText();
+        Assert.That(result, Is.EqualTo("-1"));
+        App.ClearText(Issue30181Entry);
+
+        App.EnterText(Issue30181Entry, "0.1");
+        result = App.WaitForElement(Issue30181Entry).GetText();
+        Assert.That(result, Is.EqualTo("0.1"));
     }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Detail

When using a numeric Entry bound to a  double, entering small negative is not handled correctly due to premature value conversion.

### Root Cause
The issue was caused by the logic relying on the parsed numeric value (double) rather than preserving the raw string input 
 
### Description of Change
To address this, the logic was updated to preserve input strings that begin with "0" or "-0" for decimal types. This prevents premature type conversion during user input and allows the full value to be typed correctly without interference.

### Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed:
Fixes #30181 

### Screenshots

| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/6c5680fa-0035-4f97-b6ca-f551de6af359"> |   <video src="https://github.com/user-attachments/assets/f38d9c75-dc3e-4166-8ca3-07c87b8620f9"> |