### PR TITLE
[Windows] Optimize `Label.CharacterSpacing` on initial load

### DIFF
--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -53,8 +53,15 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateTextColor(label);
 
-		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label) =>
+		public static void MapCharacterSpacing(ILabelHandler handler, ILabel label)
+		{
+			if (handler.IsConnectingHandler() && label.CharacterSpacing == 0)
+			{
+				return;
+			}
+
 			handler.PlatformView?.UpdateCharacterSpacing(label);
+		}
 
 		public static void MapFont(ILabelHandler handler, ILabel label)
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

### Performance improvement

* `main` - [maui.sandbox.2025-08-29_08-49-20.main.speedscope.json](https://github.com/user-attachments/files/22040168/maui.sandbox.2025-08-29_08-49-20.main.speedscope.json)
* PR - [maui.sandbox.2025-08-29_08-45-53.pr.speedscope.json](https://github.com/user-attachments/files/22040166/maui.sandbox.2025-08-29_08-45-53.pr.speedscope.json)

<img width="3419" height="75" alt="image" src="https://github.com/user-attachments/assets/a5669b07-4513-4132-be2b-bb72af8c3f1b" />

So this PR should translate to saving about 15 ms in my grid scenario (#21787). I'm not sure why it is so costly but it's like that:

<img width="1719" height="995" alt="image" src="https://github.com/user-attachments/assets/f4f0b609-bf07-4ce0-936a-3559697c1eea" />


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Contributes to #21787

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
