### PR TITLE
[iOS, Catalyst] Fixed CollectionView items height appears larger in Developer Balance sample

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -205,10 +205,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			// Get the CollectionView orientation
 			var scrollDirection = Controller.GetScrollDirection();
 
-			// If contentSize comes back null, it means none of the content has been realized yet;
-			// we need to return the expansive size the collection view wants by default to get
-			// it to start measuring its content
-
+			// If contentSize is zero in the relevant dimension (height for vertical, width for horizontal),
+			// it means none of the content has been realized yet; we need to return the expansive size
+			// the collection view wants by default to get it to start measuring its content
 			if ((scrollDirection == UICollectionViewScrollDirection.Vertical && contentSize.Height == 0) ||
 				(scrollDirection == UICollectionViewScrollDirection.Horizontal && contentSize.Width == 0))
 			{

--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -186,14 +186,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			var contentSize = Controller.GetSize();
-
-			// If contentSize comes back null, it means none of the content has been realized yet;
-			// we need to return the expansive size the collection view wants by default to get
-			// it to start measuring its content
-			if (contentSize.Height == 0 || contentSize.Width == 0)
-			{
-				return base.GetDesiredSize(widthConstraint, heightConstraint);
-			}
+			contentSize = EnsureContentSizeForScrollDirection(widthConstraint, heightConstraint, contentSize);
 
 			// Our target size is the smaller of it and the constraints
 			var width = contentSize.Width <= widthConstraint ? contentSize.Width : widthConstraint;
@@ -205,6 +198,32 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			height = ViewHandlerExtensions.ResolveConstraints(height, virtualView.Height, virtualView.MinimumHeight, virtualView.MaximumHeight);
 
 			return new Size(width, height);
+		}
+
+		Size EnsureContentSizeForScrollDirection(double widthConstraint, double heightConstraint, Size contentSize)
+		{
+			// Get the CollectionView orientation
+			var scrollDirection = Controller.GetScrollDirection();
+
+			// If contentSize comes back null, it means none of the content has been realized yet;
+			// we need to return the expansive size the collection view wants by default to get
+			// it to start measuring its content
+
+			if ((scrollDirection == UICollectionViewScrollDirection.Vertical && contentSize.Height == 0) ||
+				(scrollDirection == UICollectionViewScrollDirection.Horizontal && contentSize.Width == 0))
+			{
+				var desiredSize = base.GetDesiredSize(widthConstraint, heightConstraint);
+				if (scrollDirection == UICollectionViewScrollDirection.Vertical)
+				{
+					contentSize.Height = desiredSize.Height;
+				}
+				else
+				{
+					contentSize.Width = desiredSize.Width;
+				}
+			}
+
+			return contentSize;
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -449,6 +449,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			return CollectionView.CollectionViewLayout.CollectionViewContentSize.ToSize();
 		}
 
+		internal UICollectionViewScrollDirection GetScrollDirection()
+		{
+			return ScrollDirection;
+		}
+
 		internal void UpdateView(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)
 		{
 			// Is view set on the ItemsView?

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
@@ -1,13 +1,10 @@
-using System.Collections.ObjectModel;
 using System.ComponentModel;
-using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 31897, "CollectionView card height appears larger in Developer Balance sample", PlatformAffected.iOS | PlatformAffected.macOS)]
-public partial class Issue31897 : ContentPage
+public class Issue31897 : ContentPage
 {
-	ObservableCollection<string> Countries = new();
 	Button getHeight;
 	Label HeightLabel;
 	CollectionView2 ProjectsCollectionView;
@@ -127,9 +124,8 @@ public partial class Issue31897 : ContentPage
 		Content = mainGrid;
 	}
 
