### PR TITLE
[Android,Windows] Fix NavigatingFrom event order inconsistency with PushAsync

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -869,6 +869,7 @@ namespace Microsoft.Maui.Controls
 				return Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
+						// Move the SendNavigating here so that it's fired prior to the stack being modified
 						Owner.SendNavigating(previousPage);
 						Owner.PushPage(root);
 					},

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -869,11 +869,11 @@ namespace Microsoft.Maui.Controls
 				return Owner.SendHandlerUpdateAsync(animated,
 					() =>
 					{
+						Owner.SendNavigating(previousPage);
 						Owner.PushPage(root);
 					},
 					() =>
 					{
-						Owner.SendNavigating(previousPage);
 						Owner.FireDisappearing(previousPage);
 						Owner.FireAppearing(root);
 					},

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -870,6 +870,7 @@ namespace Microsoft.Maui.Controls
 					() =>
 					{
 						// Move the SendNavigating here so that it's fired prior to the stack being modified
+						// This ensures consistent event ordering across all platforms (iOS, Catalyst, Android, Windows)
 						Owner.SendNavigating(previousPage);
 						Owner.PushPage(root);
 					},

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31520.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31520.cs
@@ -1,0 +1,123 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31520, "NavigatingFrom is triggered first when using PushAsync", PlatformAffected.Android)]
+public class Issue31520 : NavigationPage
+{
+    public static int count = 0;
+    public static Label statusLabel;
+    public static Issue31520Page2 currentPage2;
+
+    public Issue31520() : base(new Issue31520Page1())
+    {
+
+    }
+}
+
+public class Issue31520Page1 : ContentPage
+{
+    public Issue31520Page1()
+    {
+        SetupPageContent();
+
+        Disappearing += (s, e) =>
+        {
+            Issue31520.count++;
+        };
+
+        NavigatingFrom += (s, e) =>
+        {
+            if (Issue31520.statusLabel is not null)
+            {
+                Issue31520.statusLabel.Text = (Issue31520.count == 0)
+                    ? "NavigatingFrom triggered before Disappearing"
+                    : "NavigatingFrom triggered after Disappearing";
+
+                Issue31520.currentPage2?.UpdateNavigatingStatusLabel();
+            }
+        };
+    }
+
+    private void SetupPageContent()
+    {
+        Title = "Page 1";
+
+        Issue31520.statusLabel = new Label
+        {
+            Text = "Ready",
+            AutomationId = "statusLabel"
+        };
+
+        var button = new Button
+        {
+            Text = "Push",
+            AutomationId = "PushButton"
+        };
+        button.Clicked += OnCounterClicked;
+
+        Content = new VerticalStackLayout
+        {
+            Padding = new Thickness(30, 0),
+            Spacing = 25,
+            Children =
+                {
+                    Issue31520.statusLabel,
+                    button
+                }
+        };
+    }
+
+    private void OnCounterClicked(object sender, EventArgs e)
+    {
+        Navigation.PushAsync(new Issue31520Page2());
+    }
+}
+
+public class Issue31520Page2 : ContentPage
+{
+    private Label navigatingStatusLabel;
+
+    public Issue31520Page2()
+    {
+        Issue31520.currentPage2 = this;
+
+        Appearing += (s, e) =>
+        {
+            Issue31520.count++;
+        };
+
+        Title = "Page 2";
+
+        var button = new Button
+        {
+            Text = "Pop",
+            AutomationId = "ChildPageButton"
+        };
+        button.Clicked += OnButtonClicked;
+
+        navigatingStatusLabel = new Label
+        {
+            Text = Issue31520.statusLabel?.Text ?? "Ready",
+            AutomationId = "NavigatingStatusLabel"
+        };
+
+        Content = new StackLayout
+        {
+            Children =
+                {
+                    navigatingStatusLabel,
+                    button
+                }
+        };
+    }
+
+    public void UpdateNavigatingStatusLabel()
+    {
+        if (navigatingStatusLabel is not null && Issue31520.statusLabel is not null)
+            navigatingStatusLabel.Text = Issue31520.statusLabel.Text;
+    }
+
+    private void OnButtonClicked(object sender, EventArgs e)
+    {
+        Navigation.PopAsync();
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31520.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31520.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31520 : _IssuesUITest
+{
+	public Issue31520(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "NavigatingFrom is triggered first when using PushAsync";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void NavigatingFromTriggeredFirst()
+	{
+		App.WaitForElement("PushButton");
+		App.Tap("PushButton");
+		var label = App.WaitForElement("NavigatingStatusLabel");
+		Assert.That(label.GetText(), Is.EqualTo("NavigatingFrom triggered before Disappearing"));
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Detail
NavigatingFrom event order is inconsistent across platforms when using PushAsync.

### Root Cause
The NavigatingFrom event is currently invoked after the page is pushed.

### Description of Change
Moved the NavigatingFrom event to be invoked before pushing the page.

Comment: https://github.com/dotnet/maui/pull/28998#issuecomment-3255940036

### Reference:  
iOS: https://github.com/dotnet/maui/blob/e838b500c3f62c579d97bcbaeacf321dc1632d2c/src/Controls/src/Core/NavigationPage/NavigationPage.Legacy.cs#L186 
Modal Navigation: https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs#L268

<img width="1644" height="420" alt="image" src="https://github.com/user-attachments/assets/60fe763d-e7b2-4b48-a977-8f94e1ed7bf0" />

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31520

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/7186aac2-2046-4bff-8944-33a8b2d45cef"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/6402a013-27e0-4aa6-8948-e37193b1ab47">) |