### PR TITLE
Check if tab bar hidden value actually changed for Shell

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -459,6 +459,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (OperatingSystem.IsMacCatalystVersionAtLeast(18) || OperatingSystem.IsIOSVersionAtLeast(18))
 			{
+				if (TabBarHidden == !ShellItemController.ShowTabs)
+				{
+					return;
+				}
+	   
 				TabBarHidden = !ShellItemController.ShowTabs;
 			}
 			else


### PR DESCRIPTION
### Description of Change

Adds a check to see if the value is actually different and only apply the change when it _is_ different. It seems that for iOS 26 a change has been made that setting the `TabBarHidden` property now causes `ViewWillLayoutSubviews` to be triggered, which in turns updates the `TabBarHidden` causing an infinite loop. This change prevents that.

Since its a good thing to check anyway, not making this specific to iOS 26, although we could to be on the safe side