### PR TITLE
[release/9.0.1xx-sr8] Fix signing of fonts with arcade infra

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,6 +29,7 @@
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".ttf" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,7 +29,7 @@
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-    <FileExtensionSignInfo Include=".ttf" CertificateName="None" />
+    <FileExtensionSignInfo Include=".ttf" CertificateName="Microsoft400" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

Our ttf files weren't being signed and failed vs insertion when changing to use arcade ci. This change should fix the missing fonts.

This pull request includes a small update to the `eng/Signing.props` file to add signing information for `.ttf` files.

* [`eng/Signing.props`](diffhunk://#diff-a923a7746e08ef5df4bfd49f340d9f93055d66ba792770a7e1c227b3eaf3d4efR32): Added a new `FileExtensionSignInfo` entry for `.ttf` files with the certificate name `Microsoft400`.