### PR TITLE
[net10.0] Update rc1 packages on net10.0 branch

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "10.0.0-prerelease.25375.1",
+      "version": "10.0.0-prerelease.25412.1",
       "commands": [
         "xharness"
       ],

--- a/NuGet.config
+++ b/NuGet.config
@@ -29,8 +29,8 @@
     <add key="darc-pub-dotnet-maui-a33a875e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-a33a875e/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 8.0.18 -->
     <add key="darc-pub-dotnet-runtime-c0390586" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-c0390586/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 9.0.8 -->
-    <add key="darc-pub-dotnet-runtime-b4fb3656" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-89d42fdf/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 9.0.9 -->
+    <add key="darc-pub-dotnet-runtime-3b1cfdc3" value="- https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-3b1cfdc3/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 Android -->
     <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
     <!-- Added manually for .NET 8 Android -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -30,7 +30,7 @@
     <!-- Added manually for dotnet/runtime 8.0.18 -->
     <add key="darc-pub-dotnet-runtime-c0390586" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-c0390586/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 9.0.9 -->
-    <add key="darc-pub-dotnet-runtime-3b1cfdc3" value="- https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-3b1cfdc3/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-3b1cfdc3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-3b1cfdc3/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 Android -->
     <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
     <!-- Added manually for .NET 8 Android -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,9 +6,12 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-a618557" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-a618557d/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-a618557-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-a618557d-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-af20d0b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-af20d0b6/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-60f5c7b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-60f5c7b1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-60f5c7b-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-60f5c7b1-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="local" value="LOCAL_PLACEHOLDER" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -27,8 +27,8 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" protocolVersion="3" />
     <!-- Added manually for .NET 8 MAUI -->
     <add key="darc-pub-dotnet-maui-a33a875e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-a33a875e/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 8.0.18 -->
-    <add key="darc-pub-dotnet-runtime-c0390586" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-c0390586/nuget/v3/index.json" />
+    <!-- Added manually for dotnet/runtime 8.0.20 -->
+    <add key="darc-pub-dotnet-runtime-4514d64d" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-4514d64d/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 9.0.9 -->
     <add key="darc-pub-dotnet-runtime-3b1cfdc3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-3b1cfdc3/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 Android -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,37 +1,37 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.1.25416.112">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.1.280">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.1.284">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>4ce12a75894f0da815756b15a96d77d11c78109d</Sha>
+      <Sha>f2346125138c29a94bffcf29e84d3c6f9a46b36b</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.92" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>be1cab92326783479054e72990da08008e5be819</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10722-net10-rc.1">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10727-net10-rc.1">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>10c08b4ed0b4ffee3005cef20ff6ad1969da38c6</Sha>
+      <Sha>fc770723ce68a02aa0b637455cb2eec502f50d2c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10722-net10-rc.1">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10727-net10-rc.1">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>10c08b4ed0b4ffee3005cef20ff6ad1969da38c6</Sha>
+      <Sha>fc770723ce68a02aa0b637455cb2eec502f50d2c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10722-net10-rc.1">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10727-net10-rc.1">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>10c08b4ed0b4ffee3005cef20ff6ad1969da38c6</Sha>
+      <Sha>fc770723ce68a02aa0b637455cb2eec502f50d2c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10722-net10-rc.1">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10727-net10-rc.1">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>10c08b4ed0b4ffee3005cef20ff6ad1969da38c6</Sha>
+      <Sha>fc770723ce68a02aa0b637455cb2eec502f50d2c</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.1.25416.112">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.1.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25375.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25416.112">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25421.120">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>8c49b059243665b9c1a4ce01c24bedb4f5641f15</Sha>
+      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.1.25421.120">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.1.284">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.1.25421.120">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.1.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25412.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25421.120">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25422.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
+      <Sha>7f7a0a3a9390835a3666f5ca0e9c687bf7eaea5d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,9 +13,9 @@
       <Sha>f2346125138c29a94bffcf29e84d3c6f9a46b36b</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
