### PR TITLE
[ci] Fix issue with duplicate License on msi

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -106,7 +106,7 @@
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(LicenseFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(LicenseFile)'))"
-          Pack="true" />
+          Pack="true" Condition="'$(MSBuildProjectFile)' != 'msi.csproj'" />
     <None Include="$(PackageThirdPartyNoticesFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(PackageThirdPartyNoticesFile)'))"
           Pack="true" />


### PR DESCRIPTION
### Description of Change

Fixes issues where MSI.nupkg gets 2 License files.

Follow up of https://github.com/dotnet/maui/pull/29477/files