### PR TITLE
[ci] Some fixes to clear the _tool project

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -134,11 +134,12 @@ steps:
 
 # Provisioning .NET - Clear all NuGet caches
 - ${{ if eq(parameters.clearCaches, 'true') }}:
-  - pwsh: dotnet nuget locals all --clear
+  - script: dotnet nuget locals all --clear
     displayName: 'Clear all NuGet caches'
+    continueOnError: true
 
 # Provisioning .NET - .NET tools
-- pwsh: |
+- script: |
     dotnet tool restore
   displayName: 'Restore .NET Tools'
 
@@ -148,19 +149,19 @@ steps:
 
 # Provisioning Android - JDK
 - ${{ if ne(parameters.skipJdk, 'true') }}:
-  - pwsh: dotnet build -t:ProvisionJdk -bl:"$(LogDirectory)/provision-jdk.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - script: dotnet build -t:ProvisionJdk -bl:"$(LogDirectory)/provision-jdk.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision JDK'
     condition: succeeded()
 
 # Provisioning Android - Android SDK common packages (eg: cmdline-tools, emulator, platform-tools, build-tools)
 - ${{ if ne(parameters.skipAndroidCommonSdks, 'true') }}:
-  - pwsh: dotnet build -t:ProvisionAndroidSdkCommonPackages -bl:"$(LogDirectory)/provision-androidsdk-common.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - script: dotnet build -t:ProvisionAndroidSdkCommonPackages -bl:"$(LogDirectory)/provision-androidsdk-common.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Common Packages'
     condition: succeeded()
 
 # Provisioning Android - Android environment variables
 - ${{ if ne(parameters.skipAndroidCommonSdks, 'true') }}:
-  - pwsh: |
+  - script: |
       echo "Setting ANDROID_SDK_ROOT and ANDROID_HOME..."
       $jsonOutput = & dotnet android sdk info --format=Json | ConvertFrom-Json
       $preferredSdk = $jsonOutput.SdkInfo.Path
@@ -173,7 +174,7 @@ steps:
 
 # Provisioning Android - Android SDK platform APIs (eg: platforms;android-29, platforms;android-30)
 - ${{ if ne(parameters.skipAndroidPlatformApis, 'true') }}:
-  - pwsh: dotnet build -t:ProvisionAndroidSdkPlatformApiPackages -p:AndroidSdkProvisionDefaultApiLevelsOnly="$Env:AndroidSdkProvisionDefaultApiLevelsOnly" -bl:"$(LogDirectory)/provision-androidsdk-platform-apis.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - script: dotnet build -t:ProvisionAndroidSdkPlatformApiPackages -p:AndroidSdkProvisionDefaultApiLevelsOnly="$Env:AndroidSdkProvisionDefaultApiLevelsOnly" -bl:"$(LogDirectory)/provision-androidsdk-platform-apis.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Platform APIs'
     condition: succeeded()
     env:
@@ -181,7 +182,7 @@ steps:
 
 # Provisioning Android - Emulator images (eg: system-images;android-34;google_apis;aarch64)
 - ${{ if ne(parameters.skipAndroidEmulatorImages, 'true') }}:
-  - pwsh: dotnet build -t:ProvisionAndroidSdkEmulatorImagePackages -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-emulator-images.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - script: dotnet build -t:ProvisionAndroidSdkEmulatorImagePackages -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-emulator-images.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Emulator Images'
     condition: succeeded()
     env:
@@ -189,7 +190,7 @@ steps:
 
 # Provisioning Android - Android AVDs (actual emulator virtual devices)
 - ${{ if ne(parameters.skipAndroidCreateAvds, 'true') }}:
-  - pwsh: dotnet build -t:ProvisionAndroidSdkAvdCreateAvds -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-create-avds.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - script: dotnet build -t:ProvisionAndroidSdkAvdCreateAvds -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-create-avds.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Create AVDs'
     condition: succeeded()
     env:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -33,20 +33,26 @@ parameters:
   skipInternalFeeds: false
 
 steps:
-
 ##################################################
 #               Provisioning macOS               #
 ##################################################
 
-# Provisioning macOS - Agent cleanser
-- ${{ if ne(parameters.skipProvisionator, true) }}:
-  - template: agent-cleanser/v1.yml@yaml-templates
-    parameters:
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-      UninstallMono: false
-      UninstallXamarinMac: true
-      CleanseAgentToolsDotNet: true
-      SelfHealPowerShell: false
+#check if the _tool directory exists and remove it
+- pwsh: |
+    $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
+    Write-Host "Agent-Cleanser: Agent tools path for .NET installations: ${dotnetToolsPath}"
+    try {
+      if ([IO.Directory]::Exists($dotnetToolsPath)) {
+        Write-Host "Agent-Cleanser: Deleting: ${dotnetToolsPath}"
+        [IO.Directory]::Delete($dotnetToolsPath, $true)
+      } else {
+        Write-Host "Agent-Cleanser: Skipping cleansing of .NET: No .NET installations found under the agent tools directory: $(Agent.ToolsDirectory)"
+      }
+    } catch {
+      Write-Host "ERROR: EXCEPTION: $($_.Exception.Message)"
+    }
+  displayName: Clean $(Agent.ToolsDirectory)/dotnet directory
+  condition: eq(variables['Agent.OS'], 'Darwin')
 
 # Provisioning macOS - Xcode
 - ${{ if ne(parameters.skipXcode, 'true') }}:
