### PR TITLE
Delete GlobalXmlns.cs from maui-mobile template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/GlobalXmlns.cs
+++ b/src/Templates/src/templates/maui-mobile/GlobalXmlns.cs
@@ -1,2 +1,0 @@
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/maui/global", "MauiApp._1")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/maui/global", "MauiApp._1.Pages")]


### PR DESCRIPTION
This reverts #29203

While adding this file is useful for people to make a start, people still need to make changes to their template/app to make it work. So in its current form this is confusing to have it in the templates.

Removing this for now to avoid confusion. We're going to take our time to make sure the XAML Simplifications (and XAML Source Generation) are solid, before we want to introduce this (as options) in the templates.

We also need to "back"port this to .NET 10