### PR TITLE
[ci] Allow to continue if error downloading packages

### DIFF
--- a/eng/pipelines/maui-release-internal.yml
+++ b/eng/pipelines/maui-release-internal.yml
@@ -130,7 +130,7 @@ extends:
                   exit 1
                 }
                 Write-Host "Getting drop for Bar ID: $barId"
-                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --verbose
+                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --include-released  --skip-existing  --continue-on-error --verbose
                 Write-Host "List downloaded artifacts"
                 Get-ChildItem -Name -Recurse -Path $(Build.StagingDirectory)
                 $manifestPack = Get-ChildItem -Path "$(Build.StagingDirectory)\nupkgs\shipping\packages\" -Filter "*.Manifest-*.nupkg" | Select-Object -First 1
@@ -195,6 +195,7 @@ extends:
 
           - task: AzureCLI@2
             displayName: Get build for commit
+            continueOnError: true
             inputs:
               azureSubscription: "Darc: Maestro Production"
               scriptType: pscore
@@ -212,7 +213,7 @@ extends:
                   exit 1
                 }
                 Write-Host "Getting drop for Bar ID: $barId"
-                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --verbose  
+                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --include-released  --skip-existing  --continue-on-error --verbose  
 
           - pwsh: Get-ChildItem -Name -Recurse -Path $(Build.StagingDirectory)
             displayName: list downloaded artifacts
@@ -262,6 +263,7 @@ extends:
 
           - task: AzureCLI@2
             displayName: Get build for commit
+            continueOnError: true
             inputs:
               azureSubscription: "Darc: Maestro Production"
               scriptType: pscore
@@ -279,7 +281,7 @@ extends:
                   exit 1
                 }
                 Write-Host "Getting drop for Bar ID: $barId"
-                & $darc gather-drop --ci --id $barId -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --verbose  
+                & $darc gather-drop --ci --id $barId --asset-filter "^Microsoft.*Manifest" -o "$(Build.StagingDirectory)\nupkgs" --azdev-pat $(System.AccessToken) --include-released  --skip-existing  --continue-on-error --verbose  
 
           - pwsh: Get-ChildItem -Name -Recurse -Path $(Build.StagingDirectory)
             displayName: list downloaded artifacts


### PR DESCRIPTION
### Description of Change

Small fixes to the release pipeline. 

Once the packages are pushed to nuget.org maestro will delete them from the feed, so get-drop might fail trying to download packages that don t exist, even it that happens we want to continue and push the other packages that weren't pushed.

Also added a filter for when pushing manifests we filter for only those so they should be there even if  2 weeks early we pushed the packs to nuget.org
