### PR TITLE
[Testing] Fix for flaky test(PullToRefreshWorksWhenEnabled) in CI

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30690.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30690.cs
@@ -119,13 +119,24 @@ public class Issue30690 : _IssuesUITest
 	{
 		// Find the scroll view content to perform pull gesture on
 		App.WaitForElement(ScrollViewContent);
+		bool refreshSucceeded = false;
+		for (int i = 0; i < 3 && !refreshSucceeded; i++)
+		{
+			// Perform pull-to-refresh
+			App.ScrollUp(ScrollViewContent, ScrollStrategy.Gesture, swipePercentage: 0.90, swipeSpeed: 1000);
+			try
+			{
+				// Wait for refresh to complete and verify it worked
+				App.WaitForTextToBePresentInElement(StatusLabel, "Refreshing...", timeout: TimeSpan.FromSeconds(5));
+				refreshSucceeded = App.WaitForTextToBePresentInElement(StatusLabel, "Refresh completed", timeout: TimeSpan.FromSeconds(5));
+			}
 
-		// Perform pull-to-refresh
-		App.ScrollUp(ScrollViewContent);
-		App.WaitForTextToBePresentInElement(StatusLabel, "Refreshing...", timeout: TimeSpan.FromSeconds(5));
-
-		// Wait for refresh to complete and verify it worked
-		Assert.That(App.WaitForTextToBePresentInElement(StatusLabel, "Refresh completed", timeout: TimeSpan.FromSeconds(5)), Is.True);
+			catch (Exception)
+			{
+				// Refresh not completed yet, will retry
+			}
+		}
+		Assert.That(refreshSucceeded, Is.True, "Pull-to-refresh did not complete after multiple attempts");
 	}
 
 	[Test]


### PR DESCRIPTION
 
This pull request improves the reliability of the pull-to-refresh test in `Issue30690.cs` by adding retry logic and more robust verification for the refresh completion. The main change is to ensure the test does not fail due to transient issues with the pull gesture or UI timing.

**Test robustness improvements:**

* Added a retry loop to attempt the pull-to-refresh gesture up to three times, increasing the likelihood of a successful refresh in case of intermittent failures.
* Enhanced the gesture by specifying `ScrollStrategy.Gesture`, a high swipe percentage, and a defined swipe speed for more consistent interaction.
* Improved verification by waiting for both "Refreshing..." and "Refresh completed" statuses, and only passing the test if refresh succeeds within the retries.