### PR TITLE
GraphicsView event handlers are triggered even when IsEnabled is set to False 

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30649.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30649.cs
@@ -1,0 +1,69 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 30649, "GraphicsView event handlers are triggered even when IsEnabled is set to False", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue30649 : ContentPage
+{
+    Label statusLabel;
+    GraphicsView graphicsView;
+    public Issue30649()
+    {
+        Label label = new Label
+        {
+            Text = "The test passes if GraphicsView event handlers are not triggered when IsEnabled is set to False.",
+        };
+
+        graphicsView = new GraphicsView
+        {
+            Drawable = new Issue30649_Drawble(),
+            AutomationId = "Issue30649_GraphicsView",
+            HeightRequest = 300,
+            WidthRequest = 300,
+            IsEnabled = false,
+        };
+        graphicsView.StartInteraction += OnStartInteraction;
+
+        statusLabel = new Label
+        {
+            Text = "Success",
+            AutomationId = "Issue30649_Label",
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        Content = new StackLayout
+        {
+            Children =
+            {
+                label,
+                graphicsView,
+                statusLabel
+            }
+        };
+    }
+
+    private void OnStartInteraction(object sender, TouchEventArgs e)
+    {
+        statusLabel.Text = "Failure";
+    }
+}
+
+public class Issue30649_Drawble : IDrawable
+{
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        // Draw a simple rectangle
+        canvas.StrokeColor = Colors.Blue;
+        canvas.FillColor = Colors.Gray;
+        canvas.StrokeSize = 4;
+
+        // Create rectangle that fills most of the available area
+        float width = dirtyRect.Width * 0.8f;
+        float height = dirtyRect.Height * 0.8f;
+        float x = (dirtyRect.Width - width) / 2;
+        float y = (dirtyRect.Height - height) / 2;
+
+        // Draw the rectangle
+        canvas.FillRectangle(x, y, width, height);
+        canvas.DrawRectangle(x, y, width, height);
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30649.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30649.cs
@@ -1,0 +1,25 @@
+#if TEST_FAILS_ON_WINDOWS // https://github.com/dotnet/maui/issues/27195 
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30649 : _IssuesUITest
+{
+    public override string Issue => "GraphicsView event handlers are triggered even when IsEnabled is set to False";
+
+    public Issue30649(TestDevice device) : base(device)
+    {
+    }
+
+    [Test]
+    [Category(UITestCategories.GraphicsView)]
+    public void TestGraphicsViewTouchEventsIgnoredWhenIsEnabledFalse()
+    {
+        App.WaitForElement("Issue30649_GraphicsView");
+        App.Tap("Issue30649_GraphicsView");
+        Assert.That(App.WaitForElement("Issue30649_Label").GetText(), Is.EqualTo("Success"));
+    }
+}
+#endif

--- a/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
@@ -36,12 +36,23 @@ namespace Microsoft.Maui.Platform
 		public override bool OnTouchEvent(MotionEvent? e)
 		{
 			if (e == null)
+			{
 				throw new ArgumentNullException(nameof(e));
+			}
+
+			// If the GraphicsView is disabled, we don't want to handle touch events.
+			// This is to prevent any interaction when the view is not interactive.
+			if (_graphicsView is null || !_graphicsView.IsEnabled)
+			{
+				return false;
+			}
 
 			int touchCount = e.PointerCount;
 			var touchPoints = new PointF[touchCount];
 			for (int i = 0; i < touchCount; i++)
+			{
 				touchPoints[i] = new PointF(e.GetX(i) / _scale, e.GetY(i) / _scale);
+			}
 
 			var actionMasked = e.Action & MotionEventActions.Mask;
 
@@ -64,6 +75,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return true;
+
 		}
 		public void TouchesBegan(PointF[] points)
 		{
@@ -107,12 +119,21 @@ namespace Microsoft.Maui.Platform
 		public override bool OnHoverEvent(MotionEvent? e)
 		{
 			if (e == null)
+			{
 				throw new ArgumentNullException(nameof(e));
+			}
+
+			if (_graphicsView is null || !_graphicsView.IsEnabled)
+			{
+				return false;
+			}
 
 			int touchCount = e.PointerCount;
 			var touchPoints = new PointF[touchCount];
 			for (int i = 0; i < touchCount; i++)
+			{
 				touchPoints[i] = new PointF(e.GetX(i) / _scale, e.GetY(i) / _scale);
+			}
 
 			var actionMasked = e.Action & MotionEventActions.Mask;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue detail:
The GraphicsView control should ignore user input when IsEnabled is set to false. However, on Android, iOS, and Mac, input events still fire, unlike on Windows where the behavior is correct.
### Root Cause
This discrepancy occurred because these platform-specific overrides did not explicitly verify the IsEnabled state. In contrast, the Windows implementation behaved correctly.

 
### Description of Change
Introduced a conditional check at the beginning of the OnTouchEvent and OnHoverEvent methods to validate whether _graphicsView is null or not enabled (!_graphicsView.IsEnabled). If this condition is met, the method exits early by returning false, preventing any further event processing.
 
Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed:
Fixes 
 
### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/dc5ca904-322f-4003-b518-0f6aeac316fa"> |   <video src="https://github.com/user-attachments/assets/883189a8-1786-427a-b2ea-3783ef7cad4d">  |