### PR TITLE
[workloads] Move the latest workloads and xcode

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,12 +50,12 @@
     <MicrosoftExtensionsLoggingDebugVersion>9.0.8</MicrosoftExtensionsLoggingDebugVersion>
     <MicrosoftExtensionsPrimitivesVersion>9.0.8</MicrosoftExtensionsPrimitivesVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.61</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>35.0.78</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet90_180PackageVersion>18.0.9617</MicrosoftMacCatalystSdknet90_180PackageVersion>
-    <MicrosoftmacOSSdknet90_150PackageVersion>15.0.9617</MicrosoftmacOSSdknet90_150PackageVersion>
-    <MicrosoftiOSSdknet90_180PackageVersion>18.0.9617</MicrosoftiOSSdknet90_180PackageVersion>
-    <MicrosofttvOSSdknet90_180PackageVersion>18.0.9617</MicrosofttvOSSdknet90_180PackageVersion>
+    <MicrosoftMacCatalystSdknet90_180PackageVersion>18.5.9207</MicrosoftMacCatalystSdknet90_180PackageVersion>
+    <MicrosoftmacOSSdknet90_150PackageVersion>15.5.9207</MicrosoftmacOSSdknet90_150PackageVersion>
+    <MicrosoftiOSSdknet90_180PackageVersion>18.5.9207</MicrosoftiOSSdknet90_180PackageVersion>
+    <MicrosofttvOSSdknet90_180PackageVersion>18.5.9207</MicrosofttvOSSdknet90_180PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 9.0.100
 - name: REQUIRED_XCODE
-  value: 16.3.0
+  value: 16.4.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 16.3.0
+  value: 16.4.0
 - name: POWERSHELL_VERSION
   value: 7.4.0
 # Localization variables


### PR DESCRIPTION
### Description of Change

Move to latest public workloads for iOS and Android, and use the latest Xcode too.

This pull request updates several version numbers for dependencies and tools in the project to ensure compatibility with the latest releases. The most important changes include updates to the Xamarin SDK versions in `eng/Versions.props` and the required Xcode version in the pipeline configuration.

### Dependency version updates:

* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L53-R58): Updated the Xamarin SDK versions for Android, Mac Catalyst, macOS, iOS, and tvOS to their latest releases.

### Pipeline configuration updates:

* [`eng/pipelines/common/variables.yml`](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL11-R13): Updated the required Xcode version from `16.3.0` to `16.4.0` for both general and device tests.
