### PR TITLE
[iOS] Fix WebView.Reload() with HtmlWebViewSource returns WebNavigationResult.Failure in Navigated event

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30515.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30515.cs
@@ -1,0 +1,135 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 30515, "[iOS] WebView.Reload() with HtmlWebViewSource returns WebNavigationResult.Failure in Navigated event", PlatformAffected.iOS)]
+public class Issue30515 : ContentPage
+{
+	WebView webView;
+	Label statusTextLabel;
+	Label statusValueLabel;
+
+	public Issue30515()
+	{
+		Title = "Issue 30515";
+		
+		// Create the navigation status labels - split into static text and dynamic value
+		statusTextLabel = new Label
+		{
+			Text = "Status:",
+			FontSize = 14,
+			TextColor = Colors.Gray,
+			VerticalOptions = LayoutOptions.Center
+		};
+		
+		statusValueLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = "NavigationStatusLabel",
+			FontSize = 14,
+			TextColor = Colors.Blue,
+			VerticalOptions = LayoutOptions.Center
+		};
+		
+		// Create a horizontal stack for the status display
+		var statusContainer = new StackLayout
+		{
+			Orientation = StackOrientation.Horizontal,
+			Spacing = 5,
+			HorizontalOptions = LayoutOptions.Center,
+			Children = { statusTextLabel, statusValueLabel }
+		};
+
+		// Create the WebView
+		webView = new WebView
+		{
+			HeightRequest = 300,
+			WidthRequest = 400,
+			Source = new HtmlWebViewSource
+			{
+				Html = @"
+				<html>
+				<head>
+					<title>HTML WebView Source</title>
+				</head>
+				<body style='font-family:sans-serif; padding:20px;'>
+					<h1>WebView Feature Matrix</h1>
+					<p>This page demonstrates various capabilities of the .NET MAUI WebView control, such as:</p>
+					<ul>
+						<li>Rendering HTML content</li>
+						<li>Executing JavaScript</li>
+						<li>Cookie management</li>
+						<li>Back/Forward navigation</li>
+					</ul>
+					<h2>Test Content</h2>
+					<p>
+						This is a longer body paragraph to help test the <strong>EvaluateJavaScript</strong> functionality 
+						and how it extracts body text. You can use this text to verify substring operations and test scrolling 
+						or formatting in the WebView.
+						
+					</p>
+					<p>
+						Try interacting with navigation buttons, loading multiple pages, or checking cookie behavior.
+					</p>
+					
+					<h2>Navigation Test Links</h2>
+					<p>Click these links to test URL navigation:</p>
+					<ul>
+						<li><a href='https://www.google.com'>Google</a></li>
+						<li><a href='https://www.microsoft.com'>Microsoft</a></li>
+						<li><a href='https://github.com'>GitHub</a></li>
+						<li><a href='https://docs.microsoft.com/dotnet/maui/'>MAUI Documentation</a></li>
+						<li><a href='https://httpbin.org/html'>HTTPBin HTML Test</a></li>
+					</ul>
+					
+					<footer style='margin-top:40px; font-size:0.9em; color:gray;'>Generated for testing WebView features.</footer>
+				</body>
+				</html>"
+			}
+		};
+		
+		// Set up event handlers
+		webView.Navigated += OnWebViewNavigated;
+		
+		// Create the reload button
+		var reloadButton = new Button
+		{
+			Text = "Reload",
+			AutomationId = "ReloadButton",
+			HorizontalOptions = LayoutOptions.Center
+		};
+		reloadButton.Clicked += OnReloadClicked;
+		
+		// Add all elements to the page
+		Content = new StackLayout
+		{
+			Padding = new Thickness(10),
+			Spacing = 10,
+			Children =
+			{
+				statusContainer,
+				webView,
+				new StackLayout
+				{
+					Orientation = StackOrientation.Horizontal,
+					Spacing = 10,
+					HorizontalOptions = LayoutOptions.Center,
+					Children =
+					{
+						reloadButton
+					}
+				}
+			}
+		};
+	}
+
+	void OnReloadClicked(object sender, EventArgs e)
+	{
+		statusValueLabel.Text = "Reloading...";
+		webView.Reload();
+	}
+
+	void OnWebViewNavigated(object sender, WebNavigatedEventArgs e)
+	{
+		statusValueLabel.Text = e.Result.ToString();
+		statusValueLabel.TextColor = Colors.Green;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30515.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30515.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30515 : _IssuesUITest
+{
+	public override string Issue => "[iOS] WebView.Reload() with HtmlWebViewSource returns WebNavigationResult.Failure in Navigated event";
+
+	public Issue30515(TestDevice device)
+	: base(device)
+	{ }
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void VerifyWebViewHTMLSourceReloadStatus()
+	{
+		App.WaitForElement("NavigationStatusLabel");
+		App.Tap("ReloadButton");
+		Assert.That(App.FindElement("NavigationStatusLabel").GetText(), Is.EqualTo("Success"));
+	}
+}

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -55,7 +55,15 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-			platformDatePicker.CharacterSpacing = datePicker.CharacterSpacing.ToEm();
+		    var characterSpacing = datePicker.CharacterSpacing.ToEm();
+			platformDatePicker.CharacterSpacing = characterSpacing;
+
+			var dateTextBlock = platformDatePicker.GetDescendantByName<TextBlock>("DateText");
+			if (dateTextBlock is not null)
+			{
+				dateTextBlock.CharacterSpacing = characterSpacing;
+				dateTextBlock.RefreshThemeResources();
+			}
 		}
 
 		public static void UpdateFont(this CalendarDatePicker platformDatePicker, IDatePicker datePicker, IFontManager fontManager) =>

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -55,15 +55,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-		    var characterSpacing = datePicker.CharacterSpacing.ToEm();
-			platformDatePicker.CharacterSpacing = characterSpacing;
-
-			var dateTextBlock = platformDatePicker.GetDescendantByName<TextBlock>("DateText");
-			if (dateTextBlock is not null)
-			{
-				dateTextBlock.CharacterSpacing = characterSpacing;
-				dateTextBlock.RefreshThemeResources();
-			}
+			platformDatePicker.CharacterSpacing = datePicker.CharacterSpacing.ToEm();
 		}
 
 		public static void UpdateFont(this CalendarDatePicker platformDatePicker, IDatePicker datePicker, IFontManager fontManager) =>

