### PR TITLE
Fix ProjectList not displaying due to missing BindingContext update in template sample

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -87,7 +87,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
-		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.6" />
+		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.7" />
 	</ItemGroup>
 	
 <!--#endif -->

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -87,7 +87,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
-		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.7" />
+		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.6" />
 	</ItemGroup>
 	
 <!--#endif -->

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -7,11 +7,13 @@
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="MauiApp._1.Pages.ProjectListPage"
              x:DataType="pageModels:ProjectListPageModel"
+             x:Name="ProjectList"
              Title="Projects">
 
 
     <ContentPage.Behaviors>
         <toolkit:EventToCommandBehavior
+                BindingContext="{Binding Path=BindingContext, Source={x:Reference ProjectList}, x:DataType=ContentPage}"
                 EventName="Appearing"                
                 Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue details
The project list was not displayed when navigating to ProjectList in net9 sample.

### Description of change
The BindingContext of the project was not being updated. This issue is resolved by explicitly setting the BindingContext.

Fixes https://github.com/syncfusion/maui-toolkit/issues/261

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="400" height="800" alt="image" src="https://github.com/user-attachments/assets/b3836fe0-5d61-4b67-ae5f-0648173cbaa2"> | <img width="400" height="800" alt="image" src="https://github.com/user-attachments/assets/a0f7d9ad-7024-43b0-9243-036f613c0f4c"> |