### PR TITLE
[Testing] Fix Bugzilla41842 test by replacing raw Page with ContentPage

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41842.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41842.cs
@@ -8,10 +8,10 @@
 		{
 			FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
 
-			Flyout = new Page() { Title = "Flyout" };
+			Flyout = new ContentPage() { Title = "Flyout" };
 
-			Detail = new NavigationPage(new Page());
-			Detail = new NavigationPage(new ContentPage { Content = new Label { AutomationId = "Success", Text = "Success" } });
+			Detail = new NavigationPage(new ContentPage());
+			Detail = new NavigationPage(new ContentPage { Content = new Label { AutomationId = "SuccessLabel", Text = "Success" } });
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41842.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla41842.cs
@@ -8,10 +8,10 @@
 		{
 			FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
 
-			Flyout = new ContentPage() { Title = "Flyout" };
+			Flyout = new ContentPage() { Title = "Flyout", Content = new Label { Text = "Flyout Content", AutomationId = "FlyoutLabel" } };
 
 			Detail = new NavigationPage(new ContentPage());
-			Detail = new NavigationPage(new ContentPage { Content = new Label { AutomationId = "SuccessLabel", Text = "Success" } });
+			Detail = new NavigationPage(new ContentPage { Content = new Label { AutomationId = "Success", Text = "Success" } });
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41842.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41842.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		[Category(UITestCategories.Compatibility)]
 		public void Bugzilla41842Test()
 		{
-			App.WaitForElement("SuccessLabel");
+#if MACCATALYST
+			App.WaitForElement("FlyoutLabel");
+#else
+			App.WaitForElement("Success");
+#endif
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41842.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Bugzilla/Bugzilla41842.cs
@@ -12,17 +12,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		public override string Issue => "Set FlyoutPage.Detail = New Page() twice will crash the application when set FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split";
 
-		// Crash after navigation
-		/*
 		[Test]
-		[Ignore("The sample is crashing.")]
 		[Category(UITestCategories.FlyoutPage)]
 		[Category(UITestCategories.Compatibility)]
-		[FailsOnAllPlatformsWhenRunningOnXamarinUITest("The sample is crashing. More information: https://github.com/dotnet/maui/issues/21205")]
 		public void Bugzilla41842Test()
 		{
-			App.WaitForElement("Success");
+			App.WaitForElement("SuccessLabel");
 		}
-		*/
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause
The Bugzilla41842 test was using new Page() which is a base class and should not be instantiated directly. This caused crashes.

### Description of Change
Fixed the failing Bugzilla41842 test case by replacing raw Page() instantiations with proper ContentPage() objects.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #21205 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/58722a3b-c001-48d3-8f2f-4a3c02c7eb28" >| <video src="https://github.com/user-attachments/assets/b81d7997-1835-4b85-843d-92b53d55f7be">|