### PR TITLE
re-introduce nullcheck to prevent exception in base classes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override void UpdateItemsSource()
 		{
+			var itemsSource = ItemsView?.ItemsSource;
+
+            if (itemsSource == null)
+                return;
+				
 			var itemTemplate = ItemsView?.ItemTemplate;
 
 			if (itemTemplate == null)


### PR DESCRIPTION
A Nullcheck was removed in 9.0.80 and can lead to a crash in Windows Carouselview due to exceptions in base classes.

### Description of Change

Re-Introduces a nullcheck for Itemsource that was removed in Maui 9.0.80.
The null check was removed in Maui 9.0.80. 

### Issues Fixed

#31760 

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
