### PR TITLE
[NET 10/ WinUI] Open item template context

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemTemplateContext.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemTemplateContext.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	internal class ItemTemplateContext
+	public class ItemTemplateContext
 	{
 		readonly WeakReference<BindableObject> _container;
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public double ItemWidth { get; }
 		public Thickness ItemSpacing { get; }
 
-		public ItemTemplateContext(DataTemplate formsDataTemplate, object item, BindableObject container,
+		internal ItemTemplateContext(DataTemplate formsDataTemplate, object item, BindableObject container,
 			double? height = null, double? width = null, Thickness? itemSpacing = null, IMauiContext mauiContext = null)
 		{
 			FormsDataTemplate = formsDataTemplate;

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -30,10 +30,6 @@ Microsoft.Maui.Controls.ContentPage.SafeAreaEdges.get -> Microsoft.Maui.SafeArea
 Microsoft.Maui.Controls.ContentPage.SafeAreaEdges.set -> void
 Microsoft.Maui.Controls.ContentPresenter.CascadeInputTransparent.get -> bool
 Microsoft.Maui.Controls.ContentPresenter.CascadeInputTransparent.set -> void
-Microsoft.Maui.Controls.Platform.MauiViewPager
-Microsoft.Maui.Controls.Platform.MauiViewPager.EnableGesture.get -> bool
-Microsoft.Maui.Controls.Platform.MauiViewPager.EnableGesture.set -> void
-Microsoft.Maui.Controls.Platform.MauiViewPager.MauiViewPager(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
 ~Microsoft.Maui.Controls.ContentPresenter.Children.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Element>
 ~Microsoft.Maui.Controls.ContentPresenter.LowerChild(Microsoft.Maui.Controls.View view) -> void
 Microsoft.Maui.Controls.ContentPresenter.Padding.get -> Microsoft.Maui.Thickness
@@ -146,6 +142,12 @@ Microsoft.Maui.Controls.PickerClosedEventArgs
 Microsoft.Maui.Controls.PickerClosedEventArgs.PickerClosedEventArgs() -> void
 Microsoft.Maui.Controls.PickerOpenedEventArgs
 Microsoft.Maui.Controls.PickerOpenedEventArgs.PickerOpenedEventArgs() -> void
+Microsoft.Maui.Controls.Platform.MauiViewPager
+Microsoft.Maui.Controls.Platform.MauiViewPager.EnableGesture.get -> bool
+Microsoft.Maui.Controls.Platform.MauiViewPager.EnableGesture.set -> void
+~Microsoft.Maui.Controls.Platform.MauiViewPager.MauiViewPager(Android.Content.Context context) -> void
+~Microsoft.Maui.Controls.Platform.MauiViewPager.MauiViewPager(Android.Content.Context context, Android.Util.IAttributeSet attrs) -> void
+Microsoft.Maui.Controls.Platform.MauiViewPager.MauiViewPager(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
 Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.Popover = 5 -> Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle
 Microsoft.Maui.Controls.PlatformWebViewInitializedEventArgs
 Microsoft.Maui.Controls.PlatformWebViewInitializedEventArgs.Sender.get -> Android.Webkit.WebView!
@@ -159,8 +161,6 @@ Microsoft.Maui.Controls.PlatformWebViewWebResourceRequestedEventArgs.Response.se
 Microsoft.Maui.Controls.PlatformWebViewWebResourceRequestedEventArgs.Sender.get -> Android.Webkit.WebView!
 Microsoft.Maui.Controls.ScrollView.CascadeInputTransparent.get -> bool
 Microsoft.Maui.Controls.ScrollView.CascadeInputTransparent.set -> void
-~Microsoft.Maui.Controls.Platform.MauiViewPager.MauiViewPager(Android.Content.Context context) -> void
-~Microsoft.Maui.Controls.Platform.MauiViewPager.MauiViewPager(Android.Content.Context context, Android.Util.IAttributeSet attrs) -> void
 ~Microsoft.Maui.Controls.ScrollView.Children.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Element>
 ~Microsoft.Maui.Controls.ScrollView.LowerChild(Microsoft.Maui.Controls.View view) -> void
 Microsoft.Maui.Controls.ScrollView.Padding.get -> Microsoft.Maui.Thickness
@@ -325,6 +325,8 @@ override Microsoft.Maui.Controls.ListStringTypeConverter.CanConvertTo(System.Com
 override Microsoft.Maui.Controls.ListStringTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Controls.ListStringTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 override Microsoft.Maui.Controls.Picker.OnHandlerChanged() -> void
+~override Microsoft.Maui.Controls.Platform.MauiViewPager.OnInterceptTouchEvent(Android.Views.MotionEvent ev) -> bool
+~override Microsoft.Maui.Controls.Platform.MauiViewPager.OnTouchEvent(Android.Views.MotionEvent e) -> bool
 override Microsoft.Maui.Controls.ReferenceTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Controls.ReferenceTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.ReferenceTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
@@ -333,8 +335,6 @@ override Microsoft.Maui.Controls.RowDefinitionCollectionTypeConverter.CanConvert
 override Microsoft.Maui.Controls.RowDefinitionCollectionTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Controls.RowDefinitionCollectionTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Controls.RowDefinitionCollectionTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
-~override Microsoft.Maui.Controls.Platform.MauiViewPager.OnInterceptTouchEvent(Android.Views.MotionEvent ev) -> bool
-~override Microsoft.Maui.Controls.Platform.MauiViewPager.OnTouchEvent(Android.Views.MotionEvent e) -> bool
 ~override Microsoft.Maui.Controls.ScrollView.ComputeConstraintForView(Microsoft.Maui.Controls.View view) -> void
 override Microsoft.Maui.Controls.ScrollView.InvalidateLayout() -> void
 override Microsoft.Maui.Controls.ScrollView.Measure(double widthConstraint, double heightConstraint, Microsoft.Maui.Controls.MeasureFlags flags = Microsoft.Maui.Controls.MeasureFlags.None) -> Microsoft.Maui.SizeRequest

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,8 +1,4 @@
 ﻿#nullable enable
-Microsoft.Maui.Controls.Platform.ItemTemplateContext
-Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemHeight.get -> double
-Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemSpacing.get -> Microsoft.Maui.Thickness
-Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemWidth.get -> double
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
@@ -132,6 +128,14 @@ Microsoft.Maui.Controls.PickerClosedEventArgs
 Microsoft.Maui.Controls.PickerClosedEventArgs.PickerClosedEventArgs() -> void
 Microsoft.Maui.Controls.PickerOpenedEventArgs
 Microsoft.Maui.Controls.PickerOpenedEventArgs.PickerOpenedEventArgs() -> void
+Microsoft.Maui.Controls.Platform.ItemTemplateContext
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.Container.get -> Microsoft.Maui.Controls.BindableObject
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.FormsDataTemplate.get -> Microsoft.Maui.Controls.DataTemplate
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.Item.get -> object
+Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemHeight.get -> double
+Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemSpacing.get -> Microsoft.Maui.Thickness
+Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemWidth.get -> double
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.MauiContext.get -> Microsoft.Maui.IMauiContext
 Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.Popover = 5 -> Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle
 Microsoft.Maui.Controls.PlatformWebViewInitializedEventArgs
 Microsoft.Maui.Controls.PlatformWebViewInitializedEventArgs.Sender.get -> Microsoft.Web.WebView2.Core.CoreWebView2!
@@ -362,11 +366,6 @@ override Microsoft.Maui.Controls.Shapes.TransformTypeConverter.ConvertTo(System.
 override Microsoft.Maui.Controls.TemplatedView.InvalidateLayout() -> void
 override Microsoft.Maui.Controls.TemplatedView.OnChildMeasureInvalidated() -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
-virtual Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDeclarer, TPropertyType>.Invoke(TDeclarer bindable) -> TPropertyType
-~Microsoft.Maui.Controls.Platform.ItemTemplateContext.Container.get -> Microsoft.Maui.Controls.BindableObject
-~Microsoft.Maui.Controls.Platform.ItemTemplateContext.FormsDataTemplate.get -> Microsoft.Maui.Controls.DataTemplate
-~Microsoft.Maui.Controls.Platform.ItemTemplateContext.Item.get -> object
-~Microsoft.Maui.Controls.Platform.ItemTemplateContext.MauiContext.get -> Microsoft.Maui.IMauiContext
 override Microsoft.Maui.Controls.TemplatedView.ShouldInvalidateOnChildAdded(Microsoft.Maui.Controls.View! child) -> bool
 override Microsoft.Maui.Controls.TemplatedView.ShouldInvalidateOnChildRemoved(Microsoft.Maui.Controls.View! child) -> bool
 override Microsoft.Maui.Controls.TextDecorationConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Platform.ItemTemplateContext
+Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemHeight.get -> double
+Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemSpacing.get -> Microsoft.Maui.Thickness
+Microsoft.Maui.Controls.Platform.ItemTemplateContext.ItemWidth.get -> double
 *REMOVED*Microsoft.Maui.Controls.Accelerator
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.get -> System.Collections.Generic.IEnumerable<string>
 *REMOVED*~Microsoft.Maui.Controls.Accelerator.Keys.set -> void
@@ -358,6 +362,11 @@ override Microsoft.Maui.Controls.Shapes.TransformTypeConverter.ConvertTo(System.
 override Microsoft.Maui.Controls.TemplatedView.InvalidateLayout() -> void
 override Microsoft.Maui.Controls.TemplatedView.OnChildMeasureInvalidated() -> void
 override Microsoft.Maui.Controls.TemplatedView.OnSizeAllocated(double width, double height) -> void
+virtual Microsoft.Maui.Controls.BindableProperty.CreateDefaultValueDelegate<TDeclarer, TPropertyType>.Invoke(TDeclarer bindable) -> TPropertyType
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.Container.get -> Microsoft.Maui.Controls.BindableObject
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.FormsDataTemplate.get -> Microsoft.Maui.Controls.DataTemplate
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.Item.get -> object
+~Microsoft.Maui.Controls.Platform.ItemTemplateContext.MauiContext.get -> Microsoft.Maui.IMauiContext
 override Microsoft.Maui.Controls.TemplatedView.ShouldInvalidateOnChildAdded(Microsoft.Maui.Controls.View! child) -> bool
 override Microsoft.Maui.Controls.TemplatedView.ShouldInvalidateOnChildRemoved(Microsoft.Maui.Controls.View! child) -> bool
 override Microsoft.Maui.Controls.TextDecorationConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -52,14 +52,14 @@ Microsoft.Maui.ITimePicker.IsOpen.set -> void
 Microsoft.Maui.ITimePicker.Time.get -> System.TimeSpan?
 Microsoft.Maui.IWebRequestInterceptingWebView
 Microsoft.Maui.IWebRequestInterceptingWebView.WebResourceRequested(Microsoft.Maui.WebResourceRequestedEventArgs! args) -> bool
-*REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.get -> bool
-*REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.set -> void
 Microsoft.Maui.Platform.MauiHorizontalScrollView
 Microsoft.Maui.Platform.MauiHorizontalScrollView.MauiHorizontalScrollView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
 Microsoft.Maui.Platform.MauiHorizontalScrollView.MauiHorizontalScrollView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
 Microsoft.Maui.Platform.MauiHorizontalScrollView.MauiHorizontalScrollView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyleAttr, int defStyleRes) -> void
 Microsoft.Maui.Platform.MauiHorizontalScrollView.MauiHorizontalScrollView(Android.Content.Context? context, Microsoft.Maui.Platform.MauiScrollView! parentScrollView) -> void
 Microsoft.Maui.Platform.MauiHorizontalScrollView.MauiHorizontalScrollView(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+*REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.get -> bool
+*REMOVED*Microsoft.Maui.Platform.MauiPicker.ShowPopupOnFocus.set -> void
 Microsoft.Maui.Platform.MauiShapeableImageView
 Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context) -> void
 Microsoft.Maui.Platform.MauiShapeableImageView.MauiShapeableImageView(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
@@ -189,14 +189,14 @@ override Microsoft.Maui.Handlers.OpenWindowRequest.ToString() -> string!
 override Microsoft.Maui.Handlers.RefreshViewHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.TimePickerHandler.ConnectHandler(Microsoft.Maui.Platform.MauiTimePicker! platformView) -> void
 override Microsoft.Maui.Platform.MauiDatePicker.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
-*REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
-*REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnTouchEvent(Android.Views.MotionEvent? e) -> bool
 override Microsoft.Maui.Platform.MauiHorizontalScrollView.Draw(Android.Graphics.Canvas? canvas) -> void
 override Microsoft.Maui.Platform.MauiHorizontalScrollView.HorizontalScrollBarEnabled.get -> bool
 override Microsoft.Maui.Platform.MauiHorizontalScrollView.HorizontalScrollBarEnabled.set -> void
 override Microsoft.Maui.Platform.MauiHorizontalScrollView.OnInterceptTouchEvent(Android.Views.MotionEvent? ev) -> bool
 override Microsoft.Maui.Platform.MauiHorizontalScrollView.OnScrollChanged(int l, int t, int oldl, int oldt) -> void
 override Microsoft.Maui.Platform.MauiHorizontalScrollView.OnTouchEvent(Android.Views.MotionEvent? ev) -> bool
+*REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
+*REMOVED*override Microsoft.Maui.Platform.MauiPicker.OnTouchEvent(Android.Views.MotionEvent? e) -> bool
 override Microsoft.Maui.Platform.MauiPickerBase.DefaultMovementMethod.get -> Android.Text.Method.IMovementMethod?
 override Microsoft.Maui.Platform.MauiShapeableImageView.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
 override Microsoft.Maui.Platform.MauiSwipeRefreshLayout.OnLayout(bool changed, int left, int top, int right, int bottom) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -54,6 +54,8 @@ Microsoft.Maui.IWindow.IsMinimizable.get -> bool
 Microsoft.Maui.Platform.CalendarDatePickerExtensions
 Microsoft.Maui.Platform.MauiSlider
 Microsoft.Maui.Platform.MauiSlider.MauiSlider() -> void
+~Microsoft.Maui.Platform.MauiSlider.ThumbImageSource.get -> Microsoft.UI.Xaml.Media.ImageSource
+~Microsoft.Maui.Platform.MauiSlider.ThumbImageSource.set -> void
 Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.SafeAreaEdges.Bottom.get -> Microsoft.Maui.SafeAreaRegions
 Microsoft.Maui.SafeAreaEdges.Equals(Microsoft.Maui.SafeAreaEdges other) -> bool
@@ -232,6 +234,7 @@ static Microsoft.Maui.SwipeViewSwipeEnded.operator !=(Microsoft.Maui.SwipeViewSw
 static Microsoft.Maui.SwipeViewSwipeEnded.operator ==(Microsoft.Maui.SwipeViewSwipeEnded? left, Microsoft.Maui.SwipeViewSwipeEnded? right) -> bool
 static Microsoft.Maui.SwipeViewSwipeStarted.operator !=(Microsoft.Maui.SwipeViewSwipeStarted? left, Microsoft.Maui.SwipeViewSwipeStarted? right) -> bool
 static Microsoft.Maui.SwipeViewSwipeStarted.operator ==(Microsoft.Maui.SwipeViewSwipeStarted? left, Microsoft.Maui.SwipeViewSwipeStarted? right) -> bool
+~static readonly Microsoft.Maui.Platform.MauiSlider.ThumbImageSourceProperty -> Microsoft.UI.Xaml.DependencyProperty
 virtual Microsoft.Maui.Animations.Lerp.LerpDelegate.Invoke(object! start, object! end, double progress) -> object!
 virtual Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.<Clone>$() -> Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate!
 virtual Microsoft.Maui.Handlers.ContextFlyoutItemHandlerUpdate.EqualityContract.get -> System.Type!
@@ -292,6 +295,3 @@ virtual Microsoft.Maui.SwipeViewSwipeStarted.<Clone>$() -> Microsoft.Maui.SwipeV
 virtual Microsoft.Maui.SwipeViewSwipeStarted.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.SwipeViewSwipeStarted.Equals(Microsoft.Maui.SwipeViewSwipeStarted? other) -> bool
 virtual Microsoft.Maui.SwipeViewSwipeStarted.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Platform.MauiSlider.ThumbImageSource.get -> Microsoft.UI.Xaml.Media.ImageSource
-~Microsoft.Maui.Platform.MauiSlider.ThumbImageSource.set -> void
-~static readonly Microsoft.Maui.Platform.MauiSlider.ThumbImageSourceProperty -> Microsoft.UI.Xaml.DependencyProperty


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This class holds all information needed between the platform `ListViewItem` and `CollectionView` (Maui). Opening this type will allow devs (app/libs) to easily access data from `CollectionViewHandler` and access, as well, the Maui's `ItemTemplate`.

### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Related to #30762

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
