### PR TITLE
Fixed Test case failure in PR 31327

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs
@@ -62,9 +62,9 @@ namespace Microsoft.Maui.Controls
 			bool isLastPage = InternalChildren.Last() == page;
 			RemoveFromInnerChildren(page);
 
-			if (isLastPage && NavigationPageController.StackDepth >= 2)
+			if (isLastPage && InternalChildren.Count > 0)
 			{
-				FireAppearing((Page)InternalChildren[NavigationPageController.StackDepth - 2]);
+				FireAppearing((Page)InternalChildren.Last());
 			}
 
 			CurrentPage = (Page)InternalChildren.Last();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
In the failed test `AppDoesntCrashWhenSettingNewTitleViewOnExistingPage`, the TitleView was updated in the OnAppearing method. When popping the page using PopAsync, the OnAppearing event is triggered twice with my fix, whereas previously it was triggered only once: once from [FireAppearing](https://github.com/dotnet/maui/blob/b2c3452f68298f407ca18f8fe9e0f8841e7c9cad/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs#L67) and once from [CurrentPageChanged](https://github.com/dotnet/maui/blob/b2c3452f68298f407ca18f8fe9e0f8841e7c9cad/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs#L70).
This additional trigger causes the title to mismatch the expected value, resulting in the test failure.

### Root Cause
The fix moves FireAppearing to after RemoveFromInnerChildren(page), but at that point InternalChildren.Last() has already changed. Currently, StackDepth - 2 is calculated based on the original stack depth. Once the popped page is removed from stack, accessing InternalChildren[StackDepth - 2] is not valid.

### Description of Change
Remove the page first, then use InternalChildren.Last(); directly to get the correct page that should appear.

Regressed PR: https://github.com/dotnet/maui/pull/28666

Fixes AppDoesntCrashWhenSettingNewTitleViewOnExistingPage test failure in PR: https://github.com/dotnet/maui/pull/31327

### Screenshots

<img width="540" height="300" alt="image" src="https://github.com/user-attachments/assets/9dfaed05-0b66-489b-9b81-9a285088cc96" />
<img width="540" height="300" alt="image" src="https://github.com/user-attachments/assets/81626605-6567-4a30-b183-d26513d5f60c" />
<img width="540" height="300" alt="image" src="https://github.com/user-attachments/assets/260ca192-4baa-45e2-9991-8abcdadb2961" />
