### PR TITLE
[NET10.0][Catalyst] Add API to Enable/Disable Minimize and Maximize Buttons on Windows

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
@@ -21,6 +21,11 @@
             <Label Text="{Binding Window.Width, StringFormat='W = {0:0.00}'}" />
             <Label Text="{Binding Window.Height, StringFormat='H = {0:0.00}'}" />
 
+            <Label Text="IsMinimizable:" />
+            <CheckBox x:Name="IsMinimizableCheckBox" IsChecked="True" CheckedChanged="OnIsMinimizableCheckBoxCheckedChanged" />
+            <Label Text="IsMaximizable:" />
+            <CheckBox x:Name="IsMaximizableCheckBox" IsChecked="True" CheckedChanged="OnIsMaximizableCheckBoxCheckedChanged" />
+          
             <Label Text="Open/Close Windows:" />
             <Button
                 Clicked="OnNewWindowClicked"

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -83,5 +83,21 @@ namespace Maui.Controls.Sample.Pages
 			Window.X = (disp.Width / disp.Density - Window.Width) / 2;
 			Window.Y = (disp.Height / disp.Density - Window.Height) / 2;
 		}
-	}
+
+		void OnIsMinimizableCheckBoxCheckedChanged(object sender, CheckedChangedEventArgs e)
+		{
+			UpdateWindowButtons();
+		}
+
+		void OnIsMaximizableCheckBoxCheckedChanged(object sender, CheckedChangedEventArgs e)
+		{
+			UpdateWindowButtons();
+		}
+
+		void UpdateWindowButtons()
+		{
+			Window.IsMinimizable = IsMinimizableCheckBox.IsChecked;
+			Window.IsMaximizable = IsMaximizableCheckBox.IsChecked;
+		}
+    }
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -252,6 +252,12 @@ static Microsoft.Maui.Controls.ViewExtensions.ScaleToAsync(this Microsoft.Maui.C
 static Microsoft.Maui.Controls.ViewExtensions.ScaleXToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.ScaleYToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Maui.Controls.VisualElement! view, double x, double y, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -257,6 +257,12 @@ static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Ma
 virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.RemoveSearchController(UIKit.UINavigationItem! navigationItem) -> void
 virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.UpdateSearchIsEnabled(UIKit.UISearchController! searchController) -> void
 virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.UpdateSearchVisibility(UIKit.UISearchController! searchController) -> void
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -259,6 +259,12 @@ virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.
 *REMOVED*~Microsoft.Maui.Controls.Handlers.Compatibility.ShellScrollViewTracker.ShellScrollViewTracker(Microsoft.Maui.IPlatformViewHandler renderer) -> void
 virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.UpdateSearchIsEnabled(UIKit.UISearchController! searchController) -> void
 virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.UpdateSearchVisibility(UIKit.UISearchController! searchController) -> void
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -197,6 +197,12 @@ static Microsoft.Maui.Controls.ViewExtensions.ScaleToAsync(this Microsoft.Maui.C
 static Microsoft.Maui.Controls.ViewExtensions.ScaleXToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.ScaleYToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Maui.Controls.VisualElement! view, double x, double y, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -249,6 +249,12 @@ static Microsoft.Maui.Controls.ViewExtensions.ScaleToAsync(this Microsoft.Maui.C
 static Microsoft.Maui.Controls.ViewExtensions.ScaleXToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.ScaleYToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Maui.Controls.VisualElement! view, double x, double y, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -242,6 +242,12 @@ static Microsoft.Maui.Controls.ViewExtensions.ScaleToAsync(this Microsoft.Maui.C
 static Microsoft.Maui.Controls.ViewExtensions.ScaleXToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.ScaleYToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Maui.Controls.VisualElement! view, double x, double y, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -242,6 +242,12 @@ static Microsoft.Maui.Controls.ViewExtensions.ScaleToAsync(this Microsoft.Maui.C
 static Microsoft.Maui.Controls.ViewExtensions.ScaleXToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.ScaleYToAsync(this Microsoft.Maui.Controls.VisualElement! view, double scale, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
 static Microsoft.Maui.Controls.ViewExtensions.TranslateToAsync(this Microsoft.Maui.Controls.VisualElement! view, double x, double y, uint length = 250, Microsoft.Maui.Easing? easing = null) -> System.Threading.Tasks.Task<bool>!
+Microsoft.Maui.Controls.Window.IsMaximizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMaximizable.set -> void
+Microsoft.Maui.Controls.Window.IsMinimizable.get -> bool
+Microsoft.Maui.Controls.Window.IsMinimizable.set -> void
+static readonly Microsoft.Maui.Controls.Window.IsMaximizableProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.IsMinimizableProperty -> Microsoft.Maui.Controls.BindableProperty!
 override Microsoft.Maui.Controls.ScrollView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -66,11 +66,11 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="IsMinimizable"/>.</summary>
 		public static readonly BindableProperty IsMinimizableProperty = BindableProperty.Create(nameof(IsMinimizable),
-			typeof(bool), typeof(TitleBar), defaultValue: true);
+			typeof(bool), typeof(Window), defaultValue: true);
 
 		/// <summary>Bindable property for <see cref="IsMaximizable"/>.</summary>
 		public static readonly BindableProperty IsMaximizableProperty = BindableProperty.Create(nameof(IsMaximizable),
-			typeof(bool), typeof(TitleBar), defaultValue: true);
+			typeof(bool), typeof(Window), defaultValue: true);
 
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren;

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -64,6 +64,14 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TitleBarProperty = BindableProperty.Create(
 			nameof(TitleBar), typeof(TitleBar), typeof(Window), null, propertyChanged: TitleBarChanged);
 
+		/// <summary>Bindable property for <see cref="IsMinimizable"/>.</summary>
+		public static readonly BindableProperty IsMinimizableProperty = BindableProperty.Create(nameof(IsMinimizable),
+			typeof(bool), typeof(TitleBar), defaultValue: true);
+
+		/// <summary>Bindable property for <see cref="IsMaximizable"/>.</summary>
+		public static readonly BindableProperty IsMaximizableProperty = BindableProperty.Create(nameof(IsMaximizable),
+			typeof(bool), typeof(TitleBar), defaultValue: true);
+
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren;
 		Toolbar? _toolbar;
@@ -593,6 +601,20 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public float DisplayDensity => ((IWindow)this).RequestDisplayDensity();
+
+		/// <summary>Gets or sets whether the window can be minimized.</summary>
+		public bool IsMinimizable
+		{
+			get { return (bool)GetValue(IsMinimizableProperty); }
+			set { SetValue(IsMinimizableProperty, value); }
+		}
+
+		/// <summary>Gets or sets whether the window can be maximized.</summary>
+		public bool IsMaximizable
+		{
+			get { return (bool)GetValue(IsMaximizableProperty); }
+			set { SetValue(IsMaximizableProperty, value); }
+		}
 
 		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -315,5 +315,128 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(2, deactivated);
 			}
 		}
+
+		[Fact(DisplayName = "Window respects IsMinimizable property")]
+		public async Task WindowRespectsIsMinimizableProperty()
+		{
+			SetupBuilder();
+
+			var mainPage = new ContentPage();
+			var window = new Window(mainPage)
+			{
+				IsMinimizable = false
+			};
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				var platformWindow = handler.PlatformView as UI.Xaml.Window;
+				var appWindow = platformWindow?.GetAppWindow();
+				var presenter = appWindow?.Presenter as OverlappedPresenter;
+
+				Assert.NotNull(presenter);
+
+				await Task.Yield();
+
+				// Check that minimize button is disabled when IsMinimizable is false
+				Assert.False(presenter.IsMinimizable);
+
+				// Test changing the property at runtime
+				window.IsMinimizable = true;
+				await Task.Yield();
+
+				Assert.True(presenter.IsMinimizable);
+
+				// Test setting it back to false
+				window.IsMinimizable = false;
+				await Task.Yield();
+
+				Assert.False(presenter.IsMinimizable);
+			});
+		}
+
+		[Fact(DisplayName = "Window respects IsMaximizable property")]
+		public async Task WindowRespectsIsMaximizableProperty()
+		{
+			SetupBuilder();
+
+			var mainPage = new ContentPage();
+			var window = new Window(mainPage)
+			{
+				IsMaximizable = false
+			};
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				var platformWindow = handler.PlatformView as UI.Xaml.Window;
+				var appWindow = platformWindow?.GetAppWindow();
+				var presenter = appWindow?.Presenter as OverlappedPresenter;
+
+				Assert.NotNull(presenter);
+
+				await Task.Yield();
+
+				// Check that maximize button is disabled when IsMaximizable is false
+				Assert.False(presenter.IsMaximizable);
+
+				// Test changing the property at runtime
+				window.IsMaximizable = true;
+				await Task.Yield();
+
+				Assert.True(presenter.IsMaximizable);
+
+				// Test setting it back to false
+				window.IsMaximizable = false;
+				await Task.Yield();
+
+				Assert.False(presenter.IsMaximizable);
+			});
+		}
+
+		[Fact(DisplayName = "Window respects both IsMinimizable and IsMaximizable properties together")]
+		public async Task WindowRespectsBothMinimizableAndMaximizableProperties()
+		{
+			SetupBuilder();
+
+			var mainPage = new ContentPage();
+			var window = new Window(mainPage)
+			{
+				IsMinimizable = false,
+				IsMaximizable = false
+			};
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				var platformWindow = handler.PlatformView as UI.Xaml.Window;
+				var appWindow = platformWindow?.GetAppWindow();
+				var presenter = appWindow?.Presenter as OverlappedPresenter;
+
+				Assert.NotNull(presenter);
+
+				await Task.Yield();
+
+				Assert.False(presenter.IsMinimizable);
+				Assert.False(presenter.IsMaximizable);
+
+				window.IsMinimizable = true;
+				await Task.Yield();
+
+				Assert.True(presenter.IsMinimizable);
+				Assert.False(presenter.IsMaximizable);
+
+				window.IsMinimizable = false;
+				window.IsMaximizable = true;
+				await Task.Yield();
+
+				Assert.False(presenter.IsMinimizable);
+				Assert.True(presenter.IsMaximizable);
+
+				window.IsMinimizable = true;
+				window.IsMaximizable = true;
+				await Task.Yield();
+
+				Assert.True(presenter.IsMinimizable);
+				Assert.True(presenter.IsMaximizable);
+			});
+		}
 	}
 }

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -133,9 +133,9 @@ namespace Microsoft.Maui
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
 		/// <summary>Gets a value indicating whether the window can be minimized.</summary>
