### PR TITLE
[net10] Move to rtm

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-51a08d7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-51a08d74/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-android-1dcfb6f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-android-1dcfb6f-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25474.116">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.0-rc.2.331">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.9">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>c64645f7418b7d131d00654d4662dcf916787dc8</Sha>
+      <Sha>51a08d74f33040198641b6f0e1b0d2c9518d2ed7</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.105" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.2.25474.116">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rtm.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25427.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25474.116">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25479.115">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>54303ce0f42d425c43c691e43620f5eca056bc94</Sha>
+      <Sha>e72b5bbe719d747036ce9c36582a205df9f1c361</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,29 +30,29 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.111</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-rc.2.25474.116</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rtm.25479.115</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.2.25474.116</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rtm.25479.115</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.2.25474.116</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rtm.25479.115</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.0-rc.2.331</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.0.9</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -73,19 +73,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.2.25474.116</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0-rc.2.25474.116</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rtm.25479.115</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-rtm.25479.115</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -135,13 +135,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25479.115</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25479.115</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25479.115</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25479.115</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25474.116</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25479.115</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25479.115</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
@@ -209,7 +209,7 @@
     <DotNetSdkManifestsFolder>$(DotNetVersionBand)</DotNetSdkManifestsFolder>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>9.0.100-rc2</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
     <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet100_185PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet100_155PackageVersion)</MicrosoftmacOSSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -209,7 +209,7 @@
     <DotNetSdkManifestsFolder>$(DotNetVersionBand)</DotNetSdkManifestsFolder>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>9.0.100-rc2</DotNetMaciOSManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>10.0.100-rc.2</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
     <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet100_185PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet100_155PackageVersion)</MicrosoftmacOSSdkPackageVersion>

--- a/eng/common/post-build/nuget-verification.ps1
+++ b/eng/common/post-build/nuget-verification.ps1
@@ -30,7 +30,7 @@
 [CmdletBinding(PositionalBinding = $false)]
 param(
    [string]$NuGetExePath,
-   [string]$PackageSource = "https://api.nuget.org/v3/index.json",
+   [string]$PackageSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
    [string]$DownloadPath,
    [Parameter(ValueFromRemainingArguments = $true)]
    [string[]]$args

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rc.2.25474.116"
+    "dotnet": "10.0.100-rtm.25479.115"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25474.116",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25474.116"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25479.115",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25479.115"
   },
   "sdk": {
     "allowPrerelease": true


### PR DESCRIPTION
### Description of Change

Update the net10.0 branch to rtm versions, prepping changes to branch GA

This pull request updates the project to use the latest stable (RTM) versions of several .NET, ASP.NET Core, and Android SDK dependencies, replacing previous release candidate (RC) versions. The changes ensure that the project is aligned with the final, production-ready releases for improved stability and compatibility.

Dependency version upgrades:

* Updated all `Microsoft.NET.Sdk`, `Microsoft.NETCore.App.Ref`, and related .NET SDK and runtime dependencies from RC to RTM versions in `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R13) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L33-R55)
* Upgraded various ASP.NET Core packages (including authorization, authentication, components, metadata, and JSInterop) to their RTM versions in both `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L57-R159) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L76-R88)
* Updated Microsoft.Extensions packages (configuration, dependency injection, logging, hosting, etc.) to RTM versions in `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L57-R159) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L33-R55)

Android SDK updates:

* Upgraded `Microsoft.Android.Sdk.Windows` to version `36.0.9` (from RC) in both `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R13) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L33-R55)
* Added a new NuGet package source for the updated Android SDK in `NuGet.config`.

Build and toolset updates:

* Updated build tool dependencies (Arcade SDK, Build Tasks, Helix SDK, Remote Executor, XUnit Extensions) to newer beta versions in `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L175-R205) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L138-R144)