-    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.92" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.101" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>be1cab92326783479054e72990da08008e5be819</Sha>
+      <Sha>a618557d1fa38074e0256317fb17c1baee245a79</Sha>
     </Dependency>
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10727-net10-rc.1">
       <Uri>https://github.com/dotnet/macios</Uri>
@@ -35,21 +35,21 @@
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9216" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_18.5">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9219" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_18.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af20d0b615668b2e13d0ffe81ba7ec4f89a398c9</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.5" Version="15.5.9216" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_15.5">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.5" Version="15.5.9219" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_15.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af20d0b615668b2e13d0ffe81ba7ec4f89a398c9</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.5" Version="18.5.9216" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_18.5">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.5" Version="18.5.9219" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_18.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af20d0b615668b2e13d0ffe81ba7ec4f89a398c9</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.5" Version="18.5.9216" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_18.5">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.5" Version="18.5.9219" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_18.5">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>af20d0b615668b2e13d0ffe81ba7ec4f89a398c9</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
@@ -158,17 +158,17 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>d5539bb825f9d1376b6002463dd26f9e8c5a570f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25375.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25412.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>dfe773f0763677ba3044e9913813e9a581009924</Sha>
+      <Sha>fe850ca677efa9ed62009b929f55ff59d5e24c0e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="10.0.0-prerelease.25375.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="10.0.0-prerelease.25412.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>dfe773f0763677ba3044e9913813e9a581009924</Sha>
+      <Sha>fe850ca677efa9ed62009b929f55ff59d5e24c0e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25375.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25412.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>dfe773f0763677ba3044e9913813e9a581009924</Sha>
+      <Sha>fe850ca677efa9ed62009b929f55ff59d5e24c0e</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,7 +53,7 @@
     <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.1.284</MicrosoftAndroidSdkWindowsPackageVersion>
-    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.92</MicrosoftNETSdkAndroidManifest90100PackageVersion>
+    <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.101</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
     <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10727-net10-rc.1</MicrosoftMacCatalystSdknet100_185PackageVersion>
@@ -61,10 +61,10 @@
     <MicrosoftiOSSdknet100_185PackageVersion>18.5.10727-net10-rc.1</MicrosoftiOSSdknet100_185PackageVersion>
     <MicrosofttvOSSdknet100_185PackageVersion>18.5.10727-net10-rc.1</MicrosofttvOSSdknet100_185PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9216</MicrosoftMacCatalystSdknet90_185PackageVersion>
-    <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9216</MicrosoftmacOSSdknet90_155PackageVersion>
-    <MicrosoftiOSSdknet90_185PackageVersion>18.5.9216</MicrosoftiOSSdknet90_185PackageVersion>
-    <MicrosofttvOSSdknet90_185PackageVersion>18.5.9216</MicrosofttvOSSdknet90_185PackageVersion>
+    <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9219</MicrosoftMacCatalystSdknet90_185PackageVersion>
+    <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9219</MicrosoftmacOSSdknet90_155PackageVersion>
+    <MicrosoftiOSSdknet90_185PackageVersion>18.5.9219</MicrosoftiOSSdknet90_185PackageVersion>
+    <MicrosofttvOSSdknet90_185PackageVersion>18.5.9219</MicrosofttvOSSdknet90_185PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
@@ -126,9 +126,9 @@
     <_HarfBuzzSharpVersion>8.3.0.1</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.e57e2a11dac4ccc72bea52939dede49816842005.1728</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.120</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>10.0.0-prerelease.25375.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>10.0.0-prerelease.25375.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25375.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>10.0.0-prerelease.25412.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>10.0.0-prerelease.25412.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25412.1</MicrosoftDotNetXHarnessCLIVersion>
     <TizenUIExtensionsVersion>0.9.2</TizenUIExtensionsVersion>
     <SvgSkiaPackageVersion>2.0.0.4</SvgSkiaPackageVersion>
     <FizzlerPackageVersion>1.3.0</FizzlerPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,36 +30,36 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.82</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-rc.1.25416.112</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rc.1.25421.120</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.1.25416.112</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.1.25421.120</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.1.25416.112</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.1.280</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.1.284</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.92</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10722-net10-rc.1</MicrosoftMacCatalystSdknet100_185PackageVersion>
