### PR TITLE
[net10.0, Testing] Disabling the Graphics IImage related test cases on Android platform

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and For Android: https://github.com/dotnet/maui/issues/30576
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and for Android: https://github.com/dotnet/maui/issues/30576
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and For Android: https://github.com/dotnet/maui/issues/30576
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and for Android : https://github.com/dotnet/maui/issues/30576
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and for Android : https://github.com/dotnet/maui/issues/30576
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and for Android: https://github.com/dotnet/maui/issues/30576
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // Issue Link for Windows: https://github.com/dotnet/maui/issues/16767 and for Android:https://github.com/dotnet/maui/issues/30576
+#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // Issue Link for Windows: https://github.com/dotnet/maui/issues/16767 and for Android: https://github.com/dotnet/maui/issues/30576
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/16767
+#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // Issue Link for Windows: https://github.com/dotnet/maui/issues/16767 and for Android:https://github.com/dotnet/maui/issues/30576
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
This pull request updates preprocessor directives in several test files to reflect that certain tests also fail on Android, in addition to the previously noted platforms. The updates include references to the relevant GitHub issues for better traceability.

### Updates to preprocessor directives:

* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs`](diffhunk://#diff-2d787e475b7f808c152f47312d431ad7376bca06f5ea5bc25363917977083f25L1-R1): Modified the `#if` directive to include `TEST_FAILS_ON_ANDROID` and added a reference to GitHub issue #30576 for Android-specific failures.
* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs`](diffhunk://#diff-5cd9b0108cf3bb480e3acc7d1a670c9b55e32c0b5c1fe89de1092e01d34311feL1-R1): Updated the `#if` directive to include `TEST_FAILS_ON_ANDROID` and appended the corresponding GitHub issue reference (#30576) for Android failures.
* [`src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs`](diffhunk://#diff-c5f2691071322621acbf5c93775eb8c5024259f5c7ca85ae9a4a10dfaa9eb57cL1-R1): Adjusted the `#if` directive to include `TEST_FAILS_ON_ANDROID` and added a reference to GitHub issue #30576 for Android-specific issues.