### PR TITLE
[Android] Fixed a release-mode crash in stream handling caused by MarshalMethods

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Downsize.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and for Android: https://github.com/dotnet/maui/issues/30576
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue16767_Resize.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS && TEST_FAILS_ON_ANDROID //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642 and for Android: https://github.com/dotnet/maui/issues/30576
+﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS //NullReferenceException throws on iOS and mac Issue link - https://github.com/dotnet/maui/issues/19642
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30006.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID // Issue Link for Windows: https://github.com/dotnet/maui/issues/16767 and for Android: https://github.com/dotnet/maui/issues/30576
+#if TEST_FAILS_ON_WINDOWS // Issue Link for Windows: https://github.com/dotnet/maui/issues/16767
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
@@ -156,15 +156,26 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
-			// Copy stream data to a byte array to ensure marshaling stability
-			byte[] buffer;
+			Bitmap bitmap;
+
+			if (stream is null)
+			{
+				return null;
+			}
+			//For memory efficiency, use a single MemoryStream and access its buffer directly
 			using (var memoryStream = new MemoryStream())
 			{
+				if (stream.CanSeek)
+				{
+					stream.Position = 0;
+				}
 				stream.CopyTo(memoryStream);
-				buffer = memoryStream.ToArray();
-			}
 
-			var bitmap = BitmapFactory.DecodeByteArray(buffer, 0, buffer.Length);
+				// Get the buffer and actual length
+				byte[] buffer = memoryStream.GetBuffer();
+				int length = (int)memoryStream.Length;
+				bitmap = BitmapFactory.DecodeByteArray(buffer, 0, length);
+			}
 			return new PlatformImage(bitmap);
 		}
 	}

--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
@@ -156,7 +156,15 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
-			var bitmap = BitmapFactory.DecodeStream(stream);
+			// Copy stream data to a byte array to ensure marshaling stability
+			byte[] buffer;
+			using (var memoryStream = new MemoryStream())
+			{
+				stream.CopyTo(memoryStream);
+				buffer = memoryStream.ToArray();
+			}
+
+			var bitmap = BitmapFactory.DecodeByteArray(buffer, 0, buffer.Length);
 			return new PlatformImage(bitmap);
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- In .NET 10.0, `<AndroidEnableMarshalMethods>` is enabled (true) by default. 
<img width="2250" height="484" alt="image" src="https://github.com/user-attachments/assets/ca2ea7c9-7b10-49b4-96c0-88f2f05c97ca" />

[release notes- 10.0/preview/preview1](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/dotnetmaui.md#enable-marshal-methods-by-default%E2%80%AF)

- When this setting is enabled, passing a Stream parameter to the native BitmapFactory.DecodeStream() method can lead to lifecycle issues. Specifically, the stream may be prematurely closed or incorrectly positioned before the native code finishes reading it. This results in crash when decoding the image. 



### Description of Change



- Use BitmapFactory.`DecodeByteArray()` instead of DecodeStream(). 
This method has more reliable marshaling behavior under the new interop system. 

- Avoid passing Stream objects directly into JNI(Java Native Interface)-bound methods. 



### Issues Fixed



Fixes #30576
Fixes #30783



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/ddc4c0d8-95e7-474a-9933-3d2ef2336e55"> | <video src="https://github.com/user-attachments/assets/a0a43d7c-b858-430d-a370-680093cb2be0"> |