### PR TITLE
[Windows] Optimize use of `TransformationExtensions`

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -6,171 +6,218 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 
-namespace Microsoft.Maui.Handlers
+namespace Microsoft.Maui.Handlers;
+
+public partial class ViewHandler
 {
-	public partial class ViewHandler
+	readonly static ConditionalWeakTable<PlatformView, ViewHandler> FocusManagerMapping = new();
+
+	static ViewHandler()
 	{
-		readonly static ConditionalWeakTable<PlatformView, ViewHandler> FocusManagerMapping = new();
+		FocusManager.GotFocus += FocusManager_GotFocus;
+		FocusManager.LostFocus += FocusManager_LostFocus;
+	}
 
-		static ViewHandler()
+	partial void ConnectingHandler(PlatformView? platformView)
+	{
+		if (platformView is not null)
 		{
-			FocusManager.GotFocus += FocusManager_GotFocus;
-			FocusManager.LostFocus += FocusManager_LostFocus;
+			FocusManagerMapping.Add(platformView, this);
+		}
+	}
+
+	partial void DisconnectingHandler(PlatformView platformView)
+	{
+		FocusManagerMapping.Remove(platformView);
+		UpdateIsFocused(false);
+	}
+
+	static partial void MappingFrame(IViewHandler handler, IView view)
+	{
+		// Both Clip and Shadow depend on the Control size.
+		handler.ToPlatform().UpdateClip(view);
+		handler.ToPlatform().UpdateShadow(view);
+	}
+
+	public static void MapTranslationX(IViewHandler handler, IView view)
+	{
+		// When a handler is connected, all properties are initialized using this method. So we can skip other properties.
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapTranslationY(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
+		{
+			return;
 		}
 
-		partial void ConnectingHandler(PlatformView? platformView)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapScale(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			if (platformView is not null)
-			{
-				FocusManagerMapping.Add(platformView, this);
-			}
+			return;
 		}
 
-		partial void DisconnectingHandler(PlatformView platformView)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapScaleX(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			FocusManagerMapping.Remove(platformView);
-			UpdateIsFocused(false);
+			return;
 		}
 
-		static partial void MappingFrame(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapScaleY(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			// Both Clip and Shadow depend on the Control size.
-			handler.ToPlatform().UpdateClip(view);
-			handler.ToPlatform().UpdateShadow(view);
+			return;
 		}
 
-		public static void MapTranslationX(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapRotation(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			return;
 		}
 
-		public static void MapTranslationY(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapRotationX(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			return;
 		}
 
-		public static void MapScale(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapRotationY(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			return;
 		}
 
-		public static void MapScaleX(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapAnchorX(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			return;
 		}
 
-		public static void MapScaleY(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapAnchorY(IViewHandler handler, IView view)
+	{
+		if (view.IsConnectingHandler())
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			return;
 		}
 
-		public static void MapRotation(IViewHandler handler, IView view)
+		handler.ToPlatform().UpdateTransformation(view);
+	}
+
+	public static void MapToolbar(IViewHandler handler, IView view)
+	{
+		if (view is IToolbarElement tb)
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			MapToolbar(handler, tb);
 		}
+	}
 
-		public static void MapRotationX(IViewHandler handler, IView view)
+	internal static void MapToolbar(IElementHandler handler, IToolbarElement toolbarElement)
+	{
+		_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
+
+		if (toolbarElement.Toolbar != null)
 		{
-			handler.ToPlatform().UpdateTransformation(view);
+			var toolBar = toolbarElement.Toolbar.ToPlatform(handler.MauiContext);
+			handler.MauiContext.GetNavigationRootManager().SetToolbar(toolBar);
 		}
+	}
 
-		public static void MapRotationY(IViewHandler handler, IView view)
+	public static void MapContextFlyout(IViewHandler handler, IView view)
+	{
+		if (view is IContextFlyoutElement contextFlyoutContainer)
 		{
-			handler.ToPlatform().UpdateTransformation(view);
-		}
-
-		public static void MapAnchorX(IViewHandler handler, IView view)
-		{
-			handler.ToPlatform().UpdateTransformation(view);
-		}
-
-		public static void MapAnchorY(IViewHandler handler, IView view)
-		{
-			handler.ToPlatform().UpdateTransformation(view);
-		}
-
-		public static void MapToolbar(IViewHandler handler, IView view)
-		{
-			if (view is IToolbarElement tb)
-			{
-				MapToolbar(handler, tb);
-			}
-		}
-
-		internal static void MapToolbar(IElementHandler handler, IToolbarElement toolbarElement)
-		{
-			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
-
-			if (toolbarElement.Toolbar != null)
-			{
-				var toolBar = toolbarElement.Toolbar.ToPlatform(handler.MauiContext);
-				handler.MauiContext.GetNavigationRootManager().SetToolbar(toolBar);
-			}
-		}
-
-		public static void MapContextFlyout(IViewHandler handler, IView view)
-		{
-			if (view is IContextFlyoutElement contextFlyoutContainer)
-			{
-				if (handler.IsConnectingHandler() && contextFlyoutContainer.ContextFlyout is null)
-					return;
-
-				MapContextFlyout(handler, contextFlyoutContainer);
-			}
-		}
-
-		internal static void MapContextFlyout(IElementHandler handler, IContextFlyoutElement contextFlyoutContainer)
-		{
-			_ = handler.MauiContext ?? throw new InvalidOperationException($"The handler's {nameof(handler.MauiContext)} cannot be null.");
-
-			if (handler.PlatformView is Microsoft.UI.Xaml.UIElement uiElement)
-			{
-				if (contextFlyoutContainer.ContextFlyout != null)
-				{
-					var contextFlyoutHandler = contextFlyoutContainer.ContextFlyout.ToHandler(handler.MauiContext);
-					var contextFlyoutPlatformView = contextFlyoutHandler.PlatformView;
-
-					if (contextFlyoutPlatformView is FlyoutBase flyoutBase)
-					{
-						uiElement.ContextFlyout = flyoutBase;
-					}
-				}
-				else
-				{
-					uiElement.ClearValue(UIElement.ContextFlyoutProperty);
-				}
-			}
-		}
-
-		static void FocusManager_GotFocus(object? sender, FocusManagerGotFocusEventArgs e)
-		{
-			if (e.NewFocusedElement is PlatformView platformView && FocusManagerMapping.TryGetValue(platformView, out ViewHandler? handler))
-			{
-				handler.UpdateIsFocused(true);
-			}
-		}
-
-		static void FocusManager_LostFocus(object? sender, FocusManagerLostFocusEventArgs e)
-		{
-			if (e.OldFocusedElement is PlatformView platformView && FocusManagerMapping.TryGetValue(platformView, out ViewHandler? handler))
-			{
-				handler.UpdateIsFocused(false);
-			}
-		}
-
-		private protected void UpdateIsFocused(bool isFocused)
-		{
-			if (VirtualView is not { } virtualView)
+			if (handler.IsConnectingHandler() && contextFlyoutContainer.ContextFlyout is null)
 			{
 				return;
 			}
 
-			bool updateIsFocused = (isFocused && !virtualView.IsFocused) || (!isFocused && virtualView.IsFocused);
+			MapContextFlyout(handler, contextFlyoutContainer);
+		}
+	}
 
-			if (updateIsFocused)
+	internal static void MapContextFlyout(IElementHandler handler, IContextFlyoutElement contextFlyoutContainer)
+	{
+		_ = handler.MauiContext ?? throw new InvalidOperationException($"The handler's {nameof(handler.MauiContext)} cannot be null.");
+
+		if (handler.PlatformView is Microsoft.UI.Xaml.UIElement uiElement)
+		{
+			if (contextFlyoutContainer.ContextFlyout != null)
 			{
-				virtualView.IsFocused = isFocused;
+				var contextFlyoutHandler = contextFlyoutContainer.ContextFlyout.ToHandler(handler.MauiContext);
+				var contextFlyoutPlatformView = contextFlyoutHandler.PlatformView;
+
+				if (contextFlyoutPlatformView is FlyoutBase flyoutBase)
+				{
+					uiElement.ContextFlyout = flyoutBase;
+				}
 			}
+			else
+			{
+				uiElement.ClearValue(UIElement.ContextFlyoutProperty);
+			}
+		}
+	}
+
+	static void FocusManager_GotFocus(object? sender, FocusManagerGotFocusEventArgs e)
+	{
+		if (e.NewFocusedElement is PlatformView platformView && FocusManagerMapping.TryGetValue(platformView, out ViewHandler? handler))
+		{
+			handler.UpdateIsFocused(true);
+		}
+	}
+
+	static void FocusManager_LostFocus(object? sender, FocusManagerLostFocusEventArgs e)
+	{
+		if (e.OldFocusedElement is PlatformView platformView && FocusManagerMapping.TryGetValue(platformView, out ViewHandler? handler))
+		{
+			handler.UpdateIsFocused(false);
+		}
+	}
+
+	private protected void UpdateIsFocused(bool isFocused)
+	{
+		if (VirtualView is not { } virtualView)
+		{
+			return;
+		}
+
+		bool updateIsFocused = (isFocused && !virtualView.IsFocused) || (!isFocused && virtualView.IsFocused);
+
+		if (updateIsFocused)
+		{
+			virtualView.IsFocused = isFocused;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/TransformationExtensions.cs
+++ b/src/Core/src/Platform/Windows/TransformationExtensions.cs
@@ -2,63 +2,65 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 
-namespace Microsoft.Maui.Platform
-{
-	public static class TransformationExtensions
-	{
-		public static void UpdateTransformation(this FrameworkElement frameworkElement, IView view)
-		{
-			double rotationX = view.RotationX;
-			double rotationY = view.RotationY;
-			double rotation = view.Rotation;
-			double translationX = view.TranslationX;
-			double translationY = view.TranslationY;
-			double scaleX = view.Scale * view.ScaleX;
-			double scaleY = view.Scale * view.ScaleY;
+namespace Microsoft.Maui.Platform;
 
-			if (rotationX % 360 == 0 && rotationY % 360 == 0 && rotation % 360 == 0 &&
-				translationX == 0 && translationY == 0 && scaleX == 1 && scaleY == 1)
+public static class TransformationExtensions
+{
+	public static void UpdateTransformation(this FrameworkElement frameworkElement, IView view)
+	{
+		double rotationX = view.RotationX;
+		double rotationY = view.RotationY;
+		double rotation = view.Rotation;
+		double translationX = view.TranslationX;
+		double translationY = view.TranslationY;
+		double scaleX = view.Scale * view.ScaleX;
+		double scaleY = view.Scale * view.ScaleY;
+
+		if (rotationX % 360 == 0 && rotationY % 360 == 0 && rotation % 360 == 0 &&
+			translationX == 0 && translationY == 0 && scaleX == 1 && scaleY == 1)
+		{
+			if (!view.IsConnectingHandler())
 			{
 				frameworkElement.Projection = null;
 				frameworkElement.RenderTransform = null;
 			}
+		}
+		else
+		{
+			double anchorX = view.AnchorX;
+			double anchorY = view.AnchorY;
+
+			frameworkElement.RenderTransformOrigin = new global::Windows.Foundation.Point(anchorX, anchorY);
+			frameworkElement.RenderTransform = new ScaleTransform { ScaleX = scaleX, ScaleY = scaleY };
+
+			// PlaneProjection removes touch and scrollwheel functionality on scrollable views such
+			// as ScrollView, ListView, and TableView. If neither RotationX or RotationY are set
+			// (i.e. their absolute value is 0), a CompositeTransform is instead used to allow for
+			// rotation of the control on a 2D plane, and the other values are set. Otherwise, the
+			// rotation values are set, but the aforementioned functionality will be lost.
+			if (Math.Abs(view.RotationX) != 0 || Math.Abs(view.RotationY) != 0)
+			{
+				frameworkElement.Projection = new PlaneProjection
+				{
+					CenterOfRotationX = anchorX,
+					CenterOfRotationY = anchorY,
+					GlobalOffsetX = translationX,
+					GlobalOffsetY = translationY,
+					RotationX = -rotationX,
+					RotationY = -rotationY,
+					RotationZ = -rotation
+				};
+			}
 			else
 			{
-				double anchorX = view.AnchorX;
-				double anchorY = view.AnchorY;
-
-				frameworkElement.RenderTransformOrigin = new global::Windows.Foundation.Point(anchorX, anchorY);
-				frameworkElement.RenderTransform = new ScaleTransform { ScaleX = scaleX, ScaleY = scaleY };
-
-				// PlaneProjection removes touch and scrollwheel functionality on scrollable views such
-				// as ScrollView, ListView, and TableView. If neither RotationX or RotationY are set
-				// (i.e. their absolute value is 0), a CompositeTransform is instead used to allow for
-				// rotation of the control on a 2D plane, and the other values are set. Otherwise, the
-				// rotation values are set, but the aforementioned functionality will be lost.
-				if (Math.Abs(view.RotationX) != 0 || Math.Abs(view.RotationY) != 0)
+				frameworkElement.RenderTransform = new CompositeTransform
 				{
-					frameworkElement.Projection = new PlaneProjection
-					{
-						CenterOfRotationX = anchorX,
-						CenterOfRotationY = anchorY,
-						GlobalOffsetX = translationX,
-						GlobalOffsetY = translationY,
-						RotationX = -rotationX,
-						RotationY = -rotationY,
-						RotationZ = -rotation
-					};
-				}
-				else
-				{
-					frameworkElement.RenderTransform = new CompositeTransform
-					{
-						Rotation = rotation,
-						ScaleX = scaleX,
-						ScaleY = scaleY,
-						TranslateX = translationX,
-						TranslateY = translationY
-					};
-				}
+					Rotation = rotation,
+					ScaleX = scaleX,
+					ScaleY = scaleY,
+					TranslateX = translationX,
+					TranslateY = translationY
+				};
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

This PR is a follow-up to #27259 and optimizes performance by calling `TransformationExtensions.UpdateTransformation` only when necessary as the method is quite expensive.

### Performance improvement

* `main` - [maui.sandbox.2025-08-26_19-11-50.main.speedscope.json](https://github.com/user-attachments/files/21993113/maui.sandbox.2025-08-26_19-11-50.main.speedscope.json)
*  PR - [maui.sandbox.2025-08-26_20-00-06.pr.speedscope.json](https://github.com/user-attachments/files/21993119/maui.sandbox.2025-08-26_20-00-06.pr.speedscope.json)

<img width="3825" height="214" alt="image" src="https://github.com/user-attachments/assets/1a69dd06-b673-4418-a804-e57c9b5968b8" />


### Issues Fixed

Contributes to #21787