### PR TITLE
Invert NavigationPage UseMauiHandler flag

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -56,10 +56,10 @@ namespace Microsoft.Maui.Controls
 
 		partial void Init();
 
-#if WINDOWS || ANDROID || TIZEN
-		const bool UseMauiHandler = true;
-#else
+#if IOS || MACCATALYST
 		const bool UseMauiHandler = false;
+#else
+		const bool UseMauiHandler = true;
 #endif
 
 		bool _setForMaui;


### PR DESCRIPTION
This pull request updates the platform-specific configuration for the `UseMauiHandler` constant in the `NavigationPage` class. The change ensures that the handler is only disabled for iOS and MacCatalyst platforms, while remaining enabled for all other platforms.

This is necessary because if you want to create custom NavigationPage handler implementations that don't target Windows, Android, or Tizen as TFMs (for example, for test projects that target generic frameworks), they will fall back on using renderers. This should only apply to iOS and Catalyst, so we should be safe inverting this check to ensure it only occurs on iOS and Catalyst.