### PR TITLE
[Windows] Fix RefreshView Command executes multiple times when IsRefreshing is set to True

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31375.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31375.cs
@@ -29,26 +29,24 @@ public class Issue31375 : ContentPage
 		_textLabel = new Label() { AutomationId = "CounterLabel" };
 		_textLabel.Text = count++.ToString();
 
-		var refreshView = new RefreshView
-		{
-			Margin = 16,
-			Content = new VerticalStackLayout
-		{
-			Children = { button, _textLabel }
-		}
-		};
-
-		Content = refreshView;
-
 		// Set BindingContext
 		BindingContext = this;
 
 		// Assign command
 		RefreshCommand = new Command(AddItems);
+		var refreshView = new RefreshView
+		{
+			Margin = 16,
+			Content = _textLabel,
+		};
 		refreshView.SetBinding(RefreshView.IsRefreshingProperty, nameof(IsLoading));
 		refreshView.SetBinding(RefreshView.CommandProperty, nameof(RefreshCommand));
+		Content = new StackLayout
+		{
+			Children = { refreshView, button }
+		};
 	}
-	
+
 	void Button_Clicked(object sender, EventArgs e)
     {
         IsLoading = true;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31375.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31375.cs
@@ -1,0 +1,62 @@
+﻿using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31375, "[Windows] RefreshView Command executes multiple times when IsRefreshing is set to True", PlatformAffected.UWP)]
+public class Issue31375 : ContentPage
+{
+	bool _isLoading = false;
+	Label _textLabel;
+	int count = 0;
+
+	public bool IsLoading
+	{
+		get => _isLoading;
+		set
+		{
+			_isLoading = value;
+			OnPropertyChanged(nameof(IsLoading));
+		}
+	}
+
+	public ICommand RefreshCommand { get; set; }
+	public Issue31375()
+	{
+		// Create UI elements
+		var button = new Button { Text = "Click To Refresh", AutomationId = "RefreshButton" };
+		button.Clicked += Button_Clicked;
+
+		_textLabel = new Label() { AutomationId = "CounterLabel" };
+		_textLabel.Text = count++.ToString();
+
+		var refreshView = new RefreshView
+		{
+			Margin = 16,
+			Content = new VerticalStackLayout
+		{
+			Children = { button, _textLabel }
+		}
+		};
+
+		Content = refreshView;
+
+		// Set BindingContext
+		BindingContext = this;
+
+		// Assign command
+		RefreshCommand = new Command(AddItems);
+		refreshView.SetBinding(RefreshView.IsRefreshingProperty, nameof(IsLoading));
+		refreshView.SetBinding(RefreshView.CommandProperty, nameof(RefreshCommand));
+	}
+	
+	void Button_Clicked(object sender, EventArgs e)
+    {
+        IsLoading = true;
+    }
+
+    void AddItems()
+    {
+        IsLoading = false;
+        _textLabel.Text = count++.ToString();
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31375.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31375.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue31375 : _IssuesUITest
+	{
+		public Issue31375(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "[Windows] RefreshView Command executes multiple times when IsRefreshing is set to True";
+
+		[Test]
+		[Category(UITestCategories.RefreshView)]
+		public void VerifyRefreshViewCommandExecution()
+		{
+			App.WaitForElement("CounterLabel");
+			App.Tap("RefreshButton");
+			Assert.That(App.FindElement("CounterLabel").GetText(), Is.EqualTo("1"));
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31375.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31375.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		{
 			App.WaitForElement("CounterLabel");
 			App.Tap("RefreshButton");
-			Assert.That(App.FindElement("CounterLabel").GetText(), Is.EqualTo("1"));
+			App.Tap("RefreshButton");
+			Assert.That(App.FindElement("CounterLabel").GetText(), Is.EqualTo("2"));
 		}
 	}
 }

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Maui.Handlers
 	{
 		bool _isLoaded;
 		Deferral? _refreshCompletionDeferral;
-		bool isProgrammaticRefresh;
 
 		protected override RefreshContainer CreatePlatformView()
 		{
@@ -70,7 +69,6 @@ namespace Microsoft.Maui.Handlers
 				CompleteRefresh();
 			else if (_refreshCompletionDeferral == null)
 			{
-				isProgrammaticRefresh = true;
 				PlatformView?.RequestRefresh();
 			}
 		}
@@ -143,12 +141,9 @@ namespace Microsoft.Maui.Handlers
 			CompleteRefresh();
 			_refreshCompletionDeferral = args.GetDeferral();
 
-			if (VirtualView != null)
+			if (VirtualView != null && !VirtualView.IsRefreshing)
 			{
-				if (!isProgrammaticRefresh)
-					VirtualView.IsRefreshing = true;
-
-				isProgrammaticRefresh = false;
+				VirtualView.IsRefreshing = true;
 			}
 		}
 

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -144,7 +144,6 @@ namespace Microsoft.Maui.Handlers
 			_refreshCompletionDeferral = args.GetDeferral();
 
 			if (VirtualView != null)
-				VirtualView.IsRefreshing = true;
 			{
 				if (!isProgrammaticRefresh)
 					VirtualView.IsRefreshing = true;

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Maui.Handlers
 				CompleteRefresh();
 			else if (_refreshCompletionDeferral == null)
 			{
+				isProgrammaticRefresh = true;
 				PlatformView?.RequestRefresh();
 			}
 		}

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		bool _isLoaded;
 		Deferral? _refreshCompletionDeferral;
+		bool isProgrammaticRefresh;
 
 		protected override RefreshContainer CreatePlatformView()
 		{
@@ -68,7 +69,9 @@ namespace Microsoft.Maui.Handlers
 			if (!VirtualView?.IsRefreshing ?? false)
 				CompleteRefresh();
 			else if (_refreshCompletionDeferral == null)
+			{
 				PlatformView?.RequestRefresh();
+			}
 		}
 
 		static void UpdateContent(IRefreshViewHandler handler)
@@ -141,6 +144,12 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView != null)
 				VirtualView.IsRefreshing = true;
+			{
+				if (!isProgrammaticRefresh)
+					VirtualView.IsRefreshing = true;
+
+				isProgrammaticRefresh = false;
+			}
 		}
 
 		void CompleteRefresh()

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -68,9 +68,7 @@ namespace Microsoft.Maui.Handlers
 			if (!VirtualView?.IsRefreshing ?? false)
 				CompleteRefresh();
 			else if (_refreshCompletionDeferral == null)
-			{
 				PlatformView?.RequestRefresh();
-			}
 		}
 
 		static void UpdateContent(IRefreshViewHandler handler)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause
On Windows, setting IsRefreshing = true programmatically triggered RequestRefresh(), which fired the refresh event again and caused an infinite loop.

### Description of Change

<!-- Enter description of the fix in this section -->
In the Refresh event, the IsRefreshing property should be set to true only when its current value is false. This prevents unnecessary refresh cycles and avoids triggering the refresh logic repeatedly when it is already in progress.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #31375 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Validated the behaviour in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot
| Before  | After  |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/e6d83689-ceaa-443e-adfd-b5682f756beb" width="600" height="300" controls></video>   |   <video src="https://github.com/user-attachments/assets/b81ebdc3-47bf-40f9-a32f-2b1ad6c813df" width="600" height="300" controls></video>   |
