### PR TITLE
[net10.0] [ci] Update sdk workload

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25378.103">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-preview.7.229">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -32,7 +32,7 @@
     <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10601-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>b7705312033433f3f4de8fcc314c49ef2954261a</Sha>
-    </Dependency>   
+    </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9215" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_18.5">
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25378.103">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.7.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25375.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25378.103">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25380.108">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>ca69fc430c58fc8ea9f0d01d4dfceaaa75fd1536</Sha>
+      <Sha>30000d883e06c122311a66894579bc12329a09d4</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>be1cab92326783479054e72990da08008e5be819</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10601-net10-p7">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10603-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b7705312033433f3f4de8fcc314c49ef2954261a</Sha>
+      <Sha>cf8e458a7acc484e3a50f64e427680e35d7bf49f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10601-net10-p7">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10603-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b7705312033433f3f4de8fcc314c49ef2954261a</Sha>
+      <Sha>cf8e458a7acc484e3a50f64e427680e35d7bf49f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10601-net10-p7">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10603-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b7705312033433f3f4de8fcc314c49ef2954261a</Sha>
+      <Sha>cf8e458a7acc484e3a50f64e427680e35d7bf49f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10601-net10-p7">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10603-net10-p7">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b7705312033433f3f4de8fcc314c49ef2954261a</Sha>
+      <Sha>cf8e458a7acc484e3a50f64e427680e35d7bf49f</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,10 @@
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.92</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10601-net10-p7</MicrosoftMacCatalystSdknet100_185PackageVersion>
-    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10601-net10-p7</MicrosoftmacOSSdknet100_155PackageVersion>
-    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10601-net10-p7</MicrosoftiOSSdknet100_185PackageVersion>
-    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10601-net10-p7</MicrosofttvOSSdknet100_185PackageVersion>
+    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10603-net10-p7</MicrosoftMacCatalystSdknet100_185PackageVersion>
+    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10603-net10-p7</MicrosoftmacOSSdknet100_155PackageVersion>
+    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10603-net10-p7</MicrosoftiOSSdknet100_185PackageVersion>
+    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10603-net10-p7</MicrosofttvOSSdknet100_185PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9215</MicrosoftMacCatalystSdknet90_185PackageVersion>
     <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9215</MicrosoftmacOSSdknet90_155PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,27 +30,27 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.82</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25378.103</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-preview.7.25380.108</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25378.103</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.7.25380.108</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25378.103</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-preview.7.25380.108</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-preview.7.229</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.92</MicrosoftNETSdkAndroidManifest90100PackageVersion>
@@ -73,19 +73,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25378.103</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25378.103</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-preview.7.25380.108</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-preview.7.25380.108</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -142,13 +142,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25378.103</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25378.103</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25378.103</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25378.103</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25380.108</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25380.108</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25380.108</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25380.108</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25378.103</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25378.103</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25380.108</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25380.108</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.7.25378.103"
+    "dotnet": "10.0.100-preview.7.25380.108"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25378.103",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25378.103"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25380.108",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25380.108"
   },
   "sdk": {
     "allowPrerelease": true


### PR DESCRIPTION
### Description of Change

This pull request updates various dependencies to newer versions across multiple configuration files. The changes ensure the project uses the latest preview versions of the .NET SDK, runtime, and related libraries.

```
➜  maui git:(update-277408) ✗ darc update-dependencies --id "277408" --verbose
```

### Dependency Updates

* Updated `Microsoft.NET.Sdk` and `Microsoft.NETCore.App.Ref` dependencies to version `10.0.100-preview.7.25380.108` in `eng/Version.Details.xml` and `eng/Versions.props` files. Corresponding SHA values were also updated. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R9) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L33-R53)
* Updated various `Microsoft.AspNetCore.*` and `Microsoft.Extensions.*` package versions to `10.0.0-preview.7.25380.108` in `eng/Version.Details.xml` and `eng/Versions.props` files. This includes libraries for authorization, authentication, dependency injection, logging, and more. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L57-R159) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L76-R88)
* Updated toolset dependencies such as `Microsoft.DotNet.Build.Tasks.Feed`, `Microsoft.DotNet.Arcade.Sdk`, and `Microsoft.DotNet.Helix.Sdk` to version `10.0.0-beta.25380.108` in `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L175-R205) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L145-R151)

### Tooling Configuration

* Updated the `dotnet` SDK version to `10.0.100-preview.7.25380.108` in `global.json`. Updated `Microsoft.DotNet.Arcade.Sdk` and `Microsoft.DotNet.Helix.Sdk` versions as well.