### PR TITLE
[iOS][CV2] Fix CollectionView renders large empty space at bottom of view

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -558,6 +558,35 @@ internal static class LayoutFactory2
 					Configuration.ScrollDirection);
 		}
 
+		public override CGSize CollectionViewContentSize
+		{
+			get
+			{
+				// Check if the collection has no items
+				if (CollectionView != null)
+				{
+					var numberOfSections = CollectionView.NumberOfSections();
+					bool hasItems = false;
+					
+					for (nint section = 0; section < numberOfSections; section++)
+					{
+						if (CollectionView.NumberOfItemsInSection(section) > 0)
+						{
+							hasItems = true;
+							break;
+						}
+					}
+					
+					if (!hasItems)
+					{
+						return CGSize.Empty;
+					}
+				}
+				
+				return base.CollectionViewContentSize;
+			}
+		}
+
 		CGPoint ScrollSingle(SnapPointsAlignment alignment, CGPoint proposedContentOffset, CGPoint scrollingVelocity)
 		{
 			// Get the viewport of the UICollectionView at the current content offset

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -503,7 +503,7 @@ internal static class LayoutFactory2
 				}
 			}
 		}
-		
+
 		public override CGPoint TargetContentOffset(CGPoint proposedContentOffset, CGPoint scrollingVelocity)
 		{
 			var snapPointsType = _snapInfo.SnapType;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -562,30 +562,25 @@ internal static class LayoutFactory2
 		{
 			get
 			{
-				// Check if the collection has no items
 				if (CollectionView != null)
 				{
 					var numberOfSections = CollectionView.NumberOfSections();
-					bool hasItems = false;
-					
 					for (nint section = 0; section < numberOfSections; section++)
 					{
 						if (CollectionView.NumberOfItemsInSection(section) > 0)
 						{
-							hasItems = true;
-							break;
+							return base.CollectionViewContentSize;
 						}
 					}
-					
-					if (!hasItems)
-					{
-						return CGSize.Empty;
-					}
+
+					// No items found
+					return CGSize.Empty;
 				}
-				
+
 				return base.CollectionViewContentSize;
 			}
 		}
+
 
 		CGPoint ScrollSingle(SnapPointsAlignment alignment, CGPoint proposedContentOffset, CGPoint scrollingVelocity)
 		{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -453,7 +453,7 @@ internal static class LayoutFactory2
 		LayoutGroupingInfo? _groupingInfo;
 		LayoutHeaderFooterInfo? _headerFooterInfo;
 
-		public CustomUICollectionViewCompositionalLayout(LayoutSnapInfo snapInfo, UICollectionViewCompositionalLayoutSectionProvider sectionProvider, UICollectionViewCompositionalLayoutConfiguration configuration, ItemsUpdatingScrollMode itemsUpdatingScrollMode) : base(sectionProvider, configuration)
+		public CustomUICollectionViewCompositionalLayout(LayoutSnapInfo snapInfo, LayoutGroupingInfo? groupingInfo, LayoutHeaderFooterInfo? headerFooterInfo, UICollectionViewCompositionalLayoutSectionProvider sectionProvider, UICollectionViewCompositionalLayoutConfiguration configuration, ItemsUpdatingScrollMode itemsUpdatingScrollMode) : base(sectionProvider, configuration)
 		{
 			_snapInfo = snapInfo;
 			_itemsUpdatingScrollMode = itemsUpdatingScrollMode;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -568,26 +568,20 @@ internal static class LayoutFactory2
 			{
 				if (CollectionView != null)
 				{
-					var numberOfSections = CollectionView.NumberOfSections();
-					for (nint section = 0; section < numberOfSections; section++)
-					{
-						if (CollectionView.NumberOfItemsInSection(section) > 0)
-						{
-							return base.CollectionViewContentSize;
-						}
-					}
-
-					// No items found, but check if we have headers or footers that should still be shown
 					bool hasGlobalHeaders = _headerFooterInfo?.HasHeader == true || _headerFooterInfo?.HasFooter == true;
 					bool hasGroupHeaders = _groupingInfo?.HasHeader == true || _groupingInfo?.HasFooter == true;
 
 					if (hasGlobalHeaders || hasGroupHeaders)
 					{
-						// Return the base content size to allow headers/footers to be displayed
 						return base.CollectionViewContentSize;
 					}
 
-					// No items and no headers/footers found
+					if (CollectionView.NumberOfSections() > 0 &&
+				CollectionView.NumberOfItemsInSection(0) > 0)
+					{
+						return base.CollectionViewContentSize;
+					}
+
 					return CGSize.Empty;
 				}
 

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -55,7 +55,15 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-			platformDatePicker.CharacterSpacing = datePicker.CharacterSpacing.ToEm();
+		    var characterSpacing = datePicker.CharacterSpacing.ToEm();
+			platformDatePicker.CharacterSpacing = characterSpacing;
+
+			var dateTextBlock = platformDatePicker.GetDescendantByName<TextBlock>("DateText");
+			if (dateTextBlock is not null)
+			{
+				dateTextBlock.CharacterSpacing = characterSpacing;
+				dateTextBlock.RefreshThemeResources();
+			}
 		}
 
 		public static void UpdateFont(this CalendarDatePicker platformDatePicker, IDatePicker datePicker, IFontManager fontManager) =>

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -55,15 +55,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this CalendarDatePicker platformDatePicker, IDatePicker datePicker)
 		{
-		    var characterSpacing = datePicker.CharacterSpacing.ToEm();
-			platformDatePicker.CharacterSpacing = characterSpacing;
-
-			var dateTextBlock = platformDatePicker.GetDescendantByName<TextBlock>("DateText");
-			if (dateTextBlock is not null)
-			{
-				dateTextBlock.CharacterSpacing = characterSpacing;
-				dateTextBlock.RefreshThemeResources();
-			}
+			platformDatePicker.CharacterSpacing = datePicker.CharacterSpacing.ToEm();
 		}
 
 		public static void UpdateFont(this CalendarDatePicker platformDatePicker, IDatePicker datePicker, IFontManager fontManager) =>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
In CV2, when there are no items, the CollectionView becomes horizontally scrollable. This issue is not seen in CV1.

### Description of Change

<!-- Enter description of the fix in this section -->
Overrode CollectionViewContentSize to return CGSize.Empty when no items are present, preventing unwanted scrolling.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #17799 
Fixes #33201

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Regarding Test case
For this case, it's not possible to write a test because the scrollbar does not appear during initial loading. It only becomes visible when a scroll action is performed, and even then, it remains visible only for a few seconds.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/b40d9b89-c5d7-41f0-bd26-0510f2a0547f" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/5aaba964-6999-43eb-88d8-43e95deca353" width="300" height="600"> |
