### PR TITLE
[ci] Add branch classification file

### DIFF
--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -1,0 +1,14 @@
+description: Branch classification configuration for repository
+resource: repository
+configuration:
+  branchClassificationSettings:
+    defaultClassification: nonproduction
+    ruleset:
+      - name: prod-branches
+        branchNames:
+          - main
+          - release/*
+          - net10.0
+          - net9.0
+          - inflight/current
+        classification: production


### PR DESCRIPTION
### Description of Change

This pull request introduces a branch classification configuration to the repository. The new configuration file defines which branches are considered production versus non-production, helping to enforce policies and improve clarity around branch usage.

Branch classification configuration:

* Added `.azuredevops/policies/branchClassification.yml` to specify branch classification settings, marking `main`, `release/*`, `net10.0`, `net9.0`, and `inflight/current` as production branches, with all others defaulting to nonproduction.
