### PR TITLE
Clean up Extensions.cs by removing TODO comments

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
@@ -112,15 +112,6 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
-        // TODO MAUI: this code comes from the Aspire service defaults, we will want to check if this works for us and if yes
-        // how integration works for us because the AspNetCore package cannot be added to a MAUI project and we can't read the connection string like this
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
-        //{
-        //    builder.Services.AddOpenTelemetry()
-        //       .UseAzureMonitor();
-        //}
-
         return builder;
     }
 }


### PR DESCRIPTION
Removed commented-out code related to Azure Monitor exporter.