### PR TITLE
[net10.0] Fix DeveloperBalance ProjectList page fails to load correctly

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -6,14 +6,16 @@
              xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="MauiApp._1.Pages.ProjectListPage"
+             x:Name="ProjectList"
              x:DataType="pageModels:ProjectListPageModel"
              Title="Projects">
 
 
     <ContentPage.Behaviors>
         <toolkit:EventToCommandBehavior
-                EventName="Appearing"                
-                Command="{Binding AppearingCommand}" />
+            EventName="Appearing"
+            BindingContext="{Binding Path=BindingContext, Source={x:Reference ProjectList}, x:DataType=ContentPage}"
+            Command="{Binding AppearingCommand}"/>
     </ContentPage.Behaviors>
     <Grid>
       <ScrollView>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
Fixed an issue where the binding context on the ProjectList page was not updating correctly by assigning the binding context to `ContentPage.Behavior`.

> Reference
https://github.com/dotnet/maui/blob/60ee621dcdea156d6c15a43a9999252ca5cbdb2e/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml#L14

### Issues Fixed
Fixes #31152 

### Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<image width="500" height="350" alt="Before Fix" src="https://github.com/user-attachments/assets/7f2e422e-2fe5-47a9-87d7-ccd30ab99a26">|<image width="500" height="350" alt="After Fix" src ="https://github.com/user-attachments/assets/4a8b583a-66be-45c6-b815-374a1d2ae371">|