### PR TITLE
[Android] Fix status bar issues on Android API 36

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -249,18 +249,15 @@ namespace Microsoft.Maui.Controls.Platform
 					dialog.Window.SetNavigationBarColor(new AColor(navigationBarColor));
 #pragma warning restore CA1422
 					// For Android API 36+, cannot set status bar color directly due to edge-to-edge enforcement
-
 					if (Build.VERSION.SdkInt < (BuildVersionCodes)36)
 					{
 #pragma warning disable CA1422
 						dialog.Window.SetStatusBarColor(new AColor(statusBarColor));
 #pragma warning restore CA1422
 					}
-
-					// Set status bar appearance for API 36+ using WindowInsetsController
-					if (Build.VERSION.SdkInt >= (BuildVersionCodes)36 && mainActivity is not null)
+					else
 					{
-						mainActivity.SetStatusBarColor(new AColor(statusBarColor));
+						dialog.Window.SetStatusBarColorWithEdgeToEdge(new AColor(statusBarColor));
 					}
 				}
 

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -260,13 +260,7 @@ namespace Microsoft.Maui.Controls.Platform
 					// Set status bar appearance for API 36+ using WindowInsetsController
 					if (Build.VERSION.SdkInt >= (BuildVersionCodes)36 && mainActivity is not null)
 					{
-						var windowInsetsController =
-							new WindowInsetsControllerCompat(dialog.Window, dialog.Window.DecorView);
-						
-						// Determine if we should use light status bar based on current theme
-						var uiModeFlags = mainActivity.Resources?.Configuration?.UiMode & UiMode.NightMask;
-						bool isLightTheme = uiModeFlags != UiMode.NightYes;
-						windowInsetsController.AppearanceLightStatusBars = isLightTheme;
+						mainActivity.SetStatusBarColor(new AColor(statusBarColor));
 					}
 				}
 

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -232,8 +232,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				dialog.Window.SetBackgroundDrawable(TransparentColorDrawable);
 
-				var mainActivity = Context?.GetActivity();
-				var mainActivityWindow = mainActivity?.Window;
+				var mainActivityWindow = Context?.GetActivity()?.Window;
 				var attributes = mainActivityWindow?.Attributes;
 
 				if (attributes is not null)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29954.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29954.cs
@@ -1,0 +1,80 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29954, "The status bar is blank when ManualMAUITests sample project debugging on the Android API 36 emulator", PlatformAffected.Android)]
+public class Issue29954 : ContentPage
+{
+	public Issue29954()
+	{
+		Content = new StackLayout
+		{
+			Children =
+			{
+				new Label
+				{
+					Text = "Android API 36 Status Bar Test",
+					FontSize = 18,
+					HorizontalOptions = LayoutOptions.Center,
+					Margin = new Thickness(10, 50, 10, 10)
+				},
+				new Label
+				{
+					Text = "On Android API 36 (Android 16), the status bar should display correctly with proper light/dark appearance based on the current theme, not appear blank.",
+					HorizontalOptions = LayoutOptions.Center,
+					Margin = new Thickness(10),
+					AutomationId = "StatusBarDescriptionLabel"
+				},
+				new Button
+				{
+					Text = "Open Modal to Test Status Bar",
+					AutomationId = "OpenModalButton",
+					Command = new Command(() =>
+					{
+						Window!.Page!.Navigation.PushModalAsync(new ContentPage
+						{
+							Title = "Modal Page",
+							Content = new StackLayout
+							{
+								Children =
+								{
+									new Label
+									{
+										Text = "Modal Page - Status bar should still be visible and properly themed",
+										VerticalOptions = LayoutOptions.Center,
+										HorizontalOptions = LayoutOptions.Center,
+										AutomationId = "ModalStatusBarTestLabel"
+									},
+									new Button
+									{
+										Text = "Close Modal",
+										AutomationId = "CloseModalButton",
+										Command = new Command(async () =>
+										{
+											await Window!.Page!.Navigation.PopModalAsync();
+										})
+									}
+								}
+							}
+						}, false);
+					})
+				},
+				new Label
+				{
+					Text = $"Current Android API Level: {GetAndroidApiLevel()}",
+					FontSize = 12,
+					HorizontalOptions = LayoutOptions.Center,
+					Margin = new Thickness(10),
+					AutomationId = "ApiLevelLabel"
+				}
+			}
+		};
+	}
+
+	string GetAndroidApiLevel()
+	{
+#if ANDROID
+ 		return Android.OS.Build.VERSION.SdkInt.ToString();
+#else
+		return "N/A (Not Android)";
+#endif
+	}
+} 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29954.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29954.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue29954: _IssuesUITest
 {
-	public Issue29882(TestDevice device) : base(device)
+	public Issue29954(TestDevice device) : base(device)
 	{
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29954.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29954.cs
@@ -1,0 +1,34 @@
+using System;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29954: _IssuesUITest
+{
+	public Issue29882(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "The status bar is blank when ManualMAUITests sample project debugging on the Android API 36 emulator";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void StatusBarShouldBeVisibleOnAndroidAPI36()
+	{
+		App.WaitForElement("StatusBarDescriptionLabel");
+		
+		App.WaitForElement("ApiLevelLabel");
+
+		// Test opening modal which should also have proper status bar handling
+		App.WaitForElement("OpenModalButton");
+		App.Click("OpenModalButton");
+		App.WaitForElement("ModalStatusBarTestLabel");
+
+		// The modal content should not overlap with the status bar
+		// Close modal and verify main page is still correct
+		App.Click("CloseModalButton");
+		App.WaitForElement("StatusBarDescriptionLabel");
+	}
+}

--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Maui.Platform
 
 			activity.SetWindowHandler(window, mauiContext);
 			
-			// Set status bar appearance for Android API 36+ edge-to-edge enforcement
-			activity.SetStatusBarAppearance();
+			// Set up edge-to-edge handling for Android API 36+ where edge-to-edge is enforced
+			activity.SetEdgeToEdge();
 		}
 
 		public static Bundle ToBundle(this IPersistedState? state)

--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Platform
 			activity.SetWindowHandler(window, mauiContext);
 			
 			// Set status bar appearance for Android API 36+ edge-to-edge enforcement
-			activity.SetStatusBarAppearanceForCurrentTheme();
+			activity.SetStatusBarAppearance();
 		}
 
 		public static Bundle ToBundle(this IPersistedState? state)

--- a/src/Core/src/Platform/Android/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Android/ApplicationExtensions.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Maui.Platform
 			}
 
 			activity.SetWindowHandler(window, mauiContext);