--- a/src/Core/src/Platform/iOS/WebViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/WebViewExtensions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Platform
 				// If the source is an HTML source, we need to reload from the source
 				// since WKWebView.Reload() doesn't work properly with LoadHtmlString
 				var sourceType = webView.Source.GetType().Name;
-				if (sourceType == "HtmlWebViewSource")
+				if (string.Equals(sourceType, "HtmlWebViewSource", StringComparison.Ordinal))
 				{
 					// For HTML sources, always reload from the source
 					webView.Source.Load(webViewDelegate);
@@ -76,6 +76,10 @@ namespace Microsoft.Maui.Platform
 					// For URL sources, use the standard reload
 					platformWebView.Reload();
 				}
+			}
+			else
+			{
+				platformWebView.Reload();
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/WebViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/WebViewExtensions.cs
@@ -56,7 +56,27 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateReload(this WKWebView platformWebView, IWebView webView)
 		{
-			platformWebView?.Reload();
+			//platformWebView?.Reload();
+			if (platformWebView == null)
+				return;
+
+			// Check if we have a source and platformWebView implements IWebViewDelegate
+			if (webView.Source != null && platformWebView is IWebViewDelegate webViewDelegate)
+			{
+				// If the source is an HTML source, we need to reload from the source
+				// since WKWebView.Reload() doesn't work properly with LoadHtmlString
+				var sourceType = webView.Source.GetType().Name;
+				if (sourceType == "HtmlWebViewSource")
+				{
+					// For HTML sources, always reload from the source
+					webView.Source.Load(webViewDelegate);
+				}
+				else
+				{
+					// For URL sources, use the standard reload
+					platformWebView.Reload();
+				}
+			}
 		}
 
 		internal static void UpdateCanGoBackForward(this WKWebView platformWebView, IWebView webView)

--- a/src/Core/src/Platform/iOS/WebViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/WebViewExtensions.cs
@@ -56,9 +56,10 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateReload(this WKWebView platformWebView, IWebView webView)
 		{
-			//platformWebView?.Reload();
 			if (platformWebView == null)
+			{
 				return;
+			}
 
 			// Check if we have a source and platformWebView implements IWebViewDelegate
 			if (webView.Source != null && platformWebView is IWebViewDelegate webViewDelegate)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
Reloading HtmlWebViewSource on iOS causes the Navigated event to return Failure due to WKWebView not supporting .reload() for HTML strings.

### Description of Change

<!-- Enter description of the fix in this section -->
Added a check for HtmlWebViewSource and reloaded the HTML manually to ensure successful navigation.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #30515 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac





| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/dd8cf28d-7081-4d29-8058-0d4f97916f1d" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/7a448500-07f9-48d2-843a-095656d44707" width="300" height="600"> |
