### PR TITLE
[.NET 10] Fix RadioButton Test Failure

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
@@ -162,20 +162,31 @@ namespace Microsoft.Maui.Controls
 
 		void SetSelectedValue(object radioButtonValue)
 		{
-			if(object.Equals(_selectedValue, radioButtonValue))
+			if (object.Equals(_selectedValue, radioButtonValue))
 			{
 				return;
 			}
 
 			_selectedValue = radioButtonValue;
 
-			if (radioButtonValue != null)
+			foreach (var child in _layout.Descendants())
 			{
-				foreach (var child in _layout.Descendants())
+				if (child is RadioButton radioButton && radioButton.GroupName == _groupName)
 				{
-					if (child is RadioButton radioButton && radioButton.GroupName == _groupName && radioButton.Value is not null && radioButton.Value.Equals(radioButtonValue))
+					if (radioButtonValue is not null)
 					{
-						radioButton.SetValue(RadioButton.IsCheckedProperty, true, specificity: SetterSpecificity.FromHandler);
+						if (radioButton.Value is not null && radioButton.Value.Equals(radioButtonValue))
+						{
+							radioButton.SetValue(RadioButton.IsCheckedProperty, true, specificity: SetterSpecificity.FromHandler);
+						}
+					}
+					else
+					{
+						// Setting null - uncheck the selected radio button in the group
+						if (radioButton.IsChecked)
+						{
+							radioButton.SetValue(RadioButton.IsCheckedProperty, false, specificity: SetterSpecificity.FromHandler);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

- Ported the changes from PR https://github.com/dotnet/maui/pull/31175 into .NET 10 update branch.
- This update allows the RadioButtonGroupController.Value to be set to null, which clears any selected radio button(s).
- The absence of these changes in .NET 10 update branch caused the related test case from that PR to fail.

<img width="1441" height="241" alt="image" src="https://github.com/user-attachments/assets/8aaf6ffe-bc30-4189-a5fd-ddd37692147a" />

- **Note**: Since **`MessagingCenter`** was removed in .NET 10, I refactored the logic accordingly.


### Screenshots

<img width="455" height="626" alt="Screenshot" src="https://github.com/user-attachments/assets/3681c374-5639-4047-962c-2b9f92f74fa5" />