-		bool IsMinimizable { get; }
+		bool IsMinimizable => true;
 		/// <summary>Gets a value indicating whether the window can be maximized.</summary>
-		bool IsMaximizable { get; }
+		bool IsMaximizable => true;
 #endif
 
 #if WINDOWS

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -132,6 +132,10 @@ namespace Microsoft.Maui
 
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
+		/// <summary>Gets or sets whether the window can be minimized.</summary>
+		bool IsMinimizable { get; }
+		/// <summary>Gets or sets whether the window can be maximized.</summary>
+		bool IsMaximizable { get; }
 #endif
 
 #if WINDOWS

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -132,9 +132,9 @@ namespace Microsoft.Maui
 
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
-		/// <summary>Gets or sets whether the window can be minimized.</summary>
+		/// <summary>Gets a value indicating whether the window can be minimized.</summary>
 		bool IsMinimizable { get; }
-		/// <summary>Gets or sets whether the window can be maximized.</summary>
+		/// <summary>Gets a value indicating whether the window can be maximized.</summary>
 		bool IsMaximizable { get; }
 #endif
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -108,6 +108,12 @@ namespace Microsoft.Maui.Handlers
 		public static void MapMinimumHeight(IWindowHandler handler, IWindow view) =>
 			handler.PlatformView?.UpdateMinimumHeight(view);
 
