### PR TITLE
Revert "[testing] Use latest simulator main (#30664)"

### DIFF
--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -1,8 +1,8 @@
 #addin nuget:?package=Cake.AppleSimulator&version=0.2.0
 #load "./uitests-shared.cake"
 
-const string DefaultVersion = "18.4";
-const string DefaultTestDevice = $"ios-simulator-64";
+const string DefaultVersion = "18.0";
+const string DefaultTestDevice = $"ios-simulator-64_{DefaultVersion}";
 
 // Required arguments
 string DEFAULT_IOS_PROJECT = "../../src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj";

--- a/eng/pipelines/common/device-tests-jobs.yml
+++ b/eng/pipelines/common/device-tests-jobs.yml
@@ -76,9 +76,6 @@ jobs:
             ${{ if contains(version, 'device') }}:
               device: ios-device
               apiVersion: ${{ replace(version, 'device-', '') }}
-            ${{ if contains(version, 'latest') }}:
-              device: ios-simulator-64
-              apiVersion: 18.4
             ${{ else }}:
               device: ios-simulator-64_${{ replace(version, 'simulator-', '') }}
               apiVersion: ${{ replace(version, 'simulator-', '') }}

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -157,7 +157,7 @@ stages:
                     parameters:
                       platform: ios
                       ${{ if eq(version, 'latest') }}:
-                        version: 18.4
+                        version: 16.4
                       ${{ if ne(version, 'latest') }}:
                         version: ${{ version }}
                       path: ${{ project.ios }}
@@ -194,7 +194,7 @@ stages:
                     parameters:
                       platform: ios
                       ${{ if eq(version, 'latest') }}:
-                        version: 18.4
+                        version: 16.4
                       ${{ if ne(version, 'latest') }}:
                         version: ${{ version }}
                       path: ${{ project.ios }}
@@ -232,7 +232,7 @@ stages:
                     parameters:
                       platform: ios
                       ${{ if eq(version, 'latest') }}:
-                        version: 18.4
+                        version: 16.4
                       ${{ if ne(version, 'latest') }}:
                         version: ${{ version }}
                       path: ${{ project.ios }}
@@ -276,7 +276,7 @@ stages:
                       parameters:
                         platform: ios
                         ${{ if eq(version, 'latest') }}:
-                          version: 18.4
+                          version: 17.2
                         ${{ if ne(version, 'latest') }}:
                           version: ${{ version }}
                         path: ${{ project.ios }}
@@ -347,7 +347,7 @@ stages:
                   - template: ui-tests-steps.yml
                     parameters:
                       platform: catalyst
-                      version: "15.3"
+                      version: "13.1"
                       device: mac
                       path: ${{ project.mac }}
                       app: ${{ project.app }}

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -116,14 +116,14 @@ stages:
       targetFrameworkVersion: ${{ targetFrameworkVersion }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
-        iosVersions: [ 'latest']
+        iosVersions: [ 'simulator-18.0']
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
         skipProvisioning: ${{ or(not(parameters.UseProvisionator), false) }}
       ${{ else }}:
         androidApiLevels: [ 33, 23 ]
-        iosVersions: [ 'latest' ]
+        iosVersions: [ 'simulator-18.0' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: ['packaged', 'unpackaged']
         provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -150,11 +150,11 @@ stages:
       agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]
-        iosVersions: [ 'latest' ]
+        iosVersions: [ '18.0' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ else }}:
         androidApiLevels: [ 30 ]
-        iosVersions: [ 'latest' ]
+        iosVersions: [ '18.0' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if parameters.CompatibilityTests }}:
         runCompatibilityTests: true

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.TestCases.Tests
 #if ANDROID
 	[TestFixture(TestDevice.Android)]
 #elif IOSUITEST
-	[TestFixture(TestDevice.iOS)]
+		[TestFixture(TestDevice.iOS)]
 #elif MACUITEST
 		[TestFixture(TestDevice.Mac)]
 #elif WINTEST
@@ -22,8 +22,6 @@ namespace Microsoft.Maui.TestCases.Tests
 #endif
 	public abstract class UITest : UITestBase
 	{
-		string _defaultiOSVersion = "18.4";
-
 		protected const int SetupMaxRetries = 1;
 		readonly VisualRegressionTester _visualRegressionTester;
 		readonly IImageEditorFactory _imageEditorFactory;
@@ -243,9 +241,7 @@ namespace Microsoft.Maui.TestCases.Tests
 						var device = (string?)((AppiumApp)App).Driver.Capabilities.GetCapability("deviceName")
 							?? throw new InvalidOperationException("deviceName capability is missing or null.");
 
-						environmentName = "ios";
-
-						if (device.Contains(" Xs", StringComparison.OrdinalIgnoreCase) && platformVersion == _defaultiOSVersion)
+						if (device.Contains(" Xs", StringComparison.OrdinalIgnoreCase) && platformVersion == "18.0")
 						{
 							environmentName = "ios";
 						}
@@ -259,7 +255,7 @@ namespace Microsoft.Maui.TestCases.Tests
 						}
 						else
 						{
-							//Assert.Fail($"iOS visual tests should be run on iPhone Xs (iOS {_defaultiOSVersion}) or iPhone X (iOS 16.4) simulator images, but the current device is '{deviceName}' '{platformVersion}'. Follow the steps on the MAUI UI testing wiki.");
+							Assert.Fail($"iOS visual tests should be run on iPhone Xs (iOS 17.2) or iPhone X (iOS 16.4) simulator images, but the current device is '{deviceName}'. Follow the steps on the MAUI UI testing wiki.");
 						}
 						break;
 


### PR DESCRIPTION
This reverts commit 6137fa1764d44098eed24b2d7daeebe2894827a1.

### Description of Change

Seems the devicetests are failing , problem with Xcode 16.3 and loading 18.5 simulators.
