### PR TITLE
Use `ToLowerInvariant().Contains(...)` for .NET Framework

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -87,9 +87,9 @@
 	    <_MauiXaml_SG Remove="@(_MauiXaml_SG)" />
 	    <_MauiXaml_RT Remove="@(_MauiXaml_RT)" />
 	    <_MauiXaml_XC Remove="@(_MauiXaml_XC)" />
-	    <_MauiXaml_SG Include="@(MauiXaml)" Condition="$([System.String]::new('%(MauiXaml.Inflator)').Contains('SourceGen', StringComparison.OrdinalIgnoreCase))" />
-	    <_MauiXaml_RT Include="@(MauiXaml)" Condition="$([System.String]::new('%(MauiXaml.Inflator)').Contains('Runtime', StringComparison.OrdinalIgnoreCase))" />
-	    <_MauiXaml_XC Include="@(MauiXaml)" Condition="$([System.String]::new('%(MauiXaml.Inflator)').Contains('XamlC', StringComparison.OrdinalIgnoreCase))" />
+	    <_MauiXaml_SG Include="@(MauiXaml)" Condition="$([System.String]::new('%(MauiXaml.Inflator)').ToLowerInvariant().Contains('sourcegen'))" />
+	    <_MauiXaml_RT Include="@(MauiXaml)" Condition="$([System.String]::new('%(MauiXaml.Inflator)').ToLowerInvariant().Contains('runtime'))" />
+	    <_MauiXaml_XC Include="@(MauiXaml)" Condition="$([System.String]::new('%(MauiXaml.Inflator)').ToLowerInvariant().Contains('xamlc'))" />
       <_MauiXaml_AsEmbeddedResource Include="@(_MauiXaml_RT)" />
       <_MauiXaml_AsEmbeddedResource Include="@(_MauiXaml_XC)" KeepDuplicates="false" />      
 	</ItemGroup>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Replaces `Contains(..., StringComparison.OrdinalIgnoreCase)` with `ToLowerInvariant().Contains(...)` for case-insensitive string matching because .NET Standard 2.0 and/or .NET Framework 4.x does not have the nice new overloads.
