### PR TITLE
[android] 20250820 net10.0 ecosystem updates

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -3,34 +3,22 @@
   <ItemGroup>
     <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
     <!-- must be kept in sync with the binding library version to it here: -->
-    <PackageReference Update="Xamarin.Android.Glide" Version="4.16.0.13" />
-    <PackageReference Update="Xamarin.AndroidX.Activity" Version="1.10.1.2" />
-    <PackageReference Update="Xamarin.AndroidX.AppCompat.AppCompatResources" Version="1.7.1" />
-    <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.8.0.10" />
-    <PackageReference Update="Xamarin.AndroidX.DynamicAnimation" Version="1.1.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.9.1" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.1" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.1" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.9.1" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.9.1" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.9.1" />
-    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.8.0" />
-    <PackageReference Update="Xamarin.AndroidX.Migration" Version="1.0.10" NoWarn="NU1701" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Runtime" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.9.0" />
-    <PackageReference Update="Xamarin.AndroidX.Palette" Version="1.0.0.33" />
-    <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.4.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.SavedState" Version="1.3.0.1" />
+    <PackageReference Update="Xamarin.Android.Glide" Version="4.16.0.14" />
+    <PackageReference Update="Xamarin.AndroidX.Activity" Version="1.10.1.3" />
+    <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.8.0.11" />
+    <PackageReference Update="Xamarin.AndroidX.DynamicAnimation" Version="1.1.0.3" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.9.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.9.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.9.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Runtime" Version="2.9.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.9.2.1" />
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
-    <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.28" />
-    <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.6.0" />
-    <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.4.0" />
-    <PackageReference Update="Xamarin.Build.Download" Version="0.11.4" />
-    <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.25" />
-    <PackageReference Update="Xamarin.Google.Android.Material" Version="1.12.0.4" />
-    <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.18.0" />
-    <PackageReference Update="Xamarin.GooglePlayServices.Maps" Version="119.2.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.29" />
+    <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.6.0.1" />
+    <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.4.0.1" />
+    <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.26" />
+    <PackageReference Update="Xamarin.Google.Android.Material" Version="1.12.0.5" />
+    <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.18.0.1" />
+    <PackageReference Update="Xamarin.GooglePlayServices.Maps" Version="119.2.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
+++ b/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
@@ -12,11 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Firebase.AppIndexing" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
+++ b/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
@@ -11,11 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" />
   </ItemGroup>

--- a/src/Controls/Foldable/src/Controls.Foldable.csproj
+++ b/src/Controls/Foldable/src/Controls.Foldable.csproj
@@ -35,11 +35,6 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(UseMaui)' != 'true' and '$(TargetPlatformIdentifier)' == 'android' ">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -50,12 +50,6 @@
     <AndroidGradleProject Include="../AndroidNative/build.gradle" ModuleName="maui" />
     <PackageReference Include="Xamarin.Android.Glide" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" />
-    <PackageReference Include="Xamarin.AndroidX.SavedState" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />


### PR DESCRIPTION
Updates to the latest AndroidX & Google Play Services packages from the dotnet/android-libraries repo.

I took this approach to clean things up:

* Removed any extra `<PackageReference/>` that was needed in 6ddecf5e. This should reduce pain of customers updating these packages themselves.

* Remove any `<PackageReference Update="..."/>` that is not used in this repo.

* Update all packages to latest.

* I had to mirror one new package to `dotnet-public`:

```
error NU1101: Unable to find package Xamarin.AndroidX.Tracing.Tracing.Android
```

The main potential behavior changes here will be updating the Java/Kotlin AndroidX.Navigation libraries to 2.9.2.