### PR TITLE
Only enable Aspire functionality in non-optimized builds (i.e. Debug)

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -16,6 +16,7 @@ The following switches are toggled for applications running on Mono for `TrimMod
 | MauiNamescopesSupported | Microsoft.Maui.RuntimeFeature.AreNamescopesSupported | Enable support for Namescopes, FindByName if the application uses it, or to keep supporting runtime and XamlC XAML inflators |
 | EnableDiagnostics | Microsoft.Maui.RuntimeFeature.EnableDiagnostics | Enables diagnostic for the running app |
 | EnableMauiDiagnostics | Microsoft.Maui.RuntimeFeature.EnableMauiDiagnostics | Enables MAUI specific diagnostics, like VisualDiagnostics and BindingDiagnostics. Defaults to EnableDiagnostics |
+| _EnableMauiAspire | Microsoft.Maui.RuntimeFeature.EnableMauiAspire | When enabled, MAUI Aspire integration features are available. **Warning**: Using Aspire outside of Debug configuration may introduce performance and security risks in production. |
 
 ## MauiEnableIVisualAssemblyScanning
 
@@ -99,3 +100,28 @@ Defaults to `false`
 Enable VisualDiagnostics and BindingDiagnostics
 
 Defaults to `EnableDiagnostics`
+
+## _EnableMauiAspire
+
+Controls whether MAUI Aspire integration features are enabled at runtime.
+
+**Default Value**: `true`
+
+**Automatic Configuration**: This feature switch is automatically configured by the MAUI build system:
+- **Debug builds with AOT/Trimming**: Enabled (`true`)
+- **Release builds with AOT/Trimming**: Disabled (`false`) 
+- **Regular builds (no AOT/Trimming)**: Uses runtime default (`true`)
+
+The automatic configuration only applies when `PublishAot=true` OR `TrimMode=full` is set.
+
+**Manual Override** (Not Recommended): While it's possible to manually override this setting, it's not recommended as it may introduce performance and security risks in production:
+
+```xml
+<PropertyGroup>
+  <_EnableMauiAspire>true</_EnableMauiAspire>
+</PropertyGroup>
+```
+
+**Warning**: Manually setting this property will trigger build warning MA002.
+
+**Trimming Behavior**: When `_EnableMauiAspire=false` and trimming is enabled, the .NET trimmer can eliminate MAUI Aspire-related code paths, reducing the final application size and potentially improving performance in production scenarios.

--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -107,9 +107,9 @@ Controls whether MAUI Aspire integration features are enabled at runtime.
 
 **Default Value**: `true`
 
-**Automatic Configuration**: This feature switch is automatically configured by the MAUI build system:
-- **Debug builds with AOT/Trimming**: Enabled (`true`)
-- **Release builds with AOT/Trimming**: Disabled (`false`) 
+**Automatic Configuration**: This feature switch is automatically configured by the MAUI build system based on optimization settings:
+- **Non-optimized builds (Debug)**: Enabled (`true`)
+- **Optimized builds (Release)**: Disabled (`false`) 
 - **Regular builds (no AOT/Trimming)**: Uses runtime default (`true`)
 
 The automatic configuration only applies when `PublishAot=true` OR `TrimMode=full` is set.
@@ -122,6 +122,6 @@ The automatic configuration only applies when `PublishAot=true` OR `TrimMode=ful
 </PropertyGroup>
 ```
 
-**Warning**: Manually setting this property will trigger build warning MA002.
+**Warning**: Manually setting this property in optimized builds (where `Optimize=true`) will trigger build warning MA002.
 
 **Trimming Behavior**: When `_EnableMauiAspire=false` and trimming is enabled, the .NET trimmer can eliminate MAUI Aspire-related code paths, reducing the final application size and potentially improving performance in production scenarios.

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -84,6 +84,16 @@
 			Condition="'$(_XFTargetsImported)' == 'true'"/>
 	</Target>
 
+	<Target
+		Name="_ValidateMauiAspireProperty"
+		BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+		Condition="'$(MauiDisableAspireValidation)' != 'True'">
+		<Warning
+			Code="MA002"
+			Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside of the Debug configuration might introduce performance and security risks in production. This property is automatically configured based on build configuration."
+			Condition="'$(_EnableMauiAspire)' != '' and '$(_MauiAspireSetByTargets)' != 'true'"/>
+	</Target>
+
   <Target Name="_MauiXamlComputeInflator">
   	<ItemGroup>
       <!-- Assign the default inflator to MauiXaml that don't have any -->
@@ -282,6 +292,7 @@
       <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
       <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Configuration)' == 'Debug'">true</_EnableMauiAspire>
       <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
+      <_MauiAspireSetByTargets>true</_MauiAspireSetByTargets>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -90,7 +90,7 @@
 		Condition="'$(MauiDisableAspireValidation)' != 'True'">
 		<Warning
 			Code="MA002"
-			Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside of the Debug configuration might introduce performance and security risks in production. This property is automatically configured based on build configuration."
+			Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside the Debug configuration may introduce performance and security risks in production. This property is automatically configured based on build configuration."
 			Condition="'$(_EnableMauiAspire)' != '' and '$(_MauiAspireSetByTargets)' != 'true'"/>
 	</Target>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -84,16 +84,6 @@
 			Condition="'$(_XFTargetsImported)' == 'true'"/>
 	</Target>
 
-	<Target
-		Name="_ValidateMauiAspireProperty"
-		BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-		Condition="'$(MauiDisableAspireValidation)' != 'True'">
-		<Warning
-			Code="MA002"
-			Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside the Debug configuration may introduce performance and security risks in production. This property is automatically configured based on build configuration."
-			Condition="'$(_EnableMauiAspire)' != '' and '$(_MauiAspireSetByTargets)' != 'true'"/>
-	</Target>
-
   <Target Name="_MauiXamlComputeInflator">
   	<ItemGroup>
       <!-- Assign the default inflator to MauiXaml that don't have any -->
@@ -282,6 +272,13 @@
     <PropertyGroup>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>
+    
+    <!-- Validate _EnableMauiAspire usage -->
+    <Warning
+      Code="MA002"
+      Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside the Debug configuration may introduce performance and security risks in production. This property is automatically configured based on build configuration."
+      Condition="'$(_EnableMauiAspire)' != '' and '$(_MauiAspireSetByTargets)' != 'true' and '$(MauiDisableAspireValidation)' != 'True'"/>
+    
     <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
       <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
       <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == ''">false</MauiQueryPropertyAttributeSupport>
@@ -289,9 +286,14 @@
       <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
       <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
       <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
+      
       <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
+      
+      <!-- Set _EnableMauiAspire based on configuration when not already set -->
       <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Configuration)' == 'Debug'">true</_EnableMauiAspire>
       <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
+      
+      <!-- Mark that targets set the value (this will only be true when we're in AOT/Trimming mode) -->
       <_MauiAspireSetByTargets>true</_MauiAspireSetByTargets>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -280,6 +280,8 @@
       <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
       <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
       <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
+      <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Configuration)' == 'Debug'">true</_EnableMauiAspire>
+      <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"
@@ -317,6 +319,10 @@
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.EnableDiagnostics"
                                       Condition="'$(EnableDiagnostics)' != ''"
                                       Value="$(EnableDiagnostics)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.EnableMauiAspire"
+                                      Condition="'$(_EnableMauiAspire)' != ''"
+                                      Value="$(_EnableMauiAspire)"
                                       Trim="true" />
     </ItemGroup>
   </Target>

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -273,11 +273,11 @@
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>
     
-    <!-- Validate _EnableMauiAspire usage -->
+    <!-- Validate _EnableMauiAspire usage - warn when user manually sets it in optimized builds where it conflicts with intended behavior -->
     <Warning
       Code="MA002"
       Text="The _EnableMauiAspire property should not be set manually. Using Aspire outside the Debug configuration may introduce performance and security risks in production. This property is automatically configured based on build configuration."
-      Condition="'$(_EnableMauiAspire)' != '' and '$(_MauiAspireSetByTargets)' != 'true' and '$(MauiDisableAspireValidation)' != 'True'"/>
+      Condition="'$(_EnableMauiAspire)' != '' and '$(Optimize)' == 'true' and '$(MauiDisableAspireValidation)' != 'True'"/>
     
     <PropertyGroup Condition="'$(PublishAot)' == 'true' or '$(TrimMode)' == 'full'">
       <MauiShellSearchResultsRendererDisplayMemberNameSupported Condition="'$(MauiShellSearchResultsRendererDisplayMemberNameSupported)' == ''">false</MauiShellSearchResultsRendererDisplayMemberNameSupported>
@@ -286,15 +286,11 @@
       <MauiEnableXamlCBindingWithSourceCompilation Condition="'$(MauiEnableXamlCBindingWithSourceCompilation)' == ''">true</MauiEnableXamlCBindingWithSourceCompilation>
       <MauiHybridWebViewSupported Condition="'$(MauiHybridWebViewSupported)' == ''">false</MauiHybridWebViewSupported>
       <!-- FIXME: https://github.com/xamarin/xamarin-macios/issues/22065 -->
-      
       <MobileAggressiveAttributeTrimming Condition="'$(PublishAot)' == 'true' and '$(MobileAggressiveAttributeTrimming)' == ''">false</MobileAggressiveAttributeTrimming>
       
-      <!-- Set _EnableMauiAspire based on configuration when not already set -->
-      <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Configuration)' == 'Debug'">true</_EnableMauiAspire>
+      <!-- Set _EnableMauiAspire based on whether optimizations are enabled when not already set -->
+      <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == '' and '$(Optimize)' != 'true'">true</_EnableMauiAspire>
       <_EnableMauiAspire Condition="'$(_EnableMauiAspire)' == ''">false</_EnableMauiAspire>
-      
-      <!-- Mark that targets set the value (this will only be true when we're in AOT/Trimming mode) -->
-      <_MauiAspireSetByTargets>true</_MauiAspireSetByTargets>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled"

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -52,8 +52,8 @@ namespace Microsoft.Maui.Hosting
 			{
 				var envVarLines = System.IO.File.ReadAllLines(androidEnvVarFilePath);
 
+				var fileEnvironmentVariables = envVarLines
 					.Select(line => line.Split('=', 2))
-					.Where(parts => parts.Length == 2 && !string.IsNullOrEmpty(parts[0]))
 					.ToDictionary(parts => parts[0], parts => parts[1]);
 
 				// Merge file environment variables into the existing environment variables

--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -52,8 +52,8 @@ namespace Microsoft.Maui.Hosting
 			{
 				var envVarLines = System.IO.File.ReadAllLines(androidEnvVarFilePath);
 
-				var fileEnvironmentVariables = envVarLines
 					.Select(line => line.Split('=', 2))
+					.Where(parts => parts.Length == 2 && !string.IsNullOrEmpty(parts[0]))
 					.ToDictionary(parts => parts[0], parts => parts[1]);
 
 				// Merge file environment variables into the existing environment variables

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui
 		const bool SupportNamescopesByDefault = true;
 		const bool EnableDiagnosticsByDefault = false;
 		const bool IsMeterSupportedByDefault = true;
+		const bool EnableAspireByDefault = true;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if NET9_0_OR_GREATER
@@ -138,6 +139,14 @@ namespace Microsoft.Maui
 				AppContext.SetSwitch($"{FeatureSwitchPrefix}.{nameof(EnableMauiDiagnostics)}", value);
 			}
 		}
+
+#if NET9_0_OR_GREATER
+		[FeatureSwitchDefinition($"{FeatureSwitchPrefix}.{nameof(EnableMauiAspire)}")]
+#endif
+		public static bool EnableMauiAspire => AppContext.TryGetSwitch($"{FeatureSwitchPrefix}.{nameof(EnableMauiAspire)}", out bool isEnabled)
+				? isEnabled
+				: EnableAspireByDefault;
+
 #pragma warning restore IL4000
 	}
 }

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui
 		const bool SupportNamescopesByDefault = true;
 		const bool EnableDiagnosticsByDefault = false;
 		const bool IsMeterSupportedByDefault = true;
-		const bool EnableAspireByDefault = false;
+		const bool EnableAspireByDefault = true;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if NET9_0_OR_GREATER

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui
 		const bool SupportNamescopesByDefault = true;
 		const bool EnableDiagnosticsByDefault = false;
 		const bool IsMeterSupportedByDefault = true;
-		const bool EnableAspireByDefault = true;
+		const bool EnableAspireByDefault = false;
 
 #pragma warning disable IL4000 // Return value does not match FeatureGuardAttribute 'System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute'. 
 #if NET9_0_OR_GREATER


### PR DESCRIPTION
TL;DR: enable Aspire integration only for non optimized build (MS Build property `Optimize` == false), with an option to override, but that will trigger a warning to discourage the user.

---

This pull request introduces a new feature switch, `EnableMauiAspire`, to control the availability of MAUI Aspire integration features at runtime. The changes ensure Aspire features are enabled by default in Debug builds and disabled in optimized (Release) builds, with automatic configuration and safety checks to prevent misuse in production. Documentation and warnings are added to guide developers and avoid performance or security issues.

**Feature: MAUI Aspire Integration**

* Added a new feature switch, `EnableMauiAspire`, to the `RuntimeFeature` class, with default logic and AppContext support for runtime configuration. [[1]](diffhunk://#diff-0fd447e39a83800f1f629c61f23d5a18a5c4d3d30fa3ecd81dbafbc15eb3a402R29) [[2]](diffhunk://#diff-0fd447e39a83800f1f629c61f23d5a18a5c4d3d30fa3ecd81dbafbc15eb3a402R142-R149)
* Updated build targets (`Microsoft.Maui.Controls.targets`) to automatically set the `_EnableMauiAspire` property based on build optimization settings, and emit a warning (MA002) if the property is manually set in an optimized build. [[1]](diffhunk://#diff-59cefde4ef74a9adcaff4aa8bc3271bd2d795d2b4214d7d56327b5edcca73c14R275-R281) [[2]](diffhunk://#diff-59cefde4ef74a9adcaff4aa8bc3271bd2d795d2b4214d7d56327b5edcca73c14R290-R293)
* Ensured the runtime host configuration option for `EnableMauiAspire` is included in the build output when appropriate.

**Documentation**

* Added documentation for the new `_EnableMauiAspire` switch in `FeatureSwitches.md`, including default values, automatic configuration behavior, manual override warning, and trimming implications. [[1]](diffhunk://#diff-747f0b69be961f2f583dd7b6a03e23f772a61f3a0b5536d882aab649a8808eccR19) [[2]](diffhunk://#diff-747f0b69be961f2f583dd7b6a03e23f772a61f3a0b5536d882aab649a8808eccR103-R127)

**Platform-Specific Behavior**

* Updated `AppHostBuilderExtensions.cs` to check `RuntimeFeature.EnableMauiAspire` before configuring environment variables, and added Android-specific logic to read environment variables from a device file if present. [[1]](diffhunk://#diff-d6d1eff30f175dfccc3a154b3f416f8c8fbd5f641707b299f1e4647866df90b9R4) [[2]](diffhunk://#diff-d6d1eff30f175dfccc3a154b3f416f8c8fbd5f641707b299f1e4647866df90b9R39-R66)