### PR TITLE
[net9.0] Clean up template options for the CLI

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/dotnetcli.host.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/dotnetcli.host.json
@@ -1,8 +1,70 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "msExtensionsLoggingDebugVersion": {
+      "isHidden": true
+    },
+    "componentsWebVersion": {
+      "isHidden": true
+    },
+    "componentsWebAssemblyVersion": {
+      "isHidden": true
+    },
+    "componentsWebAssemblyServerVersion": {
+      "isHidden": true
+    },
     "Framework": {
       "longName": "framework"
+    },
+    "FrameworkAspNet": {
+      "isHidden": true
+    },
+    "UserSecretsId": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
+    },
+    "kestrelHttpPort": {
+      "isHidden": true
+    },
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
+      "isHidden": true
+    },
+    "InteractivityPlatform": {
+      "longName": "interactivity",
+      "shortName": "int"
+    },
+    "InteractivityLocation": {
+      "isHidden": true
+    },
+    "AllInteractive": {
+      "longName": "all-interactive"
+    },
+    "IncludeSampleContent": {
+      "isHidden": true
+    },
+    "Empty": {
+      "longName": "empty"
+    },
+    "UseLocalDB": {
+      "longName": "use-local-db",
+      "isHidden": true
+    },
+    "NoHttps": {
+      "longName": "no-https",
+      "shortName": ""
+    },
+    "UseProgramMain": {
+      "longName": "use-program-main",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/src/Templates/src/templates/maui-blazor/.template.config/dotnetcli.host.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/dotnetcli.host.json
@@ -1,11 +1,20 @@
 {
-    "$schema": "http://json.schemastore.org/dotnetcli.host",
-    "symbolInfo": {
-      "Framework": {
-        "longName": "framework"
-      }
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "msExtensionsLoggingDebugVersion": {
+      "isHidden": true
     },
-    "usageExamples": [
-      "--framework DOTNET_TFM_VALUE"
-    ]
-  }
+    "Framework": {
+      "longName": "framework"
+    },
+    "IncludeSampleContent": {
+      "isHidden": true
+    },
+    "Empty": {
+      "longName": "empty"
+    }
+  },
+  "usageExamples": [
+    "--framework DOTNET_TFM_VALUE"
+  ]
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/dotnetcli.host.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/dotnetcli.host.json
@@ -1,20 +1,22 @@
 {
-    "$schema": "http://json.schemastore.org/dotnetcli.host",
-    "symbolInfo": {
-      "Framework": {
-        "longName": "framework"
-      },
-      "IncludeSampleContent": {
-
-        "longName":  "sample-content",
-        "shortName": "sc"
-      },
-      "skipRestore": {
-        "longName": "no-restore",
-        "shortName": ""
-      }
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "msExtensionsLoggingDebugVersion": {
+      "isHidden": true
     },
-    "usageExamples": [
-      "--framework DOTNET_TFM_VALUE"
-    ]
-  }
+    "Framework": {
+      "longName": "framework"
+    },
+    "IncludeSampleContent": {
+      "longName": "sample-content",
+      "shortName": "sc"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    "--framework DOTNET_TFM_VALUE"
+  ]
+}

--- a/src/Templates/src/templates/maui-multiproject/.template.config/dotnetcli.host.json
+++ b/src/Templates/src/templates/maui-multiproject/.template.config/dotnetcli.host.json
@@ -1,6 +1,9 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "msExtensionsLoggingDebugVersion": {
+      "isHidden": true
+    },
     "Framework": {
       "longName": "framework"
     },


### PR DESCRIPTION
This pull request updates the `.template.config/dotnetcli.host.json` files for several MAUI template projects to improve symbol configuration and control visibility of template options. The main changes involve marking certain template symbols as hidden, updating symbol descriptions, and standardizing symbol definitions across templates.

> [!NOTE]
> This is part of #23168. We have to update the .NET 9 templates because the CLI is a merge of all the installed template options. If .NET 9 uses bad options, then it flows through to .NET 10.  
> This does not affect the available options and all previous ones work, it just affects the "pretty" options.

**Symbol visibility and configuration improvements:**

* Added the `msExtensionsLoggingDebugVersion` symbol and marked it as hidden in all affected templates to prevent it from appearing in user-facing options. [[1]](diffhunk://#diff-f1f958e8b56f24698ab0b491f8d3aa251ea2338100efbb94de16f0bf5cdd10f1R4-R67) [[2]](diffhunk://#diff-61c70a2ff25e219c297d00b8e1d04b4fc7e6ae16da64488d1bb453c8f3abb5c9R4-R14) [[3]](diffhunk://#diff-5ae71211f1f4ce43513eefb8af2b9b99944ce5065c29752a0ade72664f20b17cR4-L8) [[4]](diffhunk://#diff-8bd59b09e602d21dc8f427e8805292800858b685d50e2847da3fde5fe69e7ed7R4-R6)
* Marked the `IncludeSampleContent` symbol as hidden in `maui-blazor-solution`, `maui-blazor`, and `maui-mobile` templates to restrict its visibility. [[1]](diffhunk://#diff-f1f958e8b56f24698ab0b491f8d3aa251ea2338100efbb94de16f0bf5cdd10f1R4-R67) [[2]](diffhunk://#diff-61c70a2ff25e219c297d00b8e1d04b4fc7e6ae16da64488d1bb453c8f3abb5c9R4-R14) [[3]](diffhunk://#diff-5ae71211f1f4ce43513eefb8af2b9b99944ce5065c29752a0ade72664f20b17cR4-L8)
* Added or updated several symbol definitions in `maui-blazor-solution`, including hiding symbols related to web components, ports, user secrets, and sample content, and providing long names for others to improve clarity.
* Standardized the `Framework` symbol definition by adding a `longName` property across all templates for consistency. [[1]](diffhunk://#diff-f1f958e8b56f24698ab0b491f8d3aa251ea2338100efbb94de16f0bf5cdd10f1R4-R67) [[2]](diffhunk://#diff-61c70a2ff25e219c297d00b8e1d04b4fc7e6ae16da64488d1bb453c8f3abb5c9R4-R14) [[3]](diffhunk://#diff-5ae71211f1f4ce43513eefb8af2b9b99944ce5065c29752a0ade72664f20b17cR4-L8) [[4]](diffhunk://#diff-8bd59b09e602d21dc8f427e8805292800858b685d50e2847da3fde5fe69e7ed7R4-R6)
* Updated the `Empty` symbol in `maui-blazor-solution` and `maui-blazor` templates to include a `longName` property, clarifying its usage. [[1]](diffhunk://#diff-f1f958e8b56f24698ab0b491f8d3aa251ea2338100efbb94de16f0bf5cdd10f1R4-R67) [[2]](diffhunk://#diff-61c70a2ff25e219c297d00b8e1d04b4fc7e6ae16da64488d1bb453c8f3abb5c9R4-R14)

> [!NOTE]
> The formatting was bad, so review with ignoring whitespaces: https://github.com/dotnet/maui/pull/31848/files?w=1