### PR TITLE
[iOS] ToolbarItems can no longer be manipulated after an incomplete "Back" gesture on iOS - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1339,6 +1339,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				_tracker.Target = Child;
 				_tracker.AdditionalTargets = Child.GetParentPages();
+				_tracker.CollectionChanged += TrackerOnCollectionChanged;
 
 				UpdateToolbarItems();
 			}
@@ -1360,20 +1361,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			public override void WillMoveToParentViewController(UIViewController parent)
 			{
 				base.WillMoveToParentViewController(parent);
-
-				if (_tracker is null)
-				{
-					return;
-				}
-
-				if (parent is null)
-				{
-					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
-				}
-				else
-				{
-					_tracker.CollectionChanged += TrackerOnCollectionChanged;
-				}
 			}
 
 			internal void Disconnect(bool dispose)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Moved the CollectionChanged event handler attachment for _tracker to the initialization logic, removing redundant event handler management from WillMoveToParentViewController. This simplifies event handling and ensures the handler is consistently attached.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/31278