### PR TITLE
ContentPresenter: Propagate binding context to children with explicit TemplateBinding

### DIFF
--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 
 		internal override void SetChildInheritedBindingContext(Element child, object context)
 		{
-			// We never want to use the standard inheritance mechanism, we will get this set by our parent
+			SetInheritedBindingContext(child, context);
 		}
 
 		static async void OnContentChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23797.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23797.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 23797, "Binding context in ContentPresenter", PlatformAffected.All)]
+public class Issue23797 : ContentPage
+{
+    public static Issue23797_ViewModel Issue23797_ViewModel { get; } = new Issue23797_ViewModel();
+
+    public Issue23797()
+    {
+        Title = "Issue23797";
+
+        var stackLayout = new StackLayout
+        {
+            Spacing = 20,
+            Padding = 20
+        };
+
+        var label = new Label
+        {
+            FontSize = 16,
+            BackgroundColor = Colors.LightGray,
+            Padding = 10,
+            AutomationId = "CurrentMessageLabel"
+        };
+        label.SetBinding(Label.TextProperty, new Binding("Message", source: Issue23797_ViewModel));
+        stackLayout.Children.Add(label);
+
+        var customControl = new CustomControlWithCustomContent
+        {
+            BindingContext = Issue23797_ViewModel
+        };
+
+        var button = new Button
+        {
+            Text = "Click to change to 'success'",
+            BackgroundColor = Colors.LightBlue,
+            AutomationId = "Issue23797Btn"
+        };
+        button.SetBinding(Button.CommandProperty, new Binding("TestCommand"));
+
+        customControl.MyContent = button;
+        stackLayout.Children.Add(customControl);
+
+        Content = stackLayout;
+    }
+}
+
+public class CustomControlWithCustomContent : ContentView
+{
+    public static readonly BindableProperty MyContentProperty = BindableProperty.Create(
+        nameof(MyContent),
+        typeof(View),
+        typeof(CustomControlWithCustomContent),
+        null);
+
+    public View MyContent
+    {
+        get => (View)GetValue(MyContentProperty);
+        set => SetValue(MyContentProperty, value);
+    }
+
+    public CustomControlWithCustomContent()
+    {
+        ControlTemplate = new ControlTemplate(() =>
+        {
+            var border = new Border
+            {
+                Stroke = Colors.Red,
+                StrokeThickness = 2,
+                Padding = 10
+            };
+
+            var contentPresenter = new ContentPresenter();
+            contentPresenter.SetBinding(ContentPresenter.ContentProperty, new Binding(nameof(MyContent), source: RelativeBindingSource.TemplatedParent));
+
+            border.Content = contentPresenter;
+            return border;
+        });
+    }
+}
+
+public class Issue23797_ViewModel : INotifyPropertyChanged
+{
+    private string _message = "failure";
+
+    public string Message
+    {
+        get => _message;
+        set
+        {
+            _message = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public ICommand TestCommand { get; }
+
+    public Issue23797_ViewModel()
+    {
+        TestCommand = new Command(() =>
+        {
+            Message = "success";
+        });
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+    protected virtual void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue23797.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue23797.cs
@@ -29,7 +29,7 @@ public class Issue23797 : ContentPage
         label.SetBinding(Label.TextProperty, new Binding("Message", source: Issue23797_ViewModel));
         stackLayout.Children.Add(label);
 
-        var customControl = new CustomControlWithCustomContent
+        var customControl = new CustomControlWithCustomContent_Issue23797
         {
             BindingContext = Issue23797_ViewModel
         };
@@ -49,12 +49,12 @@ public class Issue23797 : ContentPage
     }
 }
 
-public class CustomControlWithCustomContent : ContentView
+public class CustomControlWithCustomContent_Issue23797 : ContentView
 {
     public static readonly BindableProperty MyContentProperty = BindableProperty.Create(
         nameof(MyContent),
         typeof(View),
-        typeof(CustomControlWithCustomContent),
+        typeof(CustomControlWithCustomContent_Issue23797),
         null);
 
     public View MyContent
@@ -63,7 +63,7 @@ public class CustomControlWithCustomContent : ContentView
         set => SetValue(MyContentProperty, value);
     }
 
-    public CustomControlWithCustomContent()
+    public CustomControlWithCustomContent_Issue23797()
     {
         ControlTemplate = new ControlTemplate(() =>
         {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23797.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue23797.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue23797 : _IssuesUITest
+{
+    public Issue23797(TestDevice testDevice) : base(testDevice)
+    {
+    }
+
+    public override string Issue => "Binding context in ContentPresenter";
+
+    [Test]
+    [Category(UITestCategories.Layout)]
+    public void ContentPresenterShouldPropagateBindingContextForTemplateBindings()
+    {
+        App.WaitForElement("Issue23797Btn");
+        App.Tap("Issue23797Btn");
+        var messageAfterClick = App.WaitForElement("CurrentMessageLabel").GetText();
+        Assert.That(messageAfterClick, Is.EqualTo("success"));
+    }
+}


### PR DESCRIPTION

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

When using a `ContentPresenter` with an **explicit** `TemplateBinding` to a custom `BindableProperty` in a `ControlTemplate`, child elements inside the `ContentPresenter` do not inherit the binding context. This causes data bindings (e.g. `Command`) to fail silently.

**Repro:** Create a `ContentView` subclass with a custom `BindableProperty` of type `View` (e.g. `MyContent`), use it in a `ControlTemplate` with `ContentPresenter.ContentProperty` explicitly bound to that property via `TemplateBinding`, and place a `Button` with a `Command` binding inside. The command will not fire.

### Root Cause

`ContentPresenter` overrides `SetChildInheritedBindingContext` with an intentional no-op:

```csharp
// We never want to use the standard inheritance mechanism, we will get this set by our parent
```

This design came from the Xamarin.Forms era where the binding context was assumed to be set through a different propagation path. With the **default** `ContentPresenter` behavior (content bound via `ContentConverter` on `IContentView.Content`), the binding context eventually propagates correctly because the ControlTemplate's content tree is wired up through `ParentOverride` and the templated parent.

However, with an **explicit** `TemplateBinding` to a custom `BindableProperty`, the binding resolves directly without going through the templated parent propagation path. The `SetChildInheritedBindingContext` override silently discards the inherited context, so child elements never receive the `BindingContext` from the templated parent.

Note: `ContentConverter` does NOT handle binding context — it only forwards text/font properties from ancestor elements.

### Description of Change

**`src/Controls/src/Core/ContentPresenter.cs`**

Removed the no-op override in `SetChildInheritedBindingContext` and replaced it with an actual call to `SetInheritedBindingContext(child, context)`.

This ensures that when binding context flows down the element tree to a `ContentPresenter`, its children receive the inherited context — matching the standard MAUI/WinUI behavior where `DataContext` always propagates through the template tree.

This is consistent with the direction taken in PR #26072, which committed to always propagating `BindingContext` through `ControlTemplate` hierarchies.

### Key Technical Details

- `SetChildInheritedBindingContext` is called by the element tree's inherited binding context propagation mechanism when a parent's `BindingContext` changes.
- The `ContentPresenter` constructor sets up a default binding on `ContentProperty` using `ContentConverter` and `RelativeBindingSource.TemplatedParent`. This default path is NOT affected by this change.
- `ContentConverter` only handles text/font property propagation — it does not participate in `BindingContext` inheritance.
- The fix aligns `ContentPresenter` with standard `SetInheritedBindingContext` behavior used by all other layout types.

### Issues Fixed

Fixes #23797

### Platforms Tested

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac