### PR TITLE
Document FillPath exceptions and improve PathF documentation

### DIFF
--- a/src/Graphics/src/Graphics/CanvasExtensions.cs
+++ b/src/Graphics/src/Graphics/CanvasExtensions.cs
@@ -152,11 +152,48 @@ namespace Microsoft.Maui.Graphics
 			target.DrawPath(path);
 		}
 
+		/// <summary>
+		/// Fills the specified path using the current fill color and the non-zero winding rule.
+		/// </summary>
+		/// <param name="target">The canvas to draw on.</param>
+		/// <param name="path">The path to fill.</param>
+		/// <exception cref="System.ArgumentException">
+		/// Thrown when the path is invalid for fill operations. This can occur when:
+		/// <list type="bullet">
+		/// <item><description>The path is empty or contains no drawable segments</description></item>
+		/// <item><description>The path contains invalid coordinates or operations</description></item>
+		/// <item><description>The path is not properly formed for the underlying graphics implementation</description></item>
+		/// </list>
+		/// </exception>
+		/// <remarks>
+		/// For best results with fill operations, ensure the path represents a closed shape by calling
+		/// <see cref="PathF.Close()"/> or manually connecting the end point back to the start point.
+		/// Unclosed paths may produce unexpected results or exceptions depending on the graphics backend.
+		/// </remarks>
 		public static void FillPath(this ICanvas target, PathF path)
 		{
 			target.FillPath(path, WindingMode.NonZero);
 		}
 
+		/// <summary>
+		/// Fills the specified path using the current fill color and the specified winding rule.
+		/// </summary>
+		/// <param name="target">The canvas to draw on.</param>
+		/// <param name="path">The path to fill.</param>
+		/// <param name="windingMode">The winding rule to use for determining which areas are inside the path.</param>
+		/// <exception cref="System.ArgumentException">
+		/// Thrown when the path is invalid for fill operations. This can occur when:
+		/// <list type="bullet">
+		/// <item><description>The path is empty or contains no drawable segments</description></item>
+		/// <item><description>The path contains invalid coordinates or operations</description></item>
+		/// <item><description>The path is not properly formed for the underlying graphics implementation</description></item>
+		/// </list>
+		/// </exception>
+		/// <remarks>
+		/// For best results with fill operations, ensure the path represents a closed shape by calling
+		/// <see cref="PathF.Close()"/> or manually connecting the end point back to the start point.
+		/// Unclosed paths may produce unexpected results or exceptions depending on the graphics backend.
+		/// </remarks>
 		public static void FillPath(this ICanvas target, PathF path, WindingMode windingMode)
 		{
 			target.FillPath(path, windingMode);

--- a/src/Graphics/src/Graphics/PathF.cs
+++ b/src/Graphics/src/Graphics/PathF.cs
@@ -8,6 +8,17 @@ namespace Microsoft.Maui.Graphics
 	/// <summary>
 	/// Represents a geometric path consisting of lines, curves, and shapes using single-precision floating-point coordinates.
 	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// A path is composed of one or more sub-paths, each beginning with a Move operation and consisting of connected
+	/// line segments, curves, and arcs. For fill operations to work reliably, paths should typically be closed using
+	/// the <see cref="Close()"/> method or by explicitly connecting the end point back to the starting point.
+	/// </para>
+	/// <para>
+	/// When creating paths for filling, ensure proper path construction to avoid exceptions during rendering.
+	/// Paths that start with <see cref="LineTo(PointF)"/> operations will automatically create an initial MoveTo operation.
+	/// </para>
+	/// </remarks>
 	public class PathF : IDisposable
 	{
 		private const float K_RATIO = 0.551784777779014f; // ideal ratio of cubic Bezier points for a quarter circle
@@ -358,6 +369,11 @@ namespace Microsoft.Maui.Graphics
 		/// <summary>
 		/// Closes the current sub-path by appending a close segment if it is not already closed.
 		/// </summary>
+		/// <remarks>
+		/// Closing a path is typically required for fill operations to work correctly. Attempting to fill
+		/// an unclosed path may result in undefined behavior or exceptions in some graphics implementations.
+		/// A closed path ensures that the shape is properly defined for filling operations.
+		/// </remarks>
 		public void Close()
 		{
 			if (!Closed)
@@ -401,6 +417,11 @@ namespace Microsoft.Maui.Graphics
 		/// </summary>
 		/// <param name="point">The end point.</param>
 		/// <returns>The current path.</returns>
+		/// <remarks>
+		/// If this is the first operation on an empty path, it will automatically create an initial MoveTo operation
+		/// to the specified point. For paths intended to be filled, ensure the path forms a closed shape by calling
+		/// <see cref="Close()"/> or explicitly connecting back to the starting point.
+		/// </remarks>
 		public PathF LineTo(PointF point)
 		{
 			if (_points.Count == 0)


### PR DESCRIPTION
- Add comprehensive documentation for CanvasExtensions.FillPath methods explaining ArgumentException scenarios
- Document potential exceptions when path is empty, invalid, or improperly formed
- Enhance PathF.LineTo documentation with remarks about fill operations
- Improve PathF.Close documentation explaining importance for fill operations
- Add class-level documentation for PathF with guidance on proper path construction for filling
- Include recommendations for using Close() method to ensure reliable fill operations

Fixes: https://github.com/dotnet/dotnet-maui-api-docs/issues/113
