### PR TITLE
[iOS, Android] Fix for CollectionView IsEnabled=false allows touch interactions

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -524,6 +524,28 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			// If ItemsView is disabled, don't handle touch events
+			if (ItemsView?.IsEnabled == false)
+			{
+				return false;
+			}
+
+			return base.OnTouchEvent(e);
+		}
+
+		public override bool OnInterceptTouchEvent(MotionEvent e)
+		{
+			// If ItemsView is disabled, intercept all touch events to prevent interactions
+			if (ItemsView?.IsEnabled == false)
+			{
+				return true;
+			}
+
+			return base.OnInterceptTouchEvent(e);
+		}
+
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			base.OnLayout(changed, l, t, r, b);

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
+~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19771.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19771.cs
@@ -1,0 +1,93 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 19771, "CollectionView IsEnabled=false allows touch interactions on iOS and Android", PlatformAffected.iOS | PlatformAffected.Android)]
+public class Issue19771 : ContentPage
+{
+	const string DisableButton = "DisableButton";
+	const string TestCollectionView = "TestCollectionView";
+	const string InteractionCountLabel = "InteractionCountLabel";
+	const string StatusLabel = "StatusLabel";
+
+	private int _interactionCount = 0;
+	private Label _interactionLabel;
+	private Label _statusLabel;
+	private CollectionView _collectionView;
+
+	public Issue19771()
+	{
+		var items = new List<string> { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
+
+		_statusLabel = new Label
+		{
+			AutomationId = StatusLabel,
+			Text = "CollectionView is ENABLED",
+			FontSize = 16,
+			FontAttributes = FontAttributes.Bold,
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(10)
+		};
+
+		_interactionLabel = new Label
+		{
+			AutomationId = InteractionCountLabel,
+			Text = "Interaction Count: 0",
+			FontSize = 14,
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(5)
+		};
+
+		var disableButton = new Button
+		{
+			AutomationId = DisableButton,
+			Text = "IsEnabled=False",
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(10)
+		};
+		disableButton.Clicked += (s, e) => SetEnabled(false);
+
+		_collectionView = new CollectionView
+		{
+			AutomationId = TestCollectionView,
+			Background = Colors.AliceBlue,
+			ItemsSource = items,
+			SelectionMode = SelectionMode.Single,
+			HeightRequest = 300,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid { Padding = 10 };
+				var label = new Label { TextColor = Colors.Black };
+				label.SetBinding(Label.TextProperty, ".");
+				grid.Children.Add(label);
+				return grid;
+			})
+		};
+
+		_collectionView.SelectionChanged += (s, e) =>
+		{
+			_interactionCount++;
+			_interactionLabel.Text = $"Interaction Count: {_interactionCount}";
+		};
+
+		Content = new StackLayout
+		{
+			Children = 
+			{
+				_statusLabel,
+				_interactionLabel,
+				new StackLayout
+				{
+					Orientation = StackOrientation.Horizontal,
+					HorizontalOptions = LayoutOptions.Center,
+					Children = { disableButton }
+				},
+				_collectionView
+			}
+		};
+	}
+
+	private void SetEnabled(bool isEnabled)
+	{
+		_collectionView.IsEnabled = isEnabled;
+		_statusLabel.Text = isEnabled ? "CollectionView is ENABLED" : "CollectionView is DISABLED";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19771.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19771.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue19771 : _IssuesUITest
+{
+	public Issue19771(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "CollectionView IsEnabled=false allows touch interactions on iOS and Android";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewIsEnabledFalsePreventsInteractions()
+	{
+		App.WaitForElement("Item 1");
+		App.Tap("Item 1");
+        App.WaitForElement("DisableButton");
+        App.Tap("DisableButton");
+        App.WaitForElement("Item 3");
+		App.Tap("Item 3");
+		var text = App.WaitForElement("InteractionCountLabel").GetText();
+		Assert.That(text, Is.EqualTo("Interaction Count: 1"));
+	}
+}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -17,10 +17,16 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIsEnabled(this UIView platformView, IView view)
 		{
-			if (platformView is not UIControl uiControl)
-				return;
-
-			uiControl.Enabled = view.IsEnabled;
+			if (platformView is UIControl uiControl)
+			{
+				// UIControl has native Enabled property with visual feedback
+				uiControl.Enabled = view.IsEnabled;
+			}
+			else
+			{
+				// Non-UIControl views (like UICollectionView) only get interaction disable
+				platformView.UserInteractionEnabled = view.IsEnabled;
+			}
 		}
 
 		public static void Focus(this UIView platformView, FocusRequest request)


### PR DESCRIPTION
### Root Cause

**iOS**
The underlying `UICollectionView` does not inherit from `UIControl`, so it has no native Enabled property. In `ViewExtensions.UpdateIsEnabled`, this caused an early return for non-UIControl views, leaving touch interactions active when `IsEnabled = false`.

**Android**
`RecyclerView` does not support a native enabled/disabled state. While `UpdateIsEnabled` is called when `IsEnabled = false`, there was no platform-specific handling, so touch interactions remained functional.
 
### Description of Change

**iOS**
Modified `ViewExtensions.UpdateIsEnabled` to branch between UIControl and non-UIControl views. For UIControl, the native Enabled property is applied to block interactions and provide visual feedback. For non-UIControl views such as `UICollectionView`, `UserInteractionEnabled` is set to disable touch input while preserving visual appearance.

**Android**
Enhanced `MauiRecyclerView` with touch event overrides to handle the disabled state. `OnInterceptTouchEvent` returns true when the CollectionView is disabled, blocking child interactions. `OnTouchEvent` returns false to prevent `RecyclerView` itself from processing gestures. Both methods check `ItemsView?.IsEnabled` to ensure correct state handling.
 
### Issues Fixed
Fixes #19771 
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/2bab10f4-f614-4457-a97b-193e1abab866">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/ed8e29f2-5bd6-4365-a928-cfca67a4ae6e">|