### PR TITLE
[release/10.0.1xx-rc1] Fix Build NativeAOT stages on rc1 

### DIFF
--- a/eng/pipelines/common/device-tests-jobs.yml
+++ b/eng/pipelines/common/device-tests-jobs.yml
@@ -4,7 +4,6 @@ parameters:
   versions: []
   provisionatorChannel: 'latest'
   skipProvisioning: true
-  agentPoolAccessToken: ''
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)
@@ -41,7 +40,6 @@ jobs:
         targetFrameworkVersion: ${{ parameters.targetFrameworkVersion.tfm }}
         packageid: ${{ parameters.project.packageid }}
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
-        agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
         artifactName: ${{ parameters.artifactName }}
         artifactItemPattern: ${{ parameters.artifactItemPattern }}
         checkoutDirectory: ${{ parameters.checkoutDirectory }}
@@ -95,7 +93,6 @@ jobs:
           targetFrameworkVersion: ${{ parameters.targetFrameworkVersion.tfm }}
           packageid: ${{ parameters.project.packageid }}
           provisionatorChannel: ${{ parameters.provisionatorChannel }}
-          agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
           artifactName: ${{ parameters.artifactName }}
           artifactItemPattern: ${{ parameters.artifactItemPattern }}
           checkoutDirectory: ${{ parameters.checkoutDirectory }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -6,7 +6,6 @@ parameters:
   cakeArgs: '' # additional cake args
   deviceTestConfiguration: '' # Indicates the configuration to use for Android. We're slowly enabling this for all projects
   provisionatorChannel: 'latest'
-  agentPoolAccessToken: ''
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -1,15 +1,14 @@
 parameters:
-  androidPool: { }
-  iosPool: { }
-  catalystPool: { }
-  windowsPool: { }
+  androidPool: {}
+  iosPool: {}
+  catalystPool: {}
+  windowsPool: {}
   androidApiLevels: [ 33 ]
   iosVersions: [ 'latest' ]
   iosDeviceVersions: [ '15' ]
   catalystVersions: [ 'latest' ]
   provisionatorChannel: 'latest'
   skipProvisioning: true
-  agentPoolAccessToken: ''
   artifactName: 'nuget'
   artifactItemPattern: '**/*.nupkg'
   checkoutDirectory: $(System.DefaultWorkingDirectory)
@@ -19,16 +18,16 @@ parameters:
     tfm: ''
     dependsOn: ''
   projects:
-    - name: name
-      desc: Human Description
-      android: /optional/path/to/android.csproj
-      ios: /optional/path/to/ios.csproj
-      catalyst: /optional/path/to/catalyst.csproj
+  - name: name
+    desc: Human Description
+    android: /optional/path/to/android.csproj
+    ios: /optional/path/to/ios.csproj
+    catalyst: /optional/path/to/catalyst.csproj
   platforms:
-    - android
-    - ios
-    - catalyst
-    - windows
+  - android
+  - ios
+  - catalyst
+  - windows
 
 stages:
 
@@ -39,7 +38,7 @@ stages:
       dependsOn: []
     ${{ else }}:
       dependsOn:
-        - ${{ platform }}_device_tests_${{ replace(parameters.targetFrameworkVersion.dependsOn, '.', '') }}
+      - ${{ platform }}_device_tests_${{ replace(parameters.targetFrameworkVersion.dependsOn, '.', '') }}
     jobs:
 
     - ${{ if eq(platform, 'android') }}:
@@ -62,7 +61,6 @@ stages:
                 configuration: ${{ project.androidConfiguration }}
               provisionatorChannel: ${{ parameters.provisionatorChannel }}
               skipProvisioning: ${{ parameters.skipProvisioning }}
-              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
               artifactName: ${{ parameters.artifactName }}
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
@@ -86,7 +84,6 @@ stages:
                 configuration: ${{ project.iOSConfiguration }}
               provisionatorChannel: ${{ parameters.provisionatorChannel }}
               skipProvisioning: ${{ parameters.skipProvisioning }}
-              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
               artifactName: ${{ parameters.artifactName }}
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
@@ -110,7 +107,6 @@ stages:
                 configuration: ${{ project.iOSConfiguration }}
               provisionatorChannel: ${{ parameters.provisionatorChannel }}
               skipProvisioning: ${{ parameters.skipProvisioning }}
-              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
               artifactName: ${{ parameters.artifactName }}
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
@@ -136,7 +132,6 @@ stages:
                   configuration: ${{ project.windowsConfiguration }}
                 provisionatorChannel: ${{ parameters.provisionatorChannel }}
                 skipProvisioning: ${{ parameters.skipProvisioning }}
-                agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                 artifactName: ${{ parameters.artifactName }}
                 artifactItemPattern: ${{ parameters.artifactItemPattern }}
                 useArtifacts: ${{ parameters.useArtifacts }}

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -6,7 +6,6 @@ parameters:
   app: '' #path to app to test
   version: '' #the iOS version'
   provisionatorChannel: 'latest'
-  agentPoolAccessToken: ''
   skipProvisioning: true
   configuration: "Release"
   testFilter: ''

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -6,7 +6,6 @@ parameters:
   app: '' #path to app to test
   version: '' #the iOS version'
   provisionatorChannel: 'latest'
-  agentPoolAccessToken: ''
   configuration: "Release"
   runtimeVariant: "Mono"
   testFilter: ''
@@ -183,7 +182,7 @@ steps:
     displayName: 'Enable Notification Center'
     continueOnError: true
     timeoutInMinutes: 60
-    
+
   - ${{ if eq(parameters.platform, 'android')}}:
     - task: PowerShell@2
       inputs:

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -76,8 +76,8 @@ stages:
                 runtimeVariant: "CoreCLR"
                 skipProvisioning: ${{ parameters.skipProvisioning }}
   
-  # NativeAOT UI tests build stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
-  - ${{ if or(ne(parameters.RunNativeAOT, 'False'), and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+  # NativeAOT UI tests build stage - only run when RunNativeAOT parameter is explicitly set
+  - ${{ if eq(parameters.RunNativeAOT, true) }}:
     - stage: build_ui_tests_nativeaot
       displayName: Build UITests NativeAOT Sample App
       dependsOn: []
@@ -305,8 +305,8 @@ stages:
                       testConfigurationArgs: "CollectionView2"
                       skipProvisioning: ${{ parameters.skipProvisioning }}
 
-  # NativeAOT iOS UI tests stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
-  - ${{ if or(ne(parameters.RunNativeAOT, 'False'), and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+  # NativeAOT iOS UI tests stage - only run when RunNativeAOT parameter is explicitly set
+  - ${{ if eq(parameters.RunNativeAOT, true) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
       dependsOn: build_ui_tests_nativeaot

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -10,6 +10,7 @@ parameters:
   provisionatorChannel: 'latest'
   timeoutInMinutes: 180
   skipProvisioning: true
+  BuildNativeAOT: false # Parameter to control whether NativeAOT artifacts should be built
   RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
@@ -75,8 +76,8 @@ stages:
                 runtimeVariant: "CoreCLR"
                 skipProvisioning: ${{ parameters.skipProvisioning }}
   
-  # NativeAOT UI tests build stage - only run when RunNativeAOT parameter is explicitly set
-  - ${{ if eq(parameters.RunNativeAOT, true) }}:
+  # NativeAOT UI tests build stage - only run when BuildNativeAOT parameter is true
+  - ${{ if eq(parameters.BuildNativeAOT, true) }}:
     - stage: build_ui_tests_nativeaot
       displayName: Build UITests NativeAOT Sample App
       dependsOn: []
@@ -300,8 +301,8 @@ stages:
                       testConfigurationArgs: "CollectionView2"
                       skipProvisioning: ${{ parameters.skipProvisioning }}
 
-  # NativeAOT iOS UI tests stage - only run when RunNativeAOT parameter is explicitly set
-  - ${{ if eq(parameters.RunNativeAOT, true) }}:
+  # NativeAOT iOS UI tests stage - only run when both BuildNativeAOT and RunNativeAOT parameters are true
+  - ${{ if and(eq(parameters.BuildNativeAOT, true), eq(parameters.RunNativeAOT, true)) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
       dependsOn: build_ui_tests_nativeaot

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -10,7 +10,7 @@ parameters:
   provisionatorChannel: 'latest'
   timeoutInMinutes: 180
   skipProvisioning: true
-  RunNativeAOT: False # Parameter to control whether NativeAOT UI tests should run
+  RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
     # we might want to improve this somehow depending on how much the categories change over time

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -11,6 +11,7 @@ parameters:
   timeoutInMinutes: 180
   skipProvisioning: true
   agentPoolAccessToken: ''
+  RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
     # we might want to improve this somehow depending on how much the categories change over time
@@ -75,7 +76,8 @@ stages:
                 runtimeVariant: "CoreCLR"
                 skipProvisioning: ${{ parameters.skipProvisioning }}
   
-  - ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+  # NativeAOT UI tests build stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
+  - ${{ if or(parameters.RunNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
     - stage: build_ui_tests_nativeaot
       displayName: Build UITests NativeAOT Sample App
       dependsOn: []
@@ -303,7 +305,8 @@ stages:
                       testConfigurationArgs: "CollectionView2"
                       skipProvisioning: ${{ parameters.skipProvisioning }}
 
-  - ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+  # NativeAOT iOS UI tests stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
+  - ${{ if or(parameters.RunNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
       dependsOn: build_ui_tests_nativeaot

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -306,7 +306,7 @@ stages:
                       skipProvisioning: ${{ parameters.skipProvisioning }}
 
   # NativeAOT iOS UI tests stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
-  - ${{ if or(parameters.RunNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+  - ${{ if or(parameters.RunNativeAOT, eq(variables['System.TeamProject'], 'devdiv')) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
       dependsOn: build_ui_tests_nativeaot

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -10,7 +10,6 @@ parameters:
   provisionatorChannel: 'latest'
   timeoutInMinutes: 180
   skipProvisioning: true
-  agentPoolAccessToken: ''
   RunNativeAOT: False # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
@@ -144,7 +143,6 @@ stages:
                       ${{ if not(eq(api, 27)) }}:
                         device: android-emulator-64_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
   
@@ -224,7 +222,6 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       runtimeVariant : "Mono"
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
@@ -261,7 +258,6 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       runtimeVariant : "Mono"
                       testFilter: "CollectionView"
                       testConfigurationArgs: "CollectionView2"
@@ -299,7 +295,6 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       runtimeVariant : "Mono"
                       testFilter: "CarouselView"
                       testConfigurationArgs: "CollectionView2"
@@ -344,7 +339,6 @@ stages:
                         ${{ if ne(version, 'latest') }}:
                           device: ios-simulator-64_${{ version }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                        agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                         runtimeVariant : "NativeAOT"
                         testFilter: $(CATEGORYGROUP)
                         skipProvisioning: ${{ parameters.skipProvisioning }}
@@ -377,7 +371,6 @@ stages:
                       path: ${{ project.winui }}
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
 
@@ -410,6 +403,5 @@ stages:
                       path: ${{ project.mac }}
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -306,7 +306,7 @@ stages:
                       skipProvisioning: ${{ parameters.skipProvisioning }}
 
   # NativeAOT iOS UI tests stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
-  - ${{ if or(parameters.RunNativeAOT, eq(variables['System.TeamProject'], 'devdiv')) }}:
+  - ${{ if or(ne(parameters.RunNativeAOT, 'False'), and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
       dependsOn: build_ui_tests_nativeaot

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -11,7 +11,7 @@ parameters:
   timeoutInMinutes: 180
   skipProvisioning: true
   agentPoolAccessToken: ''
-  RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
+  RunNativeAOT: False # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
     # we might want to improve this somehow depending on how much the categories change over time
@@ -77,7 +77,7 @@ stages:
                 skipProvisioning: ${{ parameters.skipProvisioning }}
   
   # NativeAOT UI tests build stage - only run on DevDiv builds or when RunNativeAOT parameter is explicitly set
-  - ${{ if or(parameters.RunNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+  - ${{ if or(ne(parameters.RunNativeAOT, 'False'), and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
     - stage: build_ui_tests_nativeaot
       displayName: Build UITests NativeAOT Sample App
       dependsOn: []

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -129,7 +129,7 @@ stages:
         windows: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
       - name: graphics
         desc: Graphics
-        androidApiLevelsExclude: [ 25 ] # Ignore for now API25 since the runs's are not stable
+        androidApiLevelsExclude: [ 25, 28 ] # Ignore for now API25 and API28 since the runs's are not stable
         androidConfiguration: 'Release'
         iOSConfiguration: 'Debug'
         windowsConfiguration: 'Debug'

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -48,61 +48,48 @@ variables:
 
 parameters:
 
-  - name: UseProvisionator
-    type: boolean
-    default: false
+- name: UseProvisionator
+  type: boolean
+  default: false
 
-  - name: provisionatorChannel
-    displayName: 'Provisionator channel'
-    type: string
-    default: 'latest'
+- name: BuildEverything
+  type: boolean
+  default: false
 
-  - name: BuildEverything
-    type: boolean
-    default: false
+- name: androidPool
+  type: object
+  default:
+    name: $(1ESPTPool)
+    vmImage: $(androidTestsVmImage)
+    demands:
+    - ImageOverride -equals 1ESPT-Ubuntu22.04
 
-  - name: androidPool
-    type: object
-    default:
-      name: $(1ESPTPool)
-      vmImage: $(androidTestsVmImage)
-      demands:
-        - ImageOverride -equals 1ESPT-Ubuntu22.04
+- name: iosPool
+  type: object
+  default:
+    name: $(iosDeviceTestsVmPool)
+    vmImage: $(iosDeviceTestsVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
 
-  - name: iosPool
-    type: object
-    default:
-      name: $(iosDeviceTestsVmPool)
-      vmImage: $(iosDeviceTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
-        
-  - name: catalystPool
-    type: object
-    default:
-      name: $(iosDeviceTestsVmPool)
-      vmImage: $(iosDeviceTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
+- name: catalystPool
+  type: object
+  default:
+    name: $(iosDeviceTestsVmPool)
+    vmImage: $(iosDeviceTestsVmImage)
+    demands:
+    - macOS.Name -equals Sequoia
 
-  - name: windowsPool
-    type: object
-    default:
-      name: $(windowsTestsVmPool)
-      vmImage: $(windowsTestsVmImage)
+- name: windowsPool
+  type: object
+  default:
+    name: $(windowsTestsVmPool)
+    vmImage: $(windowsTestsVmImage)
 
-  - name: targetFrameworkVersions
-    type: object
-    default:
-      - tfm: net10.0
-
-resources:
-  repositories:
-    - repository: yaml-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
-      ref: refs/heads/main
+- name: targetFrameworkVersions
+  type: object
+  default:
+  - tfm: net10.0
 
 stages:
 - ${{ each targetFrameworkVersion in parameters.targetFrameworkVersions }}:
@@ -116,72 +103,71 @@ stages:
       targetFrameworkVersion: ${{ targetFrameworkVersion }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
-        iosVersions: [ 'latest']
+        iosVersions: [ 'latest' ]
         catalystVersions: [ 'latest' ]
-        windowsVersions: ['packaged', 'unpackaged']
+        windowsVersions: [ 'packaged', 'unpackaged' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
         skipProvisioning: ${{ or(not(parameters.UseProvisionator), false) }}
       ${{ else }}:
         androidApiLevels: [ 33, 23 ]
         iosVersions: [ 'latest' ]
         catalystVersions: [ 'latest' ]
-        windowsVersions: ['packaged', 'unpackaged']
+        windowsVersions: [ 'packaged', 'unpackaged' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
         skipProvisioning: ${{ not(parameters.UseProvisionator) }}
       projects:
-        - name: essentials
-          desc: Essentials
-          androidApiLevelsExclude: [25, 27] # Ignore for now API25 since the runs's are not stable
-          androidConfiguration: 'Release'
-          iOSConfiguration: 'Debug'
-          windowsConfiguration: 'Debug'
-          windowsPackageId: 'com.microsoft.maui.essentials.devicetests'
-          android: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
-          ios: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
-          catalyst: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
-          windows: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
-        - name: graphics
-          desc: Graphics
-          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
-          androidConfiguration: 'Release'
-          iOSConfiguration: 'Debug'
-          windowsConfiguration: 'Debug'
-          windowsPackageId: 'com.microsoft.maui.graphics.devicetests'
-          android: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
-          ios: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
-          catalyst: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
-          windows: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
-        - name: core
-          desc: Core
-          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
-          androidConfiguration: 'Release'
-          iOSConfiguration: 'Debug'
-          windowsConfiguration: 'Debug'
-          windowsPackageId: 'com.microsoft.maui.core.devicetests'
-          android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
-          ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
-          catalyst: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
-          windows: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
-        - name: controls
-          desc: Controls
-          androidApiLevelsExclude: [27, 25] # Ignore for now API25 since the runs's are not stable
-          androidConfiguration: 'Debug'
-          iOSConfiguration: 'Debug'
-          windowsConfiguration: 'Debug'
-          windowsPackageId: 'com.microsoft.maui.controls.devicetests'
-          android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-          ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-          catalyst: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-          windows: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-        - name: blazorwebview
-          desc: BlazorWebView
-          androidApiLevelsExclude: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
-          androidConfiguration: 'Release'
-          iOSConfiguration: 'Debug'
-          windowsConfiguration: 'Debug'
-          windowsPackageId: 'Microsoft.Maui.MauiBlazorWebView.DeviceTests'
-          android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-          ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-          catalyst: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-          windows: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-
+      - name: essentials
+        desc: Essentials
+        androidApiLevelsExclude: [ 25, 27 ] # Ignore for now API25 since the runs's are not stable
+        androidConfiguration: 'Release'
+        iOSConfiguration: 'Debug'
+        windowsConfiguration: 'Debug'
+        windowsPackageId: 'com.microsoft.maui.essentials.devicetests'
+        android: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+        ios: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+        catalyst: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+        windows: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+      - name: graphics
+        desc: Graphics
+        androidApiLevelsExclude: [ 25 ] # Ignore for now API25 since the runs's are not stable
+        androidConfiguration: 'Release'
+        iOSConfiguration: 'Debug'
+        windowsConfiguration: 'Debug'
+        windowsPackageId: 'com.microsoft.maui.graphics.devicetests'
+        android: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
+        ios: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
+        catalyst: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
+        windows: $(System.DefaultWorkingDirectory)/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
+      - name: core
+        desc: Core
+        androidApiLevelsExclude: [ 25 ] # Ignore for now API25 since the runs's are not stable
+        androidConfiguration: 'Release'
+        iOSConfiguration: 'Debug'
+        windowsConfiguration: 'Debug'
+        windowsPackageId: 'com.microsoft.maui.core.devicetests'
+        android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+        ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+        catalyst: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+        windows: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+      - name: controls
+        desc: Controls
+        androidApiLevelsExclude: [ 27, 25 ] # Ignore for now API25 since the runs's are not stable
+        androidConfiguration: 'Debug'
+        iOSConfiguration: 'Debug'
+        windowsConfiguration: 'Debug'
+        windowsPackageId: 'com.microsoft.maui.controls.devicetests'
+        android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+        ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+        catalyst: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+        windows: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+      - name: blazorwebview
+        desc: BlazorWebView
+        androidApiLevelsExclude: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
+        androidConfiguration: 'Release'
+        iOSConfiguration: 'Debug'
+        windowsConfiguration: 'Debug'
+        windowsPackageId: 'Microsoft.Maui.MauiBlazorWebView.DeviceTests'
+        android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+        ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+        catalyst: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+        windows: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -129,7 +129,7 @@ stages:
         windows: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
       - name: graphics
         desc: Graphics
-        androidApiLevelsExclude: [ 25, 28 ] # Ignore for now API25 and API28 since the runs's are not stable
+        androidApiLevelsExclude: [ 25, 28 ] # Ignore for now API25 and API28 since the runs are not stable
         androidConfiguration: 'Release'
         iOSConfiguration: 'Debug'
         windowsConfiguration: 'Debug'

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -52,11 +52,6 @@ parameters:
     type: boolean
     default: false
 
-  - name: provisionatorChannel
-    displayName: 'Provisionator channel'
-    type: string
-    default: 'latest'
-
   - name: BuildEverything
     type: boolean
     default: false
@@ -114,32 +109,6 @@ parameters:
       name: Azure Pipelines
       vmImage: macOS-14
 
-  - name: androidCompatibilityPool
-    type: object
-    default:
-      name: $(androidTestsVmPool)
-      vmImage: $(androidTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
-        - macOS.Architecture -equals x64
-
-  - name: iosCompatibilityPool
-    type: object
-    default:
-      name: $(androidTestsVmPool)
-      vmImage: $(androidTestsVmImage)
-      demands:
-        - macOS.Name -equals Sequoia
-        - macOS.Architecture -equals x64
-
-resources:
-  repositories:
-    - repository: yaml-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
-      ref: refs/heads/main
-
 stages:
 
   - template: common/ui-tests.yml
@@ -150,18 +119,14 @@ stages:
       windowsPool: ${{ parameters.windowsPool }}
       windowsBuildPool: ${{ parameters.windowsBuildPool }}
       macosPool: ${{ parameters.macosPool }}
-      androidCompatibilityPool: ${{ parameters.androidCompatibilityPool }}
-      iosCompatibilityPool: ${{ parameters.iosCompatibilityPool }}
       agentPoolAccessToken: $(AgentPoolAccessToken)
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ 'latest' ]
-        provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ 'latest' ]
-        provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if parameters.CompatibilityTests }}:
         runCompatibilityTests: true
       ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -56,6 +56,11 @@ parameters:
     type: boolean
     default: false
 
+  - name: BuildNativeAOT
+    displayName: 'Build NativeAOT artifacts'
+    type: boolean
+    default: false
+
   - name: RunNativeAOT
     displayName: 'Run NativeAOT UI Tests'
     type: boolean
@@ -115,6 +120,8 @@ stages:
       windowsPool: ${{ parameters.windowsPool }}
       windowsBuildPool: ${{ parameters.windowsBuildPool }}
       macosPool: ${{ parameters.macosPool }}
+      # BuildNativeAOT is false by default, but true in devdiv environment
+      BuildNativeAOT: ${{ or(parameters.BuildNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -56,10 +56,6 @@ parameters:
     type: boolean
     default: false
 
-  - name: CompatibilityTests
-    type: boolean
-    default: false
-
   - name: RunNativeAOT
     displayName: 'Run NativeAOT UI Tests'
     type: boolean
@@ -119,7 +115,6 @@ stages:
       windowsPool: ${{ parameters.windowsPool }}
       windowsBuildPool: ${{ parameters.windowsBuildPool }}
       macosPool: ${{ parameters.macosPool }}
-      agentPoolAccessToken: $(AgentPoolAccessToken)
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]
@@ -127,8 +122,6 @@ stages:
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ 'latest' ]
-      ${{ if parameters.CompatibilityTests }}:
-        runCompatibilityTests: true
       ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
         skipProvisioning: false
       ${{ else }}:  

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -65,6 +65,11 @@ parameters:
     type: boolean
     default: false
 
+  - name: RunNativeAOT
+    displayName: 'Run NativeAOT UI Tests'
+    type: boolean
+    default: false
+
   - name: androidPool
     type: object
     default:
@@ -148,6 +153,7 @@ stages:
       androidCompatibilityPool: ${{ parameters.androidCompatibilityPool }}
       iosCompatibilityPool: ${{ parameters.iosCompatibilityPool }}
       agentPoolAccessToken: $(AgentPoolAccessToken)
+      RunNativeAOT: ${{ parameters.RunNativeAOT }}
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ 'latest' ]


### PR DESCRIPTION
### Description of Change

This pull request primarily removes the unused `agentPoolAccessToken` parameter from multiple pipeline YAML templates and stages, simplifying the configuration for device and UI test jobs. Additionally, it introduces new parameters for NativeAOT UI test builds and cleans up some unused resource and pool definitions. There are also minor updates to test exclusion lists.

Key changes include:

### Pipeline configuration simplification

* Removed the `agentPoolAccessToken` parameter from all relevant YAML templates and job/stage definitions, as it is no longer used in the test pipelines (`eng/pipelines/common/device-tests-jobs.yml`, `eng/pipelines/common/device-tests-steps.yml`, `eng/pipelines/common/device-tests.yml`, `eng/pipelines/common/ui-tests-build-sample.yml`, `eng/pipelines/common/ui-tests-steps.yml`, `eng/pipelines/common/ui-tests.yml`, `eng/pipelines/device-tests.yml`, `eng/pipelines/ui-tests.yml`). [[1]](diffhunk://#diff-b725a04a316c277f38da1d69d0e5e5a548dff501330577adc3f40a273af01ffdL7) [[2]](diffhunk://#diff-b725a04a316c277f38da1d69d0e5e5a548dff501330577adc3f40a273af01ffdL44) [[3]](diffhunk://#diff-b725a04a316c277f38da1d69d0e5e5a548dff501330577adc3f40a273af01ffdL98) [[4]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL9) [[5]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5L12) [[6]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5L65) [[7]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5L89) [[8]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5L113) [[9]](diffhunk://#diff-7338096e4bae3a6a64beb70cc5bd2ff68bd18b5e36c49f61a58e52bdc19813c5L139) [[10]](diffhunk://#diff-5d0763fa79fb5e8f8d535acf38d8796d9450d36e0e320f41f99c38f686641840L9) [[11]](diffhunk://#diff-7f18f6022c6d1ed045dfb10263501a775e790161f1ac317c376306110e54461eL9) [[12]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL13-R14) [[13]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL145) [[14]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL225) [[15]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL262) [[16]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL300-R305) [[17]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL344) [[18]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL377) [[19]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL410) [[20]](diffhunk://#diff-d2d1c388a0fb3196dbfcdab96421bc88336637a3d44480c96717f92d000facaeL55-L59) [[21]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L55-R65) [[22]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L148-L160)
* Removed unused resource and pool definitions related to compatibility pools and external YAML templates (`eng/pipelines/device-tests.yml`, `eng/pipelines/ui-tests.yml`). [[1]](diffhunk://#diff-d2d1c388a0fb3196dbfcdab96421bc88336637a3d44480c96717f92d000facaeL99-L106) [[2]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L112-L137)

### NativeAOT UI Tests support

* Added new `BuildNativeAOT` and `RunNativeAOT` parameters to control whether NativeAOT artifacts should be built and tested in the UI test pipelines (`eng/pipelines/common/ui-tests.yml`, `eng/pipelines/ui-tests.yml`). [[1]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL13-R14) [[2]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L55-R65) [[3]](diffhunk://#diff-01226bae9fe7277cc2f291d47499e45e220b58b560fc0735c13fa6d13e21acd4L148-L160)
* Updated pipeline stage conditions and logic to enable NativeAOT build and test stages only when these parameters are set (`eng/pipelines/common/ui-tests.yml`). [[1]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL78-R80) [[2]](diffhunk://#diff-8f76930e2126f6e5f60cae836de1df54dd41263baac4d4baf04789be312b257aL300-R305)

### Test exclusion updates

* Updated `androidApiLevelsExclude` for the graphics test group to also exclude API level 28, improving test reliability (`eng/pipelines/device-tests.yml`).

These changes streamline the pipeline configuration, reduce maintenance overhead, and add flexibility for running NativeAOT UI tests.
