### PR TITLE
[iOS] Fix NSInternalInconsistencyException in CarouselViewHandler2 when setting ItemsSource

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -397,6 +397,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				return;
 			}
 
+			if (goToPosition >= ItemsSource.ItemCount)
+			{
+				goToPosition = Math.Max(0, ItemsSource.ItemCount - 1);
+			}
+			
 			if (goToPosition != carouselPosition || forceScroll)
 			{
 				UICollectionViewScrollPosition uICollectionViewScrollPosition = IsHorizontal ? UICollectionViewScrollPosition.CenteredHorizontally : UICollectionViewScrollPosition.CenteredVertically;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -175,6 +175,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		internal NSIndexPath GetScrollToIndexPath(int position)
 		{
+			var itemCount = ItemsSource.ItemCount;
+			
+			// Ensure the requested position is within bounds.
+			if (position >= itemCount)
+			{
+				System.Diagnostics.Debug.WriteLine($"Invalid scroll position {position} for collection with {itemCount} items");
+				position = Math.Max(0, itemCount - 1); // Default to last item (or 0 if empty).
+			}
+			
 			if (ItemsView?.Loop == true && _carouselViewLoopManager != null)
 			{
 				return _carouselViewLoopManager.GetCorrectedIndexPathFromIndex(position);
@@ -395,11 +404,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			if (ItemsSource is null || ItemsSource.ItemCount == 0)
 			{
 				return;
-			}
-
-			if (goToPosition >= ItemsSource.ItemCount)
-			{
-				goToPosition = Math.Max(0, ItemsSource.ItemCount - 1);
 			}
 			
 			if (goToPosition != carouselPosition || forceScroll)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31339.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31339.cs
@@ -1,0 +1,67 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.None, 31339, "[iOS] CarouselViewHandler2 NSInternalInconsistencyException thrown when setting ItemsSources", PlatformAffected.iOS)]
+public class Issue31339 : ContentPage
+{
+	readonly CarouselView2 _carouselView;
+	readonly ObservableCollection<string> _items;
+	readonly Button _button;
+
+	public Issue31339()
+	{
+		_items = new ObservableCollection<string>();
+
+		_carouselView = new CarouselView2
+		{
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					BackgroundColor = Colors.Red,
+					HorizontalTextAlignment = TextAlignment.Center,
+					VerticalTextAlignment = TextAlignment.Center
+				};
+				label.SetBinding(Label.TextProperty, new Binding("."));
+				return label;
+			}),
+			AutomationId = "TestCarouselView"
+		};
+
+		_button = new Button
+		{
+			Text = "Update CarouselView ItemsSource",
+			AutomationId = "UpdateButton"
+		};
+		_button.Clicked += OnUpdateClicked;
+
+		var grid = new Grid
+		{
+			RowDefinitions = 
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		grid.Children.Add(_button);
+		Grid.SetRow(_carouselView, 1);
+		grid.Children.Add(_carouselView);
+
+		Content = grid;
+	}
+
+	void OnUpdateClicked(object sender, EventArgs e)
+	{
+		// Start with high position to simulate the issue
+		_carouselView.Position = 15;
+
+		// Create items with random count (5-20) as in reproduction case
+		var itemCount = new Random().Next(5, 20);
+		var items = Enumerable.Range(0, itemCount).Select(i => $"Item {i}").ToList();
+
+		// This should not throw NSInternalInconsistencyException with our fix
+		_carouselView.ItemsSource = items;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31339.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31339.cs
@@ -29,7 +29,8 @@ public class Issue31339 : _IssuesUITest
 		// Verify we can interact with the CarouselView after the update
 		// The CarouselView should be visible and functional, not crashed
 		var carouselView = App.FindElement("TestCarouselView");
-		Assert.IsNotNull(carouselView, "CarouselView should be available after ItemsSource update");
+		Assert.That(carouselView, Is.Not.Null,
+			"CarouselView should be available after ItemsSource update");
 	}
 
 	[Test]
@@ -48,6 +49,7 @@ public class Issue31339 : _IssuesUITest
 
 		// Verify the CarouselView is still functional after multiple updates
 		var carouselView = App.FindElement("TestCarouselView");
-		Assert.IsNotNull(carouselView, "CarouselView should remain available after multiple updates");
+		Assert.That(carouselView, Is.Not.Null,
+			"CarouselView should remain available after multiple updates");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31339.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31339.cs
@@ -11,7 +11,7 @@ public class Issue31339 : _IssuesUITest
 	{
 	}
 
-	public override string Issue => "[iOS] CarouselViewHandler2 - NSInternalInconsistencyException thrown when setting ItemsSources";
+	public override string Issue => "[iOS] CarouselViewHandler2 NSInternalInconsistencyException thrown when setting ItemsSources";
 
 	[Test]
 	[Category(UITestCategories.CarouselView)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31339.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31339.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31339 : _IssuesUITest
+{
+	public Issue31339(TestDevice device)
+		: base(device)
+	{
+	}
+
+	public override string Issue => "[iOS] CarouselViewHandler2 - NSInternalInconsistencyException thrown when setting ItemsSources";
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void CarouselViewHandler2OutOfBoundsTest()
+	{
+		App.WaitForElement("UpdateButton");
+
+		// Tap the button to trigger the issue reproduction scenario
+		// This sets Position = 15 and then sets ItemsSource to a collection with 5-20 items
+		App.Tap("UpdateButton");
+
+		// Wait for the CarouselView to be available, if no crash occurred, this should succeed
+		App.WaitForElement("TestCarouselView");
+
+		// Verify we can interact with the CarouselView after the update
+		// The CarouselView should be visible and functional, not crashed
+		var carouselView = App.FindElement("TestCarouselView");
+		Assert.IsNotNull(carouselView, "CarouselView should be available after ItemsSource update");
+	}
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void CarouselViewHandler2OutOfBoundsMultipleUpdates()
+	{
+		// Test multiple rapid updates to ensure stability
+		App.WaitForElement("UpdateButton");
+
+		// Perform multiple updates to stress test the bounds validation
+		for (int i = 0; i < 3; i++)
+		{
+			App.Tap("UpdateButton");
+			App.WaitForElement("TestCarouselView");
+		}
+
+		// Verify the CarouselView is still functional after multiple updates
+		var carouselView = App.FindElement("TestCarouselView");
+		Assert.IsNotNull(carouselView, "CarouselView should remain available after multiple updates");
+	}
+}


### PR DESCRIPTION
### Description of Change

An exception is thrown when trying to scroll to item 20 when only 12 items exist, because the ItemsSource have been updated. The cause is a stale position values from previous ItemsSource being used with new smaller ItemsSource.

This PR addresses the issue by clamping the requested position to the last valid index of the updated ItemsSource, preventing out-of-range access and ensuring safe scrolling behavior, invoked when setting the position property.

### Issues Fixed

Fixes #31339
Fixes #31431