### PR TITLE
[iOS, Mac] TabbedPage overflow "More" button does not works

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -51,6 +51,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			set
 			{
 				base.SelectedViewController = value;
+				// If the selected view controller is the "More" navigation controller, do not update the current page
+				// because it is a special case where the user is navigating to a different set of tabs
+				if (value == MoreNavigationController)
+					return;
+
 				UpdateCurrentPage();
 			}
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31377.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31377.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TabbedPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			xmlns:controls="clr-namespace:Maui.Controls.Sample.Issues"
+			xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
+			ItemsSource="{Binding ItemsSource}"
+			x:Class="Maui.Controls.Sample.Issues.Issue31377">
+	<TabbedPage.ItemTemplate>
+		<DataTemplate>
+			<ContentPage Title="{Binding Name}"
+						 IconImageSource="coffee.png">
+				<StackLayout Padding="5, 25">
+					<Label Text="{Binding Name}"
+						   FontAttributes="Bold"
+						   FontSize="18"
+						   HorizontalOptions="Center"/>
+					<Image Source="{Binding ImageUrl}"
+						   HorizontalOptions="Center"
+						   WidthRequest="100"
+						   HeightRequest="100"/>
+				</StackLayout>
+			</ContentPage>
+		</DataTemplate>
+	</TabbedPage.ItemTemplate>
+</TabbedPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31377.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31377.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31377, "TabbedPage overflow 'More' button does not work", PlatformAffected.iOS)]
+public partial class Issue31377 : TabbedPage
+{
+	public Issue31377()
+	{
+		InitializeComponent();
+		BindingContext = new TabbedPageViewModel();
+	}
+
+	public class TabbedPageViewModel
+	{
+		public ObservableCollection<TabbedPageItemSource> ItemsSource { get; } =
+		[
+			new TabbedPageItemSource { Name = "Tab 1", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 2", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 3", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 4", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 5", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 6", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 7", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 8", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 9", ImageUrl = "dotnet_bot.png" },
+			new TabbedPageItemSource { Name = "Tab 10", ImageUrl = "dotnet_bot.png" }
+		];
+	}
+
+	public class TabbedPageItemSource
+	{
+		public string Name { get; set; }
+		public string ImageUrl { get; set; }
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31377.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31377.cs
@@ -1,0 +1,23 @@
+﻿#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_ANDROID //The more page works differently on these platforms
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31377 : _IssuesUITest
+{
+	public Issue31377(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "TabbedPage overflow 'More' button does not work";
+
+	[Test]
+	[Category(UITestCategories.TabbedPage)]
+	public void Issue31377TestsOverflowMoreButton()
+	{
+		App.WaitForElement("More");
+		App.Tap("More");
+		App.WaitForElement("Tab 10");
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Prevents UpdateCurrentPage from being called when the 'More' navigation controller is selected in TabbedRenderer on iOS, handling the special case where the user navigates to additional tabs.

### Issues Fixed

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/19137b3c-ae2c-4ee0-8bca-4c914023a823" width="300px"></video>|<video src="https://github.com/user-attachments/assets/79fa162b-d42e-4ec6-b7e0-f2ca87661d27" width="300px"></video>|

Fixes https://github.com/dotnet/maui/issues/31377

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
