### PR TITLE
[ci] Remove more warnings

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,7 +26,8 @@
   <PropertyGroup>
     <!-- Microsoft.Build.Msix.props" cannot be imported again -->
     <!-- Found version-specific or distribution-specific runtime identifier(s)-->
-    <NoWarn>$(NoWarn);MSB4011;NETSDK1206</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;NU1702</NoWarn>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB4011;MSB3277;NETSDK1206;NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <!-- platform version number information -->

--- a/eng/pipelines/arcade/stage-pack.yml
+++ b/eng/pipelines/arcade/stage-pack.yml
@@ -1,4 +1,4 @@
-# Template for build + pack on dnceng
+x# Template for build + pack on dnceng
 parameters:
 - name: prepareSteps
   type: stepList

--- a/eng/pipelines/arcade/stage-pack.yml
+++ b/eng/pipelines/arcade/stage-pack.yml
@@ -1,4 +1,4 @@
-x# Template for build + pack on dnceng
+# Template for build + pack on dnceng
 parameters:
 - name: prepareSteps
   type: stepList


### PR DESCRIPTION
### Description of Change

This pull request includes a modification to the `Directory.Build.targets` file to adjust how specific MSBuild warnings are handled. The change moves the `MSB4011` warning from being suppressed to being treated as a message instead.

Build configuration changes:

* [`Directory.Build.targets`](diffhunk://#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcL29-R30): Updated the `NoWarn` property to remove suppression of `MSB4011` and added `MSBuildWarningsAsMessages` to treat `MSB4011` and `NETSDK1206` warnings as messages instead.

### Issues Fixed

Fixes #
