### PR TITLE
[iOS] Update net10 iOS to rc2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -157,16 +157,16 @@
   <!-- version number information -->
   <PropertyGroup>
     <!-- Default versions from the SDKs (update when there is a new TFM version) -->
-    <IosTargetFrameworkVersionSdkDefault>18.5</IosTargetFrameworkVersionSdkDefault>
-    <TvosTargetFrameworkVersionSdkDefault>18.5</TvosTargetFrameworkVersionSdkDefault>
-    <MacCatalystTargetFrameworkVersionSdkDefault>18.5</MacCatalystTargetFrameworkVersionSdkDefault>
-    <MacosTargetFrameworkVersionSdkDefault>15.5</MacosTargetFrameworkVersionSdkDefault>
-    <AndroidTargetFrameworkVersionSdkDefault>36.0</AndroidTargetFrameworkVersionSdkDefault>
+    <IosTargetFrameworkVersionSdkDefault>26.0</IosTargetFrameworkVersionSdkDefault>
+    <TvosTargetFrameworkVersionSdkDefault>26.0</TvosTargetFrameworkVersionSdkDefault>
+    <MacCatalystTargetFrameworkVersionSdkDefault>26.0</MacCatalystTargetFrameworkVersionSdkDefault>
+    <MacosTargetFrameworkVersionSdkDefault>26.0</MacosTargetFrameworkVersionSdkDefault>
+    <AndroidTargetFrameworkVersionSdkDefault>26.0</AndroidTargetFrameworkVersionSdkDefault>
     <!-- Current .NET -->
-    <IosTargetFrameworkVersion>18.5</IosTargetFrameworkVersion>
-    <TvosTargetFrameworkVersion>18.5</TvosTargetFrameworkVersion>
-    <MacCatalystTargetFrameworkVersion>18.5</MacCatalystTargetFrameworkVersion>
-    <MacosTargetFrameworkVersion>15.5</MacosTargetFrameworkVersion>
+    <IosTargetFrameworkVersion>26.0</IosTargetFrameworkVersion>
+    <TvosTargetFrameworkVersion>26.0</TvosTargetFrameworkVersion>
+    <MacCatalystTargetFrameworkVersion>26.0</MacCatalystTargetFrameworkVersion>
+    <MacosTargetFrameworkVersion>26.0</MacosTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion>36.0</AndroidTargetFrameworkVersion>
     <WindowsTargetFrameworkVersion>10.0.19041.0</WindowsTargetFrameworkVersion>
     <Windows2TargetFrameworkVersion>10.0.20348.0</Windows2TargetFrameworkVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -161,7 +161,7 @@
     <TvosTargetFrameworkVersionSdkDefault>26.0</TvosTargetFrameworkVersionSdkDefault>
     <MacCatalystTargetFrameworkVersionSdkDefault>26.0</MacCatalystTargetFrameworkVersionSdkDefault>
     <MacosTargetFrameworkVersionSdkDefault>26.0</MacosTargetFrameworkVersionSdkDefault>
-    <AndroidTargetFrameworkVersionSdkDefault>26.0</AndroidTargetFrameworkVersionSdkDefault>
+    <AndroidTargetFrameworkVersionSdkDefault>36.0</AndroidTargetFrameworkVersionSdkDefault>
     <!-- Current .NET -->
     <IosTargetFrameworkVersion>26.0</IosTargetFrameworkVersion>
     <TvosTargetFrameworkVersion>26.0</TvosTargetFrameworkVersion>

--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,7 @@
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
     <add key="darc-pub-dotnet-macios-177f431" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-177f4311/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-177f431-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-177f4311-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="local" value="LOCAL_PLACEHOLDER" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -10,8 +10,7 @@
     <add key="darc-pub-dotnet-android-1dcfb6f-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-4681bf9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-4681bf92/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-macios-4681bf9-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-4681bf92-1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-177f431" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-177f4311/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="local" value="LOCAL_PLACEHOLDER" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25474.116">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.2.331">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.2.332">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>c64645f7418b7d131d00654d4662dcf916787dc8</Sha>
