### PR TITLE
[iOS] Fixed the Items not displayed properly in CarouselView2

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -38,6 +38,22 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			UICollectionViewCell cell;
 
+			// In iOS 15 and 16, when the ItemsSource of the CarouselView is updated from another page
+			// via the ViewModel (or similar), GetCell is called immediately—while _carouselViewLoopManager
+			// is still null. As a result, an invalid index get from the GetAdjustedIndexPathForItemSource method in the base.GetCell , So unexpected items shown.
+			// 
+			// However, in iOS 17 and 18, GetCell is only called after navigating back to the page containing
+			// the CarouselView. By that time, CarouselViewLoopManager has been properly initialized during
+			// the window attachment, so the proper valid index get from GetAdjustedIndexPathForItemSource method in the base.GetCell
+
+			// Initialize the loop manager if needed to ensure proper index calculations
+			// This is critical for scenarios where GetCell is called before normal initialization
+			// such as when navigating back to a page after updating the ItemsSource
+			if (ItemsView?.Loop == true && _carouselViewLoopManager is null)
+			{
+				InitializeCarouselViewLoopManager();
+			}
+
 			cell = base.GetCell(collectionView, indexPath);
 
 			var element = (cell as TemplatedCell2)?.PlatformHandler?.VirtualView as VisualElement;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -177,11 +177,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				return;
 			}