+			
+			// Set status bar appearance for Android API 36+ edge-to-edge enforcement
+			activity.SetStatusBarAppearanceForCurrentTheme();
 		}
 
 		public static Bundle ToBundle(this IPersistedState? state)

--- a/src/Core/src/Platform/Android/Resources/values-v36/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values-v36/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <style name="Maui.MainTheme" parent="Maui.MainTheme.Base">
+    <!-- Android 16 (API 36) enforces edge-to-edge display, cannot opt out -->
+    <!-- Status bar appearance must be set via WindowInsetsControllerCompat -->
+    <item name="android:windowTranslucentStatus">false</item>
+    <item name="android:windowTranslucentNavigation">false</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="android:navigationBarColor">@android:color/transparent</item>
+  </style>
+</resources>

--- a/src/Core/src/Platform/Android/StatusBarExtensions.cs
+++ b/src/Core/src/Platform/Android/StatusBarExtensions.cs
@@ -1,0 +1,97 @@
+using Android.Content.Res;
+using Android.OS;
+using Android.Views;
+using AndroidX.Core.View;
+using Activity = Android.App.Activity;
+
+namespace Microsoft.Maui.Platform;
+
+internal static class StatusBarExtensions
+{
+	/// <summary>
+	/// Sets the status bar appearance for Android API 36+ where edge-to-edge is enforced.
+	/// On Android 16 (API 36), you can no longer change the status bar color directly,
+	/// and must use WindowInsetsControllerCompat to set the appearance.
+	/// </summary>
+	/// <param name="activity">The activity to set the status bar appearance for</param>
+	/// <param name="isLightStatusBar">Whether to use light status bar (dark icons) or dark status bar (light icons)</param>
+	public static void SetStatusBarAppearance(this Activity activity, bool isLightStatusBar)
+	{
+		if (activity?.Window == null)
+		{
+			return;
+		}
+
+		// For Android API 36+, use WindowInsetsControllerCompat
+		if (Build.VERSION.SdkInt >= (BuildVersionCodes)36)
+		{
+			var windowInsetsController =
+				WindowCompat.GetInsetsController(activity.Window, activity.Window.DecorView);
+
+			if (windowInsetsController is not null)
+			{
+				windowInsetsController.AppearanceLightStatusBars = isLightStatusBar;
+			}
+
+			// Set up window insets handling to prevent content overlap
+			SetupWindowInsets(activity);
+		}
+
+		// NOTE: For older versions, the existing status bar color setting approach continues to work
+		// This is handled by other parts of the framework that call SetStatusBarColor directly.
+	}
+
+	/// <summary>
+	/// Sets the status bar appearance based on the current theme.
+	/// </summary>
+	/// <param name="activity">The activity to set the status bar appearance for</param>
+	public static void SetStatusBarAppearanceForCurrentTheme(this Activity activity)
+	{
+		if (activity?.Window == null)
+		{
+			return;
+		}
+
+		// Determine if we should use light status bar based on current theme
+		bool isLightTheme = IsLightTheme(activity);
+		activity.SetStatusBarAppearance(isLightTheme);
+	}
+
+	static bool IsLightTheme(Activity activity)
+	{
+		var uiModeFlags = activity.Resources?.Configuration?.UiMode & UiMode.NightMask;
+		return uiModeFlags != UiMode.NightYes;
+	}
+
+	static void SetupWindowInsets(Activity activity)
+	{
+		if (activity?.Window?.DecorView == null)
+		{
+			return;
+		}
+
+		ViewCompat.SetOnApplyWindowInsetsListener(activity.Window.DecorView, new WindowInsetsListener());
+
+		// Trigger the initial insets application
+		ViewCompat.RequestApplyInsets(activity.Window.DecorView);
+	}
+}
+
+class WindowInsetsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+{
+	public WindowInsetsCompat? OnApplyWindowInsets(View? view, WindowInsetsCompat? insets)
+	{
+		// Get the system bars insets (status bar and navigation bar)
+		var systemBarsInsets = insets?.GetInsets(WindowInsetsCompat.Type.SystemBars());
+
+		// Apply padding to the root view to prevent content overlap with system bars
+		view?.SetPadding(
+			systemBarsInsets?.Left ?? 0,
+			systemBarsInsets?.Top ?? 0,
+			systemBarsInsets?.Right ?? 0,
+			systemBarsInsets?.Bottom ?? 0
+		);
+		
+		return insets;
+	}
+}