+      <Sha>971bf7e0a40b44ec0fccdcc77836f827138ecc37</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.105" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.2.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25427.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25475.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,39 +17,39 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>1dcfb6f8779c33b6f768c996495cb90ecd729329</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10892-net10-rc.2">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f7fc1a300221412643d5e29802d78f93acadd8b0</Sha>
+      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10892-net10-rc.2">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f7fc1a300221412643d5e29802d78f93acadd8b0</Sha>
+      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10892-net10-rc.2">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f7fc1a300221412643d5e29802d78f93acadd8b0</Sha>
+      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10892-net10-rc.2">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f7fc1a300221412643d5e29802d78f93acadd8b0</Sha>
+      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9227" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_18.5">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9752" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4681bf928d70aa79cff2c33ad324b3be9c62b66d</Sha>
+      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.5" Version="15.5.9227" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_15.5">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9752" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4681bf928d70aa79cff2c33ad324b3be9c62b66d</Sha>
+      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.5" Version="18.5.9227" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_18.5">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9752" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4681bf928d70aa79cff2c33ad324b3be9c62b66d</Sha>
+      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.5" Version="18.5.9227" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_18.5">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9752" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4681bf928d70aa79cff2c33ad324b3be9c62b66d</Sha>
+      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25475.109">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.2.332">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.2.331">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>971bf7e0a40b44ec0fccdcc77836f827138ecc37</Sha>
+      <Sha>c64645f7418b7d131d00654d4662dcf916787dc8</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.105" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.2.25475.109">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.2.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25427.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25475.109">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25474.116">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>195fc667648537b4d2d20690568ba8d790599bf7</Sha>
+      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>1dcfb6f8779c33b6f768c996495cb90ecd729329</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
+      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
+      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
+      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.0" Version="26.0.10961-net10-rc.2">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>932dc04f223d4b74d2c0d1fa543be48d4a6aff6b</Sha>
+      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,21 +17,21 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>1dcfb6f8779c33b6f768c996495cb90ecd729329</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.0" Version="26.0.10970-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
+      <Sha>042ba3e24d9c81be1f2a19e84cebc17d672080b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.0" Version="26.0.10970-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
+      <Sha>042ba3e24d9c81be1f2a19e84cebc17d672080b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.0" Version="26.0.10970-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
+      <Sha>042ba3e24d9c81be1f2a19e84cebc17d672080b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.0" Version="26.0.10968-net10-rc.2">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.0" Version="26.0.10970-net10-rc.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>01a7f212b5dfe3a2baad8d0b3abc7b1af98e8cdd</Sha>
+      <Sha>042ba3e24d9c81be1f2a19e84cebc17d672080b2</Sha>
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,10 @@
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosofttvOSSdknet100_260PackageVersion>
+    <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosoftMacCatalystSdknet100_260PackageVersion>
+    <MicrosoftmacOSSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosoftmacOSSdknet100_260PackageVersion>
+    <MicrosoftiOSSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosoftiOSSdknet100_260PackageVersion>
+    <MicrosofttvOSSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosofttvOSSdknet100_260PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet90_260PackageVersion>26.0.9752</MicrosoftMacCatalystSdknet90_260PackageVersion>
     <MicrosoftmacOSSdknet90_260PackageVersion>26.0.9752</MicrosoftmacOSSdknet90_260PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,29 +30,29 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.111</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-rc.2.25474.116</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rc.2.25475.109</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.2.25474.116</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.2.25475.109</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.2.331</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.2.332</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -73,19 +73,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-rc.2.25474.116</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-rc.2.25475.109</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -135,13 +135,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25475.109</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,10 @@
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_260PackageVersion>26.0.10968-net10-rc.2</MicrosofttvOSSdknet100_260PackageVersion>
+    <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.10970-net10-rc.2</MicrosoftMacCatalystSdknet100_260PackageVersion>
+    <MicrosoftmacOSSdknet100_260PackageVersion>26.0.10970-net10-rc.2</MicrosoftmacOSSdknet100_260PackageVersion>
+    <MicrosoftiOSSdknet100_260PackageVersion>26.0.10970-net10-rc.2</MicrosoftiOSSdknet100_260PackageVersion>
+    <MicrosofttvOSSdknet100_260PackageVersion>26.0.10970-net10-rc.2</MicrosofttvOSSdknet100_260PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet90_260PackageVersion>26.0.9752</MicrosoftMacCatalystSdknet90_260PackageVersion>
     <MicrosoftmacOSSdknet90_260PackageVersion>26.0.9752</MicrosoftmacOSSdknet90_260PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -211,9 +211,9 @@
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
     <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
