### PR TITLE
Enable OpenTelemetry metrics and tracing for MAUI in Service Defaults

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
@@ -52,12 +52,18 @@ public static class Extensions
 
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
-            {                
+            {
+				// Enable reporting metrics coming from the .NET MAUI SDK
+				metrics.AddMeter("Microsoft.Maui");
+				
                 metrics.AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>
             {
+				// Enable reporting tracing coming from the .NET MAUI SDK
+				tracing.AddSource("Microsoft.Maui");
+				
                 tracing.AddSource(builder.Environment.ApplicationName)
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()

--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
@@ -53,17 +53,17 @@ public static class Extensions
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
-				// Enable reporting metrics coming from the .NET MAUI SDK
-				metrics.AddMeter("Microsoft.Maui");
-				
+                // Enable reporting metrics coming from the .NET MAUI SDK
+                metrics.AddMeter("Microsoft.Maui");
+                
                 metrics.AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>
             {
-				// Enable reporting tracing coming from the .NET MAUI SDK
-				tracing.AddSource("Microsoft.Maui");
-				
+                // Enable reporting tracing coming from the .NET MAUI SDK
+                tracing.AddSource("Microsoft.Maui");
+                
                 tracing.AddSource(builder.Environment.ApplicationName)
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()


### PR DESCRIPTION
Enables the metric and tracing information coming from the .NET MAUI SDK in the Aspire Service Defaults project

Fixes #31846