### PR TITLE
Improve iOS Label performance

### DIFF
--- a/src/Controls/src/Core/Entry/Entry.Mapper.cs
+++ b/src/Controls/src/Core/Entry/Entry.Mapper.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 			EntryHandler.Mapper.ReplaceMapping<Entry, IEntryHandler>(PlatformConfiguration.iOSSpecific.Entry.AdjustsFontSizeToFitWidthProperty.PropertyName, MapAdjustsFontSizeToFitWidth);
 #endif
 			EntryHandler.Mapper.ReplaceMapping<Entry, IEntryHandler>(nameof(Text), MapText);
-			EntryHandler.Mapper.ReplaceMapping<Entry, IEntryHandler>(nameof(TextTransform), MapText);
+			EntryHandler.Mapper.ReplaceMapping<Entry, IEntryHandler>(nameof(TextTransform), MapTextTransform);
 
 #if IOS || ANDROID
 			EntryHandler.Mapper.AppendToMapping(nameof(VisualElement.IsFocused), InputView.MapIsFocused);
@@ -27,6 +27,17 @@ namespace Microsoft.Maui.Controls
 #if ANDROID
 			EntryHandler.CommandMapper.PrependToMapping(nameof(IEntry.Focus), InputView.MapFocus);
 #endif
+		}
+
+		static void MapTextTransform(IEntryHandler handler, Entry label)
+		{
+			if (label.IsConnectingHandler())
+			{
+				// If we're connecting the handler, we don't want to map the text multiple times.
+				return;
+			}
+
+			MapText(handler, label);
 		}
 	}
 }

--- a/src/Controls/src/Core/Entry/Entry.iOS.cs
+++ b/src/Controls/src/Core/Entry/Entry.iOS.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Maui.Controls
 		public static void MapText(IEntryHandler handler, Entry entry)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, entry);
-			EntryHandler.MapFormatting(handler, entry);
+
+			if (!handler.IsConnectingHandler())
+			{
+				// If we're not connecting the handler, we need to update the text formatting
+				// This is because the text may have changed, and we need to ensure that
+				// any attributed string formatting is applied correctly.
+				EntryHandler.MapFormatting(handler, entry);
+			}
 		}
 
 		public static void MapCursorColor(EntryHandler handler, Entry entry) =>

--- a/src/Controls/src/Core/Label/Label.Mapper.cs
+++ b/src/Controls/src/Core/Label/Label.Mapper.cs
@@ -57,7 +57,10 @@ namespace Microsoft.Maui.Controls
 		static void MapFormattedText(ILabelHandler handler, Label label)
 		{
 			if (label.IsConnectingHandler())
+			{
+				// If we're connecting the handler, we don't want to map the text multiple times.
 				return;
+			}
 
 			MapText(handler, label);
 		}
