### PR TITLE
General nativeAOT support improvements

### DIFF
--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -23,9 +23,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+    <IsAotCompatible>true</IsAotCompatible>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+
+    <!-- This project implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the WinRT ABI. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="$(MauiSrcDirectory)MultiTargeting.targets" />

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -24,6 +24,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+		<IsAotCompatible>true</IsAotCompatible>
 		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 		<EnableAotAnalyzer>true</EnableAotAnalyzer>
 		<EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Core/maps/src/Maps.csproj
+++ b/src/Core/maps/src/Maps.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+    <IsAotCompatible>true</IsAotCompatible>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -14,8 +14,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+    <IsAotCompatible>true</IsAotCompatible>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
+
+    <!-- This project implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the WinRT ABI. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 

--- a/src/Core/src/Platform/Windows/ColorConverter.cs
+++ b/src/Core/src/Platform/Windows/ColorConverter.cs
@@ -5,7 +5,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 
 namespace Microsoft.Maui.Platform
 {
-	public sealed class ColorConverter : UI.Xaml.Data.IValueConverter
+	public sealed partial class ColorConverter : UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -14,7 +14,7 @@ using Microsoft.UI.Xaml.Shapes;
 
 namespace Microsoft.Maui.Platform
 {
-	public class ContentPanel : MauiPanel
+	public partial class ContentPanel : MauiPanel
 	{
 		readonly Path? _borderPath;
 		IBorderStroke? _borderStroke;

--- a/src/Core/src/Platform/Windows/DefaultOrUserDataTemplateSelector.cs
+++ b/src/Core/src/Platform/Windows/DefaultOrUserDataTemplateSelector.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
 {
-	class DefaultOrUserDataTemplateSelector : DataTemplateSelector
+	partial class DefaultOrUserDataTemplateSelector : DataTemplateSelector
 	{
 		public string? UserTemplateName { get; set; }
 		public string? DefaultTemplateName { get; set; }

--- a/src/Core/src/Platform/Windows/KeyboardAcceleratorExtensions.cs
+++ b/src/Core/src/Platform/Windows/KeyboardAcceleratorExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	/// <summary>
 	/// Group of helper extension methods related to KeyboardAccelerators.
 	/// </summary>
-	public static class KeyboardAcceleratorExtensions
+	public static partial class KeyboardAcceleratorExtensions
 	{
 		/// <summary>
 		/// Updates the collection of KeyboardAccelerators used by a MenuFlyoutItemBase.

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -7,7 +7,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 
 namespace Microsoft.Maui.Platform
 {
-	public class LayoutPanel : MauiPanel
+	public partial class LayoutPanel : MauiPanel
 	{
 		Canvas? _backgroundLayer;
 		public bool ClipsToBounds { get; set; }

--- a/src/Core/src/Platform/Windows/MauiButton.cs
+++ b/src/Core/src/Platform/Windows/MauiButton.cs
@@ -9,7 +9,7 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiButton : Button
+	public partial class MauiButton : Button
 	{
 		public MauiButton()
 		{
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Platform
 		}
 	}
 
-	internal class DefaultMauiButtonContent : MauiPanel
+	internal partial class DefaultMauiButtonContent : MauiPanel
 	{
 		readonly Image _image;
 		readonly TextBlock _textBlock;

--- a/src/Core/src/Platform/Windows/MauiButtonAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiButtonAutomationPeer.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiButtonAutomationPeer : ButtonAutomationPeer
+	public partial class MauiButtonAutomationPeer : ButtonAutomationPeer
 	{
 		public MauiButtonAutomationPeer(Button owner) : base(owner)
 		{

--- a/src/Core/src/Platform/Windows/MauiCancelButton.cs
+++ b/src/Core/src/Platform/Windows/MauiCancelButton.cs
@@ -5,7 +5,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiCancelButton : Button
+	public partial class MauiCancelButton : Button
 	{
 		TextBlock _cancelButtonGlyph;
 		Border _cancelButtonBackground;

--- a/src/Core/src/Platform/Windows/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiHybridWebView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Platform
 #if !NETSTANDARD
 	[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
 #endif
-	public class MauiHybridWebView : WebView2, IHybridPlatformWebView
+	public partial class MauiHybridWebView : WebView2, IHybridPlatformWebView
 	{
 		private readonly WeakReference<HybridWebViewHandler> _handler;
 		internal Task<bool>? WebViewReadyTask { get; set; }

--- a/src/Core/src/Platform/Windows/MauiPageControl.cs
+++ b/src/Core/src/Platform/Windows/MauiPageControl.cs
@@ -12,7 +12,7 @@ using WShape = Microsoft.UI.Xaml.Shapes.Shape;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiPageControl : ItemsControl
+	public partial class MauiPageControl : ItemsControl
 	{
 		IIndicatorView? _indicatorView;
 		const int DefaultPadding = 4;

--- a/src/Core/src/Platform/Windows/MauiPasswordTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiPasswordTextBox.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Platform
 {
 	// TODO: Replace this all with a real PasswordBox and not do this
 	//       as we lose many default password box features.
-	public class MauiPasswordTextBox : TextBox
+	public partial class MauiPasswordTextBox : TextBox
 	{
 		const char ObfuscationCharacter = '●';
 

--- a/src/Core/src/Platform/Windows/MauiSlider.cs
+++ b/src/Core/src/Platform/Windows/MauiSlider.cs
@@ -8,7 +8,7 @@ using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
 
 namespace Microsoft.Maui.Platform
 {
-	internal class MauiSlider : Slider
+	internal partial class MauiSlider : Slider
 	{
 		Thumb _thumb;
 		Style _originalThumbStyle;

--- a/src/Core/src/Platform/Windows/MauiStepper.cs
+++ b/src/Core/src/Platform/Windows/MauiStepper.cs
@@ -14,7 +14,7 @@ using WVisualStateManager = Microsoft.UI.Xaml.VisualStateManager;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiStepper : Control
+	public partial class MauiStepper : Control
 	{
 		Button _plus;
 		Button _minus;

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -7,7 +7,7 @@ using Windows.ApplicationModel;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiWebView : WebView2, IWebViewDelegate
+	public partial class MauiWebView : WebView2, IWebViewDelegate
 	{
 		readonly WeakReference<WebViewHandler> _handler;
 

--- a/src/Core/src/Platform/Windows/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Windows/PlatformTouchGraphicsView.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml.Input;
 
 namespace Microsoft.Maui.Platform
 {
-	public class PlatformTouchGraphicsView : UserControl
+	public partial class PlatformTouchGraphicsView : UserControl
 	{
 		IGraphicsView? _graphicsView;
 		readonly W2DGraphicsView _platformGraphicsView;

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Platform
 
 		internal new MauiToolbar? Toolbar
 		{
-			get => base.Toolbar as MauiToolbar;
+			get => base.Toolbar as MauiToolbar; 
 			set
 			{
 				if (base.Toolbar == value)
@@ -367,7 +367,7 @@ namespace Microsoft.Maui.Platform
 		// We use a container because if we just assign our Flyout to the PaneFooter on the NavigationView 
 		// The measure call passes in PositiveInfinity for the measurements which causes the layout system
 		// to crash. So we use this Panel to facilitate more constrained measuring values
-		class FlyoutPanel : Panel
+	    partial class FlyoutPanel : Panel
 		{
 			public Maui.IView? FlyoutView { get; set; }
 

--- a/src/Core/src/Platform/Windows/RootPanel.cs
+++ b/src/Core/src/Platform/Windows/RootPanel.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Controls;
 namespace Microsoft.Maui.Platform
 {
 	[Obsolete("Use Microsoft.Maui.Platform.ContentPanel")]
-	public class RootPanel : Panel
+	public partial class RootPanel : Panel
 	{
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Rect, Size>? CrossPlatformArrange { get; set; }

--- a/src/Core/src/Platform/Windows/TextAlignmentToHorizontalAlignmentConverter.cs
+++ b/src/Core/src/Platform/Windows/TextAlignmentToHorizontalAlignmentConverter.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Platform
 {
-	public sealed class TextAlignmentToHorizontalAlignmentConverter : Microsoft.UI.Xaml.Data.IValueConverter
+	public sealed partial class TextAlignmentToHorizontalAlignmentConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -5,7 +5,7 @@ using Windows.Foundation;
 
 namespace Microsoft.Maui.Platform
 {
-	internal class WindowRootViewContainer : Panel
+	internal partial class WindowRootViewContainer : Panel
 	{
 		FrameworkElement? _topPage;
 		UIElementCollection? _cachedChildren;

--- a/src/Graphics/src/Graphics.Skia/Graphics.Skia.csproj
+++ b/src/Graphics/src/Graphics.Skia/Graphics.Skia.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+    <IsAotCompatible>true</IsAotCompatible>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Graphics/src/Graphics.Skia/Views/SkiaGraphicsView.Windows.cs
+++ b/src/Graphics/src/Graphics.Skia/Views/SkiaGraphicsView.Windows.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Graphics.Skia.Views
 	/// <summary>
 	/// A SkiaSharp-based graphics view for Windows that can render <see cref="IDrawable"/> objects.
 	/// </summary>
-	public class SkiaGraphicsView : SKXamlCanvas
+	public partial class SkiaGraphicsView : SKXamlCanvas
 	{
 		private IDrawable _drawable;
 		private SkiaCanvas _canvas;

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsAotCompatible>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">
+    <IsAotCompatible>true</IsAotCompatible>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>

--- a/src/Graphics/src/Graphics/Platforms/Windows/PlatformGraphicsView.cs
+++ b/src/Graphics/src/Graphics/Platforms/Windows/PlatformGraphicsView.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Maui.Graphics.Platform
 	/// A Windows platform view that can be used to host drawings.
 	/// </summary>
 #if MAUI_GRAPHICS_WIN2D
-	public sealed class W2DGraphicsView
+	public sealed partial class W2DGraphicsView
 #else
-	public class PlatformGraphicsView
+	public partial class PlatformGraphicsView
 #endif
 		: UserControl
 	{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This pull request introduces changes across several project and source files to improve compatibility with Ahead-of-Time (AOT) compilation and code trimming, as well as to support partial class declarations for future extensibility and code generation. The most important changes are grouped below:

* Added the `<IsAotCompatible>true</IsAotCompatible>` property to multiple `.csproj` files (`Core.csproj`, `Controls.Core.csproj`, `Controls.Xaml.csproj`, `Maps.csproj`) to explicitly mark these projects as compatible with AOT compilation. 
* Refactored many Windows platform classes (e.g., `ColorConverter`, `ContentPanel`, `LayoutPanel`, `MauiButton`, `MauiCancelButton`, `MauiHybridWebView`, `MauiWebView`, `MauiSlider`, `MauiStepper`, `PlatformTouchGraphicsView`, etc.) to use the `partial` keyword, preparing them for code generation.

<!-- Enter description of the fix in this section -->

### Issues Fixed

- Many core projects are not marked IsAotCompatible, so no AOT incompatibility warnings are surfaced
- Several important classes are missing partial declarations
- Some projects require AllowUnsafeBlocks due to generated code that uses unsafe for trimming (e.g., LoopableCollectionView.cs, RelativeLayout.cs, …)

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Part of #31227 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
