### PR TITLE
Fix GraphicsView event handlers are triggered even when IsEnabled is set to False

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30649.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30649.cs
@@ -1,0 +1,102 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 30649, "GraphicsView event handlers should respect IsEnabled property", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue30649 : TestContentPage
+{
+	protected override void Init()
+	{
+		var eventCountLabel = new Label
+		{
+			AutomationId = "EventCountLabel",
+			Text = "Touch Events: 0",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		var touchCount = 0;
+
+		var graphicsView = new GraphicsView
+		{
+			AutomationId = "TestGraphicsView",
+			HeightRequest = 200,
+			WidthRequest = 300,
+			BackgroundColor = Colors.LightBlue,
+			Drawable = new Issue34Drawable(),
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		// Add event handlers to track touch interactions
+		graphicsView.StartInteraction += (s, e) =>
+		{
+			touchCount++;
+			eventCountLabel.Text = $"Touch Events: {touchCount}";
+		};
+
+		var toggleButton = new Button
+		{
+			AutomationId = "ToggleIsEnabledButton",
+			Text = "Disable GraphicsView",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		toggleButton.Clicked += (s, e) =>
+		{
+			graphicsView.IsEnabled = !graphicsView.IsEnabled;
+			toggleButton.Text = graphicsView.IsEnabled ? "Disable GraphicsView" : "Enable GraphicsView";
+		};
+
+		var resetButton = new Button
+		{
+			AutomationId = "ResetCountButton",
+			Text = "Reset Count",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		resetButton.Clicked += (s, e) =>
+		{
+			touchCount = 0;
+			eventCountLabel.Text = $"Touch Events: {touchCount}";
+		};
+
+		var instructionsLabel = new Label
+		{
+			Text = "1. Tap the blue GraphicsView area - events should be counted\n" +
+				   "2. Tap 'Disable GraphicsView'\n" +
+				   "3. Tap the blue area again - no events should be counted\n" +
+				   "4. Tap 'Enable GraphicsView'\n" +
+				   "5. Tap the blue area - events should be counted again",
+			FontSize = 12,
+			Margin = new Thickness(10)
+		};
+
+		Content = new StackLayout
+		{
+			Spacing = 20,
+			Padding = new Thickness(20),
+			Children =
+			{
+				instructionsLabel,
+				graphicsView,
+				eventCountLabel,
+				toggleButton,
+				resetButton
+			}
+		};
+	}
+}
+
+public class Issue34Drawable : IDrawable
+{
+	public void Draw(ICanvas canvas, RectF dirtyRect)
+	{
+		canvas.FillColor = Colors.LightBlue;
+		canvas.FillRectangle(dirtyRect);
+		
+		canvas.StrokeColor = Colors.DarkBlue;
+		canvas.StrokeSize = 2;
+		canvas.DrawRectangle(dirtyRect);
+		
+		canvas.FontColor = Colors.DarkBlue;
+		canvas.FontSize = 16;
+		canvas.DrawString("Tap here to trigger events", dirtyRect, HorizontalAlignment.Center, VerticalAlignment.Center);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30649.cs
@@ -1,3 +1,4 @@
+#if !WINDOWS // The fix is related with Android, iOS and Mac.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -77,3 +78,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30649.cs
@@ -1,0 +1,79 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue30649 : _IssuesUITest
+	{
+		public Issue30649(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "GraphicsView event handlers should respect IsEnabled property";
+
+		[Test]
+		[Category(UITestCategories.GraphicsView)]
+		[Category(UITestCategories.IsEnabled)]
+		[Category(UITestCategories.Gestures)]
+		public void GraphicsViewEventsRespectIsEnabled()
+		{
+			// Wait for the page to load
+			App.WaitForElement("TestGraphicsView");
+			App.WaitForElement("EventCountLabel");
+			App.WaitForElement("ToggleIsEnabledButton");
+			App.WaitForElement("ResetCountButton");
+
+			// Reset the count to start fresh
+			App.Click("ResetCountButton");
+
+			// Verify initial state shows 0 events
+			var initialCount = App.FindElement("EventCountLabel").GetText();
+			Assert.That(initialCount, Is.EqualTo("Touch Events: 0"));
+
+			// Tap the GraphicsView when enabled - should trigger events
+			App.Click("TestGraphicsView");
+			
+			// Wait a moment for the event to be processed
+			System.Threading.Thread.Sleep(500);
+			
+			var countAfterFirstTap = App.FindElement("EventCountLabel").GetText();
+			Assert.That(countAfterFirstTap, Is.EqualTo("Touch Events: 1"), 
+				"GraphicsView should respond to touch when IsEnabled is true");
+
+			// Disable the GraphicsView
+			App.Click("ToggleIsEnabledButton");
+			
+			// Verify button text changed to indicate GraphicsView is now disabled
+			var disableButtonText = App.FindElement("ToggleIsEnabledButton").GetText();
+			Assert.That(disableButtonText, Is.EqualTo("Enable GraphicsView"));
+
+			// Tap the GraphicsView when disabled - should NOT trigger events
+			App.Click("TestGraphicsView");
+			
+			// Wait a moment to ensure no event is processed
+			System.Threading.Thread.Sleep(500);
+			
+			var countAfterDisabledTap = App.FindElement("EventCountLabel").GetText();
+			Assert.That(countAfterDisabledTap, Is.EqualTo("Touch Events: 1"), 
+				"GraphicsView should NOT respond to touch when IsEnabled is false");
+
+			// Re-enable the GraphicsView
+			App.Click("ToggleIsEnabledButton");
+			
+			// Verify button text changed back
+			var enableButtonText = App.FindElement("ToggleIsEnabledButton").GetText();
+			Assert.That(enableButtonText, Is.EqualTo("Disable GraphicsView"));
+
+			// Tap the GraphicsView when re-enabled - should trigger events again
+			App.Click("TestGraphicsView");
+			
+			// Wait a moment for the event to be processed
+			System.Threading.Thread.Sleep(500);
+			
+			var countAfterReenabledTap = App.FindElement("EventCountLabel").GetText();
+			Assert.That(countAfterReenabledTap, Is.EqualTo("Touch Events: 2"), 
+				"GraphicsView should respond to touch again when IsEnabled is set back to true");
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
@@ -67,9 +67,12 @@ namespace Microsoft.Maui.Platform
 		}
 		public void TouchesBegan(PointF[] points)
 		{
+			if (_graphicsView is null || !_graphicsView.IsEnabled)
+				return;
+			
 			_dragStarted = false;
 			_lastMovedViewPoints = points;
-			_graphicsView?.StartInteraction(points);
+			_graphicsView.StartInteraction(points);
 			_pressedContained = true;
 		}
 
@@ -95,13 +98,19 @@ namespace Microsoft.Maui.Platform
 
 		public void TouchesEnded(PointF[] points)
 		{
+			if (_graphicsView is null || !_graphicsView.IsEnabled)
+				return;
+			
 			_graphicsView?.EndInteraction(points, _pressedContained);
 		}
 
 		public void TouchesCanceled()
 		{
+			if (_graphicsView is null || !_graphicsView.IsEnabled)
+				return;
+			
 			_pressedContained = false;
-			_graphicsView?.CancelInteraction();
+			_graphicsView.CancelInteraction();
 		}
 
 		public override bool OnHoverEvent(MotionEvent? e)

--- a/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/iOS/PlatformTouchGraphicsView.cs
@@ -49,8 +49,13 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_graphicsView is null || !_graphicsView.TryGetTarget(out var graphicsView))
 				return;
+			
+			if (!graphicsView.IsEnabled)
+				return;
+			
 			if (!IsFirstResponder)
 				BecomeFirstResponder();
+			
 			var viewPoints = this.GetPointsInView(evt);
 			graphicsView.StartInteraction(viewPoints);
 			_pressedContained = true;
@@ -60,6 +65,10 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_graphicsView is null || !_graphicsView.TryGetTarget(out var graphicsView))
 				return;
+
+			if (!graphicsView.IsEnabled)
+				return;
+			
 			var viewPoints = this.GetPointsInView(evt);
 			_pressedContained = _rect.ContainsAny(viewPoints);
 			graphicsView.DragInteraction(viewPoints);
@@ -69,6 +78,10 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_graphicsView is null || !_graphicsView.TryGetTarget(out var graphicsView))
 				return;
+
+			if (!graphicsView.IsEnabled)
+				return;
+			
 			graphicsView.EndInteraction(this.GetPointsInView(evt), _pressedContained);
 		}
 
@@ -76,6 +89,10 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_graphicsView is null || !_graphicsView.TryGetTarget(out var graphicsView))
 				return;
+
+			if (!graphicsView.IsEnabled)
+				return;
+			
 			_pressedContained = false;
 			graphicsView.CancelInteraction();
 		}


### PR DESCRIPTION
### Description of Change

This PR fixes an issue where GraphicsView event handlers (StartInteraction, DragInteraction, EndInteraction, etc.) were being triggered even when the IsEnabled property was set to False on Android, iOS, and macOS platforms.

The issue occurred because the platform-specific `PlatformTouchGraphicsView` implementations were not checking the IsEnabled property before processing and forwarding touch events. Added IsEnabled checks at the touch event methods in the platform implementations.

Added UI test to verify the fix.

<img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/e604b798-a0e2-43d8-a5cc-f17b82e174b9" />

<img width="968" height="290" alt="image" src="https://github.com/user-attachments/assets/11c8d47c-0b39-4d77-ac58-fbea86311ade" />

### Issues Fixed

Fixes #30649
