### PR TITLE
[CV2] Fix CarouselView vertical scrolling when orientation is horizontal

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		internal static void MapItemsLayout(CarouselViewHandler2 handler, CarouselView carouselView)
 		{
 			handler?.UpdateLayout();
+			(handler.Controller as CarouselViewController2)?.UpdateScrollingConstraints();
 		}
 
 		public static void MapPeekAreaInsets(CarouselViewHandler2 handler, CarouselView carouselView)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public override async void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
+			UpdateScrollingConstraints();
 			await UpdateInitialPosition();
 		}
 
@@ -154,6 +155,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			_carouselViewLoopManager?.Dispose();
 			_carouselViewLoopManager = null;
 			_isUpdating = false;
+		}
+
+		void UpdateScrollingConstraints()
+		{
+			CollectionView.AlwaysBounceVertical = !IsHorizontal;
+			CollectionView.AlwaysBounceHorizontal = IsHorizontal;
 		}
 
 		void Setup(CarouselView carouselView)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public override async void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
-			UpdateScrollingConstraints();
 			await UpdateInitialPosition();
 		}
 
@@ -157,7 +156,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			_isUpdating = false;
 		}
 
-		void UpdateScrollingConstraints()
+		internal void UpdateScrollingConstraints()
 		{
 			CollectionView.AlwaysBounceVertical = !IsHorizontal;
 			CollectionView.AlwaysBounceHorizontal = IsHorizontal;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
@@ -20,6 +20,8 @@ public class Issue31361 : ContentPage
 		{
 			ItemsSource = carouselItems,
 			AutomationId = "carouselview",
+			HeightRequest = 300,
+			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal),
 			ItemTemplate = new DataTemplate(() =>
 			{
 				var grid = new Grid
@@ -49,9 +51,27 @@ public class Issue31361 : ContentPage
 			Padding = new Thickness(20),
 		};
 
+		var orientationButton = new Button
+		{
+			Text = "Change Orientation",
+			AutomationId = "orientationButton",
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(20)
+		};
+
+		orientationButton.Clicked += (s, e) =>
+		{
+			carouselView.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical);
+			contentLabel.Text = "The content is not scrollable";
+		};
+
 		carouselView.Scrolled += (s, e) =>
 		{
 			if (e.VerticalDelta != 0)
+			{
+				contentLabel.Text = "The content is scrollable";
+			}
+			else if (e.HorizontalDelta != 0)
 			{
 				contentLabel.Text = "The content is scrollable";
 			}
@@ -59,6 +79,7 @@ public class Issue31361 : ContentPage
 
 		verticalStackLayout.Children.Add(contentLabel);
 		verticalStackLayout.Children.Add(carouselView);
+		verticalStackLayout.Children.Add(orientationButton);
 		Content = verticalStackLayout;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
@@ -65,6 +65,18 @@ public class Issue31361 : ContentPage
 			contentLabel.Text = "The content is not scrollable";
 		};
 
+		var changeLoopButton = new Button
+		{
+			Text = "Change Loop",
+			AutomationId = "changeLoopButton",
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(20)
+		};
+		changeLoopButton.Clicked += (s, e) =>
+		{
+			carouselView.Loop = !carouselView.Loop;
+		};
+
 		carouselView.Scrolled += (s, e) =>
 		{
 			if (e.VerticalDelta != 0)
@@ -80,6 +92,7 @@ public class Issue31361 : ContentPage
 		verticalStackLayout.Children.Add(contentLabel);
 		verticalStackLayout.Children.Add(carouselView);
 		verticalStackLayout.Children.Add(orientationButton);
+		verticalStackLayout.Children.Add(changeLoopButton);
 		Content = verticalStackLayout;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
@@ -1,0 +1,70 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31361, "CarouselView content is scrolling vertically", PlatformAffected.iOS)]
+public class Issue31361 : ContentPage
+{
+	bool isBounce;
+	public Issue31361()
+	{
+		var verticalStackLayout = new VerticalStackLayout();
+		var carouselItems = new ObservableCollection<string>
+		{
+			"Item 1",
+			"Item 2",
+			"Item 3",
+			"Item 4",
+		};
+
+		CarouselView2 carouselView = new CarouselView2
+		{
+			ItemsSource = carouselItems,
+			AutomationId = "carouselview",
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid
+				{
+					Margin = 50,
+					BackgroundColor = Colors.LightGray
+				};
+
+				var label = new Label
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					FontSize = 18,
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				grid.Children.Add(label);
+				return grid;
+			}),
+			HorizontalOptions = LayoutOptions.Fill,
+		};
+
+		var contentLabel = new Label
+		{
+			AutomationId = "contentLabel",
+			Text = "Test Content",
+			HorizontalOptions = LayoutOptions.Center,
+			Padding = new Thickness(20),
+		};
+
+		carouselView.Scrolled += (s, e) =>
+		{
+			isBounce = e.VerticalDelta == 0;
+			if (isBounce)
+			{
+				contentLabel.Text = "The content is not scrollable";
+			}
+			else
+			{
+				contentLabel.Text = "The content is scrollable";
+			}
+		};
+
+		verticalStackLayout.Children.Add(contentLabel);
+		verticalStackLayout.Children.Add(carouselView);
+		Content = verticalStackLayout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
@@ -5,7 +5,6 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 31361, "CarouselView content is scrolling vertically", PlatformAffected.iOS)]
 public class Issue31361 : ContentPage
 {
-	bool isBounce;
 	public Issue31361()
 	{
 		var verticalStackLayout = new VerticalStackLayout();
@@ -45,19 +44,14 @@ public class Issue31361 : ContentPage
 		var contentLabel = new Label
 		{
 			AutomationId = "contentLabel",
-			Text = "Test Content",
+			Text = "The content is not scrollable",
 			HorizontalOptions = LayoutOptions.Center,
 			Padding = new Thickness(20),
 		};
 
 		carouselView.Scrolled += (s, e) =>
 		{
-			isBounce = e.VerticalDelta == 0;
-			if (isBounce)
-			{
-				contentLabel.Text = "The content is not scrollable";
-			}
-			else
+			if (e.VerticalDelta < 0)
 			{
 				contentLabel.Text = "The content is scrollable";
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31361.cs
@@ -51,7 +51,7 @@ public class Issue31361 : ContentPage
 
 		carouselView.Scrolled += (s, e) =>
 		{
-			if (e.VerticalDelta < 0)
+			if (e.VerticalDelta != 0)
 			{
 				contentLabel.Text = "The content is scrollable";
 			}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
@@ -15,7 +15,7 @@ public class Issue31361 : _IssuesUITest
 
     [Test, Order(1)]
     [Category(UITestCategories.CarouselView)]
-    public void VerifyHorizontalCarouselViewPreventsVerticalScrolling()
+    public void VerifyHorizontalLoopableCarouselViewPreventsVerticalScrolling()
     {
         App.WaitForElement("carouselview");
         App.ScrollDown("carouselview");
@@ -25,10 +25,32 @@ public class Issue31361 : _IssuesUITest
 
     [Test, Order(2)]
     [Category(UITestCategories.CarouselView)]
+    public void VerifyHorizontalCarouselViewPreventsVerticalScrolling()
+    {
+        App.WaitForElement("carouselview");
+        App.Tap("changeLoopButton");
+        App.ScrollDown("carouselview");
+        var text = App.FindElement("contentLabel").GetText();
+        Assert.That(text, Is.EqualTo("The content is not scrollable"));
+    }
+
+    [Test, Order(3)]
+    [Category(UITestCategories.CarouselView)]
     public void VerifyVerticalCarouselViewPreventsHorizontalScrolling()
     {
         App.WaitForElement("carouselview");
         App.Tap("orientationButton");
+        App.ScrollLeft("carouselview");
+        var text = App.FindElement("contentLabel").GetText();
+        Assert.That(text, Is.EqualTo("The content is not scrollable"));
+    }
+
+    [Test, Order(4)]
+    [Category(UITestCategories.CarouselView)]
+    public void VerifyVerticalLoopableCarouselViewPreventsHorizontalScrolling()
+    {
+        App.WaitForElement("carouselview");
+        App.Tap("changeLoopButton");
         App.ScrollLeft("carouselview");
         var text = App.FindElement("contentLabel").GetText();
         Assert.That(text, Is.EqualTo("The content is not scrollable"));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
@@ -13,12 +13,23 @@ public class Issue31361 : _IssuesUITest
     : base(device)
     { }
 
-    [Test]
+    [Test, Order(1)]
     [Category(UITestCategories.CarouselView)]
     public void VerifyHorizontalCarouselViewPreventsVerticalScrolling()
     {
         App.WaitForElement("carouselview");
         App.ScrollDown("carouselview");
+        var text = App.FindElement("contentLabel").GetText();
+        Assert.That(text, Is.EqualTo("The content is not scrollable"));
+    }
+
+    [Test, Order(2)]
+    [Category(UITestCategories.CarouselView)]
+    public void VerifyVerticalCarouselViewPreventsHorizontalScrolling()
+    {
+        App.WaitForElement("carouselview");
+        App.Tap("orientationButton");
+        App.ScrollLeft("carouselview");
         var text = App.FindElement("contentLabel").GetText();
         Assert.That(text, Is.EqualTo("The content is not scrollable"));
     }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_CATALYST || TEST_FAILS_ON_WINDOWS //In Catalyst and Windows, `ScrollDown` isn't functioning correctly with Appium.
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS //In Catalyst and Windows, `ScrollDown` isn't functioning correctly with Appium.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_CATALYST  //In Catalyst, `ScrollDown` isn't functioning correctly with Appium.
+#if TEST_FAILS_ON_CATALYST || TEST_FAILS_ON_WINDOWS //In Catalyst and Windows, `ScrollDown` isn't functioning correctly with Appium.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31361.cs
@@ -1,0 +1,26 @@
+#if TEST_FAILS_ON_CATALYST  //In Catalyst, `ScrollDown` isn't functioning correctly with Appium.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31361 : _IssuesUITest
+{
+    public override string Issue => "CarouselView content is scrolling vertically";
+
+    public Issue31361(TestDevice device)
+    : base(device)
+    { }
+
+    [Test]
+    [Category(UITestCategories.CarouselView)]
+    public void VerifyHorizontalCarouselViewPreventsVerticalScrolling()
+    {
+        App.WaitForElement("carouselview");
+        App.ScrollDown("carouselview");
+        var text = App.FindElement("contentLabel").GetText();
+        Assert.That(text, Is.EqualTo("The content is not scrollable"));
+    }
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
The CarouselView's current item content scrolls vertically even when the orientation is set to horizontal.

### Root Cause
The bounce behavior was not properly disabled in CarouselView. Specifically, the UICollectionView’s AlwaysBounceVertical and AlwaysBounceHorizontal properties were not configured according to the CarouselView's orientation.

### Description of Change
Configured the UICollectionView’s AlwaysBounceVertical and AlwaysBounceHorizontal properties based on the CarouselView's orientation to prevent unintended scrolling.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #31361  

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/7fd05b39-aa65-47b6-918e-307e0b0ad32c" >| <video src="https://github.com/user-attachments/assets/a2dc8973-1132-40ba-a900-3e8a59213560">|