### PR TITLE
Fix pan and pinch gesture completion on Windows

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -261,21 +261,18 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			SendEventArgs<DragGestureRecognizer>(rec =>
 			{
-				var view = Element as View;
-
-				if (!rec.CanDrag || view is null)
+				if (!rec.CanDrag || Element is not View view)
 				{
 					e.Cancel = true;
 					return;
 				}
 
-				var handler = sender as IViewHandler;
 				var args = rec.SendDragStarting(view, (relativeTo) => GetPosition(relativeTo, e), new PlatformDragStartingEventArgs(sender, e));
 
 				e.Data.Properties[_doNotUsePropertyString] = args.Data;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-				if ((!args.Handled || (!args.PlatformArgs?.Handled ?? true)) && handler != null)
+				if ((!args.Handled || (!args.PlatformArgs?.Handled ?? true)) && sender is IViewHandler handler)
 #pragma warning restore CS0618 // Type or member is obsolete
 				{
 					if (handler?.PlatformView is UI.Xaml.Controls.Image nativeImage &&
@@ -545,9 +542,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
 		{
-			var view = Element as View;
-
-			if (view == null)
+			if (Element is not View view)
 			{
 				return;
 			}
@@ -559,8 +554,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
 		{
-			var view = Element as View;
-			if (view == null)
+			if (Element is not View view)
 			{
 				return;
 			}
@@ -708,8 +702,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		private void HandlePgrPointerEvent(PointerRoutedEventArgs e, Action<View, PointerGestureRecognizer> SendPointerEvent)
 		{
-			var view = Element as View;
-			if (view == null)
+			if (Element is not View view)
 			{
 				return;
 			}
@@ -776,8 +769,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnTap(object sender, RoutedEventArgs e)
 		{
-			var view = Element as View;
-			if (view == null)
+			if (Element is not View view)
 			{
 				return;
 			}
@@ -853,8 +845,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void SwipeComplete(bool success)
 		{
-			var view = Element as View;
-			if (view == null || !_isSwiping)
+			if (Element is not View view || !_isSwiping)
 			{
 				return;
 			}
@@ -872,8 +863,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void PanComplete(bool success)
 		{
-			var view = Element as View;
-			if (view == null || !_isPanning)
+			if (Element is not View view || !_isPanning)
 			{
 				return;
 			}
@@ -896,8 +886,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void PinchComplete(bool success)
 		{
-			var view = Element as View;
-			if (view is null || !_isPinching)
+			if (Element is not View view || !_isPinching)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Maui.Controls.Platform
 				// for example
 				// e.AcceptedOperation = Windows.ApplicationModel.DataTransfer.DataPackageOperation.Copy;
 				// Even if AcceptedOperation is already set to Copy it will cause the copy animation
-				// to remain even after the the dragged element has left
+				// to remain even after the dragged element has left
 				if (!dragEventArgs.PlatformArgs?.Handled ?? true && operationPriorToSend != dragEventArgs.AcceptedOperation)
 				{
 					var result = (int)dragEventArgs.AcceptedOperation;
@@ -565,11 +565,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnPointerCanceled(object sender, PointerRoutedEventArgs e)
 		{
-			uint id = e.Pointer.PointerId;
-			if (_fingers.Contains(id))
-			{
-				_fingers.Remove(id);
-			}
+			_fingers.Remove(e.Pointer.PointerId);
 
 			SwipeComplete(false);
 			PinchComplete(false);
@@ -580,9 +576,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (!_isPanning)
 			{
-				uint id = e.Pointer.PointerId;
-				if (_fingers.Contains(id))
-					_fingers.Remove(id);
+				_fingers.Remove(e.Pointer.PointerId);
 			}
 
 			SwipeComplete(true);
@@ -600,11 +594,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
 		{
-			uint id = e.Pointer.PointerId;
-			if (_fingers.Contains(id))
-			{
-				_fingers.Remove(id);
-			}
+			_fingers.Remove(e.Pointer.PointerId);
 
 			SwipeComplete(true);
 			PinchComplete(true);

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -506,8 +506,6 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			_isPinching = true;
-
 			if (e.OriginalSource is UIElement container)
 			{
 				global::Windows.Foundation.Point translationPoint = container.TransformToVisual(Container).TransformPoint(e.Position);
@@ -538,6 +536,8 @@ namespace Microsoft.Maui.Controls.Platform
 			SwipeComplete(true);
 			PinchComplete(true);
 			PanComplete(true);
+
+			_fingers.Clear();
 		}
 
 		void OnManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
@@ -559,28 +559,28 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			_isPinching = true;
 			_wasPinchGestureStartedSent = false;
 			_wasPanGestureStartedSent = false;
 		}
 
 		void OnPointerCanceled(object sender, PointerRoutedEventArgs e)
 		{
-			_fingers.Remove(e.Pointer.PointerId);
-
 			SwipeComplete(false);
 			PinchComplete(false);
 			PanComplete(false);
+
+			_fingers.Clear();
 		}
 
 		void OnPointerExited(object sender, PointerRoutedEventArgs e)
 		{
+			SwipeComplete(true);
+
 			if (!_isPanning)
 			{
 				_fingers.Remove(e.Pointer.PointerId);
 			}
-
-			SwipeComplete(true);
-			PinchComplete(true);
 		}
 
 		void OnPointerPressed(object sender, PointerRoutedEventArgs e)
@@ -594,11 +594,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
 		{
-			_fingers.Remove(e.Pointer.PointerId);
-
 			SwipeComplete(true);
-			PinchComplete(true);
 			PanComplete(true);
+
+			_fingers.Remove(e.Pointer.PointerId);
 		}
 
 		void OnPgrPointerEntered(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Fixes various issues with completion events not being received and pinch gestures not operating correctly on Windows.

### Issues Fixed

Fixes #31033

- Pinches running with only one touch point when interrupted by a popup/alert
- Pan completion events not being received when more than one touch point is specified
- Pinches becoming inoperable before both touch points are removed

