### PR TITLE
[Mac] Fix for DeviceDisplay.MainDisplayInfoChanged event not getting raised

### DIFF
--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Runtime.InteropServices;
 using Foundation;
 using UIKit;
 
@@ -9,11 +10,112 @@ namespace Microsoft.Maui.Devices
 	{
 		NSObject? observer;
 
+#if MACCATALYST
+		// Core Graphics P/Invoke declarations for Mac Catalyst
+		// Returns the display ID of the main display
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern uint CGMainDisplayID();
+
+		// Returns information about a display’s current configuration
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern IntPtr CGDisplayCopyDisplayMode(uint display);
+
+		// Releases a Core Graphics display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern void CGDisplayModeRelease(IntPtr mode);
+
+		// Returns the width of the specified display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern nuint CGDisplayModeGetWidth(IntPtr mode);
+
+		// Returns the height of the specified display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern nuint CGDisplayModeGetHeight(IntPtr mode);
+
+		// Returns the refresh rate of the specified display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern double CGDisplayModeGetRefreshRate(IntPtr mode);
+
+		// Returns the rotation angle of a display in degrees
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern double CGDisplayRotation(uint display);
+
+#endif
+
 		protected override bool GetKeepScreenOn() => UIApplication.SharedApplication.IdleTimerDisabled;
 
 		protected override void SetKeepScreenOn(bool keepScreenOn) => UIApplication.SharedApplication.IdleTimerDisabled = keepScreenOn;
 
 		protected override DisplayInfo GetMainDisplayInfo()
+		{
+#if MACCATALYST
+			// On Mac Catalyst, bypass UIScreen entirely and use Core Graphics APIs
+			// This gets fresh, non-cached screen information directly from the system
+			var displayId = CGMainDisplayID();
+			var mode = CGDisplayCopyDisplayMode(displayId);
+			
+			if (mode == IntPtr.Zero)
+			{
+				System.Diagnostics.Debug.WriteLine("[DeviceDisplay] Failed to get display mode, falling back to UIScreen");
+				return GetFallbackDisplayInfo();
+			}
+
+			var width = (double)CGDisplayModeGetWidth(mode);
+			var height = (double)CGDisplayModeGetHeight(mode);
+			var refreshRate = CGDisplayModeGetRefreshRate(mode);
+
+			// Release the display mode to avoid memory leaks
+			CGDisplayModeRelease(mode);
+
+			// Get rotation from Core Graphics
+			var rotationDegrees = CGDisplayRotation(displayId);
+			var rotation = ConvertRotationDegreesToDisplayRotation(rotationDegrees);
+
+			// Get scale factor from UIScreen as a fallback (this is usually stable)
+			var scale = UIScreen.MainScreen.Scale;
+
+			// For Mac Catalyst, calculate orientation based on actual dimensions and rotation
+			var orientation = CalculateOrientationFromDimensionsAndRotation(width, height, rotationDegrees);
+
+			return new DisplayInfo(
+				width: width,
+				height: height,
+				density: scale,
+				orientation: orientation,
+				rotation: rotation,
+				rate: (float)refreshRate);
+#else
+			// iOS implementation
+			return GetFallbackDisplayInfo();
+#endif
+		}
+
+		static DisplayRotation ConvertRotationDegreesToDisplayRotation(double degrees) =>
+			degrees switch
+			{
+				0 => DisplayRotation.Rotation0,
+				90 => DisplayRotation.Rotation90,
+				180 => DisplayRotation.Rotation180,
+				270 => DisplayRotation.Rotation270,
+				_ => DisplayRotation.Rotation0
+			};
+
+		static DisplayOrientation CalculateOrientationFromDimensionsAndRotation(double width, double height, double rotationDegrees)
+		{
+			// For 90° and 270° rotations, the effective orientation is swapped
+			if (rotationDegrees == 90 || rotationDegrees == 270)
+			{
+				// Swap width and height for orientation calculation
+				return height >= width ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
+			}
+			else
+			{
+				// 0° and 180° rotations don't change the orientation
+				return width >= height ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
+			}
+		}
+
+		DisplayInfo GetFallbackDisplayInfo()
 		{
 			var bounds = UIScreen.MainScreen.Bounds;
 			var scale = UIScreen.MainScreen.Scale;
@@ -35,8 +137,16 @@ namespace Microsoft.Maui.Devices
 		protected override void StartScreenMetricsListeners()
 		{
 			var notificationCenter = NSNotificationCenter.DefaultCenter;
+
+#if MACCATALYST
+			// On Mac Catalyst, use multiple notifications to cover all display changes
+			// NSApplicationDidChangeScreenParametersNotification - for resolution/refresh rate changes
+			observer = notificationCenter.AddObserver(new NSString("NSApplicationDidChangeScreenParametersNotification"), OnMainDisplayInfoChanged);
+#else
+			// On iOS, use status bar orientation changes (deprecated but still works)
 			var notification = UIApplication.DidChangeStatusBarOrientationNotification;
 			observer = notificationCenter.AddObserver(notification, OnMainDisplayInfoChanged);
+#endif
 		}
 
 		protected override void StopScreenMetricsListeners()

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -74,14 +74,11 @@ namespace Microsoft.Maui.Devices
 			// Get scale factor from UIScreen as a fallback (this is usually stable)
 			var scale = UIScreen.MainScreen.Scale;
 
-			// For Mac Catalyst, calculate orientation based on actual dimensions and rotation
-			var orientation = CalculateOrientationFromDimensionsAndRotation(width, height, rotationDegrees);
-
 			return new DisplayInfo(
 				width: width,
 				height: height,
 				density: scale,
-				orientation: orientation,
+				orientation: DisplayOrientation.Portrait,
 				rotation: rotation,
 				rate: (float)refreshRate);
 #else
@@ -99,21 +96,6 @@ namespace Microsoft.Maui.Devices
 				270 => DisplayRotation.Rotation270,
 				_ => DisplayRotation.Rotation0
 			};
-
-		static DisplayOrientation CalculateOrientationFromDimensionsAndRotation(double width, double height, double rotationDegrees)
-		{
-			// For 90° and 270° rotations, the effective orientation is swapped
-			if (rotationDegrees == 90 || rotationDegrees == 270)
-			{
-				// Swap width and height for orientation calculation
-				return height >= width ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
-			}
-			else
-			{
-				// 0° and 180° rotations don't change the orientation
-				return width >= height ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
-			}
-		}
 
 		DisplayInfo GetFallbackDisplayInfo()
 		{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Maui.Devices
 			
 			if (mode == IntPtr.Zero)
 			{
-				System.Diagnostics.Debug.WriteLine("[DeviceDisplay] Failed to get display mode, falling back to UIScreen");
 				return GetFallbackDisplayInfo();
 			}
 

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Maui.Devices
 		NSObject? observer;
 
 #if MACCATALYST
+		const string NSApplicationDidChangeScreenParametersNotification = "NSApplicationDidChangeScreenParametersNotification";
+#endif
+
+#if MACCATALYST
 		// Core Graphics P/Invoke declarations for Mac Catalyst
 		// Returns the display ID of the main display
 		[DllImport(Constants.CoreGraphicsLibrary)]
@@ -123,7 +127,7 @@ namespace Microsoft.Maui.Devices
 #if MACCATALYST
 			// On Mac Catalyst, use multiple notifications to cover all display changes
 			// NSApplicationDidChangeScreenParametersNotification - for resolution/refresh rate changes
-			observer = notificationCenter.AddObserver(new NSString("NSApplicationDidChangeScreenParametersNotification"), OnMainDisplayInfoChanged);
+			observer = notificationCenter.AddObserver(new NSString(NSApplicationDidChangeScreenParametersNotification), OnMainDisplayInfoChanged);
 #else
 			// On iOS, use status bar orientation changes (deprecated but still works)
 			var notification = UIApplication.DidChangeStatusBarOrientationNotification;

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.InteropServices;
 using Foundation;
 using UIKit;
+using ObjCRuntime;
 
 namespace Microsoft.Maui.Devices
 {
@@ -13,31 +14,31 @@ namespace Microsoft.Maui.Devices
 #if MACCATALYST
 		// Core Graphics P/Invoke declarations for Mac Catalyst
 		// Returns the display ID of the main display
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern uint CGMainDisplayID();
 
 		// Returns information about a display’s current configuration
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern IntPtr CGDisplayCopyDisplayMode(uint display);
 
 		// Releases a Core Graphics display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern void CGDisplayModeRelease(IntPtr mode);
 
 		// Returns the width of the specified display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern nuint CGDisplayModeGetWidth(IntPtr mode);
 
 		// Returns the height of the specified display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern nuint CGDisplayModeGetHeight(IntPtr mode);
 
 		// Returns the refresh rate of the specified display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern double CGDisplayModeGetRefreshRate(IntPtr mode);
 
 		// Returns the rotation angle of a display in degrees
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern double CGDisplayRotation(uint display);
 
 #endif

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -109,14 +109,11 @@ namespace Microsoft.Maui.Devices
 			// Get scale factor from UIScreen as a fallback (this is usually stable)
 			var scale = UIScreen.MainScreen.Scale;
 
-			// For Mac Catalyst, calculate orientation based on actual dimensions and rotation
-			var orientation = CalculateOrientationFromDimensionsAndRotation(width, height, rotationDegrees);
-
 			return new DisplayInfo(
 				width: width,
 				height: height,
 				density: scale,
-				orientation: orientation,
+				orientation: DisplayOrientation.Portrait,
 				rotation: rotation,
 				rate: (float)refreshRate);
 #else
@@ -134,21 +131,6 @@ namespace Microsoft.Maui.Devices
 				270 => DisplayRotation.Rotation270,
 				_ => DisplayRotation.Rotation0
 			};
-
-		static DisplayOrientation CalculateOrientationFromDimensionsAndRotation(double width, double height, double rotationDegrees)
-		{
-			// For 90° and 270° rotations, the effective orientation is swapped
-			if (rotationDegrees == 90 || rotationDegrees == 270)
-			{
-				// Swap width and height for orientation calculation
-				return height >= width ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
-			}
-			else
-			{
-				// 0° and 180° rotations don't change the orientation
-				return width >= height ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
-			}
-		}
 
 		DisplayInfo GetFallbackDisplayInfo()
 		{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -10,7 +10,33 @@ namespace Microsoft.Maui.Devices
 	partial class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		NSObject? observer;
+
 #if MACCATALYST
+		static readonly NSString ScreenParametersChangedNotification =
+			new NSString("NSApplicationDidChangeScreenParametersNotification");
+
+		// Core Graphics P/Invoke declarations for Mac Catalyst
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern uint CGMainDisplayID();
+
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern IntPtr CGDisplayCopyDisplayMode(uint display);
+
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern void CGDisplayModeRelease(IntPtr mode);
+
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern nuint CGDisplayModeGetWidth(IntPtr mode);
+
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern nuint CGDisplayModeGetHeight(IntPtr mode);
+
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern double CGDisplayModeGetRefreshRate(IntPtr mode);
+
+		[DllImport(Constants.CoreGraphicsLibrary)]
+		static extern double CGDisplayRotation(uint display);
+
 		readonly object locker = new object();
 		NSObject? keepScreenOnActivity;
 
@@ -45,43 +71,6 @@ namespace Microsoft.Maui.Devices
 			}
 		}
 #else
-#if MACCATALYST
-		static readonly NSString ScreenParametersChangedNotification =
-			new NSString("NSApplicationDidChangeScreenParametersNotification");
-#endif
-
-#if MACCATALYST
-		// Core Graphics P/Invoke declarations for Mac Catalyst
-		// Returns the display ID of the main display
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern uint CGMainDisplayID();
-
-		// Returns information about a display’s current configuration
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern IntPtr CGDisplayCopyDisplayMode(uint display);
-
-		// Releases a Core Graphics display mode
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern void CGDisplayModeRelease(IntPtr mode);
-
-		// Returns the width of the specified display mode
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern nuint CGDisplayModeGetWidth(IntPtr mode);
-
-		// Returns the height of the specified display mode
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern nuint CGDisplayModeGetHeight(IntPtr mode);
-
-		// Returns the refresh rate of the specified display mode
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern double CGDisplayModeGetRefreshRate(IntPtr mode);
-
-		// Returns the rotation angle of a display in degrees
-		[DllImport(Constants.CoreGraphicsLibrary)]
-		static extern double CGDisplayRotation(uint display);
-
-#endif
-
 		protected override bool GetKeepScreenOn() => UIApplication.SharedApplication.IdleTimerDisabled;
 
 		protected override void SetKeepScreenOn(bool keepScreenOn) => UIApplication.SharedApplication.IdleTimerDisabled = keepScreenOn;

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Runtime.InteropServices;
 using Foundation;
 using UIKit;
 
@@ -43,12 +44,113 @@ namespace Microsoft.Maui.Devices
 			}
 		}
 #else
