### PR TITLE
Fix safe area defaults

### DIFF
--- a/src/Controls/src/Core/Border/Border.cs
+++ b/src/Controls/src/Core/Border/Border.cs
@@ -357,6 +357,12 @@ namespace Microsoft.Maui.Controls
 			// Use direct property
 			var regionForEdge = SafeAreaEdges.GetEdge(edge);
 
+			if (regionForEdge == SafeAreaRegions.Default)
+			{
+				// If no safe area edges are set, return None
+				return SafeAreaRegions.None;
+			}
+
 			// For Border, return as-is
 			return regionForEdge;
 		}

--- a/src/Controls/src/Core/ContentView/ContentView.cs
+++ b/src/Controls/src/Core/ContentView/ContentView.cs
@@ -88,6 +88,12 @@ namespace Microsoft.Maui.Controls
 			// Use direct property
 			var regionForEdge = SafeAreaEdges.GetEdge(edge);
 
+			if (regionForEdge == SafeAreaRegions.Default)
+			{
+				// If no safe area edges are set, return None
+				return SafeAreaRegions.None;
+			}
+
 			// For ContentView, return the region directly
 			return regionForEdge;
 		}

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -265,11 +265,15 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc cref="ISafeAreaView2.GetSafeAreaRegionsForEdge"/>
 		SafeAreaRegions ISafeAreaView2.GetSafeAreaRegionsForEdge(int edge)
 		{
-			// Use new SafeAreaElement method
-			var regionForEdge = SafeAreaElement.GetEdgeValue(this, edge);
-
-			// For Page (but not ContentPage), return as-is
-			return regionForEdge;
+			var ignoreSafeArea = ((ISafeAreaView)this).IgnoreSafeArea;
+			if (ignoreSafeArea)
+			{
+				return SafeAreaRegions.None; // If legacy says "ignore", return None (edge-to-edge)
+			}
+			else
+			{
+				return SafeAreaRegions.Container; // If legacy says "don't ignore", return Container
+			}
 		}
 
 		/// <summary>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28986_Border.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28986_Border.xaml
@@ -3,156 +3,190 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue28986_Border"
              Title="SafeArea Border Test">