+		public static void MapIsMinimizable(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView?.UpdateIsMinimizable(window);
+
+		public static void MapIsMaximizable(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView?.UpdateIsMaximizable(window);
+
 		public static void MapToolbar(IWindowHandler handler, IWindow view)
 		{
 			if (view is IToolbarElement tb)

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.MinimumWidth)] = MapMinimumWidth,
 			[nameof(IWindow.MinimumHeight)] = MapMinimumHeight,
 			[nameof(IWindow.TitleBar)] = MapTitleBar,
-			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
-			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 #if ANDROID || WINDOWS || TIZEN
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,
@@ -40,6 +38,8 @@ namespace Microsoft.Maui.Handlers
 #if WINDOWS
 			[nameof(IWindow.FlowDirection)] = MapFlowDirection,
 			[nameof(IWindow.TitleBarDragRectangles)] = MapTitleBarDragRectangles,
+			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
+			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 		};
 

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.MinimumWidth)] = MapMinimumWidth,
 			[nameof(IWindow.MinimumHeight)] = MapMinimumHeight,
 			[nameof(IWindow.TitleBar)] = MapTitleBar,
+			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
+			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 #if ANDROID || WINDOWS || TIZEN
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.MinimumWidth)] = MapMinimumWidth,
 			[nameof(IWindow.MinimumHeight)] = MapMinimumHeight,
 			[nameof(IWindow.TitleBar)] = MapTitleBar,
