### PR TITLE
[Android] Fix to MemoryStream.Read ObjectDisposed_StreamClosed

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
@@ -156,7 +156,24 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public static IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
-			var bitmap = BitmapFactory.DecodeStream(stream);
+			Bitmap bitmap;
+
+			if (stream is null)
+			{
+				return null;
+			}
+
+			using (var memoryStream = new MemoryStream())
+			{
+				if (stream.CanSeek)
+				{
+					stream.Position = 0;
+				}
+				stream.CopyTo(memoryStream);
+				byte[] buffer = memoryStream.GetBuffer();
+				int length = (int)memoryStream.Length;
+				bitmap = BitmapFactory.DecodeByteArray(buffer, 0, length);
+			}
 			return new PlatformImage(bitmap);
 		}
 	}


### PR DESCRIPTION

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

The issue indicates that the Android implementation of PlatformImage.FromStream() was causing app crashes in release builds when loading images from streams, particularly when using embedded resources via GetManifestResourceStream().

The issue occurred because the stream could be disposed or become invalid before BitmapFactory.DecodeStream() completed reading the data. Applied the same defensive pattern used in the generic PlatformImage implementation and other platforms, copy the stream data to memory before processing to ensure all data is available before native decoding begins.

Added test coverage for stream disposal scenarios, including the exact scenario from the reported issue. Creating tests also notice that the method to get a PNG dimensions was not correct. Fixed the PNG dimension parsing in the generic PlatformImage implementation, was reading wrong byte positions.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/30636

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
