### PR TITLE
[SG] generated code behind for RD in global xmlns

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -312,15 +312,29 @@ static class CodeBehindCodeWriter
 			XmlnsHelper.ParseXmlns(rootClass.Value, out rootType, out rootClrNamespace, out _, out _);
 		}
 #if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-		else if (hasXamlCompilationProcessingInstruction && root.NamespaceURI == XamlParser.MauiUri)
+		else if (hasXamlCompilationProcessingInstruction
+				&& (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri))
+#else
+		else if (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri)
+#endif
 		{
+			//make sure the base type can be resolved. if not, don't consider this as xaml, and move away
+			var typeArgs = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
+			try
+			{
+				var basetype = new XmlType(root.NamespaceURI, root.LocalName, typeArgs != null ? TypeArgumentsParser.ParseExpression(typeArgs, nsmgr, null) : null).GetTypeSymbol(null, compilation, xmlnsCache);
+			}
+			catch
+			{
+				return false;
+			}
+
 			rootClrNamespace = "__XamlGeneratedCode__";
 			rootType = $"__Type{uid}";
 			generateDefaultCtor = true;
 			addXamlCompilationAttribute = true;
 			hideFromIntellisense = true;
 		}
-#endif
 		else if (parseResult?.ProjectItem?.ManifestResourceName != null && parseResult.ProjectItem.TargetPath != null)
 		{ // rootClass == null && !hasXamlCompilationProcessingInstruction) {
 			xamlResourceIdOnly = true; //only generate the XamlResourceId assembly attribute

--- a/src/Controls/src/SourceGen/ISymbolExtensions.cs
+++ b/src/Controls/src/SourceGen/ISymbolExtensions.cs
@@ -1,11 +1,6 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 


### PR DESCRIPTION
### Description of Change

we weren't generating the boiler plate for ResourceDictionary using the global xmlns for XamlC compilation or sourcegen.

fixing that, and getting back the #performance

### Issues Fixed

- fixes #31602
