### PR TITLE
[templates] do not use 'required' in xaml controls

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
@@ -4,8 +4,8 @@ namespace MauiApp._1.Pages.Controls;
 
 public class ChipDataTemplateSelector : DataTemplateSelector
 {
-	public DataTemplate SelectedTagTemplate { get; set; }
-	public DataTemplate NormalTagTemplate { get; set; }
+	public DataTemplate? SelectedTagTemplate { get; set; }
+	public DataTemplate? NormalTagTemplate { get; set; }
 
 	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 	{

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/ChipDataTemplateSelector.cs
@@ -4,11 +4,11 @@ namespace MauiApp._1.Pages.Controls;
 
 public class ChipDataTemplateSelector : DataTemplateSelector
 {
-	public required DataTemplate SelectedTagTemplate { get; set; }
-	public required DataTemplate NormalTagTemplate { get; set; }
+	public DataTemplate SelectedTagTemplate { get; set; }
+	public DataTemplate NormalTagTemplate { get; set; }
 
 	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 	{
-		return (item as Tag)?.IsSelected ?? false ? SelectedTagTemplate : NormalTagTemplate;
+		return ((item as Tag)?.IsSelected ?? false ? SelectedTagTemplate : NormalTagTemplate) ?? throw new InvalidOperationException("DataTemplates SelectedTagTemplate and NormalTagTemplate must be set to a non-null value.");
 	}
 }


### PR DESCRIPTION
Runtime XAML and XamlC inflators ignore the required fields and props. XSG can do it in soem cases but fails for complex, or long references. Replace the compiler check (ignored) by a runtime check

