### PR TITLE
[iOS] Fixed the crash occurred on CarouselView2 when deleting last one remaining item with loop as false

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LoopObservableItemsSource2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LoopObservableItemsSource2.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				return base.CreateIndexesFrom(startIndex, count);
 			}
+			var collectionView = CollectionView;
+			if (collectionView is null || count < 0)
+			{
+				return Array.Empty<NSIndexPath>();
+			}
+
 			if (ItemCount == 0)
 			{
 				count += 2;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LoopObservableItemsSource2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LoopObservableItemsSource2.cs
@@ -22,6 +22,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		protected override NSIndexPath[] CreateIndexesFrom(int startIndex, int count)
 		{
+			if (!Loop)
+			{
+				return base.CreateIndexesFrom(startIndex, count);
+			}
 			if (ItemCount == 0)
 			{
 				count += 2;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31535.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31535.cs
@@ -17,12 +17,8 @@ public class Issue31535 : ContentPage
     }
     public Issue31535()
     {
-        // Initialize items
-        Items = new ObservableCollection<string>
-        {
-            "Item 1",
-            "Item 2",
-        };
+        // Start with empty collection to test all scenarios
+        Items = new ObservableCollection<string>();
 
         // Create CarouselView
         var carousel = new CarouselView2
@@ -48,25 +44,86 @@ public class Issue31535 : ContentPage
             })
         };
 
-        // Create Button
-        var button = new Button
+        // Create Buttons for testing different scenarios
+        var addSingleItemButton = new Button
         {
-            AutomationId = "RemoveLastItemButton",
-            Text = "Remove last item"
+            AutomationId = "AddSingleItemButton",
+            Text = "Add Single Item"
         };
 
-        button.Clicked += (s, e) =>
+        var removeSingleItemButton = new Button
+        {
+            AutomationId = "RemoveSingleItemButton",
+            Text = "Remove Single Item"
+        };
+
+        var addMultipleItemsButton = new Button
+        {
+            AutomationId = "AddMultipleItemsButton",
+            Text = "Add Multiple Items"
+        };
+
+        var removeAllItemsButton = new Button
+        {
+            AutomationId = "RemoveAllItemsButton",
+            Text = "Remove All Items"
+        };
+
+        var itemCountLabel = new Label
+        {
+            Text = $"Items Count: {Items.Count}",
+            HorizontalOptions = LayoutOptions.Center
+        };
+
+        // Event handlers
+        addSingleItemButton.Clicked += (s, e) =>
+        {
+            Items.Add($"Item {Items.Count + 1}");
+            itemCountLabel.Text = $"Items Count: {Items.Count}";
+        };
+
+        removeSingleItemButton.Clicked += (s, e) =>
         {
             if (Items.Count > 0)
+            {
                 Items.RemoveAt(Items.Count - 1);
+                itemCountLabel.Text = $"Items Count: {Items.Count}";
+            }
+        };
+
+        addMultipleItemsButton.Clicked += (s, e) =>
+        {
+            var currentCount = Items.Count;
+            Items.Add($"Item {currentCount + 1}");
+            Items.Add($"Item {currentCount + 2}");
+            Items.Add($"Item {currentCount + 3}");
+            itemCountLabel.Text = $"Items Count: {Items.Count}";
+        };
+
+        removeAllItemsButton.Clicked += (s, e) =>
+        {
+            Items.Clear();
+            itemCountLabel.Text = $"Items Count: {Items.Count}";
         };
 
         Content = new VerticalStackLayout
         {
+            Spacing = 10,
+            Padding = 20,
             Children =
             {
+                new Label
+                {
+                    Text = "CarouselView2 Loop=false Test",
+                    FontSize = 18,
+                    HorizontalOptions = LayoutOptions.Center
+                },
+                itemCountLabel,
                 carousel,
-                button
+                addSingleItemButton,
+                removeSingleItemButton,
+                addMultipleItemsButton,
+                removeAllItemsButton
             }
         };
         BindingContext = this;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31535.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31535.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31535, "[iOS] Crash occured on CarouselView2 when deleting last one remaining item with loop as false", PlatformAffected.iOS)]