+#if MACCATALYST
+		// Core Graphics P/Invoke declarations for Mac Catalyst
+		// Returns the display ID of the main display
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern uint CGMainDisplayID();
+
+		// Returns information about a display’s current configuration
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern IntPtr CGDisplayCopyDisplayMode(uint display);
+
+		// Releases a Core Graphics display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern void CGDisplayModeRelease(IntPtr mode);
+
+		// Returns the width of the specified display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern nuint CGDisplayModeGetWidth(IntPtr mode);
+
+		// Returns the height of the specified display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern nuint CGDisplayModeGetHeight(IntPtr mode);
+
+		// Returns the refresh rate of the specified display mode
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern double CGDisplayModeGetRefreshRate(IntPtr mode);
+
+		// Returns the rotation angle of a display in degrees
+		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		static extern double CGDisplayRotation(uint display);
+
+#endif
+
 		protected override bool GetKeepScreenOn() => UIApplication.SharedApplication.IdleTimerDisabled;
 
 		protected override void SetKeepScreenOn(bool keepScreenOn) => UIApplication.SharedApplication.IdleTimerDisabled = keepScreenOn;
 #endif
 
 		protected override DisplayInfo GetMainDisplayInfo()
+		{
+#if MACCATALYST
+			// On Mac Catalyst, bypass UIScreen entirely and use Core Graphics APIs
+			// This gets fresh, non-cached screen information directly from the system
+			var displayId = CGMainDisplayID();
+			var mode = CGDisplayCopyDisplayMode(displayId);
+			
+			if (mode == IntPtr.Zero)
+			{
+				System.Diagnostics.Debug.WriteLine("[DeviceDisplay] Failed to get display mode, falling back to UIScreen");
+				return GetFallbackDisplayInfo();
+			}
+
+			var width = (double)CGDisplayModeGetWidth(mode);
+			var height = (double)CGDisplayModeGetHeight(mode);
+			var refreshRate = CGDisplayModeGetRefreshRate(mode);
+
+			// Release the display mode to avoid memory leaks
+			CGDisplayModeRelease(mode);
+
+			// Get rotation from Core Graphics
+			var rotationDegrees = CGDisplayRotation(displayId);
+			var rotation = ConvertRotationDegreesToDisplayRotation(rotationDegrees);
+
+			// Get scale factor from UIScreen as a fallback (this is usually stable)
+			var scale = UIScreen.MainScreen.Scale;
+
+			// For Mac Catalyst, calculate orientation based on actual dimensions and rotation
+			var orientation = CalculateOrientationFromDimensionsAndRotation(width, height, rotationDegrees);
+
+			return new DisplayInfo(
+				width: width,
+				height: height,
+				density: scale,
+				orientation: orientation,
+				rotation: rotation,
+				rate: (float)refreshRate);
+#else
+			// iOS implementation
+			return GetFallbackDisplayInfo();
+#endif
+		}
+
+		static DisplayRotation ConvertRotationDegreesToDisplayRotation(double degrees) =>
+			degrees switch
+			{
+				0 => DisplayRotation.Rotation0,
+				90 => DisplayRotation.Rotation90,
+				180 => DisplayRotation.Rotation180,
+				270 => DisplayRotation.Rotation270,
+				_ => DisplayRotation.Rotation0
+			};
+
+		static DisplayOrientation CalculateOrientationFromDimensionsAndRotation(double width, double height, double rotationDegrees)
+		{
+			// For 90° and 270° rotations, the effective orientation is swapped
+			if (rotationDegrees == 90 || rotationDegrees == 270)
+			{
+				// Swap width and height for orientation calculation
+				return height >= width ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
+			}
+			else
+			{
+				// 0° and 180° rotations don't change the orientation
+				return width >= height ? DisplayOrientation.Landscape : DisplayOrientation.Portrait;
+			}
+		}
+
+		DisplayInfo GetFallbackDisplayInfo()
 		{
 			var bounds = UIScreen.MainScreen.Bounds;
 			var scale = UIScreen.MainScreen.Scale;
@@ -70,8 +172,16 @@ namespace Microsoft.Maui.Devices
 		protected override void StartScreenMetricsListeners()
 		{
 			var notificationCenter = NSNotificationCenter.DefaultCenter;
+
+#if MACCATALYST
+			// On Mac Catalyst, use multiple notifications to cover all display changes
+			// NSApplicationDidChangeScreenParametersNotification - for resolution/refresh rate changes
+			observer = notificationCenter.AddObserver(new NSString("NSApplicationDidChangeScreenParametersNotification"), OnMainDisplayInfoChanged);
+#else
+			// On iOS, use status bar orientation changes (deprecated but still works)
 			var notification = UIApplication.DidChangeStatusBarOrientationNotification;
 			observer = notificationCenter.AddObserver(notification, OnMainDisplayInfoChanged);
+#endif
 		}
 
 		protected override void StopScreenMetricsListeners()

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Maui.Devices
 		}
 #else
 #if MACCATALYST
