### PR TITLE
Fix `DisplayAlert` to properly pass the `cancel` parameter to `DisplayAlertAsync`

### DIFF
--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Maui.Controls
 		/// <inheritdoc cref="DisplayAlertAsync(string, string, string, string, FlowDirection)"/>
 		[Obsolete("Use DisplayAlertAsync instead")]
 		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection)
-			=> DisplayAlertAsync(title, message, accept, null, flowDirection);
+			=> DisplayAlertAsync(title, message, accept, cancel, flowDirection);
 
 		/// <inheritdoc cref="DisplayAlertAsync(string, string, string, string, FlowDirection)"/>
 		public Task DisplayAlertAsync(string title, string message, string cancel)


### PR DESCRIPTION
### Description of Change

Fixed ArgumentNullException in `Page.DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection)`.

### Issues Fixed

Fixes #31473 
