### PR TITLE
[iOS] Update date format in iOS DatePickerExtensions

### DIFF
--- a/src/Core/src/Platform/iOS/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/DatePickerExtensions.cs
@@ -88,13 +88,13 @@ public static class DatePickerExtensions
 
 			if (format.Equals("D", StringComparison.Ordinal) == true)
 			{
-				dateFormatter.DateStyle = NSDateFormatterStyle.Long;
+				dateFormatter.DateFormat = "EEEE, dd MMMM yyyy";
 				var strDate = dateFormatter.StringFor(picker.Date);
 				platformDatePicker.Text = strDate;
 			}
 			else
 			{
-				dateFormatter.DateStyle = NSDateFormatterStyle.Short;
+				dateFormatter.DateFormat = "dd/MM/yyyy";
 				var strDate = dateFormatter.StringFor(picker.Date);
 				platformDatePicker.Text = strDate;
 			}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Replaces usage of NSDateFormatterStyle with explicit date format strings for both long and short date formats. Ensures consistent date display regardless of locale settings.

The implementation of NSDateFormatter APIs didn’t change. We just started hitting this path. The question is whether we should:

**Honor the user’s region (iOS-native behavior)**
Use NSDateFormatterStyle and don’t set DateFormat. This lets “D”/“d” map to the platform’s Long/Short patterns and shows what users expect per locale.

**Enforce a cross-platform, invariant pattern (to mirror Android exactly)**
When a custom pattern is supplied (e.g., "dd/MM/yyyy"), set DateFormat and pin the formatter to en_US_POSIX so iOS won’t reshuffle components.


|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/1d575428-e849-4f27-af9f-8979f6924062" width="300px"></video>|<video src="https://github.com/user-attachments/assets/184a1f0c-da97-4f4f-bde8-198263cedd35" width="300px"></video>|
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/31167

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