+public class Issue31535 : ContentPage
+{
+    ObservableCollection<string> _items = new();
+    public ObservableCollection<string> Items
+    {
+        get => _items;
+        set
+        {
+            _items = value;
+            OnPropertyChanged();
+        }
+    }
+    public Issue31535()
+    {
+        // Initialize items
+        Items = new ObservableCollection<string>
+        {
+            "Item 1",
+            "Item 2",
+        };
+
+        // Create CarouselView
+        var carousel = new CarouselView2
+        {
+            Loop = false,
+            HeightRequest = 200,
+            ItemsSource = Items,
+            AutomationId = "TestCarouselView",
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var border = new Border
+                {
+                    Margin = 10,
+                    WidthRequest = 200,
+                    BackgroundColor = Colors.Red
+                };
+
+                var label = new Label();
+                label.SetBinding(Label.TextProperty, ".");
+
+                border.Content = label;
+                return border;
+            })
+        };
+
+        // Create Button
+        var button = new Button
+        {
+            AutomationId = "RemoveLastItemButton",
+            Text = "Remove last item"
+        };
+
+        button.Clicked += (s, e) =>
+        {
+            if (Items.Count > 0)
+                Items.RemoveAt(Items.Count - 1);
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Children =
+            {
+                carousel,
+                button
+            }
+        };
+        BindingContext = this;
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31535.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31535.cs
@@ -2,7 +2,7 @@
 
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 31535, "[iOS] Crash occured on CarouselView2 when deleting last one remaining item with loop as false", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 31535, "[iOS] Crash occurred on CarouselView2 when deleting last one remaining item with loop as false", PlatformAffected.iOS)]
 public class Issue31535 : ContentPage
 {
     ObservableCollection<string> _items = new();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31535.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31535.cs
@@ -12,12 +12,14 @@ public class Issue31535 : _IssuesUITest
 
     [Test]
     [Category(UITestCategories.CarouselView)]
-    public void CarouselView2ShouldNotCrashOnRemoveLastItem()
+    public void CarouselView2ShouldNotCrashOnRemovingItems()
     {
-        App.WaitForElement("RemoveLastItemButton");
-        App.Tap("RemoveLastItemButton");
-        //remove last one remaining item
-        App.Tap("RemoveLastItemButton");
+        App.WaitForElement("AddSingleItemButton");
+        App.Tap("AddSingleItemButton");
+        //remove one single item, crash should not occured
+        App.Tap("RemoveSingleItemButton");
+        App.Tap("AddMultipleItemsButton");
+        App.Tap("RemoveAllItemsButton");
         App.WaitForElement("TestCarouselView");
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31535.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31535.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31535 : _IssuesUITest
+{
+    public Issue31535(TestDevice device) : base(device) { }
+
+    public override string Issue => "[iOS] Crash occured on CarouselView2 when deleting last one remaining item with loop as false";
+
+    [Test]
+    [Category(UITestCategories.CarouselView)]
+    public void CarouselView2ShouldNotCrashOnRemoveLastItem()
+    {
+        App.WaitForElement("RemoveLastItemButton");
+        App.Tap("RemoveLastItemButton");
+        //remove last one remaining item
+        App.Tap("RemoveLastItemButton");
+        App.WaitForElement("TestCarouselView");
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31535.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31535.cs
@@ -8,7 +8,7 @@ public class Issue31535 : _IssuesUITest
 {
     public Issue31535(TestDevice device) : base(device) { }
 
-    public override string Issue => "[iOS] Crash occured on CarouselView2 when deleting last one remaining item with loop as false";
+    public override string Issue => "[iOS] Crash occurred on CarouselView2 when deleting last one remaining item with loop as false";
 
     [Test]
     [Category(UITestCategories.CarouselView)]


### PR DESCRIPTION

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- When removing the last item in `CarouselView2` with Loop = false, the item count is updated with an additional +2. This logic is specific to the looping scenario (to handle duplicate items), but there was no handling for the non-looping case. As a result, the update produced invalid indices and caused the exception. 



### Description of Change



- Added proper handling for the non-looping case (Loop = false) to prevent exceptions when removing the last item in CarouselView2. 

### Reference

- https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Handlers/Items/iOS/LoopObservableItemsSource.cs#L25

### Issues Fixed



Fixes #31535 

### Regression PR's

- #29318
- #26868

### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/53817665-393c-4b52-bfc4-2555d7339477"> | <video src="https://github.com/user-attachments/assets/dbe6e111-0217-47e4-a2f5-f897923cc566"> |