@@ -139,9 +142,12 @@ namespace Microsoft.Maui.Controls
 		{
 			if (label.HasFormattedTextSpans)
 			{
-				// if there is formatted text,
-				// then we re-apply the whole formatted text
-				handler.UpdateValue(nameof(FormattedText));
+				if (!handler.IsConnectingHandler())
+				{
+					// if there is formatted text,
+					// then we re-apply the whole formatted text
+					handler.UpdateValue(nameof(FormattedText));
+				}
 			}
 			else if (label.TextType == TextType.Text || !IsDefaultFont(label))
 			{

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -1,5 +1,4 @@
 #nullable disable
-using System;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using UIKit;
@@ -23,7 +22,11 @@ namespace Microsoft.Maui.Controls
 		{
 			Platform.LabelExtensions.UpdateText(handler.PlatformView, label);
 
-			MapFormatting(handler, label);
+			if (!handler.IsConnectingHandler())
+			{
+				// Any text update requires that we update any attributed string formatting
+				MapFormatting(handler, label);
+			}
 		}
 
 		public static void MapLineBreakMode(ILabelHandler handler, Label label)

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Button/ButtonControlPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Button/ButtonControlPage.xaml
@@ -55,12 +55,17 @@
               </Button>
 
               <Label Grid.Row="1"
-                     Text="Clicked Event: "/>
+                     Text="Clicked Event: "
+                     AutomationId="MainLabel">
+                <Label.GestureRecognizers>
+                  <TapGestureRecognizer Tapped="MainLabel_Tapped"/>
+                </Label.GestureRecognizers>
+              </Label>
               <Label Grid.Row="1"
                      Grid.Column="1"
                      x:Name="ClickedEventLabel"
                      AutomationId="ClickedEventLabel"/>
-
+              
               <Label Grid.Row="2"
                      Text="Pressed Event: "/>
               <Label Grid.Row="2"

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Button/ButtonControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Button/ButtonControlPage.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Controls.Internals;
+
 namespace Maui.Controls.Sample;
 
 public class ButtonControlPage : NavigationPage
@@ -51,5 +53,18 @@ public partial class ButtonControlMainPage : ContentPage
 		{
 			ReleasedEventLabel.Text = "Released Event Executed";
 		}
+	}
+	
+	void MainLabel_Tapped(object sender, TappedEventArgs e)
+	{
+		// Recreate the page to verify initial mappers
+		ToolbarItems.Clear();
+		Content = new ContentView();
+		INameScope scope = this;
+		scope.UnregisterName("ClickedEventLabel");
+		scope.UnregisterName("ReleasedEventLabel");
+		scope.UnregisterName("PressedEventLabel");
+		scope.UnregisterName("ButtonShadow");
+		InitializeComponent();
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/EntryControl/EntryControlPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/EntryControl/EntryControlPage.xaml
@@ -6,10 +6,14 @@
        <VerticalStackLayout Padding="20"
                             Spacing="8">
               <Label Text="Entry Control"
+                     AutomationId="MainLabel"
                      FontSize="20"
                      Margin="0,0,0,50"
-                     HorizontalOptions="Center"/>
-
+                     HorizontalOptions="Center">
+                <Label.GestureRecognizers>
+                  <TapGestureRecognizer Tapped="MainLabel_Tapped"/>
+                </Label.GestureRecognizers>
+              </Label>
               <local:UITestEntry x:Name="EntryControl"
                                  IsCursorVisible="False"
                                  Text="{Binding Text}"

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/EntryControl/EntryControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/EntryControl/EntryControlPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Maui.Controls.Sample;
 
@@ -121,5 +122,21 @@ public partial class EntryControlMainPage : ContentPage
 		{
 			vm.UnfocusedText = eventInfo;
 		}
+	}
+
+	void MainLabel_Tapped(object sender, TappedEventArgs e)
+	{
+		// Recreate the page to verify initial mappers
+		ToolbarItems.Clear();
+		Content = new ContentView();
+		INameScope scope = this;
+		scope.UnregisterName("EntryControl");
+		scope.UnregisterName("TextChangedLabel");
+		scope.UnregisterName("SelectionLengthEntry");
+		scope.UnregisterName("CursorPositionEntry");
+		scope.UnregisterName("CompletedLabel");
+		scope.UnregisterName("FocusedLabel");
+		scope.UnregisterName("UnfocusedLabel");
+		InitializeComponent();
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/EntryControl/EntryOptionsPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/EntryControl/EntryOptionsPage.xaml
@@ -45,6 +45,7 @@
                                     Clicked="HorizontalAlignmentButton_Clicked"/>
                             <Button Text="End"
                                     AutomationId="HEnd"
+                                    FontSize="10"
                                     Clicked="HorizontalAlignmentButton_Clicked"/>
                      </HorizontalStackLayout>
                      <!-- Vertical Alignment -->

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml
@@ -30,6 +30,10 @@
         TextType="{Binding TextType}"
         VerticalTextAlignment="{Binding VerticalTextAlignment}"
         BackgroundColor="LightGray"
-        AutomationId="MainLabel"/>
+        AutomationId="MainLabel">
+        <Label.GestureRecognizers>
+          <TapGestureRecognizer Tapped="MainLabel_Tapped"/>
+        </Label.GestureRecognizers>
+      </Label>
     </VerticalStackLayout>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/Label/LabelControlPage.xaml.cs
@@ -30,4 +30,12 @@ public partial class LabelControlMainPage : ContentPage
 		BindingContext = _viewModel = new LabelViewModel();
 		await Navigation.PushAsync(new LabelOptionsPage(_viewModel));
 	}
+
+	void MainLabel_Tapped(object sender, TappedEventArgs e)
+	{
+		// Recreate the page to verify initial mappers
+		ToolbarItems.Clear();
+		Content = new ContentView();
+		InitializeComponent();
+	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ButtonFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/ButtonFeatureTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.TestCases.Tests;
 
 public class ButtonFeatureTests : UITest
 {
+	const string MainLabel = "ClickedEventLabel";
 	public const string ButtonFeatureMatrix = "Button Feature Matrix";
 	public ButtonFeatureTests(TestDevice testDevice) : base(testDevice)
 	{
@@ -38,6 +39,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -58,6 +61,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 #if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST //CharacterSpacingEntry property not working on iOS and Catalyst, Issue: https://github.com/dotnet/maui/issues/21488
@@ -75,6 +80,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif
@@ -116,6 +123,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -145,6 +154,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -160,6 +171,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -179,6 +192,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -194,6 +209,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -212,6 +229,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -233,6 +252,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -249,6 +270,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -268,6 +291,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -315,6 +340,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -331,6 +358,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -349,6 +378,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -366,6 +397,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -382,6 +415,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -405,6 +440,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -421,6 +458,8 @@ public class ButtonFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test]
@@ -436,6 +475,8 @@ public class ButtonFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElementTillPageNavigationSettled("ButtonControl");
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/EntryFeatureTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.TestCases.Tests;
 public class EntryFeatureTests : UITest
 {
 	public const string EntryFeatureMatrix = "Entry Feature Matrix";
+	public const string MainLabel = "MainLabel";
 
 #if IOS
 	private const int CropBottomValue = 1550;
@@ -35,6 +36,8 @@ public class EntryFeatureTests : UITest
 	{
 		App.WaitForElement("TestEntry");
 		Assert.That(App.WaitForElement("UnfocusedLabel").GetText(), Is.EqualTo("Unfocused: Not triggered"));
+		App.Tap(MainLabel);
+		Assert.That(App.WaitForElement("UnfocusedLabel").GetText(), Is.EqualTo("Unfocused: Not triggered"));
 		Assert.That(App.WaitForElement("CompletedLabel").GetText(), Is.EqualTo("Completed: Not triggered"));
 		Assert.That(App.WaitForElement("TextChangedLabel").GetText(), Is.EqualTo("TextChanged: Old='', New='Test Entry'"));
 	}
@@ -43,6 +46,8 @@ public class EntryFeatureTests : UITest
 	public void VerifyEntryCompletedEvent()
 	{
 		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		App.Tap(MainLabel);
 		App.Tap("TestEntry");
 		App.PressEnter();
 		App.DismissKeyboard();
@@ -54,6 +59,8 @@ public class EntryFeatureTests : UITest
 	{
 
 		App.WaitForElement("TestEntry");
+		App.ClearText("TestEntry");
+		App.Tap(MainLabel);
 		App.ClearText("TestEntry");
 		App.EnterText("TestEntry", "New Text");
 
@@ -70,6 +77,9 @@ public class EntryFeatureTests : UITest
 	{
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.Tap(MainLabel);
+		App.Tap("TestEntry");
+		
 #if ANDROID || IOS
 		if (App.WaitForKeyboardToShow())
 			App.DismissKeyboard();
@@ -81,6 +91,8 @@ public class EntryFeatureTests : UITest
 	public void VerifyEntryUnfocusedEvent()
 	{
 		App.WaitForElement("TestEntry");
+		App.WaitForElement("SelectionLengthEntry");
+		App.Tap(MainLabel);
 		App.WaitForElement("SelectionLengthEntry");
 		App.Tap("SelectionLengthEntry");
 		App.DismissKeyboard();
@@ -119,6 +131,9 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
 		VerifyScreenshotWithKeyboardHandling();
+		App.Tap(MainLabel);
+		App.Tap("TestEntry");
+		VerifyScreenshotWithKeyboardHandling();
 	}
 
 	[Test]
@@ -131,6 +146,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		App.Tap(MainLabel);
 		App.Tap("TestEntry");
 		VerifyScreenshotWithKeyboardHandling();
 	}
@@ -146,6 +163,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		App.Tap(MainLabel);
 		App.Tap("TestEntry");
 		VerifyScreenshotWithKeyboardHandling();
 	}
@@ -163,6 +182,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.Tap(MainLabel);
+		App.Tap("TestEntry");
 		VerifyScreenshotWithKeyboardHandling();
 	}
 #endif
@@ -176,6 +197,10 @@ public class EntryFeatureTests : UITest
 		App.Tap("TextColorRed");
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
+		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		VerifyScreenshotWithKeyboardHandling();
+		App.Tap(MainLabel);
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
 		VerifyScreenshotWithKeyboardHandling();
@@ -207,6 +232,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -218,6 +245,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -232,6 +261,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		// On Android, using App.EnterText in UI tests (e.g., with Appium UITest) can programmatically enter text into an Entry control even if its IsReadOnly property is set to true.
+		App.Tap(MainLabel);
 		// On Android, using App.EnterText in UI tests (e.g., with Appium UITest) can programmatically enter text into an Entry control even if its IsReadOnly property is set to true.
 		App.EnterText("TestEntry", "123");
 		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("Test Entry"));
@@ -249,6 +280,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -262,6 +295,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -279,6 +314,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -294,6 +331,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -312,6 +351,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 #endif
 
@@ -329,6 +370,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 #if TEST_FAILS_ON_IOS // When taking a screenshot of a password field (<Entry IsPassword="true" />), iOS hides the password text for security reasons.
@@ -343,6 +386,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -355,6 +400,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -370,6 +417,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -408,6 +457,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -424,6 +475,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("Test E"));
+		App.Tap(MainLabel);
 		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("Test E"));
 	}
 
