### PR TITLE
[iOS] ScrollView.ScrollToAsync(x, y, animated) doesn't work when called from Page.OnAppearing - fix

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31177.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31177.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  x:Class="Maui.Controls.Sample.Issues.Issue31177">
+  <ScrollView
+    HeightRequest="100"
+    x:Name="scrollView">
+    <VerticalStackLayout>
+      <Label Text="This is a scroll view scrolled to y pos"/>
+      <Label AutomationId="SuccessLabel"
+             Margin="0,200,0,0"
+             Text="Success if visible"/>
+    </VerticalStackLayout>
+  </ScrollView>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31177.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31177.xaml.cs
@@ -1,0 +1,14 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31177, "ScrollView.ScrollToAsync doesn't work when called from Page.OnAppearing", PlatformAffected.iOS | PlatformAffected.Android)]
+public partial class Issue31177 : ContentPage
+{
+	public Issue31177()
+	{
+		InitializeComponent();
+	}
+	protected override async void OnAppearing()
+	{
+		await scrollView.ScrollToAsync(0, 2000, true);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31177.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31177.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31177 : _IssuesUITest
+{
+	public Issue31177(TestDevice testDevice) : base(testDevice) { }
+	public override string Issue => "ScrollView.ScrollToAsync doesn't work when called from Page.OnAppearing";
+
+	[Test]
+	[Category(UITestCategories.ScrollView)]
+	public void ScrollToAsyncShouldWork()
+	{
+		App.WaitForElement("SuccessLabel");
+	}
+}


### PR DESCRIPTION
Extracted scroll logic into a static ScrollTo method for better code organization and reuse. Pending scroll requests are now executed after layout when content size is available, ensuring correct scroll behavior.

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31177
Fixes https://github.com/dotnet/maui/issues/26781
Fixes https://github.com/dotnet/maui/issues/31423

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
