### PR TITLE
Remove excessive measure call

### DIFF
--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -42,10 +42,6 @@ namespace Microsoft.Maui.Platform
 			if (ChildCount == 0 || GetChildAt(0) is not AView child)
 				return;
 
-			var widthMeasureSpec = MeasureSpecMode.Exactly.MakeMeasureSpec(right - left);
-			var heightMeasureSpec = MeasureSpecMode.Exactly.MakeMeasureSpec(bottom - top);
-
-			child.Measure(widthMeasureSpec, heightMeasureSpec);
 			child.Layout(0, 0, child.MeasuredWidth, child.MeasuredHeight);
 			_borderView?.Layout(0, 0, child.MeasuredWidth, child.MeasuredHeight);
 		}


### PR DESCRIPTION
### Description of Change

The platformWrapperView.java base class already calls measure

https://github.com/dotnet/maui/blob/bac24321c886bad1998692242617fd7fdfc1e879/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java#L135-L146

I'm not sure why we have an extra measure call inside layout. 

If anything the tests will fail and I can add some comments to clarify why we are measuring again inside layout :-) 
