### PR TITLE
Fixed CollectionView does not update layout correctly when ItemsSource changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -182,7 +182,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var contentSize = Controller.GetSize();
+			var potentialContentSize = Controller.GetSize();
+
+			// If contentSize comes back null, it means none of the content has been realized yet;
+			// we need to return the expansive size the collection view wants by default to get
+			// it to start measuring its content
+			if (potentialContentSize.Height == 0 || potentialContentSize.Width == 0)
+			{
+				return base.GetDesiredSize(widthConstraint, heightConstraint);
+			}
+
+			var contentSize = potentialContentSize;
 
 			// Our target size is the smaller of it and the constraints
 			var width = contentSize.Width <= widthConstraint ? contentSize.Width : widthConstraint;

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -182,17 +182,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var potentialContentSize = Controller.GetSize();
+			var contentSize = Controller.GetSize();
 
 			// If contentSize comes back null, it means none of the content has been realized yet;
 			// we need to return the expansive size the collection view wants by default to get
 			// it to start measuring its content
-			if (potentialContentSize.Height == 0 || potentialContentSize.Width == 0)
+			if (contentSize.Height == 0 || contentSize.Width == 0)
 			{
 				return base.GetDesiredSize(widthConstraint, heightConstraint);
 			}
-
-			var contentSize = potentialContentSize;
 
 			// Our target size is the smaller of it and the constraints
 			var width = contentSize.Width <= widthConstraint ? contentSize.Width : widthConstraint;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30953.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30953.cs
@@ -1,0 +1,70 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 30953, "CollectionView does not update layout correctly when ItemsSource changes", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue30953 : ContentPage
+{
+	private ObservableCollection<string> Countries = new();
+
+	public Issue30953()
+	{
+		LoadCountries();
+		var collectionView = new CollectionView2();
+		var button = new Button
+		{
+			Text = "Set ItemsSource",
+			AutomationId = "Issue30953Button",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		button.Clicked += (sender, args) =>
+		{
+			collectionView.ItemsSource = Countries;
+		};
+
+		var label = new Label
+		{
+			Text = "The test passed if the CollectionView ItemsSource is set and the items are displayed correctly in runtime.",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		var stack = new VerticalStackLayout
+		{
+			Children = {
+				label,
+				button,
+				collectionView
+			}
+		};
+
+		Content = stack;
+	}
+
+	void LoadCountries()
+	{
+		Countries = new ObservableCollection<string>
+		{
+			"United States",
+			"Canada",
+			"United Kingdom",
+			"Germany",
+			"France",
+			"Italy",
+			"Spain",
+			"Japan",
+			"Australia",
+			"Brazil",
+			"India",
+			"China",
+			"Russia",
+			"Mexico",
+			"Argentina",
+			"South Africa",
+			"Egypt",
+			"Turkey",
+			"Netherlands",
+			"Sweden"
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30953.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30953.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30953 : _IssuesUITest
+{
+	public Issue30953(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "CollectionView does not update layout correctly when ItemsSource changes";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void EnsureCollectionViewLayoutOnItemsSourceChange()
+	{
+		App.WaitForElement("Issue30953Button");
+		App.Tap("Issue30953Button");
+		App.WaitForElement("United States");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

The CollectionView is initially loaded with its ItemsSource set to null. When the ItemsSource is updated at runtime, the items are not displayed, and the CollectionView height remains at 0, resulting in no visible content.

### Root Cause

- When the CollectionView is initially arranged with no items (i.e., ItemsSource is null), the layout system measures it with zero height. 
- Later, when the ItemsSource is updated at runtime, the CollectionView attempts to re-measure, but in CollectionViewHandler2, the GetDesiredSize method still returns a height of 0 because Controller.GetSize() is called before any cells have been realized or measured. Since the layout system continues to receive a zero height, it does not allocate space for the CollectionView, and as a result, the cells are never created or displayed.

### Description of Change
Added a fallback in GetDesiredSize to return base.GetDesiredSize() when Controller.GetSize() returns a zero width or height. This ensures proper layout measurement and allows the CollectionView to render correctly once data is set.

### Reference https://github.com/dotnet/maui/blob/3ca9527c6fccc763124af318465974d40fead9fb/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs#L160-L163

### Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed:
Fixes #30953 

### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/aab53881-6d1b-495f-ade6-20af37aff227"> |   <video src="https://github.com/user-attachments/assets/cd6165ec-00be-4af0-96fd-1906f2cb00f7">  |