### PR TITLE
Misc nativeAOT Windows stability adjustments

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -270,4 +270,14 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_MauiSetWinUIDefaultsForPublishAot" BeforeTargets="PrepareForBuild" Condition="'$(PublishAot)' == 'true' and '$(_MauiTargetPlatformIsWindows)' == 'True'">
+    <PropertyGroup>
+      <DebugSymbols Condition="'$(DebugSymbols)' == ''">false</DebugSymbols>
+      <DebugType Condition="'$(DebugType)' == ''">None</DebugType>
+      <EmbedXbfInPri Condition="'$(EmbedXbfInPri)' == ''">false</EmbedXbfInPri>
+      <SelfContained Condition="'$(SelfContained)' == ''">true</SelfContained>
+      <WindowsPackageType Condition="'$(WindowsPackageType)' == ''">None</WindowsPackageType>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -45,12 +45,6 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (PlatformView is not null)
 				PlatformView.Loaded -= OnNavigationViewLoaded;
 
-			// Now that the NavigationView is fully loaded assign the MenuItemsSource if it
-			// hasn't been set yet. This avoids a crash observed when assigning during
-			// ConnectHandler on Native AOT builds.
-			if (PlatformView is NavigationView nv && nv.MenuItemsSource == null)
-				nv.MenuItemsSource = _mainLevelTabs;
-
 			UpdateSearchHandler();
 			MapMenuItems();
 		}
@@ -66,13 +60,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				mauiNavView.IsSettingsVisible = false;
 				mauiNavView.IsPaneToggleButtonVisible = false;
 				mauiNavView.MenuItemTemplate = (UI.Xaml.DataTemplate)WApp.Current.Resources["TabBarNavigationViewMenuItem"];
-				// Delay assigning MenuItemsSource until the control is Loaded. Under some conditions
-				// setting MenuItemsSource during handler connection
-				// can trigger an internal WinUI failure while the template is still being applied.
-				if (platformView.IsLoaded)
-				{
-					mauiNavView.MenuItemsSource = _mainLevelTabs;
-				}
+				mauiNavView.MenuItemsSource = _mainLevelTabs;
 
 				platformView.SetApplicationResource("NavigationViewMinimalHeaderMargin", null);
 				platformView.SetApplicationResource("NavigationViewHeaderMargin", null);
@@ -164,7 +152,6 @@ namespace Microsoft.Maui.Controls.Handlers
 		void OnShellNavigated(object? sender, ShellNavigatedEventArgs e)
 		{
 			UpdateSearchHandler();
-			MapMenuItems();
 		}
 
 		private void OnItemsChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -14,6 +14,8 @@
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
 		<NoWarn>$(NoWarn);CA1416</NoWarn>
 		<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+		<!-- Disable PRI generation to avoid conflicts with Core project's PRI file -->
+		<AppxGeneratePriEnabled>false</AppxGeneratePriEnabled>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -162,6 +162,13 @@ namespace Microsoft.Maui
 			if (fontFile == null)
 				return null;
 
+			// Under Native AOT, observed crashes when invoking Win2D CanvasFontSet -> GetPropertyValues
+			// This lookup is an optimization; returning null should just cause callers to use the
+			// PostScript name already embedded in the file path.
+#if USE_NATIVE_AOT
+			return null;
+#endif
+
 			try
 			{
 				var fontUri = new Uri(fontFile, UriKind.RelativeOrAbsolute);

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -167,8 +167,7 @@ namespace Microsoft.Maui
 			// PostScript name already embedded in the file path.
 #if USE_NATIVE_AOT
 			return null;
-#endif
-
+#else
 			try
 			{
 				var fontUri = new Uri(fontFile, UriKind.RelativeOrAbsolute);
@@ -203,6 +202,7 @@ namespace Microsoft.Maui
 
 				return null;
 			}
+#endif
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(ScrollViewer))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(Grid))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(StackPanel))]
 		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(SplitView))]
 		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(ItemsRepeater))]
 		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(Button))]

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WGridLength = Microsoft.UI.Xaml.GridLength;
@@ -64,6 +65,12 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(SplitView))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(ItemsRepeater))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(Button))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(ColumnDefinition))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(RowDefinition))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicFields, typeof(ContentControl))]
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

This pull request introduces several targeted improvements to support Native AOT publishing and to address issues specific to WinUI and Windows platform builds. The main focus is on increasing stability for Native AOT scenarios, avoiding runtime crashes, and improving build configuration for Windows projects. Inlcuding added `DynamicDependency` attributes to `MauiNavigationView.cs` to ensure required types and members are preserved during trimming for Native AOT scenarios.

### Issues Fixed

Improving MAUI WinUI nativeAOT stability.

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Part of #31227 