### PR TITLE
[Windows] Fix FlyoutPage test case failure on main

### DIFF
--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Maui.Handlers
 
 		void OnLoaded(object sender, RoutedEventArgs e)
 		{
+			// Unwire the event to ensure it only fires once
+			PlatformView.Loaded -= OnLoaded;
+
 			if (VirtualView is not null)
 			{
 				PlatformView.IsPaneOpen = VirtualView.IsPresented;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Fix Details
This PR is an extension of [#31515](https://github.com/dotnet/maui/pull/31515) which included a fix for the IsPresented initial loading issue.
However, the changes in [#31515](https://github.com/dotnet/maui/pull/31515) caused the EnsureFlyoutBehaviorChanges test to fail.
This PR provides an additional fix to resolve that test failure and ensure consistent behavior of the IsPresented property during navigation and layout mode changes.

### Root Cause

When navigating to a new page and changing the FlyoutLayoutBehavior, the Loaded event fires again after returning (Pop) to the original page. Inside the OnLoaded method, the following line re-applied the IsPresented value


### Description of Change

<!-- Enter description of the fix in this section -->
To prevent the repeated application of the IsPresented value, the Loaded event is now unwired within the method itself after execution.