+			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
+			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 #if ANDROID || WINDOWS || TIZEN
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,
@@ -38,8 +40,6 @@ namespace Microsoft.Maui.Handlers
 #if WINDOWS
 			[nameof(IWindow.FlowDirection)] = MapFlowDirection,
 			[nameof(IWindow.TitleBarDragRectangles)] = MapTitleBarDragRectangles,
-			[nameof(IWindow.IsMinimizable)] = MapIsMinimizable,
-			[nameof(IWindow.IsMaximizable)] = MapIsMaximizable,
 #endif
 		};
 

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AppKit;
 using Foundation;
 using UIKit;
 
@@ -47,6 +48,16 @@ namespace Microsoft.Maui.Handlers
 			{
 				controller.SetUpTitleBar(window, mauiContext);
 			}
+		}
+
+		public static void MapIsMaximizable(IWindowHandler handler, IWindow window)
+		{
+				
+		}
+
+		public static void MapIsMinimizable(IWindowHandler handler, IWindow window)
+		{
+			
 		}
 #endif
 

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -127,7 +127,13 @@ namespace Microsoft.Maui.Handlers
 				request.SetResult(handler.PlatformView.GetDisplayDensity());
 			}
 		}
+#if MACCATALYST
+		public static void MapIsMinimizable(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView?.UpdateIsMinimizableAsync(window).FireAndForget();
 
+		public static void MapIsMaximizable(IWindowHandler handler, IWindow window) =>
+			handler.PlatformView?.UpdateIsMaximizableAsync(window).FireAndForget();
+#endif
 		void UpdateVirtualViewFrame(UIWindow window)
 		{
 			VirtualView.FrameChanged(window.Bounds.ToRectangle());

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using AppKit;
 using Foundation;
 using UIKit;
 

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -49,16 +49,6 @@ namespace Microsoft.Maui.Handlers
 				controller.SetUpTitleBar(window, mauiContext);
 			}
 		}
-
-		public static void MapIsMaximizable(IWindowHandler handler, IWindow window)
-		{
-				
-		}
-
-		public static void MapIsMinimizable(IWindowHandler handler, IWindow window)
-		{
-			
-		}
 #endif
 
 		public static void MapContent(IWindowHandler handler, IWindow window)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		internal static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
 			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
 			{
@@ -226,7 +226,7 @@ namespace Microsoft.Maui.Platform
 			});
 		}
 
-		public static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
+		internal static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
 			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
 			{

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -209,24 +209,29 @@ namespace Microsoft.Maui.Platform
 				appWindow.Resize(temp);
 		}
 