-    
-    <Grid BackgroundColor="Red">
-        <!-- Border with SafeAreaEdges property -->
-        <Border x:Name="TestBorder" SafeAreaEdges="All" BackgroundColor="LightPink" Stroke="Purple" StrokeThickness="5">
-            <ScrollView>
-                <StackLayout Spacing="20" Padding="20">
-                    <Label Text="SafeArea Border Test" 
-                           FontSize="24" 
-                           FontAttributes="Bold"
-                           HorizontalOptions="Center" />
-                    
-                    <Label Text="This Border has SafeAreaEdges='All' and should extend behind system UI areas. The red background shows areas outside safe area."
-                           FontSize="14"
-                           HorizontalOptions="Center" />
-                    
-                    <Label x:Name="CurrentSettingsLabel"
-                           Text="Current Border SafeAreaEdges: All"
-                           FontSize="16"
-                           FontAttributes="Bold"
-                           HorizontalOptions="Center"
-                           AutomationId="CurrentSettings" />
-                    
-                    <!-- Control panel for Border SafeAreaEdges -->
-                    <Border BackgroundColor="White" Stroke="Gray" StrokeThickness="2" Padding="15">
-                        <VerticalStackLayout Spacing="15">
-                            <Label Text="Border SafeAreaEdges Control:" 
-                                   FontSize="18" 
-                                   FontAttributes="Bold"
-                                   HorizontalOptions="Center" />
-                            
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                
-                                <!-- Top -->
-                                <StackLayout Grid.Row="0" Grid.Column="1" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Top:" VerticalOptions="Center" />
-                                    <Picker x:Name="TopPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="TopPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <!-- Left and Right -->
-                                <StackLayout Grid.Row="1" Grid.Column="0" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Left:" VerticalOptions="Center" />
-                                    <Picker x:Name="LeftPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="LeftPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <StackLayout Grid.Row="1" Grid.Column="2" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Right:" VerticalOptions="Center" />
-                                    <Picker x:Name="RightPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="RightPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <!-- Bottom -->
-                                <StackLayout Grid.Row="2" Grid.Column="1" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Bottom:" VerticalOptions="Center" />
-                                    <Picker x:Name="BottomPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="BottomPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <!-- SoftInput test area -->
-                                <StackLayout Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="SoftInput Test:" VerticalOptions="Center" />
-                                    <Entry x:Name="SoftInputTestEntry" 
-                                           Placeholder="Tap to show keyboard" 
-                                           WidthRequest="200"
-                                           AutomationId="SoftInputTestEntry" />
-                                </StackLayout>
-                            </Grid>
-                            
-                            <Button Text="Reset All to Default" 
-                                    Clicked="OnResetDefaultClicked"
-                                    AutomationId="ResetDefaultButton" />
-                            <Button Text="Reset All to None" 
-                                    Clicked="OnResetNoneClicked"
-                                    AutomationId="ResetNoneButton" />
-                            <Button Text="Reset All to All" 
-                                    Clicked="OnResetAllClicked"
-                                    AutomationId="ResetAllButton" />
-                        </VerticalStackLayout>
-                    </Border>
-                    
-                    <!-- Sample content -->
-                    <Label Text="Border Sample Content" FontSize="18" FontAttributes="Bold" />
-                    <Label Text="This content is inside the Border that has SafeAreaEdges settings." />
-                    <Label Text="The Border should respect the SafeAreaEdges settings on each edge." />
-                    <Label Text="Notice the purple border around the entire content area." />
-                    <Label Text="Line 1" />
-                    <Label Text="Line 2" />
-                    <Label Text="Line 3" />
-                    <Label Text="Line 4" />
-                    <Label Text="Line 5" />
-                    <Label Text="Line 6" />
-                    <Label Text="Line 7" />
-                    <Label Text="Line 8" />
-                    <Label Text="Line 9" />
-                    <Label Text="Line 10" />
-                    <Label Text="End of Border Content" FontSize="18" FontAttributes="Bold" />
-                </StackLayout>
-            </ScrollView>
-        </Border>
-    </Grid>
+
+    <!-- Border with SafeAreaEdges property -->
+    <Border x:Name="TestBorder"
+            SafeAreaEdges="Default"
+            BackgroundColor="LightPink"
+            Stroke="Purple"
+            StrokeThickness="5">
+        <ScrollView SafeAreaEdges="None"
+                    x:Name="BorderContent"
+                    AutomationId="BorderContent"
+                    BackgroundColor="LightGray">
+            <StackLayout Spacing="20"
+                         Padding="20">
+                <Label Text="SafeArea Border Test"
+                       FontSize="24"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"/>
+
+                <Label Text="This Border has SafeAreaEdges='All' and should extend behind system UI areas. The red background shows areas outside safe area."
+                       FontSize="14"
+                       HorizontalOptions="Center"/>
+
+                <Label x:Name="CurrentSettingsLabel"
+                       Text="Current Border SafeAreaEdges: All"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"
+                       AutomationId="CurrentSettings"/>
+
+                <!-- Control panel for Border SafeAreaEdges -->
+                <Border BackgroundColor="White"
+                        Stroke="Gray"
+                        StrokeThickness="2"
+                        Padding="15">
+                    <VerticalStackLayout Spacing="15">
+                        <Label Text="Border SafeAreaEdges Control:"
+                               FontSize="18"
+                               FontAttributes="Bold"
+                               HorizontalOptions="Center"/>
+
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Top -->
+                            <StackLayout Grid.Row="0"
+                                         Grid.Column="1"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Top:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="TopPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="TopPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <!-- Left and Right -->
+                            <StackLayout Grid.Row="1"
+                                         Grid.Column="0"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Left:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="LeftPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="LeftPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <StackLayout Grid.Row="1"
+                                         Grid.Column="2"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Right:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="RightPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="RightPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <!-- Bottom -->
+                            <StackLayout Grid.Row="2"
+                                         Grid.Column="1"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Bottom:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="BottomPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="BottomPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <!-- SoftInput test area -->
+                            <StackLayout Grid.Row="3"
+                                         Grid.Column="0"
+                                         Grid.ColumnSpan="3"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="SoftInput Test:"
+                                       VerticalOptions="Center"/>
+                                <Entry x:Name="SoftInputTestEntry"
+                                       Placeholder="Tap to show keyboard"
+                                       WidthRequest="200"
+                                       AutomationId="SoftInputTestEntry"/>
+                            </StackLayout>
+                        </Grid>
+
+                        <Button Text="Reset All to Default"
+                                Clicked="OnResetDefaultClicked"
+                                AutomationId="ResetDefaultButton"/>
+                        <Button Text="Reset All to None"
+                                Clicked="OnResetNoneClicked"
+                                AutomationId="ResetNoneButton"/>
+                        <Button Text="Reset All to All"
+                                Clicked="OnResetAllClicked"
+                                AutomationId="ResetAllButton"/>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Sample content -->
+                <Label Text="Border Sample Content"
+                       FontSize="18"
+                       FontAttributes="Bold"/>
+                <Label Text="This content is inside the Border that has SafeAreaEdges settings."/>
+                <Label Text="The Border should respect the SafeAreaEdges settings on each edge."/>
+                <Label Text="Notice the purple border around the entire content area."/>
+                <Label Text="Line 1"/>
+                <Label Text="Line 2"/>
+                <Label Text="Line 3"/>
+                <Label Text="Line 4"/>
+                <Label Text="Line 5"/>
+                <Label Text="Line 6"/>
+                <Label Text="Line 7"/>
+                <Label Text="Line 8"/>
+                <Label Text="Line 9"/>
+                <Label Text="Line 10"/>
+                <Label Text="End of Border Content"
+                       FontSize="18"
+                       FontAttributes="Bold"/>
+            </StackLayout>
+        </ScrollView>
+    </Border>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue28986_ContentView.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue28986_ContentView.xaml
@@ -3,155 +3,186 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue28986_ContentView"
              Title="SafeArea ContentView Test">