-    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10722-net10-rc.1</MicrosoftmacOSSdknet100_155PackageVersion>
-    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10722-net10-rc.1</MicrosoftiOSSdknet100_185PackageVersion>
-    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10722-net10-rc.1</MicrosofttvOSSdknet100_185PackageVersion>
+    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10727-net10-rc.1</MicrosoftMacCatalystSdknet100_185PackageVersion>
+    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10727-net10-rc.1</MicrosoftmacOSSdknet100_155PackageVersion>
+    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10727-net10-rc.1</MicrosoftiOSSdknet100_185PackageVersion>
+    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10727-net10-rc.1</MicrosofttvOSSdknet100_185PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9216</MicrosoftMacCatalystSdknet90_185PackageVersion>
     <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9216</MicrosoftmacOSSdknet90_155PackageVersion>
@@ -73,19 +73,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.1.25416.112</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-rc.1.25416.112</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-rc.1.25421.120</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -135,13 +135,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25416.112</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25416.112</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25416.112</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25416.112</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25421.120</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25416.112</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25416.112</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,27 +30,27 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.82</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-rc.1.25421.120</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rc.1.25422.107</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.1.25421.120</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.1.25422.107</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.1.25421.120</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.1.25422.107</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.1.284</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.101</MicrosoftNETSdkAndroidManifest90100PackageVersion>
@@ -73,19 +73,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.1.25421.120</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-rc.1.25421.120</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.1.25422.107</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-rc.1.25422.107</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -135,13 +135,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25421.120</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25422.107</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25422.107</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25422.107</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25422.107</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25421.120</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25422.107</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25422.107</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -10,8 +10,8 @@
 #    displayName: Setup Private Feeds Credentials
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
-#      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-#      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+#      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
+#      arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
 #    env:
 #      Token: $(dn-bot-dnceng-artifact-feeds-rw)
 #

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -11,8 +11,8 @@
 #  - task: Bash@3
 #    displayName: Setup Internal Feeds
 #    inputs:
-#      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-#      arguments: $(Build.SourcesDirectory)/NuGet.config
+#      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.sh
+#      arguments: $(System.DefaultWorkingDirectory)/NuGet.config
 #    condition: ne(variables['Agent.OS'], 'Windows_NT')
 #  - task: NuGetAuthenticate@1
 #

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -163,7 +163,7 @@ jobs:
       inputs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -174,7 +174,7 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)'
         testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-trx
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
@@ -218,7 +218,7 @@ jobs:
     - task: CopyFiles@2
       displayName: Gather buildconfiguration for build retry
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/eng/common/BuildConfiguration'
+        SourceFolder: '$(System.DefaultWorkingDirectory)/eng/common/BuildConfiguration'
         Contents: '**'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/eng/common/BuildConfiguration'
       continueOnError: true

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -8,7 +8,7 @@ parameters:
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
-  SourcesDirectory: $(Build.SourcesDirectory)
+  SourcesDirectory: $(System.DefaultWorkingDirectory)
   CreatePr: true
   AutoCompletePr: false
   ReusePr: true
