### PR TITLE
[Android] Create a Java layer for LayoutViewGroup

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformViewGroup.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformViewGroup.java
@@ -1,0 +1,25 @@
+package com.microsoft.maui;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.util.AttributeSet;
+import android.view.ViewGroup;
+
+public abstract class PlatformViewGroup extends ViewGroup {
+    public PlatformViewGroup(Context context) {
+        super(context);
+    }
+
+    public PlatformViewGroup(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public PlatformViewGroup(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public PlatformViewGroup(Context context, AttributeSet attrs, int defStyle, int defStyleRes) {
+        super(context, attrs, defStyle, defStyleRes);
+    }
+}

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -11,7 +11,7 @@ using Size = Microsoft.Maui.Graphics.Size;
 
 namespace Microsoft.Maui.Platform
 {
-	public class LayoutViewGroup : ViewGroup, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
+	public class LayoutViewGroup : PlatformViewGroup, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
 	{
 		readonly ARect _clipRect = new();
 		readonly Context _context;

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -21,6 +21,15 @@ Microsoft.Maui.Handlers.OpenWindowRequest.Deconstruct(out Microsoft.Maui.IPersis
 Microsoft.Maui.Handlers.OpenWindowRequest.OpenWindowRequest(Microsoft.Maui.Handlers.OpenWindowRequest! original) -> void
 Microsoft.Maui.Hosting.MauiAppBuilder.Environment.get -> Microsoft.Maui.Hosting.MauiHostEnvironment!
 Microsoft.Maui.Hosting.MauiAppBuilder.Properties.get -> System.Collections.Generic.IDictionary<object!, object!>!
+Microsoft.Maui.PlatformViewGroup
+override Microsoft.Maui.PlatformViewGroup.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Microsoft.Maui.PlatformViewGroup.ThresholdClass.get -> nint
+override Microsoft.Maui.PlatformViewGroup.ThresholdType.get -> System.Type!
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
+Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle, int defStyleRes) -> void
 Microsoft.Maui.Hosting.MauiHostEnvironment
 Microsoft.Maui.Hosting.MauiHostEnvironment.ApplicationName.get -> string!
 Microsoft.Maui.Hosting.MauiHostEnvironment.ApplicationName.set -> void

--- a/src/Core/src/Transforms/Metadata.xml
+++ b/src/Core/src/Transforms/Metadata.xml
@@ -8,6 +8,7 @@
   <!-- Public types -->
   <attr path="//class[@name='PlatformAppCompatTextView']" name="visibility">public</attr>
   <attr path="//class[@name='PlatformContentViewGroup']" name="visibility">public</attr>
+  <attr path="//class[@name='PlatformViewGroup']" name="visibility">public</attr>
   <attr path="//class[@name='PlatformWrapperView']" name="visibility">public</attr>
   <attr path="//class[@name='MauiViewGroup']" name="visibility">public</attr>
   <attr path="//interface[@name='ImageLoaderCallback']" name="visibility">public</attr>


### PR DESCRIPTION
### Description of Change

#31595 contains a PoC that tries to speed up the layout pass by avoiding Java -> .NET calls.

It's too late to make this happen in .NET10 GA, so we prepare the ground for a later SR by introducing a Java class to be used by `LayoutViewGroup` as superclass.
