### PR TITLE
[Android] Fix App Unresponsive when prompting the user from a new page

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
 			{
+				// Wait for handler to be ready before showing dialog
 				if (sender.Handler is null && sender is VisualElement ve)
 				{
 					void OnHandlerReady(object s, EventArgs e)
@@ -181,6 +182,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnAlertRequested(IView sender, AlertArguments arguments)
 			{
+				// Wait for handler to be ready before showing dialog
 				if (sender.Handler is null && sender is VisualElement ve)
 				{
 					void OnHandlerReady(object s, EventArgs e)
@@ -272,6 +274,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnPromptRequested(IView sender, PromptArguments arguments)
 			{
+				// Wait for handler to be ready before showing dialog
 				if (sender.Handler is null && sender is VisualElement ve)
 				{
 					void OnHandlerReady(object s, EventArgs e)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -111,10 +111,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
 			{
-				if (sender.Handler == null)
-				{
-					sender.ToHandler(MauiContext);
-				}
+				EnsureHandlerExists(sender);
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -175,10 +172,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnAlertRequested(IView sender, AlertArguments arguments)
 			{
-				if (sender.Handler == null)
-				{
-					sender.ToHandler(MauiContext);
-				}
+				EnsureHandlerExists(sender);
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -260,10 +254,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnPromptRequested(IView sender, PromptArguments arguments)
 			{
-				if (sender.Handler == null)
-				{
-					sender.ToHandler(MauiContext);
-				}
+				EnsureHandlerExists(sender);
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -305,6 +296,14 @@ namespace Microsoft.Maui.Controls.Platform
 				alertDialog.Window.SetSoftInputMode(SoftInput.StateVisible);
 				alertDialog.Show();
 				editText.RequestFocus();
+			}
+
+			void EnsureHandlerExists(IView sender)
+			{
+				if (sender.Handler == null)
+				{
+					sender.ToHandler(MauiContext);
+				}
 			}
 
 			void UpdateProgressBarVisibility(bool isBusy)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -8,7 +8,6 @@ using Android.Text;
 using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
 using static Android.Views.ViewGroup;
 using AButton = Android.Widget.Button;

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -112,17 +112,9 @@ namespace Microsoft.Maui.Controls.Platform
 			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
 			{
 				// Wait for handler to be ready before showing dialog
-				if (sender.Handler is null && sender is VisualElement ve)
-				{
-					void OnHandlerReady(object s, EventArgs e)
-					{
-						ve.HandlerChanged -= OnHandlerReady;
-						OnActionSheetRequested(sender, arguments);
-					}
-
-					ve.HandlerChanged += OnHandlerReady;
+				if (WaitForHandlerIfNeeded(sender, () => OnActionSheetRequested(sender, arguments)))
 					return;
-				}
+
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{
@@ -183,17 +175,9 @@ namespace Microsoft.Maui.Controls.Platform
 			void OnAlertRequested(IView sender, AlertArguments arguments)
 			{
 				// Wait for handler to be ready before showing dialog
-				if (sender.Handler is null && sender is VisualElement ve)
-				{
-					void OnHandlerReady(object s, EventArgs e)
-					{
-						ve.HandlerChanged -= OnHandlerReady;
-						OnAlertRequested(sender, arguments);
-					}
-
-					ve.HandlerChanged += OnHandlerReady;
+				if (WaitForHandlerIfNeeded(sender, () => OnAlertRequested(sender, arguments)))
 					return;
-				}
+
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{
@@ -275,17 +259,8 @@ namespace Microsoft.Maui.Controls.Platform
 			void OnPromptRequested(IView sender, PromptArguments arguments)
 			{
 				// Wait for handler to be ready before showing dialog
-				if (sender.Handler is null && sender is VisualElement ve)
-				{
-					void OnHandlerReady(object s, EventArgs e)
-					{
-						ve.HandlerChanged -= OnHandlerReady;
-						OnPromptRequested(sender, arguments);
-					}
-
-					ve.HandlerChanged += OnHandlerReady;
+				if (WaitForHandlerIfNeeded(sender, () => OnPromptRequested(sender, arguments)))
 					return;
-				}
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -327,6 +302,22 @@ namespace Microsoft.Maui.Controls.Platform
 				alertDialog.Window.SetSoftInputMode(SoftInput.StateVisible);
 				alertDialog.Show();
 				editText.RequestFocus();
+			}
+
+			bool WaitForHandlerIfNeeded(IView sender, System.Action action)
+			{
+				if (sender.Handler is null && sender is VisualElement ve)
+				{
+					void OnHandlerReady(object s, EventArgs e)
+					{
+						ve.HandlerChanged -= OnHandlerReady;
+						action();
+					}
+
+					ve.HandlerChanged += OnHandlerReady;
+					return true;
+				}
+				return false;
 			}
 
 			void UpdateProgressBarVisibility(bool isBusy)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -4,10 +4,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Android.App;
 using Android.Content;
+using Android.OS;
 using Android.Text;
 using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
 using static Android.Views.ViewGroup;
 using AButton = Android.Widget.Button;
@@ -109,6 +111,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
 			{
+				if (sender.Handler == null)
+				{
+					sender.ToHandler(MauiContext);
+				}
+
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{
@@ -168,6 +175,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnAlertRequested(IView sender, AlertArguments arguments)
 			{
+				if (sender.Handler == null)
+				{
+					sender.ToHandler(MauiContext);
+				}
+
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{
@@ -248,6 +260,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnPromptRequested(IView sender, PromptArguments arguments)
 			{
+				if (sender.Handler == null)
+				{
+					sender.ToHandler(MauiContext);
+				}
+
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -111,8 +111,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnActionSheetRequested(IView sender, ActionSheetArguments arguments)
 			{
-				EnsureHandlerExists(sender);
+				if (sender.Handler is null && sender is VisualElement ve)
+				{
+					void OnHandlerReady(object s, EventArgs e)
+					{
+						ve.HandlerChanged -= OnHandlerReady;
+						OnActionSheetRequested(sender, arguments);
+					}
 
+					ve.HandlerChanged += OnHandlerReady;
+					return;
+				}
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{
@@ -172,8 +181,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnAlertRequested(IView sender, AlertArguments arguments)
 			{
-				EnsureHandlerExists(sender);
+				if (sender.Handler is null && sender is VisualElement ve)
+				{
+					void OnHandlerReady(object s, EventArgs e)
+					{
+						ve.HandlerChanged -= OnHandlerReady;
+						OnAlertRequested(sender, arguments);
+					}
 
+					ve.HandlerChanged += OnHandlerReady;
+					return;
+				}
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
 				{
@@ -254,7 +272,17 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnPromptRequested(IView sender, PromptArguments arguments)
 			{
-				EnsureHandlerExists(sender);
+				if (sender.Handler is null && sender is VisualElement ve)
+				{
+					void OnHandlerReady(object s, EventArgs e)
+					{
+						ve.HandlerChanged -= OnHandlerReady;
+						OnPromptRequested(sender, arguments);
+					}
+
+					ve.HandlerChanged += OnHandlerReady;
+					return;
+				}
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -296,14 +324,6 @@ namespace Microsoft.Maui.Controls.Platform
 				alertDialog.Window.SetSoftInputMode(SoftInput.StateVisible);
 				alertDialog.Show();
 				editText.RequestFocus();
-			}
-
-			void EnsureHandlerExists(IView sender)
-			{
-				if (sender.Handler == null)
-				{
-					sender.ToHandler(MauiContext);
-				}
 			}
 
 			void UpdateProgressBarVisibility(bool isBusy)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Android.App;
 using Android.Content;
-using Android.OS;
 using Android.Text;
 using Android.Views;
 using Android.Widget;

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -112,7 +112,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// Wait for handler to be ready before showing dialog
 				if (WaitForHandlerIfNeeded(sender, () => OnActionSheetRequested(sender, arguments)))
+				{
 					return;
+				}
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -175,7 +177,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// Wait for handler to be ready before showing dialog
 				if (WaitForHandlerIfNeeded(sender, () => OnAlertRequested(sender, arguments)))
+				{
 					return;
+				}
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))
@@ -259,7 +263,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// Wait for handler to be ready before showing dialog
 				if (WaitForHandlerIfNeeded(sender, () => OnPromptRequested(sender, arguments)))
+				{
 					return;
+				}
 
 				// Verify that the page making the request is part of this activity 
 				if (!PageIsInThisContext(sender))

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25585.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25585.cs
@@ -1,0 +1,52 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 25585, "App Unresponsive when prompting the user from a new page", PlatformAffected.Android)]
+
+public class Issue25585 : Shell
+{
+	public Issue25585()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Flyout;
+
+		var shellContent = new ShellContent
+		{
+			Title = "Second Page",
+			Route = "MainPage",
+			Content = new Issue25585ContentPage()
+		};
+
+		Items.Add(new ShellContent
+		{
+			Title = "First Page",
+			Route = "First",
+			Content = new ContentPage
+			{
+				Content = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Text = "Go to SecondPage",
+					AutomationId = "GoToSecondPage",
+				}
+			}
+		});
+		Items.Add(shellContent);
+	}
+}
+
+public class Issue25585ContentPage : ContentPage
+{
+	public Issue25585ContentPage()
+	{
+		Content = new StackLayout
+		{
+			Children =
+				{
+					new Label { Text = "If DisplayAlert is shown, the test passed" },
+				}
+		};
+		DisplayAlert("Hi", "This is from Constructor", "OK", "Cancel");
+	}
+}
+
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25585.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25585.cs
@@ -17,7 +17,7 @@ public class Issue25585 : _IssuesUITest
 		App.TapShellFlyoutIcon();
 		App.Tap("Second Page");
 #if MACCATALYST
-			App.WaitForElement(AppiumQuery.ById($"action-button--{999 - 0}"));
+		App.WaitForElement(AppiumQuery.ById($"action-button--{999 - 0}"));
 #else
 		App.WaitForElement("OK");
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25585.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25585.cs
@@ -2,25 +2,24 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
-{
-	public class Issue25585 : _IssuesUITest
-	{
-		public Issue25585(TestDevice device) : base(device) { }
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
-		public override string Issue => "App Unresponsive when prompting the user from a new page";
-		[Test]
-		[Category(UITestCategories.DisplayAlert)]
-		public void VerifyDisplayAlertIsShown()
-		{
-			App.WaitForElement("GoToSecondPage");
-			App.TapShellFlyoutIcon();
-			App.Tap("Second Page");
+public class Issue25585 : _IssuesUITest
+{
+	public Issue25585(TestDevice device) : base(device) { }
+
+	public override string Issue => "App Unresponsive when prompting the user from a new page";
+	[Test]
+	[Category(UITestCategories.DisplayAlert)]
+	public void VerifyDisplayAlertIsShown()
+	{
+		App.WaitForElement("GoToSecondPage");
+		App.TapShellFlyoutIcon();
+		App.Tap("Second Page");
 #if MACCATALYST
 			App.WaitForElement(AppiumQuery.ById($"action-button--{999 - 0}"));
 #else
-			App.WaitForElement("OK");
+		App.WaitForElement("OK");
 #endif
-		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25585.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25585.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25585 : _IssuesUITest
+	{
+		public Issue25585(TestDevice device) : base(device) { }
+
+		public override string Issue => "App Unresponsive when prompting the user from a new page";
+		[Test]
+		[Category(UITestCategories.DisplayAlert)]
+		public void VerifyDisplayAlertIsShown()
+		{
+			App.WaitForElement("GoToSecondPage");
+			App.TapShellFlyoutIcon();
+			App.Tap("Second Page");
+#if MACCATALYST
+			App.WaitForElement(AppiumQuery.ById($"action-button--{999 - 0}"));
+#else
+			App.WaitForElement("OK");
+#endif
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
DisplayPrompt/DisplayAlert/DisplayActionSheet don't display when called in new page constructor or OnAppearing.

### Description of Change

<!-- Enter description of the fix in this section -->
The fix ensures alerts, action sheets, and prompts are only executed when the view’s Handler is ready. If the handler is not yet set, the action is deferred using the HandlerChanged event, so the UI request executes once the view is fully initialized. This  ensures dialogs appear reliably on Android platform platforms

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25585

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Screenshot

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/9d8c4dec-7412-4a18-bbde-7dbf1e2b9ec8" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/de4e428f-c1f1-4e6a-81b0-63952e41bd8a" width="300" height="600"> |
