### PR TITLE
[iOS] Fix CollectionView dragging issue when empty with Header and EmptyView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
+		bool IsItemsSourceEmpty => (ItemsSource?.ItemCount ?? 0) == 0;
+
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
@@ -140,7 +142,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var wasEmpty = _isEmpty;
 
-			_isEmpty = ItemsSource?.ItemCount == 0 || ItemsSource is null;
+			_isEmpty = IsItemsSourceEmpty;
 
 			if (wasEmpty != _isEmpty)
 			{
@@ -296,8 +298,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
 			// Update bouncing behavior when ItemsSource changes
-			var isEmpty = ItemsSource?.ItemCount == 0 || ItemsSource is null;
-			UpdateBouncingBehavior(isEmpty);
+			UpdateBouncingBehavior(IsItemsSourceEmpty);
 
 			(ItemsView as IView)?.InvalidateMeasure();
 		}
@@ -479,9 +480,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
 
 			// We may need to show the updated empty view
-			var isEmpty = ItemsSource?.ItemCount == 0 || ItemsSource is null;
-			UpdateEmptyViewVisibility(isEmpty);
-			UpdateBouncingBehavior(isEmpty);
+			UpdateEmptyViewVisibility(IsItemsSourceEmpty);
+			UpdateBouncingBehavior(IsItemsSourceEmpty);
 		}
 
 		void UpdateEmptyViewVisibility(bool isEmpty)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31465.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31465.cs
