### PR TITLE
[Android] GraphicsView scaling after canvas.ResetState - fix

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31182.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31182.cs
@@ -1,0 +1,56 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31182, "GraphicsView draws at half size after canvas.ResetState()", PlatformAffected.Android)]
+public class Issue31182 : TestContentPage
+{
+	protected override void Init()
+	{
+		var someView = new SomeView
+		{
+			WidthRequest = 200,
+			HeightRequest = 200
+		};
+
+		var label = new Label
+		{
+			Text = "Invalidated",
+			AutomationId = "label",
+			IsVisible = true
+		};
+
+		someView.Loaded += (s, e) =>
+		{
+			Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(100), () =>
+			{
+				someView.Invalidate();
+				label.IsVisible = true;
+			});
+
+			someView.Invalidate();
+		};
+
+		Content = new VerticalStackLayout
+		{
+			WidthRequest = 200,
+			HeightRequest = 200,
+			Background = Colors.Red,
+			Children =
+			{
+				someView,
+				label
+			}
+		};
+	}
+
+	class SomeView : GraphicsView, IDrawable
+	{
+		public SomeView() { Drawable = this; }
+
+		public void Draw(ICanvas canvas, RectF dirtyRect)
+		{
+			canvas.ResetState();
+			canvas.FillColor = Colors.Yellow;
+			canvas.FillRectangle(dirtyRect);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31182.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31182.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31182 : _IssuesUITest
+{
+	public Issue31182(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "GraphicsView draws at half size after canvas.ResetState()";
+
+	[Test]
+	[Category(UITestCategories.GraphicsView)]
+	public void GraphicsViewShouldDrawAtFullSize()
+	{
+		App.WaitForElement("label");
+		VerifyScreenshot();
+	}
+}

--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformGraphicsView.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformGraphicsView.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Graphics.Platform
 		{
 			_scale = Resources.DisplayMetrics.Density;
 			_canvas = new PlatformCanvas(context);
-			_scalingCanvas = new ScalingCanvas(_canvas);
+			_scalingCanvas = new ScalingCanvas(_canvas, _scale);
 			Drawable = drawable;
 		}
 
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Graphics.Platform
 		{
 			_scale = Resources.DisplayMetrics.Density;
 			_canvas = new PlatformCanvas(context);
-			_scalingCanvas = new ScalingCanvas(_canvas);
+			_scalingCanvas = new ScalingCanvas(_canvas, _scale);
 			Drawable = drawable;
 		}
 

--- a/src/Graphics/src/Graphics/ScalingCanvas.cs
+++ b/src/Graphics/src/Graphics/ScalingCanvas.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Graphics
 		private readonly Stack<float> _scaleYStack = new Stack<float>();
 		private float _scaleX = 1f;
 		private float _scaleY = 1f;
+		private float _initialScaleX = 1f;
+		private float _initialScaleY = 1f;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ScalingCanvas"/> class.
@@ -27,6 +29,12 @@ namespace Microsoft.Maui.Graphics
 		{
 			_canvas = wrapped;
 			_blurrableCanvas = _canvas as IBlurrableCanvas;
+		}
+
+		internal ScalingCanvas(ICanvas wrapped, float scale) : this(wrapped)
+		{
+			_initialScaleX = scale;
+			_initialScaleY = scale;
 		}
 
 		/// <inheritdoc/>
@@ -271,8 +279,8 @@ namespace Microsoft.Maui.Graphics
 			_canvas.ResetState();
 			_scaleXStack.Clear();
 			_scaleYStack.Clear();
-			_scaleX = 1;
-			_scaleY = 1;
+			_scaleX = _initialScaleX;
+			_scaleY = _initialScaleY;
 		}
 
 		public bool RestoreState()
@@ -285,8 +293,8 @@ namespace Microsoft.Maui.Graphics
 			}
 			else
 			{
-				_scaleX = 1;
-				_scaleY = 1;
+				_scaleX = _initialScaleX;
+				_scaleY = _initialScaleY;
 			}
 
 			return restored;


### PR DESCRIPTION
### REVERTED THIS PR

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Addresses issue #31182 where GraphicsView would draw at half size after calling canvas.ResetState() on Android. ScalingCanvas now preserves the initial scale and restores it after ResetState and RestoreState. Added related test cases to verify correct drawing behavior.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31182

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/9bf55951-aafc-4294-b6fe-8f400269212b" width="300px"/>|<img src="https://github.com/user-attachments/assets/e5c74a36-1180-46cb-8580-888b7a4bd64c" width="300px"/>|