-			//Get current visible item index paths to ensure proper refresh of carousel items
+			// Get current visible item index paths to ensure proper refresh of carousel items
+			// Create a defensive copy to avoid issues if ItemsSource changes during execution
 			var indexPaths = CollectionView.IndexPathsForVisibleItems;
 			if (indexPaths?.Length > 0)
 			{
-				CollectionView.ReloadItems(indexPaths);
+				// Create a copy of the array to prevent concurrent modification issues
+				var indexPathsCopy = new NSIndexPath[indexPaths.Length];
+				Array.Copy(indexPaths, indexPathsCopy, indexPaths.Length);
+
+				CollectionView.ReloadItems(indexPathsCopy);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -159,13 +159,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		private protected override async void AttachingToWindow()
 		{
 			base.AttachingToWindow();
-			Setup(ItemsView);
 			// Refresh the current visible item to catch any ItemsSource changes that occurred on other pages
 			// This ensures that updates made on other pages are reflected when navigating back
 			if (_wasDetachedFromWindow)
 			{
 				RefreshVisibleItems();
 			}
+			Setup(ItemsView);
 			_wasDetachedFromWindow = false;
 			// if we navigate back on NavigationController LayoutSubviews might not fire.
 			await UpdateInitialPosition();

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		void RefreshVisibleItems()
 		{
-			if (ItemsView is not CarouselView || CollectionView is null || ItemsSource?.ItemCount == 0)
+			if (CollectionView is null || ItemsSource?.ItemCount == 0)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -159,15 +159,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		private protected override async void AttachingToWindow()
 		{
 			base.AttachingToWindow();
-			// Refresh the current visible item to catch any ItemsSource changes that occurred on other pages
+			Setup(ItemsView);
+			// Refresh the current visible items after setup to catch any ItemsSource changes that occurred on other pages
 			// This ensures that updates made on other pages are reflected when navigating back
-			// IMPORTANT: Must be called BEFORE Setup() to avoid querying stale IndexPathsForVisibleItems
-			// during the layout transition that Setup() triggers
 			if (_wasDetachedFromWindow)
 			{
 				RefreshVisibleItems();
 			}
-			Setup(ItemsView);
 			_wasDetachedFromWindow = false;
 			// if we navigate back on NavigationController LayoutSubviews might not fire.
 			await UpdateInitialPosition();
@@ -179,6 +177,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				return;
 			}
+
 			// Get current visible item index paths to ensure proper refresh of carousel items
 			var indexPaths = CollectionView.IndexPathsForVisibleItems;
 			if (indexPaths?.Length > 0)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -161,6 +161,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			base.AttachingToWindow();
 			// Refresh the current visible item to catch any ItemsSource changes that occurred on other pages
 			// This ensures that updates made on other pages are reflected when navigating back
+			// IMPORTANT: Must be called BEFORE Setup() to avoid querying stale IndexPathsForVisibleItems
+			// during the layout transition that Setup() triggers
 			if (_wasDetachedFromWindow)
 			{
 				RefreshVisibleItems();
@@ -178,15 +180,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				return;
 			}
 			// Get current visible item index paths to ensure proper refresh of carousel items
-			// Create a defensive copy to avoid issues if ItemsSource changes during execution
 			var indexPaths = CollectionView.IndexPathsForVisibleItems;
 			if (indexPaths?.Length > 0)
 			{
-				// Create a copy of the array to prevent concurrent modification issues
-				var indexPathsCopy = new NSIndexPath[indexPaths.Length];
-				Array.Copy(indexPaths, indexPathsCopy, indexPaths.Length);
-
-				CollectionView.ReloadItems(indexPathsCopy);
+				CollectionView.ReloadItems(indexPaths);
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31148.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31148.cs
@@ -108,7 +108,7 @@ public class Issue31148ViewModel : INotifyPropertyChanged
 
     public Issue31148ViewModel()
     {
-        _source = new ObservableCollection<string>(["Test1", "Test2", "Test3"]);
+        _source = new ObservableCollection<string> { "Test1", "Test2", "Test3" };
     }
 
     public event PropertyChangedEventHandler PropertyChanged;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31148.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31148.cs
@@ -1,0 +1,122 @@
+﻿namespace Controls.TestCases.HostApp.Issues;
+
+using Maui.Controls.Sample;
+using Maui.Controls.Sample.Issues;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+[Issue(IssueTracker.Github, 31148, "[iOS] Items are not updated properly in CarouselView2", PlatformAffected.iOS)]
+public class Issue31148 : TestNavigationPage
+{
+    protected override void Init()
+    {
+        PushAsync(new Issue31148FirstPage());
+    }
+}
+
+public class Issue31148FirstPage : ContentPage
+{
+    private readonly Issue31148ViewModel _model = new();
+    public Issue31148FirstPage()
+    {
+        BindingContext = _model;
+
+        var carouselView = new CarouselView2
+        {
+            ItemsSource = _model.Source,
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var label = new Label
+                {
+                    HorizontalOptions = LayoutOptions.Center,
+                    VerticalOptions = LayoutOptions.Center
+                };
+                label.SetBinding(Label.TextProperty, ".");
+                label.SetBinding(Label.AutomationIdProperty, ".");
+                return new Grid { Children = { label } };
+            })
+        };
+
+        var navigateButton = new Button
+        {
+            Text = "Navigate",
+            AutomationId = "NavigateToButton",
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center
+        };
+        navigateButton.Clicked += async (s, e) =>
+        {
+            await Navigation.PushAsync(new Issue31148SecondPage(_model));
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto)
+            }
+        };
+        grid.Add(carouselView);
+        grid.Add(navigateButton, 0, 1);
+        Content = grid;
+    }
+}
+
+public class Issue31148SecondPage : ContentPage
+{
+    private readonly Issue31148ViewModel _viewModel;
+
+    public Issue31148SecondPage(Issue31148ViewModel viewModel)
+    {
+        _viewModel = viewModel;
+
+        var replaceButton = new Button
+        {
+            Text = "Replace Item",
+            AutomationId = "ReplaceItemAndNavigateBackButton",
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        replaceButton.Clicked += async (s, e) =>
+        {
+            if (_viewModel?.Source != null && _viewModel.Source.Count > 0)
+            {
+                _viewModel.Source[0] = "Replaced Item";
+                await Task.Delay(1000);
+                await Navigation.PopAsync();
+            }
+        };
+        Content = replaceButton;
+    }
+}
+public class Issue31148ViewModel : INotifyPropertyChanged
+{
+    private ObservableCollection<string> _source;
+
+    public ObservableCollection<string> Source
+    {
+        get => _source;
+        set
+        {
+            _source = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public Issue31148ViewModel()
+    {
+        _source = new ObservableCollection<string>(["Test1", "Test2", "Test3"]);
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31148.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31148.cs
@@ -1,0 +1,25 @@
+﻿#if TEST_FAILS_ON_WINDOWS // https://github.com/dotnet/maui/issues/29245 - test fails on windows due to appium related issues in carouselview
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31148 : _IssuesUITest
+{
+	public Issue31148(TestDevice device) : base(device) { }
+
+	public override string Issue => "[iOS] Items are not updated properly in CarouselView2";
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void CarouselViewItemsShouldUpdateProperlyOnSourceUpdateWithPageNavigation()
+	{
+		App.WaitForElement("NavigateToButton");
+		App.Tap("NavigateToButton");
+		App.WaitForElement("ReplaceItemAndNavigateBackButton");
+		App.Tap("ReplaceItemAndNavigateBackButton");
+		App.WaitForElement("Replaced Item");
+	}
+}
+#endif


### PR DESCRIPTION
### Root Cause of the issue

- The `CollectionViewUpdated` method in CarouselViewController2 is not called when the ItemsSource is updated from another page, because CollectionViewUpdated is null at the time of invocation. When navigating away from the page, the event handler is unsubscribed, leaving it null. As a result, the replaced items were not reflected. 



### Description of Change



- When the ItemsSource is updated on another page and navigate back to the page containing the CarouselView, refresh the currently visible items in AttachingToWindow so they are properly updated.


### Issues Fixed



Fixes #31148 



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/956a5bad-2064-46c5-8ae7-1f6dde3c85d4"> | <video src="https://github.com/user-attachments/assets/eac1d3c5-69d6-45ad-81c7-a745d5b4c581"> |