### PR TITLE
[iOS] Fix extra bottom space in ScrollView when using SafeAreaEdges

### DIFF
--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -307,13 +307,14 @@ public static class KeyboardAutoManagerScroll
 	{
 		if (IsKeyboardShowing)
 		{
-			// If we are going to a new view that has an InputAccessoryView
-			// while we have the keyboard up, we need a delay to recalculate
-			// the height of the InputAccessoryView
-			if (View?.InputAccessoryView is not null)
-			{
-				await Task.Delay(30);
-			}
+			// Universal 30ms delay for all input controls to ensure proper timing coordination
+			// between keyboard auto-scroll and safe area adjustments. 
+			// This delay allows the InputAccessoryView setup completion for input controls.
+			// Safe area system to process keyboard notifications first
+			// Conflict resolution between auto-scroll and SafeAreaEdges.SoftInput settings
+			// Without this delay, timing conflicts can cause double padding or incorrect positioning
+			await Task.Delay(30);
+
 			AdjustPosition();
 
 			// See if the layout requests to scroll again after our initial scroll

--- a/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
+++ b/src/Core/src/Platform/iOS/KeyboardAutoManagerScroll.cs
@@ -318,7 +318,7 @@ public static class KeyboardAutoManagerScroll
 			AdjustPosition();
 
 			// See if the layout requests to scroll again after our initial scroll
-			await Task.Delay(5);
+			await Task.Delay(30);
 			if (ShouldScrollAgain)
 			{
 				AdjustPosition();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause of the Issue: 
- The issue was caused by a race condition between KeyboardAutoManagerScroll and the ScrollView’s SafeAreaEdges.SoftInput logic. The KeyboardAutoManagerScroll executed before the layout adjustments for SafeAreaEdges.SoftInput, resulting in padding being applied without considering the updated safe area values. As a result, extra/unwanted padding was added below the bottom of the ScrollView.

### Description of Change

- To resolve this, a consistent 30ms delay is now applied to all input controls within the KeyboardAutoManagerScroll logic. Previously, the delay was applied only when the InputAccessoryView was present. This change ensures that KeyboardAutoManagerScroll executes after layout updates, based on the recalculated layout. As a result, it maintains consistent behavior and prevents conflicts between the scrolling logic and SafeAreaEdges.SoftInput adjustments.


### Screenshot
| Before Fix | After Fix |
|----------|----------|
| <video  src="https://github.com/user-attachments/assets/e045896c-5428-4fd3-bfd8-6de2e363b4d0"> | <video  src="https://github.com/user-attachments/assets/5c92a557-4927-4dde-b342-fe3addd0d844"> |
