### PR TITLE
[inflight/candidate] September 15th - Adjust header content inset for iOS Shell flyout

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -199,8 +199,43 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				HeaderView.SizeThatFits(new CGSize(ContentView.Superview.Frame.Width, double.PositiveInfinity));
 			}
 
+			SetHeaderContentInset();
 			UpdateHeaderMaximumSize(ScrollView?.ContentOffset.Y);
 			LayoutParallax();
+		}
+
+
+		internal void SetHeaderContentInset()
+		{
+			var headerBehavior = _context.Shell.FlyoutHeaderBehavior;
+
+			if (ScrollView is null || headerBehavior == FlyoutHeaderBehavior.Fixed || headerBehavior == FlyoutHeaderBehavior.Default)
+				return;
+
+			var offset = ScrollView.ContentInset.Top;
+
+			if (HeaderView is not null)
+			{
+				if (double.IsNaN(MeasuredHeaderViewHeightWithNoMargin))
+				{
+					return;
+				}
+
+				// We take the measured header height without margin, since the margin is already accounted for in the positioning of the scroll view itself.
+				ScrollView.ContentInset = new UIEdgeInsets((nfloat)Math.Max(HeaderMinimumHeight, MeasuredHeaderViewHeightWithNoMargin), 0, 0, 0);
+			}
+			else
+			{
+				ScrollView.ContentInset = new UIEdgeInsets(UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top, 0, 0, 0);
+			}
+
+			offset -= ScrollView.ContentInset.Top;
+
+			var yContentOffset = ScrollView.ContentOffset.Y;
+			ScrollView.ContentOffset =
+				new CGPoint(ScrollView.ContentOffset.X, yContentOffset + offset);
+
+			UpdateVerticalScrollMode();
 		}
 
 		public void UpdateVerticalScrollMode()
@@ -286,7 +321,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (HeaderView is not null)
 			{
-				contentYOffset += HeaderView.Frame.Height;
+				var headerBehavior = _context.Shell.FlyoutHeaderBehavior;
+
+				if (ScrollView is null || headerBehavior == FlyoutHeaderBehavior.Fixed || headerBehavior == FlyoutHeaderBehavior.Default)
+				{
+					// The margin is already managed by MAUI's layout system, so we don't need to add it here and we just offset the content by the header's height.				
+					contentYOffset += HeaderView.Frame.Height;
+				}
+				else
+				{
+					// For ScrollView, we need to consider the margin, but we should not consider the header height, since it should overlap with the scroll view. 
+					// The content inset is already managed by SetHeaderContentInset.
+					contentYOffset += HeaderView.View.Margin.VerticalThickness;
+				}
 			}
 
 			var contentFrame = new Rect(parentBounds.X, contentYOffset, parentBounds.Width, parentBounds.Height - contentYOffset - footerHeight);
@@ -313,6 +360,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			if (e.Is(Shell.FlyoutHeaderBehaviorProperty))
 			{
+				SetHeaderContentInset();
 				LayoutParallax();
 			}
 			else if (e.Is(Shell.FlyoutVerticalScrollModeProperty))

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		[System.Runtime.Versioning.SupportedOSPlatform("tvos11.0")]
 		public override void ViewSafeAreaInsetsDidChange()
 		{
+			ShellFlyoutContentManager.SetHeaderContentInset();
 			base.ViewSafeAreaInsetsDidChange();
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Introduces SetHeaderContentInset to properly manage the header's content inset based on FlyoutHeaderBehavior, ensuring correct layout and scroll behavior.

This PR resolves an issue pointed by this comment https://github.com/dotnet/maui/pull/31525#issuecomment-3286285365