### PR TITLE
[Windows] Build warnings with older WinAppSDK version

### DIFF
--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

On the main branch, WinAppSDK 1.6 is mentiond in the warnings when `dotnet build ./Microsoft.Maui.BuildTasks.slnf` is run:

#### `main`

```
Restore complete (9,7s)
X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Essentials\src\Essentials.csproj]
X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Essentials\src\Essentials.csproj]
  Controls.Xaml.Design net472 succeeded (2,9s) → artifacts\bin\Controls.Xaml.Design\Debug\net472\Microsoft.Maui.Controls.Xaml.DesignTools.dll
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Core\src\Core.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Core\src\Core.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Xaml\Controls.Xaml.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Xaml\Controls.Xaml.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Core\Controls.Core.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Core\Controls.Core.csproj]
X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj]
X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj]
X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics\Graphics.csproj]
X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.6.241114003\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics\Graphics.csproj]
```

#### PR

With the PR, `dotnet build ./Microsoft.Maui.BuildTasks.slnf` does not mention WinAppSdk 1.6:

```
Restore complete (7,8s)
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Core\src\Core.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Core\src\Core.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Essentials\src\Essentials.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Essentials\src\Essentials.csproj]
  Controls.Xaml.Design net472 succeeded (2,8s) → artifacts\bin\Controls.Xaml.Design\Debug\net472\Microsoft.Maui.Controls.Xaml.DesignTools.dll
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Core\Controls.Core.csproj]
  Controls.Core.Design net472 succeeded (3,5s) → artifacts\bin\Controls.Core.Design\Debug\net472\Microsoft.Maui.Controls.DesignTools.dll
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Core\Controls.Core.csproj]
  Graphics netstandard2.1 succeeded (3,3s) → artifacts\bin\Graphics\Debug\netstandard2.1\Microsoft.Maui.Graphics.dll
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics\Graphics.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics\Graphics.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Graphics\src\Graphics.Win2D\Graphics.Win2D.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Xaml\Controls.Xaml.csproj]
X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.BeforeCommon.targets(31,3): warning MSB4011: "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.Build.Msix.props" cannot be imported again. It was already imported at "X:\.nuget\microsoft.windowsappsdk\1.7.250606001\buildTransitive\Microsoft.WinUI.props (22,3)". This is most likely a build authoring error. This subsequent import will be ignored. [X:\maui\src\Controls\src\Xaml\Controls.Xaml.csproj]
```

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #31668

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
