### PR TITLE
Fix UseProvisionator parameter not working in the UITests pipeline

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -33,6 +33,13 @@ parameters:
   skipInternalFeeds: false
 
 steps:
+
+# Always print skipProvisionator value
+- script: |
+    echo "Current skipProvisionator value: ${{ parameters.skipProvisionator }}"
+  displayName: 'Print Provisionator Information'
+  condition: always()
+
 ##################################################
 #               Provisioning macOS               #
 ##################################################

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -11,6 +11,7 @@ parameters:
   testFilter: ''
   testConfigurationArgs: ''
   skipProvisioning: true
+  gitHubToken: ''
   checkoutDirectory: $(System.DefaultWorkingDirectory)
 
 steps:
@@ -65,6 +66,7 @@ steps:
     androidEmulatorApiLevel: ${{ parameters.version }}
     skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
+    gitHubToken: ${{ parameters.gitHubToken }}
     ${{ if parameters.skipProvisioning }}:
       skipProvisionator: true
     ${{ else }}:

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -11,6 +11,7 @@ parameters:
   timeoutInMinutes: 180
   skipProvisioning: true
   gitHubToken: ''
+  UseProvisionator: false # Parameter to control whether to use Provisionator
   BuildNativeAOT: false # Parameter to control whether NativeAOT artifacts should be built
   RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -10,6 +10,7 @@ parameters:
   provisionatorChannel: 'latest'
   timeoutInMinutes: 180
   skipProvisioning: true
+  gitHubToken: ''
   BuildNativeAOT: false # Parameter to control whether NativeAOT artifacts should be built
   RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
@@ -130,6 +131,7 @@ stages:
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
+                      gitHubToken: ${{ parameters.gitHubToken }}
                   
                   # Collect and publish Android snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
@@ -177,6 +179,7 @@ stages:
                       runtimeVariant : "Mono"
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
+                      gitHubToken: ${{ parameters.gitHubToken }}
                   
                   # Collect and publish iOS snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
@@ -220,6 +223,7 @@ stages:
                       testFilter: "CollectionView"
                       testConfigurationArgs: "CollectionView2"
                       skipProvisioning: ${{ parameters.skipProvisioning }}
+                      gitHubToken: ${{ parameters.gitHubToken }}
                   
                   # Collect and publish iOS CV2 snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
@@ -263,6 +267,7 @@ stages:
                       testFilter: "CarouselView"
                       testConfigurationArgs: "CollectionView2"
                       skipProvisioning: ${{ parameters.skipProvisioning }}
+                      gitHubToken: ${{ parameters.gitHubToken }}
                   
                   # Collect and publish iOS CARV2 snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
@@ -312,6 +317,7 @@ stages:
                         runtimeVariant : "NativeAOT"
                         testFilter: $(CATEGORYGROUP)
                         skipProvisioning: ${{ parameters.skipProvisioning }}
+                        gitHubToken: ${{ parameters.gitHubToken }}
 
   - stage: winui_ui_tests
     displayName: WinUI UITests
@@ -343,6 +349,7 @@ stages:
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
+                      gitHubToken: ${{ parameters.gitHubToken }}
                   
                   # Collect and publish Windows snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
@@ -381,6 +388,7 @@ stages:
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
+                      gitHubToken: ${{ parameters.gitHubToken }}
                   
                   # Collect and publish Mac snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -120,6 +120,7 @@ stages:
       windowsPool: ${{ parameters.windowsPool }}
       windowsBuildPool: ${{ parameters.windowsBuildPool }}
       macosPool: ${{ parameters.macosPool }}
+      UseProvisionator: ${{ parameters.UseProvisionator }}
       # BuildNativeAOT is false by default, but true in devdiv environment
       BuildNativeAOT: ${{ or(parameters.BuildNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
@@ -129,7 +130,7 @@ stages:
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.0' ]
-      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'], 'true') ) }}:
+      ${{ if or(eq(parameters.UseProvisionator, true), eq(variables['internalProvisioning'], 'true') ) }}:
         skipProvisioning: false
         gitHubToken: $(provisionator--github--pat)
       ${{ else }}:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -129,7 +129,7 @@ stages:
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.0' ]
-      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
+      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'], true) ) }}:
         skipProvisioning: false
         gitHubToken: $(provisionator--github--pat)
       ${{ else }}:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -131,8 +131,10 @@ stages:
         iosVersions: [ '18.0' ]
       ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
         skipProvisioning: false
-      ${{ else }}:  
+        gitHubToken: $(provisionator--github--pat)
+      ${{ else }}:
         skipProvisioning: true
+        gitHubToken: ''
       projects:
         - name: controls
           desc: Controls

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -129,7 +129,7 @@ stages:
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.0' ]
-      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'], true) ) }}:
+      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'], 'true') ) }}:
         skipProvisioning: false
         gitHubToken: $(provisionator--github--pat)
       ${{ else }}:


### PR DESCRIPTION
### Description of Change

The` UseProvisionator: true` parameter wasn't working in the UITests pipeline due to missing `gitHubToken` parameter propagation through the pipeline hierarchy. The GitHub token required for Xcode provisioning wasn't being passed from the main pipeline down through the template chain, causing provisioning to fail silently. The GitHub token propagation is important because without it, the provisionator task cannot authenticate with GitHub to download the provisioning scripts needed.

In this PR we applied changes to add missing `gitHubToken` parameter to `common/ui-tests.yml` and `common/ui-tests-steps.yml`. Updated all template calls to properly pass the GitHub token through the pipeline hierarchy. The pipeline now should correctly sets `gitHubToken: $(provisionator--github--pat)` when `UseProvisionator: true`

We must verify that setting` UseProvisionator: true` now enables Xcode provisioning and the "Provision Xcode" step executes successfully.

### Issues Fixed

Fixes #29355