### PR TITLE
30985:Fix FlyoutPage Navigating args to not reach down into the NavigationPage

### DIFF
--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -54,19 +54,7 @@ namespace Microsoft.Maui.Controls
 
 				var previousDetail = _detail;
 
-				// Get the actual pages for navigation events (unwrap NavigationPages)
-				var destinationPage =
-					value is NavigationPage destinationNavPage ? destinationNavPage.CurrentPage : value;
-				var previousPage = previousDetail is NavigationPage previousNavPage
-					? previousNavPage.CurrentPage
-					: previousDetail;
-
-				// Send NavigatingFrom event to the previous detail (if any)
-				if (previousDetail is not null)
-				{
-					previousDetail.SendNavigatingFrom(new NavigatingFromEventArgs(destinationPage,
-						NavigationType.Replace));
-				}
+				previousDetail?.SendNavigatingFrom(new NavigatingFromEventArgs(destinationPage: value, navigationType: NavigationType.Replace));
 
 				// Update the detail property
 				OnPropertyChanging();
@@ -87,10 +75,10 @@ namespace Microsoft.Maui.Controls
 				if (previousDetail is not null)
 				{
 					previousDetail.SendNavigatedFrom(
-						new NavigatedFromEventArgs(destinationPage, NavigationType.Replace));
+						new NavigatedFromEventArgs(destinationPage: value, NavigationType.Replace));
 				}
 
-				_detail.SendNavigatedTo(new NavigatedToEventArgs(previousPage, NavigationType.Replace));
+				_detail.SendNavigatedTo(new NavigatedToEventArgs(previousDetail, NavigationType.Replace));
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change 

This PR updates the PageDetail property in FlyoutPage.cs.
The change simplifies the navigation logic by:
 - Removing the NavigationPage unwrapping.
 - Replacing the explicit null-check with the null-conditional operator.
With this update, `SendNavigatingFrom` is invoked directly on the current `value`.

> Related PR 
PR Link #28384 

### Issues Fixed
Fixes #30985 

### Tested the existing UI and DeviceTest in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

