### PR TITLE
Workaround Revocation Error

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -100,10 +100,28 @@
       Inputs="$(_Inputs)"
       Outputs="$(DotNetInstallScriptPath)"
       Condition=" '$(InstallDotNet)' == 'true' ">
+
+
+
+    <!--
+      On macOS, we do not use the DownloadFile task because it does not support disabling SSL certificate revocation checks,
+      which can cause failures due to unavailable CRL endpoints in some environments. Instead, we use curl with
+      DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true to work around these issues.
+      For more information, see:
+      https://learn.microsoft.com/dotnet/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default
+    -->
+
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(DotNetInstallScriptPath)'))" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
+    <Exec
+      Condition="$([MSBuild]::IsOSPlatform('osx'))"
+      Command="curl -sSL &quot;$(DotNetInstallScriptUrl)&quot; -o &quot;$(DotNetInstallScriptPath)&quot;"
+    />
+
     <DownloadFile
         SourceUrl="$(DotNetInstallScriptUrl)"
         DestinationFolder="$(DotNetTempDirectory)"
         DestinationFileName="$(DotNetInstallScriptName)"
+        Condition="!$([MSBuild]::IsOSPlatform('osx'))"
     />
   </Target>
 
@@ -175,6 +193,17 @@
       Outputs="$(DotNetSdkManifestsDirectory).stamp">
     <PropertyGroup>
       <_WorkloadManifestDir>$(DotNetTempDirectory)workload/</_WorkloadManifestDir>
+      <_WorkloadRestoreEnvVars>NUGET_PACKAGES=$(_WorkloadManifestDir);DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1</_WorkloadRestoreEnvVars>
+
+    <!--
+      Disabling SSL certificate revocation checks via DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true
+      is a workaround for issues with certificate revocation list (CRL) endpoints being unavailable in some environments.
+      This is only applied on macOS where SSL certificate revocation issues are more common.
+      For more information, see:
+      https://learn.microsoft.com/dotnet/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default
+    -->
+
+      <_WorkloadRestoreEnvVars Condition="$([MSBuild]::IsOSPlatform('osx'))">$(_WorkloadRestoreEnvVars);DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true</_WorkloadRestoreEnvVars>
     </PropertyGroup>
     <ItemGroup>
       <_WorkloadDirectoriesToRemove Include="$(DotNetDirectory)sdk-manifests/$(DotNetVersionBand)" />
@@ -184,7 +213,7 @@
     <MakeDir Directories="$(_WorkloadManifestDir)" />
     <Exec
         Command="&quot;$(DotNetToolPath)&quot; restore &quot;$(MSBuildThisFileDirectory)Dependencies/Workloads.csproj&quot; -bl:$(ArtifactsLogDir)/DotNetWorkloads.binlog"
-        EnvironmentVariables="NUGET_PACKAGES=$(_WorkloadManifestDir);DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1"
+        EnvironmentVariables="$(_WorkloadRestoreEnvVars)"
     />
     <!--
       NOTE: Workloads need to go in dotnet/sdk-manifests/6.0.100/microsoft.net.*/


### PR DESCRIPTION
### Description of Change

Builds look like they are starting to fail from this https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default

Setting this property on our restore to workaround
