### PR TITLE
Revert part of #30777 to allow empty strings to be converted to PointCollection

### DIFF
--- a/src/Controls/src/Core/Shapes/PointCollectionConverter.cs
+++ b/src/Controls/src/Core/Shapes/PointCollectionConverter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.Shapes
 				return (PointCollection)pointArray;
 			}
 
-			var strValue = value.ToString();
+			var strValue = value?.ToString() ?? string.Empty;
 
 			string[] points = strValue.Split(new char[] { ' ', ',' });
 			var pointCollection = new PointCollection();

--- a/src/Controls/src/Core/Shapes/PointCollectionConverter.cs
+++ b/src/Controls/src/Core/Shapes/PointCollectionConverter.cs
@@ -23,13 +23,9 @@ namespace Microsoft.Maui.Controls.Shapes
 				return (PointCollection)pointArray;
 			}
 
-			var strValue = value?.ToString();
-			if (string.IsNullOrWhiteSpace(strValue))
-			{
-				throw new InvalidOperationException("Cannot convert null or empty string into PointCollection.");
-			}
+			var strValue = value.ToString();
 
-			string[] points = strValue!.Split(new char[] { ' ', ',' });
+			string[] points = strValue.Split(new char[] { ' ', ',' });
 			var pointCollection = new PointCollection();
 			double x = 0;
 			bool hasX = false;


### PR DESCRIPTION


<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The PR #30777 added an additional check that may be incorrect and is now filing tests. Regardless of perfect code, this behavior should be reverted until an investigation is done.

However, I think that the change was more to fix the nullability warnings and the better fix may have been to remove the `?` from the ToString part.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Reverts part of https://github.com/dotnet/maui/pull/30777

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
