### PR TITLE
[Testing] Fixed Test cases TimePickerFeatureTests failure in PR 30696 - [07/21/2025] Candidate

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/TimePickerFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/TimePickerFeatureTests.cs
@@ -18,6 +18,8 @@ public class TimePickerFeatureTests : UITest
 		App.NavigateToGallery(TimePickerFeatureMatrix);
 	}
 
+#if TEST_FAILS_ON_IOS // Issue Link - https://github.com/dotnet/maui/issues/30837
+
 #if TEST_FAILS_ON_CATALYST
 
 	[Test, Order(1)]
@@ -33,76 +35,6 @@ public class TimePickerFeatureTests : UITest
 #else
 		VerifyScreenshot();
 #endif
-	}
-#endif
-
-#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST
-
-	[Test, Order(2)]
-	[Category(UITestCategories.TimePicker)]
-	public void TimePicker_ModifyOldTimeAndNewTime_VerifyVisualState()
-	{
-#if ANDROID
-		App.WaitForElement("OK");
-		App.Tap("OK");
-		App.WaitForElement("TimePickerControl");
-		App.Tap("TimePickerControl");
-		App.WaitForElement(AppiumQuery.ByAccessibilityId("6"));
-		App.Tap(AppiumQuery.ByAccessibilityId("6"));
-		App.WaitForElement("OK");
-		App.Tap("OK");
-#elif WINDOWS
-        App.WaitForElement("AcceptButton");
-        App.Tap("AcceptButton");
-        App.WaitForElement("TimePickerControl");
-        App.Tap("TimePickerControl");
-        App.WaitForElement("6");
-        App.Tap("6");
-        App.WaitForElement("AcceptButton");
-        App.Tap("AcceptButton");
-#endif
-		Assert.That(App.WaitForElement("NewTimeSelectedLabel").GetText(), Is.EqualTo("06:00:00"));
-		Assert.That(App.WaitForElement("OldTimeSelectedLabel").GetText(), Is.EqualTo("10:00:00"));
-		VerifyScreenshot();
-	}
-#endif
-
-#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST
-
-	[Test, Order(3)]
-	[Category(UITestCategories.TimePicker)]
-	public void TimePicker_OldTimeAndNewTime_VerifyVisualState()
-	{
-#if ANDROID
-		App.WaitForElement("TimePickerControl");
-		App.Tap("TimePickerControl");
-		App.WaitForElement(AppiumQuery.ByAccessibilityId("7"));
-		App.Tap(AppiumQuery.ByAccessibilityId("7"));
-		App.WaitForElement("OK");
-		App.Tap("OK");
-		App.WaitForElement("TimePickerControl");
-		App.Tap("TimePickerControl");
-		App.WaitForElement(AppiumQuery.ByAccessibilityId("8"));
-		App.Tap(AppiumQuery.ByAccessibilityId("8"));
-		App.WaitForElement("Cancel");
-		App.Tap("Cancel");
-#elif WINDOWS
-        App.WaitForElement("TimePickerControl");
-        App.Tap("TimePickerControl");
-        App.WaitForElement("7");
-        App.Tap("7");
-        App.WaitForElement("AcceptButton");
-        App.Tap("AcceptButton");
-        App.WaitForElement("TimePickerControl");
-        App.Tap("TimePickerControl");
-        App.WaitForElement("8");
-        App.Tap("8");
-        App.WaitForElement("DismissButton");
-        App.Tap("DismissButton");
-#endif
-		Assert.That(App.WaitForElement("NewTimeSelectedLabel").GetText(), Is.EqualTo("07:00:00"));
-		Assert.That(App.WaitForElement("OldTimeSelectedLabel").GetText(), Is.EqualTo("06:00:00"));
-		VerifyScreenshot();
 	}
 #endif
 
@@ -122,23 +54,6 @@ public class TimePickerFeatureTests : UITest
 		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
 		VerifyScreenshot();
 	}
-#endif
-
-#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/30192
-
-    [Test, Order(5)]
-    [Category(UITestCategories.TimePicker)]
-    public void TimePicker_SetFlowDirectionAndTime_VerifyVisualState()
-    {
-        App.WaitForElement("Options");
-        App.Tap("Options");
-        App.WaitForElement("FlowDirectionRTL");
-        App.Tap("FlowDirectionRTL");
-        App.WaitForElement("Apply");
-        App.Tap("Apply");
-        App.WaitForElementTillPageNavigationSettled("TimePickerControl");
-        VerifyScreenshot();
-    }
 #endif
 
 #if TEST_FAILS_ON_CATALYST
