### PR TITLE
[SG] Decorate generated types with [Generated]

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -85,6 +85,9 @@ static class CodeBehindCodeWriter
 			sb.AppendLine($"\t[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
 		}
 
+		if (generateDefaultCtor)
+			sb.AppendLine($"\t[global::System.CodeDom.Compiler.GeneratedCode(\"Microsoft.Maui.Controls.SourceGen\", \"1.0.0.0\")]");
+
 		sb.AppendLine($"\t{accessModifier} partial class {rootType} : {baseType!.ToFQDisplayString()}");
 		sb.AppendLine("\t{");
 


### PR DESCRIPTION
### Description of Change

some types are 100% generated (for xaml-only resourcedictionaries). They should cause documentation to be generated, so mark them as [Generated]

### Issues Fixed

- fixes #27911
- closes #30259
