### PR TITLE
Avoid useless measure passes on iOS

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.iOS.cs
@@ -74,9 +74,11 @@ namespace Microsoft.Maui.DeviceTests
 
 				// Wait for image to load and force the grid to measure itself again
 				await Task.Delay(1000);
-#pragma warning disable CS0618 // Type or member is obsolete
+
+				// The layout and buttons are not connected to a window, so the measure invalidation won't propagate.
+				// Therefore, we have to invalidate and measure the layout manually.
+				layout.InvalidateMeasure();
 				layout.Measure(double.PositiveInfinity, double.PositiveInfinity);
-#pragma warning restore CS0618 // Type or member is obsolete
 
 				await handler.ToPlatform().AssertContainsColor(Colors.Blue, MauiContext); // Grid renders
 				await handler.ToPlatform().AssertContainsColor(Colors.Red, MauiContext); // Image within button renders

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25671.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25671.cs
@@ -42,13 +42,13 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			var arrangePasses = int.Parse(match.Groups[2].Value);
 
 #if IOS
-            var maxMeasurePasses = 225;
-            var maxArrangePasses = 247;
+			var maxMeasurePasses = 203;
+			var maxArrangePasses = 214;
 
             if (App.FindElement("HeadingLabel").GetText() == "CollectionViewHandler2")
             {
-	            maxMeasurePasses = 380;
-	            maxArrangePasses = 295;
+	            maxMeasurePasses = 373;
+	            maxArrangePasses = 276;
             }
 #elif ANDROID
 			const int maxMeasurePasses = 353;

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -36,6 +36,13 @@ namespace Microsoft.Maui.Platform
 		double _lastMeasureWidth = double.NaN;
 
 		/// <summary>
+		/// Cached measured cross-platform size from the last measure operation tight to <see cref="_lastMeasureWidth"/> and <see cref="_lastMeasureHeight"/>.
+		/// Used to avoid redundant measure calls when constraints haven't changed.
+		/// NaN indicates no previous measure has been performed.
+		/// </summary>
+		Size? _lastMeasuredSize;
+
+		/// <summary>
 		/// Current safe area padding values (top, left, bottom, right) in device-independent units.
 		/// These values represent the insets needed to avoid system UI elements like status bars,
 		/// navigation bars, and home indicators.
@@ -348,15 +355,34 @@ namespace Microsoft.Maui.Platform
 		/// <returns>True if the cached measure is still valid, false otherwise</returns>
 		protected bool IsMeasureValid(double widthConstraint, double heightConstraint)
 		{
-			return !HasFixedConstraints
-				&& widthConstraint == _lastMeasureWidth
+			return widthConstraint == _lastMeasureWidth
 				&& heightConstraint == _lastMeasureHeight;
 		}
 
+		/// <summary>
+		/// Caches the measure constraints and the resulting measured size from the last measure operation.
+		/// </summary>
+		/// <param name="widthConstraint">The width constraint used.</param>
+		/// <param name="heightConstraint">The height constraint used.</param>
+		[Obsolete("Use CacheMeasureConstraints(double widthConstraint, double heightConstraint, Size measuredSize) instead.")]
 		protected void CacheMeasureConstraints(double widthConstraint, double heightConstraint)
 		{
 			_lastMeasureWidth = widthConstraint;
 			_lastMeasureHeight = heightConstraint;
+			_lastMeasuredSize = null;
+		}
+
+		/// <summary>
+		/// Caches the measure constraints and the resulting measured size from the last measure operation.
+		/// </summary>
+		/// <param name="widthConstraint">The width constraint used.</param>
+		/// <param name="heightConstraint">The height constraint used.</param>
+		/// <param name="measuredSize">The resulting measured cross-platform size.</param>
+		protected void CacheMeasureConstraints(double widthConstraint, double heightConstraint, Size measuredSize)
+		{
+			_lastMeasureWidth = widthConstraint;
+			_lastMeasureHeight = heightConstraint;
+			_lastMeasuredSize = measuredSize;
 		}
 
 		/// <summary>
@@ -366,7 +392,7 @@ namespace Microsoft.Maui.Platform
 		/// <returns>True if the view has been measured, false otherwise</returns>
 		bool HasBeenMeasured()
 		{
-			return !double.IsNaN(_lastMeasureWidth) && !double.IsNaN(_lastMeasureHeight);
+			return _lastMeasuredSize.HasValue;
 		}
 
 		/// <summary>
@@ -378,6 +404,7 @@ namespace Microsoft.Maui.Platform
 		{
 			_lastMeasureWidth = double.NaN;
 			_lastMeasureHeight = double.NaN;
+			_lastMeasuredSize = null;
 		}
 
 		public ICrossPlatformLayout? CrossPlatformLayout
@@ -446,9 +473,14 @@ namespace Microsoft.Maui.Platform
 			var widthConstraint = (double)size.Width;
 			var heightConstraint = (double)size.Height;
 
-			var crossPlatformSize = CrossPlatformMeasure(widthConstraint, heightConstraint);
+			if (IsMeasureValid(widthConstraint, heightConstraint) && _lastMeasuredSize is { } crossPlatformSize)
+			{
+				return crossPlatformSize.ToCGSize();
+			}
 
-			CacheMeasureConstraints(widthConstraint, heightConstraint);
+			crossPlatformSize = CrossPlatformMeasure(widthConstraint, heightConstraint);
+
+			CacheMeasureConstraints(widthConstraint, heightConstraint, crossPlatformSize);
 
 			return crossPlatformSize.ToCGSize();
 		}