@@ -445,6 +498,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		// On Android, using App.EnterText in UI tests (e.g., with Appium UITest) can programmatically enter text into an Entry control even if its IsReadOnly property is set to true.
+		App.Tap(MainLabel);
+		// On Android, using App.EnterText in UI tests (e.g., with Appium UITest) can programmatically enter text into an Entry control even if its IsReadOnly property is set to true.
 		App.EnterText("TestEntry", "123");
 		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("Test E"));
 
@@ -464,6 +519,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -476,6 +533,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -490,6 +549,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -506,6 +567,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 #endif
 
@@ -520,6 +583,8 @@ public class EntryFeatureTests : UITest
 			App.WaitForElement("Apply");
 			App.Tap("Apply");
 			App.WaitForElement("TestEntry");
+			App.ClearText("TestEntry");
+			App.Tap(MainLabel);
 			App.ClearText("TestEntry");
 			App.EnterText("TestEntry", "Testig");
 			App.EnterText("TestEntry", " ");
@@ -536,6 +601,8 @@ public class EntryFeatureTests : UITest
 			App.WaitForElement("Apply");
 			App.Tap("Apply");
 			App.WaitForElement("TestEntry");
+			App.ClearText("TestEntry");
+			App.Tap(MainLabel);
 			App.ClearText("TestEntry");
 			App.EnterText("TestEntry", "Testig");
 			App.EnterText("TestEntry", " ");