-		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		internal static void UpdateWindowOverlappedPresenter(this UI.Xaml.Window platformWindow, Action<UI.Windowing.OverlappedPresenter> updateAction)
 		{
 			var appWindow = platformWindow.GetAppWindow();
-
 			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
 			{
-				presenter.IsMinimizable = window.IsMinimizable;
+				updateAction(presenter);
 			}
+		}
+
+		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		{
+			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
+			{
+				presenter.IsMinimizable = window.IsMinimizable;
+			});
 		}
 
 		public static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
-			var appWindow = platformWindow.GetAppWindow();
-
-			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
 			{
 				presenter.IsMaximizable = window.IsMaximizable;
-			}
+			});
 		}
 
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -209,29 +209,24 @@ namespace Microsoft.Maui.Platform
 				appWindow.Resize(temp);
 		}
 
-		internal static void UpdateWindowOverlappedPresenter(this UI.Xaml.Window platformWindow, Action<UI.Windowing.OverlappedPresenter> updateAction)
-		{
-			var appWindow = platformWindow.GetAppWindow();
-			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
-			{
-				updateAction(presenter);
-			}
-		}
-
 		internal static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
-			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
 			{
 				presenter.IsMinimizable = window.IsMinimizable;
-			});
+			}
 		}
 
 		internal static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
 		{
-			platformWindow.UpdateWindowOverlappedPresenter(presenter =>
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
 			{
 				presenter.IsMaximizable = window.IsMaximizable;
-			});
+			}
 		}
 
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -209,6 +209,26 @@ namespace Microsoft.Maui.Platform
 				appWindow.Resize(temp);
 		}
 
