### PR TITLE
[net10.0] Move to 10.0.1xx-preview7

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,144 +1,144 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.6.25358.103">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.6.169">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-ci.main.206">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>a526dd5da85cf1d231c0b719550ecbf9b446c6f7</Sha>
+      <Sha>1fe4229b4fd76ca608229b64ac0bf97d90646ef1</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.78" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>9abff7703206541fdb83ffa80fe2c2753ad1997b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10415-net10-p6">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10546-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>96ea7cf2db5943ee8dc6c5cf572db03edebd6a90</Sha>
+      <Sha>a1ff6354a74138da50850624e3fab0fac3ab16d5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10415-net10-p6">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10546-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>96ea7cf2db5943ee8dc6c5cf572db03edebd6a90</Sha>
+      <Sha>a1ff6354a74138da50850624e3fab0fac3ab16d5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10415-net10-p6">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10546-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>96ea7cf2db5943ee8dc6c5cf572db03edebd6a90</Sha>
+      <Sha>a1ff6354a74138da50850624e3fab0fac3ab16d5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10415-net10-p6">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10546-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>96ea7cf2db5943ee8dc6c5cf572db03edebd6a90</Sha>
+      <Sha>a1ff6354a74138da50850624e3fab0fac3ab16d5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.6.25358.103">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25330.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -154,37 +154,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25358.103">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25364.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>75972a5ba730bdaf7cf3a34f528ab0f5c7f05183</Sha>
+      <Sha>eceae8f6e934ad6a121e53f90a67f2aa3797af69</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,36 +30,36 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.51</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-preview.6.25358.103</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25364.110</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.6.25358.103</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25364.110</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.6.25358.103</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25364.110</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.6.169</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-ci.main.206</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.78</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10415-net10-p6</MicrosoftMacCatalystSdknet100_185PackageVersion>
-    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10415-net10-p6</MicrosoftmacOSSdknet100_155PackageVersion>
-    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10415-net10-p6</MicrosoftiOSSdknet100_185PackageVersion>
-    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10415-net10-p6</MicrosofttvOSSdknet100_185PackageVersion>
+    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10546-net10-p7</MicrosoftMacCatalystSdknet100_185PackageVersion>
+    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10546-net10-p7</MicrosoftmacOSSdknet100_155PackageVersion>
+    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10546-net10-p7</MicrosoftiOSSdknet100_185PackageVersion>
+    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10546-net10-p7</MicrosofttvOSSdknet100_185PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
@@ -68,19 +68,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.6.25358.103</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-preview.6.25358.103</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25364.110</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25364.110</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -136,13 +136,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25358.103</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25358.103</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25358.103</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25358.103</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25364.110</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25364.110</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25364.110</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25364.110</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25358.103</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25358.103</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25364.110</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25364.110</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -1,5 +1,5 @@
 parameters:
-  # Job schema parameters - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#job
+# Job schema parameters - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#job
   cancelTimeoutInMinutes: ''
   condition: ''
   container: ''
@@ -14,7 +14,7 @@ parameters:
   workspace: ''
   templateContext: {}
 
-  # Job base template specific parameters
+# Job base template specific parameters
   # See schema documentation - https://github.com/dotnet/arcade/blob/master/Documentation/AzureDevOps/TemplateSchema.md
   # publishing defaults
   artifacts: ''
@@ -33,7 +33,7 @@ parameters:
   artifactPublishSteps: []
   runAsPublic: false
 
-  # 1es specific parameters
+# 1es specific parameters
   is1ESPipeline: ''
 
 jobs:
@@ -202,7 +202,7 @@ jobs:
           TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/log'
         continueOnError: true
         condition: always()
-
+      
   - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
     - task: CopyFiles@2
       displayName: Gather logs for publish to artifacts

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -30,6 +30,10 @@ steps:
         ${{ if and(eq(parameters.enableMicrobuildForMacAndLinux, 'true'), ne(variables['Agent.Os'], 'Windows_NT')) }}:
           azureSubscription: 'MicroBuild Signing Task (DevDiv)'
           useEsrpCli: true
+        ${{ elseif eq(variables['System.TeamProject'], 'DevDiv') }}:
+          ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
+        ${{ else }}:
+          ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
       env:
         TeamName: $(_TeamName)
         MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -38,11 +38,6 @@ steps:
       targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
     fi
 
-    baseRidArgs=
-    if [ '${{ parameters.platform.baseRID }}' != '' ]; then
-      baseRidArgs='/p:BaseRid=${{ parameters.platform.baseRID }}'
-    fi
-
     portableBuildArgs=
     if [ '${{ parameters.platform.portableBuild }}' != '' ]; then
       portableBuildArgs='/p:PortableBuild=${{ parameters.platform.portableBuild }}'