@@ -132,6 +138,12 @@ steps:
     version: $(DOTNET_VERSION)
     includePreviewVersions: true
 
+- script: |
+    dotnet --list-sdks
+    dotnet --version
+  displayName: 'List all .NET SDKs'
+  continueOnError: true
+
 # Provisioning .NET - Clear all NuGet caches
 - ${{ if eq(parameters.clearCaches, 'true') }}:
   - script: dotnet nuget locals all --clear
@@ -140,7 +152,7 @@ steps:
 
 # Provisioning .NET - .NET tools
 - script: |
-    dotnet tool restore
+    dotnet tool restore --verbosity diag
   displayName: 'Restore .NET Tools'
 
 ##################################################
@@ -149,19 +161,19 @@ steps:
 
 # Provisioning Android - JDK
 - ${{ if ne(parameters.skipJdk, 'true') }}:
-  - script: dotnet build -t:ProvisionJdk -bl:"$(LogDirectory)/provision-jdk.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - pwsh: dotnet build -t:ProvisionJdk -bl:"$(LogDirectory)/provision-jdk.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision JDK'
     condition: succeeded()
 
 # Provisioning Android - Android SDK common packages (eg: cmdline-tools, emulator, platform-tools, build-tools)
 - ${{ if ne(parameters.skipAndroidCommonSdks, 'true') }}:
-  - script: dotnet build -t:ProvisionAndroidSdkCommonPackages -bl:"$(LogDirectory)/provision-androidsdk-common.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - pwsh: dotnet build -t:ProvisionAndroidSdkCommonPackages -bl:"$(LogDirectory)/provision-androidsdk-common.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Common Packages'
     condition: succeeded()
 
 # Provisioning Android - Android environment variables
 - ${{ if ne(parameters.skipAndroidCommonSdks, 'true') }}:
-  - script: |
+  - pwsh: |
       echo "Setting ANDROID_SDK_ROOT and ANDROID_HOME..."
       $jsonOutput = & dotnet android sdk info --format=Json | ConvertFrom-Json
       $preferredSdk = $jsonOutput.SdkInfo.Path
@@ -174,7 +186,7 @@ steps:
 
 # Provisioning Android - Android SDK platform APIs (eg: platforms;android-29, platforms;android-30)
 - ${{ if ne(parameters.skipAndroidPlatformApis, 'true') }}:
-  - script: dotnet build -t:ProvisionAndroidSdkPlatformApiPackages -p:AndroidSdkProvisionDefaultApiLevelsOnly="$Env:AndroidSdkProvisionDefaultApiLevelsOnly" -bl:"$(LogDirectory)/provision-androidsdk-platform-apis.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - pwsh: dotnet build -t:ProvisionAndroidSdkPlatformApiPackages -p:AndroidSdkProvisionDefaultApiLevelsOnly="$Env:AndroidSdkProvisionDefaultApiLevelsOnly" -bl:"$(LogDirectory)/provision-androidsdk-platform-apis.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Platform APIs'
     condition: succeeded()
     env:
@@ -182,7 +194,7 @@ steps:
 
 # Provisioning Android - Emulator images (eg: system-images;android-34;google_apis;aarch64)
 - ${{ if ne(parameters.skipAndroidEmulatorImages, 'true') }}:
-  - script: dotnet build -t:ProvisionAndroidSdkEmulatorImagePackages -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-emulator-images.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - pwsh: dotnet build -t:ProvisionAndroidSdkEmulatorImagePackages -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-emulator-images.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Emulator Images'
     condition: succeeded()
     env:
@@ -190,7 +202,7 @@ steps:
 
 # Provisioning Android - Android AVDs (actual emulator virtual devices)
 - ${{ if ne(parameters.skipAndroidCreateAvds, 'true') }}:
-  - script: dotnet build -t:ProvisionAndroidSdkAvdCreateAvds -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-create-avds.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
+  - pwsh: dotnet build -t:ProvisionAndroidSdkAvdCreateAvds -p:AndroidSdkProvisionApiLevel="$Env:AndroidSdkProvisionApiLevel" -bl:"$(LogDirectory)/provision-androidsdk-create-avds.binlog" ./src/Provisioning/Provisioning.csproj -v:detailed
     displayName: 'Provision Android SDK - Create AVDs'
     condition: succeeded()
     env:


### PR DESCRIPTION
### Description of Change

Different branches can install other dotnet versions on the _tool folder. 
Try to delete them so we don t have any interference with other versions. 


### Issues Fixed

Fixes crashes running dotnet commands

<img width="800" height="232" alt="image" src="https://github.com/user-attachments/assets/280cb282-27fb-455e-97a0-f8012daa05a9" />
