### PR TITLE
[XSG] Correct lineinfo for expanded markups

### DIFF
--- a/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
@@ -7,9 +7,15 @@ using Microsoft.Maui.Controls.Xaml;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 
-class ExpandMarkupsVisitor : IXamlNodeVisitor
+class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 {
-	public ExpandMarkupsVisitor(SourceGenContext context) => Context = context;
+	record XmlLineInfoProvider(IXmlLineInfo XmlLineInfo) : IXmlLineInfoProvider
+	{
+	}
+
+	record SGContextProvider(SourceGenContext Context)
+	{
+	}
 
 	public static readonly IList<XmlName> Skips =
 	[
@@ -19,7 +25,7 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 		XmlName.xName,
 	];
 
-	SourceGenContext Context { get; }
+	SourceGenContext Context { get; } = context;
 	public TreeVisitingMode VisitingMode => TreeVisitingMode.BottomUp;
 	public bool StopOnDataTemplate => false;
 	public bool StopOnResourceDictionary => false;
@@ -63,7 +69,7 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 	INode? ParseExpression(ref string expression, IXmlNamespaceResolver nsResolver, IXmlLineInfo xmlLineInfo, INode node, INode parentNode)
 	{
 		if (expression.StartsWith("{}", StringComparison.Ordinal))
-			return new ValueNode(expression.Substring(2), null);
+			return new ValueNode(expression.Substring(2), null, xmlLineInfo?.LineNumber ?? -1, xmlLineInfo?.LinePosition ?? -1);
 
 		if (expression[expression.Length - 1] != '}')
 		{
@@ -92,16 +98,12 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 		var serviceProvider = new XamlServiceProvider(node, Context);
 		serviceProvider.Add(typeof(IXmlNamespaceResolver), nsResolver);
 		serviceProvider.Add(typeof(SGContextProvider), new SGContextProvider(Context));
+		if (xmlLineInfo != null)
+			serviceProvider.Add(typeof(IXmlLineInfoProvider), new XmlLineInfoProvider(xmlLineInfo));
 
 		return new MarkupExpansionParser().Parse(match!, ref expression, serviceProvider);
 	}
 
-	class SGContextProvider
-	{
-		public SGContextProvider(SourceGenContext context) => Context = context;
-
-		public SourceGenContext Context { get; }
-	}
 
 	public class MarkupExpansionParser : MarkupExpressionParser, IExpressionParser<INode>
 	{
@@ -110,7 +112,7 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 
 		public INode Parse(string match, ref string remaining, IServiceProvider serviceProvider)
 		{
-			if (!(serviceProvider.GetService(typeof(IXmlNamespaceResolver)) is IXmlNamespaceResolver nsResolver))
+			if (serviceProvider.GetService(typeof(IXmlNamespaceResolver)) is not IXmlNamespaceResolver nsResolver)
 				throw new ArgumentException();
 			IXmlLineInfo? xmlLineInfo = null;
 			if (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider xmlLineInfoProvider)
@@ -149,7 +151,10 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 					catch (XamlParseException xpe)
 					{
 						if (contextProvider != null)
+						{
 							contextProvider.Context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, LocationHelpers.LocationCreate(contextProvider.Context.ProjectItem.RelativePath!, xmlLineInfo!, match), xpe.Message));
+							return null!;
+						}
 						else
 							throw;
 					}
@@ -174,11 +179,11 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 					if (childname == XmlName.xTypeArguments)
 					{
 						typeArguments = TypeArgumentsParser.ParseExpression(parsed.strValue, nsResolver, xmlLineInfo);
-						childnodes.Add((childname, new ValueNode(typeArguments, nsResolver)));
+						childnodes.Add((childname, new ValueNode(typeArguments, nsResolver, xmlLineInfo?.LineNumber ?? -1, xmlLineInfo?.LinePosition ?? -1)));
 					}
 					else
 					{
-						var childnode = parsed.value as INode ?? new ValueNode(parsed.strValue, nsResolver);
+						var childnode = parsed.value as INode ?? new ValueNode(parsed.strValue, nsResolver, xmlLineInfo?.LineNumber ?? -1, xmlLineInfo?.LinePosition ?? -1);
 						childnodes.Add((childname, childnode));
 					}
 				}
@@ -198,9 +203,7 @@ class ExpandMarkupsVisitor : IXamlNodeVisitor
 				throw new NotSupportedException();
 
 
-			_node = xmlLineInfo == null
-				? new ElementNode(xmltype, null, nsResolver)
-				: new ElementNode(xmltype, null, nsResolver, xmlLineInfo.LineNumber, xmlLineInfo.LinePosition);
+			_node = new ElementNode(xmltype, null, nsResolver, xmlLineInfo?.LineNumber ?? -1, xmlLineInfo?.LinePosition ?? -1);
 
 			foreach (var (childname, childnode) in childnodes)
 			{

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/CompiledBindings.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/CompiledBindings.cs
@@ -73,7 +73,7 @@ public partial class TestPage
 	private partial void InitializeComponent()
 	{
 		var bindingExtension = new global::Microsoft.Maui.Controls.Xaml.BindingExtension();
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingExtension!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), -1, -1);
+		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingExtension!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 5);
 		var __root = this;
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(__root!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 2, 2);
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
@@ -82,12 +82,12 @@ public partial class TestPage
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		global::Microsoft.Maui.Controls.Internals.NameScope.SetNameScope(__root, iNameScope);
 #endif
