### PR TITLE
[Android] Prevent CollectionView SelectionChanged from triggering on SwipeView gesture

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15778.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15778.cs
@@ -1,18 +1,11 @@
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 15778, "CollectionView SelectionChanged gets fired when performing swipe using swipe view", PlatformAffected.Android)]
-public class Issue15778 : NavigationPage
-{
-    public Issue15778() : base(new Issue15778Page1())
-    {
-    }
-}
-
-public class Issue15778Page1 : ContentPage
+public class Issue15778 : ContentPage
 {
     private Label statusLabel;
 
-    public Issue15778Page1()
+    public Issue15778()
     {
         Title = "SwipeView in CollectionView";
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue15778.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue15778.cs
@@ -1,0 +1,78 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 15778, "CollectionView SelectionChanged gets fired when performing swipe using swipe view", PlatformAffected.Android)]
+public class Issue15778 : NavigationPage
+{
+    public Issue15778() : base(new Issue15778Page1())
+    {
+    }
+}
+
+public class Issue15778Page1 : ContentPage
+{
+    private Label statusLabel;
+
+    public Issue15778Page1()
+    {
+        Title = "SwipeView in CollectionView";
+
+        statusLabel = new Label
+        {
+            Text = "SelectionChanged Not Triggered",
+            Padding = new Thickness(10),
+            AutomationId = "StatusLabel"
+        };
+
+        var collectionView = new CollectionView
+        {
+            SelectionMode = SelectionMode.Single,
+            AutomationId = "TestCollectionView",
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var swipeView = new SwipeView
+                {
+                    LeftItems = new SwipeItems
+                    {
+                        new SwipeItem
+                        {
+                            Text = "Delete",
+                            BackgroundColor = Colors.Red,
+                            AutomationId = "DeleteSwipeItem"
+                        }
+                    }
+                };
+
+                var label = new Label { Padding = new Thickness(10) };
+                label.SetBinding(Label.TextProperty, ".");
+
+                swipeView.Content = new VerticalStackLayout
+                {
+                    BackgroundColor = Colors.LightGray,
+                    Padding = new Thickness(5),
+                    Children = { label }
+                };
+
+                return swipeView;
+            }),
+            ItemsSource = new List<string>
+            {
+                "Item 1",
+                "Item 2",
+                "Item 3"
+            }
+        };
+        collectionView.SelectionChanged += OnSelectionChanged;
+
+        Content = new VerticalStackLayout
+        {
+            Padding = new Thickness(10),
+            Spacing = 10,
+            Children = { statusLabel, collectionView }
+        };
+    }
+
+    private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        statusLabel.Text = "SelectionChanged Triggered";
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15778.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15778.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue15778 : _IssuesUITest
+    {
+        public Issue15778(TestDevice testDevice) : base(testDevice)
+        {
+        }
+        public override string Issue => "CollectionView SelectionChanged gets fired when performing swipe using swipe view";
+
+        [Test]
+        [Category(UITestCategories.CollectionView)]
+        public void SwipeViewInCollectionViewDoesNotTriggerSelection()
+        {
+            App.WaitForElement("Item 1");
+            App.SwipeLeftToRight("Item 1");
+            var label = App.WaitForElement("StatusLabel");
+            Assert.That(label.GetText(), Is.EqualTo("SelectionChanged Not Triggered"));
+        }
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15778.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue15778.cs
@@ -2,23 +2,22 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
-{
-    public class Issue15778 : _IssuesUITest
-    {
-        public Issue15778(TestDevice testDevice) : base(testDevice)
-        {
-        }
-        public override string Issue => "CollectionView SelectionChanged gets fired when performing swipe using swipe view";
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
-        [Test]
-        [Category(UITestCategories.CollectionView)]
-        public void SwipeViewInCollectionViewDoesNotTriggerSelection()
-        {
-            App.WaitForElement("Item 1");
-            App.SwipeLeftToRight("Item 1");
-            var label = App.WaitForElement("StatusLabel");
-            Assert.That(label.GetText(), Is.EqualTo("SelectionChanged Not Triggered"));
-        }
+public class Issue15778 : _IssuesUITest
+{
+    public Issue15778(TestDevice testDevice) : base(testDevice)
+    {
+    }
+    public override string Issue => "CollectionView SelectionChanged gets fired when performing swipe using swipe view";
+
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void SwipeViewInCollectionViewDoesNotTriggerSelection()
+    {
+        App.WaitForElement("Item 1");
+        App.SwipeLeftToRight("Item 1");
+        var label = App.WaitForElement("StatusLabel");
+        Assert.That(label.GetText(), Is.EqualTo("SelectionChanged Not Triggered"));
     }
 }

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -210,7 +210,10 @@ namespace Microsoft.Maui.Platform
 				else
 				{
 					ResetSwipe(e);
-					PropagateParentTouch();
+					if (!_isSwiping)
+					{
+						PropagateParentTouch();
+					}
 				}
 			}
 

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -210,6 +210,8 @@ namespace Microsoft.Maui.Platform
 				else
 				{
 					ResetSwipe(e);
+
+					// Prevent parent touch propagation during swipe gestures to avoid interference with swipe functionality.
 					if (!_isSwiping)
 					{
 						PropagateParentTouch();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Detail
CollectionView.SelectionChanged gets fired when performing swipe using swipe view.

### Root Cause
SwipeView implementation calls PropagateParentTouch() after every touch release. This causes the parent CollectionView to receive click events and trigger SelectionChanged inappropriately when users perform swipe actions.

### Description of Change
Added a conditional check to prevent parent touch propagation when a swipe gesture has occurred.

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/15778

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/44ae62b9-53ae-4307-af91-3b106aac004e"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/9dab8af8-155e-4882-86b6-cf382b837a53">) |