-	public partial class Issue31897ViewModel : INotifyPropertyChanged
+	public class Issue31897ViewModel : INotifyPropertyChanged
 	{
-
 		List<Issue31897Project> _projects = new();
 
 		public event PropertyChangedEventHandler PropertyChanged;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Controls;
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 31897, "CollectionView card height appears larger in Developer Balance sample", PlatformAffected.iOS | PlatformAffected.macOS)]
-public class Issue31897 : ContentPage
+public partial class Issue31897 : ContentPage
 {
 	ObservableCollection<string> Countries = new();
 	Button getHeight;
@@ -39,7 +39,7 @@ public class Issue31897 : ContentPage
 
 		getHeight.Clicked += (object sender, EventArgs e) =>
 		{
-			HeightLabel.Text = ProjectsCollectionView.Height.ToString();
+			HeightLabel.Text = Math.Round(ProjectsCollectionView.Height).ToString();
 		};
 
 		getHeight.SetValue(SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
@@ -1,0 +1,180 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31897, "CollectionView card height appears larger in Developer Balance sample", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue31897 : ContentPage
+{
+	ObservableCollection<string> Countries = new();
+	Button getHeight;
+	Label HeightLabel;
+	CollectionView2 ProjectsCollectionView;
+
+	public Issue31897()
+	{
+		var mainGrid = new Grid();
+
+		var scrollView = new ScrollView();
+
+		// Create the inner grid with padding and row spacing
+		var innerGrid = new Grid
+		{
+			Padding = new Thickness(10),
+			RowSpacing = 10
+		};
+
+		// Add row definitions
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+		// Create the "Get CV Height" button
+		getHeight = new Button
+		{
+			Text = "Get CV Height",
+			AutomationId = "GetHeightButton"
+		};
+
+		getHeight.Clicked += (object sender, EventArgs e) =>
+		{
+			HeightLabel.Text = ProjectsCollectionView.Height.ToString();
+		};
+
+		getHeight.SetValue(SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1);
+		Grid.SetRow(getHeight, 0);
+
+		// Create the height label
+		HeightLabel = new Label();
+		HeightLabel.AutomationId = "HeightLabel";
+		HeightLabel.SetValue(SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1);
+		Grid.SetRow(HeightLabel, 1);
+
+		// Create the CollectionView
+		ProjectsCollectionView = new CollectionView2
+		{
+			Margin = new Thickness(-7.5, 0),
+			MinimumHeightRequest = 250,
+			SelectionMode = SelectionMode.Single
+		};
+
+		// Set up the ItemsLayout
+		ProjectsCollectionView.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+		{
+			ItemSpacing = 7.5
+		};
+
+		// Create the DataTemplate for items
+		var itemTemplate = new DataTemplate(() =>
+		{
+			var border = new Border
+			{
+				WidthRequest = 200,
+				Background = Colors.GreenYellow
+			};
+
+			var contentView = new ContentView();
+
+			var verticalStackLayout = new VerticalStackLayout
+			{
+				Spacing = 15,
+				Background = Colors.Red,
+				VerticalOptions = LayoutOptions.Start
+			};
+
+			// Name label
+			var nameLabel = new Label
+			{
+				TextColor = Colors.Gray,
+				FontSize = 14,
+				TextTransform = TextTransform.Uppercase
+			};
+			nameLabel.SetBinding(Label.TextProperty, "Name");
+
+			// Description label
+			var descriptionLabel = new Label
+			{
+				LineBreakMode = LineBreakMode.WordWrap
+			};
+			descriptionLabel.SetBinding(Label.TextProperty, "Description");
+
+			verticalStackLayout.Children.Add(nameLabel);
+			verticalStackLayout.Children.Add(descriptionLabel);
+			contentView.Content = verticalStackLayout;
+			border.Content = contentView;
+
+			return border;
+		});
+
+		ProjectsCollectionView.ItemTemplate = itemTemplate;
+
+		// Set up data binding
+		var viewModel = new Issue31897ViewModel();
+		BindingContext = viewModel;
+		ProjectsCollectionView.SetBinding(CollectionView.ItemsSourceProperty, "Projects");
+
+		Grid.SetRow(ProjectsCollectionView, 2);
+
+		// Add all controls to the inner grid
+		innerGrid.Children.Add(getHeight);
+		innerGrid.Children.Add(HeightLabel);
+		innerGrid.Children.Add(ProjectsCollectionView);
+
+		// Set up the hierarchy
+		scrollView.Content = innerGrid;
+		mainGrid.Children.Add(scrollView);
+		Content = mainGrid;
+	}
+
+	public partial class Issue31897ViewModel : INotifyPropertyChanged
+	{
+
+		List<Issue31897Project> _projects = new();
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected virtual void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		public List<Issue31897Project> Projects
+		{
+			get { return _projects; }
+			set
+			{
+				_projects = value;
+				OnPropertyChanged(nameof(Projects));
+			}
+		}
+
+		public Issue31897ViewModel()
+		{
+			LoadData();
+		}
+
+		void LoadData()
+		{
+			var projects = new List<Issue31897Project>();
+			for (int i = 0; i < 4; i++)
+			{
+				projects.Add(new Issue31897Project
+				{
+					ID = i,
+					Name = "Developer balance card view " + (i + 1),
+					Description = "This is a sample description for project " + (i + 1)
+				});
+			}
+
+			Projects = projects;
+		}
+	}
+
+	public class Issue31897Project
+	{
+		public int ID { get; set; }
+		public string Name { get; set; } = string.Empty;
+		public string Description { get; set; } = string.Empty;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31897.cs
@@ -6,8 +6,13 @@ namespace Maui.Controls.Sample.Issues;
 public class Issue31897 : ContentPage
 {
 	Button getHeight;
+	Button addItemsButton;
+	Button removeItemsButton;
+	Button updateNewItemsButton;
 	Label HeightLabel;
+	Label ItemCountLabel;
 	CollectionView2 ProjectsCollectionView;
+	Issue31897ViewModel viewModel;
 
 	public Issue31897()
 	{
@@ -23,9 +28,16 @@ public class Issue31897 : ContentPage
 		};
 
 		// Add row definitions
-		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // Controls row
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // Height label
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // Item count label
+		innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // CollectionView
+
+		// Create a horizontal stack for control buttons
+		var controlsStack = new HorizontalStackLayout
+		{
+			Spacing = 10
+		};
 
 		// Create the "Get CV Height" button
 		getHeight = new Button
@@ -39,14 +51,68 @@ public class Issue31897 : ContentPage
 			HeightLabel.Text = Math.Round(ProjectsCollectionView.Height).ToString();
 		};
 
+		// Create the "Add Items" button
+		addItemsButton = new Button
+		{
+			Text = "Add Items",
+			AutomationId = "AddItemsButton"
+		};
+
+		addItemsButton.Clicked += (object sender, EventArgs e) =>
+		{
+			viewModel.AddItems(1); // Add 1 item
+			UpdateItemCount();
+		};
+
+		// Create the "Remove Items" button
+		removeItemsButton = new Button
+		{
+			Text = "Remove Items",
+			AutomationId = "RemoveItemsButton"
+		};
+
+		removeItemsButton.Clicked += (object sender, EventArgs e) =>
+		{
+			viewModel.RemoveItems(2); // Remove 2 items
+			UpdateItemCount();
+		};
+
+		// Create the "Update New Items" button
+		updateNewItemsButton = new Button
+		{
+			Text = "Update New",
+			AutomationId = "UpdateNewItemsButton"
+		};
+
+		updateNewItemsButton.Clicked += (object sender, EventArgs e) =>
+		{
+			viewModel.UpdateWithNewItems();
+			UpdateItemCount();
+		};
+
+		// Add buttons to horizontal stack
+		controlsStack.Children.Add(getHeight);
+		controlsStack.Children.Add(addItemsButton);
+		controlsStack.Children.Add(removeItemsButton);
+		controlsStack.Children.Add(updateNewItemsButton);
+
 		getHeight.SetValue(SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1);
-		Grid.SetRow(getHeight, 0);
+		Grid.SetRow(controlsStack, 0);
 
 		// Create the height label
 		HeightLabel = new Label();
 		HeightLabel.AutomationId = "HeightLabel";
 		HeightLabel.SetValue(SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1);
 		Grid.SetRow(HeightLabel, 1);
+
+		// Create the item count label
+		ItemCountLabel = new Label
+		{
+			AutomationId = "ItemCountLabel",
+			Text = "Items: 0"
+		};
+		ItemCountLabel.SetValue(SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1);
+		Grid.SetRow(ItemCountLabel, 2);
 
 		// Create the CollectionView
 		ProjectsCollectionView = new CollectionView2
@@ -107,26 +173,36 @@ public class Issue31897 : ContentPage
 		ProjectsCollectionView.ItemTemplate = itemTemplate;
 
 		// Set up data binding
-		var viewModel = new Issue31897ViewModel();
+		viewModel = new Issue31897ViewModel();
 		BindingContext = viewModel;
 		ProjectsCollectionView.SetBinding(CollectionView.ItemsSourceProperty, "Projects");
 
-		Grid.SetRow(ProjectsCollectionView, 2);
+		Grid.SetRow(ProjectsCollectionView, 3);
 
 		// Add all controls to the inner grid
-		innerGrid.Children.Add(getHeight);
+		innerGrid.Children.Add(controlsStack);
 		innerGrid.Children.Add(HeightLabel);
+		innerGrid.Children.Add(ItemCountLabel);
 		innerGrid.Children.Add(ProjectsCollectionView);
 
 		// Set up the hierarchy
 		scrollView.Content = innerGrid;
 		mainGrid.Children.Add(scrollView);
 		Content = mainGrid;
+
+		// Initialize item count display
+		UpdateItemCount();
+	}
+
+	void UpdateItemCount()
+	{
+		ItemCountLabel.Text = $"Items: {viewModel.Projects.Count}";
 	}
 
 	public class Issue31897ViewModel : INotifyPropertyChanged
 	{
 		List<Issue31897Project> _projects = new();
+		int _nextId = 0;
 
 		public event PropertyChangedEventHandler PropertyChanged;
 
@@ -161,8 +237,68 @@ public class Issue31897 : ContentPage
 					Name = "Developer balance card view " + (i + 1),
 					Description = "This is a sample description for project " + (i + 1)
 				});
+				_nextId = i + 1;
 			}
 
+			Projects = projects;
+		}
+
+		public void AddItems(int count)
+		{
+			var currentProjects = new List<Issue31897Project>(_projects);
+			
+			for (int i = 0; i < count; i++)
+			{
+				currentProjects.Add(new Issue31897Project
+				{
+					ID = _nextId,
+					Name = "Added card view " + (_nextId + 1),
+					Description = "This is a dynamically added description for project " + (_nextId + 1)
+				});
+				_nextId++;
+			}
+
+			Projects = currentProjects;
+		}
+
+		public void RemoveItems(int count)
+		{
+			var currentProjects = new List<Issue31897Project>(_projects);
+			
+			int itemsToRemove = Math.Min(count, currentProjects.Count);
+			for (int i = 0; i < itemsToRemove; i++)
+			{
+				if (currentProjects.Count > 0)
+				{
+					currentProjects.RemoveAt(currentProjects.Count - 1);
+				}
+			}
+
+			if (currentProjects.Count == 0)
+			{
+				_nextId = 0; // Reset ID counter if all items are removed
+			}
+
+			Projects = currentProjects;
+		}
+
+		public void ClearItems()
+		{
+			Projects = new List<Issue31897Project>();
+		}
+
+		public void UpdateWithNewItems()
+		{
+			var projects = new List<Issue31897Project>();
+			for (int i = 0; i < 6; i++)
+			{
+				projects.Add(new Issue31897Project
+				{
+					ID = i + 500,
+					Name = "New updated item " + (i + 1),
+					Description = "This is a completely new item set with fresh content " + (i + 1)
+				});
+			}
 			Projects = projects;
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31897.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31897 : _IssuesUITest
+{
+	public Issue31897(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "CollectionView card height appears larger in Developer Balance sample";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void EnsureCollectionViewLayoutOnItemsSourceChange()
+	{
+		App.WaitForElement("GetHeightButton");
+		App.Tap("GetHeightButton");
+		var label = App.WaitForElement("HeightLabel");
+		Assert.Equal("250", label.Height);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31897.cs
@@ -17,7 +17,19 @@ public class Issue31897 : _IssuesUITest
 	{
 		App.WaitForElement("GetHeightButton");
 		App.Tap("GetHeightButton");
-		var label = App.WaitForElement("HeightLabel");
-		Assert.That(label.GetText(), Is.EqualTo("250"));
+		var heightLabel = App.WaitForElement("HeightLabel");
+		Assert.That(heightLabel.GetText(), Is.EqualTo("250"));
+		App.Tap("RemoveItemsButton");
+		App.Tap("GetHeightButton");
+		Assert.That(heightLabel.GetText(), Is.EqualTo("250"));
+		App.Tap("RemoveItemsButton");
+		App.Tap("GetHeightButton");
+		Assert.That(heightLabel.GetText(), Is.EqualTo("250"));
+		App.Tap("AddItemsButton");
+		App.Tap("GetHeightButton");
+		Assert.That(heightLabel.GetText(), Is.EqualTo("250"));
+		App.Tap("UpdateNewItemsButton");
+		App.Tap("GetHeightButton");
+		Assert.That(heightLabel.GetText(), Is.EqualTo("250"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31897.cs
@@ -18,6 +18,6 @@ public class Issue31897 : _IssuesUITest
 		App.WaitForElement("GetHeightButton");
 		App.Tap("GetHeightButton");
 		var label = App.WaitForElement("HeightLabel");
-		Assert.Equal("250", label.Height);
+		Assert.That(label.GetText(), Is.EqualTo("250"));
 	}
 }


### PR DESCRIPTION
### Issue Details
In the Developer Balance sample, the CollectionView items appear larger than expected on iOS and Mac. Additional vertical space is observed within the cards.

### Root Cause
Breaking PR: https://github.com/dotnet/maui/pull/30978
In that PR, when the content size isn’t set, the desired size of the CollectionView is used. This causes the issue when a horizontal CollectionView stretches to full size without resizing to its actual height.

### Description of change
Instead of returning the desired size from the base, the content size is now updated based on the CollectionView orientation, ensuring proper size constraints are applied

### Validated the behaviour in the following platforms
- [x] Android
- [x] iOS
- [x] MacOS
- [x] Windows

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/31897

### Screenshots
| Before | After |
|-----------|-----------|
|  <img width="700" height="1500" alt="image" src="https://github.com/user-attachments/assets/f77d719a-5ffc-465a-af33-a8f37e2fbf83" />    |    <img width="700" height="1500" alt="image" src="https://github.com/user-attachments/assets/b506474f-5bf8-4b2a-b781-003c3df8b6be" />   |