@@ -558,6 +625,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("UpdateCursorAndSelectionButton");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.Tap(MainLabel);
+		App.Tap("TestEntry");
 		App.DismissKeyboard();
 		Assert.That(App.WaitForElement("SelectionLengthEntry").GetText(), Is.EqualTo("0"));
 	}
@@ -576,6 +645,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("UpdateCursorAndSelectionButton");
 		App.Tap("UpdateCursorAndSelectionButton");
 		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		App.Tap(MainLabel);
 		App.Tap("TestEntry");
 		App.DismissKeyboard();
 		Assert.That(App.WaitForElement("CursorPositionEntry").GetText(), Is.EqualTo("10"));
@@ -598,6 +669,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("UpdateCursorAndSelectionButton");
 		App.Tap("UpdateCursorAndSelectionButton");
 		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		App.Tap(MainLabel);
 		App.Tap("TestEntry");
 		App.DismissKeyboard();
 		Assert.That(App.WaitForElement("CursorPositionEntry").GetText(), Is.EqualTo("10"));
@@ -640,6 +713,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.Tap(MainLabel);
+		App.Tap("TestEntry");
 		Assert.That(App.WaitForElement("CursorPositionEntry").GetText(), Is.EqualTo("0"));
 	}
 
@@ -659,6 +734,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("UpdateCursorAndSelectionButton");
 		App.WaitForElement("TestEntry");
 		App.Tap("TestEntry");
