### PR TITLE
[c] Run apiscan on release branches and main

### DIFF
--- a/eng/pipelines/azure-pipelines-internal.yml
+++ b/eng/pipelines/azure-pipelines-internal.yml
@@ -97,10 +97,11 @@ extends:
             skipProvisioning: true
             skipXcode: true
 
-    - template: /eng/pipelines/arcade/stage-api-scan.yml@self
-      parameters:
-        pool: ${{ parameters.VM_IMAGE_HOST }}
-        dependsOnStage: Pack
+    - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/net10.0'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+      - template: /eng/pipelines/arcade/stage-api-scan.yml@self
+        parameters:
+          pool: ${{ parameters.VM_IMAGE_HOST }}
+          dependsOnStage: Pack
 
     # Publish and validation steps. Only run in official builds
     - template: /eng/common/templates-official/post-build/post-build.yml@self


### PR DESCRIPTION
### Description of Change

This pull request updates the pipeline configuration to conditionally include the API scan stage based on the source branch. The change ensures that the API scan runs only for the main branch, the `net10.0` branch, and all release branches.

Pipeline configuration update:

* Modified the `eng/pipelines/azure-pipelines-internal.yml` file to conditionally extend the `arcade/stage-api-scan.yml` template only when building from `main`, `net10.0`, or any `release/` branch.