### PR TITLE
Add test to MAUI Manual test runner to verify issue #31483

### DIFF
--- a/src/Controls/tests/ManualTests/Categories/Category.cs
+++ b/src/Controls/tests/ManualTests/Categories/Category.cs
@@ -13,4 +13,5 @@ public static class Category
 	public const string CollectionView = nameof(CollectionView);
 	public const string TitleBar = nameof(TitleBar);
 	public const string Performance = nameof(Performance);
+	public const string BugFixes = nameof(BugFixes);
 }

--- a/src/Controls/tests/ManualTests/Categories/CategoryViewModel.cs
+++ b/src/Controls/tests/ManualTests/Categories/CategoryViewModel.cs
@@ -86,3 +86,9 @@ public class PerformanceCategoryViewModel : CategoryViewModel
 {
 	public override string CategoryName => Category.Performance;
 }
+
+[Category(id: "L", title: Category.BugFixes)]
+public class BugFixesCategoryViewModel : CategoryViewModel
+{
+	public override string CategoryName => Category.BugFixes;
+}

--- a/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml
+++ b/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.ManualTests.Tests.BugFixes.L1_TapGestureRecognizer"
+             Title="L1_TapGestureRecognizer">
+    <ScrollView>
+        <VerticalStackLayout
+         Padding="30,0"
+         Spacing="25">
+            <Label Text="1. This test is to check TapGestureRecognizer can trigger the Tapped event when TalkBack is enabled on an Android device or VoiceOver isenabled on iOS device.(https://github.com/dotnet/maui/issues/31483)" />
+            <Label Text="2. Click Label 'Click me (Label TapGestureRecognizer)',Talkback/VoiceOver will announce 'Double tap to activate'. " />
+            <Label Text="3. Double click the screen, verify it triages the Tapped event, count increase by 1 " />
+
+            <Label
+             Text="TapGestureRecognizer with TalkBack/VoiceOver" 
+             HorizontalTextAlignment="Center"
+             FontAttributes="Bold" />
+
+            <Label
+             x:Name="CounterLabel"
+             Text="Clicks 0"
+             HorizontalTextAlignment="Center"
+             FontAttributes="Bold" />
+
+            <Label
+             Text="Click me (Label TapGestureRecognizer)"
+             SemanticProperties.Hint="Counts the number of times you click"
+             BackgroundColor="Red"
+             HorizontalOptions="Fill"
+             TextColor="White"
+             HorizontalTextAlignment="Center"
+             Padding="10">
+                <Label.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnCounterClicked" />
+                </Label.GestureRecognizers>
+            </Label>
+
+            <Button
+             Text="Click me (Button)" 
+             SemanticProperties.Hint="Counts the number of times you click"
+             Clicked="OnCounterClicked"
+             BackgroundColor="Red"
+             HorizontalOptions="Fill" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml
+++ b/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml
@@ -7,7 +7,7 @@
         <VerticalStackLayout
          Padding="30,0"
          Spacing="25">
-            <Label Text="1. This test is to check TapGestureRecognizer can trigger the Tapped event when TalkBack is enabled on an Android device or VoiceOver isenabled on iOS device.(https://github.com/dotnet/maui/issues/31483)" />
+            <Label Text="1. This test is to check TapGestureRecognizer can trigger the Tapped event when TalkBack is enabled on an Android device or VoiceOver is enabled on iOS device.(https://github.com/dotnet/maui/issues/31483)" />
             <Label Text="2. Click Label 'Click me (Label TapGestureRecognizer)',Talkback/VoiceOver will announce 'Double tap to activate'. " />
             <Label Text="3. Double click the screen, verify it triages the Tapped event, count increase by 1 " />
 

--- a/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml
+++ b/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml
@@ -9,7 +9,7 @@
          Spacing="25">
             <Label Text="1. This test is to check TapGestureRecognizer can trigger the Tapped event when TalkBack is enabled on an Android device or VoiceOver is enabled on iOS device.(https://github.com/dotnet/maui/issues/31483)" />
             <Label Text="2. Click Label 'Click me (Label TapGestureRecognizer)',Talkback/VoiceOver will announce 'Double tap to activate'. " />
-            <Label Text="3. Double click the screen, verify it triages the Tapped event, count increase by 1 " />
+            <Label Text="3. Double click the screen, verify it triggers the Tapped event, count increase by 1 " />
 
             <Label
              Text="TapGestureRecognizer with TalkBack/VoiceOver" 

--- a/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml.cs
+++ b/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui.ManualTests.Categories;
+
+namespace Microsoft.Maui.ManualTests.Tests.BugFixes;
+
+[Test(
+    id: "L1",
+    title: "TapGestureRecognizer",
+    category: Category.BugFixes)]
+public partial class L1_TapGestureRecognizer : ContentPage
+{
+    int count = 0;
+    public L1_TapGestureRecognizer()
+	{
+		InitializeComponent();
+	}
+
+    private void OnCounterClicked(object sender, EventArgs e)
+    {
+        count++;
+
+        if (count == 1)
+            CounterLabel.Text = $"Clicked {count} time";
+        else
+            CounterLabel.Text = $"Clicked {count} times";
+
+        SemanticScreenReader.Announce(CounterLabel.Text);
+    }
+}

--- a/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml.cs
+++ b/src/Controls/tests/ManualTests/Tests/BugFixes/L1_TapGestureRecognizer.xaml.cs
@@ -10,7 +10,7 @@ public partial class L1_TapGestureRecognizer : ContentPage
 {
     int count = 0;
     public L1_TapGestureRecognizer()
-	{
+    {
 		InitializeComponent();
 	}
 


### PR DESCRIPTION
Add test to MAUI Manual test runner to verify issue #31483
[Issue #31483 ](https://github.com/dotnet/maui/issues/31483): TapGestureRecognizer cannot be tapped using Android Talkback in MAUI 9.0.100
[Test Case 2571395](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2571395): [Mobile] L1 - Check if TapGestureRecognizer can trigger the Tapped event when TalkBack is enabled on an Android device or VoiceOver isenabled on iOS device