### PR TITLE
Added UpdateTextColor extension for TimePicker (fixed test failure in August 25th, 2025 Candidate)

### DIFF
--- a/src/Core/src/Platform/Android/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/TimePickerExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Platform
 			mauiTimePicker.Text = time.ToFormattedString(format);
 		}
 
-		// Make it public in Net10
+		// TODO: Make it public in Net10
 		internal static void UpdateTextColor(this MauiTimePicker platformTimePicker, ITimePicker timePicker)
 		{
 			var textColor = timePicker.TextColor;

--- a/src/Core/src/Platform/Android/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/TimePickerExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui.Platform
+﻿using Android.Content.Res;
+
+namespace Microsoft.Maui.Platform
 {
 	public static class TimePickerExtensions
 	{
@@ -18,6 +20,17 @@
 			var format = timePicker.Format;
 
 			mauiTimePicker.Text = time.ToFormattedString(format);
+		}
+
+		internal static void UpdateTextColor(this MauiTimePicker platformTimePicker, ITimePicker timePicker)
+		{
+			var textColor = timePicker.TextColor;
+
+			if (textColor != null)
+			{
+				if (PlatformInterop.CreateEditTextColorStateList(platformTimePicker.TextColors, textColor.ToPlatform()) is ColorStateList c)
+					platformTimePicker.SetTextColor(c);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Introduces an internal UpdateTextColor method to TimePickerExtensions for updating the text color of MauiTimePicker based on the ITimePicker's TextColor property.

Fixes https://github.com/dotnet/maui/pull/31327#issuecomment-3244913810