### PR TITLE
[testing] Don t test api28

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -176,7 +176,7 @@ stages:
         agentPoolAccessToken: $(AgentPoolAccessToken)
         targetFrameworkVersion: ${{ targetFrameworkVersion }}
         ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
-          androidApiLevels: [ 36, 35, 33, 30, 29, 28, 27, 26, 25, 24, 23 ]
+          androidApiLevels: [ 36, 35, 33, 30, 29, 27, 26, 25, 24, 23 ]
           iosVersions: [ 'simulator-18.0' ]
           catalystVersions: [ 'latest' ]
           windowsVersions: [ 'packaged', 'unpackaged' ]


### PR DESCRIPTION
### Description of Change

API28 device tests are failing a lot, we have a lot of coverage with the other api levels so skipping this one 