### PR TITLE
[testing] Update device testing

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -173,7 +173,7 @@ stages:
         windowsPool: ${{ parameters.windowsPool }}
         targetFrameworkVersion: ${{ targetFrameworkVersion }}
         ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
-          androidApiLevels: [ 33, 30, 29, 27, 26, 25, 24, 23 ]
+          androidApiLevels: [ 36, 35, 33, 30, 29, 27, 26, 25, 24, 23 ]
           iosVersions: [ 'simulator-18.4' ]
           catalystVersions: [ 'latest' ]
           windowsVersions: [ 'packaged', 'unpackaged' ]
@@ -212,7 +212,7 @@ stages:
         - name: core
           desc: Core
           androidApiLevelsExclude: [ 25 ] # Ignore for now API25 since the runs's are not stable
-          androidApiLevelsCoreClrExclude: [ 25, 23]
+          androidApiLevelsCoreClrExclude: [ 28, 25, 23]
           androidConfiguration: 'Release'
           iOSConfiguration: 'Debug'
           windowsConfiguration: 'Debug'


### PR DESCRIPTION

### Description of Change

Update device tests matrix 


This pull request updates the configuration for Android device testing in the `eng/pipelines/device-tests.yml` pipeline. The changes expand the range of Android API levels tested and adjust exclusions for CoreCLR tests to improve coverage and stability.

**Android device test coverage updates:**

* Expanded the list of `androidApiLevels` to include API levels 36 and 35, increasing the breadth of Android versions tested.

**Test exclusion adjustments:**

* Updated `androidApiLevelsCoreClrExclude` to exclude API level 28 in addition to 25 and 23, likely to address instability or compatibility issues for CoreCLR tests on these versions.