@@ -199,35 +114,6 @@ public class TimePickerFeatureTests : UITest
 
 #if TEST_FAILS_ON_CATALYST
 
-	[Test, Order(9)]
-	[Category(UITestCategories.TimePicker)]
-	public void TimePicker_SetFontAttributesAndFormat_VerifyVisualState()
-	{
-		App.WaitForElement("Options");
-		App.Tap("Options");
-		App.WaitForElement("FontAttributesItalicButton");
-		App.Tap("FontAttributesItalicButton");
-		App.WaitForElement("FormatEntry");
-		App.ClearText("FormatEntry");
-		App.EnterText("FormatEntry", "HH:mm");
-		App.WaitForElement("SetFormatButton");
-		App.Tap("SetFormatButton");
-		App.WaitForElement("TimeEntry");
-		App.ClearText("TimeEntry");
-		App.EnterText("TimeEntry", "17:00");
-		App.WaitForElement("SetTimeButton");
-		App.Tap("SetTimeButton");
-		App.WaitForElement("Apply");
-		App.Tap("Apply");
-		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
-		App.WaitForElement("CultureFormatLabel");
-		App.Tap("CultureFormatLabel");
-		VerifyScreenshot();
-	}
-#endif
-
-#if TEST_FAILS_ON_CATALYST
-
 	[Test, Order(10)]
 	[Category(UITestCategories.TimePicker)]
 	public void TimePicker_SetFontFamilyAndFontSize_VerifyVisualState()
@@ -246,60 +132,6 @@ public class TimePickerFeatureTests : UITest
 	}
 #endif
 
-#if TEST_FAILS_ON_CATALYST
-
-	[Test, Order(11)]
-	[Category(UITestCategories.TimePicker)]
-	public void TimePicker_SetFontFamilyAndFormat_VerifyVisualState()
-	{
-		App.WaitForElement("Options");
-		App.Tap("Options");
-		App.WaitForElement("FontFamilyDokdoButton");
-		App.Tap("FontFamilyDokdoButton");
-		App.WaitForElement("FormatEntry");
-		App.ClearText("FormatEntry");
-		App.EnterText("FormatEntry", "HH:mm");
-		App.WaitForElement("SetFormatButton");
-		App.Tap("SetFormatButton");
-		App.WaitForElement("TimeEntry");
-		App.ClearText("TimeEntry");
-		App.EnterText("TimeEntry", "17:00");
-		App.WaitForElement("SetTimeButton");
-		App.Tap("SetTimeButton");
-		App.WaitForElement("Apply");
-		App.Tap("Apply");
-		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
-		App.WaitForElement("CultureFormatLabel");
-		App.Tap("CultureFormatLabel");
-		VerifyScreenshot();
-	}
-#endif
-
-#if TEST_FAILS_ON_CATALYST
-
-	[Test, Order(12)]
-	[Category(UITestCategories.TimePicker)]
-	public void TimePicker_SetFontSizeAndFormat_VerifyVisualState()
-	{
-		App.WaitForElement("Options");
-		App.Tap("Options");
-		App.WaitForElement("FontSizeEntry");
-		App.ClearText("FontSizeEntry");
-		App.EnterText("FontSizeEntry", "20");
-		App.WaitForElement("FormatEntry");
-		App.ClearText("FormatEntry");
-		App.EnterText("FormatEntry", "hh:mm");
-		App.WaitForElement("SetFormatButton");
-		App.Tap("SetFormatButton");
-		App.WaitForElement("Apply");
-		App.Tap("Apply");
-		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
-		App.WaitForElement("CultureFormatLabel");
-		App.Tap("CultureFormatLabel");
-		VerifyScreenshot();
-	}
-#endif
-
 	[Test, Order(13)]
 	[Category(UITestCategories.TimePicker)]
 	public void TimePicker_SetTimeAndIsEnabled_VerifyVisualState()
@@ -313,19 +145,6 @@ public class TimePickerFeatureTests : UITest
 		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
 		App.Tap("TimePickerControl");
 		VerifyScreenshot();
-	}
-
-	[Test, Order(14)]
-	[Category(UITestCategories.TimePicker)]
-	public void TimePicker_SetTimeAndIsVisible_VerifyVisualState()
-	{
-		App.WaitForElement("Options");
-		App.Tap("Options");
-		App.WaitForElement("IsVisibleFalseButton");
-		App.Tap("IsVisibleFalseButton");
-		App.WaitForElement("Apply");
-		App.Tap("Apply");
-		App.WaitForNoElement("TimePickerControl");
 	}
 
 #if TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/29812
