### PR TITLE
Fix Provision JDK step for Linux on CI

### DIFF
--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -359,7 +359,7 @@
 		</PropertyGroup>
 		<ItemGroup>
 			<_ProvisionJdkLinuxCommands Include="wget https://packages.microsoft.com/config/ubuntu/`lsb_release -rs`/packages-microsoft-prod.deb -O packages-microsoft-prod.deb" />
-			<_ProvisionJdkLinuxCommands Include="$(_JdkSudo)dpkg -i packages-microsoft-prod.deb" />
+			<_ProvisionJdkLinuxCommands Include="$(_JdkSudo)dpkg --force-confdef -i packages-microsoft-prod.deb" />
 			<_ProvisionJdkLinuxCommands Include="rm packages-microsoft-prod.deb" />
 			<_ProvisionJdkLinuxCommands Include="$(_JdkSudo)apt-get update" />
 			<_ProvisionJdkLinuxCommands Include="$(_JdkSudo)apt-get install -y msopenjdk-$(_AndroidJdkMajorVersion)" />


### PR DESCRIPTION
This change adds the `--force-confdef` switch to the `dpkg` that happens while provisioning the JDK on Linux. This means that the default option is selected when interactive feedback is requested. In our case at the time of writing, this was the output that would hang the builds:

```
Task "Exec"
         Task Parameter:Command=sudo dpkg -i packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         (Reading database ... 295979 files and directories currently installed.)
         Preparing to unpack packages-microsoft-prod.deb ...
         Unpacking packages-microsoft-prod (1.2-ubuntu22.04) over (1.0-ubuntu22.04.1) ...
         Setting up packages-microsoft-prod (1.2-ubuntu22.04) ...
         
         Configuration file '/etc/apt/sources.list.d/microsoft-prod.list'
          ==> Modified (by you or by a script) since installation.
          ==> Package distributor has shipped an updated version.
            What would you like to do about it ?  Your options are:
             Y or I  : install the package maintainer's version
             N or O  : keep your currently-installed version
               D     : show the differences between the versions
               Z     : start a shell to examine the situation
          The default action is to keep your current version.
```

With this switch, the default action (in this case N, keep currently installed version) is selected.