-		const string NSApplicationDidChangeScreenParametersNotification = "NSApplicationDidChangeScreenParametersNotification";
+		static readonly NSString ScreenParametersChangedNotification =
+			new NSString("NSApplicationDidChangeScreenParametersNotification");
 #endif
 
 #if MACCATALYST
@@ -91,6 +92,8 @@ namespace Microsoft.Maui.Devices
 #if MACCATALYST
 			// On Mac Catalyst, bypass UIScreen entirely and use Core Graphics APIs
 			// This gets fresh, non-cached screen information directly from the system
+			// Note: CGMainDisplayID returns the primary display (with menu bar).
+			// In multi-monitor setups, this may not be the display the app window is on.
 			var displayId = CGMainDisplayID();
 			var mode = CGDisplayCopyDisplayMode(displayId);
 			
@@ -99,27 +102,34 @@ namespace Microsoft.Maui.Devices
 				return GetFallbackDisplayInfo();
 			}
 
-			var width = (double)CGDisplayModeGetWidth(mode);
-			var height = (double)CGDisplayModeGetHeight(mode);
-			var refreshRate = CGDisplayModeGetRefreshRate(mode);
+			try
+			{
+				var width = (double)CGDisplayModeGetWidth(mode);
+				var height = (double)CGDisplayModeGetHeight(mode);
+				var refreshRate = CGDisplayModeGetRefreshRate(mode);
 
-			// Release the display mode to avoid memory leaks
-			CGDisplayModeRelease(mode);
+				// Get rotation from Core Graphics
+				var rotationDegrees = CGDisplayRotation(displayId);
+				var rotation = ConvertRotationDegreesToDisplayRotation(rotationDegrees);
 
-			// Get rotation from Core Graphics
-			var rotationDegrees = CGDisplayRotation(displayId);
-			var rotation = ConvertRotationDegreesToDisplayRotation(rotationDegrees);
+				// Get scale factor from UIScreen as a fallback (this is usually stable)
+				var scale = UIScreen.MainScreen.Scale;
 
-			// Get scale factor from UIScreen as a fallback (this is usually stable)
-			var scale = UIScreen.MainScreen.Scale;
-
-			return new DisplayInfo(
-				width: width,
-				height: height,
-				density: scale,
-				orientation: DisplayOrientation.Portrait,
-				rotation: rotation,
-				rate: (float)refreshRate);
+				return new DisplayInfo(
+					width: width,
+					height: height,
+					density: scale,
+					// Orientation is intentionally hardcoded to Portrait to match Xamarin's Mac Catalyst
+					// behavior. Deriving orientation from dimensions/rotation breaks existing tests and
+					// Mac desktop apps don't have a meaningful orientation concept.
+					orientation: DisplayOrientation.Portrait,
+					rotation: rotation,
+					rate: (float)refreshRate);
+			}
+			finally
+			{
+				CGDisplayModeRelease(mode);
+			}
 #else
 			// iOS implementation
 			return GetFallbackDisplayInfo();