@@ -453,6 +272,193 @@ public class TimePickerFeatureTests : UITest
 		VerifyScreenshot();
 	}
 #endif
+
+#endif
+
+#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST
+
+	[Test, Order(2)]
+	[Category(UITestCategories.TimePicker)]
+	public void TimePicker_ModifyOldTimeAndNewTime_VerifyVisualState()
+	{
+#if ANDROID
+		App.WaitForElement("OK");
+		App.Tap("OK");
+		App.WaitForElement("TimePickerControl");
+		App.Tap("TimePickerControl");
+		App.WaitForElement(AppiumQuery.ByAccessibilityId("6"));
+		App.Tap(AppiumQuery.ByAccessibilityId("6"));
+		App.WaitForElement("OK");
+		App.Tap("OK");
+#elif WINDOWS
+        App.WaitForElement("AcceptButton");
+        App.Tap("AcceptButton");
+        App.WaitForElement("TimePickerControl");
+        App.Tap("TimePickerControl");
+        App.WaitForElement("6");
+        App.Tap("6");
+        App.WaitForElement("AcceptButton");
+        App.Tap("AcceptButton");
+#endif
+		Assert.That(App.WaitForElement("NewTimeSelectedLabel").GetText(), Is.EqualTo("06:00:00"));
+		Assert.That(App.WaitForElement("OldTimeSelectedLabel").GetText(), Is.EqualTo("10:00:00"));
+		VerifyScreenshot();
+	}
+#endif
+
+#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST
+
+	[Test, Order(3)]
+	[Category(UITestCategories.TimePicker)]
+	public void TimePicker_OldTimeAndNewTime_VerifyVisualState()
+	{
+#if ANDROID
+		App.WaitForElement("TimePickerControl");
+		App.Tap("TimePickerControl");
+		App.WaitForElement(AppiumQuery.ByAccessibilityId("7"));
+		App.Tap(AppiumQuery.ByAccessibilityId("7"));
+		App.WaitForElement("OK");
+		App.Tap("OK");
+		App.WaitForElement("TimePickerControl");
+		App.Tap("TimePickerControl");
+		App.WaitForElement(AppiumQuery.ByAccessibilityId("8"));
+		App.Tap(AppiumQuery.ByAccessibilityId("8"));
+		App.WaitForElement("Cancel");
+		App.Tap("Cancel");
+#elif WINDOWS
+        App.WaitForElement("TimePickerControl");
+        App.Tap("TimePickerControl");
+        App.WaitForElement("7");
+        App.Tap("7");
+        App.WaitForElement("AcceptButton");
+        App.Tap("AcceptButton");
+        App.WaitForElement("TimePickerControl");
+        App.Tap("TimePickerControl");
+        App.WaitForElement("8");
+        App.Tap("8");
+        App.WaitForElement("DismissButton");
+        App.Tap("DismissButton");
+#endif
+		Assert.That(App.WaitForElement("NewTimeSelectedLabel").GetText(), Is.EqualTo("07:00:00"));
+		Assert.That(App.WaitForElement("OldTimeSelectedLabel").GetText(), Is.EqualTo("06:00:00"));
+		VerifyScreenshot();
+	}
+#endif
+
+
+
+#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/30192
+
+    [Test, Order(5)]
+    [Category(UITestCategories.TimePicker)]
+    public void TimePicker_SetFlowDirectionAndTime_VerifyVisualState()
+    {
+        App.WaitForElement("Options");
+        App.Tap("Options");
+        App.WaitForElement("FlowDirectionRTL");
+        App.Tap("FlowDirectionRTL");
+        App.WaitForElement("Apply");
+        App.Tap("Apply");
+        App.WaitForElementTillPageNavigationSettled("TimePickerControl");
+        VerifyScreenshot();
+    }
+#endif
+
+#if TEST_FAILS_ON_CATALYST
+
+	[Test, Order(9)]
+	[Category(UITestCategories.TimePicker)]
+	public void TimePicker_SetFontAttributesAndFormat_VerifyVisualState()
+	{
+		App.WaitForElement("Options");
+		App.Tap("Options");
+		App.WaitForElement("FontAttributesItalicButton");
+		App.Tap("FontAttributesItalicButton");
+		App.WaitForElement("FormatEntry");
+		App.ClearText("FormatEntry");
+		App.EnterText("FormatEntry", "HH:mm");
+		App.WaitForElement("SetFormatButton");
+		App.Tap("SetFormatButton");
+		App.WaitForElement("TimeEntry");
+		App.ClearText("TimeEntry");
+		App.EnterText("TimeEntry", "17:00");
+		App.WaitForElement("SetTimeButton");
+		App.Tap("SetTimeButton");
+		App.WaitForElement("Apply");
+		App.Tap("Apply");
+		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
+		App.WaitForElement("CultureFormatLabel");
+		App.Tap("CultureFormatLabel");
+		VerifyScreenshot();
+	}
+#endif
+
+#if TEST_FAILS_ON_CATALYST
+
+	[Test, Order(11)]
+	[Category(UITestCategories.TimePicker)]
+	public void TimePicker_SetFontFamilyAndFormat_VerifyVisualState()
+	{
+		App.WaitForElement("Options");
+		App.Tap("Options");
+		App.WaitForElement("FontFamilyDokdoButton");
+		App.Tap("FontFamilyDokdoButton");
+		App.WaitForElement("FormatEntry");
+		App.ClearText("FormatEntry");
+		App.EnterText("FormatEntry", "HH:mm");
+		App.WaitForElement("SetFormatButton");
+		App.Tap("SetFormatButton");
+		App.WaitForElement("TimeEntry");
+		App.ClearText("TimeEntry");
+		App.EnterText("TimeEntry", "17:00");
+		App.WaitForElement("SetTimeButton");
+		App.Tap("SetTimeButton");
+		App.WaitForElement("Apply");
+		App.Tap("Apply");
+		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
+		App.WaitForElement("CultureFormatLabel");
+		App.Tap("CultureFormatLabel");
+		VerifyScreenshot();
+	}
+#endif
+
+#if TEST_FAILS_ON_CATALYST
+
+	[Test, Order(12)]
+	[Category(UITestCategories.TimePicker)]
+	public void TimePicker_SetFontSizeAndFormat_VerifyVisualState()
+	{
+		App.WaitForElement("Options");
+		App.Tap("Options");
+		App.WaitForElement("FontSizeEntry");
+		App.ClearText("FontSizeEntry");
+		App.EnterText("FontSizeEntry", "20");
+		App.WaitForElement("FormatEntry");
+		App.ClearText("FormatEntry");
+		App.EnterText("FormatEntry", "hh:mm");
+		App.WaitForElement("SetFormatButton");
+		App.Tap("SetFormatButton");
+		App.WaitForElement("Apply");
+		App.Tap("Apply");
+		App.WaitForElementTillPageNavigationSettled("TimePickerControl");
+		App.WaitForElement("CultureFormatLabel");
+		App.Tap("CultureFormatLabel");
+		VerifyScreenshot();
+	}
+#endif
+
+	[Test, Order(14)]
+	[Category(UITestCategories.TimePicker)]
+	public void TimePicker_SetTimeAndIsVisible_VerifyVisualState()
+	{
+		App.WaitForElement("Options");
+		App.Tap("Options");
+		App.WaitForElement("IsVisibleFalseButton");
+		App.Tap("IsVisibleFalseButton");
+		App.WaitForElement("Apply");
+		App.Tap("Apply");
+		App.WaitForNoElement("TimePickerControl");
+	}
 
 #if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/30197
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/TimePickerFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/TimePickerFeatureTests.cs
@@ -345,8 +345,6 @@ public class TimePickerFeatureTests : UITest
 	}
 #endif
 
