### PR TITLE
[testing] Test xcode26 with maui

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <SignAssembly>false</SignAssembly>
     <MauiRootDirectory>$(MSBuildThisFileDirectory)</MauiRootDirectory>
     <MauiSrcDirectory>$(MSBuildThisFileDirectory)src/</MauiSrcDirectory>
+    <IncludeCurrentTfms>true</IncludeCurrentTfms>
     <IncludePreviousTfms>false</IncludePreviousTfms>
     <IncludePreviousTfmsEssentials>false</IncludePreviousTfmsEssentials>
     <IncludePreviousTfmsGraphics>false</IncludePreviousTfmsGraphics>
@@ -129,6 +130,7 @@
     <DefineConstants Condition="'$(_MauiTargetPlatformIsWindows)' == 'True'">$(DefineConstants);WINDOWS</DefineConstants>
     <DefineConstants Condition="'$(IncludeCompatibilityProjects)' == 'True'">$(DefineConstants);COMPATIBILITY_ENABLED</DefineConstants>
     <DefineConstants Condition="'$(IncludePreviousTfms)' == 'True'">$(DefineConstants);ENABLE_PREVIOUS_TFM_BUILDS</DefineConstants>
+    <DefineConstants Condition="'$(IncludeCurrentTfms)' == 'True'">$(DefineConstants);ENABLE_CURRENT_TFM_BUILDS</DefineConstants>
     <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat> -->
     <!-- <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles> -->
     <!-- HACK: WinUI seems to have issues without this -->
@@ -170,21 +172,24 @@
     <TizenPreviousTargetFrameworkVersion>7.0</TizenPreviousTargetFrameworkVersion>
     <!-- Minimums -->
     <MinimumWindowsTargetFrameworkVersion>10.0.17763.0</MinimumWindowsTargetFrameworkVersion>
+    
+    <!-- Disable current TFMs when building with Xcode 26 to use only net9 (previous) TFMs -->
+    <IncludeCurrentTfms Condition="'$(IosTargetFrameworkVersion)' == '26.0' or '$(MacCatalystTargetFrameworkVersion)' == '26.0' or '$(MacosTargetFrameworkVersion)' == '26.0'">false</IncludeCurrentTfms>
   </PropertyGroup>
 
   <Import Condition="Exists('Directory.Build.Override.props')" Project="Directory.Build.Override.props" />
 
   <PropertyGroup>
     <!-- Library: The Real TFMs -->