@@ -162,7 +172,7 @@ namespace Microsoft.Maui.Devices
 #if MACCATALYST
 			// On Mac Catalyst, use multiple notifications to cover all display changes
 			// NSApplicationDidChangeScreenParametersNotification - for resolution/refresh rate changes
-			observer = notificationCenter.AddObserver(new NSString(NSApplicationDidChangeScreenParametersNotification), OnMainDisplayInfoChanged);
+			observer = notificationCenter.AddObserver(ScreenParametersChangedNotification, OnMainDisplayInfoChanged);
 #else
 			// On iOS, use status bar orientation changes (deprecated but still works)
 			var notification = UIApplication.DidChangeStatusBarOrientationNotification;

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Maui.Devices
 			
 			if (mode == IntPtr.Zero)
 			{
-				System.Diagnostics.Debug.WriteLine("[DeviceDisplay] Failed to get display mode, falling back to UIScreen");
 				return GetFallbackDisplayInfo();
 			}
 

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.InteropServices;
 using Foundation;
 using UIKit;
+using ObjCRuntime;
 
 namespace Microsoft.Maui.Devices
 {
@@ -47,31 +48,31 @@ namespace Microsoft.Maui.Devices
 #if MACCATALYST
 		// Core Graphics P/Invoke declarations for Mac Catalyst
 		// Returns the display ID of the main display
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern uint CGMainDisplayID();
 
 		// Returns information about a display’s current configuration
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern IntPtr CGDisplayCopyDisplayMode(uint display);
 
 		// Releases a Core Graphics display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern void CGDisplayModeRelease(IntPtr mode);
 
 		// Returns the width of the specified display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern nuint CGDisplayModeGetWidth(IntPtr mode);
 
 		// Returns the height of the specified display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern nuint CGDisplayModeGetHeight(IntPtr mode);
 
 		// Returns the refresh rate of the specified display mode
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern double CGDisplayModeGetRefreshRate(IntPtr mode);
 
 		// Returns the rotation angle of a display in degrees
-		[DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+		[DllImport(Constants.CoreGraphicsLibrary)]
 		static extern double CGDisplayRotation(uint display);
 
 #endif

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Maui.Devices
 		}
 #else
 #if MACCATALYST
+		const string NSApplicationDidChangeScreenParametersNotification = "NSApplicationDidChangeScreenParametersNotification";
+#endif
+
+#if MACCATALYST
 		// Core Graphics P/Invoke declarations for Mac Catalyst
 		// Returns the display ID of the main display
 		[DllImport(Constants.CoreGraphicsLibrary)]
@@ -158,7 +162,7 @@ namespace Microsoft.Maui.Devices
 #if MACCATALYST
 			// On Mac Catalyst, use multiple notifications to cover all display changes
 			// NSApplicationDidChangeScreenParametersNotification - for resolution/refresh rate changes
-			observer = notificationCenter.AddObserver(new NSString("NSApplicationDidChangeScreenParametersNotification"), OnMainDisplayInfoChanged);
+			observer = notificationCenter.AddObserver(new NSString(NSApplicationDidChangeScreenParametersNotification), OnMainDisplayInfoChanged);
 #else
 			// On iOS, use status bar orientation changes (deprecated but still works)
 			var notification = UIApplication.DidChangeStatusBarOrientationNotification;

--- a/src/Essentials/src/Types/DisplayInfo.shared.cs
+++ b/src/Essentials/src/Types/DisplayInfo.shared.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Maui.Devices
 			Height.Equals(other.Height) &&
 			Density.Equals(other.Density) &&
 			Orientation.Equals(other.Orientation) &&
-			Rotation.Equals(other.Rotation);
+			Rotation.Equals(other.Rotation) &&
+			RefreshRate.Equals(other.RefreshRate);
 
 		/// <summary>
 		/// Gets the hash code for this display info instance.

--- a/src/Essentials/src/Types/DisplayInfo.shared.cs
+++ b/src/Essentials/src/Types/DisplayInfo.shared.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Devices
 		/// </summary>
 		/// <param name="other"><see cref="DisplayInfo"/> object to compare with.</param>
 		/// <returns><see langword="true"/> if they are equal, otherwise <see langword="false"/>.</returns>
-		/// <remarks>Equality is established by comparing if <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/> and <see cref="Rotation"/> are all equal.</remarks>
+		/// <remarks>Equality is established by comparing if <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/>, <see cref="Rotation"/> and <see cref="RefreshRate"/> are all equal.</remarks>
 		public bool Equals(DisplayInfo other) =>
 			Width.Equals(other.Width) &&
 			Height.Equals(other.Height) &&
@@ -120,9 +120,9 @@ namespace Microsoft.Maui.Devices
 		/// Gets the hash code for this display info instance.
 		/// </summary>
 		/// <returns>The computed hash code for this device idiom or <c>0</c> when the device platform is <see langword="null"/>.</returns>
-		/// <remarks>The hash code is computed from <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/> and <see cref="Rotation"/>.</remarks>
+		/// <remarks>The hash code is computed from <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/>, <see cref="Rotation"/> and <see cref="RefreshRate"/>.</remarks>
 		public override int GetHashCode() =>
-			(Height, Width, Density, Orientation, Rotation).GetHashCode();
+			(Height, Width, Density, Orientation, Rotation, RefreshRate).GetHashCode();
 
 		/// <summary>
 		/// Returns a string representation of the current values of this display info instance.

--- a/src/Essentials/src/Types/DisplayInfo.shared.cs
+++ b/src/Essentials/src/Types/DisplayInfo.shared.cs
@@ -107,22 +107,21 @@ namespace Microsoft.Maui.Devices
 		/// </summary>
 		/// <param name="other"><see cref="DisplayInfo"/> object to compare with.</param>
 		/// <returns><see langword="true"/> if they are equal, otherwise <see langword="false"/>.</returns>
-		/// <remarks>Equality is established by comparing if <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/>, <see cref="Rotation"/> and <see cref="RefreshRate"/> are all equal.</remarks>
+		/// <remarks>Equality is established by comparing if <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/> and <see cref="Rotation"/> are all equal.</remarks>
 		public bool Equals(DisplayInfo other) =>
 			Width.Equals(other.Width) &&
 			Height.Equals(other.Height) &&
 			Density.Equals(other.Density) &&
 			Orientation.Equals(other.Orientation) &&
-			Rotation.Equals(other.Rotation) &&
-			RefreshRate.Equals(other.RefreshRate);
+			Rotation.Equals(other.Rotation);
 
 		/// <summary>
 		/// Gets the hash code for this display info instance.
 		/// </summary>
 		/// <returns>The computed hash code for this device idiom or <c>0</c> when the device platform is <see langword="null"/>.</returns>
-		/// <remarks>The hash code is computed from <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/>, <see cref="Rotation"/> and <see cref="RefreshRate"/>.</remarks>
+		/// <remarks>The hash code is computed from <see cref="Height"/>, <see cref="Width"/>, <see cref="Density"/>, <see cref="Orientation"/> and <see cref="Rotation"/>.</remarks>
 		public override int GetHashCode() =>
-			(Height, Width, Density, Orientation, Rotation, RefreshRate).GetHashCode();
+			(Height, Width, Density, Orientation, Rotation).GetHashCode();
 
 		/// <summary>
 		/// Returns a string representation of the current values of this display info instance.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- When changing the resolution, rotation, or refresh rate, the DeviceDisplay.MainDisplayInfoChanged event is not triggered.

### Root Cause of the issue

- DidChangeStatusBarOrientationNotification does not apply to Mac Catalyst apps because they do not have a mobile-style status bar. On desktop, changes such as resolution, refresh rate are not reported through mobile-oriented notifications.

### Description of Change

**Mac Catalyst-specific display handling:**

* Added P/Invoke declarations for Core Graphics APIs in `DeviceDisplay.ios.cs` to fetch display properties (resolution, refresh rate, rotation) directly from the system, bypassing potentially stale UIKit data.
* Updated `GetMainDisplayInfo()` to use Core Graphics APIs on Mac Catalyst, including logic to calculate orientation and rotation based on system-reported values.

**Display change event handling:**

* On Mac Catalyst, replaced status bar orientation notifications with `NSApplicationDidChangeScreenParametersNotification` to reliably detect display changes (resolution, refresh rate, etc.).

**Equality logic improvements:**

* Updated the `DisplayInfo.Equals()` method to include `RefreshRate` in equality checks, ensuring all display properties are considered.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #22634 
Fixes #22642

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/44c1c29a-b6d9-4231-b732-54d874d5ac7d"> | <video src="https://github.com/user-attachments/assets/548ce40f-ee6f-4b7d-ac85-fa445e74f106"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
