### PR TITLE
[Android] - Appbar Extends Toolbar for NavigationPage

### DIFF
--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Maui.Handlers
 
 				var appBarLayout = rootView.FindViewById<AppBarLayout>(Resource.Id.navigationlayout_appbar);
 				var navigationLayout = rootView.FindViewById<FragmentContainerView>(Resource.Id.navigationlayout_content);
+				bool hasNavigationBar = appBarLayout?.Visibility == ViewStates.Visible && appBarLayout.LayoutParameters?.Height > 0;
 
 				var toolbar = appBarLayout?.GetChildAt(0) as MaterialToolbar;
 				var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
@@ -148,10 +149,10 @@ namespace Microsoft.Maui.Handlers
 				var contentPaddingLeft = Math.Max(systemBars?.Left ?? 0, displayCutout?.Left ?? 0);
 				var contentPaddingRight = Math.Max(systemBars?.Right ?? 0, displayCutout?.Right ?? 0);
 
-				if (appBarLayout is not null && toolbar is not null)
+				if (appBarLayout is not null)
 				{
 					// Store the original height on first call, then always calculate from that base
-					var currentHeight = toolbar.LayoutParameters?.Height ?? 0;
+					var currentHeight = toolbar?.LayoutParameters?.Height ?? 0;
 					if (!_originalHeight.HasValue)
 					{
 						_originalHeight = currentHeight;
@@ -161,7 +162,7 @@ namespace Microsoft.Maui.Handlers
 					var newHeight = _originalHeight.Value + appbarInsets.Top;
 
 					// Update the layout parameters to extend into status bar area
-					if (toolbar.LayoutParameters != null)
+					if (toolbar?.LayoutParameters != null)
 					{
 						toolbar.LayoutParameters.Height = newHeight;
 						toolbar.RequestLayout();
@@ -176,14 +177,21 @@ namespace Microsoft.Maui.Handlers
 						appBarLayout.LayoutParameters = appBarLayoutParams;
 					}
 
-
-
 					var contentPaddingTop = appbarInsets.Top;
 					// Apply padding to toolbar content to avoid both system bars and display cutouts
-					toolbar.SetPadding(contentPaddingLeft, contentPaddingTop, contentPaddingRight, 0);
+					toolbar?.SetPadding(contentPaddingLeft, contentPaddingTop, contentPaddingRight, 0);
 
 					// Clear AppBarLayout padding to allow toolbar to extend fully
 					appBarLayout.SetPadding(0, 0, 0, 0);
+				}
+				else if (appBarLayout is not null && !hasNavigationBar)
+				{
+					// Set AppBarLayout height to 0 when HasNavigationBar is false
+					if (appBarLayout.LayoutParameters != null)
+					{
+						appBarLayout.LayoutParameters.Height = 0;
+						appBarLayout.RequestLayout();
+					}
 				}
 
 				// REMOVE MARGINS FROM NAVIGATION LAYOUT - Let it extend edge-to-edge

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -139,9 +139,10 @@ namespace Microsoft.Maui.Handlers
 
 				var appBarLayout = rootView.FindViewById<AppBarLayout>(Resource.Id.navigationlayout_appbar);
 				var navigationLayout = rootView.FindViewById<FragmentContainerView>(Resource.Id.navigationlayout_content);
-				bool hasNavigationBar = appBarLayout?.Visibility == ViewStates.Visible && appBarLayout.LayoutParameters?.Height > 0;
 
 				var toolbar = appBarLayout?.GetChildAt(0) as MaterialToolbar;
+				bool hasNavigationBar = appBarLayout?.Visibility == ViewStates.Visible && toolbar?.LayoutParameters?.Height > 0;
+
 				var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
 				var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
 
@@ -149,7 +150,7 @@ namespace Microsoft.Maui.Handlers
 				var contentPaddingLeft = Math.Max(systemBars?.Left ?? 0, displayCutout?.Left ?? 0);
 				var contentPaddingRight = Math.Max(systemBars?.Right ?? 0, displayCutout?.Right ?? 0);
 
-				if (appBarLayout is not null)
+				if (appBarLayout is not null && hasNavigationBar)
 				{
 					// Store the original height on first call, then always calculate from that base
 					var currentHeight = toolbar?.LayoutParameters?.Height ?? 0;
@@ -184,13 +185,13 @@ namespace Microsoft.Maui.Handlers
 					// Clear AppBarLayout padding to allow toolbar to extend fully
 					appBarLayout.SetPadding(0, 0, 0, 0);
 				}
-				else if (appBarLayout is not null && !hasNavigationBar)
+				else if (toolbar is not null && !hasNavigationBar)
 				{
 					// Set AppBarLayout height to 0 when HasNavigationBar is false
-					if (appBarLayout.LayoutParameters != null)
+					if (toolbar.LayoutParameters != null)
 					{
-						appBarLayout.LayoutParameters.Height = 0;
-						appBarLayout.RequestLayout();
+						toolbar.LayoutParameters.Height = 0;
+						toolbar.RequestLayout();
 					}
 				}
 
@@ -211,14 +212,14 @@ namespace Microsoft.Maui.Handlers
 					systemBars?.Left ?? 0,
 					0, // Top consumed by toolbar
 					systemBars?.Right ?? 0,
-					systemBars?.Bottom ?? 0
+					0 // Top consumed by rootview
 				) ?? Insets.None;
 
 				var newDisplayCutout = Insets.Of(
 					displayCutout?.Left ?? 0,
 					0, // Top consumed by toolbar
 					displayCutout?.Right ?? 0,
-					displayCutout?.Bottom ?? 0
+					0 // Top consumed by rootview
 				) ?? Insets.None;
 
 				// Return insets that the navigation content can use to respect side/bottom insets

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -210,16 +210,16 @@ namespace Microsoft.Maui.Handlers
 				// Only consume top insets since we handled them in the toolbar
 				var newSystemBars = Insets.Of(
 					systemBars?.Left ?? 0,
-					0, // Top consumed by toolbar
+					!hasNavigationBar ? displayCutout?.Top ?? 0 : 0, // Top consumed by toolbar
 					systemBars?.Right ?? 0,
-					0 // Top consumed by rootview
+					0 // Bottom consumed by rootview
 				) ?? Insets.None;
 
 				var newDisplayCutout = Insets.Of(
 					displayCutout?.Left ?? 0,
-					0, // Top consumed by toolbar
+					!hasNavigationBar ? displayCutout?.Top ?? 0 : 0, // Top consumed by toolbar
 					displayCutout?.Right ?? 0,
-					0 // Top consumed by rootview
+					0 // Bottom consumed by rootview
 				) ?? Insets.None;
 
 				// Return insets that the navigation content can use to respect side/bottom insets

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -4,6 +4,7 @@ using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using AndroidX.Core.View;
 using Microsoft.Maui.Graphics;
 using ARect = Android.Graphics.Rect;
 using Rectangle = Microsoft.Maui.Graphics.Rect;
