### PR TITLE
Fixed System.ArgumentException when setting FlyoutLayoutBehavior dynamically [Windows]

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31390.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31390.cs
@@ -1,0 +1,144 @@
+﻿using System.ComponentModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31390, "System.ArgumentException thrown when setting FlyoutLayoutBehavior dynamically", PlatformAffected.UWP)]
+public class Issue31390 : NavigationPage
+{
+    private Issue31390ViewModel _viewModel;
+    public Issue31390()
+    {
+        _viewModel = new Issue31390ViewModel();
+        PushAsync(new Issue31390FlyoutPage(_viewModel));
+    }
+}
+
+public partial class Issue31390FlyoutPage : FlyoutPage
+{
+    Issue31390ViewModel _viewModel;
+    public Issue31390FlyoutPage(Issue31390ViewModel _viewModel)
+    {
+        _viewModel = new Issue31390ViewModel();
+        BindingContext = _viewModel;
+
+        var flyoutPage = new ContentPage
+        {
+            Title = "Flyout",
+            Content = new StackLayout
+            {
+                Children =
+                {
+                        new Label
+                        {
+                            Text = "This is Flyout",
+                            AutomationId = "Issue31390_FlyoutLabel"
+                        }
+                }
+            }
+        };
+
+        var detailPage = new ContentPage
+        {
+            Content = new StackLayout
+            {
+                Padding = 16,
+                Spacing = 16,
+                Children =
+                {
+                    new Label { Text = "This is Detail Page" }
+                }
+            }
+        };
+
+        var navigationPage = new NavigationPage(detailPage)
+        {
+            Title = "Detail"
+        };
+
+        Flyout = flyoutPage;
+        Detail = navigationPage;
+
+        var ChangeToPopover = new ToolbarItem
+        {
+            Text = "GoToNextPage",
+            AutomationId = "GoToNextPage"
+        };
+        ChangeToPopover.Clicked += NavigateToPopover_Clicked;
+
+        ToolbarItems.Add(ChangeToPopover);
+
+        SetBinding(FlyoutLayoutBehaviorProperty, new Binding(nameof(Issue31390ViewModel.FlyoutLayoutBehavior)));
+    }
+
+    private async void NavigateToPopover_Clicked(object sender, EventArgs e)
+    {
+        BindingContext = _viewModel = new Issue31390ViewModel();
+        await Navigation.PushAsync(new Issue31390SecondPage(_viewModel));
+    }
+}
+
+public class Issue31390SecondPage : ContentPage
+{
+    private readonly Issue31390ViewModel _viewModel;
+
+    public Issue31390SecondPage(Issue31390ViewModel viewModel)
+    {
+        _viewModel = viewModel;
+        BindingContext = _viewModel;
+        ToolbarItems.Add(new ToolbarItem
+        {
+            Text = "Apply",
+            AutomationId = "Apply",
+            Command = new Command(() =>
+            {
+                Navigation.PopAsync();
+            })
+        });
+        var ChangeToPopoverButton = new Button
+        {
+            Text = "Change to Popover",
+            AutomationId = "ChangeToPopover"
+        };
+        ChangeToPopoverButton.Clicked += ChangeToPopoverButton_Clicked;
+
+        Content = new StackLayout
+        {
+            Padding = 16,
+            Children =
+                {
+                    ChangeToPopoverButton
+                }
+        };
+    }
+
+    private void ChangeToPopoverButton_Clicked(object sender, EventArgs e)
+    {
+        if (sender is Button button && BindingContext is Issue31390ViewModel vm)
+        {
+
+            vm.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover;
+
+        }
+    }
+}
+
+public class Issue31390ViewModel : INotifyPropertyChanged
+{
+    private FlyoutLayoutBehavior _flyoutLayoutBehavior = FlyoutLayoutBehavior.Default;
+    public FlyoutLayoutBehavior FlyoutLayoutBehavior
+    {
+        get => _flyoutLayoutBehavior;
+        set
+        {
+            if (_flyoutLayoutBehavior != value)
+            {
+                _flyoutLayoutBehavior = value;
+                OnPropertyChanged(nameof(FlyoutLayoutBehavior));
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+    protected void OnPropertyChanged(string propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31390.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31390.cs
@@ -1,0 +1,27 @@
+#if TEST_FAILS_ON_ANDROID // https://github.com/dotnet/maui/issues/22116
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31390 : _IssuesUITest
+{
+    public Issue31390(TestDevice testDevice) : base(testDevice)
+    {
+    }
+    public override string Issue => "System.ArgumentException thrown when setting FlyoutLayoutBehavior dynamically";
+
+    [Test]
+    [Category(UITestCategories.FlyoutPage)]
+    public void EnsureFlyoutLayoutBehaviorChanges()
+    {
+        App.WaitForElement("GoToNextPage");
+        App.Tap("GoToNextPage");
+        App.Tap("ChangeToPopover");
+        App.Tap("Apply");
+        App.TapFlyoutPageIcon("Flyout");
+        App.WaitForElement("Issue31390_FlyoutLabel");
+    }
+}
+#endif

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -170,9 +170,6 @@ namespace Microsoft.Maui.Platform
 			{
 				case FlyoutBehavior.Flyout:
 					IsPaneToggleButtonVisible = true;
-					// Workaround for
-					// https://github.com/microsoft/microsoft-ui-xaml/issues/6493
-					PaneDisplayMode = NavigationViewPaneDisplayMode.LeftCompact;
 					PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
 					break;
 				case FlyoutBehavior.Locked:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details:

- When dynamically setting the FlyoutLayoutBehavior of a FlyoutPage on Windows to Popover or SplitOnPortrait, the app throws a System.ArgumentException.
- The exception was triggered specifically when navigating to a second page and changing the FlyoutLayoutBehavior to Popover, which maps LeftCompact  and LeftMinimal to the native PaneDisplayMode.

### Root Cause

- The exception thrown because the transition to PaneDisplayMode.LeftCompact occurs after the NavigationView has already been initialized but before it is fully loaded.
- In this partially initialized state, WinUI’s internal validation blocks transitions to LeftCompact, since the required visual tree/template parts are not yet ready.
- Previously, LeftCompact was used as a workaround for [WinUI issue #6493](https://github.com/microsoft/microsoft-ui-xaml/issues/6493?utm_source=chatgpt.com), where setting LeftMinimal directly caused the back button and hamburger icon to overlap.
- Since that native WinUI issue has now been fixed, the LeftCompact workaround is no longer necessary.

### Description of Change

- Removed the PaneDisplayMode = LeftCompact; transition from the dynamic behavior switch.
- The control now transitions directly to PaneDisplayMode.LeftMinimal.
- This avoids the runtime ArgumentException while preserving correct behavior, since the native WinUI issue has already been resolved.

Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed:
Fixes #31390 

### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/bc382291-f203-4a56-bb7d-ba2228ead875"> |   <video src="https://github.com/user-attachments/assets/a7c1459a-b31b-47f0-9365-9aeabc9a571d">  |






