### PR TITLE
Android: reduce Java to .NET layout pass calls (alternative)

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
@@ -36,11 +36,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (Content.VirtualView.Handler is IPlatformViewHandler pvh)
 			{
-				var widthSpec = Context.CreateMeasureSpec(targetWidth,
+				var (widthSpec, _, _) = Context.CreateMeasureSpec(targetWidth,
 					double.IsInfinity(targetWidth) ? double.NaN : targetWidth
 					, minimumSize: double.NaN, maximumSize: targetWidth);
 
-				var heightSpec = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
+				var (heightSpec, _, _) = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
 					, minimumSize: double.NaN, maximumSize: targetHeight);
 
 				var size = pvh.MeasureVirtualView(widthSpec, heightSpec);

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformContentViewGroup.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformContentViewGroup.java
@@ -6,7 +6,7 @@ import android.graphics.Path;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
 
-public abstract class PlatformContentViewGroup extends ViewGroup {
+public abstract class PlatformContentViewGroup extends PlatformViewGroup {
 
     public PlatformContentViewGroup(Context context) {
         super(context);

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformViewGroup.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformViewGroup.java
@@ -7,6 +7,13 @@ import android.util.AttributeSet;
 import android.view.ViewGroup;
 
 public abstract class PlatformViewGroup extends ViewGroup {
+    boolean needsMeasure;
+    boolean nativeMeasure = true;
+
+    // We use a bit on each packed measured size to indicate the need for cross platform measure
+    // See also https://developer.android.com/reference/android/view/View#MEASURED_SIZE_MASK
+    public static final long NEEDS_MEASURE = 0x0800000008000000L;
+
     public PlatformViewGroup(Context context) {
         super(context);
     }
@@ -21,5 +28,39 @@ public abstract class PlatformViewGroup extends ViewGroup {
 
     public PlatformViewGroup(Context context, AttributeSet attrs, int defStyle, int defStyleRes) {
         super(context, attrs, defStyle, defStyleRes);
+    }
+
+    public long measureAndGetWidthAndHeight(int widthMeasureSpec, int heightMeasureSpec) {
+        this.needsMeasure = false;
+        this.nativeMeasure = false;
+        this.measure(widthMeasureSpec, heightMeasureSpec);
+        this.nativeMeasure = true;
+
+        if (this.needsMeasure) {
+            return NEEDS_MEASURE;
+        }
+
+        int width = this.getMeasuredWidth();
+        int height = this.getMeasuredHeight();
+        long measure = ((long)width << 32) | (height & 0xffffffffL);
+        return measure;
+    }
+    
+    public void overrideMeasuredDimension(int width, int height) {
+        setMeasuredDimension(width, height);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if (nativeMeasure) {
+            doMeasure(widthMeasureSpec, heightMeasureSpec);
+        } else {
+            this.needsMeasure = true;
+            setMeasuredDimension(0, 0);
+        }
+    }
+
+    protected void doMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 }

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformWrapperView.java
@@ -128,7 +128,7 @@ public abstract class PlatformWrapperView extends PlatformContentViewGroup {
     }
 
     @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    protected void doMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if (getChildCount() == 0) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
             return;
@@ -138,6 +138,34 @@ public abstract class PlatformWrapperView extends PlatformContentViewGroup {
         viewBounds.set(0, 0, MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec));
         child.measure(widthMeasureSpec, heightMeasureSpec);
         setMeasuredDimension(child.getMeasuredWidth(), child.getMeasuredHeight());
+    }
+
+    @Override
+    public long measureAndGetWidthAndHeight(int widthMeasureSpec, int heightMeasureSpec) {
+        if (getChildCount() == 0 || !(getChildAt(0) instanceof PlatformViewGroup)) {
+            this.measure(widthMeasureSpec, heightMeasureSpec);
+            int width = this.getMeasuredWidth();
+            int height = this.getMeasuredHeight();
+            long measure = ((long)width << 32) | (height & 0xffffffffL);
+            return measure;
+        } else {
+            PlatformViewGroup child = (PlatformViewGroup)getChildAt(0);
+            long measure = super.measureAndGetWidthAndHeight(widthMeasureSpec, heightMeasureSpec);
+            child.measureAndGetWidthAndHeight(widthMeasureSpec, heightMeasureSpec);
+            return measure;
+        }
+    }
+
+    @Override
+    public void overrideMeasuredDimension(int width, int height) {
+        setMeasuredDimension(width, height);
+
+        if (getChildCount() == 0 || !(getChildAt(0) instanceof PlatformViewGroup)) {
+            return;
+        }
+
+        PlatformViewGroup child = (PlatformViewGroup)getChildAt(0);
+        child.overrideMeasuredDimension(width, height);
     }
 
     @Override

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			// Create a spec to handle the native measure
-			var widthSpec = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MinimumWidth, virtualView.MaximumWidth);
-			var heightSpec = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
+			var (widthSpec, _, _) = Context.CreateMeasureSpec(widthConstraint, virtualView.Width, virtualView.MinimumWidth, virtualView.MaximumWidth);
+			var (heightSpec, _, _) = Context.CreateMeasureSpec(heightConstraint, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
 
 			if (platformView.FillViewport)
 			{

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -109,11 +109,14 @@ namespace Microsoft.Maui
 		{
 			int measuredWidth;
 			int measuredHeight;
-			if (platformViewGroup is not ICrossPlatformLayoutBacking { CrossPlatformLayout: { } crossPlatformLayout })
+
+			// If it's a WrapperView we need to check the wrapped view instead
+			var unwrappedView = ((platformViewGroup as WrapperView)?.WrappedView ?? platformViewGroup) as PlatformViewGroup;
+			var crossPlatformLayout = (unwrappedView as ICrossPlatformLayoutBacking)?.CrossPlatformLayout;
+
+			// This instance of PlatformViewGroup is not backed by a crossPlatformLayout, so we need to go through the default measure method
+			if (crossPlatformLayout is null)
 			{
-				// TODO: Make WrapperView an ICrossPlatformLayoutBacking,
-				// or even better, create two abstract methods PlatformMeasure / PlatformLayout so we can avoid ICrossPlatformLayoutBacking
-				// throw new InvalidOperationException("PlatformViewGroup inheritors must implement ICrossPlatformLayoutBacking.");
 				var nativePacked = PlatformInterop.MeasureAndGetWidthAndHeight(platformViewGroup, widthSpec, heightSpec);
 
 				var nativeWidth = (int)(nativePacked >> 32);

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Maui.Platform
 		{
 			return CrossPlatformLayout?.CrossPlatformArrange(bounds) ?? Graphics.Size.Zero;
 		}
-
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		
+		internal override void DoMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
 			if (CrossPlatformLayout is null)
 			{

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -415,14 +415,17 @@ namespace Microsoft.Maui.Platform
 			return _navigationBarHeight ?? 0;
 		}
 
-		internal static int CreateMeasureSpec(this Context context, double constraint, double explicitSize, double minimumSize, double maximumSize)
+		internal static (int MeasureSpec, double CrossPlatformConstraint, bool Exact) CreateMeasureSpec(this Context context, double constraint, double explicitSize, double minimumSize, double maximumSize)
 		{
 			var mode = MeasureSpecMode.AtMost;
+			var exact = false;
+			var crossPlatformConstraint = constraint;
 
 			if (IsExplicitSet(explicitSize))
 			{
 				// We have a set value (i.e., a Width or Height)
 				mode = MeasureSpecMode.Exactly;
+				exact = true;
 
 				// Since the mode is "Exactly", we have to return the exact final value clamped to the minimum/maximum.
 				constraint = Math.Max(explicitSize, ResolveMinimum(minimumSize));
@@ -431,11 +434,14 @@ namespace Microsoft.Maui.Platform
 				{
 					constraint = Math.Min(constraint, maximumSize);
 				}
+
+				crossPlatformConstraint = constraint;
 			}
 			else if (IsMaximumSet(maximumSize) && maximumSize < constraint)
 			{
 				mode = MeasureSpecMode.AtMost;
 				constraint = maximumSize;
+				crossPlatformConstraint = constraint;
 			}
 			else if (double.IsInfinity(constraint))
 			{
@@ -447,7 +453,7 @@ namespace Microsoft.Maui.Platform
 			// Convert to a platform size to create the spec for measuring
 			var deviceConstraint = (int)context.ToPixels(constraint);
 
-			return mode.MakeMeasureSpec(deviceConstraint);
+			return (mode.MakeMeasureSpec(deviceConstraint), crossPlatformConstraint, exact);
 		}
 
 		public static float GetDisplayDensity(this Context? context)

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -61,11 +61,11 @@ namespace Microsoft.Maui.Platform
 		{
 			return CrossPlatformLayout?.CrossPlatformArrange(bounds) ?? Graphics.Size.Zero;
 		}
-
+		
 		// TODO: Possibly reconcile this code with ViewHandlerExtensions.MeasureVirtualView
 		// If you make changes here please review if those changes should also
 		// apply to ViewHandlerExtensions.MeasureVirtualView
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		internal override void DoMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
 			if (CrossPlatformMeasure == null)
 			{

--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Maui.Platform
 
 		public bool InputTransparent { get; set; }
 
+		internal AView WrappedView => ChildCount > 0 ? GetChildAt(0) : null;
+
 		public WrapperView(Context context)
 			: base(context)
 		{

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -32,6 +32,8 @@ Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? cont
 Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs) -> void
 Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle) -> void
 Microsoft.Maui.PlatformViewGroup.PlatformViewGroup(Android.Content.Context? context, Android.Util.IAttributeSet? attrs, int defStyle, int defStyleRes) -> void
+*REMOVED*override Microsoft.Maui.Platform.ContentViewGroup.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
+*REMOVED*override Microsoft.Maui.Platform.LayoutViewGroup.OnMeasure(int widthMeasureSpec, int heightMeasureSpec) -> void
 Microsoft.Maui.Hosting.MauiHostEnvironment
 Microsoft.Maui.Hosting.MauiHostEnvironment.ApplicationName.get -> string!
 Microsoft.Maui.Hosting.MauiHostEnvironment.ApplicationName.set -> void

--- a/src/Core/src/Transforms/Metadata.xml
+++ b/src/Core/src/Transforms/Metadata.xml
@@ -16,6 +16,10 @@
   <attr path="//class[@name='PlatformAppCompatTextView']/method" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformAppCompatTextView']/constructor" name="visibility">internal</attr>
   <attr path="//class[@name='PlatformWrapperView']/method[@name='updateShadow']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/method[@name='measureAndGetWidthAndHeight']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/method[@name='overrideMeasuredDimension']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/method[@name='doMeasure']" name="visibility">internal</attr>
+  <attr path="//class[@name='PlatformViewGroup']/field[@name='NEEDS_MEASURE']" name="visibility">internal</attr>
 
   <remove-node path="//package[@name='com.bumptech.glide']" />
   <remove-node path="//package[@name='com.microsoft.maui.glide']" />


### PR DESCRIPTION
### Description of Change

This is an alternative for #31595 which aims to further reduce java interop.

Instead of preparing the measure for the actual `Android.Views.View.Measure` call, we invoke a custom measure method which eventually returns a special flag telling us whether a measure is needed.

If it is, we run the cross-platform-layout measure method and store the result by using an internal `OverrideMeasuredDimension`.

### Benchmarks

Benchmarks are totally unreliable, I tried multiple times and I always get different results.