### PR TITLE
[ci] Move back to 15.6 for catalyst UITests

### DIFF
--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -110,7 +110,7 @@ parameters:
     type: object
     default:
       name: Azure Pipelines
-      vmImage: macOS-15
+      vmImage: macOS-14
 
 stages:
 


### PR DESCRIPTION
### Description of Change

Fix failing UITests on catalyst because of move to macOS-15