### PR TITLE
[iOS] Fix added for Navigation.SetTitleView does not work in ios 26.

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1918,8 +1918,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			public Container(View view, UINavigationBar bar) : base(bar.Bounds)
 			{
-				// For iOS 18+, we need to use autoresizing masks instead of constraints to ensure proper TitleView display
-				if (OperatingSystem.IsIOSVersionAtLeast(18) || OperatingSystem.IsMacCatalystVersionAtLeast(18))
+				// For iOS 26+, we need to use autoresizing masks instead of constraints to ensure proper TitleView display
+				if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				{
 					TranslatesAutoresizingMaskIntoConstraints = true;
 					AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
@@ -2013,8 +2013,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					if (Superview != null)
 					{
-						// For iOS 18+ and pre-iOS 11, we use autoresizing masks and need to adjust the frame manually
-						if (OperatingSystem.IsIOSVersionAtLeast(18) || OperatingSystem.IsMacCatalystVersionAtLeast(18) ||
+						// For iOS 26+ and pre-iOS 11, we use autoresizing masks and need to adjust the frame manually
+						if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26) ||
 							!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)))
 						{
 							value.Y = Superview.Bounds.Y;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1918,7 +1918,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			public Container(View view, UINavigationBar bar) : base(bar.Bounds)
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11))
+				// For iOS 18+, we need to use autoresizing masks instead of constraints to ensure proper TitleView display
+				if (OperatingSystem.IsIOSVersionAtLeast(18) || OperatingSystem.IsMacCatalystVersionAtLeast(18))
+				{
+					TranslatesAutoresizingMaskIntoConstraints = true;
+					AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
+				}
+				else if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11))
 				{
 					TranslatesAutoresizingMaskIntoConstraints = false;
 				}
@@ -2007,7 +2013,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					if (Superview != null)
 					{
-						if (!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)))
+						// For iOS 18+ and pre-iOS 11, we use autoresizing masks and need to adjust the frame manually
+						if ((OperatingSystem.IsIOSVersionAtLeast(18) || OperatingSystem.IsMacCatalystVersionAtLeast(18)) ||
+							!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)))
 						{
 							value.Y = Superview.Bounds.Y;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -2014,7 +2014,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					if (Superview != null)
 					{
 						// For iOS 18+ and pre-iOS 11, we use autoresizing masks and need to adjust the frame manually
-						if ((OperatingSystem.IsIOSVersionAtLeast(18) || OperatingSystem.IsMacCatalystVersionAtLeast(18)) ||
+						if (OperatingSystem.IsIOSVersionAtLeast(18) || OperatingSystem.IsMacCatalystVersionAtLeast(18) ||
 							!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)))
 						{
 							value.Y = Superview.Bounds.Y;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


### Description of Change
This pull request updates the handling of layout logic for the navigation bar's `TitleView` container in the iOS compatibility renderer. The changes ensure correct display and sizing behavior on iOS 26+ by switching to autoresizing masks, while maintaining compatibility with older iOS versions.

**Platform-specific layout adjustments:**

* In the `Container` class constructor, for iOS 26+ and Mac Catalyst 26+, the container now uses autoresizing masks (`TranslatesAutoresizingMaskIntoConstraints = true` and sets `AutoresizingMask`) instead of constraints to ensure proper TitleView display. For iOS 11+ and Mac Catalyst 11+, constraints are still used.
* In the `Frame` property override, the logic is updated so that for iOS 26+, Mac Catalyst 26+, and pre-iOS 11, autoresizing masks are used and the frame is manually adjusted. This maintains correct sizing and positioning across different platform versions.

Fixes #31671
Fixes #31815

