### PR TITLE
[iOS] Fix CV2 more slow than CV1 on updating columns count at runtime

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 	internal readonly struct LayoutCacheKey : IEquatable<LayoutCacheKey>
     {
 	    // Pack 5 boolean fields into a single byte using bit flags
-	    // Used to reduces struct size as much as possible.
+	    // Used to reduce struct size as much as possible.
         [Flags]
         enum LayoutFlags : byte
         {

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -11,7 +11,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items2
 {
-	internal struct LayoutCacheKey : IEquatable<LayoutCacheKey>
+	internal readonly struct LayoutCacheKey : IEquatable<LayoutCacheKey>
 	{
 		public readonly bool IsGrouped;
 		public readonly bool HasGroupHeader;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issues.Issue31071"
+    xmlns:local="clr-namespace:Maui.Controls.Sample">
+   <Page.Resources>
+        <ResourceDictionary>
+            <DataTemplate
+                x:Key="GroupHeaderTemplate"
+                x:DataType="{x:Null}">
+
+                <Label
+                    Padding="5"
+                    FontAttributes="Bold"
+                    Text="{Binding Key, StringFormat='Group: {0}'}" />
+            </DataTemplate>
+
+            <DataTemplate
+                x:Key="ItemTemplate"
+                x:DataType="x:Int32">
+
+                <local:Issue31071Item />
+            </DataTemplate>
+
+            <x:Int32 x:Key="Cols4">4</x:Int32>
+            <x:Int32 x:Key="Cols6">6</x:Int32>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <Grid
+        Padding="10"
+        RowSpacing="10"
+        ColumnSpacing="10"
+        ColumnDefinitions="*,*"
+        RowDefinitions="Auto,Auto,Auto,Auto,*">
+
+        <Label
+            AutomationId="MemoryLabel"
+            Text="{Binding TotalMemory,
+                StringFormat='Heap size: {0:0.0} mb'}" />
+
+        <Label
+            Grid.Column="1"
+            AutomationId="ItemsCountLabel"
+            Text="{Binding CollViewItemsCount,
+                StringFormat='CV items count: {0}'}" />
+
+        <Label
+            Grid.Row="1"
+            Grid.ColumnSpan="2"
+            AutomationId="ActionTimeLabel"
+            Text="{Binding ActionTime,
+                StringFormat='Last action duration: {0:0.000} s'}" />
+
+        <Button
+            Grid.Row="2"
+            AutomationId="UngroupedButton"
+            Text="Ungrouped CollView"
+            Command="{Binding SetUnGroupedCommand}" />
+
+        <Button
+            Grid.Row="2"
+            Grid.Column="1"
+            AutomationId="GroupedButton"
+            Text="Grouped CollView"
+            Command="{Binding SetGroupedCommand}" />
+
+        <Button
+            Grid.Row="3"
+            AutomationId="Cols4Button"
+            Text="4 columns CollView"
+            CommandParameter="{StaticResource Cols4}"
+            Command="{Binding SetColumnsCommand}" />
+
+        <Button
+            Grid.Row="3"
+            Grid.Column="1"
+            AutomationId="Cols6Button"
+            Text="6 columns CollView"
+            CommandParameter="{StaticResource Cols6}"
+            Command="{Binding SetColumnsCommand}" />
+
+        <local:CollectionView2
+            Grid.Row="4"
+            Grid.ColumnSpan="2"
+            AutomationId="TestCollectionView"
+            Scrolled="OnScrolled"
+            IsGrouped="{Binding IsGrouped}"
+            ItemsSource="{Binding CollectionItems}"
+            ItemTemplate="{StaticResource ItemTemplate}"
+            GroupHeaderTemplate="{StaticResource GroupHeaderTemplate}">
+
+            <local:CollectionView2.ItemsLayout>
+                <GridItemsLayout
+                    Span="{Binding CVColumns}"
+                    Orientation="Vertical" />
+            </local:CollectionView2.ItemsLayout>
+        </local:CollectionView2>
+     </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.Github, 31071, ".NET MAUI set AppShell custom FlyoutIcon display problem",
+	[Issue(IssueTracker.Github, 31071, "CollectionView2 (CollectionViewHandler2) much more slow than CV1 on updating columns count at runtime",
 		PlatformAffected.iOS)]
 	public partial class Issue31071 : ContentPage
 	{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 31071, ".NET MAUI set AppShell custom FlyoutIcon display problem",
+		PlatformAffected.iOS)]
+	public partial class Issue31071 : ContentPage
+	{
+		public Issue31071()
+		{
+			SetGroupedCommand = new Command(() =>
+			{
+				var now = DateTime.Now;
+				IsGrouped = true;
+				CollectionItems = Enumerable.Range(0, 1000)
+					.GroupBy(i => i / 20).ToList();
+				SetActionTime(now);
+			});
+			SetUnGroupedCommand = new Command(() =>
+			{
+				var now = DateTime.Now;
+				IsGrouped = false;
+				CollectionItems = Enumerable.Range(0, 1000).ToList();
+				SetActionTime(now);
+			});
+			SetColumnsCommand = new Command<int>(columns =>
+			{
+				var now = DateTime.Now;
+				CVColumns = columns;
+				SetActionTime(now);
+			});
+
+			void SetActionTime(DateTime now) =>
+				ActionTime = (DateTime.Now - now).TotalSeconds;
+
+			BindingContext = this;
+			InitializeComponent();
+
+			MessagingCenter.Subscribe<Issue31071Item, int>(
+				this, string.Empty, (s, i) =>
+					Dispatcher.Dispatch(() => CollViewItemsCount += i));
+		}
+
+		public ICommand SetGroupedCommand { get; }
+		public ICommand SetUnGroupedCommand { get; }
+		public ICommand SetColumnsCommand { get; }
+
+		public bool IsGrouped
+		{
+			get => isGrouped;
+			set
+			{
+				isGrouped = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private bool isGrouped;
+
+		public IEnumerable CollectionItems
+		{
+			get => collectionItems;
+			set
+			{
+				collectionItems = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private IEnumerable collectionItems;
+
+		public int CVColumns
+		{
+			get => cvColumns;
+			set
+			{
+				cvColumns = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private int cvColumns = 4;
+
+		public int CollViewItemsCount
+		{
+			get => collViewItemsCount;
+			set
+			{
+				collViewItemsCount = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private int collViewItemsCount;
+
+		public double ActionTime
+		{
+			get => actionTime;
+			set
+			{
+				actionTime = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private double actionTime;
+
+		public double TotalMemory =>
+			GC.GetTotalMemory(false) / 1024.0 / 1024;
+
+		private void OnScrolled(object sender, ItemsViewScrolledEventArgs e) =>
+			OnPropertyChanged(nameof(TotalMemory));
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31071.xaml.cs
@@ -68,7 +68,7 @@ namespace Maui.Controls.Sample.Issues
 			}
 		}
 
-		private IEnumerable collectionItems;
+		IEnumerable collectionItems;
 
 		public int CVColumns
 		{
@@ -80,7 +80,7 @@ namespace Maui.Controls.Sample.Issues
 			}
 		}
 
-		private int cvColumns = 4;
+		int cvColumns = 4;
 
 		public int CollViewItemsCount
 		{
@@ -92,7 +92,7 @@ namespace Maui.Controls.Sample.Issues
 			}
 		}
 
-		private int collViewItemsCount;
+		int collViewItemsCount;
 
 		public double ActionTime
 		{
@@ -104,12 +104,12 @@ namespace Maui.Controls.Sample.Issues
 			}
 		}
 
-		private double actionTime;
+		double actionTime;
 
 		public double TotalMemory =>
 			GC.GetTotalMemory(false) / 1024.0 / 1024;
 
-		private void OnScrolled(object sender, ItemsViewScrolledEventArgs e) =>
+		void OnScrolled(object sender, ItemsViewScrolledEventArgs e) =>
 			OnPropertyChanged(nameof(TotalMemory));
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31071Item.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31071Item.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentView
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Issue31071Item">
+  <Border
+    BackgroundColor="Green"
+    Padding="5"
+    Margin="2">
+
+    <Grid
+      ColumnDefinitions="Auto,Auto">
+
+      <Label
+        Text="#" />
+
+      <Label
+        Grid.Column="1"
+        Text="{Binding StringFormat='{0:0000}'}" />
+    </Grid>
+  </Border>
+</ContentView>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31071Item.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31071Item.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace Maui.Controls.Sample
+{
+	public partial class Issue31071Item : ContentView
+	{
+		public Issue31071Item()
+		{
+			InitializeComponent();
+			MessagingCenter.Send(this, string.Empty, 1);
+		}
+
+		~Issue31071Item()
+		{
+			MessagingCenter.Send(this, string.Empty, -1);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31071.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31071.cs
@@ -1,0 +1,152 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31071 : _IssuesUITest
+{
+	public Issue31071(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue =>
+		"CollectionView2 (CollectionViewHandler2) much more slow than CV1 on updating columns count at runtime";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void GroupingChangesUpdateLayoutCorrectly()
+	{
+		App.WaitForElement("UngroupedButton");
+
+		// Start with ungrouped
+		App.Tap("UngroupedButton");
+		App.WaitForElement("TestCollectionView");
+
+		// Verify initial ungrouped state
+		var ungroupedActionTime = GetActionTime();
+		Assert.That(ungroupedActionTime, Is.GreaterThan(0), "Should record action time for ungrouping");
+
+		// Switch to grouped
+		App.Tap("GroupedButton");
+		App.WaitForElement("TestCollectionView");
+
+		// Verify grouped state change
+		var groupedActionTime = GetActionTime();
+		Assert.That(groupedActionTime, Is.GreaterThan(0), "Should record action time for grouping");
+
+		// Switch back to ungrouped to test the issue was fixed
+		App.Tap("UngroupedButton");
+		App.WaitForElement("TestCollectionView");
+
+		var secondUngroupedActionTime = GetActionTime();
+		Assert.That(secondUngroupedActionTime, Is.GreaterThan(0), "Should record action time for second ungrouping");
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void ColumnChangesDoNotCauseExponentialPerformanceDegradation()
+	{
+		App.WaitForElement("Cols4Button");
+
+		// Record baseline performance for 4 columns
+		App.Tap("Cols4Button");
+		App.WaitForElement("TestCollectionView");
+		var cols4Time1 = GetActionTime();
+
+		// Switch to 6 columns
+		App.Tap("Cols6Button");
+		App.WaitForElement("TestCollectionView");
+		var cols6Time1 = GetActionTime();
+
+		// Switch back to 4 columns multiple times to test for exponential degradation
+		App.Tap("Cols4Button");
+
+		App.Tap("Cols6Button");
+
+		App.Tap("Cols4Button");
+		var cols4Time2 = GetActionTime();
+
+		App.Tap("Cols6Button");
+		var cols6Time2 = GetActionTime();
+
+		// Verify that performance doesn't degrade exponentially
+		// With the fix, subsequent changes should be similar to the first change
+		// Allow some variance but ensure no exponential growth
+		Assert.That(cols4Time2, Is.LessThan(cols4Time1 * 5),
+			"Column changes should not cause exponential performance degradation");
+		Assert.That(cols6Time2, Is.LessThan(cols6Time1 * 5),
+			"Column changes should not cause exponential performance degradation");
+
+		// All times should be reasonable (under 1 second for layout changes)
+		Assert.That(cols4Time2, Is.LessThan(1.0), "Layout changes should complete quickly");
+		Assert.That(cols6Time2, Is.LessThan(1.0), "Layout changes should complete quickly");
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void PerformanceTimesAreRecordedCorrectly()
+	{
+		App.WaitForElement("ActionTimeLabel");
+
+		// Initial state should have 0 or minimal time
+		var initialTime = GetActionTime();
+
+		// Perform an action
+		App.Tap("UngroupedButton");
+		App.WaitForElement("TestCollectionView");
+
+		// Verify action time was recorded
+		var actionTime = GetActionTime();
+		Assert.That(actionTime, Is.GreaterThan(0), "Action time should be recorded");
+		Assert.That(actionTime, Is.LessThan(10.0), "Action time should be reasonable");
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void MemoryUsageIsDisplayed()
+	{
+		App.WaitForElement("MemoryLabel");
+
+		var memoryText = App.FindElement("MemoryLabel").GetText();
+		Assert.That(memoryText, Does.Contain("Heap size:"), "Memory usage should be displayed");
+		Assert.That(memoryText, Does.Contain("mb"), "Memory usage should show units");
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void ItemCountIsTracked()
+	{
+		App.WaitForElement("ItemsCountLabel");
+
+		var itemCountText = App.FindElement("ItemsCountLabel").GetText();
+		Assert.That(itemCountText, Does.Contain("CV items count:"), "Item count should be displayed");
+	}
+
+	double GetActionTime()
+	{
+		var actionTimeText = App.FindElement("ActionTimeLabel").GetText();
+
+		if (actionTimeText is null)
+		{
+			return 0.0;
+		}
+
+		// Extract the numeric value from "Last action duration: X.XXX s"
+		var startIndex = actionTimeText.IndexOf(": ", StringComparison.Ordinal) + 2;
+		var endIndex = actionTimeText.IndexOf(" s", StringComparison.Ordinal);
+
+		if (startIndex > 1 && endIndex > startIndex)
+		{
+			var timeString = actionTimeText.Substring(startIndex, endIndex - startIndex);
+			if (double.TryParse(timeString, out double time))
+			{
+				return time;
+			}
+		}
+
+		return 0.0;
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

CollectionView2 was experiencing severe performance issues where layout changes became exponentially slower with each subsequent update. This was caused by unnecessarily recreating `UICollectionViewLayout` instances on every layout update, even when the layout configuration hadn't actually changed.

In this PR we apply changes to optimize it:
- Adding layout caching to avoid unnecessary recreation
- Only recreating layout when essential properties change

| Before | After |
|----------|----------|
| ![fix-31071-before](https://github.com/user-attachments/assets/3f3924bc-d869-4acd-b0a7-5cd28de407c7) | ![fix-31071-after](https://github.com/user-attachments/assets/6ca2d779-0630-4468-8b53-40fcdb3e5a14) |

Added UITests to validate the changes:
<img width="1066" height="354" alt="image" src="https://github.com/user-attachments/assets/e55f73b5-22b2-4080-bbf1-a1ac18fc9775" />

### Issues Fixed

Fixes #31071 
