### PR TITLE
Fix for SafeArea management on iOS Failing test case - PointerGestureTest

### DIFF
--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -101,6 +101,16 @@ namespace Microsoft.Maui.Platform
 		/// </summary>
 		public MauiScrollView()
 		{
+			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)
+#if TVOS
+				|| OperatingSystem.IsTvOSVersionAtLeast(11)
+#endif
+				)
+			{
+				// Disable iOS automatic content inset adjustments to avoid conflicts with MAUI's safe area logic.
+				// Prevents layout instability and infinite loops caused by overlapping inset management.
+				ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
PR - https://github.com/dotnet/maui/pull/30629 Failing test case details :

### Root Cause
The issue arises due to conflicting safe area handling between iOS's native `UIScrollView` behavior and MAUI's safe area management for iOS. When the safe area changes (e.g., due to device rotation or UI updates), iOS automatically updates the content insets — for instance, adjusting from {0,0,0,0} to {44,0,34,0} on devices with a notch.

This automatic adjustment triggers MAUI's layout invalidation. MAUI then re-measures and rearranges the layout to apply its own safe area logic, causing layout bounds to change. iOS detects this change and readjusts the insets again. This results in a feedback loop:

iOS adjusts insets → MAUI detects layout change → MAUI re-measures → layout bounds change → iOS adjusts insets again — leading to an infinite layout loop.
 
### Description of Change
The fix disables iOS’s automatic content inset adjustments by setting `ContentInsetAdjustmentBehavior` to Never on iOS 11 and above. This ensures that only MAUI’s cross-platform safe area system handles inset logic, preventing conflicts and infinite layout loops. By allowing a single source of truth for safe area management, the fix provides stable and consistent layout behavior across platforms.
 
### Issues Fixed
Fixes #30629  failing test case -  **PointerGestureTest**

### Fix Reference
A similar approach can be seen in [ShellTableViewController](https://github.com/dotnet/maui/blob/PureWeen/safe-area-fixes-ios-net10/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs#L85), where ContentInsetAdjustmentBehavior is set to avoid native inset interference.
 
Tested the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [ ] Mac

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/c8e96094-bb10-4012-a8e9-2484bd85876d">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/5eb98abb-44d2-486f-acce-28681fdf3c56">|