### PR TITLE
[Net10] [iOS] Set NavigationBar.Translucent based on NavigationPage BarBackgroundColor transparency

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Mapper.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Mapper.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Maui.Controls
 			// Adjust the mappings to preserve Controls.NavigationPage legacy behaviors
 #if IOS
 			NavigationViewHandler.Mapper.ReplaceMapping<NavigationPage, NavigationViewHandler>(PlatformConfiguration.iOSSpecific.NavigationPage.PrefersLargeTitlesProperty.PropertyName, MapPrefersLargeTitles);
-			NavigationViewHandler.Mapper.ReplaceMapping<NavigationPage, NavigationViewHandler>(PlatformConfiguration.iOSSpecific.NavigationPage.IsNavigationBarTranslucentProperty.PropertyName, MapIsNavigationBarTranslucent);
 #endif
 		}
 	}

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.iOS.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.iOS.cs
@@ -8,19 +8,10 @@ namespace Microsoft.Maui.Controls
 		public static void MapPrefersLargeTitles(NavigationViewHandler handler, NavigationPage navigationPage) =>
 			MapPrefersLargeTitles((INavigationViewHandler)handler, navigationPage);
 
-		public static void MapIsNavigationBarTranslucent(NavigationViewHandler handler, NavigationPage navigationPage) =>
-			MapPrefersLargeTitles((INavigationViewHandler)handler, navigationPage);
-
 		public static void MapPrefersLargeTitles(INavigationViewHandler handler, NavigationPage navigationPage)
 		{
 			if (handler is IPlatformViewHandler nvh && nvh.ViewController is UINavigationController navigationController)
 				Platform.NavigationPageExtensions.UpdatePrefersLargeTitles(navigationController, navigationPage);
-		}
-
-		public static void MapIsNavigationBarTranslucent(INavigationViewHandler handler, NavigationPage navigationPage)
-		{
-			if (handler is IPlatformViewHandler nvh && nvh.ViewController is UINavigationController navigationController)
-				Platform.NavigationPageExtensions.UpdateIsNavigationBarTranslucent(navigationController, navigationPage);
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/iOS/Extensions/NavigationPageExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/NavigationPageExtensions.cs
@@ -10,18 +10,14 @@ namespace Microsoft.Maui.Controls.Platform
 		public static void UpdatePrefersLargeTitles(this UINavigationController platformView, NavigationPage navigationPage)
 		{
 			if (platformView.NavigationBar is null)
+			{
 				return;
+			}
 
 			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11))
