### PR TITLE
[Android] CollectionView: Fix RemainingItemsThreshold not firing when Header/Footer is present

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31814.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31814.cs
@@ -1,0 +1,63 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31814, "CollectionView RemainingItemsThreshold incorrectly including Header and Footer in counts", PlatformAffected.Android)]
+public class Issue31814 : ContentPage
+{
+    public ObservableCollection<int> Items { get; set; } = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    Label label;
+
+    public Issue31814()
+    {
+        BindingContext = this;
+        label = new Label
+        {
+            Text = "Initial Label",
+            AutomationId = "Issue31814Label"
+        };
+
+        CollectionView collectionView = new CollectionView
+        {
+            ItemsSource = Items,
+            AutomationId = "Issue31814CollectionView",
+            RemainingItemsThreshold = 0,
+            ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+            {
+                ItemSpacing = 4
+            },
+            Header = new BoxView
+            {
+                BackgroundColor = Colors.Green,
+                HeightRequest = 120
+            },
+            Footer = new BoxView
+            {
+                BackgroundColor = Colors.Red,
+                HeightRequest = 120
+            },
+            ItemTemplate = new DataTemplate(() =>
+            {
+                return new BoxView
+                {
+                    HeightRequest = 120,
+                    BackgroundColor = Colors.Yellow
+                };
+            })
+        };
+
+        collectionView.RemainingItemsThresholdReached += CollectionView_RemainingItemsThresholdReached;
+        Grid grid = new Grid();
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+        grid.Add(label, 0, 0);
+        grid.Add(collectionView, 0, 1);
+        Content = grid;
+    }
+
+    void CollectionView_RemainingItemsThresholdReached(object sender, EventArgs e)
+    {
+        Items.Add(0);
+        label.Text = "RemainingItemsThresholdReached fired";
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31814.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31814.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31814 : _IssuesUITest
+{
+    public Issue31814(TestDevice testDevice) : base(testDevice)
+    {
+    }
+    public override string Issue => "CollectionView RemainingItemsThreshold incorrectly including Header and Footer in counts";
+
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void AdjustRemainingItemsThresholdForHeaderFooter()
+    {
+        App.WaitForElement("Issue31814CollectionView");
+        App.ScrollDown("Issue31814CollectionView", ScrollStrategy.Gesture, 0.99);
+        App.WaitForElement("RemainingItemsThresholdReached fired");
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details:
On Android, when a CollectionView has a Header, Footer defined, setting RemainingItemsThreshold to 0 does not trigger the threshold event. 
 
### Root Cause
On Android, the ItemsSource.Count reported by ItemsViewAdapter includes header and footer elements when they are defined.
However, the indices returned by GetVisibleItemsIndex are already normalized to exclude header/footer.
As a result, when RemainingItemsThreshold was set to 0, the event was never triggered if a header or footer was present, because Last could never equal ItemsSource.Count - 1.
 
### Description of Change
The fix ensures both values are aligned by adjusting the item count to exclude header and footer elements. This way, the last visible index (Last) is always compared against the correct number of data items (logicalItemCount). With this change, the threshold event now works correctly for both 0 and non-zero thresholds, regardless of whether headers or footers are defined.
 
### Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
 ### Break PR: #26468 
### Issues Fixed:
Fixes #31814 
 
### Screenshots
| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/102297fa-7912-46c6-ac20-22f3cfa29ccd"> |   <video src="https://github.com/user-attachments/assets/c8daea19-4b35-4e4d-9f46-96d0a77bd0fb">  |