-    <WindowsMauiPlatforms Condition="'$(WindowsMauiPlatforms)' == ''">net$(_MauiDotNetVersion)-windows$(WindowsTargetFrameworkVersion);net$(_MauiDotNetVersion)-windows$(Windows2TargetFrameworkVersion)</WindowsMauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-tizen$(TizenTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(WindowsMauiPlatforms);$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-android$(AndroidTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true' and '$(AndroidTargetFrameworkVersion)' != '$(AndroidTargetFrameworkVersionSdkDefault)'">net$(_MauiDotNetVersion)-android;$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst$(MacCatalystTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true' and '$(MacCatalystTargetFrameworkVersion)' != '$(MacCatalystTargetFrameworkVersionSdkDefault)'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-ios$(IosTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true' and '$(IosTargetFrameworkVersion)' != '$(IosTargetFrameworkVersionSdkDefault)'">net$(_MauiDotNetVersion)-ios;$(MauiPlatforms)</MauiPlatforms>
+    <WindowsMauiPlatforms Condition="'$(WindowsMauiPlatforms)' == '' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-windows$(WindowsTargetFrameworkVersion);net$(_MauiDotNetVersion)-windows$(Windows2TargetFrameworkVersion)</WindowsMauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeTizenTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-tizen$(TizenTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">$(WindowsMauiPlatforms);$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-android$(AndroidTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true' and '$(AndroidTargetFrameworkVersion)' != '$(AndroidTargetFrameworkVersionSdkDefault)' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst$(MacCatalystTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true' and '$(MacCatalystTargetFrameworkVersion)' != '$(MacCatalystTargetFrameworkVersionSdkDefault)' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-ios$(IosTargetFrameworkVersion);$(MauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true' and '$(IosTargetFrameworkVersion)' != '$(IosTargetFrameworkVersionSdkDefault)' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiPlatforms)</MauiPlatforms>
 
     <!-- Library: Previous .NET -->
     <WindowsMauiPreviousPlatforms Condition="'$(WindowsMauiPreviousPlatforms)' == ''">net$(_MauiPreviousDotNetVersion)-windows$(WindowsPreviousTargetFrameworkVersion);net$(_MauiPreviousDotNetVersion)-windows$(Windows2PreviousTargetFrameworkVersion)</WindowsMauiPreviousPlatforms>
@@ -195,11 +200,11 @@
     <MauiPreviousPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true'">net$(_MauiPreviousDotNetVersion)-ios$(IosPreviousTargetFrameworkVersion);$(MauiPreviousPlatforms)</MauiPreviousPlatforms>
 
     <!-- App: Sample Apps -->
-    <MauiSamplePlatforms Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-tizen;$(MauiSamplePlatforms)</MauiSamplePlatforms>
-    <MauiSamplePlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(WindowsMauiPlatforms);$(MauiSamplePlatforms)</MauiSamplePlatforms>
-    <MauiSamplePlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiSamplePlatforms)</MauiSamplePlatforms>
-    <MauiSamplePlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiSamplePlatforms)</MauiSamplePlatforms>
-    <MauiSamplePlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiSamplePlatforms)</MauiSamplePlatforms>
+    <MauiSamplePlatforms Condition="'$(IncludeTizenTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-tizen;$(MauiSamplePlatforms)</MauiSamplePlatforms>
+    <MauiSamplePlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">$(WindowsMauiPlatforms);$(MauiSamplePlatforms)</MauiSamplePlatforms>
+    <MauiSamplePlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiSamplePlatforms)</MauiSamplePlatforms>
+    <MauiSamplePlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiSamplePlatforms)</MauiSamplePlatforms>
+    <MauiSamplePlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiSamplePlatforms)</MauiSamplePlatforms>
     <MauiSamplePreviousPlatforms Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">net$(_MauiPreviousDotNetVersion)-tizen;$(MauiSamplePreviousPlatforms)</MauiSamplePreviousPlatforms>
     <MauiSamplePreviousPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(WindowsMauiPreviousPlatforms);$(MauiSamplePreviousPlatforms)</MauiSamplePreviousPlatforms>
     <MauiSamplePreviousPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true'">net$(_MauiPreviousDotNetVersion)-android;$(MauiSamplePreviousPlatforms)</MauiSamplePreviousPlatforms>
@@ -207,20 +212,20 @@
     <MauiSamplePreviousPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true'">net$(_MauiPreviousDotNetVersion)-ios;$(MauiSamplePreviousPlatforms)</MauiSamplePreviousPlatforms>
 
     <!-- App: Device Tests TFMs (no Tizen yet) -->
-    <MauiDeviceTestsPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(WindowsMauiPlatforms);$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
-    <MauiDeviceTestsPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
-    <MauiDeviceTestsPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
-    <MauiDeviceTestsPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
+    <MauiDeviceTestsPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">$(WindowsMauiPlatforms);$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
+    <MauiDeviceTestsPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
+    <MauiDeviceTestsPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
+    <MauiDeviceTestsPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiDeviceTestsPlatforms)</MauiDeviceTestsPlatforms>
 
     <!-- App: Embedding Sample TFMs (no Tizen yet) -->
-    <MauiEmbeddingPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(WindowsMauiPlatforms);$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
-    <MauiEmbeddingPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
-    <MauiEmbeddingPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
-    <MauiEmbeddingPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
+    <MauiEmbeddingPlatforms Condition="'$(IncludeWindowsTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">$(WindowsMauiPlatforms);$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
+    <MauiEmbeddingPlatforms Condition="'$(IncludeAndroidTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-android;$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
+    <MauiEmbeddingPlatforms Condition="'$(IncludeMacCatalystTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-maccatalyst;$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
+    <MauiEmbeddingPlatforms Condition="'$(IncludeIosTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">net$(_MauiDotNetVersion)-ios;$(MauiEmbeddingPlatforms)</MauiEmbeddingPlatforms>
 
     <!-- Library: Graphics TFMs -->
