### PR TITLE
[Android][Permissions]Requesting permissions using RequestAsync while the app is in the background - fix

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -84,7 +84,9 @@ namespace Microsoft.Maui.ApplicationModel
 					return PermissionStatus.Granted;
 
 				var permissionResult = await DoRequest(runtimePermissions);
-				if (permissionResult.GrantResults.Any(g => g == Permission.Denied))
+				// OnRequestPermissionsResult can be called with an empty grantResults array if the user interaction was interrupted. 
+				// Ignoring this could lead to incorrect assumptions that permissions were granted.
+				if (permissionResult.GrantResults.Length == 0 || permissionResult.GrantResults.Any(g => g == Permission.Denied))
 					return PermissionStatus.Denied;
 
 				return PermissionStatus.Granted;


### PR DESCRIPTION
### Description of Change

This check is necessary because in Android, OnRequestPermissionsResult can be called with an empty grantResults array if the user interaction was interrupted. Ignoring this could lead to incorrect assumptions that permissions were granted.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/30678