### PR TITLE
[XSG] Fix ValueProvider creation

### DIFF
--- a/src/Controls/src/SourceGen/ServiceProviderExtensions.cs
+++ b/src/Controls/src/SourceGen/ServiceProviderExtensions.cs
@@ -40,37 +40,38 @@ static class ServiceProviderExtensions
 	static void AddServices(this INode node, IndentedTextWriter writer, string serviceProviderVariableName, ImmutableArray<ITypeSymbol>? requiredServices, SourceGenContext context, IFieldSymbol? bpFieldSymbol, IPropertySymbol? propertySymbol)
 	{
 		var createAllServices = requiredServices is null;
-		var objectAndParents = node.ObjectAndParents(context).ToArray();
-		if ((createAllServices
+		var parentObjects = node.ParentObjects(context).Select(v => v.Name).ToArray();
+		if (parentObjects.Length == 0)
+			parentObjects = ["null"];
+		if (createAllServices
 				|| requiredServices!.Value.Contains(context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.IProvideParentValues")!, SymbolEqualityComparer.Default)
 				|| requiredServices!.Value.Contains(context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.IProvideValueTarget")!, SymbolEqualityComparer.Default)
 				|| requiredServices!.Value.Contains(context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.IReferenceProvider")!, SymbolEqualityComparer.Default))
-			&& objectAndParents.Length > 0)
-		{
-			var simpleValueTargetProvider = NamingHelpers.CreateUniqueVariableName(context, context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.IProvideValueTarget")!);
-			writer.WriteLine($"var {simpleValueTargetProvider} = new global::Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider(");
-			writer.Indent++;
-			writer.WriteLine($"new object[] {{{string.Join(", ", node.ObjectAndParents(context).Select(v => v.Name))}}},");
-			var bpinfo = bpFieldSymbol?.ToFQDisplayString() ?? String.Empty;
-			var pinfo = $"typeof({propertySymbol?.ContainingSymbol.ToFQDisplayString()}).GetProperty(\"{propertySymbol?.Name}\")" ?? string.Empty;
-			writer.WriteLine($"{(bpFieldSymbol != null ? bpFieldSymbol : propertySymbol != null ? pinfo : "null")},");
-			if (context.Scopes.TryGetValue(node, out var scope))
 			{
-				List<string> scopes = [scope.namescope.Name];
-				var values = context.ParentContext?.Scopes.Select(s => s.Value.namescope.Name).Distinct();
-				scopes.AddRange(values ?? Enumerable.Empty<string>());
-				using (PrePost.NewConditional(writer, "!_MAUIXAML_SG_NAMESCOPE_DISABLE", orElse: () => writer.WriteLine($"null,")))
+				var simpleValueTargetProvider = NamingHelpers.CreateUniqueVariableName(context, context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.IProvideValueTarget")!);
+				writer.WriteLine($"var {simpleValueTargetProvider} = new global::Microsoft.Maui.Controls.Xaml.Internals.SimpleValueTargetProvider(");
+				writer.Indent++;
+				writer.WriteLine($"new object?[] {{{string.Join(", ", parentObjects)}}},");
+				var bpinfo = bpFieldSymbol?.ToFQDisplayString() ?? String.Empty;
+				var pinfo = $"typeof({propertySymbol?.ContainingSymbol.ToFQDisplayString()}).GetProperty(\"{propertySymbol?.Name}\")" ?? string.Empty;
+				writer.WriteLine($"{(bpFieldSymbol != null ? bpFieldSymbol : propertySymbol != null ? pinfo : "null")},");
+				if (context.Scopes.TryGetValue(node, out var scope))
 				{
-					writer.WriteLine($"new [] {{ {string.Join(", ", scopes)} }},");
+					List<string> scopes = [scope.namescope.Name];
+					var values = context.ParentContext?.Scopes.Select(s => s.Value.namescope.Name).Distinct();
+					scopes.AddRange(values ?? Enumerable.Empty<string>());
+					using (PrePost.NewConditional(writer, "!_MAUIXAML_SG_NAMESCOPE_DISABLE", orElse: () => writer.WriteLine($"null,")))
+					{
+						writer.WriteLine($"new [] {{ {string.Join(", ", scopes)} }},");
+					}
 				}
+				else
+					writer.WriteLine($"null,");
+				writer.WriteLine($"this);");
+				writer.Indent--;
+				writer.WriteLine($"{serviceProviderVariableName}.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IReferenceProvider), {simpleValueTargetProvider});");
+				writer.WriteLine($"{serviceProviderVariableName}.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IProvideValueTarget), {simpleValueTargetProvider});");
 			}
-			else
-				writer.WriteLine($"null,");
-			writer.WriteLine($"false);");
-			writer.Indent--;
-			writer.WriteLine($"{serviceProviderVariableName}.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IReferenceProvider), {simpleValueTargetProvider});");
-			writer.WriteLine($"{serviceProviderVariableName}.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IProvideValueTarget), {simpleValueTargetProvider});");
-		}
 
 		if (createAllServices
 			|| requiredServices!.Value.Contains(context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.IXamlTypeResolver")!, SymbolEqualityComparer.Default))
@@ -85,13 +86,11 @@ static class ServiceProviderExtensions
 		}
 	}
 
-	static IEnumerable<LocalVariable> ObjectAndParents(this INode node, SourceGenContext context)
+	static IEnumerable<LocalVariable> ParentObjects(this INode node, SourceGenContext context)
 	{
 		var currentCtx = context;
 		while (currentCtx != null)
 		{
-			if (currentCtx.Variables.TryGetValue(node, out var variable))
-				yield return variable;
 			var n = node.Parent;
 			while (n is not null)
 			{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh3862.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh3862.xaml.cs
@@ -19,11 +19,7 @@ public partial class Gh3862 : ContentPage
 		[TearDown] public void TearDown() => DeviceInfo.SetCurrent(null);
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformMarkupInStyle([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void OnPlatformMarkupInStyle([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new Gh3862(inflator);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh4319.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh4319.xaml.cs
@@ -18,11 +18,7 @@ public partial class Gh4319 : ContentPage
 		[TearDown] public void TearDown() => DeviceInfo.SetCurrent(null);
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformMarkupAndNamedSizes([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void OnPlatformMarkupAndNamedSizes([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new Gh4319(inflator);

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatform.xaml.cs
@@ -26,11 +26,7 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void BoolToVisibility([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void BoolToVisibility([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);
@@ -42,11 +38,7 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void DoubleToWidth([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void DoubleToWidth([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);
@@ -62,11 +54,8 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void StringToText([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
+
 		public void StringToText([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);
@@ -82,11 +71,8 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformAsResource([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
+
 		public void OnPlatformAsResource([Values] XamlInflator inflator)
-#endif
 		{
 			var layout = new OnPlatform(inflator);
 			var onplat = layout.Resources["fontAttributes"] as OnPlatform<FontAttributes>;
@@ -100,11 +86,8 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformAsResourceAreApplied([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
+
 		public void OnPlatformAsResourceAreApplied([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);
@@ -120,11 +103,8 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatform2Syntax([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
+
 		public void OnPlatform2Syntax([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.Android;
 			var layout = new OnPlatform(inflator);
@@ -144,11 +124,7 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformDefault([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void OnPlatformDefault([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.Create("\ud83d\ude80");
 			var layout = new OnPlatform(inflator);
@@ -156,11 +132,7 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformInStyle0([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void OnPlatformInStyle0([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);
@@ -172,11 +144,7 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformInStyle1([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void OnPlatformInStyle1([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);
@@ -188,11 +156,7 @@ public partial class OnPlatform : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void OnPlatformInline([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void OnPlatformInline([Values] XamlInflator inflator)
-#endif
 		{
 			mockDeviceInfo.Platform = DevicePlatform.iOS;
 			var layout = new OnPlatform(inflator);

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml.cs
@@ -24,11 +24,7 @@ public partial class OnPlatformOptimization : ContentPage
 		}
 
 		[Test]
-#if FIXME_BEFORE_PUBLIC_RELEASE
-		public void ValuesAreSet([Values(XamlInflator.XamlC, XamlInflator.Runtime)] XamlInflator inflator)
-#else
 		public void ValuesAreSet([Values] XamlInflator inflator)
-#endif
 		{
 			var p = new OnPlatformOptimization(inflator);
 			Assert.AreEqual("ringo", p.label0.Text);


### PR DESCRIPTION
### Description of Change, Issues fixed

ValueProvider expects the first object to be the parent, not the caller.

Also 
- fixes #31381
