### PR TITLE
[Android] Pass the launched extra when resuming WebAuthenticator

### DIFF
--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorCallbackActivity.android.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Authentication
 				// start the intermediate activity again with flags to close the custom tabs
 				var intent = new Intent(this, typeof(WebAuthenticatorIntermediateActivity));
 				intent.SetData(Intent.Data);
+				intent.PutExtra(WebAuthenticatorIntermediateActivity.LaunchedExtra, true);
 				intent.AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop);
 				StartActivity(intent);
 			}

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorIntermediateActivity.android.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Maui.Authentication
 	[Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, Exported = false)]
 	class WebAuthenticatorIntermediateActivity : Activity
 	{
-		const string launchedExtra = "launched";
-		const string actualIntentExtra = "actual_intent";
+		internal const string LaunchedExtra = "launched";
+		internal const string ActualIntentExtra = "actual_intent";
 
 		bool launched;
 		Intent actualIntent;
@@ -26,11 +26,11 @@ namespace Microsoft.Maui.Authentication
 			}
 
 			// read the values
-			launched = extras.GetBoolean(launchedExtra, false);
+			launched = extras.GetBoolean(LaunchedExtra, false);
 #pragma warning disable 618 // TODO: one day use the API 33+ version: https://developer.android.com/reference/android/os/Bundle#getParcelable(java.lang.String,%20java.lang.Class%3CT%3E)
 #pragma warning disable CA1422 // Validate platform compatibility
 #pragma warning disable CA1416 // Validate platform compatibility
-			actualIntent = extras.GetParcelable(actualIntentExtra) as Intent;
+			actualIntent = extras.GetParcelable(ActualIntentExtra) as Intent;
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CA1416 // Validate platform compatibility
 #pragma warning restore 618
@@ -66,8 +66,8 @@ namespace Microsoft.Maui.Authentication
 		protected override void OnSaveInstanceState(Bundle outState)
 		{
 			// save the values
-			outState.PutBoolean(launchedExtra, launched);
-			outState.PutParcelable(actualIntentExtra, actualIntent);
+			outState.PutBoolean(LaunchedExtra, launched);
+			outState.PutParcelable(ActualIntentExtra, actualIntent);
 
 			base.OnSaveInstanceState(outState);
 		}
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Authentication
 		public static void StartActivity(Activity activity, Intent intent)
 		{
 			var intermediateIntent = new Intent(activity, typeof(WebAuthenticatorIntermediateActivity));
-			intermediateIntent.PutExtra(actualIntentExtra, intent);
+			intermediateIntent.PutExtra(ActualIntentExtra, intent);
 
 			activity.StartActivity(intermediateIntent);
 		}


### PR DESCRIPTION

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Sometimes the intermediate activity is finished prematurely and state is lost. By passing the flag directly when resuming we never even need to keep the intermediate activity around.

I am not sure why the activity is finished in some cases, but it may be memory pressure or the OS decides it can. Either way, the only extras we care about is the launched flag. This is set to true to indicate that it has already launched, and then we can just resume the auth and finish.

If you get here and it is NOT launched and the activity is cleaned up, then something else has gone wrong as this activity is only start directly from maui auth with extras, or resumed from app code. It is not an exported activity and cannot be launched from outside the app.



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24692

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
