### PR TITLE
Fix loading ResourceDictionary from source

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui31308"
+             Title="Maui31308">
+    <ContentPage.Resources>
+        <ResourceDictionary Source="Maui31308_Style.xaml" />
+    </ContentPage.Resources>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308.xaml.cs
@@ -18,11 +18,6 @@ public partial class Maui31308
 {
 	public Maui31308() => InitializeComponent();
 
-	public Maui31308(bool useCompiledXaml)
-	{
-		//this stub will be replaced at compile time
-	}
-
 	[TestFixture]
 	class Test
 	{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308.xaml.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui31308
+{
+	public Maui31308() => InitializeComponent();
+
+	public Maui31308(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Test
+	{
+		[SetUp]
+		public void Setup()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+		[Test]
+		public void MissingResourceDictionaryValueIsReported([Values] XamlInflator inflator)
+		{
+			var exception = Assert.Catch<XamlParseException>(() => new Maui31308(inflator));
+			Assert.AreEqual("Position 6:38. StaticResource not found for key ThisKeyDoesNotExistInAnyResourceDictionary", exception.Message);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308_Style.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308_Style.xaml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui31308_Style">
+    <Style TargetType="Label">
+        <Setter Property="TextColor" Value="{StaticResource ThisKeyDoesNotExistInAnyResourceDictionary}" />
+    </Style>
+</ResourceDictionary>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308_Style.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31308_Style.xaml.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Maui31308_Style : ResourceDictionary
+	{
+		public Maui31308_Style()
+		{
+			InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

This PR fixes a bug where loading ResourceDictionary from Source will swallow any exceptions thrown during RD inflation. Whenever we catch `TargetInvocationException`, we re-throw the inner exception.

### Issues Fixed

Fixes #31308