### PR TITLE
Add TargetFramework instructions for ManualTest app

### DIFF
--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -7,7 +7,7 @@
     <!-- <MauiVersion>9.0.100</MauiVersion> -->
     <!-- Uncomment the below lines to use the specified (default new .NET MAUI app) platforms instead of a variable value from externally -->
     <!-- <MauiManualTestsPlatforms>net9.0-android;net9.0-ios;net9.0-maccatalyst</MauiManualTestsPlatforms> -->
-    <!-- <MauiManualTestsPlatforms Condition="$([MSBuild]::IsOSPlatform('windows'))">$(MauiManualTestsPreviousPlatforms);net9.0-windows10.0.19041.0</MauiManualTestsPlatforms>-->
+    <!-- <MauiManualTestsPlatforms Condition="$([MSBuild]::IsOSPlatform('windows'))">$(MauiManualTestsPlatforms);net9.0-windows10.0.19041.0</MauiManualTestsPlatforms>-->
     <TargetFrameworks>$(MauiManualTestsPlatforms)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(UseMaui)' != 'true' and '$(IncludePreviousTfms)' == 'true' ">$(TargetFrameworks);$(MauiManualTestsPreviousPlatforms)</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -5,6 +5,9 @@
     <!-- <UseMaui>true</UseMaui> -->
     <!-- Uncomment the below line to use the specified .NET MAUI version instead of the version provided by the installed workload -->
     <!-- <MauiVersion>9.0.100</MauiVersion> -->
+    <!-- Uncomment the below lines to use the specified (default new .NET MAUI app) platforms instead of a variable value from externally -->
+    <!-- <MauiManualTestsPlatforms>net9.0-android;net9.0-ios;net9.0-maccatalyst</MauiManualTestsPlatforms> -->
+    <!-- <MauiManualTestsPlatforms Condition="$([MSBuild]::IsOSPlatform('windows'))">$(MauiManualTestsPreviousPlatforms);net9.0-windows10.0.19041.0</MauiManualTestsPlatforms>-->
     <TargetFrameworks>$(MauiManualTestsPlatforms)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(UseMaui)' != 'true' and '$(IncludePreviousTfms)' == 'true' ">$(TargetFrameworks);$(MauiManualTestsPreviousPlatforms)</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/src/Controls/tests/ManualTests/README.md
+++ b/src/Controls/tests/ManualTests/README.md
@@ -167,9 +167,20 @@ Navigate to the Microsoft.Maui.Controls package on the nightly feed (or use tool
 </ItemGroup>
 ```
 
+Note: you can also set the values to `$(MauiVersion)` and set a `<MauiVersion>` node with the version you want to use. See **Method 2**, below.
+
 ### How to Compile
 
 This mode is similar to Workloads Mode but allows specifying any available NuGet version for `MauiVersion`. It requires setting `UseMaui=true`.
+
+You will need to manually add the target frameworks to the `<TargetFrameworks>` node when you use this method. For example, running the project on iOS and Android will require:
+
+```xml
+<!-- Instead of: <TargetFrameworks>$(MauiManualTestsPlatforms)</TargetFrameworks> do the line below -->
+<TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+```
+
+Depending on the .NET version you want to use, replace `net10.0` prefix with the version you want to use, for example: `net9.0`.
 
 #### Method 1: Using MSBuild Property
 ```bash


### PR DESCRIPTION
Adds some more verbose instructions, and commented out csproj nodes, for enabling the TargetFrameworks in the ManualTests app.