### PR TITLE
Improve IPlatformApplication API docs

### DIFF
--- a/src/Core/src/Core/IPlatformApplication.cs
+++ b/src/Core/src/Core/IPlatformApplication.cs
@@ -1,33 +1,99 @@
 ﻿using System;
 
-namespace Microsoft.Maui
+namespace Microsoft.Maui;
+
+/// <summary>
+/// Represents the platform-specific application instance that hosts a .NET MAUI application.
+/// </summary>
+/// <remarks>
+/// This interface provides access to platform-specific services and the main application instance.
+/// Each platform (Android, iOS, Windows, etc.) provides its own implementation of this interface.
+/// Use <see cref="Current"/> to access the current platform application instance.
+/// </remarks>
+public interface IPlatformApplication
 {
-	/// <summary>
-	/// IPlatformApplication.
-	/// Hosts the platform application.
-	/// </summary>
-	public interface IPlatformApplication
-	{
 
 #if !NETSTANDARD2_0
-		/// <summary>
-		/// Gets the current IPlatformApplication.
-		/// This must be set in each implementation manually, as we can't
-		/// have a true static be used in the implementation.
-		/// </summary>
-		public static IPlatformApplication? Current { get; set; }
+	/// <summary>
+	/// Gets or sets the current platform application instance.
+	/// </summary>
+	/// <value>
+	/// The current <see cref="IPlatformApplication"/> instance, or <see langword="null"/> if not set.
+	/// </value>
+	/// <remarks>
+	/// <para>
+	/// This property provides access to the platform-specific application instance and its services.
+	/// It must be manually set by each platform implementation during application startup.
+	/// </para>
+	/// <para>
+	/// Common usage scenarios:
+	/// </para>
+	/// <list type="bullet">
+	/// <item><description>Accessing platform services: <c>IPlatformApplication.Current?.Services</c></description></item>
+	/// <item><description>Getting the application instance: <c>IPlatformApplication.Current?.Application</c></description></item>
+	/// <item><description>Platform-specific operations requiring the native application context</description></item>
+	/// </list>
+	/// <para>
+	/// Always check for <see langword="null"/> before using this property, especially during application startup
+	/// or in unit tests where the platform application may not be initialized.
+	/// </para>
+	/// </remarks>
+	/// <example>
+	/// <code>
+	/// // Accessing a service from the platform application
+	/// var platformApp = IPlatformApplication.Current;
+	/// if (platformApp != null)
+	/// {
+	///     var myService = platformApp.Services.GetService&lt;IMyService&gt;();
+	///     // Use the service...
+	/// }
+	/// </code>
+	/// </example>
+	public static IPlatformApplication? Current { get; set; }
 #endif
 
-		/// <summary>
-		/// Gets the Service Provider.
-		/// <see cref="IServiceProvider"/>.
-		/// </summary>
-		public IServiceProvider Services { get; }
+	/// <summary>
+	/// Gets the dependency injection service provider for the platform application.
+	/// </summary>
+	/// <value>
+	/// An <see cref="IServiceProvider"/> instance containing platform-specific and application services.
+	/// </value>
+	/// <remarks>
+	/// Use this service provider to resolve services that have been registered with the platform's
+	/// dependency injection container. This includes both framework services and custom services
+	/// registered during application configuration.
+	/// </remarks>
+	/// <example>
+	/// <code>
+	/// // Getting a service from the platform application
+	/// var logger = platformApp.Services.GetService&lt;ILogger&gt;();
+	/// var httpClient = platformApp.Services.GetRequiredService&lt;HttpClient&gt;();
+	/// </code>
+	/// </example>
+	public IServiceProvider Services { get; }
 
-		/// <summary>
-		/// Gets the Application.
-		/// <see cref="IApplication"/>.
-		/// </summary>
-		public IApplication Application { get; }
-	}
+	/// <summary>
+	/// Gets the .NET MAUI application instance.
+	/// </summary>
+	/// <value>
+	/// An <see cref="IApplication"/> instance representing the current MAUI application.
+	/// </value>
+	/// <remarks>
+	/// This property provides access to the main MAUI application instance, which contains
+	/// application-level configuration, the main page, and application lifecycle methods.
+	/// Use this to access application-wide properties and methods.
+	/// </remarks>
+	/// <example>
+	/// <code>
+	/// // Accessing the main page from the application
+	/// var mainPage = platformApp.Application.MainPage;
+	/// 
+	/// // Triggering application lifecycle events
+	/// if (platformApp.Application is Application app)
+	/// {
+	///     app.OnStart();
+	/// }
+	/// </code>
+	/// </example>
+	public IApplication Application { get; }
 }


### PR DESCRIPTION
This pull request improves the documentation and clarity of the `IPlatformApplication` interface in the `src/Core/src/Core/IPlatformApplication.cs` file. The changes focus on making the interface easier to understand and use, especially for developers integrating with platform-specific services and the main application instance.

Documentation and API clarity improvements:

* Enhanced XML documentation for the `IPlatformApplication` interface, providing detailed remarks, usage scenarios, and example code for each property to clarify their purpose and usage.
* Improved the summary and remarks for the `Current` static property, including usage scenarios, null-check guidance, and example code for accessing platform services and the application instance.
* Updated the documentation for the `Services` property to explain its role as a dependency injection service provider, with examples for resolving services.
* Expanded the documentation for the `Application` property to clarify its purpose and provide examples for accessing the main page and triggering lifecycle events.

Formatting and namespace changes:

* Changed the namespace declaration to use file-scoped syntax for consistency with modern C# practices.

Fixes https://github.com/dotnet/dotnet-maui-api-docs/issues/98