### PR TITLE
[iOS] iOS button crash with CharacterSpacing and TextColor - fix

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31238.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31238.cs
@@ -1,0 +1,25 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31238, "Setting CharacterSpacing property on buttons causing crashing on iOS", PlatformAffected.iOS)]
+public class Issue31238 : TestContentPage
+{
+	protected override void Init()
+	{
+		var btn = new Button
+		{
+			Text = "Click me",
+			AutomationId = "MauiButton",
+			CharacterSpacing = 5,
+			TextColor = Colors.Red
+		};
+
+		int clicks = 0;
+		btn.Command = new Command(() =>
+		{
+			clicks = (clicks + 1) % 3;
+			btn.CharacterSpacing = clicks == 0 ? 0 : clicks;
+		});
+
+		Content = btn;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31238.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31238.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31238 : _IssuesUITest
+{
+	public Issue31238(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "Setting CharacterSpacing property on buttons causing crashing on iOS";
+
+	[Test]
+	[Category(UITestCategories.Button)]
+	public void SettingCharacterSpacingShouldNotCrash()
+	{
+		App.WaitForElement("MauiButton");
+		App.Tap("MauiButton");
+		App.Tap("MauiButton");
+		App.Tap("MauiButton");
+		App.WaitForElement("MauiButton");
+	}
+}

--- a/src/Core/src/Platform/iOS/AttributedStringExtensions.cs
+++ b/src/Core/src/Platform/iOS/AttributedStringExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Platform
 			mutableAttributedString.AddAttribute
 			(
 				UIStringAttributeKey.ForegroundColor,
-				Foundation.NSObject.FromObject(color.ToPlatform().CGColor),
+				color.ToPlatform(),
 				new NSRange(0, mutableAttributedString.Length)
 			);
 			return mutableAttributedString;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Corrects the color attribute assignment in AttributedStringExtensions for iOS to prevent crashes when setting CharacterSpacing on buttons. Adds new test cases and UI tests to verify the fix for issue #31238.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31238
