### PR TITLE
[iOS] Changing IsGrouped on runtime with CollectionViewHandler2 does not properly work - fix

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CollectionViewHandler2.iOS.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public static void MapIsGrouped(CollectionViewHandler2 handler, GroupableItemsView itemsView)
 		{
 			handler.Controller?.UpdateItemsSource();
+			handler.UpdateLayout();
 		}
 
 		bool WillNeedScrollAdjustment(ScrollToRequestEventArgs args)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31096.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31096.xaml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue31096">
+    <Grid RowDefinitions="Auto, *">
+        <Switch
+            IsToggled="False"
+            AutomationId="Switch"
+            x:Name="switch"/>
+        <CollectionView
+            Grid.Row="1"
+            ItemsSource="{Binding Animals}"
+            IsGrouped="{Binding Source={x:Reference switch}, Path=IsToggled}"
+            x:Name="cv">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid
+                        Padding="10"
+                        RowDefinitions="Auto, Auto">
+                        <Label
+                            Text="{Binding Name}"
+                            FontAttributes="Bold"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="{Binding Location}"
+                            VerticalOptions="End"/>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate>
+                    <Label
+                        Text="{Binding Name}"
+                        AutomationId="GroupHeader"
+                        FontAttributes="Bold"/>
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
+            <CollectionView.GroupFooterTemplate>
+                <DataTemplate>
+                    <Label
+                        Text="Footer"
+                        AutomationId="GroupFooter"
+                        FontAttributes="Bold"/>
+                </DataTemplate>
+            </CollectionView.GroupFooterTemplate>
+        </CollectionView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31096.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31096.xaml.cs
@@ -1,0 +1,45 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31096, "Changing IsGrouped on runtime with CollectionViewHandler2 does not properly work", PlatformAffected.iOS)]
+public partial class Issue31096 : ContentPage
+{
+	public Issue31096()
+	{
+		InitializeComponent();
+		BindingContext = new GroupedAnimalsViewModel();
+	}
+
+	private void Switch_Toggled(object sender, ToggledEventArgs e) => cv.IsGrouped = e.Value;
+
+	class GroupedAnimalsViewModel
+	{
+		public List<AnimalGroup> Animals { get; private set; } = new List<AnimalGroup>();
+
+		public GroupedAnimalsViewModel()
+		{
+			Animals.Add(new AnimalGroup("Bears", new List<Animal>
+			{
+				new() {
+					Name = "American Black Bear",
+					Location = "North America",
+				},
+				new() {
+					Name = "Asian Black Bear",
+					Location = "Asia",
+				}
+			}));
+		}
+	}
+
+	class Animal
+	{
+		public string Name { get; set; }
+		public string Location { get; set; }
+		public string Details { get; set; }
+	}
+
+	class AnimalGroup(string name, List<Animal> animals) : List<Animal>(animals)
+	{
+		public string Name { get; private set; } = name;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31096.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31096.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31096 : _IssuesUITest
+{
+	public Issue31096(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Changing IsGrouped on runtime with CollectionViewHandler2 does not properly work";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void ChangingIsGroupedOnRuntime()
+	{
+		App.WaitForElement("Switch", timeout: TimeSpan.FromSeconds(15));
+		App.Tap("Switch");
+		App.WaitForElement("American Black Bear");
+		App.WaitForElement("Asian Black Bear");
+
+		App.Tap("Switch");
+		App.WaitForNoElement("American Black Bear");
+		App.WaitForNoElement("Asian Black Bear");
+
+		App.Tap("Switch");
+		App.WaitForElement("GroupHeader");
+		App.WaitForElement("GroupFooter");
+	}
+}


### PR DESCRIPTION
Added a call to handler.UpdateLayout() in the MapIsGrouped method to ensure the layout is refreshed when the grouping state changes in CollectionViewHandler2 for iOS.

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31096
