### PR TITLE
[Windows] Fixed the ArgumentOutOfRangeException when setting the null to MinimumDate property in DatePicker

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.Windows.cs
@@ -38,6 +38,29 @@ public partial class DatePickerTests
 		});
 	}
 
+	[Fact]
+	[Description("Setting the DatePicker's MinimumDate to null should not throw an ArgumentOutOfRangeException")]
+	public async Task DatePickerMinimumDateToNullShouldNotThrowArgumentOutOfRangeException()
+	{
+		SetupBuilder();
+
+		var datePicker = new Controls.DatePicker
+		{
+			MinimumDate = null
+		};
+
+		var handler = await CreateHandlerAsync<DatePickerHandler>(datePicker);
+		var platformView = GetPlatformControl(handler);
+
+		await InvokeOnMainThreadAsync(() =>
+		{
+			datePicker.MinimumDate = null;
+		});
+
+		// If we reach here without exception, the test passes
+		Assert.True(true);
+	}
+
 	static CalendarDatePicker GetPlatformControl(DatePickerHandler handler) =>
 		handler.PlatformView;
 }

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -34,6 +34,12 @@ namespace Microsoft.Maui.Platform
 			{
 				platformDatePicker.MinDate = datePicker.MinimumDate.Value;
 			}
+			else
+			{
+				// Matches WinUI default MinDate behavior by jumping 100 years back if MinDate is null.
+				// Ref: https://github.com/microsoft/microsoft-ui-xaml/blob/2aa50f0dff795cbd948588ee0e62cac7da3a396f/src/dxaml/xcp/components/DependencyObject/DependencyProperty.cpp#L253
+				platformDatePicker.MinDate = DateTime.Now.AddYears(-100);
+			}
 		}
 
 		public static void UpdateMaximumDate(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -30,7 +30,10 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMinimumDate(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-			platformDatePicker.MinDate = datePicker?.MinimumDate ?? DateTime.MinValue;
+			if (datePicker?.MinimumDate is not null)
+			{
+				platformDatePicker.MinDate = datePicker.MinimumDate.Value;
+			}
 		}
 
 		public static void UpdateMaximumDate(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- Setting the MinimumDate property of the DatePicker to null results in an ArgumentOutOfRangeException.

### Root Cause

- When MinimumDate is set to null, the platform view attempts to set the CalendarDatePicker.MinDate to DateTime.MinValue. This leads to an exception because the resulting UTC time falls outside the valid range (year 0 to 10,000).

### Description of Changes

- To align with the native WinUI behavior and avoid the exception, the minimum date is now set to 100 years prior to the current date when null is specified. This ensures the value stays within a valid UTC range

Reference:
https://github.com/microsoft/microsoft-ui-xaml/blob/2aa50f0dff795cbd948588ee0e62cac7da3a396f/src/dxaml/xcp/components/DependencyObject/DependencyProperty.cpp#L253

### Issues Fixed

Fixes #30922

### Output

|Before|After|
|--|--|
|<img  src="https://github.com/user-attachments/assets/ba79ed03-0d74-4084-8d95-a3083dd7b163" width="1200" height="900">| <video src="https://github.com/user-attachments/assets/67c552be-aae4-47c8-8f09-cb3a7d322633">|

