### PR TITLE
[testing] Update androidApiLevels for device tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -192,8 +192,9 @@
     <AndroidSdkApiLevels Include="31" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="32" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="33" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
-    <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="35" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
   </ItemGroup>
   <PropertyGroup>
     <!-- arcade -->

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -176,14 +176,14 @@ stages:
         agentPoolAccessToken: $(AgentPoolAccessToken)
         targetFrameworkVersion: ${{ targetFrameworkVersion }}
         ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
-          androidApiLevels: [ 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
+          androidApiLevels: [ 36, 35, 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
           iosVersions: [ 'simulator-18.0' ]
           catalystVersions: [ 'latest' ]
           windowsVersions: [ 'packaged', 'unpackaged' ]
           provisionatorChannel: ${{ parameters.provisionatorChannel }}
           skipProvisioning: ${{ or(not(parameters.UseProvisionator), false) }}
         ${{ else }}:
-          androidApiLevels: [ 33, 23 ]
+          androidApiLevels: [ 35, 23 ]
           iosVersions: [ 'simulator-18.0' ]
           catalystVersions: [ 'latest' ]
           windowsVersions: [ 'packaged', 'unpackaged' ]


### PR DESCRIPTION
### Description of Change

This pull request updates the Android API levels used in the device test pipeline configuration to ensure broader and more current test coverage.

Device test pipeline configuration updates:

* Expanded the `androidApiLevels` list for full builds to include API levels 36 and 35, ensuring tests run against the latest Android versions. (`eng/pipelines/device-tests.yml`)
* Updated the `androidApiLevels` list for non-full builds to test against API level 35 instead of 33, maintaining coverage for recent Android releases. (`eng/pipelines/device-tests.yml`)