### PR TITLE
Fixed bug where IPickerExtension.GetItemsAsList() would always return an empty list

### DIFF
--- a/src/Core/src/Core/Extensions/IPickerExtension.cs
+++ b/src/Core/src/Core/Extensions/IPickerExtension.cs
@@ -16,9 +16,10 @@ namespace Microsoft.Maui
 
 		public static List<string> GetItemsAsList(this IPicker picker)
 		{
-			var returnValue = new List<string>(picker.GetCount());
-			for (int i = 0; i < returnValue.Count; i++)
-				returnValue[i] = picker.GetItem(i);
+			var numberOfElements = picker.GetCount();
+			var returnValue = new List<string>(numberOfElements);
+			for (int i = 0; i < numberOfElements; i++)
+				returnValue.Add(picker.GetItem(i));
 
 			return returnValue;
 		}

--- a/src/Core/src/Core/Extensions/IPickerExtension.cs
+++ b/src/Core/src/Core/Extensions/IPickerExtension.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Maui
 {

--- a/src/Core/tests/UnitTests/Extensions/IPickerExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Extensions/IPickerExtensionTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests.Extensions
+{
+	[System.ComponentModel.Category(TestCategory.Extensions)]
+	public class IPickerExtensionTests
+	{
+		[Theory]
+		[InlineData("Macaque", "Capuchin", "Saki")]
+		[InlineData("Baboon", null, "Tamarin")]
+		[InlineData]
+		public void GetItemsAsArrayReturnsAllItems(string[] items)
+		{
+			var picker = CreateMockPicker(items);
+			var result = picker.GetItemsAsArray();
+			Assert.Equal(items, result);
+		}
+
+		[Theory]
+		[InlineData("Macaque", "Capuchin", "Saki")]
+		[InlineData("Baboon", null, "Tamarin")]
+		[InlineData]
+		public void GetItemsAsListReturnsAllItems(string[] items)
+		{
+			var picker = CreateMockPicker(items);
+			var result = picker.GetItemsAsList();
+			Assert.Equal(new List<string>(items), result);
+		}
+
+		private static IPicker CreateMockPicker(string[] items)
+		{
+			var picker = Substitute.For<IPicker>();
+			picker.GetCount().Returns(items.Length);
+			picker.GetItem(Arg.Any<int>()).Returns(x => items[(int)x[0]]);
+			return picker;
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/Extensions/IPickerExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Extensions/IPickerExtensionTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.UnitTests.Extensions
 		[InlineData("Macaque", "Capuchin", "Saki")]
 		[InlineData("Baboon", null, "Tamarin")]
 		[InlineData]
-		public void GetItemsAsArrayReturnsAllItems(string[] items)
+		public void GetItemsAsArrayReturnsAllItems(params string[] items)
 		{
 			var picker = CreateMockPicker(items);
 			var result = picker.GetItemsAsArray();
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.UnitTests.Extensions
 		[InlineData("Macaque", "Capuchin", "Saki")]
 		[InlineData("Baboon", null, "Tamarin")]
 		[InlineData]
-		public void GetItemsAsListReturnsAllItems(string[] items)
+		public void GetItemsAsListReturnsAllItems(params string[] items)
 		{
 			var picker = CreateMockPicker(items);
 			var result = picker.GetItemsAsList();

--- a/src/Core/tests/UnitTests/TestCategory.cs
+++ b/src/Core/tests/UnitTests/TestCategory.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Maui.UnitTests
 		public const string ImageSource = "ImageSource";
 		public const string Dispatching = "Dispatching";
 		public const string View = "View";
+		public const string Extensions = "Extensions";
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The existing code assumes the constructor of `List<T>` that takes an `int` will create a list of that size. In reality, it creates a list of size 0 with a *capacity* of the provided number. The change fixes this by calling `Add()` for each new element.

### Issues Fixed

Fixes #31878

