### PR TITLE
Remove edge to edge from top level container

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -91,11 +91,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (insets == null || v == null)
 					return insets;
 
-				var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+				// The flyout overlaps the status bar so we don't really care about insetting it
 				var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
-				var topInset = Math.Max(systemBars?.Top ?? 0, displayCutout?.Top ?? 0);
 
-				v.SetPadding(0, topInset, 0, 0);
+				v.SetPadding(0, displayCutout?.Top ?? 0, 0, 0);
 
 				return WindowInsetsCompat.Consumed;
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -10,6 +10,7 @@ using Android.Util;
 using Android.Views;
 using Android.Widget;
 using AndroidX.CoordinatorLayout.Widget;
+using AndroidX.Core.View;
 using AndroidX.DrawerLayout.Widget;
 using AndroidX.RecyclerView.Widget;
 using Google.Android.Material.AppBar;
@@ -72,6 +73,34 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
+		// Temporary workaround:
+		// Android 15 / API 36 removed the prior opt‑out path for edge‑to‑edge
+		// (legacy "edge to edge ignore" + decor fitting). This placeholder exists
+		// so we can keep apps from regressing (content accidentally covered by
+		// system bars) until a proper, unified edge‑to‑edge + system bar inset
+		// configuration API is implemented in MAUI.
+		//
+		// NOTE:
+		// - Keep this minimal.
+		// - Will be replaced by the planned comprehensive window insets solution.
+		// - Do not extend; add new logic to the forthcoming implementation instead.
+		internal class WindowsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+		{
+			public WindowInsetsCompat OnApplyWindowInsets(AView v, WindowInsetsCompat insets)
+			{
+				if (insets == null || v == null)
+					return insets;
+
+				var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+				var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+				var topInset = Math.Max(systemBars?.Top ?? 0, displayCutout?.Top ?? 0);
+
+				v.SetPadding(0, topInset, 0, 0);
+
+				return WindowInsetsCompat.Consumed;
+			}
+		}
+		
 		protected virtual void LoadView(IShellContext shellContext)
 		{
 			var context = shellContext.AndroidContext;
@@ -79,6 +108,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var coordinator = (ViewGroup)layoutInflator.Inflate(Controls.Resource.Layout.flyoutcontent, null);
 
 			_appBar = coordinator.FindViewById<AppBarLayout>(Controls.Resource.Id.flyoutcontent_appbar);
+			ViewCompat.SetOnApplyWindowInsetsListener(_appBar, new WindowsListener());
 
 			(_appBar.LayoutParameters as CoordinatorLayout.LayoutParams)
 				.Behavior = new AppBarLayout.Behavior();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -207,8 +207,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				Id = AView.GenerateViewId(),
 			};
 
-			_frameLayout.SetFitsSystemWindows(true);
-
 			_flyoutView.AttachFlyout(this, _frameLayout);
 
 			((IShellController)shell).AddAppearanceObserver(this, shell);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -9,6 +9,7 @@ using Android.Views;
 using AndroidX.AppCompat.App;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
+using AndroidX.Core.View;
 using AndroidX.Fragment.App;
 using AndroidX.ViewPager.Widget;
 using AndroidX.ViewPager2.Widget;
@@ -100,6 +101,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var context = Context;
 			var root = PlatformInterop.CreateShellCoordinatorLayout(context);
 			var appbar = PlatformInterop.CreateShellAppBar(context, Resource.Attribute.appBarLayoutStyle, root);
+			ViewCompat.SetOnApplyWindowInsetsListener(appbar, new WindowsListener());
 			int actionBarHeight = context.GetActionBarHeight();
 
 			var shellToolbar = new Toolbar(shellSection);
@@ -147,6 +149,34 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			HookEvents();
 
 			return _rootView = root;
+		}
+
+		// Temporary workaround:
+		// Android 15 / API 36 removed the prior opt‑out path for edge‑to‑edge
+		// (legacy "edge to edge ignore" + decor fitting). This placeholder exists
+		// so we can keep apps from regressing (content accidentally covered by
+		// system bars) until a proper, unified edge‑to‑edge + system bar inset
+		// configuration API is implemented in MAUI.
+		//
+		// NOTE:
+		// - Keep this minimal.
+		// - Will be replaced by the planned comprehensive window insets solution.
+		// - Do not extend; add new logic to the forthcoming implementation instead.
+		internal class WindowsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+		{
+			public WindowInsetsCompat OnApplyWindowInsets(AView v, WindowInsetsCompat insets)
+			{
+				if (insets == null || v == null)
+					return insets;
+
+				var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+				var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+				var topInset = Math.Max(systemBars?.Top ?? 0, displayCutout?.Top ?? 0);
+
+				v.SetPadding(0, topInset, 0, 0);
+
+				return WindowInsetsCompat.Consumed;
+			}
 		}
 
 		void OnShellContentPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -4,6 +4,7 @@ using Android.App.Roles;
 using Android.Runtime;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
+using AndroidX.Core.View;
 using AndroidX.DrawerLayout.Widget;
 using AndroidX.Fragment.App;
 using AndroidX.Lifecycle;
@@ -238,6 +239,7 @@ namespace Microsoft.Maui.Handlers
 						DrawerLayout.LayoutParams.MatchParent,
 						(int)GravityFlags.Start);
 