--- a/src/Core/src/Platform/Android/StatusBarExtensions.cs
+++ b/src/Core/src/Platform/Android/StatusBarExtensions.cs
@@ -1,97 +1,236 @@
+using System.Collections.Generic;
 using Android.Content.Res;
 using Android.OS;
 using Android.Views;
+using Android.Widget;
 using AndroidX.Core.View;
+using AColor = Android.Graphics.Color;
 using Activity = Android.App.Activity;
 
-namespace Microsoft.Maui.Platform;
-
-internal static class StatusBarExtensions
+namespace Microsoft.Maui.Platform
 {
-	/// <summary>
-	/// Sets the status bar appearance for Android API 36+ where edge-to-edge is enforced.
-	/// On Android 16 (API 36), you can no longer change the status bar color directly,
-	/// and must use WindowInsetsControllerCompat to set the appearance.
-	/// </summary>
-	/// <param name="activity">The activity to set the status bar appearance for</param>
-	/// <param name="isLightStatusBar">Whether to use light status bar (dark icons) or dark status bar (light icons)</param>
-	public static void SetStatusBarAppearance(this Activity activity, bool isLightStatusBar)
+	internal static class StatusBarExtensions
 	{
-		if (activity?.Window == null)
-		{
-			return;
-		}
+		static readonly Dictionary<Activity, View> StatusBarOverlays = new();
 
-		// For Android API 36+, use WindowInsetsControllerCompat
-		if (Build.VERSION.SdkInt >= (BuildVersionCodes)36)
+		class WindowInsetsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
 		{
-			var windowInsetsController =
-				WindowCompat.GetInsetsController(activity.Window, activity.Window.DecorView);
+			private readonly View? _overlay;
 
-			if (windowInsetsController is not null)
+			public WindowInsetsListener(View? overlay = null)
 			{
-				windowInsetsController.AppearanceLightStatusBars = isLightStatusBar;
+				_overlay = overlay;
 			}
 
-			// Set up window insets handling to prevent content overlap
-			SetupWindowInsets(activity);
+			public WindowInsetsCompat? OnApplyWindowInsets(View? view, WindowInsetsCompat? insets)
+			{
+				if (insets == null || view == null)
+				{
+					return insets;
+				}
+
+				// Get the system bars insets (status bar and navigation bar)
+				var systemBarsInsets = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+
+				if (_overlay != null)
+				{
+					// Position the overlay at the top of the screen covering the status bar area
+					var statusBarInsets = insets.GetInsets(WindowInsetsCompat.Type.StatusBars());
+					
+					var layoutParams = new FrameLayout.LayoutParams(
+						ViewGroup.LayoutParams.MatchParent,
+						statusBarInsets?.Top ?? 0)
+					{
+						Gravity = GravityFlags.Top
+					};
+					_overlay.LayoutParameters = layoutParams;
+				}
+				
+				// Apply padding to the root view to prevent content overlap with system bars
+				view.SetPadding(
+					systemBarsInsets?.Left ?? 0,
+					systemBarsInsets?.Top ?? 0,
+					systemBarsInsets?.Right ?? 0,
+					systemBarsInsets?.Bottom ?? 0
+				);
+			
+				return insets;
+			}
 		}
 
-		// NOTE: For older versions, the existing status bar color setting approach continues to work
-		// This is handled by other parts of the framework that call SetStatusBarColor directly.
-	}
-
-	/// <summary>
-	/// Sets the status bar appearance based on the current theme.
-	/// </summary>
-	/// <param name="activity">The activity to set the status bar appearance for</param>
-	public static void SetStatusBarAppearanceForCurrentTheme(this Activity activity)
-	{
-		if (activity?.Window == null)
+		/// <summary>
+		/// Sets the status bar appearance for Android API 36+ where edge-to-edge is enforced.
+		/// On Android 16 (API 36), you can no longer change the status bar color directly,
+		/// and must use WindowInsetsControllerCompat to set the appearance.
+		/// Also handles proper window insets to prevent content overlap with system bars.
+		/// </summary>
+		/// <param name="activity">The activity to set the status bar appearance for</param>
+		/// <param name="isLightStatusBar">Whether to use light status bar (dark icons) or dark status bar (light icons)</param>
+		public static void SetStatusBarAppearance(this Activity activity, bool isLightStatusBar)
 		{
-			return;
+			if (activity?.Window == null)
+			{
+				return;
+			}
+
+			// For Android API 36+, use WindowInsetsControllerCompat and handle edge-to-edge properly
+			if (Build.VERSION.SdkInt >= (BuildVersionCodes)36) // Android 16 API 36+
+			{
+				// Enable edge-to-edge display
+				WindowCompat.SetDecorFitsSystemWindows(activity.Window, false);
+
+				var windowInsetsController =
+					WindowCompat.GetInsetsController(activity.Window, activity.Window.DecorView);
+
+				if (windowInsetsController is not null)
+				{
+					windowInsetsController.AppearanceLightStatusBars = isLightStatusBar;
+				}
+
+				// Set up window insets handling to prevent content overlap
+				SetupWindowInsets(activity);
+			}
+
+			// For older versions, the existing status bar color setting approach continues to work
+			// This is handled by other parts of the framework that call SetStatusBarColor directly
 		}
 
-		// Determine if we should use light status bar based on current theme
-		bool isLightTheme = IsLightTheme(activity);
-		activity.SetStatusBarAppearance(isLightTheme);
-	}
-
-	static bool IsLightTheme(Activity activity)
-	{
-		var uiModeFlags = activity.Resources?.Configuration?.UiMode & UiMode.NightMask;
-		return uiModeFlags != UiMode.NightYes;
-	}
-
-	static void SetupWindowInsets(Activity activity)
-	{
-		if (activity?.Window?.DecorView == null)
+		/// <summary>
+		/// Sets the status bar background color for Android API 36+ by creating a colored overlay.
+		/// On Android 16 (API 36), the status bar must be transparent due to edge-to-edge enforcement,
+		/// so we create a colored overlay view behind it to achieve the desired visual appearance.
+		/// </summary>
+		/// <param name="activity">The activity to set the status bar color for</param>
+		/// <param name="color">The color to use for the status bar background</param>
+		/// <param name="isLightStatusBar">Whether to use light status bar (dark icons) or dark status bar (light icons)</param>
+		public static void SetStatusBarColor(this Activity activity, AColor color, bool isLightStatusBar)
 		{
-			return;
+			if (activity?.Window == null)
+			{
+				return;
+			}
+
+			// For Android API 36+, create a colored overlay behind the transparent status bar
+			if (Build.VERSION.SdkInt >= (BuildVersionCodes)36) // Android 16 API 36+
+			{
+				// Set the appearance first
+				activity.SetStatusBarAppearance(isLightStatusBar);
+				
+				// Create or update the status bar overlay
+				CreateStatusBarOverlay(activity, color);
+			}
+			else
+			{
+				// For older versions, use the standard approach
+				activity.Window.SetStatusBarColor(color);
+				activity.SetStatusBarAppearance(isLightStatusBar);
+			}
 		}
 
-		ViewCompat.SetOnApplyWindowInsetsListener(activity.Window.DecorView, new WindowInsetsListener());
+		/// <summary>
+		/// Sets the status bar color based on the current theme colors.
+		/// Uses the app's primary color for the status bar background.
+		/// </summary>
+		/// <param name="activity">The activity to set the status bar color for</param>
+		/// <param name="color">The color to use for the status bar background</param>
+		public static void SetStatusBarColor(this Activity activity, AColor color)
+		{
+			if (activity?.Window == null)
+			{
+				return;
+			}
 
-		// Trigger the initial insets application
-		ViewCompat.RequestApplyInsets(activity.Window.DecorView);
-	}
-}
+			// Determine if we should use light status bar based on current theme
+			bool isLightTheme = IsLightTheme(activity);
+			
+			// Set the status bar color with appropriate appearance
+			activity.SetStatusBarColor(color, isLightTheme);
+		}
 
