### PR TITLE
[Net10] OnSizeAllocated in Shell not triggered - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -412,7 +412,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			base.OnLayout(changed, left, top, right, bottom);
 
 			var destination = Context.ToCrossPlatformRectInReferenceFrame(left, top, right, bottom);
-			Shell.Frame = destination;
+			if (Shell.Frame != destination)
+				Shell.Frame = destination;
 		}
 
 		internal void Disconnect()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -407,6 +407,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			base.OnLayout(changed, left, top, right, bottom);
+
+			var destination = Context.ToCrossPlatformRectInReferenceFrame(left, top, right, bottom);
+			Shell.Frame = destination;
+		}
+
 		internal void Disconnect()
 		{
 			ShellController?.RemoveAppearanceObserver(this);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
@@ -141,6 +141,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			base.ViewDidLayoutSubviews();
 			if (_currentShellItemRenderer != null)
 				_currentShellItemRenderer.ViewController.View.Frame = View.Bounds;
+
+			Shell.Frame = View.Bounds.ToRectangle();
 		}
 
 		public override void ViewDidLoad()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
@@ -142,7 +142,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (_currentShellItemRenderer != null)
 				_currentShellItemRenderer.ViewController.View.Frame = View.Bounds;
 
-			Shell.Frame = View.Bounds.ToRectangle();
+			var destination = View.Bounds.ToRectangle();
+			if (Shell.Frame != destination)
+				Shell.Frame = destination;
 		}
 
 		public override void ViewDidLoad()

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.OnLayout(bool changed, int left, int top, int right, int bottom) -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -12,15 +12,14 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
-
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
-using Microsoft.Maui.Graphics;
 
 #endif
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -20,6 +20,8 @@ using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+using Microsoft.Maui.Graphics;
+
 #endif
 
 #if IOS || MACCATALYST
@@ -1136,6 +1138,32 @@ namespace Microsoft.Maui.DeviceTests
 				shell.Items.Clear();
 				shell.CurrentItem = new ShellContent { Content = page };
 				Assert.Equal(count, appearanceObservers.Count); // Count doesn't increase
+			});
+		}
+
+		[Fact]
+		public async Task SettingFrameDoesTriggerInvalidatedMeasure()
+		{
+			SetupBuilder();
+
+			int measureInvalidatedCount = 0;
+
+			var page = new ContentPage();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ShellContent { Content = page };
+			});
+
+			shell.MeasureInvalidated += (s, e) =>
+			{
+				measureInvalidatedCount++;
+			};
+
+			shell.Frame = new Rect(0, 0, 100, 100);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, _ =>
+			{
+				Assert.Equal(1, measureInvalidatedCount);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -12,15 +12,14 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 using static Microsoft.Maui.DeviceTests.AssertHelpers;
+
 #if ANDROID || IOS || MACCATALYST
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
-
 #endif
 
 #if IOS || MACCATALYST
@@ -1158,7 +1157,7 @@ namespace Microsoft.Maui.DeviceTests
 				measureInvalidatedCount++;
 			};
 
-			shell.Frame = new Rect(0, 0, 100, 100);
+			shell.Frame = new Microsoft.Maui.Graphics.Rect(0, 0, 100, 100);
 
 			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, _ =>
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR restores the expected behavior of the `OnSizeAllocated` method in Shell, which currently does not get called on either Android or iOS in .NET 10.

In previous .NET MAUI versions, OnSizeAllocated would fire on iOS when overridden in Shell, and still works for individual pages like MainPage. However, with .NET 10, the method is never called, which breaks layout-dependent initialization or resizing logic that developers may include in the Shell.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31055
Fixes https://github.com/dotnet/maui/issues/31020