-    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet100_185PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet100_155PackageVersion)</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet100_185PackageVersion)</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet100_185PackageVersion)</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet100_260PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet100_260PackageVersion)</MicrosoftmacOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>$(MicrosoftiOSSdknet100_260PackageVersion)</MicrosoftiOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>$(MicrosofttvOSSdknet100_260PackageVersion)</MicrosofttvOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,29 +30,29 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.111</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-rc.2.25475.109</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rc.2.25474.116</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.2.25475.109</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.2.25474.116</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.2.25475.109</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.2.332</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.2.331</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -73,19 +73,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.2.25475.109</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-rc.2.25475.109</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-rc.2.25474.116</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -135,13 +135,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25475.109</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25475.109</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,15 +56,15 @@
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet100_185PackageVersion>18.5.10892-net10-rc.2</MicrosoftMacCatalystSdknet100_185PackageVersion>
-    <MicrosoftmacOSSdknet100_155PackageVersion>15.5.10892-net10-rc.2</MicrosoftmacOSSdknet100_155PackageVersion>
-    <MicrosoftiOSSdknet100_185PackageVersion>18.5.10892-net10-rc.2</MicrosoftiOSSdknet100_185PackageVersion>
-    <MicrosofttvOSSdknet100_185PackageVersion>18.5.10892-net10-rc.2</MicrosofttvOSSdknet100_185PackageVersion>
+    <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosoftMacCatalystSdknet100_260PackageVersion>
+    <MicrosoftmacOSSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosoftmacOSSdknet100_260PackageVersion>
+    <MicrosoftiOSSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosoftiOSSdknet100_260PackageVersion>
+    <MicrosofttvOSSdknet100_260PackageVersion>26.0.10961-net10-rc.2</MicrosofttvOSSdknet100_260PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9227</MicrosoftMacCatalystSdknet90_185PackageVersion>
-    <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9227</MicrosoftmacOSSdknet90_155PackageVersion>
-    <MicrosoftiOSSdknet90_185PackageVersion>18.5.9227</MicrosoftiOSSdknet90_185PackageVersion>
-    <MicrosofttvOSSdknet90_185PackageVersion>18.5.9227</MicrosofttvOSSdknet90_185PackageVersion>
+    <MicrosoftMacCatalystSdknet90_260PackageVersion>26.0.9752</MicrosoftMacCatalystSdknet90_260PackageVersion>
+    <MicrosoftmacOSSdknet90_260PackageVersion>26.0.9752</MicrosoftmacOSSdknet90_260PackageVersion>
+    <MicrosoftiOSSdknet90_260PackageVersion>26.0.9752</MicrosoftiOSSdknet90_260PackageVersion>
+    <MicrosofttvOSSdknet90_260PackageVersion>26.0.9752</MicrosofttvOSSdknet90_260PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 10.0.100-preview.2.25164.34
 - name: REQUIRED_XCODE
-  value: 16.4.0
+  value: 26.0.0
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 16.4.0
+  value: 26.0.0
 - name: POWERSHELL_VERSION
   value: 7.4.0
 # Localization variables

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -73,6 +73,7 @@ parameters:
     vmImage: $(iosDeviceTestsVmImage)
     demands:
     - macOS.Name -equals Sequoia
+    - Agent.OSVersion -equals 15.6
 
 - name: catalystPool
   type: object
@@ -81,6 +82,7 @@ parameters:
     vmImage: $(iosDeviceTestsVmImage)
     demands:
     - macOS.Name -equals Sequoia
+    - Agent.OSVersion -equals 15.6
 
 - name: windowsPool
   type: object

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -80,6 +80,7 @@ parameters:
     demands:
     - macOS.Name -equals Sequoia
     - macOS.Architecture -equals x64
+    - Agent.OSVersion -equals 15.6
     artifact: build-macos
 
 - name: PackPlatforms
@@ -107,6 +108,7 @@ parameters:
     demands:
     - macOS.Name -equals Sequoia
     - macOS.Architecture -equals x64
+    - Agent.OSVersion -equals 15.6
     artifact: build-macos
 
 - name: RunTemplatePlatforms
@@ -117,6 +119,7 @@ parameters:
     demands:
     - macOS.Name -equals Sequoia
     - macOS.Architecture -equals x64
+    - Agent.OSVersion -equals 15.6
     testName: RunOnAndroid
     artifact: templates-run-android
   - name: $(iosTestsVmPool)
@@ -124,6 +127,7 @@ parameters:
     demands:
     - macOS.Name -equals Sequoia
     - macOS.Architecture -equals x64
+    - Agent.OSVersion -equals 15.6
     testName: RunOniOS
     artifact: templates-run-ios
 