+				ViewCompat.SetOnApplyWindowInsetsListener(flyoutView, new WindowsListener());
 				// Flyout has to get added after the content otherwise clicking anywhere
 				// on the flyout will cause it to close and gesture
 				// recognizers inside the flyout won't fire
@@ -246,6 +248,42 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView is IToolbarElement te && te.Toolbar?.Handler is ToolbarHandler th)
 				th.SetupWithDrawerLayout(DrawerLayout);
+		}
+
+		// Temporary workaround:
+		// Android 15 / API 36 removed the prior opt‑out path for edge‑to‑edge
+		// (legacy "edge to edge ignore" + decor fitting). This placeholder exists
+		// so we can keep apps from regressing (content accidentally covered by
+		// system bars) until a proper, unified edge‑to‑edge + system bar inset
+		// configuration API is implemented in MAUI.
+		//
+		// NOTE:
+		// - Keep this minimal.
+		// - Will be replaced by the planned comprehensive window insets solution.
+		// - Do not extend; add new logic to the forthcoming implementation instead.
+		internal class WindowsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+		{
+			public WindowInsetsCompat? OnApplyWindowInsets(View? v, WindowInsetsCompat? insets)
+			{
+				if (insets == null || v == null)
+					return insets;
+
+				var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+				var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+				var topInset = Math.Max(systemBars?.Top ?? 0, displayCutout?.Top ?? 0);
+
+				// Here we are using margin because the view passed in is the actual IView from the MAUI xplat control
+				// if we set padding it causes the control to inset so we need to use margin
+				// realistically this listener will probably go away once we get the SafeAreaEdges code propagated to
+				// MauiViews correctly
+				if (v.LayoutParameters is DrawerLayout.LayoutParams layoutParams)
+				{
+					layoutParams.TopMargin = topInset;
+					v.LayoutParameters = layoutParams;
+				}
+				
+				return WindowInsetsCompat.Consumed;
+			}
 		}
 
 		void UpdateIsPresented()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This pull request introduces a temporary workaround for Android 15 / API 36's removal of the legacy "edge-to-edge ignore" path, which previously helped prevent app content from being covered by system bars. The changes add a minimal `WindowsListener` class to several key Android handlers in MAUI, ensuring that content is properly inset and not obscured by system bars or display cutouts until a comprehensive edge-to-edge and system bar inset solution is implemented. This approach is intentionally minimal and will be replaced by a more robust solution in the future.

The reason for a temporary workaround is to fix this bug for now in the next NET10 release and then follow up back filling the SafeAreaEdges APIs (most likely RC2)

**Edge-to-edge and system bar insets workaround:**

* Added a temporary `WindowsListener` class implementing `IOnApplyWindowInsetsListener` to multiple handlers (`ShellFlyoutTemplatedContentRenderer`, `ShellSectionRenderer`, `FlyoutViewHandler`, and `WindowHandler`) to adjust padding/margins and prevent content from being covered by system bars or display cutouts. [[1]](diffhunk://#diff-b9dfdc6ac9c4f0123c8e17432f8ab02a5e684bd269be44484b5867b6511a354cR76-R110) [[2]](diffhunk://#diff-b713999f86b1468f6a7164c3a37f63667c758815ead1abc1764ef0d957e49bddR154-R181) [[3]](diffhunk://#diff-80a471576f03c2498cbe2d2a4ec1f134117326fe03d5adc0e65cd3603c90e8c1R253-R288) [[4]](diffhunk://#diff-aaa8de4ee29efe333fdd2340604bcb8f7ddf5c2d258009d46606e15407f183c1R109-R164)

* Integrated `ViewCompat.SetOnApplyWindowInsetsListener` calls in the relevant view setup methods to apply the new listener for managing insets in flyouts, app bars, root views, and other key UI elements. [[1]](diffhunk://#diff-b9dfdc6ac9c4f0123c8e17432f8ab02a5e684bd269be44484b5867b6511a354cR76-R110) [[2]](diffhunk://#diff-b713999f86b1468f6a7164c3a37f63667c758815ead1abc1764ef0d957e49bddR104) [[3]](diffhunk://#diff-80a471576f03c2498cbe2d2a4ec1f134117326fe03d5adc0e65cd3603c90e8c1R242) [[4]](diffhunk://#diff-aaa8de4ee29efe333fdd2340604bcb8f7ddf5c2d258009d46606e15407f183c1R31)

**Dependency updates:**

* Added missing `AndroidX.Core.View` and related using statements to ensure compatibility with the new window insets APIs. [[1]](diffhunk://#diff-b9dfdc6ac9c4f0123c8e17432f8ab02a5e684bd269be44484b5867b6511a354cR13) [[2]](diffhunk://#diff-b713999f86b1468f6a7164c3a37f63667c758815ead1abc1764ef0d957e49bddR12) [[3]](diffhunk://#diff-80a471576f03c2498cbe2d2a4ec1f134117326fe03d5adc0e65cd3603c90e8c1R7) [[4]](diffhunk://#diff-aaa8de4ee29efe333fdd2340604bcb8f7ddf5c2d258009d46606e15407f183c1R4-R8)

**Legacy system windows handling removal:**

* Removed legacy `SetFitsSystemWindows(true)` call from `ShellRenderer` to align with the new edge-to-edge handling.

Each of these changes is a targeted, minimal fix to prevent regressions in edge-to-edge layouts on the latest Android versions, while the team works on a comprehensive solution for system bar and safe area handling.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #29954
Fixes #26788
Fixes #24903

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
