### PR TITLE
Fix duplicate app icon resizing

### DIFF
--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -227,7 +227,6 @@ namespace Microsoft.Maui.Resizetizer
 					continue;
 				}
 
-				appTool.Resize(dpi, destination);
 				var r = appTool.Resize(dpi, destination);
 				resizedImages.Add(r);
 			}

--- a/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string AppIconName { get; }
 
-		public ResizedImageInfo Resize(DpiPath dpi, string destination, Func<Stream>? getStream = null)
+		public ResizedImageInfo Resize(DpiPath dpi, string destination, Stream? stream = null)
 		{
 			var sw = new Stopwatch();
 			sw.Start();
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Resizetizer
 			using (var tempBitmap = new SKBitmap(canvasSize.Width, canvasSize.Height))
 			{
 				Draw(tempBitmap, dpi, unscaledCanvasSize);
-				Save(tempBitmap, destination, getStream);
+				Save(tempBitmap, destination, stream);
 			}
 
 			sw.Stop();
@@ -60,11 +60,10 @@ namespace Microsoft.Maui.Resizetizer
 			return new ResizedImageInfo { Dpi = dpi, Filename = destination };
 		}
 
-		void Save(SKBitmap tempBitmap, string destination, Func<Stream>? getStream)
+		void Save(SKBitmap tempBitmap, string destination, Stream? stream)
 		{
-			if (getStream is not null)
+			if (stream is not null)
 			{
-				var stream = getStream();
 				tempBitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
 			}
 			else

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Maui.Resizetizer
 				return new ResizedImageInfo { Dpi = dpi, Filename = destination };
 			}
 
-			MemoryStream memoryStream = new MemoryStream();
-			tools.Resize(dpi, destination, () => memoryStream);
+			using MemoryStream memoryStream = new MemoryStream();
+			tools.Resize(dpi, destination, memoryStream);
 			memoryStream.Position = 0;
 
 			int numberOfImages = 1;


### PR DESCRIPTION
### Description of Change

Avoid encoding PNGs twice when resizing icons.

### Issues Fixed

The file stream is already correctly disposed when encoding the PNGs, so this doesn't seem like it's a root cause fix for #30900, but it probably makes it less likely to occur. I suspect that the same file is being written by two separate tasks, but need to investigate further.