### PR TITLE
[ci] Fix net10 UiTests

### DIFF
--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -154,12 +154,6 @@ stages:
                       platform: 'Android'
                       artifactName: 'uitest-snapshot-results-android-$(System.JobName)-$(System.JobAttempt)'
 
-                  # Collect and publish Android snapshot diffs
-                  - template: ui-tests-collect-snapshot-diffs.yml
-                    parameters:
-                      platform: 'Android'
-                      artifactName: 'uitest-snapshot-results-android-$(System.JobName)-$(System.JobAttempt)'
-
 
   - stage: android_ui_tests_coreclr
     displayName: Android UITests CoreClr
@@ -203,7 +197,7 @@ stages:
                   # Collect and publish Android snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
                     parameters:
-                      platform: 'Android'
+                      platform: 'Android CoreCLR'
                       artifactName: 'uitest-snapshot-results-android-$(System.JobName)-$(System.JobAttempt)'
 
   - stage: ios_ui_tests_mono

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -197,7 +197,7 @@ stages:
                   # Collect and publish Android snapshot diffs
                   - template: ui-tests-collect-snapshot-diffs.yml
                     parameters:
-                      platform: 'Android CoreCLR'
+                      platform: 'Android'
                       artifactName: 'uitest-snapshot-results-android-$(System.JobName)-$(System.JobAttempt)'
 
   - stage: ios_ui_tests_mono


### PR DESCRIPTION
### Description of Change

This fixes a issue with the latest merge from main to net10.

This pull request makes targeted updates to the UI test pipeline configuration for Android platforms. The main changes involve adjusting how Android snapshot diffs are collected and published to better align with platform distinctions and pipeline stages.

Pipeline configuration updates:

* Removed the step that collects and publishes Android snapshot diffs from the main Android UI test stage, simplifying the workflow for that stage.
* Updated the parameters for collecting snapshot diffs in the Android CoreCLR UI test stage, changing the `platform` parameter from `'Android'` to `'Android CoreCLR'` for clearer platform-specific artifact handling.
