### PR TITLE
[Android] TapGestureRecognizer cannot be tapped using Android Talkback in MAUI - fix

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui.Controls.Platform
 		bool _inputTransparent;
 		bool _isEnabled;
 		bool? _focusableDefaultValue;
-		bool? _clickableDefaultValue;
 		protected virtual VisualElement? Element => _handler?.VirtualView as VisualElement;
 
 		View? View => Element as View;
@@ -228,15 +227,12 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					platformView.KeyPress += OnKeyPress;
 					_focusableDefaultValue ??= platformView.Focusable;
-					_clickableDefaultValue ??= platformView.Clickable;
 					platformView.Focusable = true;
-					platformView.Clickable = true;
 				}
 			}
 			else
 			{
 				_focusableDefaultValue = null;
-				_clickableDefaultValue = null;
 			}
 		}
 
@@ -292,9 +288,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (platformView is not null)
 			{
 				platformView.Focusable = _focusableDefaultValue ?? platformView.Focusable;
-				platformView.Clickable = _clickableDefaultValue ?? platformView.Clickable;
 				_focusableDefaultValue = null;
-				_clickableDefaultValue = null;
 				platformView.Touch -= OnPlatformViewTouched;
 				platformView.KeyPress -= OnKeyPress;
 			}


### PR DESCRIPTION

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Setting platformView.Clickable = true caused TalkBack to send an accessibility ACTION_CLICK instead of synthesizing the underlying MotionEvents. MAUI’s gesture pipeline (Tap / Pan / Pinch detectors) depends on raw MotionEvents; since no OnClick listener forwarded ACTION_CLICK to the gesture recognizers, the double‑tap activation never reached TapGestureRecognizer.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31483