-    <MauiGraphicsPlatforms>$(MauiPlatforms)</MauiGraphicsPlatforms>
-    <MauiGraphicsPlatforms Condition="'$(IncludeMacOSTargetFrameworks)' == 'true'">$(MauiGraphicsPlatforms);net$(_MauiDotNetVersion)-macos$(MacosTargetFrameworkVersion)</MauiGraphicsPlatforms>
+    <MauiGraphicsPlatforms Condition="'$(IncludeCurrentTfms)' == 'true'">$(MauiPlatforms)</MauiGraphicsPlatforms>
+    <MauiGraphicsPlatforms Condition="'$(IncludeMacOSTargetFrameworks)' == 'true' and '$(IncludeCurrentTfms)' == 'true'">$(MauiGraphicsPlatforms);net$(_MauiDotNetVersion)-macos$(MacosTargetFrameworkVersion)</MauiGraphicsPlatforms>
     <!-- Library: Previous .NET Graphics TFMs -->
     <MauiGraphicsPreviousPlatforms>$(MauiPreviousPlatforms)</MauiGraphicsPreviousPlatforms>
     <MauiGraphicsPreviousPlatforms Condition="'$(IncludeMacOSTargetFrameworks)' == 'true'">$(MauiGraphicsPreviousPlatforms);net$(_MauiPreviousDotNetVersion)-macos$(MacosPreviousTargetFrameworkVersion)</MauiGraphicsPreviousPlatforms>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -145,16 +145,16 @@
   <!-- version number information -->
   <PropertyGroup>
     <!-- Default versions from the SDKs (update when there is a new TFM version) -->
-    <IosTargetFrameworkVersionSdkDefault>18.0</IosTargetFrameworkVersionSdkDefault>
-    <TvosTargetFrameworkVersionSdkDefault>18.0</TvosTargetFrameworkVersionSdkDefault>
-    <MacCatalystTargetFrameworkVersionSdkDefault>18.0</MacCatalystTargetFrameworkVersionSdkDefault>
-    <MacosTargetFrameworkVersionSdkDefault>15.0</MacosTargetFrameworkVersionSdkDefault>
+    <IosTargetFrameworkVersionSdkDefault>26.0</IosTargetFrameworkVersionSdkDefault>
+    <TvosTargetFrameworkVersionSdkDefault>26.0</TvosTargetFrameworkVersionSdkDefault>
+    <MacCatalystTargetFrameworkVersionSdkDefault>26.0</MacCatalystTargetFrameworkVersionSdkDefault>
+    <MacosTargetFrameworkVersionSdkDefault>26.0</MacosTargetFrameworkVersionSdkDefault>
     <AndroidTargetFrameworkVersionSdkDefault>35.0</AndroidTargetFrameworkVersionSdkDefault>
     <!-- Current .NET -->
-    <IosTargetFrameworkVersion>18.0</IosTargetFrameworkVersion>
-    <TvosTargetFrameworkVersion>18.0</TvosTargetFrameworkVersion>
-    <MacCatalystTargetFrameworkVersion>18.0</MacCatalystTargetFrameworkVersion>
-    <MacosTargetFrameworkVersion>15.0</MacosTargetFrameworkVersion>
+    <IosTargetFrameworkVersion>26.0</IosTargetFrameworkVersion>
+    <TvosTargetFrameworkVersion>26.0</TvosTargetFrameworkVersion>
+    <MacCatalystTargetFrameworkVersion>26.0</MacCatalystTargetFrameworkVersion>
+    <MacosTargetFrameworkVersion>26.0</MacosTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion>35.0</AndroidTargetFrameworkVersion>
     <WindowsTargetFrameworkVersion>10.0.19041.0</WindowsTargetFrameworkVersion>
     <Windows2TargetFrameworkVersion>10.0.20348.0</Windows2TargetFrameworkVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,23 +34,24 @@
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>13.0</TargetPlatformMinVersion>
     <!-- Workaround: https://github.com/dotnet/roslyn-analyzers/issues/6158 -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;XCODE_26_0_PREVIEW</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIstvOS)' == 'True'">
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>10.0</TargetPlatformMinVersion>
     <!-- Workaround: https://github.com/dotnet/roslyn-analyzers/issues/6158 -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;XCODE_26_0_PREVIEW</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsMacCatalyst)' == 'True'">
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>15.0</TargetPlatformMinVersion>
     <!-- Workaround: https://github.com/dotnet/roslyn-analyzers/issues/6158 -->
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;XCODE_26_0_PREVIEW</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsmacOS)' == 'True'">
     <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>12.0</TargetPlatformMinVersion>
+     <NoWarn>$(NoWarn);XCODE_26_0_PREVIEW</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsAndroid)' == 'True'">
     <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>

--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,10 @@
     <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
     <!-- Added manually for .NET 8 MAUI -->
     <add key="darc-pub-dotnet-maui-a33a875e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-a33a875e/nuget/v3/index.json" />
+    
+    <add key="darc-pub-dotnet-macios-8071534" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-80715342/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-0e1a194" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-0e1a194f/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-0e1a194-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-0e1a194f-1/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,6 +19,8 @@
     <add key="darc-pub-dotnet-macios-8071534" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-80715342/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-macios-0e1a194" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-0e1a194f/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-macios-0e1a194-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-0e1a194f-1/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/docs/DevelopmentTips.md
