### PR TITLE
[net10.0, Testing] Fixed test failures on merge main net10.0 PR 30606 - 2

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ImageButtonFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ImageButtonFeatureTests.cs
@@ -71,7 +71,7 @@ public class ImageButtonFeatureTests : UITest
 		App.WaitForElement("ImageButtonControl", timeout: TimeSpan.FromSeconds(3));
 		VerifyScreenshot();
 	}
-
+#if TEST_FAILS_ON_ANDROID // Issue Link: https://github.com/dotnet/maui/issues/30576
 	[Test]
 	[Category(UITestCategories.ImageButton)]
 	public void VerifyImageButtonAspect_AspectFitWithImageSourceFromStream()
@@ -88,6 +88,22 @@ public class ImageButtonFeatureTests : UITest
 		VerifyScreenshot();
 	}
 
+	[Test]
+	[Category(UITestCategories.ImageButton)]
+	public void VerifyImageButtonAspect_FillWithImageSourceFromStream()
+	{
+		App.WaitForElement(Options);
+		App.Tap(Options);
+		App.WaitForElement(ImageFill);
+		App.Tap(ImageFill);
+		App.WaitForElement(SourceTypeStream);
+		App.Tap(SourceTypeStream);
+		App.WaitForElement(Apply);
+		App.Tap(Apply);
+		App.WaitForElement("ImageButtonControl");
+		VerifyScreenshot();
+	}
+#endif
 	[Test]
 	[Category(UITestCategories.ImageButton)]
 	public void VerifyImageButtonAspect_AspectFitWithImageSourceFromFontImage()
@@ -156,22 +172,6 @@ public class ImageButtonFeatureTests : UITest
 
 	[Test]
 	[Category(UITestCategories.ImageButton)]
-	public void VerifyImageButtonAspect_FillWithImageSourceFromStream()
-	{
-		App.WaitForElement(Options);
-		App.Tap(Options);
-		App.WaitForElement(ImageFill);
-		App.Tap(ImageFill);
-		App.WaitForElement(SourceTypeStream);
-		App.Tap(SourceTypeStream);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElement("ImageButtonControl");
-		VerifyScreenshot();
-	}
-
-	[Test]
-	[Category(UITestCategories.ImageButton)]
 	public void VerifyImageButtonAspect_CenterWithImageSourceFromFile()
 	{
 		App.WaitForElement(Options);
@@ -189,6 +189,7 @@ public class ImageButtonFeatureTests : UITest
 
 #if TEST_FAILS_ON_WINDOWS // Issue Link: https://github.com/dotnet/maui/issues/29959
 
+#if TEST_FAILS_ON_ANDROID // Issue Link: https://github.com/dotnet/maui/issues/30576
 	[Test]
 	[Category(UITestCategories.ImageButton)]
 	public void VerifyImageButtonAspect_AspectFillWithImageSourceFromStream()
@@ -220,6 +221,7 @@ public class ImageButtonFeatureTests : UITest
 		App.WaitForElement("ImageButtonControl");
 		VerifyScreenshot();
 	}
+#endif
 
 	[Test]
 	[Category(UITestCategories.ImageButton)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ImageFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ImageFeatureTests.cs
@@ -67,7 +67,7 @@ public class ImageFeatureTests : UITest
 		App.WaitForElement("ImageControl", timeout: TimeSpan.FromSeconds(3));
 		VerifyScreenshot();
 	}
-
+#if TEST_FAILS_ON_ANDROID // Issue Link: https://github.com/dotnet/maui/issues/30576
 	[Test]
 	[Category(UITestCategories.Image)]
 	public void VerifyImageAspect_AspectFitWithImageSourceFromStream()
@@ -84,6 +84,22 @@ public class ImageFeatureTests : UITest
 		VerifyScreenshot();
 	}
 
+	[Test]
+	[Category(UITestCategories.Image)]
+	public void VerifyImageAspect_FillWithImageSourceFromStream()
+	{
+		App.WaitForElement(Options);
+		App.Tap(Options);
+		App.WaitForElement(ImageFill);
+		App.Tap(ImageFill);
+		App.WaitForElement(SourceTypeStream);
+		App.Tap(SourceTypeStream);
+		App.WaitForElement(Apply);
+		App.Tap(Apply);
+		App.WaitForElement("ImageControl");
+		VerifyScreenshot();
+	}
+#endif
 	[Test]
 	[Category(UITestCategories.Image)]
 	public void VerifyImageAspect_AspectFitWithImageSourceFromFontImage()
@@ -132,7 +148,7 @@ public class ImageFeatureTests : UITest
 		App.WaitForElement("ImageControl", timeout: TimeSpan.FromSeconds(3));
 		VerifyScreenshot();
 	}
