### PR TITLE
Update CONTRIBUTING.md links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Have a look at our [Development Guide](DEVELOPMENT.md) to learn about setting up
 
 If you're looking for something to work on, please browse our [backlog](https://github.com/dotnet/maui/issues?q=is%3Aopen+is%3Aissue+milestone%3ABacklog). Any issue that is not already assigned is up for grabs. 
 
-Follow the style used by the [.NET Foundation](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md), with two primary exceptions:
+Follow the style used by the [.NET Foundation](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md), with two primary exceptions:
 
 - We do not use the `private` keyword, as it is the default accessibility level in C#.
 - We use hard tabs over spaces.
@@ -55,7 +55,7 @@ If a BenchmarkDotNet test case is not possible, share before & after profiling i
 
 ## Proposals/Enhancements/Suggestions
 
-To propose a change or new feature, open an issue using the [Feature request template](https://github.com/dotnet/maui/issues/new?assignees=&labels=proposal-open%2C+t%2Fenhancement+➕&template=feature_request.md&title=[Enhancement]+YOUR+IDEA!). You may also use the [Spec template](https://github.com/dotnet/maui/issues/new?assignees=&labels=proposal-open%2C+t%2Fenhancement+➕&template=spec.md&title=[Spec]++) if you have an idea of what the API should look like. Be sure to also browse current issues and [discussions](https://github.com/dotnet/maui/discussions) that may be related to what you have in mind.
+To propose a change or new feature, open an issue using the [Feature request template](https://github.com/dotnet/maui/issues/new?template=feature-request.yml). You may also use the [Spec template](https://github.com/dotnet/maui/issues/new?template=spec.yml) if you have an idea of what the API should look like. Be sure to also browse current issues and [discussions](https://github.com/dotnet/maui/discussions) that may be related to what you have in mind.
 
 ## Review Process
 All pull requests need to be reviewed and tested by at least two members of the .NET MAUI team. We do our best to review pull requests in a timely manner, but please be patient! Two reviewers will be assigned and will start the review process as soon as possible. If there are any changes requested, the contributor should make them at their earliest convenience or let the reviewers know that they are unable to make further contributions. If the pull request requires only minor changes, then someone else may pick it up and finish it. We will do our best to make sure that all credit is retained for contributors. 


### PR DESCRIPTION
Updating the links for opening a new issue. The old links were not directing people to the right places anymore.

Also included a minor change for the dotnet/runtime repo we link to.