### PR TITLE
[ci]  Fix helix local

### DIFF
--- a/docs/DevelopmentTips.md
+++ b/docs/DevelopmentTips.md
@@ -216,6 +216,8 @@ Check available queues at [helix.dot.net](https://helix.dot.net). The current co
 
 ### Running Device Tests Locally
 
+The following commands assume you are on the root of the maui repository.
+
 #### Step 1: Build Build Tasks
 First, restore tools and build the required MSBuild tasks:
 
@@ -224,7 +226,7 @@ First, restore tools and build the required MSBuild tasks:
 dotnet tool restore
 
 # Build the Build tasks (required)
-./build.sh -restore -build -configuration Release -projects './Microsoft.Maui.BuildTasks.slnf' /bl:BuildBuildTasks.binlog -warnAsError false
+./build.sh -restore -build -configuration Release -projects $(PWD)/Microsoft.Maui.BuildTasks.slnf /bl:BuildBuildTasks.binlog -warnAsError false
 ```
 
 #### Step 2: Build Device Tests
@@ -237,6 +239,16 @@ Build the device test projects:
 
 #### Step 3: Send to Helix
 Submit the tests to Helix for execution:
+
+We need to ake some variables, more info about Helix can be read [here](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/Readme.md) 
+
+```bash
+export BUILD_REASON=pr
+export BUILD_REPOSITORY_NAME=maui
+export BUILD_SOURCEBRANCH=main
+export SYSTEM_TEAMPROJECT=dnceng
+export SYSTEM_ACCESSTOKEN='' 
+```
 
 ```bash
 # Send to Helix for Android

--- a/docs/DevelopmentTips.md
+++ b/docs/DevelopmentTips.md
@@ -55,7 +55,7 @@ To build and run Blazor Desktop samples, check out the [Blazor Desktop](https://
 
 ### Compile using a local `.dotnet\dotnet` via `build.*` scripts on the root folder 
 
-This method uses the arcade build infraestructure. For more information you can look [here](https://github.com/dotnet/arcade/blob/main/Documentation/ArcadeSdk.md#build-scripts-and-extensibility-points)
+This method uses the Arcade build infrastructure. For more information, you can look [here](https://github.com/dotnet/arcade/blob/main/Documentation/ArcadeSdk.md#build-scripts-and-extensibility-points)
 
 ```
 ./build.sh -restore -pack
@@ -218,14 +218,14 @@ Check available queues at [helix.dot.net](https://helix.dot.net). The current co
 
 The following commands assume you are on the root of the maui repository.
 
-#### Step 1: Build Build Tasks
+#### Step 1: Build MSBuild Tasks
 First, restore tools and build the required MSBuild tasks:
 
 ```bash
 # Restore dotnet tools
 dotnet tool restore
 
-# Build the Build tasks (required)
+# Build the MSBuild tasks (required)
 ./build.sh -restore -build -configuration Release -projects $(PWD)/Microsoft.Maui.BuildTasks.slnf /bl:BuildBuildTasks.binlog -warnAsError false
 ```
 
@@ -240,7 +240,8 @@ Build the device test projects:
 #### Step 3: Send to Helix
 Submit the tests to Helix for execution:
 
-We need to ake some variables, more info about Helix can be read [here](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/Readme.md) 
+We need to set some variables. More info about Helix can be found [here](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/Readme.md) 
+
 
 ```bash
 export BUILD_REASON=pr
@@ -252,13 +253,13 @@ export SYSTEM_ACCESSTOKEN=''
 
 ```bash
 # Send to Helix for Android
-./eng/common/msbuild.sh ./eng/helix_xharness.proj /restore /p:TreatWarningsAsErrors=false /t:Test /p:TargetOS=android /bl:sendhelix.binlog -verbosity:diag
+./eng/common/msbuild.sh ./eng/helix_xharness.proj /restore /p:TreatWarningsAsErrors=false /t:Test /p:TargetOS=android /bl:sendhelix_android.binlog -verbosity:diag
 
 # Send to Helix for iOS  
-./eng/common/msbuild.sh ./eng/helix_xharness.proj /restore /p:TreatWarningsAsErrors=false /t:Test /p:TargetOS=ios /bl:sendhelix.binlog -verbosity:diag
+./eng/common/msbuild.sh ./eng/helix_xharness.proj /restore /p:TreatWarningsAsErrors=false /t:Test /p:TargetOS=ios /bl:sendhelix_ios.binlog -verbosity:diag
 
 # Send to Helix for Mac Catalyst
-./eng/common/msbuild.sh ./eng/helix_xharness.proj /restore /p:TreatWarningsAsErrors=false /t:Test /p:TargetOS=maccatalyst /bl:sendhelix.binlog -verbosity:diag
+./eng/common/msbuild.sh ./eng/helix_xharness.proj /restore /p:TreatWarningsAsErrors=false /t:Test /p:TargetOS=maccatalyst /bl:sendhelix_catalyst.binlog -verbosity:diag
 ```
 
 ### Windows Commands
@@ -266,7 +267,15 @@ export SYSTEM_ACCESSTOKEN=''
 For Windows development, use the corresponding `.cmd` files:
 
 ```cmd
-REM Build Build tasks
+set BUILD_REASON=pr
+set BUILD_REPOSITORY_NAME=maui
+set BUILD_SOURCEBRANCH=main
+set SYSTEM_TEAMPROJECT=dnceng
+set SYSTEM_ACCESSTOKEN=
+```
+
+```cmd
+REM Build MSBuild tasks
 .\build.cmd -restore -build -configuration Release -projects ".\Microsoft.Maui.BuildTasks.slnf" /bl:BuildBuildTasks.binlog -warnAsError false
 
 REM Build device tests
@@ -290,7 +299,7 @@ The Helix configuration is defined in `eng/helix_xharness.proj` and includes:
 
 #### Common Issues
 
-1. **Build failures**: Ensure you've built the BuildTasks first
+1. **Build failures**: Ensure you've built the MSBuild tasks first
 2. **Missing devices**: Check queue availability at [helix.dot.net](https://helix.dot.net)  
 3. **Authentication**: For CI scenarios, ensure proper Azure DevOps access tokens
 4. **Timeouts**: Tests have generous timeouts but may need adjustment for complex scenarios

--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -6,6 +6,7 @@
         <HelixTargetQueues Condition="'$(TargetOS)' == 'ios'">osx.15.arm64.Open</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst'">osx.15.arm64.Open</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
+        <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>
         <Creator Condition="'$(HelixAccessToken)' == ''">maui</Creator>
         <IncludeDotNetCli>true</IncludeDotNetCli>
         <DotNetCliPackageType>sdk</DotNetCliPackageType>
@@ -24,9 +25,9 @@
         <HelixBuild>t001</HelixBuild>
     </PropertyGroup>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(SYSTEM_ACCESSTOKEN)' != ''">
         <ScenariosDir>$(BUILD_SOURCESDIRECTORY)/artifacts/bin/</ScenariosDir>
-        <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>
+       
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
### Description of Change

Small fixes to be able to run locally, and improve documentation 

This pull request updates the documentation and build configuration for running device tests locally and sending them to Helix. The main improvements clarify the setup steps, correct build commands, and introduce required environment variables for Helix integration.

Documentation improvements:
* Added a note specifying that commands should be run from the root of the maui repository to avoid confusion.
* Clarified the build command for MSBuild tasks by using `$(PWD)` to ensure the correct project path is used.
* Added instructions to export required environment variables for Helix, with a reference to more detailed documentation.

Build configuration updates:
* Set the `TargetsAppleMobile` property when targeting iOS, which helps configure Helix for Apple mobile platforms.
* Moved the conditional setting of `TargetsAppleMobile` to avoid duplication and ensure it only applies when the access token is not empty.