+++ b/docs/DevelopmentTips.md
@@ -37,6 +37,26 @@ dotnet cake --target=VS --workloads=global --android --ios
 
 *Note* you will have to `git clean -xdf` your project if you change or add platforms. 
 
+#### Build Configuration Variables
+`.NET MAUI` supports several MSBuild variables to control which target frameworks are included in builds:
+
+- `IncludeCurrentTfms` (default: `true`) - Controls whether current .NET target framework monikers are included in the build
+- `IncludePreviousTfms` (default: `false`) - Controls whether previous .NET target framework monikers are included in the build
+- `IncludePreviousTfmsEssentials` (default: `false`) - Controls previous TFMs for Essentials projects
+- `IncludePreviousTfmsGraphics` (default: `false`) - Controls previous TFMs for Graphics projects
+
+These can be used in CI scenarios to selectively build only certain target frameworks:
+
+```bash
+# Build only netstandard targets, excluding current platform TFMs
+dotnet build -p:IncludeCurrentTfms=false
+
+# Build current and previous TFMs
+dotnet build -p:IncludePreviousTfms=true
+``` 
+
+**Note:** When building with Xcode 26, the build system automatically sets `IncludeCurrentTfms=false` to use only net9 (previous) TFMs, ensuring compatibility with the Xcode 26 environment. 
+
 ### Blazor Hybrid
 
 To build and run Blazor Desktop samples, check out the [Blazor Desktop](https://github.com/dotnet/maui/wiki/Blazor-Desktop) wiki topic.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,5 +1,21 @@
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9215">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>807153429630114a7186d246285c3a4a504f23c1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.5" Version="15.5.9215">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>807153429630114a7186d246285c3a4a504f23c1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.5" Version="18.5.9215">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>807153429630114a7186d246285c3a4a504f23c1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.5" Version="18.5.9215">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>807153429630114a7186d246285c3a4a504f23c1</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="9.0.0-prerelease.25317.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>d20661676ca197f1f09a4322817b20a45da84290</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -16,6 +16,25 @@
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>807153429630114a7186d246285c3a4a504f23c1</Sha>
     </Dependency>
+
+    <!-- This is a subscription of the .NET 9/Xcode 26.0 versions of our packages -->
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9253-xcode26.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>e1329f110cb5ded0ef1fec5d9226d43c085ad28f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9253-xcode26.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>e1329f110cb5ded0ef1fec5d9226d43c085ad28f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9253-xcode26.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>e1329f110cb5ded0ef1fec5d9226d43c085ad28f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9253-xcode26.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>e1329f110cb5ded0ef1fec5d9226d43c085ad28f</Sha>
+    </Dependency>
+
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="9.0.0-prerelease.25317.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>d20661676ca197f1f09a4322817b20a45da84290</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,10 +52,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>35.0.61</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet90_180PackageVersion>18.0.9617</MicrosoftMacCatalystSdknet90_180PackageVersion>
-    <MicrosoftmacOSSdknet90_150PackageVersion>15.0.9617</MicrosoftmacOSSdknet90_150PackageVersion>
-    <MicrosoftiOSSdknet90_180PackageVersion>18.0.9617</MicrosoftiOSSdknet90_180PackageVersion>
-    <MicrosofttvOSSdknet90_180PackageVersion>18.0.9617</MicrosofttvOSSdknet90_180PackageVersion>
+    <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9215</MicrosoftMacCatalystSdknet90_185PackageVersion>
+    <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9215</MicrosoftmacOSSdknet90_155PackageVersion>
+    <MicrosoftiOSSdknet90_185PackageVersion>18.5.9215</MicrosoftiOSSdknet90_185PackageVersion>
+    <MicrosofttvOSSdknet90_185PackageVersion>18.5.9215</MicrosofttvOSSdknet90_185PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
@@ -213,9 +213,9 @@
     <DotNetAndroidManifestVersionBand>9.0.100</DotNetAndroidManifestVersionBand>
     <DotNetMaciOSManifestVersionBand>9.0.100</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
-    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet90_180PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet90_150PackageVersion)</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet90_180PackageVersion)</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet90_180PackageVersion)</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet90_185PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet90_155PackageVersion)</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet90_185PackageVersion)</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet90_185PackageVersion)</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,6 +56,11 @@
     <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9215</MicrosoftmacOSSdknet90_155PackageVersion>
     <MicrosoftiOSSdknet90_185PackageVersion>18.5.9215</MicrosoftiOSSdknet90_185PackageVersion>
     <MicrosofttvOSSdknet90_185PackageVersion>18.5.9215</MicrosofttvOSSdknet90_185PackageVersion>