@@ -68,7 +68,7 @@ jobs:
     - ${{ if ne(parameters.SkipLocProjectJsonGeneration, 'true') }}:
       - task: Powershell@2
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/generate-locproject.ps1
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/generate-locproject.ps1
           arguments: $(_GenerateLocProjectArguments)
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
@@ -103,7 +103,7 @@ jobs:
     - task: CopyFiles@2
       displayName: Copy LocProject.json
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/eng/Localize/'
+        SourceFolder: '$(System.DefaultWorkingDirectory)/eng/Localize/'
         Contents: 'LocProject.json'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/loc'
       condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -38,6 +38,8 @@ parameters:
   # Optional: A minimatch pattern for the asset manifests to publish to BAR
   assetManifestsPattern: '*/manifests/**/*.xml'
 
+  repositoryAlias: self
+
 jobs:
 - job: Asset_Registry_Publish
 
@@ -78,7 +80,7 @@ jobs:
     - 'Illegal entry point, is1ESPipeline is not defined. Repository yaml should not directly reference templates in core-templates folder.': error
 
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - checkout: self
+    - checkout: ${{ parameters.repositoryAlias }}
       fetchDepth: 3
       clean: true
 
@@ -117,7 +119,7 @@ jobs:
         azureSubscription: "Darc: Maestro Production"
         scriptType: ps
         scriptLocation: scriptPath
-        scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
+        scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
         arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
           /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
@@ -137,7 +139,7 @@ jobs:
           Add-Content -Path $filePath -Value "$(DefaultChannels)"
           Add-Content -Path $filePath -Value $(IsStableBuild)
 
-          $symbolExclusionfile = "$(Build.SourcesDirectory)/eng/SymbolPublishingExclusionsFile.txt"
+          $symbolExclusionfile = "$(System.DefaultWorkingDirectory)/eng/SymbolPublishingExclusionsFile.txt"
           if (Test-Path -Path $symbolExclusionfile)
           {
             Write-Host "SymbolExclusionFile exists"
@@ -177,7 +179,7 @@ jobs:
           azureSubscription: "Darc: Maestro Production"
           scriptType: ps
           scriptLocation: scriptPath
-          scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+          scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
           arguments: >
             -BuildId $(BARBuildId)
             -PublishingInfraVersion 3

--- a/eng/common/core-templates/jobs/codeql-build.yml
+++ b/eng/common/core-templates/jobs/codeql-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: DefaultGuardianVersion
         value: 0.109.0
       - name: GuardianPackagesConfigFile
-        value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+        value: $(System.DefaultWorkingDirectory)\eng\common\sdl\packages.config
       - name: GuardianVersion
         value: ${{ coalesce(parameters.overrideGuardianVersion, '$(DefaultGuardianVersion)') }}
   

--- a/eng/common/core-templates/jobs/jobs.yml
+++ b/eng/common/core-templates/jobs/jobs.yml
@@ -43,6 +43,7 @@ parameters:
 
   artifacts: {}
   is1ESPipeline: ''
+  repositoryAlias: self
 
 # Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
 # and some (Microbuild) should only be applied to non-PR cases for internal builds.
@@ -114,3 +115,4 @@ jobs:
         enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
         artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
         signingValidationAdditionalParameters: ${{ parameters.signingValidationAdditionalParameters }}
+        repositoryAlias: ${{ parameters.repositoryAlias }}

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -154,7 +154,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
             arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:
@@ -208,7 +208,7 @@ stages:
             filePath: eng\common\sdk-task.ps1
             arguments: -task SigningValidation -restore -msbuildEngine vs
               /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
+              /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
               ${{ parameters.signingValidationAdditionalParameters }}
 
         - template: /eng/common/core-templates/steps/publish-logs.yml
@@ -258,7 +258,7 @@ stages:
         - task: PowerShell@2
           displayName: Validate
           inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
             arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
               -ExtractPath $(Agent.BuildDirectory)/Extract/ 
               -GHRepoName $(Build.Repository.Name) 
@@ -313,7 +313,7 @@ stages:
             azureSubscription: "Darc: Maestro Production"
             scriptType: ps
             scriptLocation: scriptPath
-            scriptPath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+            scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
             arguments: >
               -BuildId $(BARBuildId)
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}

