### PR TITLE
[ci] Add words to cspell

### DIFF
--- a/eng/automation/cspell/cSpell.json
+++ b/eng/automation/cspell/cSpell.json
@@ -10,7 +10,12 @@
         "Appium",
         "XCUI",
         "Automator",
-        "cgmanifest"
+        "cgmanifest",
+        "Namescopes",
+        "sourcegen",
+        "Tizen",
+        "darc",
+        "Darc"
     ],
     "ignoreWords": [],
     "patterns": [


### PR DESCRIPTION
### Description of Change

This pull request updates the `cSpell.json` file to include new words in the spell checker dictionary. These additions ensure that terms relevant to the codebase are recognized as valid.

### Updates to the spell checker dictionary:

* [`eng/automation/cspell/cSpell.json`](diffhunk://#diff-e1dc098a91ce6189a2c6058d29e3b0a3cb33f86b0a280e6ac065b55e8337e9deL13-R18): Added the following words to the dictionary: "Namescopes," "sourcegen," "Tizen," "darc," and "Darc."