-
+#if TEST_FAILS_ON_ANDROID // Issue Link: https://github.com/dotnet/maui/issues/30576
 	[Test]
 	[Category(UITestCategories.Image)]
 	public void VerifyImageAspect_AspectFillWithImageSourceFromStream()
@@ -148,6 +164,7 @@ public class ImageFeatureTests : UITest
 		App.WaitForElement("ImageControl");
 		VerifyScreenshot();
 	}
+#endif
 
 	[Test]
 	[Category(UITestCategories.Image)]
@@ -200,22 +217,6 @@ public class ImageFeatureTests : UITest
 
 	[Test]
 	[Category(UITestCategories.Image)]
-	public void VerifyImageAspect_FillWithImageSourceFromStream()
-	{
-		App.WaitForElement(Options);
-		App.Tap(Options);
-		App.WaitForElement(ImageFill);
-		App.Tap(ImageFill);
-		App.WaitForElement(SourceTypeStream);
-		App.Tap(SourceTypeStream);
-		App.WaitForElement(Apply);
-		App.Tap(Apply);
-		App.WaitForElement("ImageControl");
-		VerifyScreenshot();
-	}
-
-	[Test]
-	[Category(UITestCategories.Image)]
 	public void VerifyImageAspect_FillWithImageSourceFromFontImage()
 	{
 		App.WaitForElement(Options);
@@ -262,7 +263,7 @@ public class ImageFeatureTests : UITest
 		VerifyScreenshot();
 	}
 
-#if TEST_FAILS_ON_WINDOWS // Issue Link: https://github.com/dotnet/maui/issues/29813
+#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // Issue Link for Windows: https://github.com/dotnet/maui/issues/29813 and for Android: https://github.com/dotnet/maui/issues/30576
 	[Test]
 	[Category(UITestCategories.Image)]
 	public void VerifyImageAspect_CenterWithImageSourceFromStream()


### PR DESCRIPTION
This pull request includes updates to the test cases for `ImageButton` and `Image` controls in the `FeatureMatrix` test suite. The updates include references to the relevant GitHub issues for better traceability.
Build Link: https://dev.azure.com/xamarin/public/_build/results?buildId=146344&view=ms.vss-test-web.build-test-results-tab

### Platform-Specific Adjustments:
* Added `#if TEST_FAILS_ON_ANDROID` directives to multiple test cases to mark them as failing on Android due to a known issue (`https://github.com/dotnet/maui/issues/30576`). Examples include `VerifyImageButtonAspect_AspectFitWithImageSourceFromStream` and `VerifyImageAspect_AspectFitWithImageSourceFromStream`. [[1]](diffhunk://#diff-3d564d66107b4d4af8f13c052d184c663cb0206a923ddc58b3313c44cb7466feL74-R74) [[2]](diffhunk://#diff-3d57768a056b285677055acfcae3d41477bc031a79021973db7d30bd4b20e30cL70-R70)
* Introduced new test cases, such as `VerifyImageButtonAspect_FillWithImageSourceFromStream` and `VerifyImageAspect_FillWithImageSourceFromStream`, to validate the "Fill" aspect with image sources from streams. These tests include UI interactions and screenshot verification. [[1]](diffhunk://#diff-3d564d66107b4d4af8f13c052d184c663cb0206a923ddc58b3313c44cb7466feR91-R106) [[2]](diffhunk://#diff-3d57768a056b285677055acfcae3d41477bc031a79021973db7d30bd4b20e30cR87-R102)
* Removed redundant or duplicate test methods, such as `VerifyImageButtonAspect_FillWithImageSourceFromStream` and `VerifyImageAspect_FillWithImageSourceFromStream`, from their respective files. These methods were likely moved or replaced with updated versions. [[1]](diffhunk://#diff-3d564d66107b4d4af8f13c052d184c663cb0206a923ddc58b3313c44cb7466feL157-L172) [[2]](diffhunk://#diff-3d57768a056b285677055acfcae3d41477bc031a79021973db7d30bd4b20e30cL201-L216)
* Modified existing conditional compilation directives to combine platform-specific conditions for tests that fail on both Windows and Android. For example, `VerifyImageAspect_CenterWithImageSourceFromStream` now uses `#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID`.
* Ensured proper use of `#endif` to close conditional compilation blocks, improving code readability and maintainability. [[1]](diffhunk://#diff-3d564d66107b4d4af8f13c052d184c663cb0206a923ddc58b3313c44cb7466feR224) [[2]](diffhunk://#diff-3d57768a056b285677055acfcae3d41477bc031a79021973db7d30bd4b20e30cR167)