### PR TITLE
[Android] Shell TitleView's child elements are cleared too early - fix

### DIFF
--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -807,11 +807,12 @@ namespace Microsoft.Maui.Controls
 
 			PresentedPageDisappearing();
 			_navStack.Remove(page);
-			PresentedPageAppearing();
 
 			InvokeNavigationRequest(args);
 			if (args.Task != null)
 				await args.Task;
+
+			PresentedPageAppearing();
 
 			if (_handlerBasedNavigationCompletionSource?.Task != null)
 				await _handlerBasedNavigationCompletionSource.Task;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
In `PoopToRootAsync`, we invoke `PresentedPageAppearing` at the end of the method - after awaiting InvokeNavigationRequest. I’m wondering if we should follow the same pattern in `OnPopAsync`. Doing so would ensure the toolbar is properly updated, and it might also resolve other related issues that haven’t been reported yet.

https://github.com/kubaflo/maui/blob/3c2e4d25d218e51bbc60117851782c404f4e7462/src/Controls/src/Core/Shell/ShellSection.cs#L874-L891

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/30834

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/60e07f55-e9e5-41e0-b8f2-fe88b642554f" width="300px"></video>|<video src="https://github.com/user-attachments/assets/b5ef2b35-e4ae-44b8-99dd-7b63aaf60211" width="300px"></video>|