+		public static void UpdateIsMinimizable(this UI.Xaml.Window platformWindow, IWindow window)
+		{
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+			{
+				presenter.IsMinimizable = window.IsMinimizable;
+			}
+		}
+
+		public static void UpdateIsMaximizable(this UI.Xaml.Window platformWindow, IWindow window)
+		{
+			var appWindow = platformWindow.GetAppWindow();
+
+			if (appWindow?.Presenter is UI.Windowing.OverlappedPresenter presenter)
+			{
+				presenter.IsMaximizable = window.IsMaximizable;
+			}
+		}
+
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)
 		{
 			foreach (var window in WindowExtensions.GetWindows())

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CoreGraphics;
+using Foundation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Devices;
+using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -36,9 +37,11 @@ namespace Microsoft.Maui.Platform
 
 		internal static void UpdateCoordinates(this UIWindow platformWindow, IWindow window)
 		{
-			if (OperatingSystem.IsMacCatalyst() && OperatingSystem.IsIOSVersionAtLeast(16) && platformWindow.WindowScene is { } windowScene)
+			if (OperatingSystem.IsMacCatalyst() && OperatingSystem.IsIOSVersionAtLeast(16) &&
+			    platformWindow.WindowScene is { } windowScene)
 			{
-				if (double.IsNaN(window.X) || double.IsNaN(window.Y) || double.IsNaN(window.Width) || double.IsNaN(window.Height))
+				if (double.IsNaN(window.X) || double.IsNaN(window.Y) || double.IsNaN(window.Width) ||
+				    double.IsNaN(window.Height))
 				{
 					return;
 				}
@@ -50,7 +53,8 @@ namespace Microsoft.Maui.Platform
 
 				windowScene.RequestGeometryUpdate(preferences, (error) =>
 				{
-					window.Handler?.MauiContext?.CreateLogger<UIWindow>()?.LogError("Requesting geometry update failed with error '{error}'.", error);
+					window.Handler?.MauiContext?.CreateLogger<UIWindow>()
+						?.LogError("Requesting geometry update failed with error '{error}'.", error);
 				});
 			}
 			else
@@ -95,6 +99,128 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMinimumSize(this UIWindow platformWindow, IWindow window) =>
 			platformWindow.UpdateMinimumSize(window.MinimumWidth, window.MinimumHeight);
+
+#if MACCATALYST
+		// See: https://gist.github.com/rolfbjarne/981b778a99425a6e630c
+		const string LibobjcDylib = "/usr/lib/libobjc.dylib";
+		
+		[DllImport(LibobjcDylib, EntryPoint = "objc_msgSend")]
+		static extern void void_objc_msgSend_bool(IntPtr receiver, IntPtr selector, bool arg1);
+		
+		[DllImport(LibobjcDylib, EntryPoint = "objc_msgSend")]
+		internal static extern IntPtr IntPtr_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
+		
+		// Lazy-loaded selector for requesting a standard window button
+		static Selector? StandardWindowButtonSelector;
+		static Selector StandardWindowButton => StandardWindowButtonSelector ??= new Selector("standardWindowButton:");
+		
+		// Lazy-loaded selector for hiding/showing a button
+		static Selector? StandardWindowButtonSetHiddenSelector;
+		static Selector StandardWindowButtonSetHidden => StandardWindowButtonSetHiddenSelector ??= new Selector("setHidden:");
+		
+		enum NSWindowButton : ulong
+		{
+			MinimizeButton,
+			MaximizeButton
+		}
+
+		public static async Task UpdateIsMinimizableAsync(this UIWindow platformWindow, IWindow window)
+		{
+			var nsWindow = await GetNSWindowFromUIWindowAsync(platformWindow);
+
+			if (nsWindow != null)
+			{
+				// Get the minimize button from the window
+				var minimizeButton = Runtime.GetNSObject(
+					IntPtr_objc_msgSend_IntPtr(
+						nsWindow.Handle,
+						StandardWindowButton.Handle,
+						(IntPtr)(ulong)NSWindowButton.MinimizeButton));
+
+				if (minimizeButton is not null)
+				{
+					// Update the button's visibility based on the window's state
+					bool isMinimizable = window.IsMinimizable;
+					
+					void_objc_msgSend_bool(
+						minimizeButton.Handle,
+						StandardWindowButtonSetHidden.Handle,
+						!isMinimizable);
+				}
+			}
+		}
+		
+		public static async Task UpdateIsMaximizableAsync(this UIWindow platformWindow, IWindow window)
+		{
+			var nsWindow = await GetNSWindowFromUIWindowAsync(platformWindow);
+
+			if (nsWindow != null)
+			{
+				// Get the maximize button from the window
+				var maximizeButton = Runtime.GetNSObject(
+					IntPtr_objc_msgSend_IntPtr(
+						nsWindow.Handle,
+						StandardWindowButton.Handle,
+						(IntPtr)(ulong)NSWindowButton.MaximizeButton));
+
+				if (maximizeButton is not null)
+				{
+					// Update the button's visibility based on the window's state
+					bool isMaximizable = window.IsMaximizable;
+					
+					void_objc_msgSend_bool(
+						maximizeButton.Handle,
+						StandardWindowButtonSetHidden.Handle,
+						!isMaximizable);
+				}
+			}
+		}
+
+		static async Task<NSObject?> GetNSWindowFromUIWindowAsync(this UIWindow window)
+		{
+			if (window is null)
+			{
+				return null;
+			}
+
+			var nsApplication = Runtime.GetNSObject(Class.GetHandle("NSApplication"));
+			if (nsApplication is null)
+			{
+				return null;
+			}
+
+			var sharedApplication = nsApplication.PerformSelector(new Selector("sharedApplication"));
+			if (sharedApplication is null)
+			{
+				return null;
+			}
+
+			var applicationDelegate = sharedApplication.PerformSelector(new Selector("delegate"));
+			if (applicationDelegate is null)
+			{
+				return null;
+			}
+
+			return await GetNSWindowAsync(window, applicationDelegate);
+		}
+
+		static async Task<NSObject?> GetNSWindowAsync(UIWindow window, NSObject applicationDelegate)
+		{
+			// Custom selector used to bridge host window with UIKit UIWindow
+			var nsWindowHandle = IntPtr_objc_msgSend_IntPtr(applicationDelegate.Handle,
+				Selector.GetHandle("hostWindowForUIWindow:"), window.Handle);
+			var nsWindow = Runtime.GetNSObject<NSObject>(nsWindowHandle);
+			
+			if (nsWindow is null)
+			{
+				// Delay to allow async window resolution
+				await Task.Delay(500);
+				return await GetNSWindowAsync(window, applicationDelegate);
+			}
+
+			return nsWindow;
+		}
+#endif
 
 		internal static void UpdateMinimumSize(this UIWindow platformWindow, double width, double height)
 		{

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -66,6 +66,7 @@ virtual Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFinishNavigatio
 *REMOVED*virtual Microsoft.Maui.PropertyMapper.UpdateKeys.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 Microsoft.Maui.IWindow.IsMaximizable.get -> bool
 Microsoft.Maui.IWindow.IsMinimizable.get -> bool
+Microsoft.Maui.IWindow.IsMinimizable.get -> bool
 virtual Microsoft.Maui.Animations.Lerp.LerpDelegate.Invoke(object! start, object! end, double progress) -> object!
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.ContextFlyoutItemHandlerUpdate(Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate! original) -> void
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.Deconstruct(out int Index, out Microsoft.Maui.IMenuElement! MenuElement) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -43,6 +43,8 @@ Microsoft.Maui.WebResourceRequestedEventArgs.UrlSchemeTask.get -> WebKit.IWKUrlS
 static Microsoft.Maui.Handlers.ButtonHandler.MapBackground(Microsoft.Maui.Handlers.IButtonHandler! handler, Microsoft.Maui.IButton! button) -> void
 static Microsoft.Maui.Handlers.GraphicsViewHandler.MapBackground(Microsoft.Maui.Handlers.IGraphicsViewHandler! handler, Microsoft.Maui.IGraphicsView! graphicsView) -> void
 static Microsoft.Maui.Handlers.SearchBarHandler.MapReturnType(Microsoft.Maui.Handlers.ISearchBarHandler! handler, Microsoft.Maui.ISearchBar! searchBar) -> void
+static Microsoft.Maui.Handlers.WindowHandler.MapIsMaximizable(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
+static Microsoft.Maui.Handlers.WindowHandler.MapIsMinimizable(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 static Microsoft.Maui.Hosting.AppHostBuilderExtensions.ConfigureEnvironmentVariables(this Microsoft.Maui.Hosting.MauiAppBuilder! builder) -> Microsoft.Maui.Hosting.MauiAppBuilder!
 *REMOVED*static Microsoft.Maui.Platform.ApplicationExtensions.CreatePlatformWindow(this UIKit.IUIApplicationDelegate! platformApplication, Microsoft.Maui.IApplication! application, UIKit.UIApplication! uiApplication, Foundation.NSDictionary! launchOptions) -> void
 static Microsoft.Maui.Platform.ApplicationExtensions.CreatePlatformWindow(this UIKit.IUIApplicationDelegate! platformApplication, Microsoft.Maui.IApplication! application, UIKit.UIApplication! uiApplication, Foundation.NSDictionary? launchOptions) -> void
@@ -53,6 +55,8 @@ static Microsoft.Maui.Platform.TextInputExtensions.SetTextRange(this UIKit.IUITe
 static Microsoft.Maui.Platform.UIApplicationExtensions.GetKeyWindow(this UIKit.UIApplication! application) -> UIKit.UIWindow?
 static Microsoft.Maui.Platform.UIApplicationExtensions.GetWindow(this UIKit.UIApplication! application) -> Microsoft.Maui.IWindow?
 *REMOVED*virtual Microsoft.Maui.MauiUIApplicationDelegate.FinishedLaunching(UIKit.UIApplication! application, Foundation.NSDictionary! launchOptions) -> bool
+static Microsoft.Maui.Platform.WindowExtensions.UpdateIsMaximizableAsync(this UIKit.UIWindow! platformWindow, Microsoft.Maui.IWindow! window) -> System.Threading.Tasks.Task!
+static Microsoft.Maui.Platform.WindowExtensions.UpdateIsMinimizableAsync(this UIKit.UIWindow! platformWindow, Microsoft.Maui.IWindow! window) -> System.Threading.Tasks.Task!
 virtual Microsoft.Maui.LifecycleEvents.iOSLifecycle.WillEnterForeground.Invoke(UIKit.UIApplication! application) -> void
 virtual Microsoft.Maui.LifecycleEvents.iOSLifecycle.WillFinishLaunching.Invoke(UIKit.UIApplication! application, Foundation.NSDictionary? launchOptions) -> bool
 virtual Microsoft.Maui.MauiUIApplicationDelegate.FinishedLaunching(UIKit.UIApplication! application, Foundation.NSDictionary? launchOptions) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -64,6 +64,8 @@ virtual Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFailProvisional
 virtual Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFinishNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation) -> void
 *REMOVED*virtual Microsoft.Maui.PropertyMapper.ClearKeyCache() -> void
 *REMOVED*virtual Microsoft.Maui.PropertyMapper.UpdateKeys.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Maui.IWindow.IsMaximizable.get -> bool
+Microsoft.Maui.IWindow.IsMinimizable.get -> bool
 virtual Microsoft.Maui.Animations.Lerp.LerpDelegate.Invoke(object! start, object! end, double progress) -> object!
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.ContextFlyoutItemHandlerUpdate(Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate! original) -> void
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.Deconstruct(out int Index, out Microsoft.Maui.IMenuElement! MenuElement) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -66,7 +66,6 @@ virtual Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFinishNavigatio
 *REMOVED*virtual Microsoft.Maui.PropertyMapper.UpdateKeys.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 Microsoft.Maui.IWindow.IsMaximizable.get -> bool
 Microsoft.Maui.IWindow.IsMinimizable.get -> bool
-Microsoft.Maui.IWindow.IsMinimizable.get -> bool
 virtual Microsoft.Maui.Animations.Lerp.LerpDelegate.Invoke(object! start, object! end, double progress) -> object!
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.ContextFlyoutItemHandlerUpdate(Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate! original) -> void
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.Deconstruct(out int Index, out Microsoft.Maui.IMenuElement! MenuElement) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -44,6 +44,10 @@ static Microsoft.Maui.Platform.TextBoxExtensions.GetCursorPosition(this Microsof
 static Microsoft.Maui.Platform.TimePickerExtensions.UpdateBackground(this Microsoft.UI.Xaml.Controls.TimePicker! platformTimePicker, Microsoft.Maui.ITimePicker! timePicker) -> void
 *REMOVED*virtual Microsoft.Maui.PropertyMapper.ClearKeyCache() -> void
 *REMOVED*virtual Microsoft.Maui.PropertyMapper.UpdateKeys.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Maui.IWindow.IsMaximizable.get -> bool
+Microsoft.Maui.IWindow.IsMinimizable.get -> bool
+static Microsoft.Maui.Handlers.WindowHandler.MapIsMaximizable(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
+static Microsoft.Maui.Handlers.WindowHandler.MapIsMinimizable(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 Microsoft.Maui.Handlers.OpenWindowRequest.Deconstruct(out Microsoft.Maui.IPersistedState? State, out Microsoft.UI.Xaml.LaunchActivatedEventArgs? LaunchArgs) -> void
 virtual Microsoft.Maui.Animations.Lerp.LerpDelegate.Invoke(object! start, object! end, double progress) -> object!
 Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.ContextFlyoutItemHandlerUpdate(Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate! original) -> void


### PR DESCRIPTION
### Description of Change

This PR adds support for the `IsMinimizable` and `IsMaximizable` properties to the Window class when running on Mac Catalyst.

Since Catalyst does not expose any public API to control native macOS window buttons, this implementation leverages the SPI (System Programming Interface) selector `standardWindowButton:` via interop. 

Note: This PR builds upon changes introduced in PR #29822. If we decide to proceed with this, ensure that PR #29822 is merged first.

This PR enables:

- Enables customization of native macOS window chrome behavior.
- Extends cross-platform parity with expected Window APIs.

### Issues Fixed

Fixes #10297