### PR TITLE
Update ui-tests.yml timeout to account for CollectionView

### DIFF
--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -8,7 +8,7 @@ parameters:
   androidApiLevels: [ 30 ]
   iosVersions: [ 'latest' ]
   provisionatorChannel: 'latest'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   skipProvisioning: true
   agentPoolAccessToken: ''
   categoryGroupsToTest:


### PR DESCRIPTION
### Description of Change

CollectionView macOS UITests are timing out currently because they are taking slightly longer than 2 hours. 

We need to split these tests up or look at speeding up CollectionView tests.

But for now let's increase the timeout to unblock builds
