### PR TITLE
Fixed DatePicker's DateSelected event not firing on Windows - NET 10 Preview 6

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Maui.Controls;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using System;
-using System.Threading.Tasks;
-using Xunit;
 using Microsoft.Maui.Platform;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests;
 
@@ -97,5 +97,58 @@ public partial class DatePickerTests : ControlsHandlerTestBase
 		}
 
 		return string.Empty;
+	}
+	[Fact(DisplayName = "DateSelected Event Fires When Platform View Date Changes")]
+	public async Task DateSelectedEventFiresWhenPlatformViewDateChanges()
+	{
+		SetupBuilder();
+
+		var originalDate = new DateTime(2023, 5, 15);
+		var newDate = new DateTime(2023, 8, 20);
+
+		var datePicker = new DatePicker
+		{
+			Date = originalDate
+		};
+
+		bool eventFired = false;
+
+		datePicker.DateSelected += (sender, e) =>
+		{
+			eventFired = true;
+		};
+
+		await CreateHandlerAndAddToWindow<DatePickerHandler>(datePicker, async (handler) =>
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+#if ANDROID
+				if (handler.DatePickerDialog != null)
+				{
+					var previousDate = handler.VirtualView.Date;
+					handler.VirtualView.Date = newDate;
+				}
+#elif IOS
+                if (handler.DatePickerDialog != null)
+                {
+                    handler.DatePickerDialog.SetDate(newDate.ToNSDate(), false);
+                    typeof(DatePickerHandler).GetMethod("SetVirtualViewDate",
+                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
+                        .Invoke(handler, null);
+                }
+#elif WINDOWS
+                if (handler.PlatformView != null)
+                {
+                    handler.PlatformView.Date = newDate;
+                }
+#else
+				handler.VirtualView.Date = newDate;
+#endif
+			});
+
+			await Task.Delay(20);
+
+			Assert.True(eventFired, "DateSelected event should fire when platform view date changes");
+		});
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
@@ -46,27 +46,22 @@ public partial class DatePickerTests : ControlsHandlerTestBase
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
+				datePicker.Date = newDate;
+
 #if ANDROID
-				if (handler.DatePickerDialog != null)
-				{
-					var previousDate = handler.VirtualView.Date;
-					handler.VirtualView.Date = newDate;
-				}
+				handler.DatePickerDialog?.UpdateDate(newDate.Year, newDate.Month - 1, newDate.Day);
 #elif IOS
                 if (handler.DatePickerDialog != null)
                 {
                     handler.DatePickerDialog.SetDate(newDate.ToNSDate(), false);
-                    typeof(DatePickerHandler).GetMethod("SetVirtualViewDate",
-                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
-                        .Invoke(handler, null);
                 }
 #elif WINDOWS
                 if (handler.PlatformView != null)
                 {
                     handler.PlatformView.Date = newDate;
                 }
-#else
-                handler.VirtualView.Date = newDate;
+#elif MACCATALYST
+	 handler.PlatformView.Date = newDate.ToNSDate();
 #endif
 			});
 

--- a/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.Maui.Controls;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests;
 
@@ -15,6 +19,60 @@ public partial class DatePickerTests : ControlsHandlerTestBase
 			{
 				handlers.AddHandler<DatePicker, DatePickerHandler>();
 			});
+		});
+	}
+
+	[Fact(DisplayName = "DateSelected Event Fires When Platform View Date Changes")]
+	public async Task DateSelectedEventFiresWhenPlatformViewDateChanges()
+	{
+		SetupBuilder();
+
+		var originalDate = new DateTime(2023, 5, 15);
+		var newDate = new DateTime(2023, 8, 20);
+
+		var datePicker = new DatePicker
+		{
+			Date = originalDate
+		};
+
+		bool eventFired = false;
+
+		datePicker.DateSelected += (sender, e) =>
+		{
+			eventFired = true;
+		};
+
+		await CreateHandlerAndAddToWindow<DatePickerHandler>(datePicker, async (handler) =>
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+#if ANDROID
+				if (handler.DatePickerDialog != null)
+				{
+					var previousDate = handler.VirtualView.Date;
+					handler.VirtualView.Date = newDate;
+				}
+#elif IOS
+                if (handler.DatePickerDialog != null)
+                {
+                    handler.DatePickerDialog.SetDate(newDate.ToNSDate(), false);
+                    typeof(DatePickerHandler).GetMethod("SetVirtualViewDate",
+                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?
+                        .Invoke(handler, null);
+                }
+#elif WINDOWS
+                if (handler.PlatformView != null)
+                {
+                    handler.PlatformView.Date = newDate;
+                }
+#else
+                handler.VirtualView.Date = newDate;
+#endif
+			});
+
+			await Task.Delay(20);
+
+			Assert.True(eventFired, "DateSelected event should fire when platform view date changes");
 		});
 	}
 }

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
@@ -62,7 +62,7 @@ public partial class DatePickerHandler : ViewHandler<IDatePicker, CalendarDatePi
 		handler.PlatformView?.UpdateIsOpen(datePicker);
 	}
 
-	private void DateChanged(CalendarDatePicker sender, CalendarDatePickerDateChangedEventArgs args)
+	void DateChanged(CalendarDatePicker sender, CalendarDatePickerDateChangedEventArgs args)
 	{
 		if (VirtualView is null)
 		{
@@ -75,7 +75,7 @@ public partial class DatePickerHandler : ViewHandler<IDatePicker, CalendarDatePi
 			return;
 		}
 
-		if (VirtualView.Date is null)
+		if (VirtualView.Date != args.NewDate.Value.DateTime)
 		{
 			VirtualView.Date = args.NewDate.Value.DateTime;
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue detail:
DatePicker's DateSelected event not firing on Windows - .NET 10 Preview 6
### Root Cause
 
The DateSelected event was not firing on Windows due to an incorrect condition check. The original code used if (VirtualView.Date is null), which did not properly capture changes to the selected date. Although Date can be set to null, the check was not sufficient to determine whether the date had actually changed. As a result, the selected date was not updated, and the event was not triggered.

### Description of Change
 
To resolve these issues, the condition was updated to if (VirtualView.Date != args.NewDate.Value.DateTime) to ensure the event triggers only when the selected date actually changes. 
 
Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed:
Fixes #30736 
 
### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/d8f31f10-0d23-4546-92bf-dd474d2ca0f8"> |   <video src="https://github.com/user-attachments/assets/89285658-f7d6-4fea-87e8-458aa0d83899">  |