### PR TITLE
[Android] Fix PlatformImage.FromStream() crash in release builds

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30783.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30783.cs
@@ -1,0 +1,83 @@
+using Maui.Controls.Sample.Issues;
+
+namespace Controls.TestCases.HostApp.Issues;
+
+[Issue(IssueTracker.Github, 30783, "Android: PlatformImage.FromStream() terminates app in release builds", PlatformAffected.Android)]
+ 	public class Issue30783 : TestContentPage
+ 	{
+ 		Button _loadImageButton;
+ 		Image _testImage;
+ 		Label _statusLabel;
+
+ 		protected override void Init()
+ 		{
+ 			Title = "Issue 30783 - PlatformImage.FromStream Test";
+
+ 			_statusLabel = new Label
+ 			{
+ 				Text = "Tap button to test image loading from stream",
+ 				AutomationId = "StatusLabel",
+ 				Margin = new Thickness(10)
+ 			};
+
+ 			_loadImageButton = new Button
+ 			{
+ 				Text = "Load Image from Stream",
+ 				AutomationId = "LoadImageButton",
+ 				Margin = new Thickness(10)
+ 			};
+ 			_loadImageButton.Clicked += OnLoadImageClicked;
+
+ 			_testImage = new Image
+ 			{
+ 				AutomationId = "TestImage",
+ 				Margin = new Thickness(10),
+ 				HeightRequest = 100,
+ 				WidthRequest = 100,
+ 				BackgroundColor = Colors.LightGray
+ 			};
+
+ 			Content = new StackLayout
+ 			{
+ 				Children = { _statusLabel, _loadImageButton, _testImage }
+ 			};
+ 		}
+
+ 		async void OnLoadImageClicked(object sender, EventArgs e)
+ 		{
+ 			try
+ 			{
+ 				_statusLabel.Text = "Loading image from stream...";
+
+ 				// This reproduces the scenario from the issue where embedded resources
+ 				// were used via GetManifestResourceStream and PlatformImage.FromStream
+ 				await LoadImageFromStream();
+
+ 				_statusLabel.Text = "Image loaded successfully from stream!";
+ 			}
+ 			catch (Exception ex)
+ 			{
+ 				_statusLabel.Text = $"Error: {ex.Message}";
+ 			}
+ 		}
+
+ 		async Task LoadImageFromStream()
+ 		{
+ 			// Create a simple PNG image data (1x1 orange pixel)
+ 			byte[] orangePngBytes = Convert.FromBase64String(
+ 				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4v5ThPwAG7wKklwQ/bwAAAABJRU5ErkJggg=="
+ 			);
+
+ 			// Simulate the scenario from the issue where a stream might be disposed
+ 			// or become invalid during processing in release builds
+ 			using (var memoryStream = new MemoryStream(orangePngBytes))
+ 			{
+ 				// Create ImageSource from stream - this internally uses PlatformImage.FromStream
+ 				var imageSource = ImageSource.FromStream(() => new MemoryStream(orangePngBytes));
+ 				_testImage.Source = imageSource;
+ 			}
+
+ 			// Give the image time to load
+ 			await Task.Delay(500);
+ 		}
+ 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30783.cs
@@ -23,7 +23,7 @@ public class Issue30783 : _IssuesUITest
 		App.WaitForElement("StatusLabel");
 
 		// Verify that the status shows success (no crash occurred)
-		var statusText = App.GetText("StatusLabel");
+		var statusText = App.FindElement("StatusLabel").GetText();
 		Assert.That(statusText, Does.Contain("Image loaded successfully"),
 			"PlatformImage.FromStream should successfully load image without crashing");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30783.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30783 : _IssuesUITest
+{
+	public Issue30783(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Android: PlatformImage.FromStream() terminates app in release builds";
+
+	[Test]
+	[Category(UITestCategories.Image)]
+	public void PlatformImageFromStreamShouldNotCrashInReleaseBuilds()
+	{
+		App.WaitForElement("LoadImageButton");
+		App.Tap("LoadImageButton");
+
+		// Wait for the image loading to complete
+		App.WaitForElement("StatusLabel");
+
+		// Verify that the status shows success (no crash occurred)
+		var statusText = App.GetText("StatusLabel");
+		Assert.That(statusText, Does.Contain("Image loaded successfully"),
+			"PlatformImage.FromStream should successfully load image without crashing");
+
+		// Verify the image is present
+		App.WaitForElement("TestImage");
+	}
+}

--- a/src/Graphics/src/Graphics/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/PlatformImage.cs
@@ -145,11 +145,19 @@ namespace Microsoft.Maui.Graphics.Platform
 			width = 0;
 			height = 0;
 
-			// Look into the byte array and get the size of the image
-			for (int i = 0; i <= 3; i++)
+			// PNG format: 8-byte signature, then chunks
+			// IHDR chunk starts at byte 8 with: 4-byte length, 4-byte "IHDR", then 4-byte width, 4-byte height
+			if (_bytes.Length >= 24)
 			{
-				width = _bytes[i] | width << 8;
-				height = _bytes[i + 4] | height << 8;
+				// Check if this is a valid PNG with IHDR chunk
+				if (_bytes[8] == 0x00 && _bytes[9] == 0x00 && _bytes[10] == 0x00 && _bytes[11] == 0x0D && // IHDR length = 13
+					_bytes[12] == 0x49 && _bytes[13] == 0x48 && _bytes[14] == 0x44 && _bytes[15] == 0x52) // "IHDR"
+				{
+					// Width is at bytes 16-19 (big-endian)
+					width = (_bytes[16] << 24) | (_bytes[17] << 16) | (_bytes[18] << 8) | _bytes[19];
+					// Height is at bytes 20-23 (big-endian)
+					height = (_bytes[20] << 24) | (_bytes[21] << 16) | (_bytes[22] << 8) | _bytes[23];
+				}
 			}
 		}
 

--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
@@ -156,8 +156,16 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
-			var bitmap = BitmapFactory.DecodeStream(stream);
-			return new PlatformImage(bitmap);
+			// Copy stream to memory to ensure data is fully available before decoding
+			// This prevents crashes in release builds where the stream might be disposed
+			// or become invalid before BitmapFactory.DecodeStream completes
+			using (var memoryStream = new MemoryStream())
+			{
+				stream.CopyTo(memoryStream);
+				memoryStream.Position = 0;
+				var bitmap = BitmapFactory.DecodeStream(memoryStream);
+				return new PlatformImage(bitmap);
+			}
 		}
 	}
 }

