### PR TITLE
[iOS] Fixed  Invalid Color warning

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/MaciOS/PlatformCanvas.cs
+++ b/src/Graphics/src/Graphics/Platforms/MaciOS/PlatformCanvas.cs
@@ -718,8 +718,7 @@ namespace Microsoft.Maui.Graphics.Platform
 		private void FillWithPattern(nfloat x, nfloat y, Action drawingAction)
 		{
 			_context.SaveState();
-			var baseColorspace = _getColorspace?.Invoke();
-			var colorspace = CGColorSpace.CreatePattern(baseColorspace);
+			var colorspace = CGColorSpace.CreatePattern(null);
 			_context.SetFillColorSpace(colorspace);
 
 			_fillPatternRect.X = 0;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause : 
Invalid color warning happens when there's a mismatch between the type of pattern and the color space used.

### Description of Change
 Created the pattern color space with null , which tells Core Graphics it's a colored pattern to avoid the mismatch.
### Tested the behavior in the following platforms:

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Reference
Here is the apple's documentation for Creating patterns https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_patterns/dq_patterns.html

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #22891 

### Screenshot

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1543" height="331" alt="Screenshot 2025-07-28 at 5 50 36 PM" src="https://github.com/user-attachments/assets/abc7b26d-fdc4-4663-b5b1-22819e3ae64f"> | <img width="1526" height="422" alt="Screenshot 2025-07-28 at 5 51 57 PM" src="https://github.com/user-attachments/assets/7deeb57b-3336-4e02-bed5-a07fe326ff8a"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
