### PR TITLE
Reduce layout pass java to dotnet jni calls

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
@@ -36,11 +36,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (Content.VirtualView.Handler is IPlatformViewHandler pvh)
 			{
-				var widthSpec = Context.CreateMeasureSpec(targetWidth,
+				var (widthSpec, _, _) = Context.CreateMeasureSpec(targetWidth,
 					double.IsInfinity(targetWidth) ? double.NaN : targetWidth
 					, minimumSize: double.NaN, maximumSize: targetWidth);
 
-				var heightSpec = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
+				var (heightSpec, _, _) = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
 					, minimumSize: double.NaN, maximumSize: targetHeight);
 
 				var size = pvh.MeasureVirtualView(widthSpec, heightSpec);

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformContentViewGroup.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformContentViewGroup.java
@@ -6,7 +6,7 @@ import android.graphics.Path;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
 
-public abstract class PlatformContentViewGroup extends ViewGroup {
+public abstract class PlatformContentViewGroup extends PlatformViewGroup {
 
     public PlatformContentViewGroup(Context context) {
         super(context);

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformViewGroup.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformViewGroup.java
@@ -1,0 +1,68 @@
+package com.microsoft.maui;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.util.AttributeSet;
+import android.view.ViewGroup;
+
+public abstract class PlatformViewGroup extends ViewGroup {
+
+    private int lastWidthMeasureSpec;
+    private int lastHeightMeasureSpec;
+    private int measuredWidth;
+    private int measuredHeight;
+    private boolean hasValidMeasure;
+
+    public PlatformViewGroup(Context context) {
+        super(context);
+    }
+
+    public PlatformViewGroup(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public PlatformViewGroup(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public PlatformViewGroup(Context context, AttributeSet attrs, int defStyle, int defStyleRes) {
+        super(context, attrs, defStyle, defStyleRes);
+    }
+
+    @Override
+    public void requestLayout() {
+        super.requestLayout();
+        hasValidMeasure = false;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if (hasValidMeasure && lastWidthMeasureSpec == widthMeasureSpec && lastHeightMeasureSpec == heightMeasureSpec) {
+            setMeasuredDimension(measuredWidth, measuredHeight);
+            return;
+        }
+
+        doMeasure(widthMeasureSpec, heightMeasureSpec);
+        lastWidthMeasureSpec = widthMeasureSpec;
+        lastHeightMeasureSpec = heightMeasureSpec;
+        measuredWidth = getMeasuredWidth();
+        measuredHeight = getMeasuredHeight();
+        hasValidMeasure = true;
+    }
+
+    protected abstract void doMeasure(int widthMeasureSpec, int heightMeasureSpec);
+
+    public void quickMeasure(int widthMeasureSpec, int heightMeasureSpec, int measuredWidth, int measuredHeight) {
+        this.measuredWidth = measuredWidth;
+        this.measuredHeight = measuredHeight;
+        lastWidthMeasureSpec = widthMeasureSpec;
+        lastHeightMeasureSpec = heightMeasureSpec;
+        hasValidMeasure = true;
+        measure(widthMeasureSpec, heightMeasureSpec);
+    }
+
+    public boolean needsMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        return !hasValidMeasure || lastWidthMeasureSpec != widthMeasureSpec || lastHeightMeasureSpec != heightMeasureSpec;
+    }
+}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			// Create a spec to handle the native measure
-			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MinimumWidth, virtualView.MaximumWidth);
-			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
+			var (widthSpec, _, _) = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MinimumWidth, virtualView.MaximumWidth);
+			var (heightSpec, _, _) = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
 
 			if (platformView.FillViewport)
 			{

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -9,7 +9,7 @@ using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Platform
 {
-	public class ContentViewGroup : PlatformContentViewGroup, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
+	public class ContentViewGroup : PlatformContentViewGroup, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable, IPlatformQuickLayout
 	{
 		IBorderStroke? _clip;
 		readonly Context _context;
@@ -56,36 +56,36 @@ namespace Microsoft.Maui.Platform
 			return CrossPlatformLayout?.CrossPlatformArrange(bounds) ?? Graphics.Size.Zero;
 		}
 
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			if (CrossPlatformLayout is null)
-			{
-				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-				return;
-			}
-
-			var deviceIndependentWidth = widthMeasureSpec.ToDouble(_context);
-			var deviceIndependentHeight = heightMeasureSpec.ToDouble(_context);
-
-			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
-			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
-
-			var measure = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
-
-			// If the measure spec was exact, we should return the explicit size value, even if the content
-			// measure came out to a different size
-			var width = widthMode == MeasureSpecMode.Exactly ? deviceIndependentWidth : measure.Width;
-			var height = heightMode == MeasureSpecMode.Exactly ? deviceIndependentHeight : measure.Height;
-
-			var platformWidth = _context.ToPixels(width);
-			var platformHeight = _context.ToPixels(height);
-
-			// Minimum values win over everything
-			platformWidth = Math.Max(MinimumWidth, platformWidth);
-			platformHeight = Math.Max(MinimumHeight, platformHeight);
-
-			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
-		}
+		// protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		// {
+		// 	if (CrossPlatformLayout is null)
+		// 	{
+		// 		base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+		// 		return;
+		// 	}
+		//
+		// 	var deviceIndependentWidth = widthMeasureSpec.ToDouble(_context);
+		// 	var deviceIndependentHeight = heightMeasureSpec.ToDouble(_context);
+		//
+		// 	var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+		// 	var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
+		//
+		// 	var measure = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+		//
+		// 	// If the measure spec was exact, we should return the explicit size value, even if the content
+		// 	// measure came out to a different size
+		// 	var width = widthMode == MeasureSpecMode.Exactly ? deviceIndependentWidth : measure.Width;
+		// 	var height = heightMode == MeasureSpecMode.Exactly ? deviceIndependentHeight : measure.Height;
+		//
+		// 	var platformWidth = _context.ToPixels(width);
+		// 	var platformHeight = _context.ToPixels(height);
+		//
+		// 	// Minimum values win over everything
+		// 	platformWidth = Math.Max(MinimumWidth, platformWidth);
+		// 	platformHeight = Math.Max(MinimumHeight, platformHeight);
+		//
+		// 	SetMeasuredDimension((int)platformWidth, (int)platformHeight);
+		// }
 
 		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
 		{
@@ -142,6 +142,41 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return null;
+		}
+		
+		internal override void DoMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			var deviceIndependentWidth = widthMeasureSpec.ToDouble(_context);
+			var deviceIndependentHeight = heightMeasureSpec.ToDouble(_context);
+
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
+
+			var measure = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+
+			// If the measure spec was exact, we should return the explicit size value, even if the content
+			// measure came out to a different size
+			var width = widthMode == MeasureSpecMode.Exactly ? deviceIndependentWidth : measure.Width;
+			var height = heightMode == MeasureSpecMode.Exactly ? deviceIndependentHeight : measure.Height;
+
+			var platformWidth = _context.ToPixels(width);
+			var platformHeight = _context.ToPixels(height);
+
+			// Minimum values win over everything
+			platformWidth = Math.Max(MinimumWidth, platformWidth);
+			platformHeight = Math.Max(MinimumHeight, platformHeight);
+
+			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
+		}
+
+		bool IPlatformQuickLayout.NeedsMeasure(int p0, int p1)
+		{
+			return base.NeedsMeasure(p0, p1);
+		}
+
+		void IPlatformQuickLayout.QuickMeasure(int p0, int p1, int p2, int p3)
+		{
+			base.QuickMeasure(p0, p1, p2, p3);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -404,14 +404,17 @@ namespace Microsoft.Maui.Platform
 			return _navigationBarHeight ?? 0;
 		}
 
-		internal static int CreateMeasureSpec(this Context context, double constraint, double explicitSize, double minimumSize, double maximumSize)
+		internal static (int MeasureSpec, double CrossPlatformConstraint, bool Exact) CreateMeasureSpec(this Context context, double constraint, double explicitSize, double minimumSize, double maximumSize)
 		{
 			var mode = MeasureSpecMode.AtMost;
+			var exact = false;
+			var crossPlatformConstraint = constraint;
 
 			if (IsExplicitSet(explicitSize))
 			{
 				// We have a set value (i.e., a Width or Height)
 				mode = MeasureSpecMode.Exactly;
+				exact = true;
 
 				// Since the mode is "Exactly", we have to return the exact final value clamped to the minimum/maximum.
 				constraint = Math.Max(explicitSize, ResolveMinimum(minimumSize));
@@ -420,11 +423,14 @@ namespace Microsoft.Maui.Platform
 				{
 					constraint = Math.Min(constraint, maximumSize);
 				}
+
+				crossPlatformConstraint = constraint;
 			}
 			else if (IsMaximumSet(maximumSize) && maximumSize < constraint)
 			{
 				mode = MeasureSpecMode.AtMost;
 				constraint = maximumSize;
+				crossPlatformConstraint = constraint;
 			}
 			else if (double.IsInfinity(constraint))
 			{
@@ -436,7 +442,7 @@ namespace Microsoft.Maui.Platform
 			// Convert to a platform size to create the spec for measuring
 			var deviceConstraint = (int)context.ToPixels(constraint);
 
-			return mode.MakeMeasureSpec(deviceConstraint);
+			return (mode.MakeMeasureSpec(deviceConstraint), crossPlatformConstraint, exact);
 		}
 
 		public static float GetDisplayDensity(this Context? context)

--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -214,5 +214,10 @@ namespace Microsoft.Maui.Platform
 				clearWrapperView.Invoke();
 			}
 		}
+		
+		internal override void DoMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -21,6 +21,17 @@ Microsoft.Maui.Handlers.OpenWindowRequest.Deconstruct(out Microsoft.Maui.IPersis
 Microsoft.Maui.Handlers.OpenWindowRequest.OpenWindowRequest(Microsoft.Maui.Handlers.OpenWindowRequest! original) -> void
 Microsoft.Maui.Hosting.MauiAppBuilder.Environment.get -> Microsoft.Maui.Hosting.MauiHostEnvironment!
 Microsoft.Maui.Hosting.MauiAppBuilder.Properties.get -> System.Collections.Generic.IDictionary<object!, object!>!
+Microsoft.Maui.PlatformViewGroup
+override Microsoft.Maui.PlatformViewGroup.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Microsoft.Maui.PlatformViewGroup.ThresholdClass.get -> nint
+override Microsoft.Maui.PlatformViewGroup.ThresholdType.get -> System.Type!
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle, int defStyleRes) -> void
+*REMOVED*override Microsoft.Maui.Platform.ContentViewGroup.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+*REMOVED*override Microsoft.Maui.Platform.LayoutViewGroup.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
 Microsoft.Maui.Hosting.MauiHostEnvironment
 Microsoft.Maui.Hosting.MauiHostEnvironment.ApplicationName.get -> string!
 Microsoft.Maui.Hosting.MauiHostEnvironment.ApplicationName.set -> void

--- a/src/Core/src/Transforms/Metadata.xml
+++ b/src/Core/src/Transforms/Metadata.xml
@@ -8,6 +8,7 @@
   <!-- Public types -->
   <attr path="//class[@name='PlatformAppCompatTextView']" name="visibility">public</attr>
   <attr path="//class[@name='PlatformContentViewGroup']" name="visibility">public</attr>
+  <attr path="//class[@name='PlatformViewGroup']" name="visibility">public</attr>
   <attr path="//class[@name='PlatformWrapperView']" name="visibility">public</attr>
   <attr path="//class[@name='MauiViewGroup']" name="visibility">public</attr>
   <attr path="//interface[@name='ImageLoaderCallback']" name="visibility">public</attr>
@@ -15,6 +16,9 @@
   <attr path="//class[@name='PlatformAppCompatTextView']/method" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformAppCompatTextView']/constructor" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformWrapperView']/method[@name='updateShadow']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/method[@name='doMeasure']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/method[@name='quickMeasure']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/method[@name='needsMeasure']" name="visibility">internal</attr>
 
   <remove-node path="//package[@name='com.bumptech.glide']" />
   <remove-node path="//package[@name='com.microsoft.maui.glide']" />


### PR DESCRIPTION
## This is a PoC, do not merge

This PR is a proof of concept on how we may **reduce Android Java calls to .NET during layout pass**.

The PoC focuses **only on the measure pass** but I think the same strategy can be applied to the layout pass.

The code needs some love to be something we really include in the main branch, so just look at the idea and do not care about naming.

An alternative can be found here: https://github.com/dotnet/maui/pull/31776

### The idea

When we know there's a cross-platform-layout view, instead of invoking `Measure` and go to Java to let it call us back, we now:

- Verify the view needs a measure and cannot work with a cached one  `NeedsMeasure` (quick C# to J)
  - When `true`
    - Measure the cross platform layout directly (C# to C#)
    - Invoke `QuickMeasure` (quick C# to J) which
      - Stores the measure on java side
      - Runs the `Measure` method from there which avoids calling us due to the prepared measure
  - When `false`
    - Invoke `MeasureAndGetWidthAndHeight` (C# to J) which is now fast because android will immediately return the cached measure

So what's the call stack?
- `net10.0`: Android invokes `Measure` on the root, and then this chain of call starts
   `override OnMeasure` (J to C#) -> `CrossPlatformLayout.Measure` -> `Measure` (C# to J) -> `override OnMeasure` (J to C#) ......... and so on
- `PR`: Android invokes `Measure` on the root, then
   `onMeasure` (override on java side) -> `doMeasure` -> `NeedsMeasure` (quick C# to J) -> CrossPlatformLayout.Measure` -> `NeedsMeasure` -> `CrossPlatformLayout.Measure` -> `NeedsMeasure` -> `CrossPlatformLayout.Measure` .... then when the call chain reaches the leaf ... `Measure` (C# to J) -> ... now up to each ancestor call -> `QuickMeasure` (quick C# to J) -> `QuickMeasure` (quick C# to J) -> `QuickMeasure` (quick C# to J) .... up to the root

### Benchmarks

The benchmark is done by using #25671 as main page and tap on `Regenerate items` 5 times.
[25671-net10.json](https://github.com/user-attachments/files/22303499/25671-net10.json)
<img width="930" height="205" alt="image" src="https://github.com/user-attachments/assets/72e0a053-95d7-4f07-81d3-5b6d9524939e" />

[25671-pr-poc.json](https://github.com/user-attachments/files/22303500/25671-pr-poc.json)
<img width="1252" height="286" alt="image" src="https://github.com/user-attachments/assets/48f007e3-9175-4963-b625-19c26877ff21" />

What's interesting is that the new `QuickMeasure`/`NeedsMeasure` java calls are not even showing up as a demonstration of how fast they are.