### PR TITLE
Update the Windows App SDK to 1.8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,8 +62,8 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.8</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.7.250606001</MicrosoftWindowsAppSDKPackageVersion>
-    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.8.250702007-experimental4</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.3233</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.8</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.8.250814004-preview</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.8.250907003</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,8 +62,8 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.8</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.8.250702007-experimental4</MicrosoftWindowsAppSDKPackageVersion>
-    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.3233</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.8.250814004-preview</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -39,6 +39,7 @@
     <Compile Include="**\*.uwp.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.uwp.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <PackageReference Include="Microsoft.Web.WebView2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

--- a/src/Graphics/src/Graphics.Skia/Graphics.Skia.csproj
+++ b/src/Graphics/src/Graphics.Skia/Graphics.Skia.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="SkiaSharp.Views.WinUI" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -39,6 +39,7 @@
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Description of Change

This PR builds on top of #30665 and updates to the stable version of the SDK:

* https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/stable-channel#version-18
* https://github.com/microsoft/WindowsAppSDK/releases/tag/v1.8.0

### Issues Fixed

Fixes #30858