### PR TITLE
[iOS] Fix Scrollbar does not align with FlowDirection=RightToLeft in WebView and HybridWebView

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static IPropertyMapper<IHybridWebView, IHybridWebViewHandler> Mapper = new PropertyMapper<IHybridWebView, IHybridWebViewHandler>(ViewHandler.ViewMapper)
 		{
-#if WINDOWS
+#if WINDOWS || IOS
 			[nameof(IView.FlowDirection)] = MapFlowDirection,
 #endif
 		};

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static IPropertyMapper<IHybridWebView, IHybridWebViewHandler> Mapper = new PropertyMapper<IHybridWebView, IHybridWebViewHandler>(ViewHandler.ViewMapper)
 		{
-#if WINDOWS || IOS
+#if WINDOWS || IOS || MACCATALYST
 			[nameof(IView.FlowDirection)] = MapFlowDirection,
 #endif
 		};

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -77,6 +77,28 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView.EvaluateJavaScript(request);
 		}
 
+		internal static void MapFlowDirection(IHybridWebViewHandler handler, IHybridWebView hybridWebView)
+		{
+			var scrollView = handler.PlatformView?.ScrollView;
+			if (scrollView == null)
+				return;
+				
+			scrollView.UpdateFlowDirection(hybridWebView);
+			
+			// On macOS, we need to refresh the scroll indicators when flow direction changes
+			if (OperatingSystem.IsMacCatalyst())
+			{
+				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
+				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
+
+				scrollView.ShowsVerticalScrollIndicator = false;
+				scrollView.ShowsHorizontalScrollIndicator = false;
+
+				scrollView.ShowsVerticalScrollIndicator = showsVertical;
+				scrollView.ShowsHorizontalScrollIndicator = showsHorizontal;
+			}
+		}
+
 		public static void MapSendRawMessage(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)
 		{
 			if (arg is not HybridWebViewRawMessage hybridWebViewRawMessage || handler.PlatformView is not IHybridPlatformWebView hybridPlatformWebView)

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		private const string ScriptMessageHandlerName = "webwindowinterop";
 
+		bool isInitialLoading = true;
+
 		protected override WKWebView CreatePlatformView()
 		{
 			var config = new WKWebViewConfiguration();
@@ -84,10 +86,17 @@ namespace Microsoft.Maui.Handlers
 				return;
 				
 			scrollView.UpdateFlowDirection(hybridWebView);
-			
+
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
-			if (OperatingSystem.IsMacCatalyst())
+			// But only for runtime changes, not during initial load
+			if (OperatingSystem.IsMacCatalyst() && handler is HybridWebViewHandler hybridWebViewHandler)
 			{
+				if (hybridWebViewHandler.isInitialLoading)
+				{
+					hybridWebViewHandler.isInitialLoading = false;
+					return;
+				}
+
 				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
 				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
 

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Handlers
 
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
 			// But only for runtime changes, not during initial load
-			if (OperatingSystem.IsMacCatalyst() && handler.PlatformView != null && handler.PlatformView.IsLoaded())
+			if (OperatingSystem.IsMacCatalyst() && hybridWebView.IsLoadedOnPlatform())
 			{
 				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
 				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Maui.Handlers
 	{
 		private const string ScriptMessageHandlerName = "webwindowinterop";
 
-		bool isInitialLoading = true;
-
 		protected override WKWebView CreatePlatformView()
 		{
 			var config = new WKWebViewConfiguration();
@@ -89,14 +87,8 @@ namespace Microsoft.Maui.Handlers
 
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
 			// But only for runtime changes, not during initial load
-			if (OperatingSystem.IsMacCatalyst() && handler is HybridWebViewHandler hybridWebViewHandler)
+			if (OperatingSystem.IsMacCatalyst() && handler.PlatformView != null && handler.PlatformView.IsLoaded())
 			{
-				if (hybridWebViewHandler.isInitialLoading)
-				{
-					hybridWebViewHandler.isInitialLoading = false;
-					return;
-				}
-
 				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
 				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
 

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -83,21 +83,7 @@ namespace Microsoft.Maui.Handlers
 			if (scrollView == null)
 				return;
 				
-			scrollView.UpdateFlowDirection(hybridWebView);
-
-			// On macOS, we need to refresh the scroll indicators when flow direction changes
-			// But only for runtime changes, not during initial load
-			if (OperatingSystem.IsMacCatalyst() && hybridWebView.IsLoadedOnPlatform())
-			{
-				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
-				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
-
-				scrollView.ShowsVerticalScrollIndicator = false;
-				scrollView.ShowsHorizontalScrollIndicator = false;
-
-				scrollView.ShowsVerticalScrollIndicator = showsVertical;
-				scrollView.ShowsHorizontalScrollIndicator = showsHorizontal;
-			}
+			scrollView.UpdateFlowDirectionForScrollView(hybridWebView);
 		}
 
 		public static void MapSendRawMessage(IHybridWebViewHandler handler, IHybridWebView hybridWebView, object? arg)

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Handlers
 			var scrollView = handler.PlatformView?.ScrollView;
 			if (scrollView == null)
 				return;
-				
+
 			scrollView.UpdateFlowDirectionForScrollView(hybridWebView);
 		}
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -31,10 +31,11 @@ namespace Microsoft.Maui.Handlers
 			[nameof(WebViewClient)] = MapWebViewClient,
 			[nameof(WebChromeClient)] = MapWebChromeClient,
 			[nameof(WebView.Settings)] =  MapWebViewSettings
+#elif __IOS__ || MACCATALYST
+			[nameof(IWebView.FlowDirection)] = MapFlowDirection,
 #elif __IOS__
 			[nameof(WKUIDelegate)] = MapWKUIDelegate,
 			[nameof(IWebView.Background)] = MapBackground,
-			[nameof(IWebView.FlowDirection)] = MapFlowDirection,
 #endif
 		};
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Handlers
 #elif __IOS__
 			[nameof(WKUIDelegate)] = MapWKUIDelegate,
 			[nameof(IWebView.Background)] = MapBackground,
+			[nameof(IWebView.FlowDirection)] = MapFlowDirection,
 #endif
 		};
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Maui.Handlers
 			[nameof(WebView.Settings)] =  MapWebViewSettings
 #elif __IOS__ || MACCATALYST
 			[nameof(IWebView.FlowDirection)] = MapFlowDirection,
-#elif __IOS__
 			[nameof(WKUIDelegate)] = MapWKUIDelegate,
 			[nameof(IWebView.Background)] = MapBackground,
 #endif

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Handlers
 
 		protected virtual float MinimumSize => 44f;
 
+		bool isInitialLoading = true;
+
 		WKUIDelegate? _delegate;
 
 		protected override WKWebView CreatePlatformView() =>
@@ -72,10 +74,17 @@ namespace Microsoft.Maui.Handlers
 			scrollView.UpdateFlowDirection(webView);
 
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
-			if (OperatingSystem.IsMacCatalyst())
+			// But only for runtime changes, not during initial load
+			if (OperatingSystem.IsMacCatalyst() && handler is WebViewHandler platformHandler)
 			{
-				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
-				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
+				if (platformHandler.isInitialLoading)
+				{
+					platformHandler.isInitialLoading = false;
+					return;
+				}
+				
+				var showsVertical = scrollView.ShowsVerticalScrollIndicator;
+				var showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
 
 				scrollView.ShowsVerticalScrollIndicator = false;
 				scrollView.ShowsHorizontalScrollIndicator = false;

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -69,21 +69,8 @@ namespace Microsoft.Maui.Handlers
 			var scrollView = handler.PlatformView?.ScrollView;
 			if (scrollView == null)
 				return;
-			scrollView.UpdateFlowDirection(webView);
-
-			// On macOS, we need to refresh the scroll indicators when flow direction changes
-			// But only for runtime changes, not during initial load
-			if (OperatingSystem.IsMacCatalyst() && webView.IsLoadedOnPlatform())
-			{
-				var showsVertical = scrollView.ShowsVerticalScrollIndicator;
-				var showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
-
-				scrollView.ShowsVerticalScrollIndicator = false;
-				scrollView.ShowsHorizontalScrollIndicator = false;
-
-				scrollView.ShowsVerticalScrollIndicator = showsVertical;
-				scrollView.ShowsHorizontalScrollIndicator = showsHorizontal;
-			}
+				
+			scrollView.UpdateFlowDirectionForScrollView(webView);
 		}
 
 		public static async void MapReload(IWebViewHandler handler, IWebView webView, object? arg)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Maui.Handlers
 
 		protected virtual float MinimumSize => 44f;
 
-		bool isInitialLoading = true;
-
 		WKUIDelegate? _delegate;
 
 		protected override WKWebView CreatePlatformView() =>
@@ -75,14 +73,8 @@ namespace Microsoft.Maui.Handlers
 
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
 			// But only for runtime changes, not during initial load
-			if (OperatingSystem.IsMacCatalyst() && handler is WebViewHandler platformHandler)
+			if (OperatingSystem.IsMacCatalyst() && handler.PlatformView != null && handler.PlatformView.IsLoaded())
 			{
-				if (platformHandler.isInitialLoading)
-				{
-					platformHandler.isInitialLoading = false;
-					return;
-				}
-				
 				var showsVertical = scrollView.ShowsVerticalScrollIndicator;
 				var showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Handlers
 
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
 			// But only for runtime changes, not during initial load
-			if (OperatingSystem.IsMacCatalyst() && handler.PlatformView != null && handler.PlatformView.IsLoaded())
+			if (OperatingSystem.IsMacCatalyst() && webView.IsLoadedOnPlatform())
 			{
 				var showsVertical = scrollView.ShowsVerticalScrollIndicator;
 				var showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -64,6 +64,27 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateGoForward(webView);
 		}
 
+		internal static void MapFlowDirection(IWebViewHandler handler, IWebView webView)
+		{
+			var scrollView = handler.PlatformView?.ScrollView;
+			if (scrollView == null)
+				return;
+			scrollView.UpdateFlowDirection(webView);
+
+			// On macOS, we need to refresh the scroll indicators when flow direction changes
+			if (OperatingSystem.IsMacCatalyst())
+			{
+				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
+				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
+
+				scrollView.ShowsVerticalScrollIndicator = false;
+				scrollView.ShowsHorizontalScrollIndicator = false;
+
+				scrollView.ShowsVerticalScrollIndicator = showsVertical;
+				scrollView.ShowsHorizontalScrollIndicator = showsHorizontal;
+			}
+		}
+
 		public static async void MapReload(IWebViewHandler handler, IWebView webView, object? arg)
 		{
 			var platformHandler = handler as WebViewHandler;

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Handlers
 			var scrollView = handler.PlatformView?.ScrollView;
 			if (scrollView == null)
 				return;
-				
+
 			scrollView.UpdateFlowDirectionForScrollView(webView);
 		}
 

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -55,7 +55,15 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-			platformDatePicker.CharacterSpacing = datePicker.CharacterSpacing.ToEm();
+		    var characterSpacing = datePicker.CharacterSpacing.ToEm();
+			platformDatePicker.CharacterSpacing = characterSpacing;
+
+			var dateTextBlock = platformDatePicker.GetDescendantByName<TextBlock>("DateText");
+			if (dateTextBlock is not null)
+			{
+				dateTextBlock.CharacterSpacing = characterSpacing;
+				dateTextBlock.RefreshThemeResources();
+			}
 		}
 
 		public static void UpdateFont(this CalendarDatePicker platformDatePicker, IDatePicker datePicker, IFontManager fontManager) =>

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -55,15 +55,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-		    var characterSpacing = datePicker.CharacterSpacing.ToEm();
-			platformDatePicker.CharacterSpacing = characterSpacing;
-
-			var dateTextBlock = platformDatePicker.GetDescendantByName<TextBlock>("DateText");
-			if (dateTextBlock is not null)
-			{
-				dateTextBlock.CharacterSpacing = characterSpacing;
-				dateTextBlock.RefreshThemeResources();
-			}
+			platformDatePicker.CharacterSpacing = datePicker.CharacterSpacing.ToEm();
 		}
 
 		public static void UpdateFont(this CalendarDatePicker platformDatePicker, IDatePicker datePicker, IFontManager fontManager) =>

--- a/src/Core/src/Platform/iOS/WebViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/WebViewExtensions.cs
@@ -64,6 +64,25 @@ namespace Microsoft.Maui.Platform
 			webView.CanGoForward = platformWebView.CanGoForward;
 		}
 
+		internal static void UpdateFlowDirectionForScrollView(this UIKit.UIScrollView scrollView, IView view)
+		{
+			scrollView.UpdateFlowDirection(view);
+
+			// On macOS, we need to refresh the scroll indicators when flow direction changes
+			// But only for runtime changes, not during initial load
+			if (OperatingSystem.IsMacCatalyst() && view.IsLoadedOnPlatform())
+			{
+				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;
+				bool showsHorizontal = scrollView.ShowsHorizontalScrollIndicator;
+
+				scrollView.ShowsVerticalScrollIndicator = false;
+				scrollView.ShowsHorizontalScrollIndicator = false;
+
+				scrollView.ShowsVerticalScrollIndicator = showsVertical;
+				scrollView.ShowsHorizontalScrollIndicator = showsHorizontal;
+			}
+		}
+
 		public static void Eval(this WKWebView platformWebView, IWebView webView, string script)
 		{
 			platformWebView.EvaluateJavaScriptAsync(script);

--- a/src/Core/src/Platform/iOS/WebViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/WebViewExtensions.cs
@@ -70,6 +70,10 @@ namespace Microsoft.Maui.Platform
 
 			// On macOS, we need to refresh the scroll indicators when flow direction changes
 			// But only for runtime changes, not during initial load
+			// The view.IsLoadedOnPlatform() check ensures that this code is executed
+			// only after the view has been loaded on the platform. During the initial load,
+			// the scroll indicators do not need to be refreshed as they are set up correctly
+			// by default. This avoids unnecessary operations during the initial load phase.
 			if (OperatingSystem.IsMacCatalyst() && view.IsLoadedOnPlatform())
 			{
 				bool showsVertical = scrollView.ShowsVerticalScrollIndicator;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
FlowDirection was only applied to the WebView and HybridWebview, not its internal ScrollView, which handles the actual content layout and scrolling.

### Description of Change

<!-- Enter description of the fix in this section -->
FlowDirection is now applied to the internal ScrollView of WKWebView to ensure correct layout direction.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #30605 

### Regarding Test case
For this case, it's not possible to write a test because the scrollbar does not appear during initial loading. It only becomes visible when a scroll action is performed, and even then, it remains visible only for a few seconds.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac


| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/eaf6620b-5f00-402c-b191-2ba881cacac2" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/b038125e-5dbf-483b-aa7d-640f2c72555e" width="300" height="600"> |