@@ -135,6 +139,7 @@ parameters:
     demands:
     - macOS.Name -equals Sequoia
     - macOS.Architecture -equals arm64
+    - Agent.OSVersion -equals 15.6
 
 resources:
   repositories:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -74,6 +74,7 @@ parameters:
       demands:
         - macOS.Name -equals Sequoia
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 15.6
   
   - name: androidPoolLinux
     type: object
@@ -91,6 +92,7 @@ parameters:
       demands:
         - macOS.Name -equals Sequoia
         - macOS.Architecture -equals x64
+        - Agent.OSVersion -equals 15.6
   
   - name: windowsBuildPool
     type: object
@@ -108,7 +110,7 @@ parameters:
     type: object
     default:
       name: Azure Pipelines
-      vmImage: macOS-14
+      vmImage: macOS-15
 
 stages:
 

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -110,7 +110,7 @@ parameters:
     type: object
     default:
       name: Azure Pipelines
-      vmImage: macOS-15
+      vmImage: macOS-14
 
 stages:
 

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rc.2.25474.116"
+    "dotnet": "10.0.100-rc.2.25475.109"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25474.116",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25474.116"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25475.109",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25475.109"
   },
   "sdk": {
     "allowPrerelease": true

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rc.2.25475.109"
+    "dotnet": "10.0.100-rc.2.25474.116"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25475.109",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25475.109"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25474.116",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25474.116"
   },
   "sdk": {
     "allowPrerelease": true

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21948.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21948.xaml.cs
@@ -24,10 +24,22 @@ namespace Maui.Controls.Sample.Issues
 #if IOS || MACCATALYST
 		async void OpenNewWindow()
 		{
-			var uIWindow = new UIWindow();
+			
 			var keyWindow = (this.Window.Handler.PlatformView as UIWindow);
 			if (keyWindow?.WindowLevel == UIWindowLevel.Normal)
 				keyWindow.WindowLevel = -1;
+
+			UIWindow uIWindow;
+			if (OperatingSystem.IsIOSVersionAtLeast(13) && keyWindow?.WindowScene is not null)
+			{
+				uIWindow = new UIWindow(keyWindow.WindowScene);
+			}
+			else
+			{
+#pragma warning disable CA1422 // This call site is reachable on iOS < 13.0
+				uIWindow = new UIWindow();
+#pragma warning restore CA1422
+			}
 
 			var page = new ContentPage();
 			this.AddLogicalChild(page);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issues16321.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issues16321.xaml.cs
@@ -46,8 +46,19 @@ namespace Maui.Controls.Sample.Issues
 
 		async void OpenPrompt(System.Object sender, System.EventArgs e, Func<Page, Task> promptAction)
 		{
-			var uIWindow = new UIWindow();
 			var keyWindow = (this.Window.Handler.PlatformView as UIWindow);
+
+			UIWindow uIWindow;
+			if (OperatingSystem.IsIOSVersionAtLeast(13) && keyWindow?.WindowScene is not null)
+			{
+				uIWindow = new UIWindow(keyWindow.WindowScene);
+			}
+			else
+			{
+#pragma warning disable CA1422 // This call site is reachable on iOS < 13.0
+				uIWindow = new UIWindow();
+#pragma warning restore CA1422
+			}
 			if (keyWindow?.WindowLevel == UIWindowLevel.Normal)
 				keyWindow.WindowLevel = -1;
 


### PR DESCRIPTION
### Description of Change

Move to Xcode 26 and rc2 packages.

This pull request updates the supported target framework and dependency versions for iOS, tvOS, macOS, and Mac Catalyst to 26.0 across the repository. It also updates the associated NuGet package sources and required Xcode version to ensure compatibility with these new SDK versions. These changes help keep the codebase aligned with the latest platform releases and dependencies.

**Platform and SDK version updates:**

* Updated default and current target framework versions for iOS, tvOS, macOS, and Mac Catalyst to `26.0` in `Directory.Build.props`.
* Updated required Xcode version for builds and device tests to `26.0.0` in `eng/pipelines/common/variables.yml`.

**Dependency and package management:**

* Updated all relevant SDK package versions for iOS, tvOS, macOS, and Mac Catalyst to `26.0` in `eng/Versions.props`. [[1]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L59-R67) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L214-R217)
* Updated SDK dependency entries and SHA hashes for iOS, tvOS, macOS, and Mac Catalyst in `eng/Version.Details.xml` to reflect the new 26.0 versions.
* Updated NuGet package source for dotnet-macios to point to the new 26.0 feed in `NuGet.config`.