### PR TITLE
[AOT] Add new VerifyReferenceAotCompatibility property to AOT integration tests

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AOTTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AOTTemplateTest.cs
@@ -88,6 +88,7 @@ public class AOTTemplateTest : BaseTemplateTests
 		extendedBuildProps.Add("IlcTreatWarningsAsErrors=false");
 		extendedBuildProps.Add("TrimmerSingleWarn=false");
 		extendedBuildProps.Add("_RequireCodeSigning=false"); // This is required to build the iOS app without a signing key
+		extendedBuildProps.Add("VerifyReferenceAotCompatibility=true"); // Verify that all input assemblies are marked as IsAotCompatible (https://github.com/dotnet/runtime/pull/118180)
 		return extendedBuildProps;
 	}
 }


### PR DESCRIPTION
### Description of Change

This PR will extend our AOT integration tests by checking that our assemblies have the right metadata.

This PR needs https://github.com/dotnet/runtime/pull/118180 to be merged and for the subsequent depenency update.