@@ -1,0 +1,70 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31465, "CollectionView with null ItemsSource and Header can be dragged down creating extra space", PlatformAffected.iOS)]
+public class Issue31465 : TestContentPage
+{
+	public string Text { get; set; }
+
+	protected override void Init()
+	{
+		Title = "Header and footer (Null)";
+
+		var grid = new Grid
+		{
+			Margin = new Thickness(20),
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		var instructionsStack = new StackLayout();
+		var instructionsLabel = new Label
+		{
+			Text = "The test passes if the header and emptyview content displayed correctly and are not overlapped when itemsource is null."
+		};
+		instructionsStack.Children.Add(instructionsLabel);
+		grid.Children.Add(instructionsStack);
+		Grid.SetRow(instructionsStack, 0);
+
+		var collectionView = new CollectionView2
+		{
+			AutomationId = "TestCollectionView"
+		};
+
+		// Set binding to Text property with null BindingContext (like the original)
+		collectionView.SetBinding(CollectionView2.ItemsSourceProperty, "Text");
+
+		collectionView.Header = new Label
+		{
+			Text = "Header: This should show for all cases.",
+			TextColor = Color.FromArgb("#512BD4"),
+			AutomationId = "HeaderLabel"
+		};
+
+		collectionView.EmptyView = new Label
+		{
+			Text = "EmptyView: This should show when no data.",
+			TextColor = Color.FromArgb("#512BD4"),
+			AutomationId = "EmptyViewLabel"
+		};
+
+		collectionView.ItemTemplate = new DataTemplate(() =>
+		{
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, ".");
+			return label;
+		});
+
+		grid.Children.Add(collectionView);
+		Grid.SetRow(collectionView, 1);
+
+		Content = grid;
+
+		// Set BindingContext to null to reproduce the original issue
+		BindingContext = null;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31465.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31465.cs
@@ -35,7 +35,6 @@ public class Issue31465 : TestContentPage
 			AutomationId = "TestCollectionView"
 		};
 
-		// Set binding to Text property with null BindingContext (like the original)
 		collectionView.SetBinding(CollectionView2.ItemsSourceProperty, "Text");
 
 		collectionView.Header = new Label

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31465.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31465.cs
@@ -14,28 +14,21 @@ public class Issue31465 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void CollectionViewWithNullBindingContextShouldDisplayHeaderAndEmptyViewCorrectly()
 	{
-		// Wait for the page to load
 		App.WaitForElement("TestCollectionView");
 		App.WaitForElement("HeaderLabel");
 		App.WaitForElement("EmptyViewLabel");
 
-		// Verify the header text is displayed
 		var headerLabel = App.FindElement("HeaderLabel");
 		Assert.That(headerLabel.GetText(), Is.EqualTo("Header: This should show for all cases."));
 
-		// Verify the empty view text is displayed
 		var emptyViewLabel = App.FindElement("EmptyViewLabel");
 		Assert.That(emptyViewLabel.GetText(), Is.EqualTo("EmptyView: This should show when no data."));
-
-		// Test passes if both header and empty view are visible and properly positioned
-		// The fix should prevent extra space from appearing between them when dragging
 	}
 
 	[Test]
 	[Category(UITestCategories.CollectionView)]
 	public void CollectionViewShouldNotBeDraggableWhenEmpty()
 	{
-		// Wait for the page to load
 		App.WaitForElement("TestCollectionView");
 		App.WaitForElement("HeaderLabel");
 		App.WaitForElement("EmptyViewLabel");
@@ -44,55 +37,41 @@ public class Issue31465 : _IssuesUITest
 		var headerLabel = App.FindElement("HeaderLabel");
 		var emptyViewLabel = App.FindElement("EmptyViewLabel");
 
-		// Get initial positions of header and empty view
 		var initialHeaderRect = headerLabel.GetRect();
 		var initialEmptyViewRect = emptyViewLabel.GetRect();
 
-		// Verify initial state - both elements should be visible with correct text
 		Assert.That(headerLabel.GetText(), Is.EqualTo("Header: This should show for all cases."));
 		Assert.That(emptyViewLabel.GetText(), Is.EqualTo("EmptyView: This should show when no data."));
 
-		// Perform a scroll down gesture on the CollectionView
-		// This attempts to reproduce the issue where users could drag down and create space
 		var collectionViewRect = collectionView.GetRect();
 		var startX = collectionViewRect.X + collectionViewRect.Width / 2;
-		var startY = collectionViewRect.Y + 50; // Start near the top
-		var endY = startY + 200; // Drag down significantly
+		var startY = collectionViewRect.Y + 50;
+		var endY = startY + 200;
 
-		// Perform the drag gesture
 		App.DragCoordinates(startX, startY, startX, endY);
 
-		// Wait a moment for any potential animation/layout changes
 		Thread.Sleep(500);
 
-		// Verify elements are still properly positioned and haven't been separated
 		App.WaitForElement("HeaderLabel");
 		App.WaitForElement("EmptyViewLabel");
 
 		var afterDragHeaderLabel = App.FindElement("HeaderLabel");
 		var afterDragEmptyViewLabel = App.FindElement("EmptyViewLabel");
 
-		// Verify text content is still correct
 		Assert.That(afterDragHeaderLabel.GetText(), Is.EqualTo("Header: This should show for all cases."));
 		Assert.That(afterDragEmptyViewLabel.GetText(), Is.EqualTo("EmptyView: This should show when no data."));
 
-		// Get positions after drag attempt
 		var afterDragHeaderRect = afterDragHeaderLabel.GetRect();
 		var afterDragEmptyViewRect = afterDragEmptyViewLabel.GetRect();
 
-		// The key test: positions should remain stable (no extra space created)
-		// Allow for minor variations due to platform differences, but positions should be essentially the same
 		var headerYDifference = Math.Abs(afterDragHeaderRect.Y - initialHeaderRect.Y);
 		var emptyViewYDifference = Math.Abs(afterDragEmptyViewRect.Y - initialEmptyViewRect.Y);
 
-		// Positions should not have changed significantly (tolerance for floating point precision)
 		Assert.That(headerYDifference, Is.LessThan(5),
 			$"Header moved too much: initial Y={initialHeaderRect.Y}, after drag Y={afterDragHeaderRect.Y}");
 		Assert.That(emptyViewYDifference, Is.LessThan(5),
 			$"EmptyView moved too much: initial Y={initialEmptyViewRect.Y}, after drag Y={afterDragEmptyViewRect.Y}");
 
-		// Additional verification: EmptyView should still be positioned directly after Header
-		// (accounting for any margins/padding)
 		var spaceBetween = afterDragEmptyViewRect.Y - (afterDragHeaderRect.Y + afterDragHeaderRect.Height);
 		Assert.That(spaceBetween, Is.LessThan(50),
 			$"Too much space between Header and EmptyView: {spaceBetween}px");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31465.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31465.cs
@@ -1,0 +1,100 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31465 : _IssuesUITest
+{
+	public Issue31465(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "CollectionView with null ItemsSource and Header can be dragged down creating extra space";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewWithNullBindingContextShouldDisplayHeaderAndEmptyViewCorrectly()
+	{
+		// Wait for the page to load
+		App.WaitForElement("TestCollectionView");
+		App.WaitForElement("HeaderLabel");
+		App.WaitForElement("EmptyViewLabel");
+
+		// Verify the header text is displayed
+		var headerLabel = App.FindElement("HeaderLabel");
+		Assert.That(headerLabel.GetText(), Is.EqualTo("Header: This should show for all cases."));
+
+		// Verify the empty view text is displayed
+		var emptyViewLabel = App.FindElement("EmptyViewLabel");
+		Assert.That(emptyViewLabel.GetText(), Is.EqualTo("EmptyView: This should show when no data."));
+
+		// Test passes if both header and empty view are visible and properly positioned
+		// The fix should prevent extra space from appearing between them when dragging
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewShouldNotBeDraggableWhenEmpty()
+	{
+		// Wait for the page to load
+		App.WaitForElement("TestCollectionView");
+		App.WaitForElement("HeaderLabel");
+		App.WaitForElement("EmptyViewLabel");
+
+		var collectionView = App.FindElement("TestCollectionView");
+		var headerLabel = App.FindElement("HeaderLabel");
+		var emptyViewLabel = App.FindElement("EmptyViewLabel");
+
+		// Get initial positions of header and empty view
+		var initialHeaderRect = headerLabel.GetRect();
+		var initialEmptyViewRect = emptyViewLabel.GetRect();
+
+		// Verify initial state - both elements should be visible with correct text
+		Assert.That(headerLabel.GetText(), Is.EqualTo("Header: This should show for all cases."));
+		Assert.That(emptyViewLabel.GetText(), Is.EqualTo("EmptyView: This should show when no data."));
+
+		// Perform a scroll down gesture on the CollectionView
+		// This attempts to reproduce the issue where users could drag down and create space
+		var collectionViewRect = collectionView.GetRect();
+		var startX = collectionViewRect.X + collectionViewRect.Width / 2;
+		var startY = collectionViewRect.Y + 50; // Start near the top
+		var endY = startY + 200; // Drag down significantly
+
+		// Perform the drag gesture
+		App.DragCoordinates(startX, startY, startX, endY);
+
+		// Wait a moment for any potential animation/layout changes
+		Thread.Sleep(500);
+
+		// Verify elements are still properly positioned and haven't been separated
+		App.WaitForElement("HeaderLabel");
+		App.WaitForElement("EmptyViewLabel");
+
+		var afterDragHeaderLabel = App.FindElement("HeaderLabel");
+		var afterDragEmptyViewLabel = App.FindElement("EmptyViewLabel");
+
+		// Verify text content is still correct
+		Assert.That(afterDragHeaderLabel.GetText(), Is.EqualTo("Header: This should show for all cases."));
+		Assert.That(afterDragEmptyViewLabel.GetText(), Is.EqualTo("EmptyView: This should show when no data."));
+
+		// Get positions after drag attempt
+		var afterDragHeaderRect = afterDragHeaderLabel.GetRect();
+		var afterDragEmptyViewRect = afterDragEmptyViewLabel.GetRect();
+
+		// The key test: positions should remain stable (no extra space created)
+		// Allow for minor variations due to platform differences, but positions should be essentially the same
+		var headerYDifference = Math.Abs(afterDragHeaderRect.Y - initialHeaderRect.Y);
+		var emptyViewYDifference = Math.Abs(afterDragEmptyViewRect.Y - initialEmptyViewRect.Y);
+
+		// Positions should not have changed significantly (tolerance for floating point precision)
+		Assert.That(headerYDifference, Is.LessThan(5),
+			$"Header moved too much: initial Y={initialHeaderRect.Y}, after drag Y={afterDragHeaderRect.Y}");
+		Assert.That(emptyViewYDifference, Is.LessThan(5),
+			$"EmptyView moved too much: initial Y={initialEmptyViewRect.Y}, after drag Y={afterDragEmptyViewRect.Y}");
+
+		// Additional verification: EmptyView should still be positioned directly after Header
+		// (accounting for any margins/padding)
+		var spaceBetween = afterDragEmptyViewRect.Y - (afterDragHeaderRect.Y + afterDragHeaderRect.Height);
+		Assert.That(spaceBetween, Is.LessThan(50),
+			$"Too much space between Header and EmptyView: {spaceBetween}px");
+	}
+}


### PR DESCRIPTION
### Description of Change

_Work in progress_

Fixes an issue on iOS where CollectionView with null ItemsSource (showing Header and EmptyView) could be dragged down, creating unwanted extra space between the Header and EmptyView content.

In this PR, we apply changes to add bouncing and scrolling behavior control in `ItemsViewController2` for iOS:
  - When empty: Disable both Bounces and ScrollEnabled to prevent any dragging
  - When populated: Enable normal bouncing and scrolling behavior
  - CarouselView: Excluded from this fix as it has its own IsBounceEnabled property
 
Added also a UITest to confirms no visual separation can occur when empty. Uses the exact same pattern as the original reported issue.

### Issues Fixed

Fixes #31465