### PR TITLE
[Essentials: Text to speech] Overwrite system default voice

### DIFF
--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -200,7 +200,8 @@ namespace Microsoft.Maui.Media
 			await Initialize();
 
 			try
-			{	// Attempt to use the new API to get the voices and their locales, a.Name is the voice's identifier
+			{	
+				// Attempt to use the new API to get the voices and their locales, a.Name is the voice's identifier
 				return tts.Voices.Select(a => new Locale( a.Locale.Language, a.Locale.Country, a.Locale.DisplayName, a.Name));
 			}
 			catch (Exception ex)

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Media
 				SetDefaultLanguage();
 			}
 			// Set the voice if specified, otherwise use the voice that based on the selected/default language
-			if (!string.IsNullOrEmpty(options?.Locale?.Id) && tts?.Voices != null)
+			if (!string.IsNullOrEmpty(options?.Locale?.Id) && tts?.Voices is not null)
 			{
 				var voice = tts.Voices.FirstOrDefault(v => v.Name == options.Locale.Id);
 				if (voice != null)

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -144,8 +144,10 @@ namespace Microsoft.Maui.Media
 			if (!string.IsNullOrEmpty(options?.Locale?.Id) && tts?.Voices is not null)
 			{
 				var voice = tts.Voices.FirstOrDefault(v => v.Name == options.Locale.Id);
-				if (voice != null)
+				if (voice is not null)
+				{				
 					tts.SetVoice(voice);
+				}
 			}
 
 			if (options?.Pitch.HasValue ?? false)

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -140,6 +140,13 @@ namespace Microsoft.Maui.Media
 			{
 				SetDefaultLanguage();
 			}
+			// Set the voice if specified, otherwise use the voice that based on the selected/default language
+			if (!string.IsNullOrEmpty(options?.Locale?.Id) && tts?.Voices != null)
+			{
+				var voice = tts.Voices.FirstOrDefault(v => v.Name == options.Locale.Id);
+				if (voice != null)
+					tts.SetVoice(voice);
+			}
 
 			if (options?.Pitch.HasValue ?? false)
 				tts.SetPitch(options.Pitch.Value);
@@ -191,8 +198,8 @@ namespace Microsoft.Maui.Media
 			await Initialize();
 
 			try
-			{
-				return tts.AvailableLanguages.Select(a => new Locale(a.Language, a.Country, a.DisplayName, string.Empty));
+			{	// Attempt to use the new API to get the voices and their locales, a.Name is the voice's identifier
+				return tts.Voices.Select(a => new Locale( a.Locale.Language, a.Locale.Country, a.Locale.DisplayName, a.Name));
 			}
 			catch (Exception ex)
 			{

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -29,9 +29,12 @@ namespace Microsoft.Maui.Media
 			if (options != null)
 			{
 				// null voice if fine - it is the default
+				// select the voice by identifier else by Language, otherwise set for default
 				speechUtterance.Voice =
-					AVSpeechSynthesisVoice.FromIdentifier(identifier: options.Locale?.Id) ?? // select the voice by identifier else set for default
-					AVSpeechSynthesisVoice.FromLanguage(AVSpeechSynthesisVoice.CurrentLanguageCode);
+				    options.Locale?.Id != null
+				        ? AVSpeechSynthesisVoice.FromIdentifier(options.Locale.Id)
+				        : AVSpeechSynthesisVoice.FromLanguage(options.Locale?.Language)
+				        ?? AVSpeechSynthesisVoice.FromLanguage(AVSpeechSynthesisVoice.CurrentLanguageCode);
 
 				// the platform has a range of 0.5 - 2.0
 				// anything lower than 0.5 is set to 0.5

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Media
 			{
 				// null voice if fine - it is the default
 				speechUtterance.Voice =
-					AVSpeechSynthesisVoice.FromLanguage(options.Locale?.Language) ??
+					AVSpeechSynthesisVoice.FromIdentifier(identifier: options.Locale?.Id) ?? // select the voice by identifier else set for default
 					AVSpeechSynthesisVoice.FromLanguage(AVSpeechSynthesisVoice.CurrentLanguageCode);
 
 				// the platform has a range of 0.5 - 2.0


### PR DESCRIPTION
system default voice with ios/macos/androids

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged? Yes
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

For ios/macos, AVSpeechSynthesisVoice.FromIdentifier is added together with FromLanguage. The Locale.Id can now be used along with Locale.Language.

For Android,
Get Locale is based on TTS voices and returns the Locale with their corresponding IDs instead of a Empty value.
tts.Voice is added for when option for speaksync is called with the Locale and its ID




### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26853

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
