### PR TITLE
[BlazorWebView] Add the new WebView Initialization events

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -29,6 +29,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			Logger.CreatingAndroidWebkitWebView();
 
+			// Invoke the WebViewInitializing event to allow custom configuration of the web view
+			var initializingArgs = new WebViewInitializationStartedEventArgs();
+			VirtualView.WebViewInitializationStarted(initializingArgs);
+
 #pragma warning disable CA1416, CA1412, CA1422 // Validate platform compatibility
 			var blazorAndroidWebView = new BlazorAndroidWebView(Context!)
 			{
@@ -54,6 +58,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			_webChromeClient = new BlazorWebChromeClient();
 			blazorAndroidWebView.SetWebChromeClient(_webChromeClient);
+
+			// Invoke the WebViewInitialized event to signal that the web view has been initialized
+			var initializedArgs = new WebViewInitializationCompletedEventArgs(blazorAndroidWebView, blazorAndroidWebView.Settings!);
+			VirtualView?.WebViewInitializationCompleted(initializedArgs);
 
 			Logger.CreatedAndroidWebkitWebView();
 
@@ -140,11 +148,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = PlatformView,
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -59,11 +59,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <summary>
 		/// Raised before the web view is initialized. On some platforms this enables customizing the web view configuration.
 		/// </summary>
+		[Obsolete("Use WebViewInitializing instead.")]
 		public event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
 
 		/// <summary>
 		/// Raised after the web view is initialized but before any component has been rendered. The event arguments provide the instance of the platform-specific web view control.
 		/// </summary>
+		[Obsolete("Use WebViewInitialized instead.")]
 		public event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
 
 		/// <summary>
@@ -77,6 +79,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// method to provide a response to the request.
 		/// </summary>
 		public event EventHandler<WebViewWebResourceRequestedEventArgs>? WebResourceRequested;
+
+		/// <summary>
+		/// Raised when the web view is initializing. This event allows the application to perform additional configuration.
+		/// </summary>
+		public event EventHandler<WebViewInitializingEventArgs>? WebViewInitializing;
+
+		/// <summary>
+		/// Raised when the web view has been initialized.
+		/// </summary>
+		public event EventHandler<WebViewInitializedEventArgs>? WebViewInitialized;
 
 		/// <inheritdoc />
 #if ANDROID
@@ -115,10 +127,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			UrlLoading?.Invoke(this, args);
 
 		/// <inheritdoc />
+		[Obsolete("Use IInitializationAwareWebView.WebViewInitializationStarted instead.")]
 		void IBlazorWebView.BlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
 			BlazorWebViewInitializing?.Invoke(this, args);
 
 		/// <inheritdoc />
+		[Obsolete("Use IInitializationAwareWebView.WebViewInitializationCompleted instead.")]
 		void IBlazorWebView.BlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
 			BlazorWebViewInitialized?.Invoke(this, args);
 
@@ -129,6 +143,22 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var e = new WebViewWebResourceRequestedEventArgs(platformArgs);
 			WebResourceRequested?.Invoke(this, e);
 			return e.Handled;
+		}
+
+		/// <inheritdoc/>
+		void IInitializationAwareWebView.WebViewInitializationStarted(WebViewInitializationStartedEventArgs args)
+		{
+			var platformArgs = new PlatformWebViewInitializingEventArgs(args);
+			var e = new WebViewInitializingEventArgs(platformArgs);
+			WebViewInitializing?.Invoke(this, e);
+		}
+
+		/// <inheritdoc/>
+		void IInitializationAwareWebView.WebViewInitializationCompleted(WebViewInitializationCompletedEventArgs args)
+		{
+			var platformArgs = new PlatformWebViewInitializedEventArgs(args);
+			var e = new WebViewInitializedEventArgs(platformArgs);
+			WebViewInitialized?.Invoke(this, e);
 		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// <summary>
 	/// Defines a contract for a view that renders Blazor content.
 	/// </summary>
-	public interface IBlazorWebView : IView, IWebRequestInterceptingWebView
+	public interface IBlazorWebView : IView, IWebRequestInterceptingWebView, IInitializationAwareWebView
 	{
 		/// <summary>
 		/// Gets the path to the HTML file to render.
@@ -54,12 +54,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// Notifies the control that the BlazorWebViewInitializing event should be raised with the specified <paramref name="args"/>.
 		/// </summary>
 		/// <param name="args">The arguments for the event.</param>
+		[Obsolete("Use WebViewInitializationStarted instead.")]
 		void BlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args);
 
 		/// <summary>
 		/// Notifies the control that the BlazorWebViewInitialized event should be raised with the specified <paramref name="args"/>.
 		/// </summary>
 		/// <param name="args">The arguments for the event.</param>
+		[Obsolete("Use WebViewInitializationCompleted instead.")]
 		void BlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
-#nullable enable
+﻿#nullable enable
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebResourceRequested -> System.EventHandler<Microsoft.Maui.Controls.WebViewWebResourceRequestedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitialized -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitializing -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializingEventArgs!>?

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
-#nullable enable
+﻿#nullable enable
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebResourceRequested -> System.EventHandler<Microsoft.Maui.Controls.WebViewWebResourceRequestedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitialized -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitializing -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializingEventArgs!>?

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
-#nullable enable
+﻿#nullable enable
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebResourceRequested -> System.EventHandler<Microsoft.Maui.Controls.WebViewWebResourceRequestedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitialized -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitializing -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializingEventArgs!>?

--- a/src/BlazorWebView/src/Maui/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
-#nullable enable
+﻿#nullable enable
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebResourceRequested -> System.EventHandler<Microsoft.Maui.Controls.WebViewWebResourceRequestedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitialized -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitializing -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializingEventArgs!>?

--- a/src/BlazorWebView/src/Maui/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
-#nullable enable
+﻿#nullable enable
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebResourceRequested -> System.EventHandler<Microsoft.Maui.Controls.WebViewWebResourceRequestedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitialized -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.WebViewInitializing -> System.EventHandler<Microsoft.Maui.Controls.WebViewInitializingEventArgs!>?

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -77,10 +77,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				config.MediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypes.None;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs()
 			{
 				Configuration = config
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			config.UserContentController.AddScriptMessageHandler(new WebViewScriptMessageHandler(MessageReceived), "webwindowinterop");
 			config.UserContentController.AddUserScript(new WKUserScript(
@@ -88,6 +90,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			// iOS WKWebView doesn't allow handling 'http'/'https' schemes, so we use the fake 'app' scheme
 			config.SetUrlSchemeHandler(new SchemeHandler(this), urlScheme: "app");
+
+			// Invoke the WebViewInitializing event to allow custom configuration of the web view
+			var initializingArgs = new WebViewInitializationStartedEventArgs(config);
+			VirtualView.WebViewInitializationStarted(initializingArgs);
 
 			var webview = new WKWebView(RectangleF.Empty, config)
 			{
@@ -107,10 +113,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				}
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = webview
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Disable bounce scrolling to make Blazor apps feel more native
 			if (webview.ScrollView != null)
@@ -119,6 +127,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				webview.ScrollView.AlwaysBounceVertical = false;
 				webview.ScrollView.AlwaysBounceHorizontal = false;
 			}
+
+			// Invoke the WebViewInitialized event to signal that the web view has been initialized
+			var initializedArgs = new WebViewInitializationCompletedEventArgs(webview, config);
+			VirtualView.WebViewInitializationCompleted(initializedArgs);
 
 			Logger.CreatedWebKitWKWebView();
 

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
@@ -22,6 +22,9 @@ namespace Microsoft.AspNetCore.Components.WebView
 	/// <summary>
 	/// Allows configuring the underlying web view after it has been initialized.
 	/// </summary>
+#if WEBVIEW2_MAUI
+	[Obsolete("Use WebViewInitializedEventArgs instead.")]
+#endif
 	public class BlazorWebViewInitializedEventArgs : EventArgs
 	{
 #nullable disable

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
@@ -21,6 +21,9 @@ namespace Microsoft.AspNetCore.Components.WebView
 	/// <summary>
 	/// Allows configuring the underlying web view when the application is initializing.
 	/// </summary>
+#if WEBVIEW2_MAUI
+	[Obsolete("Use WebViewInitializingEventArgs instead.")]
+#endif
 	public class BlazorWebViewInitializingEventArgs : EventArgs
 	{
 #nullable disable


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This will give a similar API between HybridWebView and BlazorWebView.

However, this will mean the .NET MAUI version of Blazor will differ when comparing with WPF or WinForms

The ordering of events matches the HybridWebView and is not a 1:1 replacement. However, the events are more for configuring the web view itself.

* Windows: Events are basically the same place, but the Initializing fires just before the old event and the Initialized fires slightly after
* iOS / Mac Catalyst: Mostly the sample place, but Initializing and Initialized after all the configuration defaults have been set
* Android: A fair bit earlier, the Initializing event fires before any work is done and Initialized fires after the configuration defaults are set on the web view, but potentially long before the old Initialized event fires. The old event would fire both events only once BOTH `RootComponents` and `HostPage` properties were set. But this "rule" seems to only be on Android.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

An extension of https://github.com/dotnet/maui/pull/29531

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