--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
@@ -156,16 +156,25 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
-			// Copy stream to memory to ensure data is fully available before decoding
-			// This prevents crashes in release builds where the stream might be disposed
-			// or become invalid before BitmapFactory.DecodeStream completes
+			Bitmap bitmap;
+
+			if (stream is null)
+			{
+				return null;
+			}
+
 			using (var memoryStream = new MemoryStream())
 			{
+				if (stream.CanSeek)
+				{
+					stream.Position = 0;
+				}
 				stream.CopyTo(memoryStream);
-				memoryStream.Position = 0;
-				var bitmap = BitmapFactory.DecodeStream(memoryStream);
-				return new PlatformImage(bitmap);
+				byte[] buffer = memoryStream.GetBuffer();
+				int length = (int)memoryStream.Length;
+				bitmap = BitmapFactory.DecodeByteArray(buffer, 0, length);
 			}
+			return new PlatformImage(bitmap);
 		}
 	}
 }

--- a/src/Graphics/tests/Graphics.Tests/PlatformImageTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/PlatformImageTests.cs
@@ -24,7 +24,7 @@ public class PlatformImageTests
 	[Fact]
  	public void PlatformImageFromStreamSurvivesStreamDisposal()
  	{
- 		// This test reproduces the scenario from issue #42 where the stream
+ 		// This test reproduces the scenario from issue #30783 where the stream
  		// might be disposed or become invalid during processing in release builds
  		byte[] orange1x1pxPngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4v5ThPwAG7wKklwQ/bwAAAABJRU5ErkJggg==");
 
@@ -89,7 +89,7 @@ public class PlatformImageTests
     [Fact]
     public void PlatformImageFromManifestResourceStream()
     {
-	    // This test  reproduces the https://github.com/dotnet/maui/issues/30783 scenario:
+	    // This test reproduces the https://github.com/dotnet/maui/issues/30783 scenario:
 	    // - Uses reflection to get the current assembly
 	    // - Uses GetManifestResourceStream with an embedded resource
 	    // - Calls PlatformImage.FromStream directly within a using statement

--- a/src/Graphics/tests/Graphics.Tests/PlatformImageTests.cs
+++ b/src/Graphics/tests/Graphics.Tests/PlatformImageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.Maui.Graphics.Tests;
@@ -19,6 +20,95 @@ public class PlatformImageTests
 
 		Assert.NotNull(image);
 	}
+	
+	[Fact]
+ 	public void PlatformImageFromStreamSurvivesStreamDisposal()
+ 	{
+ 		// This test reproduces the scenario from issue #42 where the stream
+ 		// might be disposed or become invalid during processing in release builds
+ 		byte[] orange1x1pxPngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4v5ThPwAG7wKklwQ/bwAAAABJRU5ErkJggg==");
+
+ 		IImage image;
+ 		using (var memoryStream = new MemoryStream(orange1x1pxPngBytes))
+ 		{
+ 			// Create image from stream while stream is valid
+ 			image = Microsoft.Maui.Graphics.Platform.PlatformImage.FromStream(memoryStream);
+ 		}
+ 		// Stream is now disposed, but image should still be valid
+
+ 		Assert.NotNull(image);
+ 		Assert.Equal(1, image.Width);
+ 		Assert.Equal(1, image.Height);
+
+ 		// Verify the image is still usable after stream disposal
+ 		using var outputStream = new MemoryStream();
+ 		image.Save(outputStream);
+ 		Assert.True(outputStream.Length > 0);
+ 	}
+
+ 	[Fact] 
+ 	public void PlatformImageFromEmbeddedResourceStream()
+ 	{
+ 		// This test simulates the real-world scenario from the issue where
+ 		// GetManifestResourceStream is used (similar to Bug3() in the issue)
+ 		byte[] orange1x1pxPngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4v5ThPwAG7wKklwQ/bwAAAABJRU5ErkJggg==");
+
+ 		using var sourceStream = new MemoryStream(orange1x1pxPngBytes);
+ 		using var resourceStream = new NonSeekableReadOnlyStream(sourceStream);
+
+ 		// This should not crash in release builds
+ 		var image = Microsoft.Maui.Graphics.Platform.PlatformImage.FromStream(resourceStream);
+
+ 		Assert.NotNull(image);
+ 		Assert.Equal(1, image.Width);
+ 		Assert.Equal(1, image.Height);
+ 	}
+
+ 	[Fact]
+ 	public void PlatformImageFromStreamWithJpegData()
+ 	{
+ 		// Test with the actual JPEG data from the issue to ensure our fix
+ 		// handles the exact scenario reported
+ 		byte[] jpegImageBytes = new byte[]
+ 		{
+ 			0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xE2, 0x01, 0xD8, 0x49, 0x43, 0x43, 0x5F, 0x50, 0x52, 0x4F, 0x46, 0x49, 0x4C, 0x45, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0xC8, 0x00, 0x00, 0x00, 0x00, 0x04, 0x30, 0x00, 0x00,
+ 			0x6D, 0x6E, 0x74, 0x72, 0x52, 0x47, 0x42, 0x20, 0x58, 0x59, 0x5A, 0x20, 0x07, 0xE0, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x61, 0x63, 0x73, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ 			0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0xF6, 0xD6, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xD3, 0x2D, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ 			0xFF, 0xD9 // Simplified JPEG end marker
+ 		};
+
+ 		using var stream = new MemoryStream(jpegImageBytes);
+
+ 		// This simulates the exact scenario from Bug3() method in the issue
+ 		var image = Microsoft.Maui.Graphics.Platform.PlatformImage.FromStream(stream);
+
+ 		Assert.NotNull(image);
+ 		// Note: Dimensions may vary based on actual JPEG decoding, just ensure no crash
+ 	}
+    
+    [Fact]
+    public void PlatformImageFromManifestResourceStream()
+    {
+	    // This test  reproduces the https://github.com/dotnet/maui/issues/30783 scenario:
+	    // - Uses reflection to get the current assembly
+	    // - Uses GetManifestResourceStream with an embedded resource
+	    // - Calls PlatformImage.FromStream directly within a using statement
+	    // - Tests the exact pattern that was causing crashes in release builds
+
+	    var assembly = GetType().GetTypeInfo().Assembly;
+	    using (var stream = assembly.GetManifestResourceStream("Graphics.Tests.Resources.royals.png"))
+	    {
+		    Assert.NotNull(stream); // Ensure resource is found
+
+		    // This was the line causing crashes in release builds in the issue
+		    var image = Platform.PlatformImage.FromStream(stream);
+
+		    Assert.NotNull(image);
+		    Assert.True(image.Width > 0);
+		    Assert.True(image.Height > 0);
+	    }
+	    // Stream is disposed here, but image should remain valid due to the fix
+    }
 
 	private class NonSeekableReadOnlyStream(Stream stream) : Stream
 	{


### PR DESCRIPTION
### Description of Change

The issue indicates that the Android implementation of `PlatformImage.FromStream()` was causing app crashes in release builds when loading images from streams, particularly when using embedded resources via `GetManifestResourceStream()`.

The issue occurred because the stream could be disposed or become invalid before `BitmapFactory.DecodeStream() `completed reading the data. Applied the same defensive pattern used in the generic PlatformImage implementation and other platforms, copy the stream data to memory before processing to ensure all data is available before native decoding begins.

Added test coverage for stream disposal scenarios, including the exact scenario from the reported issue. Creating tests also notice that the method to get a PNG dimensions was not correct. Fixed the PNG dimension parsing in the generic PlatformImage implementation, was reading wrong byte positions.

### Issues Fixed

Fixes #30783 