-
-
 #if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/30192
 
     [Test, Order(5)]


### PR DESCRIPTION
This PR addresses the UI test image failures that occurred in the inflight/candidate branch https://github.com/dotnet/maui/pull/30696 and includes updates to improve rendering and test stability across platforms.

- In TimePickerFeatureTests, added a failing condition with an issue link for iOS test cases due to the TimePicker bug https://github.com/dotnet/maui/issues/30837.

### Test cases:
- TimePicker_InitialState_VerifyVisualState
- TimePicker_SetTimeAndCharacterSpacing_VerifyVisualState
- TimePicker_SetTimeAndTextColor_VerifyVisualState
- TimePicker_SetFontAttributesAndFontFamily_VerifyVisualState
- TimePicker_SetFontAttributesAndFontSize_VerifyVisualState
- TimePicker_SetFontFamilyAndFontSize_VerifyVisualState
- TimePicker_SetTimeAndIsEnabled_VerifyVisualState
- TimePicker_SetShadow_VerifyVisualState
- TimePicker_SetFormat_t_AndTime_VerifyVisualState
- TimePicker_SetFormatTAndTime_VerifyVisualState
- TimePicker_SetFormat_T_WithFontAttributes_VerifyVisualState
- TimePicker_SetFormat_T_WithFontFamily_VerifyVisualState
- TimePicker_SetFormat_T_WithFontSize_VerifyVisualState