+		App.Tap(MainLabel);
+		App.Tap("TestEntry");
 		Assert.That(App.WaitForElement("SelectionLengthEntry").GetText(), Is.EqualTo("3"));
 	}
 #endif
@@ -671,6 +748,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		App.ClearText("TestEntry");
+		App.Tap(MainLabel);
 		App.ClearText("TestEntry");
 		App.EnterText("TestEntry", "Test");
 		App.Tap("TestEntry");
@@ -722,6 +801,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		App.ClearText("TestEntry");
+		App.Tap(MainLabel);
+		App.ClearText("TestEntry");
 		App.EnterText("TestEntry", "123");
 		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("123"));
 		App.WaitForElement("Options");
@@ -731,6 +812,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		App.EnterText("TestEntry", "123");
+		App.Tap(MainLabel);
 		App.EnterText("TestEntry", "123");
 		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("Test Entry"));
 
@@ -745,6 +828,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		App.WaitForElement("Options");
+		App.Tap(MainLabel);
 		App.WaitForElement("Options");
 		App.Tap("Options");
 		App.WaitForElement("VisibleFalse");
@@ -765,6 +850,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -780,6 +867,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 
@@ -794,6 +883,10 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		App.ClearText("TestEntry");
+		App.Tap(MainLabel);
+		App.ClearText("TestEntry");
+		App.Tap(MainLabel);
 		App.ClearText("TestEntry");
 		App.DismissKeyboard();
 		VerifyScreenshot(cropBottom: CropBottomValue);
@@ -838,6 +931,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -850,6 +945,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("TEST ENTRY"));
+		App.Tap(MainLabel);
 		Assert.That(App.WaitForElement("TestEntry").GetText(), Is.EqualTo("TEST ENTRY"));
 	}
 
@@ -881,6 +978,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 #endif
@@ -930,6 +1029,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -944,6 +1045,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -962,6 +1065,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 #endif
 
@@ -977,6 +1082,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
@@ -994,6 +1101,8 @@ public class EntryFeatureTests : UITest
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
 		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
+		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 
 	[Test]
@@ -1008,6 +1117,8 @@ public class EntryFeatureTests : UITest
 		App.WaitForElement("Apply");
 		App.Tap("Apply");
 		App.WaitForElement("TestEntry");
