### PR TITLE
[Android] Fix for incorrect scroll position when using ScrollTo with a header in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -425,9 +425,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (args.Mode == ScrollToMode.Position)
 			{
 				// Do not use `IGroupableItemsViewSource` since `UngroupedItemsSource` also implements that interface
-				if (ItemsViewAdapter.ItemsSource is UngroupedItemsSource)
+				if (ItemsViewAdapter.ItemsSource is UngroupedItemsSource ungroupedSource)
 				{
-					return args.Index;
+					return ungroupedSource.HasHeader ? args.Index + 1 : args.Index;
 				}
 				else if (ItemsViewAdapter.ItemsSource is IGroupableItemsViewSource groupItemSource)
 				{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18389.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18389.cs
@@ -6,7 +6,7 @@ namespace Maui.Controls.Sample.Issues;
 public class Issue18389 : ContentPage
 {
 	ObservableCollection<string> _items;
-	CollectionView _collectionView;
+	CollectionView2 _collectionView;
 	public Issue18389()
 	{
 		GenerateItems();
@@ -17,6 +17,8 @@ public class Issue18389 : ContentPage
 			RowSpacing = 10,
 			RowDefinitions =
 			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
 				new RowDefinition { Height = GridLength.Auto },
 				new RowDefinition { Height = GridLength.Star }
 			}
@@ -29,9 +31,25 @@ public class Issue18389 : ContentPage
 		};
 		scrollToIndexButton.Clicked += ScrollToLastItem;
 
-		mainGrid.Add(scrollToIndexButton, 0, 0);
+		Button removeHeaderButton = new Button
+		{
+			AutomationId = "Issue18389_RemoveHeaderBtn",
+			Text = "Remove Header"
+		};
+		removeHeaderButton.Clicked += RemoveHeader;
 
-		_collectionView = new CollectionView
+		Button resetCollectionViewButton = new Button
+		{
+			AutomationId = "Issue18389_ResetBtn",
+			Text = "Reset CollectionView to 0,0"
+		};
+		resetCollectionViewButton.Clicked += ResetCollectionView;
+
+		mainGrid.Add(scrollToIndexButton, 0, 0);
+		mainGrid.Add(resetCollectionViewButton, 0, 1);
+		mainGrid.Add(removeHeaderButton, 0, 2);
+
+		_collectionView = new CollectionView2
 		{
 			ItemsSource = _items,
 			ItemTemplate = new DataTemplate(() =>
@@ -63,7 +81,7 @@ public class Issue18389 : ContentPage
 			},
 		};
 
-		mainGrid.Add(_collectionView, 0, 1);
+		mainGrid.Add(_collectionView, 0, 3);
 
 		Content = mainGrid;
 	}
@@ -80,6 +98,16 @@ public class Issue18389 : ContentPage
 
 	void ScrollToLastItem(object sender, EventArgs e)
 	{
-		_collectionView.ScrollTo(_items.Count - 1);
+		_collectionView.ScrollTo(_items.Count - 1, -1, ScrollToPosition.End);
+	}
+
+	void RemoveHeader(object sender, EventArgs e)
+	{
+		_collectionView.Header = null;
+	}
+
+	void ResetCollectionView(object sender, EventArgs e)
+	{
+		_collectionView.ScrollTo(0);
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18389.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18389.cs
@@ -1,0 +1,85 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 18389, "Incorrect scroll position when scrolling to an item with header in CollectionView", PlatformAffected.Android)]
+public class Issue18389 : ContentPage
+{
+	ObservableCollection<string> _items;
+	CollectionView _collectionView;
+	public Issue18389()
+	{
+		GenerateItems();
+
+		Grid mainGrid = new Grid
+		{
+			Padding = new Thickness(20),
+			RowSpacing = 10,
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		Button scrollToIndexButton = new Button
+		{
+			AutomationId = "Issue18389_ScrollToBtn",
+			Text = "Click me to scroll to index Count - 1!"
+		};
+		scrollToIndexButton.Clicked += ScrollToLastItem;
+
+		mainGrid.Add(scrollToIndexButton, 0, 0);
+
+		_collectionView = new CollectionView
+		{
+			ItemsSource = _items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				Label label = new Label
+				{
+					FontSize = 40
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				label.SetBinding(Label.AutomationIdProperty, ".");
+
+				return label;
+			}),
+			Header = new Label
+			{
+				Text = "Header",
+				BackgroundColor = Colors.Black,
+				TextColor = Colors.White,
+				FontSize = 50,
+				FontFamily = "Bold"
+			},
+			Footer = new Label
+			{
+				Text = "Footer",
+				BackgroundColor = Colors.Black,
+				TextColor = Colors.White,
+				FontSize = 50,
+				FontFamily = "Bold"
+			},
+		};
+
+		mainGrid.Add(_collectionView, 0, 1);
+
+		Content = mainGrid;
+	}
+
+	void GenerateItems()
+	{
+		_items = new ObservableCollection<string>();
+
+		for (int i = 1; i <= 20; i++)
+		{
+			_items.Add($"Item {i}");
+		}
+	}
+
+	void ScrollToLastItem(object sender, EventArgs e)
+	{
+		_collectionView.ScrollTo(_items.Count - 1);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18389.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18389.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue18389 : _IssuesUITest
+{
+	public Issue18389(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Incorrect scroll position when scrolling to an item with header in CollectionView";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyScrollToIndexWithHeader()
+	{
+		App.WaitForElement("Issue18389_ScrollToBtn");
+		App.Tap("Issue18389_ScrollToBtn");
+
+		App.WaitForElement("Item 20");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18389.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18389.cs
@@ -20,5 +20,16 @@ public class Issue18389 : _IssuesUITest
 		App.Tap("Issue18389_ScrollToBtn");
 
 		App.WaitForElement("Item 20");
+
+		App.WaitForElement("Issue18389_ResetBtn");
+		App.Tap("Issue18389_ResetBtn");
+
+		App.WaitForElement("Item 1");
+
+		App.WaitForElement("Issue18389_RemoveHeaderBtn");
+		App.Tap("Issue18389_RemoveHeaderBtn");
+
+		App.Tap("Issue18389_ScrollToBtn");
+		App.WaitForElement("Item 20");
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- On Android, when a header is present in a CollectionView, programmatically scrolling to the last item using ScrollTo(Count - 1) does not behave as expected—it scrolls to the second-to-last item instead of the intended last item.

### Root Cause

- On Android, when using a CollectionView with a header, the header occupies the first position (index 0) in the layout. However, the original implementation did not account for this offset. As a result, when scrolling to a target index (e.g., Count - 1), the presence of the header shifted the visible items by one, causing the scroll to stop one item short—typically landing on the second-to-last item instead of the intended last item.

### Description of Change

- Updated DetermineTargetPosition in MauiRecyclerView.cs to account for the presence of a header in UngroupedItemsSource.
- The method now adjusts the target index by adding 1 if a header is present.

### Issues Fixed
Fixes #18389 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/6b0ace11-8116-4318-87ed-1a3a963ebc1d"> | <video src="https://github.com/user-attachments/assets/395e538d-dbae-4123-b94e-acf0fdc68a91"> |