+			{
 				platformView.NavigationBar.PrefersLargeTitles = navigationPage.OnThisPlatform().PrefersLargeTitles();
-		}
-
-		public static void UpdateIsNavigationBarTranslucent(this UINavigationController platformView, NavigationPage navigationPage)
-		{
-			if (platformView.NavigationBar is null)
-				return;
-
-			platformView.NavigationBar.Translucent = navigationPage.OnThisPlatform().IsNavigationBarTranslucent();
+			}
 		}
 
 		internal static void SetTransparentNavigationBar(this UINavigationBar navigationBar)

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 {
+	using System;
 	using FormsElement = Maui.Controls.NavigationPage;
 
 	/// <summary>The navigation page instance that Microsoft.Maui.Controls created on the iOS platform.</summary>
@@ -9,19 +10,23 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	{
 		#region Translucent
 		/// <summary>Bindable property for <see cref="IsNavigationBarTranslucent"/>.</summary>
+
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static readonly BindableProperty IsNavigationBarTranslucentProperty =
-			BindableProperty.Create("IsNavigationBarTranslucent", typeof(bool),
-			typeof(NavigationPage), false);
+					BindableProperty.Create("IsNavigationBarTranslucent", typeof(bool),
+					typeof(NavigationPage), false);
 
 		/// <summary>Returns a Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</summary>
 		/// <param name="element">The platform specific element on which to perform the operation.</param>
 		/// <returns>A Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</returns>
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static bool GetIsNavigationBarTranslucent(BindableObject element)
 		{
 			return (bool)element.GetValue(IsNavigationBarTranslucentProperty);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent'][1]/Docs/*" />
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static void SetIsNavigationBarTranslucent(BindableObject element, bool value)
 		{
 			element.SetValue(IsNavigationBarTranslucentProperty, value);
@@ -30,12 +35,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <summary>Returns a Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</summary>
 		/// <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
 		/// <returns>A Boolean value that tells whether the navigation bar on the platform-specific navigation page is translucent.</returns>
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static bool IsNavigationBarTranslucent(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetIsNavigationBarTranslucent(config.Element);
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent'][2]/Docs/*" />
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsNavigationBarTranslucent(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetIsNavigationBarTranslucent(config.Element, value);
@@ -45,6 +52,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <summary>Makes the navigation bar translucent on the platform-specific element.</summary>
 		/// <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
 		/// <returns>The updated configuration object on which developers can make successive method calls.</returns>
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static IPlatformElementConfiguration<iOS, FormsElement> EnableTranslucentNavigationBar(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			SetIsNavigationBarTranslucent(config.Element, true);
@@ -54,6 +62,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <summary>Makes the navigation bar opaque on the platform-specific element.</summary>
 		/// <param name="config">The platform specific configuration that contains the element on which to perform the operation.</param>
 		/// <returns>The updated configuration object on which developers can make successive method calls.</returns>
+		[Obsolete("IsNavigationBarTranslucent is deprecated. The Translucent will be enabled by default by setting the BarBackgroundColor to a transparent color.")]
 		public static IPlatformElementConfiguration<iOS, FormsElement> DisableTranslucentNavigationBar(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			SetIsNavigationBarTranslucent(config.Element, false);

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -26,6 +26,9 @@ Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css
 *REMOVED*Microsoft.Maui.Controls.ClickedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 *REMOVED*~Microsoft.Maui.Controls.ClickedEventArgs.ClickedEventArgs(Microsoft.Maui.Controls.ButtonsMask buttons, object commandParameter) -> void
 *REMOVED*~Microsoft.Maui.Controls.ClickedEventArgs.Parameter.get -> object
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.INavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.NavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Platform.NavigationPageExtensions.UpdateIsNavigationBarTranslucent(this UIKit.UINavigationController platformView, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
 Microsoft.Maui.Controls.ContentPage.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.Controls.ContentPage.SafeAreaEdges.set -> void
 Microsoft.Maui.Controls.ContentPresenter.CascadeInputTransparent.get -> bool

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -26,6 +26,9 @@ Microsoft.Maui.Controls.BrushTypeConverter.GradientBrushParser.Parse(string? css
 *REMOVED*Microsoft.Maui.Controls.ClickedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 *REMOVED*~Microsoft.Maui.Controls.ClickedEventArgs.ClickedEventArgs(Microsoft.Maui.Controls.ButtonsMask buttons, object commandParameter) -> void
 *REMOVED*~Microsoft.Maui.Controls.ClickedEventArgs.Parameter.get -> object
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.INavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.NavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Platform.NavigationPageExtensions.UpdateIsNavigationBarTranslucent(this UIKit.UINavigationController platformView, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
 Microsoft.Maui.Controls.ContentPage.SafeAreaEdges.get -> Microsoft.Maui.SafeAreaEdges
 Microsoft.Maui.Controls.ContentPage.SafeAreaEdges.set -> void
 Microsoft.Maui.Controls.ContentPresenter.CascadeInputTransparent.get -> bool

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.iOS.cs
@@ -62,7 +62,9 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 			var page = new ContentPage();
 			var navPage = new NavigationPage(page) { Title = "App Page" };
+#pragma warning disable CS0618 // Type or member is obsolete
 			Controls.PlatformConfiguration.iOSSpecific.NavigationPage.SetIsNavigationBarTranslucent(navPage, enabled);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var translucent = await GetValueAsync(navPage, (handler) => (handler.ViewController as UINavigationController).NavigationBar.Translucent);
 			Assert.Equal(enabled, translucent);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17022.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17022.cs
@@ -6,23 +6,23 @@ using UITest.Core;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues
 {
-	public class Issue17022 : _IssuesUITest
-	{
-		public Issue17022(TestDevice device)
-			: base(device)
-		{ }
+    public class Issue17022 : _IssuesUITest
+    {
+        public Issue17022(TestDevice device)
+            : base(device)
+        { }
 
-		public override string Issue => "UINavigationBar is Translucent";
+        public override string Issue => "UINavigationBar is Translucent";
 
-		// TODO: Add shell navigation bar tests when we can call shell in UITest
-		[Test]
-		[Category(UITestCategories.Navigation)]
-		[TestCase("NewNavigationPageButton", false)]
+        // TODO: Add shell navigation bar tests when we can call shell in UITest
+        [Test]
+        [Category(UITestCategories.Navigation)]
+        [TestCase("NewNavigationPageButton", false)]
         [TestCase("NewNavigationPageTransparentButton", false)]
         [TestCase("NewNavigationPageTranslucentButton", false)]
         [TestCase("NewNavigationPageTransparentTranslucentButton", false)]
         [TestCase("NewNavigationPageGridButton", false)]
-        [TestCase("NewNavigationPageGridTransparentButton", false)]
+        [TestCase("NewNavigationPageGridTransparentButton", true)] // if we set BarBackgroundColor to transparent, the boxview should be at the top.
         [TestCase("NewNavigationPageGridTranslucentButton", false, true)] // this test thinks the boxview is at the top of the screen, but it's not. Test this case manually for now.
         [TestCase("NewNavigationPageGridTransparentTranslucentButton", true)]
         [TestCase("NewFlyoutPageButton", false)]
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
         [TestCase("NewFlyoutPageTranslucentButton", false)]
         [TestCase("NewFlyoutPageTransparentTranslucentButton", false)]
         [TestCase("NewFlyoutPageGridButton", false)]
-        [TestCase("NewFlyoutPageGridTransparentButton", false)]
+        [TestCase("NewFlyoutPageGridTransparentButton", true)] // if we set BarBackgroundColor to transparent, the boxview should be at the top.
         [TestCase("NewFlyoutPageGridTranslucentButton", false, true)] // this test thinks the boxview is at the top of the screen, but it's not. Test this case manually for now.
         [TestCase("NewFlyoutPageGridTransparentTranslucentButton", true)]
         [TestCase("SemiTransparentNavigationPageBackgroundColor", true, true)]
@@ -38,14 +38,15 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
         [TestCase("SemiTransparentFlyoutPageBackgroundColor", true, true)]
         [TestCase("SemiTransparentFlyoutPageBrush", true, true)]
 
-		public void Issue17022Test(string testButtonID, bool isTopOfScreen, bool requiresScreenshot = false)
-		{
+        public void Issue17022Test(string testButtonID, bool isTopOfScreen, bool requiresScreenshot = false)
+        {
             App.WaitForElement(testButtonID).Click();
             var boxView = App.WaitForElement("TopBoxView");
             ClassicAssert.NotNull(boxView);
-			var rect = boxView.GetRect();
+            var rect = boxView.GetRect();
 
-            try { 
+            try
+            {
                 if (requiresScreenshot)
                 {
                     VerifyScreenshot(TestContext.CurrentContext.Test.MethodName + testButtonID);
@@ -58,19 +59,19 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
                     }
                     else
                     {
-						ClassicAssert.AreNotEqual(rect.Y, 0);
+                        ClassicAssert.AreNotEqual(rect.Y, 0);
                     }
                 }
             }
-            catch 
-            { 
+            catch
+            {
                 Assert.Fail("Failed with exception");
             }
             finally
             {
                 App.WaitForElement("PopPageButton").Click();
             }
-		}
-	}
+        }
+    }
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

- Currently, the NavigationBar.Translucent property could only be set using the iOS-specific platform **[configuration](https://learn.microsoft.com/en-us/dotnet/maui/ios/platform-specifics/navigation-bar-translucent?view=net-maui-9.0)**.

- This PR updates the behavior to align with Shell, where translucency is automatically determined based on the transparency (alpha) of the background color. 
- For `Shell`, it is based on `Shell.BackgroundColor`. 
- For `NavigationPage`, it is now based on `NavigationPage.BarBackgroundColor`.
- The iOS-specific platform configuration for setting Translucent has been marked as obsolete in .NET 10.
- In .NET 10:

   - If the platform-specific setting is explicitly set, it will still be respected, even if BarBackgroundColor is transparent.

   - If the platform-specific setting is not set, translucency will be determined based on the alpha value of NavigationPage.BarBackgroundColor.