+		VerifyScreenshot(cropBottom: CropBottomValue);
+		App.Tap(MainLabel);
 		VerifyScreenshot(cropBottom: CropBottomValue);
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/LabelFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/LabelFeatureTests.cs
@@ -71,6 +71,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(2)]
@@ -86,6 +88,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -103,6 +107,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(4)]
@@ -118,6 +124,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -135,6 +143,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(6)]
@@ -151,6 +161,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(7)]
@@ -166,6 +178,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -188,6 +202,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 
@@ -205,6 +221,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -224,6 +242,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(11)]
@@ -240,6 +260,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(12)]
@@ -255,6 +277,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -274,6 +298,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(14)]
@@ -289,6 +315,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -306,6 +334,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(16)]
@@ -322,6 +352,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(17)]
@@ -337,6 +369,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif
@@ -358,6 +392,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 #endif
 
@@ -376,6 +412,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(42)]
@@ -391,6 +429,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(LineBreakModeCharacterWrap);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -411,6 +451,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(41)]
@@ -426,6 +468,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(LineBreakModeTailTruncation);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif
@@ -444,6 +488,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(22)]
@@ -459,6 +505,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -477,6 +525,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(24)]
@@ -492,6 +542,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		App.WaitForElement(MainLabel);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif
@@ -525,6 +577,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(27)]
@@ -541,6 +595,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(28)]
@@ -556,6 +612,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextTransformUpper);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -574,6 +632,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(30)]
@@ -589,6 +649,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextDecorationsLine);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -606,6 +668,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(32)]
@@ -621,6 +685,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(FontAttributesItalic);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -640,6 +706,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(34)]
@@ -658,6 +726,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(35)]
@@ -675,6 +745,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(VerticalTextEnd);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -697,6 +769,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(37)]
@@ -713,6 +787,8 @@ public class LabelFeatureTests : UITest
 		App.EnterText(MaxLinesEntry, "1");
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -731,6 +807,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(38)]
@@ -746,6 +824,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(LineBreakModeNoWrap);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -764,6 +844,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(40)]
@@ -779,6 +861,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(LineBreakModeMiddleTruncation);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif
@@ -799,6 +883,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(46)]
@@ -818,6 +904,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(47)]
@@ -835,6 +923,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextColorRed);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -854,6 +944,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(49)]
@@ -872,6 +964,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 #if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS // Issue Link: https://github.com/dotnet/maui/issues/20372,  https://github.com/dotnet/maui/issues/29672, https://github.com/dotnet/maui/issues/29668 
@@ -888,6 +982,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextTypeHtml);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -907,6 +1003,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(56)]
@@ -924,6 +1022,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextColorRed);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -944,6 +1044,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(58)]
@@ -961,6 +1063,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(LineBreakModeNoWrap);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -980,6 +1084,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(60)]
@@ -997,6 +1103,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextTypeHtml);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -1018,6 +1126,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(68)]
@@ -1037,6 +1147,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 #if TEST_FAILS_ON_WINDOWS // Issue Link: https://github.com/dotnet/maui/issues/21294
@@ -1055,6 +1167,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(LineBreakModeCharacterWrap);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif
@@ -1077,6 +1191,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(52)]
@@ -1096,6 +1212,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(53)]
@@ -1113,6 +1231,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextDecorationsStrike);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -1132,6 +1252,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(55)]
@@ -1149,6 +1271,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextTransformUpper);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -1169,6 +1293,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(62)]
@@ -1186,6 +1312,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextTypeHtml);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 
@@ -1206,6 +1334,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(64)]
@@ -1224,6 +1354,8 @@ public class LabelFeatureTests : UITest
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
 		VerifyScreenshot();
+		App.Tap(MainLabel);
+		VerifyScreenshot();
 	}
 
 	[Test, Order(65)]
@@ -1241,6 +1373,8 @@ public class LabelFeatureTests : UITest
 		App.Tap(TextTypeHtml);
 		App.WaitForElement(Apply);
 		App.Tap(Apply);
