### PR TITLE
[Net10.0] Toolbar item - IconColor property

### DIFF
--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/ToolbarItemExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/ToolbarItemExtensions.cs
@@ -146,10 +146,30 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 					}
 					item.IconImageSource.LoadImage(mauiContext, result =>
 					{
-						Image = item.IconImageSource is not FontImageSource
-							? result?.Value.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal)
-							: result?.Value;
 						Style = UIBarButtonItemStyle.Plain;
+
+						if (result?.Value is null)
+						{
+							Image = null;
+							return;
+						}
+
+						Image = item.IconImageSource is not FontImageSource
+							? result.Value.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal)
+							: result.Value;
+
+						if (item.IconColor is Color iconColor)
+						{
+							if (item.IconImageSource is FontImageSource fontImageSource && fontImageSource.Color is null)
+							{
+								TintColor = iconColor.ToPlatform();
+							}
+							else
+							{
+								Image = result.Value.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+								TintColor = iconColor.ToPlatform();
+							}
+						}
 					});
 				}
 			}

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -376,8 +376,13 @@ namespace Microsoft.Maui.Controls.Platform
 					using (var newDrawable = constant!.NewDrawable())
 					using (var iconDrawable = newDrawable.Mutate())
 					{
-						if (tintColor != null)
-							iconDrawable.SetColorFilter(tintColor.ToPlatform(Colors.White), FilterMode.SrcAtop);
+						var iconColor = toolBarItem.IconColor ?? tintColor;
+
+						if (iconColor is not null)
+						{
+							iconDrawable.SetColorFilter(iconColor.ToPlatform(Colors.White), FilterMode.SrcAtop);
+						}
+
 
 						if (!menuItem.IsEnabled)
 						{

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 const Microsoft.Maui.Controls.BrushTypeConverter.Hsl = "hsl" -> string!
 const Microsoft.Maui.Controls.BrushTypeConverter.Hsla = "hsla" -> string!
 const Microsoft.Maui.Controls.BrushTypeConverter.LinearGradient = "linear-gradient" -> string!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+~static readonly Microsoft.Maui.Controls.ToolbarItem.IconColorProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.ToolbarItem.IconColor.set -> void
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void

--- a/src/Controls/src/Core/Toolbar/ToolbarItem.cs
+++ b/src/Controls/src/Core/Toolbar/ToolbarItem.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls;
 
@@ -16,6 +17,10 @@ public class ToolbarItem : MenuItem
 	});
 
 	static readonly BindableProperty PriorityProperty = BindableProperty.Create(nameof(Priority), typeof(int), typeof(ToolbarItem), 0);
+
+#pragma warning disable RS0016
+	public static readonly BindableProperty IconColorProperty = BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(ToolbarItem), null,
+		propertyChanged: (bindable, oldValue, newValue) => ((ToolbarItem)bindable).UpdateImageSource());
 
 	/// <summary>
 	/// Constructs and initializes a new instance of the ToolbarItem class.
@@ -64,5 +69,19 @@ public class ToolbarItem : MenuItem
 	{
 		get { return (int)GetValue(PriorityProperty); }
 		set { SetValue(PriorityProperty, value); }
+	}
+
+	/// <summary>
+	/// Gets or sets the color of the IconImage ToolbarItem element. This is a bindable property.
+	/// </summary>
+	public Color IconColor
+	{
+		get { return (Color)GetValue(IconColorProperty); }
+		set { SetValue(IconColorProperty, value); }
+	}
+
+	void UpdateImageSource()
+	{
+		OnPropertyChanged(IconImageSourceProperty.PropertyName);
 	}
 }

--- a/src/Controls/src/Core/Toolbar/ToolbarItem.cs
+++ b/src/Controls/src/Core/Toolbar/ToolbarItem.cs
@@ -18,7 +18,6 @@ public class ToolbarItem : MenuItem
 
 	static readonly BindableProperty PriorityProperty = BindableProperty.Create(nameof(Priority), typeof(int), typeof(ToolbarItem), 0);
 
-#pragma warning disable RS0016
 	public static readonly BindableProperty IconColorProperty = BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(ToolbarItem), null,
 		propertyChanged: (bindable, oldValue, newValue) => ((ToolbarItem)bindable).UpdateImageSource());
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30818.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30818.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue30818">
+    <ShellContent>
+        <ContentPage>
+            <ContentPage.ToolbarItems>
+                <ToolbarItem IconColor="Blue"
+                             IconImageSource="groceries.png"/>
+                <ToolbarItem IconColor="Green"
+                             IconImageSource="coffee.png"/>
+            </ContentPage.ToolbarItems>
+
+            <Label Text="This is a test page for Issue 30818"
+                   AutomationId="Label"
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center"/>
+
+        </ContentPage>
+    </ShellContent>
+
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30818.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30818.xaml.cs
@@ -1,0 +1,11 @@
+﻿namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 30818, "ToolbarItem - Icon Color property", PlatformAffected.Android | PlatformAffected.iOS)]
+	public partial class Issue30818 : Shell
+	{
+		public Issue30818()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30818.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30818.cs
@@ -1,0 +1,22 @@
+﻿#if TEST_FAILS_ON_WINDOWS // It is not implemented on Windows yet
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30818 : _IssuesUITest
+{
+	public Issue30818(TestDevice device) : base(device) { }
+
+	public override string Issue => "ToolbarItem - Icon Color property";
+
+	[Test]
+	[Category(UITestCategories.ToolbarItem)]
+	public void ToolbarItemIconColorShouldBeApplied()
+	{
+		App.WaitForElement("Label");
+		VerifyScreenshot();
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR introduces a new `IconColor` bindable property for `ToolbarItem` that allows developers to customize the color of toolbar icons directly in XAML or code, bringing more flexibility and platform consistency to the appearance of toolbars.

```xaml
<ContentPage.ToolbarItems>
       <ToolbarItem  IconColor="Blue">
              <ToolbarItem.IconImageSource>
                     <FileImageSource File="dotnet_bot.png"/>
              </ToolbarItem.IconImageSource>
       </ToolbarItem>
</ContentPage.ToolbarItems>
```

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/30818
Fixes https://github.com/dotnet/maui/issues/30990

<video src="https://github.com/user-attachments/assets/ae82da90-da85-403b-92f6-d3bf6b8568e3"/>

I will implement it on Android if this is what we actually want



