### PR TITLE
[Android] Fix control size properties not available during Loaded event

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue14364.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue14364.cs
@@ -37,7 +37,7 @@ public class Issue14364Page : ContentPage
         Content = grid;
     }
 
-    private void Label_Loaded(object sender, EventArgs e)
+    void Label_Loaded(object sender, EventArgs e)
     {
         if (sender is Label label)
         {

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue14364.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue14364.cs
@@ -1,0 +1,50 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 14364, "Control size properties are not available during Loaded event", PlatformAffected.Android)]
+public class Issue14364 : Shell
+{
+    public Issue14364()
+    {
+        ShellContent shellContent = new ShellContent
+        {
+            ContentTemplate = new DataTemplate(typeof(Issue14364Page)),
+            Route = "Issue14364Page"
+        };
+
+        Items.Add(shellContent);
+    }
+}
+
+public class Issue14364Page : ContentPage
+{
+    public Issue14364Page()
+    {
+        var grid = new Grid
+        {
+            HeightRequest = 300,
+            WidthRequest = 200
+        };
+
+        var label = new Label
+        {
+            Text = "Size",
+            AutomationId = "labelSize"
+        };
+
+        label.Loaded += Label_Loaded;
+
+        grid.Children.Add(label);
+        Content = grid;
+    }
+
+    private void Label_Loaded(object sender, EventArgs e)
+    {
+        if (sender is Label label)
+        {
+            var h1 = label.Height;
+            var h2 = label.Width;
+
+            label.Text = $"Height: {h1}, Width: {h2}";
+        }
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14364.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue14364.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue14364 : _IssuesUITest
+{
+    public Issue14364(TestDevice testDevice) : base(testDevice)
+    {
+    }
+
+    public override string Issue => "Control size properties are not available during Loaded event";
+
+    [Test]
+    [Category(UITestCategories.Layout)]
+    public void SizePropertiesAvailableDuringLoadedEvent()
+    {
+        var label = App.WaitForElement("labelSize");
+        Assert.That(label.GetText(), Is.Not.EqualTo("Height: -1, Width: -1"));
+    }
+}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -597,7 +597,13 @@ namespace Microsoft.Maui.Platform
 
 				disposable?.Dispose();
 				disposable = null;
-				view.Post(action);
+				view.Post(() =>
+				{
+					if (view.IsAttachedToWindow)
+					{
+						action();
+					}
+				});
 			};
 
 			view.ViewAttachedToWindow += routedEventHandler;

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -597,7 +597,7 @@ namespace Microsoft.Maui.Platform
 
 				disposable?.Dispose();
 				disposable = null;
-				action();
+				view.Post(action);
 			};
 
 			view.ViewAttachedToWindow += routedEventHandler;

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -595,13 +595,15 @@ namespace Microsoft.Maui.Platform
 					return;
 				}
 
-				disposable?.Dispose();
+				// Store local reference to allow cancellation inside the Post callback
+				var localDisposable = disposable;
 				disposable = null;
 				view.Post(() =>
 				{
-					if (view.IsAttachedToWindow)
+					if (view.IsAttachedToWindow && localDisposable is not null)
 					{
 						action();
+						localDisposable.Dispose();
 					}
 				});
 			};


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
On Android, controls do not provide valid size when the Loaded event fires.  

### Root Cause
On Android, the Loaded event fires before the layout pass completes, causing views to report incorrect dimensions.

### Description of Change
Modified OnLoaded method to use view.Post() instead of immediate action execution, ensuring the Loaded event fires after the layout pass completes.

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/14364
Fixes https://github.com/dotnet/maui/issues/14160

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/703766e7-c3e8-4b9d-bdc0-5a2b943cd060"> | <img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/3fa34f58-c3f1-49ca-b638-29028930d4fd"> |