+		VerifyScreenshot();
+		App.Tap(MainLabel);
 		VerifyScreenshot();
 	}
 #endif

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static IPropertyMapper<ITextButton, IButtonHandler> TextButtonMapper = new PropertyMapper<ITextButton, IButtonHandler>()
 		{
+			[nameof(IText.Text)] = MapText,
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(ITextStyle.Font)] = MapFont,
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
-			[nameof(IText.Text)] = MapText
 		};
 
 		public static IPropertyMapper<IButton, IButtonHandler> Mapper = new PropertyMapper<IButton, IButtonHandler>(TextButtonMapper, ImageButtonMapper, ViewHandler.ViewMapper)

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -98,8 +98,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateText(button);
 
-			// Any text update requires that we update any attributed string formatting
-			MapFormatting(handler, button);
+			if (!handler.IsConnectingHandler())
+			{
+				// Any text update requires that we update any attributed string formatting
+				MapFormatting(handler, button);
+			}
 		}
 
 		public static void MapTextColor(IButtonHandler handler, ITextStyle button)

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -17,25 +17,31 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class EntryHandler : IEntryHandler
 	{
-		public static IPropertyMapper<IEntry, IEntryHandler> Mapper = new PropertyMapper<IEntry, IEntryHandler>(ViewHandler.ViewMapper)
+		private static readonly IPropertyMapper<IEntry, IEntryHandler> TextMapper = new PropertyMapper<IEntry, IEntryHandler>
 		{
-			[nameof(IEntry.Background)] = MapBackground,
-			[nameof(IEntry.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEntry.ClearButtonVisibility)] = MapClearButtonVisibility,
-			[nameof(IEntry.Font)] = MapFont,
-			[nameof(IEntry.IsPassword)] = MapIsPassword,
 			[nameof(IEntry.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
 			[nameof(IEntry.VerticalTextAlignment)] = MapVerticalTextAlignment,
+			// Ensure Text is mapped before LineHeight/Decorations/CharacterSpacing/HorizontalTextAlignment/TextColor/Font
+			// due to them being applied to the native object (i.e. AttributedText on iOS) created by mapping Text
+			[nameof(IEntry.Text)] = MapText,
+			[nameof(IEntry.MaxLength)] = MapMaxLength,
+			[nameof(IEntry.Font)] = MapFont,
+			[nameof(IEntry.CharacterSpacing)] = MapCharacterSpacing,
+			[nameof(IEntry.TextColor)] = MapTextColor
+		};
+
+		public static IPropertyMapper<IEntry, IEntryHandler> Mapper = new PropertyMapper<IEntry, IEntryHandler>(TextMapper, ViewHandler.ViewMapper)
+		{
+			[nameof(IEntry.Background)] = MapBackground,
+			[nameof(IEntry.IsPassword)] = MapIsPassword,
 			[nameof(IEntry.IsReadOnly)] = MapIsReadOnly,
 			[nameof(IEntry.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled,
 			[nameof(IEntry.IsSpellCheckEnabled)] = MapIsSpellCheckEnabled,
 			[nameof(IEntry.Keyboard)] = MapKeyboard,
-			[nameof(IEntry.MaxLength)] = MapMaxLength,
 			[nameof(IEntry.Placeholder)] = MapPlaceholder,
 			[nameof(IEntry.PlaceholderColor)] = MapPlaceholderColor,
 			[nameof(IEntry.ReturnType)] = MapReturnType,
-			[nameof(IEntry.Text)] = MapText,
-			[nameof(IEntry.TextColor)] = MapTextColor,
 			[nameof(IEntry.CursorPosition)] = MapCursorPosition,
 			[nameof(IEntry.SelectionLength)] = MapSelectionLength
 		};

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -39,8 +39,13 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateText(entry);
 
-			// Any text update requires that we update any attributed string formatting
-			MapFormatting(handler, entry);
+			if (!handler.IsConnectingHandler())
+			{
+				// If we're not connecting the handler, we need to update the text formatting
+				// This is because the text may have changed, and we need to ensure that
+				// any attributed string formatting is applied correctly.
+				MapFormatting(handler, entry);
+			}
 		}
 
 		public static void MapTextColor(IEntryHandler handler, IEntry entry) =>
@@ -96,14 +101,14 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFormatting(IEntryHandler handler, IEntry entry)
 		{
-			handler.PlatformView?.UpdateMaxLength(entry);
+			handler.UpdateValue(nameof(IEntry.MaxLength));
 
 			// Update all of the attributed text formatting properties
-			handler.PlatformView?.UpdateCharacterSpacing(entry);
+			handler.UpdateValue(nameof(IEntry.CharacterSpacing));
 
 			// Setting any of those may have removed text alignment settings,
 			// so we need to make sure those are applied, too
-			handler.PlatformView?.UpdateHorizontalTextAlignment(entry);
+			handler.UpdateValue(nameof(IEntry.HorizontalTextAlignment));
 		}
 
 		protected virtual bool OnShouldReturn(UITextField view) =>

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -15,8 +15,23 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class LabelHandler : ILabelHandler
 	{
-		public static IPropertyMapper<ILabel, ILabelHandler> Mapper = new PropertyMapper<ILabel, ILabelHandler>(ViewHandler.ViewMapper)
+		private static readonly IPropertyMapper<ILabel, ILabelHandler> TextMapper = new PropertyMapper<ILabel, ILabelHandler>
 		{
+			// Ensure Text is mapped before LineHeight/Decorations/CharacterSpacing/HorizontalTextAlignment/TextColor/Font
+			// due to them being applied to the native object (i.e. AttributedText on iOS) created by mapping Text
+			[nameof(ILabel.Text)] = MapText,
+			[nameof(ITextStyle.Font)] = MapFont,
+			[nameof(ILabel.LineHeight)] = MapLineHeight,
+			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
+			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
+			[nameof(ITextAlignment.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
+			[nameof(ITextAlignment.VerticalTextAlignment)] = MapVerticalTextAlignment,
+			[nameof(ITextStyle.TextColor)] = MapTextColor,
+		};
+		
+		public static IPropertyMapper<ILabel, ILabelHandler> Mapper = new PropertyMapper<ILabel, ILabelHandler>(TextMapper, ViewHandler.ViewMapper)
+		{
+			[nameof(ILabel.Padding)] = MapPadding,
 #if IOS || TIZEN
 			[nameof(ILabel.Background)] = MapBackground,
 			[nameof(ILabel.Opacity)] = MapOpacity,
@@ -28,15 +43,6 @@ namespace Microsoft.Maui.Handlers
 #if TIZEN
 			[nameof(ILabel.Shadow)] = MapShadow,
 #endif
-			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
-			[nameof(ITextStyle.Font)] = MapFont,
-			[nameof(ITextAlignment.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
-			[nameof(ITextAlignment.VerticalTextAlignment)] = MapVerticalTextAlignment,
-			[nameof(ILabel.LineHeight)] = MapLineHeight,
-			[nameof(ILabel.Padding)] = MapPadding,
-			[nameof(ILabel.Text)] = MapText,
-			[nameof(ITextStyle.TextColor)] = MapTextColor,
-			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
 #if ANDROID
 			[nameof(ILabel.Background)] = MapBackground,
 #endif

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -24,8 +24,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateTextPlainText(label);
 
-			// Any text update requires that we update any attributed string formatting
-			MapFormatting(handler, label);
+			if (!handler.IsConnectingHandler())
+			{
+				// Any text update requires that we update any attributed string formatting
+				MapFormatting(handler, label);
+			}
 		}
 
 		public static void MapTextColor(ILabelHandler handler, ILabel label)


### PR DESCRIPTION
### Description of Change

This PR contributes on improving what's reported in #30721 regarding iOS.

`Label` is a fundamental component of all applications, and by looking at the provided speedscope I noticed that `MapText` was taking *a lot*.

The reason is (as usual) useless mapping calls.

<img width="1180" height="298" alt="image" src="https://github.com/user-attachments/assets/bbc561c8-4724-4e5a-a7b3-b2d85496148e" />
