### PR TITLE
[Android] Fixed SelectionLength Not Updated Correctly for Right-to-Left Text Selection on Editor and Entry

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
@@ -35,12 +35,7 @@ namespace Microsoft.Maui.DeviceTests
 		static int GetPlatformSelectionLength(EditorHandler editorHandler)
 		{
 			var textView = GetPlatformControl(editorHandler);
-
-			if (textView != null)
-			{
-				return textView.GetSelectedTextLength();
-			}
-			return -1;
+			return textView?.GetSelectedTextLength() ?? -1;
 		}
 
 		Task<float> GetPlatformOpacity(EditorHandler editorHandler)

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -34,14 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 		static int GetPlatformSelectionLength(EntryHandler entryHandler)
 		{
 			var editText = GetPlatformControl(entryHandler);
-
-			if (editText != null)
-			{
-				// Use the extension method from EditTextExtensions which handles right-to-left selection correctly
-				return editText.GetSelectedTextLength();
-			}
-
-			return -1;
+			return editText?.GetSelectedTextLength() ?? -1;
 		}
 		Task<float> GetPlatformOpacity(EntryHandler entryHandler)
 		{

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -261,10 +261,16 @@ namespace Microsoft.Maui.Platform
 
 		static int GetSelectionEnd(EditText editText, ITextInput entry, int start)
 		{
-			int end = start;
 			int selectionLength = entry.SelectionLength;
-			end = System.Math.Max(start, System.Math.Min(editText.Length(), start + selectionLength));
-			int newSelectionLength = System.Math.Max(0, end - start);
+			int end = start;
+			end = Math.Max(start, Math.Min(editText.Length(), start + selectionLength));
+			int newSelectionLength = Math.Max(0, end - start);
+			if (start > editText.SelectionEnd && entry.SelectionLength > 0)
+			{
+				end = editText.SelectionEnd;
+				newSelectionLength = entry.SelectionLength;
+			}
+
 			// Updating this property results in UpdateSelectionLength being called again messing things up
 			if (newSelectionLength != selectionLength)
 				entry.SelectionLength = newSelectionLength;
@@ -274,8 +280,7 @@ namespace Microsoft.Maui.Platform
 		// TODO: NET8 issoto - Revisit this, marking this method as `internal` to avoid breaking public API changes
 		internal static int GetSelectedTextLength(this EditText editText)
 		{
-			var selectedLength = editText.SelectionEnd - editText.SelectionStart;
-			return Math.Max(0, selectedLength);
+			return Math.Abs(editText.SelectionEnd - editText.SelectionStart);
 		}
 
 		internal static void SetInputType(this EditText editText, ITextInput textInput)

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -262,13 +262,12 @@ namespace Microsoft.Maui.Platform
 		static int GetSelectionEnd(EditText editText, ITextInput entry, int start)
 		{
 			int selectionLength = entry.SelectionLength;
-			int end = start;
-			end = Math.Max(start, Math.Min(editText.Length(), start + selectionLength));
+			int end = Math.Max(start, Math.Min(editText.Length(), start + selectionLength));
 			int newSelectionLength = Math.Max(0, end - start);
-			if (start > editText.SelectionEnd && entry.SelectionLength > 0)
+			if (start > editText.SelectionEnd && selectionLength > 0)
 			{
 				end = editText.SelectionEnd;
-				newSelectionLength = entry.SelectionLength;
+				newSelectionLength = selectionLength;
 			}
 
 			// Updating this property results in UpdateSelectionLength being called again messing things up

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -264,6 +264,9 @@ namespace Microsoft.Maui.Platform
 			int selectionLength = entry.SelectionLength;
 			int end = Math.Max(start, Math.Min(editText.Length(), start + selectionLength));
 			int newSelectionLength = Math.Max(0, end - start);
+
+			// If 'start > editText.SelectionEnd', it indicates a reverse selection (right-to-left selection),
+			// where the user selected text starting from the right and moving to the left.
 			if (start > editText.SelectionEnd && selectionLength > 0)
 			{
 				end = editText.SelectionEnd;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
When selecting text from right to left, the SelectionLength property in Entry and Editor is incorrectly reported as 0 on Android.
 
### Root Cause
On Android, when selecting text from right to left, GetSelectedTextLength returned 0 due to incorrect handling of reverse selection. In GetSelectionEnd, the selection length was also calculated as 0, resulting in the selection length remaining zero even though text was selected.
 
### Description of Change
 
Updated GetSelectedTextLength() to return the absolute difference between SelectionStart and SelectionEnd using Math.Abs. Modified GetSelectionEnd() to handle right-to-left selection by adjusting the end position and correctly updating SelectionLength. This ensures consistent behavior across selection directions and platforms.
 
### Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed:
Fixes #30782 
 
### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/9e6aff76-aa74-41f5-9047-e8449262b313"> |   <video src="https://github.com/user-attachments/assets/e744b5fd-0b98-40d1-8875-e36e64021ccc">  |