-    
-    <Grid BackgroundColor="Red">
-        <!-- ContentView with SafeAreaEdges property -->
-        <ContentView x:Name="TestContentView" SafeAreaEdges="All" BackgroundColor="LightGreen">
-            <ScrollView>
-                <StackLayout Spacing="20" Padding="20">
-                    <Label Text="SafeArea ContentView Test" 
-                           FontSize="24" 
-                           FontAttributes="Bold"
-                           HorizontalOptions="Center" />
-                    
-                    <Label Text="This ContentView has SafeAreaEdges='All' and should extend behind system UI areas. The red background shows areas outside safe area."
-                           FontSize="14"
-                           HorizontalOptions="Center" />
-                    
-                    <Label x:Name="CurrentSettingsLabel"
-                           Text="Current ContentView SafeAreaEdges: All"
-                           FontSize="16"
-                           FontAttributes="Bold"
-                           HorizontalOptions="Center"
-                           AutomationId="CurrentSettings" />
-                    
-                    <!-- Control panel for ContentView SafeAreaEdges -->
-                    <Border BackgroundColor="White" Stroke="Gray" StrokeThickness="2" Padding="15">
-                        <VerticalStackLayout Spacing="15">
-                            <Label Text="ContentView SafeAreaEdges Control:" 
-                                   FontSize="18" 
-                                   FontAttributes="Bold"
-                                   HorizontalOptions="Center" />
-                            
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                
-                                <!-- Top -->
-                                <StackLayout Grid.Row="0" Grid.Column="1" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Top:" VerticalOptions="Center" />
-                                    <Picker x:Name="TopPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="TopPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <!-- Left and Right -->
-                                <StackLayout Grid.Row="1" Grid.Column="0" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Left:" VerticalOptions="Center" />
-                                    <Picker x:Name="LeftPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="LeftPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <StackLayout Grid.Row="1" Grid.Column="2" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Right:" VerticalOptions="Center" />
-                                    <Picker x:Name="RightPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="RightPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <!-- Bottom -->
-                                <StackLayout Grid.Row="2" Grid.Column="1" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="Bottom:" VerticalOptions="Center" />
-                                    <Picker x:Name="BottomPicker" 
-                                            SelectedIndex="0" 
-                                            SelectedIndexChanged="OnEdgePickerChanged"
-                                            AutomationId="BottomPicker">
-                                        <Picker.Items>
-                                            <x:String>None</x:String>
-                                            <x:String>SoftInput</x:String>
-                                            <x:String>Container</x:String>
-                                            <x:String>Default</x:String>
-                                            <x:String>All</x:String>
-                                        </Picker.Items>
-                                    </Picker>
-                                </StackLayout>
-                                
-                                <!-- SoftInput test area -->
-                                <StackLayout Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalOptions="Center">
-                                    <Label Text="SoftInput Test:" VerticalOptions="Center" />
-                                    <Entry x:Name="SoftInputTestEntry" 
-                                           Placeholder="Tap to show keyboard" 
-                                           WidthRequest="200"
-                                           AutomationId="SoftInputTestEntry" />
-                                </StackLayout>
-                            </Grid>
-                            
-                            <Button Text="Reset All to Default" 
-                                    Clicked="OnResetDefaultClicked"
-                                    AutomationId="ResetDefaultButton" />
-                            <Button Text="Reset All to None" 
-                                    Clicked="OnResetNoneClicked"
-                                    AutomationId="ResetNoneButton" />
-                            <Button Text="Reset All to All" 
-                                    Clicked="OnResetAllClicked"
-                                    AutomationId="ResetAllButton" />
-                        </VerticalStackLayout>
-                    </Border>
-                    
-                    <!-- Sample content -->
-                    <Label Text="ContentView Sample Content" FontSize="18" FontAttributes="Bold" />
-                    <Label Text="This content is inside the ContentView that has SafeAreaEdges settings." />
-                    <Label Text="The ContentView should respect the SafeAreaEdges settings on each edge." />
-                    <Label Text="Line 1" />
-                    <Label Text="Line 2" />
-                    <Label Text="Line 3" />
-                    <Label Text="Line 4" />
-                    <Label Text="Line 5" />
-                    <Label Text="Line 6" />
-                    <Label Text="Line 7" />
-                    <Label Text="Line 8" />
-                    <Label Text="Line 9" />
-                    <Label Text="Line 10" />
-                    <Label Text="End of ContentView Content" FontSize="18" FontAttributes="Bold" />
-                </StackLayout>
-            </ScrollView>
-        </ContentView>
-    </Grid>
+
+    <!-- ContentView with SafeAreaEdges property -->
+    <ContentView x:Name="TestContentView"
+                 SafeAreaEdges="Default"
+                 BackgroundColor="LightGreen">
+        <ScrollView SafeAreaEdges="None"
+                    AutomationId="ContentViewContent"
+                    x:Name="ContentViewContent">
+            <StackLayout Spacing="20"
+                         Padding="20">
+                <Label Text="SafeArea ContentView Test"
+                       FontSize="24"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"/>
+
+                <Label Text="This ContentView has SafeAreaEdges='All' and should extend behind system UI areas. The red background shows areas outside safe area."
+                       FontSize="14"
+                       HorizontalOptions="Center"/>
+
+                <Label x:Name="CurrentSettingsLabel"
+                       Text="Current ContentView SafeAreaEdges: All"
+                       FontSize="16"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"
+                       AutomationId="CurrentSettings"/>
+
+                <!-- Control panel for ContentView SafeAreaEdges -->
+                <Border BackgroundColor="White"
+                        Stroke="Gray"
+                        StrokeThickness="2"
+                        Padding="15">
+                    <VerticalStackLayout Spacing="15">
+                        <Label Text="ContentView SafeAreaEdges Control:"
+                               FontSize="18"
+                               FontAttributes="Bold"
+                               HorizontalOptions="Center"/>
+
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Top -->
+                            <StackLayout Grid.Row="0"
+                                         Grid.Column="1"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Top:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="TopPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="TopPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <!-- Left and Right -->
+                            <StackLayout Grid.Row="1"
+                                         Grid.Column="0"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Left:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="LeftPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="LeftPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <StackLayout Grid.Row="1"
+                                         Grid.Column="2"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Right:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="RightPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="RightPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <!-- Bottom -->
+                            <StackLayout Grid.Row="2"
+                                         Grid.Column="1"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="Bottom:"
+                                       VerticalOptions="Center"/>
+                                <Picker x:Name="BottomPicker"
+                                        SelectedIndex="0"
+                                        SelectedIndexChanged="OnEdgePickerChanged"
+                                        AutomationId="BottomPicker">
+                                    <Picker.Items>
+                                        <x:String>None</x:String>
+                                        <x:String>SoftInput</x:String>
+                                        <x:String>Container</x:String>
+                                        <x:String>Default</x:String>
+                                        <x:String>All</x:String>
+                                    </Picker.Items>
+                                </Picker>
+                            </StackLayout>
+
+                            <!-- SoftInput test area -->
+                            <StackLayout Grid.Row="3"
+                                         Grid.Column="0"
+                                         Grid.ColumnSpan="3"
+                                         Orientation="Horizontal"
+                                         HorizontalOptions="Center">
+                                <Label Text="SoftInput Test:"
+                                       VerticalOptions="Center"/>
+                                <Entry x:Name="SoftInputTestEntry"
+                                       Placeholder="Tap to show keyboard"
+                                       WidthRequest="200"
+                                       AutomationId="SoftInputTestEntry"/>
+                            </StackLayout>
+                        </Grid>
+
+                        <Button Text="Reset All to Default"
+                                Clicked="OnResetDefaultClicked"
+                                AutomationId="ResetDefaultButton"/>
+                        <Button Text="Reset All to None"
+                                Clicked="OnResetNoneClicked"
+                                AutomationId="ResetNoneButton"/>
+                        <Button Text="Reset All to All"
+                                Clicked="OnResetAllClicked"
+                                AutomationId="ResetAllButton"/>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Sample content -->
+                <Label Text="ContentView Sample Content"
+                       FontSize="18"
+                       FontAttributes="Bold"/>
+                <Label Text="This content is inside the ContentView that has SafeAreaEdges settings."/>
+                <Label Text="The ContentView should respect the SafeAreaEdges settings on each edge."/>
+                <Label Text="Line 1"/>
+                <Label Text="Line 2"/>
+                <Label Text="Line 3"/>
+                <Label Text="Line 4"/>
+                <Label Text="Line 5"/>
+                <Label Text="Line 6"/>
+                <Label Text="Line 7"/>
+                <Label Text="Line 8"/>
+                <Label Text="Line 9"/>
+                <Label Text="Line 10"/>
+                <Label Text="End of ContentView Content"
+                       FontSize="18"
+                       FontAttributes="Bold"/>
+            </StackLayout>
+        </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_Border.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_Border.cs
@@ -1,0 +1,49 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28986_Border : _IssuesUITest
+	{
+		public override string Issue => "Test SafeArea Border for per-edge safe area control";
+
+		public Issue28986_Border(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Border)]
+		public void SafeAreaBorderBasicFunctionality()
+		{
+			var borderContent = App.WaitForElement("BorderContent");
+
+			// 1. Ensure SafeAreaEdges is Default
+			var initialSettings = App.FindElement("CurrentSettings").GetText();
+			Assert.That(initialSettings, Does.Contain("Left: Default, Top: Default, Right: Default, Bottom: Default"));
+			var borderWithDefaultSettings = borderContent.GetRect();
+			// Verify that Border starts at Y=5 when SafeAreaEdges is Default
+			// Because the border stroke thickness is 5
+			Assert.That(borderWithDefaultSettings.Y, Is.EqualTo(5), "Border should start at Y=5 when SafeAreaEdges is set to Default");
+
+			// 2. Ensure SafeAreaEdges are set to All
+			App.Tap("ResetAllButton");
+			var allSettings = App.FindElement("CurrentSettings").GetText();
+			Assert.That(allSettings, Does.Contain("Left: All, Top: All, Right: All, Bottom: All"));
+			var borderSafeAreaEdgesAll = App.WaitForElement("BorderContent").GetRect();
+			Assert.That(borderSafeAreaEdgesAll.Y, Is.GreaterThan(borderWithDefaultSettings.Y), "Border should move down (greater Y position) when SafeAreaEdges changes from Default to All");
+
+			// 3. Ensure SafeAreaEdges are set to None (edge-to-edge)
+			App.Tap("ResetNoneButton");
+			var noneSettings = App.FindElement("CurrentSettings").GetText();
+			Assert.That(noneSettings, Does.Contain("Left: None, Top: None, Right: None, Bottom: None"));
+			var borderSafeAreaEdgesNone = App.WaitForElement("BorderContent").GetRect();
+			// Verify that Border position is at Y=5 when SafeAreaEdges is None
+			// This is because the border stroke thickness is 5
+			Assert.That(borderSafeAreaEdgesNone.Y, Is.EqualTo(5),
+				"Border should be at Y=5 when SafeAreaEdges is set to None (edge-to-edge)");
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ContentView.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ContentView.cs
@@ -1,0 +1,49 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue28986_ContentView : _IssuesUITest
+	{
+		public override string Issue => "Test SafeArea ContentView for per-edge safe area control";
+
+		public Issue28986_ContentView(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.Layout)]
+		public void SafeAreaContentViewBasicFunctionality()
+		{
+			var contentViewContent = App.WaitForElement("ContentViewContent");
+
+			// 1. Ensure SafeAreaEdges is Default
+			var initialSettings = App.FindElement("CurrentSettings").GetText();
+			Assert.That(initialSettings, Does.Contain("Left: Default, Top: Default, Right: Default, Bottom: Default"));
+			var contentViewWithDefaultSettings = contentViewContent.GetRect();
+			// Verify that ContentView content starts at Y=0 when SafeAreaEdges is Default
+			Assert.That(contentViewWithDefaultSettings.Y, Is.EqualTo(0),
+				"ContentView should start at Y=0 when SafeAreaEdges is set to Default");
+
+			// 2. Ensure SafeAreaEdges are set to All
+			App.Tap("ResetAllButton");
+			var allSettings = App.FindElement("CurrentSettings").GetText();
+			Assert.That(allSettings, Does.Contain("Left: All, Top: All, Right: All, Bottom: All"));
+			var contentViewSafeAreaEdgesAll = App.WaitForElement("ContentViewContent").GetRect();
+			Assert.That(contentViewSafeAreaEdgesAll.Y, Is.GreaterThan(contentViewWithDefaultSettings.Y),
+				"ContentView should move down (greater Y position) when SafeAreaEdges changes from Default to All");
+
+			// 3. Ensure SafeAreaEdges are set to None (edge-to-edge)
+			App.Tap("ResetNoneButton");
+			var noneSettings = App.FindElement("CurrentSettings").GetText();
+			Assert.That(noneSettings, Does.Contain("Left: None, Top: None, Right: None, Bottom: None"));
+			var contentViewSafeAreaEdgesNone = App.WaitForElement("ContentViewContent").GetRect();
+			// Verify that ContentView position is at Y=0 when SafeAreaEdges is None
+			Assert.That(contentViewSafeAreaEdgesNone.Y, Is.EqualTo(0),
+				"ContentView should be at Y=0 when SafeAreaEdges is set to None (edge-to-edge)");
+		}
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change
By default we want "Border" and "ContentView" to be edge to edge controls because that's how they've always worked. We don't want this behavior to change for users.

This PR restores those defaults and adds tests to make sure that doesn't change in the future and that DEFAULT will always mean edge to edge

### Functional Improvements to Safe Area Handling:

* **`Border.cs` and `ContentView.cs`:** Added logic to return `SafeAreaRegions.None` when the safe area edges are set to `Default`, ensuring proper fallback behavior when no specific edges are configured. [[1]](diffhunk://#diff-356d119e99e7b0473adc38b35839aff1ab325ba60796b0f4774e549b47400d4aR360-R365) [[2]](diffhunk://#diff-bf425ef4a63fb3cb4ddea758d924f8ae7b0062f9d32619b79b5c1426af24775dR91-R96)
* **`Page.cs`:** Updated safe area handling to respect legacy `IgnoreSafeArea` settings, returning `SafeAreaRegions.None` for edge-to-edge behavior or `SafeAreaRegions.Container` otherwise.

### UI Test Enhancements:

* **`Issue28986_Border.cs`:** Added a new test case to validate the behavior of `SafeAreaEdges` in `Border` components, ensuring correct functionality for `Default`, `All`, and `None` configurations.

### Updates to XAML Test Cases:

* **`Issue28986_Border.xaml` and `Issue28986_ContentView.xaml`:** Refactored XAML files to use `SafeAreaEdges="Default"` and added test-specific configurations for `None` and edge-specific settings. Improved formatting for better readability. [[1]](diffhunk://#diff-a864309b38ec95f4c5327a05b31daf25850b112c5c213aa8c4aa4e2c9ef52f65L7-R18) [[2]](diffhunk://#diff-39cf85f2491e6286597562011ff0e646a30e803f0af0093132366cbb8a56ac8bL7-R15)

These changes collectively enhance safe area management and improve test coverage for edge-specific configurations.



