### PR TITLE
Use the WebView2CompositionControl in Blazor WPF

### DIFF
--- a/src/BlazorWebView/samples/BlazorWpfApp/BlazorWpfApp.csproj
+++ b/src/BlazorWebView/samples/BlazorWpfApp/BlazorWpfApp.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\src\Wpf\build\Microsoft.AspNetCore.Components.WebView.Wpf.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(_MauiDotNetTfm)-windows</TargetFrameworks>
+    <TargetFramework>$(_MauiDotNetTfm)-windows10.0.17763.0</TargetFramework>
     <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
@@ -5,7 +5,7 @@ using Microsoft.Web.WebView2.Core;
 using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
 #elif WEBVIEW2_WPF
 using Microsoft.Web.WebView2.Core;
-using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
 #elif WINDOWS && WEBVIEW2_MAUI
 using Microsoft.Web.WebView2.Core;
 using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -28,7 +28,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Components.WebView.Wpf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Web.WebView2.Core;
-using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
 using System.Reflection;
 #elif WEBVIEW2_MAUI
 using Microsoft.AspNetCore.Components.WebView.Maui;

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
 
 namespace Microsoft.AspNetCore.Components.WebView.Wpf
 {

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2!
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl!
+*REMOVED*~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl


### PR DESCRIPTION
This pull request updates the Blazor WPF integration to use the newer `WebView2CompositionControl` instead of the older `WebView2` control. This change affects multiple files and public APIs, reflecting a platform-wide migration to the new control for improved compatibility and features.

**Migration to `WebView2CompositionControl`:**

* Updated all control type aliases from `WebView2` to `WebView2CompositionControl` in shared source files, WPF-specific files, and event argument definitions (`BlazorWebViewInitializedEventArgs.cs`, `WebView2WebViewManager.cs`, `BlazorWebView.cs`). [[1]](diffhunk://#diff-223d3532e0669e7ef42da05f48416c9f468bcd99ee141cf5d1100dc09478d500L8-R8) [[2]](diffhunk://#diff-75c4562a2bc68615b8d28c071b33a112272d1e08e4ba087c461736787ff8f534L31-R31) [[3]](diffhunk://#diff-0c065d47653e514388503b6e1cb075c67ce6fef6f6f955c9cdc78d51a47e5ecfL19-R19)
* Changed public API surface in `PublicAPI.Unshipped.txt` to reflect the new control type, including removal of old getter signatures and addition of new ones for `WebView` properties.

**Project configuration update:**

* Modified the target framework in `BlazorWpfApp.csproj` to specify `windows10.0.17763.0`, ensuring compatibility with the new control and platform requirements.