@@ -15,12 +16,13 @@ namespace Microsoft.Maui.Platform
 	{
 		readonly ARect _clipRect = new();
 		readonly Context _context;
-
+		internal AndroidX.Core.Graphics.Insets? _currentInsets;
 		public bool InputTransparent { get; set; }
 
 		public LayoutViewGroup(Context context) : base(context)
 		{
 			_context = context;
+			SetupWindowInsetsHandling();
 		}
 
 		public LayoutViewGroup(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
@@ -79,10 +81,26 @@ namespace Microsoft.Maui.Platform
 			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
 			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
 
-			var measure = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+			// Always adjust measurement constraints for content when we have insets
+			var measureWidth = deviceIndependentWidth;
+			var measureHeight = deviceIndependentHeight;
 
-			// If the measure spec was exact, we should return the explicit size value, even if the content
-			// measure came out to a different size
+			if (_currentInsets != null)
+			{
+				var leftInsetDp = _context.FromPixels(_currentInsets.Left);
+				var topInsetDp = _context.FromPixels(_currentInsets.Top);
+				var rightInsetDp = _context.FromPixels(_currentInsets.Right);
+				var bottomInsetDp = _context.FromPixels(_currentInsets.Bottom);
+
+				// Always reduce available space by insets for content measurement
+				measureWidth = Math.Max(0, deviceIndependentWidth - leftInsetDp - rightInsetDp);
+				measureHeight = Math.Max(0, deviceIndependentHeight - topInsetDp - bottomInsetDp);
+			}
+
+			var measure = CrossPlatformMeasure(measureWidth, measureHeight);
+
+			// For the container size, always use original constraints in Exactly mode
+			// In other modes, use the content size (which respects insets through arrangement)
 			var width = widthMode == MeasureSpecMode.Exactly ? deviceIndependentWidth : measure.Width;
 			var height = heightMode == MeasureSpecMode.Exactly ? deviceIndependentHeight : measure.Height;
 
@@ -106,9 +124,33 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
+			// Start with the full bounds of the container (edge-to-edge)
 			var destination = _context.ToCrossPlatformRectInReferenceFrame(l, t, r, b);
 
-			CrossPlatformArrange(destination);
+			// If we have insets, adjust the content area to respect them
+			if (_currentInsets != null)
+			{
+				var leftInsetDp = _context.FromPixels(_currentInsets.Left);
+				var topInsetDp = _context.FromPixels(_currentInsets.Top);
+				var rightInsetDp = _context.FromPixels(_currentInsets.Right);
+				var bottomInsetDp = _context.FromPixels(_currentInsets.Bottom);
+
+				// Create a new rect that is inset by the safe area amounts
+				var safeDestination = new Graphics.Rect(
+					destination.X + leftInsetDp,
+					destination.Y + topInsetDp,
+					destination.Width - leftInsetDp - rightInsetDp,
+					destination.Height - topInsetDp - bottomInsetDp
+				);
+
+				// Arrange the content in the safe area
+				CrossPlatformArrange(safeDestination);
+			}
+			else
+			{
+				// No insets, use full bounds
+				CrossPlatformArrange(destination);
+			}
 
 			if (ClipsToBounds)
 			{
@@ -141,6 +183,58 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return null;
+		}
+
+		void SetupWindowInsetsHandling()
+		{
+			ViewCompat.SetOnApplyWindowInsetsListener(this, new LayoutWindowsListener());
+		}
+
+		internal void SetWindowInsets(AndroidX.Core.Graphics.Insets? insets)
+		{
+			if (_currentInsets != insets)
+			{
+				_currentInsets = insets;
+				RequestLayout(); // Trigger a layout pass when insets change
+			}
+		}
+	}
+
+	internal class LayoutWindowsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+	{
+		public WindowInsetsCompat? OnApplyWindowInsets(View? v, WindowInsetsCompat? insets)
+		{
+			if (insets is null || v is null || v is not LayoutViewGroup layoutViewGroup)
+			{
+				return insets;
+			}
+
+			var systemBars = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
+			var displayCutout = insets.GetInsets(WindowInsetsCompat.Type.DisplayCutout());
+
+			if (systemBars is null && displayCutout is null)
+			{
+				layoutViewGroup.SetWindowInsets(null);
+				return insets;
+			}
+
+			// Calculate the maximum insets from system bars and display cutouts
+			var leftInset = Math.Max(systemBars?.Left ?? 0, displayCutout?.Left ?? 0);
+			var topInset = Math.Max(systemBars?.Top ?? 0, displayCutout?.Top ?? 0);
+			var rightInset = Math.Max(systemBars?.Right ?? 0, displayCutout?.Right ?? 0);
+			var bottomInset = Math.Max(systemBars?.Bottom ?? 0, displayCutout?.Bottom ?? 0);
+
+			// Store the insets for use in layout arrangement
+			var combinedInsets = AndroidX.Core.Graphics.Insets.Of(
+				leftInset, topInset, rightInset, bottomInset);
+
+			layoutViewGroup.SetWindowInsets(combinedInsets);
+
+			// Clear any padding since we're handling insets through layout arrangement
+			v.SetPadding(0, 0, 0, 0);
+
+			// Consume the insets since we've handled them
+			return WindowInsetsCompat.Consumed;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request significantly improves how window insets (such as system bars and display cutouts) are handled in Android layout containers, ensuring that content is always arranged within the safe area and that edge-to-edge layouts work correctly. The changes introduce custom insets listeners for both `ContentViewGroup` and `LayoutViewGroup`, update measurement and arrangement logic to respect insets, and refactor the toolbar and navigation layout handling for proper system bar and cutout support.

**Insets Handling and Layout Arrangement Improvements:**

* Added custom `IOnApplyWindowInsetsListener` implementations (`ContentWindowsListener` and `LayoutWindowsListener`) to `ContentViewGroup` and `LayoutViewGroup`, which calculate and store the maximum insets from system bars and display cutouts, clear default paddings, and consume the insets to prevent double-handling. (`src/Core/src/Platform/Android/ContentViewGroup.cs` [[1]](diffhunk://#diff-5fdf872b32d4f8ee5971be75e1e5f45a53ec6c55fbdc701b54e02a175ca05ccaR203-R240) `src/Core/src/Platform/Android/LayoutViewGroup.cs` [[2]](diffhunk://#diff-3f4ba0ef39c71f2f98bc747387389cd17c63805a37849606234f7d8eb5d42e17R187-R238)
* Updated both `OnMeasure` and `OnLayout` methods in `ContentViewGroup` and `LayoutViewGroup` to always reduce the available space for content by the current insets, ensuring that content is measured and arranged within the safe area. (`src/Core/src/Platform/Android/ContentViewGroup.cs` [[1]](diffhunk://#diff-5fdf872b32d4f8ee5971be75e1e5f45a53ec6c55fbdc701b54e02a175ca05ccaL73-R108) [[2]](diffhunk://#diff-5fdf872b32d4f8ee5971be75e1e5f45a53ec6c55fbdc701b54e02a175ca05ccaR129-R156); `src/Core/src/Platform/Android/LayoutViewGroup.cs` [[3]](diffhunk://#diff-3f4ba0ef39c71f2f98bc747387389cd17c63805a37849606234f7d8eb5d42e17L82-R103) [[4]](diffhunk://#diff-3f4ba0ef39c71f2f98bc747387389cd17c63805a37849606234f7d8eb5d42e17R127-R153)

**Toolbar, AppBar, and Navigation Layout Adjustments:**

* Refactored the insets application logic in `WindowHandler.Android.cs` to dynamically adjust the `AppBarLayout` and `MaterialToolbar` height and padding, set appropriate margins, and ensure the navigation layout extends edge-to-edge while properly handling system bar and cutout insets. (`src/Core/src/Handlers/Window/WindowHandler.Android.cs` [src/Core/src/Handlers/Window/WindowHandler.Android.csL123-R216](diffhunk://#diff-aaa8de4ee29efe333fdd2340604bcb8f7ddf5c2d258009d46606e15407f183c1L123-R216))
* Ensured that only the top insets are consumed by the toolbar, while side and bottom insets are preserved for navigation content, improving compatibility with edge-to-edge layouts. (`src/Core/src/Handlers/Window/WindowHandler.Android.cs` [src/Core/src/Handlers/Window/WindowHandler.Android.csL123-R216](diffhunk://#diff-aaa8de4ee29efe333fdd2340604bcb8f7ddf5c2d258009d46606e15407f183c1L123-R216))

**General Codebase Enhancements:**

* Added necessary imports for `AndroidX.Core.View` and related classes in all affected files to support the new insets logic. (`src/Core/src/Platform/Android/ContentViewGroup.cs` [[1]](diffhunk://#diff-5fdf872b32d4f8ee5971be75e1e5f45a53ec6c55fbdc701b54e02a175ca05ccaR7) `src/Core/src/Platform/Android/LayoutViewGroup.cs` [[2]](diffhunk://#diff-3f4ba0ef39c71f2f98bc747387389cd17c63805a37849606234f7d8eb5d42e17R7); `src/Core/src/Handlers/Window/WindowHandler.Android.cs` [[3]](diffhunk://#diff-aaa8de4ee29efe333fdd2340604bcb8f7ddf5c2d258009d46606e15407f183c1R6)

These changes collectively ensure that all layouts properly respect the safe area on Android devices, especially those with display cutouts or gesture navigation, and provide a more robust and maintainable approach to window insets handling.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output
| Before | After|
|--|--|
| <img width="364" height="774" alt="Screenshot 2025-08-26 at 6 27 11 PM" src="https://github.com/user-attachments/assets/e4caf282-80ca-41a1-902f-c17b05170aeb" /> | <img width="363" height="777" alt="Portrait" src="https://github.com/user-attachments/assets/2d24c99d-5299-418d-a738-84d43ebff9aa" />|
| <img width="778" height="368" alt="Screenshot 2025-08-26 at 6 27 02 PM" src="https://github.com/user-attachments/assets/0ada20e6-f13d-4556-afd3-acd5b2e0aaea" /> | <img width="774" height="368" alt="Landscape" src="https://github.com/user-attachments/assets/5ba5470c-5089-453f-a816-af3e5c27bc35" /> |