@@ -499,11 +531,12 @@ namespace Microsoft.Maui.Platform
 			// imposed by the parent (i.e. scroll view) with the current bounds, except when our bounds are fixed by constraints.
 			// But we _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
 			// the window); there's no guarantee that SizeThatFits has been called in that case.
-			if (!IsMeasureValid(widthConstraint, heightConstraint) && !this.IsFinalMeasureHandledBySuperView() ||
-				!HasBeenMeasured() && HasFixedConstraints)
+			var hasFixedConstraints = HasFixedConstraints;
+			if ((hasFixedConstraints || !IsMeasureValid(widthConstraint, heightConstraint)) && !this.IsFinalMeasureHandledBySuperView() || 
+			    hasFixedConstraints && !HasBeenMeasured())
 			{
-				CrossPlatformMeasure(widthConstraint, heightConstraint);
-				CacheMeasureConstraints(widthConstraint, heightConstraint);
+				var crossPlatformSize = CrossPlatformMeasure(widthConstraint, heightConstraint);
+				CacheMeasureConstraints(widthConstraint, heightConstraint, crossPlatformSize);
 			}
 
 			CrossPlatformArrange(bounds);

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -531,9 +531,13 @@ namespace Microsoft.Maui.Platform
 			// imposed by the parent (i.e. scroll view) with the current bounds, except when our bounds are fixed by constraints.
 			// But we _do_ need LayoutSubviews to make a measurement pass if the parent is something else (for example,
 			// the window); there's no guarantee that SizeThatFits has been called in that case.
-			var hasFixedConstraints = HasFixedConstraints;
-			if ((hasFixedConstraints || !IsMeasureValid(widthConstraint, heightConstraint)) && !this.IsFinalMeasureHandledBySuperView() || 
-			    hasFixedConstraints && !HasBeenMeasured())
+			var needsMeasure = HasFixedConstraints switch
+			{
+				true => !HasBeenMeasured() || !this.IsFinalMeasureHandledBySuperView(),
+				false => !IsMeasureValid(widthConstraint, heightConstraint) && !this.IsFinalMeasureHandledBySuperView()
+			};
+
+			if (needsMeasure)
 			{
 				var crossPlatformSize = CrossPlatformMeasure(widthConstraint, heightConstraint);
 				CacheMeasureConstraints(widthConstraint, heightConstraint, crossPlatformSize);

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -59,6 +59,7 @@ Microsoft.Maui.Platform.MauiTimePicker.UpdateTime(System.TimeSpan? time) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFailNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation, Foundation.NSError! error) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFailProvisionalNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation, Foundation.NSError! error) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFinishNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation) -> void
+Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint, Microsoft.Maui.Graphics.Size measuredSize) -> void
 Microsoft.Maui.Platform.TextInputExtensions
 Microsoft.Maui.Platform.UIApplicationExtensions
 Microsoft.Maui.SafeAreaEdges

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -61,6 +61,7 @@ Microsoft.Maui.Platform.MauiTimePicker.UpdateTime(System.TimeSpan? time) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFailNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation, Foundation.NSError! error) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFailProvisionalNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation, Foundation.NSError! error) -> void
 *REMOVED*Microsoft.Maui.Platform.MauiWebViewNavigationDelegate.DidFinishNavigation(WebKit.WKWebView! webView, WebKit.WKNavigation! navigation) -> void
+Microsoft.Maui.Platform.MauiView.CacheMeasureConstraints(double widthConstraint, double heightConstraint, Microsoft.Maui.Graphics.Size measuredSize) -> void
 Microsoft.Maui.Platform.TextInputExtensions
 Microsoft.Maui.Platform.UIApplicationExtensions
 Microsoft.Maui.SafeAreaEdges


### PR DESCRIPTION
### Description of Change

So I was trying to compare my [Magnet Layout](https://nalu-development.github.io/nalu/layouts.html#magnet) to `Grid`, so I added some logs here and there.

Now here's what I discovered.
Imagine having this visual tree:

- `VerticalStackLayout` with `BindableLayout.ItemsSource`
  - `Grid` (A)
    - `Label IsVisible={Binding IsLabelVisible}`
    - `Button Command={Binding ToggleLableVisibilityCommand}`
  - `Grid` (B)
    - `Label IsVisible={Binding IsLabelVisible}`
    - `Button Command={Binding ToggleLableVisibilityCommand}`
  - `Grid` (C)
    - `Label IsVisible={Binding IsLabelVisible}`
    - `Button Command={Binding ToggleLableVisibilityCommand}`

Now suppose to tap on `Grid (A)` > `Button`, and let's leave aside `Label` and `Button` for simplicity.

Do this on android, and you will see that the following nodes gets measured :
`VerticalStackLayout`, `Grid (A)`

Do the same on iOS, and - suprise (or maybe not) - you'll get:
`VerticalStackLayout`, `Grid (A)`, `Grid (B)`, `Grid (C)`

Which means that Android is natively smart, and runs `Android.Views.View.OnMeasure` only on views on which `requestLayout` has been triggered (recursively on ancestors) OR when the measure constraints have changed.

iOS on the other side, should be smart too if it wasn't for the fact that we are overriding `SizeThatFits`.
So it's up to us to be smart and reuse the previous measure if the node has not been invalidated.

This should increase the performance by *a lot*.

Hopefully all the tests will pass.

I had to do obsolete a method `protected void CacheMeasureConstraints` and create a new version to take a new `Size measuredSize` parameter.

### Benchmark ###

Remember #25671 ?

Well, it goes from
```
var maxMeasurePasses = 225;
var maxArrangePasses = 247;
```
to
```
var maxMeasurePasses = 203;
var maxArrangePasses = 214;
```
