### PR TITLE
[Android] OnSizeAllocated event not fired for Android shell - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -308,6 +308,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				UpdateDrawerLockMode(_behavior);
 		}
 
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			base.OnLayout(changed, left, top, right, bottom);
+
+			var destination = Context.ToCrossPlatformRectInReferenceFrame(left, top, right, bottom);
+			Shell.Layout(destination);
+		}
+
 		protected virtual void UpdateDrawerLockMode(FlyoutBehavior behavior)
 		{
 			AddFlyoutContentToLayoutIfNeeded(behavior);

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.OnLayout(bool changed, int left, int top, int right, int bottom) -> void
 ~Microsoft.Maui.Controls.Element.transientNamescope -> Microsoft.Maui.Controls.Internals.INameScope
 Microsoft.Maui.Controls.FlexLayout.CrossPlatformMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.OnSizeAllocated(double width, double height) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description
I've made the Android implementation to mirror the behavior of the iOS version shown below for consistency across platforms.
<img width="1034" height="573" alt="Screenshot 2025-08-06 at 02 17 34" src="https://github.com/user-attachments/assets/8a80b6fc-4c2f-42cb-8384-6208d297c73c" />

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31020