--- a/eng/common/core-templates/post-build/setup-maestro-vars.yml
+++ b/eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -36,7 +36,7 @@ steps:
             $AzureDevOpsBuildId = $Env:Build_BuildId
           }
           else {
-            . $(Build.SourcesDirectory)\eng\common\tools.ps1
+            . $(System.DefaultWorkingDirectory)\eng\common\tools.ps1
             $darc = Get-Darc
             $buildInfo = & $darc get-build `
               --id ${{ parameters.BARBuildId }} `

--- a/eng/common/core-templates/steps/enable-internal-sources.yml
+++ b/eng/common/core-templates/steps/enable-internal-sources.yml
@@ -17,8 +17,8 @@ steps:
     - task: PowerShell@2
       displayName: Setup Internal Feeds
       inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+        filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
       env:
         Token: ${{ parameters.legacyCredential }}
   # If running on dnceng (internal project), just use the default behavior for NuGetAuthenticate.
@@ -29,8 +29,8 @@ steps:
       - task: PowerShell@2
         displayName: Setup Internal Feeds
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config
     - ${{ else }}:
       - template: /eng/common/templates/steps/get-federated-access-token.yml
         parameters:
@@ -39,8 +39,8 @@ steps:
       - task: PowerShell@2
         displayName: Setup Internal Feeds
         inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $(dnceng-artifacts-feeds-read-access-token)
   # This is required in certain scenarios to install the ADO credential provider.
   # It installed by default in some msbuild invocations (e.g. VS msbuild), but needs to be installed for others
   # (e.g. dotnet msbuild).

--- a/eng/common/core-templates/steps/generate-sbom.yml
+++ b/eng/common/core-templates/steps/generate-sbom.yml
@@ -6,7 +6,7 @@
 
 parameters:
   PackageVersion: 10.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
   IgnoreDirectories: ''

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -12,6 +12,7 @@ parameters:
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
   # Location of the MicroBuild output folder
+  # NOTE: There's something that relies on this being in the "default" source directory for tasks such as Signing to work properly.
   microBuildOutputFolder: '$(Build.SourcesDirectory)'
 
   continueOnError: false
@@ -46,17 +47,19 @@ steps:
       displayName: 'Validate ESRP usage (Non-Windows)'
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
+    # Two different MB install steps. This is due to not being able to use the agent OS during
+    # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
+    # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
+    # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
     - task: MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild plugin
+      displayName: Install MicroBuild plugin (Windows)
       inputs:
         signType: $(_SignType)
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
         ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-            azureSubscription: 'MicroBuild Signing Task (DevDiv)'
-            useEsrpCli: true
-          ${{ elseif eq(variables['System.TeamProject'], 'DevDiv') }}:
+          ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
             ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
           ${{ else }}:
             ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
@@ -65,16 +68,24 @@ steps:
         MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       continueOnError: ${{ parameters.continueOnError }}
-      condition: and(
-        succeeded(),
-        or(
-          and(
-            eq(variables['Agent.Os'], 'Windows_NT'),
-            in(variables['_SignType'], 'real', 'test')
-          ),
-          and(
-            ${{ eq(parameters.enableMicrobuildForMacAndLinux, true) }},
-            ne(variables['Agent.Os'], 'Windows_NT'),
-            eq(variables['_SignType'], 'real')
-          )
-        ))
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
+
+    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
+      - task: MicroBuildSigningPlugin@4
+        displayName: Install MicroBuild plugin (non-Windows)
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          ${{ if eq(parameters.microbuildUseESRP, true) }}:
+            ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+            ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+              ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+            ${{ else }}:
+              ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+        env:
+          TeamName: $(_TeamName)
+          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        continueOnError: ${{ parameters.continueOnError }}
+        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -12,22 +12,22 @@ steps:
   inputs:
     targetType: inline
     script: |
-      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
-      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      New-Item -ItemType Directory $(System.DefaultWorkingDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      Move-Item -Path $(System.DefaultWorkingDirectory)/artifacts/log/Debug/* $(System.DefaultWorkingDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
   condition: always()
     
 - task: PowerShell@2
   displayName: Redact Logs
   inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/post-build/redact-logs.ps1
+    filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/redact-logs.ps1
     # For now this needs to have explicit list of all sensitive data. Taken from eng/publishing/v3/publish.yml
-    # Sensitive data can as well be added to $(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
+    # Sensitive data can as well be added to $(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
-    arguments: -InputPath '$(Build.SourcesDirectory)/PostBuildLogs' 
+    arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
       -BinlogToolVersion ${{parameters.BinlogToolVersion}}
-      -TokensFilePath '$(Build.SourcesDirectory)/eng/BinlogSecretsRedactionFile.txt'
+      -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'
@@ -44,7 +44,7 @@ steps:
 - task: CopyFiles@2
   displayName: Gather post build logs
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/PostBuildLogs'
+    SourceFolder: '$(System.DefaultWorkingDirectory)/PostBuildLogs'
     Contents: '**'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/PostBuildLogs'
   condition: always()

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -1,6 +1,6 @@
 parameters:
-  sourceIndexUploadPackageVersion: 2.0.0-20250425.2
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250515.1
+  sourceIndexUploadPackageVersion: 2.0.0-20250818.1
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250818.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   binlogPath: artifacts/log/Debug/Build.binlog
 
@@ -20,7 +20,7 @@ steps:
   # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
   workingDirectory: $(Agent.TempDirectory)
 
-- script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
+- script: $(Agent.TempDirectory)/.source-index/tools/BinLogToSln -i ${{parameters.BinlogPath}} -r $(System.DefaultWorkingDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
   displayName: "Source Index: Process Binlog into indexable sln"
 
 - ${{ if and(ne(parameters.runAsPublic, 'true'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -7,13 +7,14 @@ Param(
   [switch] $restore,
   [switch] $prepareMachine,
   [switch][Alias('nobl')]$excludeCIBinaryLog,
+  [switch]$noWarnAsError,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
 $ci = $true
 $binaryLog = if ($excludeCIBinaryLog) { $false } else { $true }
-$warnAsError = $true
+$warnAsError = if ($noWarnAsError) { $false } else { $true }
 
 . $PSScriptRoot\tools.ps1
 

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -10,6 +10,7 @@ show_usage() {
 
     echo "Advanced settings:"
     echo "  --excludeCIBinarylog     Don't output binary log (short: -nobl)"
+    echo "  --noWarnAsError          Do not warn as error
     echo ""
     echo "Command line arguments not listed above are passed thru to msbuild."
 }
@@ -52,6 +53,7 @@ exclude_ci_binary_log=false
 restore=false
 help=false
 properties=''
+warnAsError=true
 
 while (($# > 0)); do
   lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
@@ -73,6 +75,10 @@ while (($# > 0)); do
       exclude_ci_binary_log=true
       shift 1
       ;;
+    --noWarnAsError)
+      warnAsError=false
+      shift 1
+      ;;
     --help)
       help=true
       shift 1
@@ -85,7 +91,6 @@ while (($# > 0)); do
 done
 
 ci=true
-warnAsError=true
 
 if $help; then
   show_usage

--- a/eng/common/template-guidance.md
+++ b/eng/common/template-guidance.md
@@ -50,7 +50,7 @@ extends:
           - task: CopyFiles@2
               displayName: Gather build output
               inputs:
-                SourceFolder: '$(Build.SourcesDirectory)/artifacts/marvel'
+                SourceFolder: '$(System.DefaultWorkingDirectory)/artifacts/marvel'
                 Contents: '**'
                 TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/marvel'
 ```

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -3,7 +3,7 @@ parameters:
   enableSbom: true
   runAsPublic: false
   PackageVersion: 9.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
 
 jobs:
 - template: /eng/common/core-templates/job/job.yml

--- a/eng/common/templates-official/variables/sdl-variables.yml
+++ b/eng/common/templates-official/variables/sdl-variables.yml
@@ -4,4 +4,4 @@ variables:
 - name: DefaultGuardianVersion
   value: 0.109.0
 - name: GuardianPackagesConfigFile
-  value: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+  value: $(System.DefaultWorkingDirectory)\eng\common\sdl\packages.config

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -6,7 +6,7 @@ parameters:
   enableSbom: true
   runAsPublic: false
   PackageVersion: 9.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+  BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
 
 jobs:
 - template: /eng/common/core-templates/job/job.yml
@@ -77,7 +77,7 @@ jobs:
         parameters:
           is1ESPipeline: false
           args:
-            targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
+            targetPath: '$(System.DefaultWorkingDirectory)\eng\common\BuildConfiguration'
             artifactName: 'BuildConfiguration'
             displayName: 'Publish build retry configuration'
             continueOnError: true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -544,7 +544,8 @@ function LocateVisualStudio([object]$vsRequirements = $null){
   if (Get-Member -InputObject $GlobalJson.tools -Name 'vswhere') {
     $vswhereVersion = $GlobalJson.tools.vswhere
   } else {
-    $vswhereVersion = '2.5.2'
+    # keep this in sync with the VSWhereVersion in DefaultVersions.props
+    $vswhereVersion = '3.1.7'
   }
 
   $vsWhereDir = Join-Path $ToolsDir "vswhere\$vswhereVersion"
@@ -552,7 +553,8 @@ function LocateVisualStudio([object]$vsRequirements = $null){
 
   if (!(Test-Path $vsWhereExe)) {
     Create-Directory $vsWhereDir
-    Write-Host 'Downloading vswhere'
+    Write-Host "Downloading vswhere $vswhereVersion"
+    $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
     Retry({
       Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
     })

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rc.1.25416.112"
+    "dotnet": "10.0.100-rc.1.25421.120"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25416.112",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25416.112"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25421.120",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25421.120"
   },
   "sdk": {
     "allowPrerelease": true

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rc.1.25421.120"
+    "dotnet": "10.0.100-rc.1.25422.107"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25421.120",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25421.120"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25422.107",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25422.107"
   },
   "sdk": {
     "allowPrerelease": true

--- a/src/Essentials/samples/Sample.Server.WebAuthenticator/Essentials.Sample.Server.WebAuthenticator.csproj
+++ b/src/Essentials/samples/Sample.Server.WebAuthenticator/Essentials.Sample.Server.WebAuthenticator.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change

This pull request updates several dependencies and package sources to newer versions, primarily to keep the project aligned with the latest releases from the .NET, Android, and Mac/iOS/tvOS ecosystems. The changes ensure compatibility with recent builds and improve overall stability.

Dependency updates:

* Updated multiple dependencies in `eng/Version.Details.xml` to newer versions, including `Microsoft.NET.Sdk`, `Microsoft.NETCore.App.Ref`, `Microsoft.Android.Sdk.Windows`, and various `Microsoft.AspNetCore` and `Microsoft.Extensions` packages, as well as toolset dependencies like `Microsoft.DotNet.Build.Tasks.Feed` and `Microsoft.DotNet.Arcade.Sdk`. This also includes updates for Android, MacCatalyst, macOS, iOS, and tvOS SDKs and manifests.
* Updated `Microsoft.DotNet.XHarness` dependencies and tool versions in both `eng/Version.Details.xml` and `.config/dotnet-tools.json` to the latest prerelease versions. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R205) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L27-R27)

Package source configuration:

* Added new NuGet package sources for updated Android and Mac/iOS dependencies in `NuGet.config`, and removed/updated older sources to match the new dependencies.