### PR TITLE
Fixes text centering causing offsets by some glyphs

### DIFF
--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Maui
 			using (var ds = canvasImageSource.CreateDrawingSession(UI.Colors.Transparent))
 			{
 				var x = (canvasWidth / 2d + (layout.LayoutBounds.Left + layout.DefaultFontSize / 2)); 
-                var y = (canvasHeight / 2d + (layout.LayoutBounds.Top + layout.DefaultFontSize / 2));
+				var y = (canvasHeight / 2d + (layout.LayoutBounds.Top + layout.DefaultFontSize / 2));
 
 				ds.DrawTextLayout(layout, (float)x, (float)y, color);
 			}

--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
@@ -86,9 +86,8 @@ namespace Microsoft.Maui
 			var canvasImageSource = new CanvasImageSource(device, canvasWidth, canvasHeight, dpi);
 			using (var ds = canvasImageSource.CreateDrawingSession(UI.Colors.Transparent))
 			{
-				// offset by 1px as we added a 1px padding
-				var x = (layout.DrawBounds.X * -1) + 1;
-				var y = (layout.DrawBounds.Y * -1) + 1;
+				var x = (canvasWidth / 2d + (layout.LayoutBounds.Left + layout.DefaultFontSize / 2)); 
+                var y = (canvasHeight / 2d + (layout.LayoutBounds.Top + layout.DefaultFontSize / 2));
 
 				ds.DrawTextLayout(layout, (float)x, (float)y, color);
 			}


### PR DESCRIPTION
### Description of Change

The font alignment calculation was wrong, often causing the symbols to be offset when rendering using `FontImageSource`.

### Issues Fixed

Fixes #30004

Below is an example of the adjustment. First column using `<Label />` to render the Glyph, second is how MAUI currently renders it, and 3rd column with the fix applied. I applied a background to the two images, to make it clear that the generated image sizes hasn't changed, only the alignment within them.
<img width="193" height="807" alt="image" src="https://github.com/user-attachments/assets/7f89febd-6462-4f8b-981f-d673cecbc55c" />
