### PR TITLE
[iOS] Alert popup may be displayed on wrong window when modal page navigation is in progress - fix

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -201,7 +201,8 @@ namespace Microsoft.Maui.Controls.Platform
 			static UIViewController GetTopUIViewController(UIWindow platformWindow)
 			{
 				var topUIViewController = platformWindow.RootViewController;
-				while (topUIViewController?.PresentedViewController is not null)
+				while (topUIViewController?.PresentedViewController is not null &&
+					   !topUIViewController.PresentedViewController.IsBeingDismissed)
 				{
 					topUIViewController = topUIViewController.PresentedViewController;
 				}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30970.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30970.cs
@@ -1,0 +1,48 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 30970, "Alert popup may be displayed on wrong window when modal page navigation is in progress", PlatformAffected.iOS)]
+public partial class Issue30970 : ContentPage
+{
+	private bool _modalPageWasShown;
+
+	public Issue30970()
+	{
+		Content = new VerticalStackLayout
+		{
+			Children =
+			{
+				new Button()
+				{
+					Text = "Click",
+					AutomationId = "OpenModalButton",
+					Command = new Command(() =>
+					{
+						Navigation.PushModalAsync(new ContentPage()
+						{
+							Content = new VerticalStackLayout
+							{
+								Children =
+								{
+									new Button
+									{
+										Text = "Close Modal",
+										AutomationId= "CloseModalButton",
+										Command = new Command(() => Navigation.PopModalAsync())
+									}
+								}
+							}
+						});
+						_modalPageWasShown = true;
+					})
+				}
+			}
+		};
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		if (_modalPageWasShown)
+			await Application.Current.Windows[0].Page!.DisplayAlert("My alert", "Can you see this alert?", "Yes");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30970.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30970.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30970 : _IssuesUITest
+{
+	public Issue30970(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "Alert popup may be displayed on wrong window when modal page navigation is in progress";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void PopupShouldBeDisplayed()
+	{
+		App.WaitForElement("OpenModalButton");
+		App.Click("OpenModalButton");
+		App.WaitForElement("CloseModalButton");
+		App.Click("CloseModalButton");
+		App.WaitForElement("Can you see this alert?");
+	}
+}


### PR DESCRIPTION
### Description of Change

By skipping view controllers that are being dismissed (animation is happening, for example ), we ensure DisplayAlert() and other popups are shown only on valid, active UI stacks, preventing the deadlock and improving reliability on iOS/macOS.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/30970