### PR TITLE
[Windows] Fix for NavigationPage transitions still animating when passing animated false to PushAsync or PopAsync

### DIFF
--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -120,7 +120,9 @@ namespace Microsoft.Maui.Platform
 		protected virtual NavigationTransitionInfo? GetNavigationTransition(NavigationRequest args)
 		{
 			if (!args.Animated)
-				return null;
+			{
+				return new SuppressNavigationTransitionInfo();
+			}
 
 			// GoBack just plays the animation in reverse so we always just return the same animation
 			return new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight };

--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Maui.Platform
 {
 	public class StackNavigationManager
 	{
+		static readonly SuppressNavigationTransitionInfo s_suppressTransition = new();
+
 		IView? _currentPage;
 		IMauiContext _mauiContext;
 		Frame? _navigationFrame;
@@ -121,7 +123,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!args.Animated)
 			{
-				return new SuppressNavigationTransitionInfo();
+				return s_suppressTransition;
 			}
 
 			// GoBack just plays the animation in reverse so we always just return the same animation


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details 

- When using PushAsync and PopAsync with no parameters or when passing animated: true, the page transitions animate from side to side as expected. However, when passing animated: false, a different vertical animation still occurs on Windows.

### Root Cause

- In StackNavigationManager.cs, the GetNavigationTransition method returns null when args.Animated is false. In WinUI, this causes the Frame to fall back to its default NavigationThemeTransition, resulting in a page refresh animation even when animation is intended to be disabled.
- As documented by [Microsoft](https://learn.microsoft.com/en-us/windows/apps/design/motion/page-transitions#:~:text=Note%3A%20A%20Frame%20automatically%20uses%20NavigationThemeTransition%20to%20animate%20navigation%20between%20two%20pages.%20By%20default%2C%20the%20animation%20is%20page%20refresh.), Frame applies this transition by default if no custom one is provided.
- Hence, returning null does not suppress the animation, causing the page to slide up on Windows.

### Description of Change

- [`src/Core/src/Platform/Windows/StackNavigationManager.cs`](diffhunk://#diff-bacfb8be7525ddd50f1f01c8fca339533e09abf8131e14f4f49fceefbfb0407dL123-R125): Updated the `GetNavigationTransition` method to return a `SuppressNavigationTransitionInfo` object instead of `null` when navigation is not animated. This ensures a consistent handling of non-animated transitions.
- About [SuppressNavigationTransitionInfo](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.animation.suppressnavigationtransitioninfo?view=winrt-26100#:~:text=can%20use%20SuppressNavigationTransitionInfo%20in%20the%20place%20of%20other%20NavigationTransitionInfo%20subtypes%20when%20you%20want%20to%20avoid%20playing%20any%20animation%20during%20navigation.)

### Issues Fixed
Fixes #11808 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/b72438d1-2cdc-4997-9731-0515f7fafb94"> | <video src="https://github.com/user-attachments/assets/b748a7eb-b7cd-4fe8-8bd0-0987749f71b9"> |
