### PR TITLE
Fixed the SafeArea branch test case failures issues

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.iOS.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public static void MapPeekAreaInsets(CarouselViewHandler handler, CarouselView carouselView)
 		{
+			(handler.Controller.Layout as CarouselViewLayout)?.UpdateConstraints(handler.PlatformView.Frame.Size);
 			handler.Controller.Layout.InvalidateLayout();
 		}
 
@@ -72,34 +73,30 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			// I'm not sure if this solution is fully correct or if it properly accounts
-			// for all the constraints checks that  GetDesiredSizeFromHandler takes into account 
-			if (Primitives.Dimension.IsExplicitSet(widthConstraint) && Primitives.Dimension.IsExplicitSet(heightConstraint))
+			var size = this.GetDesiredSizeFromHandler(widthConstraint, heightConstraint);
+
+			if (OperatingSystem.IsMacCatalystVersionAtLeast(11))
 			{
-				// If both width and height are explicitly set, we can use the base implementation
-				return base.GetDesiredSize(widthConstraint, heightConstraint);
+				// Ensure size never exceeds constraints.
+				// In the 22417 test sample on Mac, if widthConstraint is 1085, it becomes 1512 after the SizeThatFits call 
+				// inside ViewHandlerExtensions.iOS. This causes the view's width to appear larger on Mac.
+				// On iOS, the value remains correct — for example, if widthConstraint is 375, SizeThatFits also returns 375.
+				// This issue happened on Main also.
+
+				if (!double.IsInfinity(widthConstraint) && size.Width > widthConstraint)
+				{
+					size.Width = (float)widthConstraint;
+				}
+
+				if (!double.IsInfinity(heightConstraint) && size.Height > heightConstraint)
+				{
+					size.Height = (float)heightConstraint;
+				}
+
 			}
 
-			var result = this.GetDesiredSizeFromHandler(widthConstraint, heightConstraint);
+			return size;
 
-			if (Primitives.Dimension.IsExplicitSet(widthConstraint))
-			{
-				// If width is explicitly set, we can use the width from the result
-				result = new Size(widthConstraint, result.Height);
-			}
-			else if (Primitives.Dimension.IsExplicitSet(heightConstraint))
-			{
-				// If height is explicitly set, we can use the height from the result
-				result = new Size(result.Width, heightConstraint);
-			}
-
-			return result;
-		}
-
-		public override void PlatformArrange(Rect rect)
-		{
-			(Controller.Layout as CarouselViewLayout)?.UpdateConstraints(rect.Size);
-			base.PlatformArrange(rect);
 		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
 virtual Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDeclarer, TPropertyType>.Invoke(TDeclarer bindable) -> TPropertyType

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
-override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
 virtual Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDeclarer, TPropertyType>.Invoke(TDeclarer bindable) -> TPropertyType

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22417.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22417.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST //This test is failing, likely due to product issue, for more information: https://github.com/dotnet/maui/issues/27059
+﻿#if TEST_FAILS_ON_WINDOWS //This test is failing, likely due to product issue, for more information: https://github.com/dotnet/maui/issues/27059
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Platform
 		SafeAreaPadding _safeArea = SafeAreaPadding.Empty;
 		bool _safeAreaInvalidated = true;
 		bool _appliesSafeAreaAdjustments;
-		
+
 
 		WeakReference<IView>? _reference;
 		WeakReference<ICrossPlatformLayout>? _crossPlatformLayoutReference;
@@ -163,6 +163,9 @@ namespace Microsoft.Maui.Platform
 				// to let ancestors adjust to the measured size.
 				if (this.IsFinalMeasureHandledBySuperView())
 				{
+					//This arrangement step is essential for communicating the correct coordinate space to native iOS views before scheduling the second layout pass.
+					//This ensures the native view is aware of the correct bounds and can adjust its layout accordingly.
+					CrossPlatformArrange(Bounds.ToRectangle());
 					SetNeedsLayout();
 					this.InvalidateAncestorsMeasures();
 					return;
@@ -215,7 +218,7 @@ namespace Microsoft.Maui.Platform
 
 			// Return whether the way safe area interacts with our view has changed
 			return oldApplyingSafeAreaAdjustments == _appliesSafeAreaAdjustments &&
-			       (oldSafeArea == _safeArea || !_appliesSafeAreaAdjustments);
+				   (oldSafeArea == _safeArea || !_appliesSafeAreaAdjustments);
 		}
 
 		IVisualTreeElement? IVisualTreeElementProvidable.GetElement()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Test failures

- 22417 AddItemsToCarouselViewWorks (iOS and Mac rendering issue) 
- 7678 (iOS rendering issue)
- 25192 CarouselViewShouldRenderCorrectly (breaking issue due to safe area implementation latest fix)


### Description of Change



- Arranged the bounds before scheduling the second layout pass. This ensures the native view is aware of the correct bounds and can adjust its layout accordingly. This helps resolve test failures related to 22417 (iOS), 7678, and 25192.

- Ensure the size never exceeds the constraints.
(i.e) In the 22417 test sample on Mac (CarouselView1), if widthConstraint is 1085, it becomes 1512 after the SizeThatFits call inside the ViewHandlerExtensions.iOS, causing the view's width to appear larger on Mac.
On iOS, the value remains correct — for example, if widthConstraint is 375, SizeThatFits also returns 375.



### Tested the behaviour in the following platforms

- [x] iOS
- [x] Mac



### Screenshot

### Before fix 

| 7678 | 22417 (iOS) (adding item not added) | 25192 |
|----------|----------|----------|
| <video src="https://github.com/user-attachments/assets/f3d7a1d0-ec6d-4d45-bd5a-ce6b5ae68968"> | <video src="https://github.com/user-attachments/assets/ba40629d-5125-48a6-aadd-55620c6d8b9e"> |<video src="https://github.com/user-attachments/assets/01e46965-eed3-4c52-a046-1f40ce4c9fe3">|

### After fix 

| 22417 (Mac ) | 7678 | 22417 (iOS ) | 25192 | 
|----------|----------|----------|----------|
| <video src="https://github.com/user-attachments/assets/28dff95a-7a92-4e1e-a2b6-6feb7afe80ec"> | <video src="https://github.com/user-attachments/assets/e57ecd95-fb22-4e2c-9225-f39c5a3d498e"> |<video src="https://github.com/user-attachments/assets/d4f1cccc-6885-4697-b232-4472651b9c90"> | <video src="https://github.com/user-attachments/assets/469472ea-3ca6-44e0-b945-5f68cec24dab"> |