-class WindowInsetsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
-{
-	public WindowInsetsCompat? OnApplyWindowInsets(View? view, WindowInsetsCompat? insets)
-	{
-		// Get the system bars insets (status bar and navigation bar)
-		var systemBarsInsets = insets?.GetInsets(WindowInsetsCompat.Type.SystemBars());
+		/// <summary>
+		/// Sets the status bar appearance based on the current theme.
+		/// </summary>
+		/// <param name="activity">The activity to set the status bar appearance for</param>
+		public static void SetStatusBarAppearance(this Activity activity)
+		{
+			if (activity?.Window == null)
+			{
+				return;
+			}
 
-		// Apply padding to the root view to prevent content overlap with system bars
-		view?.SetPadding(
-			systemBarsInsets?.Left ?? 0,
-			systemBarsInsets?.Top ?? 0,
-			systemBarsInsets?.Right ?? 0,
-			systemBarsInsets?.Bottom ?? 0
-		);
-		
-		return insets;
+			// Determine if we should use light status bar based on current theme
+			bool isLightTheme = IsLightTheme(activity);
+			
+			// Set the status bar appearance
+			activity.SetStatusBarAppearance(isLightTheme);
+		}
+
+		static void CreateStatusBarOverlay(Activity activity, AColor color)
+		{
+			if (activity?.Window?.DecorView is not ViewGroup decorView)
+			{
+				return;
+			}
+
+			// Remove existing overlay if it exists
+			if (StatusBarOverlays.TryGetValue(activity, out var existingOverlay))
+			{
+				if (existingOverlay.Parent is ViewGroup parent)
+				{
+					parent.RemoveView(existingOverlay);
+				}
+
+				StatusBarOverlays.Remove(activity);
+			}
+
+			// Create a new colored overlay view
+			var overlay = new View(activity)
+			{
+				Id = View.GenerateViewId()
+			};
+			overlay.SetBackgroundColor(color);
+
+			// Add the overlay to the decor view
+			decorView.AddView(overlay);
+			StatusBarOverlays[activity] = overlay;
+
+			// Position the overlay over the status bar area
+			PositionStatusBarOverlay(activity, overlay);
+		}
+
+		static void PositionStatusBarOverlay(Activity activity, View overlay)
+		{
+			if (activity?.Window?.DecorView == null)
+			{
+				return;
+			}
+
+			// Set up a layout listener to position the overlay correctly once we have window insets
+			var listener = new WindowInsetsListener(overlay);
+			ViewCompat.SetOnApplyWindowInsetsListener(activity.Window.DecorView, listener);
+		}
+
+		static bool IsLightTheme(Activity activity)
+		{
+			// Check if the current theme is light or dark
+			var uiModeFlags = activity.Resources?.Configuration?.UiMode & UiMode.NightMask;
+			return uiModeFlags != UiMode.NightYes;
+		}
+
+		static void SetupWindowInsets(Activity activity)
+		{
+			if (activity?.Window?.DecorView == null)
+			{
+				return;
+			}
+
+			// Only set up basic window insets if no overlay is being used
+			// If an overlay is being used, PositionStatusBarOverlay handles the insets
+			if (!StatusBarOverlays.ContainsKey(activity))
+			{
+				var listener = new WindowInsetsListener();
+				ViewCompat.SetOnApplyWindowInsetsListener(activity.Window.DecorView, listener);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

On Android 16 (API 36), there are issues with the status bar: content overlapping the status bar, cannot manage the color. This occurs because:
- Android 16 enforces edge-to-edge display and applications cannot opt out
- The existing theme file values-v35/styles.xml uses `android:windowOptOutEdgeToEdgeEnforcement` which no longer works on API 36
- Direct status bar color setting via `SetStatusBarColor()` not works

This PR implements proper status bar appearance handling for Android API 36+:
- Create a StatusBarExtensions class with methods to configures window insets handling to prevent content overlap with system bars and also to create a colored overlay view. 
- Added a related UITest.

### Issues Fixed

Fixes #29954 
