### PR TITLE
Fix NRE on GetSystemResources

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls
 #pragma warning disable CS0612 // Type or member is obsolete
 			_systemResources = new Lazy<IResourceDictionary?>(() =>
 			{
-				var systemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
+				var systemResources = DependencyService.Get<ISystemResourcesProvider>()?.GetSystemResources();
 				if (systemResources is not null)
 				{
 					systemResources.ValuesChanged += OnParentResourcesChanged;


### PR DESCRIPTION
`DependencyService.Get<ISystemResourcesProvider>()` may return null if it's never set. Since the next call is a null check on ISystemResourcesProvider if it exists for attaching to an event, we can null check the dependency service call too.