@@ -55,7 +50,6 @@ steps:
       ${{ parameters.platform.buildArguments }} \
       $internalRuntimeDownloadArgs \
       $targetRidArgs \
-      $baseRidArgs \
       $portableBuildArgs \
   displayName: Build
 

--- a/eng/common/templates/vmr-build-pr.yml
+++ b/eng/common/templates/vmr-build-pr.yml
@@ -1,3 +1,21 @@
+# This pipeline is used for running the VMR verification of the PR changes in repo-level PRs.
+#
+# It will run a full set of verification jobs defined in:
+# https://github.com/dotnet/dotnet/blob/10060d128e3f470e77265f8490f5e4f72dae738e/eng/pipelines/templates/stages/vmr-build.yml#L27-L38
+#
+# For repos that do not need to run the full set, you would do the following:
+#
+# 1. Copy this YML file to a repo-specific location, i.e. outside of eng/common.
+#
+# 2. Add `verifications` parameter to VMR template reference
+#
+#    Examples:
+#    - For source-build stage 1 verification, add the following:
+#        verifications: [ "source-build-stage1" ]
+#
+#    - For Windows only verifications, add the following:
+#        verifications: [ "unified-build-windows-x64", "unified-build-windows-x86" ]
+
 trigger: none
 pr: none
 

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.6.25358.103"
+    "dotnet": "10.0.100-preview.7.25364.110"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25358.103",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25358.103"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25364.110",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25364.110"
   },
   "sdk": {
     "allowPrerelease": true

--- a/src/Essentials/src/Accelerometer/Accelerometer.ios.watchos.cs
+++ b/src/Essentials/src/Accelerometer/Accelerometer.ios.watchos.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			MotionManager.StartAccelerometerUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), DataUpdated);
 		}
 
-		void DataUpdated(CMAccelerometerData data, NSError error)
+		void DataUpdated(CMAccelerometerData? data, NSError? error)
 		{
 			if (data == null)
 				return;

--- a/src/Essentials/src/Gyroscope/Gyroscope.ios.watchos.cs
+++ b/src/Essentials/src/Gyroscope/Gyroscope.ios.watchos.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			MotionManager.StartGyroUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), DataUpdated);
 		}
 
-		void DataUpdated(CMGyroData data, NSError error)
+		void DataUpdated(CMGyroData? data, NSError? error)
 		{
 			if (data == null)
 				return;

--- a/src/Essentials/src/Magnetometer/Magnetometer.ios.watchos.cs
+++ b/src/Essentials/src/Magnetometer/Magnetometer.ios.watchos.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			MotionManager.StartMagnetometerUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), DataUpdated);
 		}
 
-		void DataUpdated(CMMagnetometerData data, NSError error)
+		void DataUpdated(CMMagnetometerData? data, NSError? error)
 		{
 			if (data == null)
 				return;

--- a/src/Essentials/src/OrientationSensor/OrientationSensor.ios.watchos.cs
+++ b/src/Essentials/src/OrientationSensor/OrientationSensor.ios.watchos.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			MotionManager.StartDeviceMotionUpdates(CMAttitudeReferenceFrame.XTrueNorthZVertical, NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), DataUpdated);
 		}
 
-		void DataUpdated(CMDeviceMotion data, NSError error)
+		void DataUpdated(CMDeviceMotion? data, NSError? error)
 		{
 			if (data == null)
 				return;


### PR DESCRIPTION
### Description of Change

Update with darc

```
darc update-dependencies --channel ".NET 10.0.1xx SDK" --verbose
```

This pull request updates dependency versions across multiple files to align with newer preview releases of the .NET SDK and related packages. The changes primarily involve incrementing version numbers and corresponding SHA hashes for dependencies used in the project.

### Dependency Updates

* Updated versions for `Microsoft.NET.Sdk`, `Microsoft.NETCore.App.Ref`, and other core .NET dependencies to `preview.7.25364.110` in `eng/Version.Details.xml`. SHA hashes were updated accordingly.
* Updated toolset dependencies, such as `Microsoft.DotNet.Build.Tasks.Feed` and `Microsoft.DotNet.Arcade.Sdk`, to `beta.25364.110` in `eng/Version.Details.xml`. SHA hashes were updated accordingly.

### Version Property Updates

* Updated version properties for various .NET SDK and runtime-related packages in `eng/Versions.props`, including `MicrosoftNETSdkPackageVersion` and `MicrosoftNETCoreAppRefPackageVersion`, to `preview.7.25364.110`.
* Updated version properties for ASP.NET Core-related packages, such as `MicrosoftAspNetCoreAuthorizationPackageVersion` and `MicrosoftAspNetCoreComponentsPackageVersion`, to `preview.7.25364.110` in `eng/Versions.props`.