+
+    <MicrosoftMacCatalystSdknet90_260PackageVersion>26.0.9253-xcode26.0</MicrosoftMacCatalystSdknet90_260PackageVersion>
+    <MicrosoftmacOSSdknet90_260PackageVersion>26.0.9253-xcode26.0</MicrosoftmacOSSdknet90_260PackageVersion>
+    <MicrosoftiOSSdknet90_260PackageVersion>26.0.9253-xcode26.0</MicrosoftiOSSdknet90_260PackageVersion>
+    <MicrosofttvOSSdknet90_260PackageVersion>26.0.9253-xcode26.0</MicrosofttvOSSdknet90_260PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
@@ -213,9 +218,9 @@
     <DotNetAndroidManifestVersionBand>9.0.100</DotNetAndroidManifestVersionBand>
     <DotNetMaciOSManifestVersionBand>9.0.100</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
-    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet90_185PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet90_155PackageVersion)</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet90_185PackageVersion)</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet90_185PackageVersion)</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet90_260PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet90_260PackageVersion)</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet90_260PackageVersion)</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet90_260PackageVersion)</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 9.0.100
 - name: REQUIRED_XCODE
-  value: 16.3.0
+  value: 26.0.0-beta4
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 16.3.0
+  value: 26.0.0-beta4
 - name: POWERSHELL_VERSION
   value: 7.4.0
 # Localization variables

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' == 'true'">$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' != 'true'"></TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreviousTfms)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiPreviousPlatforms)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);WEBVIEW2_MAUI</DefineConstants>

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' == 'true'">netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' != 'true'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreviousTfms)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiPreviousPlatforms)</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Controls</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls</AssemblyName>

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+		<TargetFrameworks Condition="'$(IncludeCurrentTfms)' == 'true'">netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+		<TargetFrameworks Condition="'$(IncludeCurrentTfms)' != 'true'">netstandard2.1;netstandard2.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(IncludePreviousTfms)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiPreviousPlatforms)</TargetFrameworks>
 		<AssemblyName>Microsoft.Maui.Controls.Xaml</AssemblyName>
 		<RootNamespace>Microsoft.Maui.Controls.Xaml</RootNamespace>

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' == 'true'">netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' != 'true'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreviousTfms)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiPreviousPlatforms)</TargetFrameworks>
     <RootNamespace>Microsoft.Maui</RootNamespace>
     <AssemblyName>Microsoft.Maui</AssemblyName>

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' == 'true'">netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' != 'true'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreviousTfmsEssentials)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiPreviousPlatforms)</TargetFrameworks>
     <AssemblyName>Microsoft.Maui.Essentials</AssemblyName>
     <RootNamespace>Microsoft.Maui.Essentials</RootNamespace>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiGraphicsPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' == 'true'">netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiGraphicsPlatforms)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeCurrentTfms)' != 'true'">netstandard2.1;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludePreviousTfmsGraphics)' == 'true'">$(TargetFrameworks);$(_MauiPreviousDotNetTfm);$(MauiGraphicsPreviousPlatforms)</TargetFrameworks>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
### Description of Change

This pull request updates the project's Apple platform dependencies and configurations to align with the latest SDK and Xcode versions. The changes ensure the project uses the most recent versions of iOS, tvOS, macOS, and Mac Catalyst SDKs, and updates related NuGet package sources and build variables accordingly.

**Apple Platform SDK and Version Updates:**

* Updated target framework versions for iOS, tvOS, Mac Catalyst, and macOS to 26.0 in `Directory.Build.props` to match the new SDK requirements.
* Updated version variables for Apple platform SDKs in `eng/Versions.props` to reference the new 18.5/15.5 SDK package versions. [[1]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L55-R58) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L216-R219)
* Added new dependencies for the latest Apple SDKs (iOS, tvOS, macOS, Mac Catalyst) in `eng/Version.Details.xml`.

**Build and Pipeline Configuration:**

* Updated the required Xcode version for builds and device tests to `26.0.0-beta4` in `eng/pipelines/common/variables.yml`.

**NuGet Package Sources:**

* Added new NuGet sources for the updated `dotnet-macios` SDK packages in `NuGet.config` to ensure the new dependencies can be restored.

### Issues Fixed

Fixes #31029

