### PR TITLE
[ci] Update android and dotnet to preview7 channel

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "10.0.0-prerelease.25330.2",
+      "version": "10.0.0-prerelease.25375.1",
       "commands": [
         "xharness"
       ],

--- a/NuGet.config
+++ b/NuGet.config
@@ -27,8 +27,8 @@
     <add key="darc-pub-dotnet-maui-a33a875e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-a33a875e/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 8.0.18 -->
     <add key="darc-pub-dotnet-runtime-c0390586" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-c0390586/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 9.0.7 -->
-    <add key="darc-pub-dotnet-runtime-b4fb3656" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-b4fb3656/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 9.0.8 -->
+    <add key="darc-pub-dotnet-runtime-b4fb3656" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-89d42fdf/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 Android -->
     <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
     <!-- Added manually for .NET 8 Android -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -140,17 +140,17 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25330.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25375.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>feac80219b22c403d32df9b6bd61cbf78e1b9986</Sha>
+      <Sha>dfe773f0763677ba3044e9913813e9a581009924</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="10.0.0-prerelease.25330.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="10.0.0-prerelease.25375.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>feac80219b22c403d32df9b6bd61cbf78e1b9986</Sha>
+      <Sha>dfe773f0763677ba3044e9913813e9a581009924</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25330.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25375.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>feac80219b22c403d32df9b6bd61cbf78e1b9986</Sha>
+      <Sha>dfe773f0763677ba3044e9913813e9a581009924</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25373.105">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.7.221">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.7.225">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>d3e797f1d46e974e47ff18c1dcca14e3ea390732</Sha>
+      <Sha>306558f7ce1555e297d4b9fe5de3b40600637593</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.78" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -36,109 +36,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25373.105">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25330.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -154,37 +154,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25373.105">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25374.104">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
+      <Sha>3f1b780b8ce94918db148a367363b3038fd994bb</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25372.103">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-ci.main.219">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.7.220">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>510fc086f837d118267bc5089abba6185e790a9e</Sha>
+      <Sha>46bae85d0949b050e4fb2f863a9b298fb5107845</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.78" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -36,109 +36,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25372.103">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25330.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -154,37 +154,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25372.103">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25372.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>96ac952a7886b565e83acc4c9cef656954ed0686</Sha>
+      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25372.102">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.7.220">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.7.221">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>46bae85d0949b050e4fb2f863a9b298fb5107845</Sha>
+      <Sha>d3e797f1d46e974e47ff18c1dcca14e3ea390732</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.78" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -36,109 +36,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25372.102">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25330.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -154,37 +154,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25372.102">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25373.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>19deb21964f2c9465b5e5c45e923c32559c7f852</Sha>
+      <Sha>b64f1193459ddeba61d78aa61f90604410734e0f</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,29 +30,29 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.51</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25373.105</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25374.104</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25373.105</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25374.104</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25374.104</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.7.221</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.7.225</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.78</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -68,19 +68,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25373.105</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25374.104</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25374.104</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -137,13 +137,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25373.105</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25374.104</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25374.104</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25374.104</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25374.104</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25374.104</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25374.104</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,29 +30,29 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.51</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25372.103</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25372.102</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25372.103</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25372.102</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25372.103</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-ci.main.219</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.7.220</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.78</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -68,19 +68,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25372.103</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25372.103</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25372.102</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -137,13 +137,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25372.103</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25372.103</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25372.103</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25372.103</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25372.102</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25372.103</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25372.103</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,9 +128,9 @@
     <_HarfBuzzSharpVersion>8.3.0.1</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.e57e2a11dac4ccc72bea52939dede49816842005.1728</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.120</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>10.0.0-prerelease.25330.2</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>10.0.0-prerelease.25330.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25330.2</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>10.0.0-prerelease.25375.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>10.0.0-prerelease.25375.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25375.1</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.2</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>2.0.0.4</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.3.0</FizzlerPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,29 +30,29 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.51</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25372.102</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25373.105</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25372.102</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25373.105</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25372.102</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25373.105</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.7.220</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.7.221</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.78</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -68,19 +68,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25372.102</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25372.102</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25373.105</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25373.105</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -137,13 +137,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25372.102</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25373.105</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25372.102</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25373.105</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.7.25368.105"
+    "dotnet": "10.0.100-preview.7.25372.102"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25372.103",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25372.103"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25372.102",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25372.102"
   },
   "sdk": {
     "allowPrerelease": true

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.7.25373.105"
+    "dotnet": "10.0.100-preview.7.25374.104"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25373.105",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25373.105"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25374.104",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25374.104"
   },
   "sdk": {
     "allowPrerelease": true

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.7.25372.102"
+    "dotnet": "10.0.100-preview.7.25373.105"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25372.102",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25372.102"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25373.105",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25373.105"
   },
   "sdk": {
     "allowPrerelease": true


### PR DESCRIPTION
### Description of Change

Using darc to update the versions 

```
darc update-dependencies --channel ".NET 10.0.1xx SDK Preview 7" --verbose
```

This pull request updates the dependency versions in the project to align with a new release. The changes primarily involve downgrading the versions of various dependencies and their associated SHA hashes in configuration files. These updates ensure compatibility with the specified versions and maintain coherence across the project.

### Dependency Version Updates:

* Updated the versions of multiple dependencies in `eng/Version.Details.xml`, including `Microsoft.NET.Sdk`, `Microsoft.NETCore.App.Ref`, and `Microsoft.Android.Sdk.Windows`, among others, to version `10.0.100-preview.7.25372.102` or equivalent. Corresponding SHA hashes were also updated. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R13) [[2]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L39-R141) [[3]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L157-R187)

* Updated toolset dependency versions in `eng/Version.Details.xml`, such as `Microsoft.DotNet.Build.Tasks.Feed` and `Microsoft.DotNet.Arcade.Sdk`, to version `10.0.0-beta.25372.102`. SHA hashes were updated accordingly.

### Configuration File Adjustments:

* Adjusted dependency versions in `eng/Versions.props` for SDKs, runtime components, and extensions, including `MicrosoftNETSdkPackageVersion`, `MicrosoftExtensionsConfigurationVersion`, and `MicrosoftAspNetCoreAuthorizationPackageVersion`, to version `10.0.0-preview.7.25372.102` or equivalent. [[1]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L33-R55) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L71-R83)

* Updated toolset-related properties in `eng/Versions.props`, such as `MicrosoftDotNetBuildTasksFeedVersion` and `MicrosoftDotNetRemoteExecutorPackageVersion`, to version `10.0.0-beta.25372.102`.