-#line 1 "{{testXamlFilePath}}"
+#line 8 "{{testXamlFilePath}}"
 		bindingExtension.Path = "Foo.Bar.Title";
 #line default
 		var bindingBase = CreateTypedBindingFrom_bindingExtension(bindingExtension);
 		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(bindingBase!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingBase!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), -1, -1);
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingBase!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 5);
 		__root.SetBinding(global::Microsoft.Maui.Controls.Page.TitleProperty, bindingBase);
 		static global::Microsoft.Maui.Controls.BindingBase CreateTypedBindingFrom_bindingExtension(global::Microsoft.Maui.Controls.Xaml.BindingExtension extension)
 {

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/DoesNotFail.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/DoesNotFail.cs
@@ -23,6 +23,7 @@ public class DoesNotFail : SourceGenXamlInitializeComponentTestBase
             <x:Int32>32</x:Int32>
         </x:Array>
     </ContentPage.Resources>
+	<Label Text="{Binding Path=., Converter={StaticResource reverseConverter}}" x:DataType="x:String"/>
 </ContentPage>
 """;
 

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/LineInfoTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/LineInfoTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Microsoft.Maui.Controls.SourceGen.UnitTests.InitializeComponent;
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
 
 public class LineInfoTests : SourceGenXamlInitializeComponentTestBase
 {

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetBinding.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetBinding.cs
@@ -59,7 +59,7 @@ public partial class TestPage
 	private partial void InitializeComponent()
 	{
 		var bindingExtension = new global::Microsoft.Maui.Controls.Xaml.BindingExtension();
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingExtension!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), -1, -1);
+		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingExtension!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 6, 5);
 		var __root = this;
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(__root!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 2, 2);
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
@@ -68,12 +68,12 @@ public partial class TestPage
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		global::Microsoft.Maui.Controls.Internals.NameScope.SetNameScope(__root, iNameScope);
 #endif
-#line 1 "{{testXamlFilePath}}"
+#line 6 "{{testXamlFilePath}}"
 		bindingExtension.Path = "Title";
 #line default
 		var bindingBase = new global::Microsoft.Maui.Controls.Binding(bindingExtension.Path, bindingExtension.Mode, bindingExtension.Converter, bindingExtension.ConverterParameter, bindingExtension.StringFormat, bindingExtension.Source) { UpdateSourceEventName = bindingExtension.UpdateSourceEventName, FallbackValue = bindingExtension.FallbackValue, TargetNullValue = bindingExtension.TargetNullValue };
 		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(bindingBase!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingBase!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), -1, -1);
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(bindingBase!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 6, 5);
 		__root.SetBinding(global::Microsoft.Maui.Controls.Page.TitleProperty, bindingBase);
 	}
 }

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SimplifyOnPlatform.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SimplifyOnPlatform.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Microsoft.Maui.Controls.SourceGen.UnitTests.InitializeComponent;
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
 
 public class SimplifyOnPlatform : SourceGenXamlInitializeComponentTestBase
 {
@@ -149,7 +149,7 @@ public partial class TestPage
 		xamlServiceProvider2.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IXamlTypeResolver), new global::Microsoft.Maui.Controls.Xaml.Internals.XamlTypeResolver(xmlNamespaceResolver2, typeof(global::Test.TestPage).Assembly));
 		setter1.Property = ((global::Microsoft.Maui.Controls.IExtendedTypeConverter)new global::Microsoft.Maui.Controls.BindablePropertyConverter()).ConvertFromInvariantString("IsVisible", xamlServiceProvider2) as global::Microsoft.Maui.Controls.BindableProperty;
 #line default
-#line 1 "{{testXamlFilePath}}"
+#line 9 "{{testXamlFilePath}}"
 		setter1.Value = "True";
 #line default
 		var setter3 = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.VisualElement.IsVisibleProperty, Value = (bool)new global::Microsoft.Maui.Controls.VisualElement.VisibilityConverter().ConvertFromInvariantString("True")!};


### PR DESCRIPTION
### Description of Change

while expanding markup nodes to element and value nodes, some line info weren't transferred. Fixing this produces better `#line` pragmas and VisualDiagnostics

### Issues Fixed

- fixes #30855
