### PR TITLE
Add unit information to VisualElement dimensional properties

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -588,9 +588,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets the current rendered height of this element. This is a read-only bindable property.
+		/// Gets the current rendered height of this element in device-independent units. This is a read-only bindable property.
 		/// </summary>
-		/// <remarks>The height of an element is set during layout.</remarks>
+		/// <value>
+		/// The height of the element in device-independent units (DIUs).
+		/// </value>
+		/// <remarks>
+		/// <para>The height of an element is set during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
+		/// </remarks>
 		public double Height
 		{
 			get { return _mockHeight == -1 ? (double)GetValue(HeightProperty) : _mockHeight; }
@@ -598,11 +607,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the desired height override of this element. This is a bindable property.
+		/// Gets or sets the desired height override of this element in device-independent units. This is a bindable property.
 		/// </summary>
+		/// <value>
+		/// The desired height in device-independent units (DIUs), or -1 if unset.
+		/// </value>
 		/// <remarks>
 		/// <para>The default value is -1, which means the value is unset; the effective minimum height will be zero.</para>
 		/// <para><see cref="HeightRequest"/> does not immediately change the <see cref="Bounds"/> of an element; setting the <see cref="HeightRequest"/> will change the resulting height of the element during the next layout pass.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
 		/// </remarks>
 		public double HeightRequest
 		{
@@ -712,11 +728,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the minimum height the element will request during layout. This is a bindable property.
+		/// Gets or sets the minimum height the element will request during layout in device-independent units. This is a bindable property.
 		/// </summary>
+		/// <value>
+		/// The minimum height in device-independent units (DIUs), or -1 if unset.
+		/// </value>
 		/// <remarks>
 		/// <para>The default value is -1, which means the value is unset and a height will be determined automatically.</para>
 		/// <para><see cref="MinimumHeightRequest"/> is used to ensure that the element has at least the specified height during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
 		/// </remarks>
 		public double MinimumHeightRequest
 		{
@@ -725,11 +748,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the minimum width the element will request during layout. This is a bindable property.
+		/// Gets or sets the minimum width the element will request during layout in device-independent units. This is a bindable property.
 		/// </summary>
+		/// <value>
+		/// The minimum width in device-independent units (DIUs), or -1 if unset.
+		/// </value>
 		/// <remarks>
 		/// <para>The default value is -1, which means the value is unset; the effective minimum width will be zero.</para>
 		/// <para><see cref="MinimumWidthRequest"/> is used to ensure that the element has at least the specified width during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
 		/// </remarks>
 		public double MinimumWidthRequest
 		{
@@ -738,11 +768,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the maximum height the element will request during layout. This is a bindable property.
+		/// Gets or sets the maximum height the element will request during layout in device-independent units. This is a bindable property.
 		/// </summary>
+		/// <value>
+		/// The maximum height in device-independent units (DIUs). The default is <see cref="double.PositiveInfinity"/>.
+		/// </value>
 		/// <remarks>
 		/// <para>The default value is <see cref="double.PositiveInfinity"/>.</para>
 		/// <para><see cref="MaximumHeightRequest"/> is used to ensure that the element has no more than the specified height during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
 		/// </remarks>
 		public double MaximumHeightRequest
 		{
@@ -751,11 +788,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the maximum width the element will request during layout. This is a bindable property.
+		/// Gets or sets the maximum width the element will request during layout in device-independent units. This is a bindable property.
 		/// </summary>
+		/// <value>
+		/// The maximum width in device-independent units (DIUs). The default is <see cref="double.PositiveInfinity"/>.
+		/// </value>
 		/// <remarks>
 		/// <para>The default value is <see cref="double.PositiveInfinity"/>.</para>
 		/// <para><see cref="MaximumWidthRequest"/> is used to ensure the element has no more than the specified width during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
 		/// </remarks>
 		public double MaximumWidthRequest
 		{
@@ -842,9 +886,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the X translation delta of the element. This is a bindable property.
+		/// Gets or sets the X translation delta of the element in device-independent units. This is a bindable property.
 		/// </summary>
-		/// <remarks>Translation is applied post layout. It is particularly good for applying animations. Translating an element outside the bounds of its parent container may prevent inputs from working.</remarks>
+		/// <value>
+		/// The X translation offset in device-independent units (DIUs).
+		/// </value>
+		/// <remarks>
+		/// <para>Translation is applied post layout. It is particularly good for applying animations. Translating an element outside the bounds of its parent container may prevent inputs from working.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
+		/// </remarks>
 		public double TranslationX
 		{
 			get { return (double)GetValue(TranslationXProperty); }
@@ -852,9 +905,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the Y translation delta of the element. This is a bindable property.
+		/// Gets or sets the Y translation delta of the element in device-independent units. This is a bindable property.
 		/// </summary>
-		/// <remarks>Translation is applied post layout. It is particularly good for applying animations. Translating an element outside the bounds of its parent container may prevent inputs from working.</remarks>
+		/// <value>
+		/// The Y translation offset in device-independent units (DIUs).
+		/// </value>
+		/// <remarks>
+		/// <para>Translation is applied post layout. It is particularly good for applying animations. Translating an element outside the bounds of its parent container may prevent inputs from working.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
+		/// </remarks>
 		public double TranslationY
 		{
 			get { return (double)GetValue(TranslationYProperty); }
@@ -867,9 +929,18 @@ namespace Microsoft.Maui.Controls
 		public IList<TriggerBase> Triggers => (IList<TriggerBase>)GetValue(TriggersProperty);
 
 		/// <summary>
-		/// Gets the current width of this element. This is a read-only bindable property.
+		/// Gets the current width of this element in device-independent units. This is a read-only bindable property.
 		/// </summary>
-		/// <remarks>The width value of an element is set during the layout cycle.</remarks>
+		/// <value>
+		/// The width of the element in device-independent units (DIUs).
+		/// </value>
+		/// <remarks>
+		/// <para>The width value of an element is set during the layout cycle.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
+		/// </remarks>
 		public double Width
 		{
 			get { return _mockWidth == -1 ? (double)GetValue(WidthProperty) : _mockWidth; }
@@ -877,11 +948,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the desired width override of this element. This is a bindable property.
+		/// Gets or sets the desired width override of this element in device-independent units. This is a bindable property.
 		/// </summary>
+		/// <value>
+		/// The desired width in device-independent units (DIUs), or -1 if unset.
+		/// </value>
 		/// <remarks>
 		/// <para>The default value is -1, which means the value is unset and a width will be determined automatically.</para>
 		/// <para><see cref="WidthRequest"/> does not immediately change the <see cref="Bounds"/> of an element; setting the <see cref="WidthRequest"/> will change the resulting width of the element during the next layout pass.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
 		/// </remarks>
 		public double WidthRequest
 		{
@@ -890,9 +968,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets the current X position of this element. This is a read-only bindable property.
+		/// Gets the current X position of this element in device-independent units. This is a read-only bindable property.
 		/// </summary>
-		/// <remarks>The position of an element is set during layout.</remarks>
+		/// <value>
+		/// The X coordinate of the element's position in device-independent units (DIUs).
+		/// </value>
+		/// <remarks>
+		/// <para>The position of an element is set during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
+		/// </remarks>
 		public double X
 		{
 			get { return _mockX == -1 ? (double)GetValue(XProperty) : _mockX; }
@@ -900,9 +987,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <summary>
-		/// Gets the current Y position of this element. This is a read-only bindable property.
+		/// Gets the current Y position of this element in device-independent units. This is a read-only bindable property.
 		/// </summary>
-		/// <remarks>The position of an element is set during layout.</remarks>
+		/// <value>
+		/// The Y coordinate of the element's position in device-independent units (DIUs).
+		/// </value>
+		/// <remarks>
+		/// <para>The position of an element is set during layout.</para>
+		/// <para>
+		/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
+		/// One device-independent unit equals one pixel on a 96-DPI display.
+		/// </para>
+		/// </remarks>
 		public double Y
 		{
 			get { return _mockY == -1 ? (double)GetValue(YProperty) : _mockY; }


### PR DESCRIPTION
## Description

Fixes dotnet/dotnet-maui-api-docs#92

This PR adds comprehensive device-independent units (DIUs) documentation to all dimensional properties in the `VisualElement` class to address the issue where developers had no indication of what units numerical values represented.

## Changes Made

Added unit specifications and explanations to the following properties:

### Position Properties
- **Width** - Added DIUs specification with detailed explanation
- **Height** - Added DIUs specification with detailed explanation  
- **X** - Added DIUs specification for position coordinates
- **Y** - Added DIUs specification for position coordinates

### Request Properties
- **WidthRequest** - Added DIUs specification with detailed explanation
- **HeightRequest** - Added DIUs specification with detailed explanation

### Size Constraint Properties
- **MinimumWidthRequest** - Added DIUs specification with detailed explanation
- **MinimumHeightRequest** - Added DIUs specification with detailed explanation
- **MaximumWidthRequest** - Added DIUs specification with detailed explanation
- **MaximumHeightRequest** - Added DIUs specification with detailed explanation

### Translation Properties
- **TranslationX** - Added DIUs specification for translation offsets
- **TranslationY** - Added DIUs specification for translation offsets

## Documentation Enhancements

Each property now includes:
- Clear unit specification in the summary and `<value>` sections
- Detailed explanation that device-independent units (DIUs) provide consistent measurement across different screen densities
- Reference definition that one device-independent unit equals one pixel on a 96-DPI display

## Impact

- **Solves the core issue**: Developers now know exactly what units these dimensional properties use
- **Consistent documentation**: All dimensional properties now have uniform documentation patterns
- **Educational content**: Explains what DIUs are and why they matter for cross-platform development
- **Better API usability**: Clear expectations for property values improve developer experience

## Example Before/After

**Before:**
```csharp
/// <summary>
/// Gets the current width of this element. This is a read-only bindable property.
/// </summary>
/// <remarks>The width value of an element is set during the layout cycle.</remarks>
public double Width { get; }
```

**After:**
```csharp
/// <summary>
/// Gets the current width of this element in device-independent units. This is a read-only bindable property.
/// </summary>
/// <value>
/// The width of the element in device-independent units (DIUs).
/// </value>
/// <remarks>
/// <para>The width value of an element is set during the layout cycle.</para>
/// <para>
/// Device-independent units (DIUs) provide a consistent unit of measurement across different screen densities.
/// One device-independent unit equals one pixel on a 96-DPI display.
/// </para>
/// </remarks>
public double Width { get; }
```

## Testing

- [x] No compilation errors
- [x] Documentation follows C# XML documentation standards
- [x] Consistent formatting across all affected properties