### PR TITLE
[iOS] Fix VoiceOver focus not shifting to Picker/DatePicker/TimePicker popups

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -101,13 +101,26 @@ namespace Microsoft.Maui.Handlers
 		static void OnStarted(object? sender)
 		{
 			if (sender is IDatePickerHandler datePickerHandler && datePickerHandler.VirtualView != null)
+			{
 				datePickerHandler.VirtualView.IsFocused = true;
+				
+				// Notify VoiceOver that the date picker popup has appeared
+				if (datePickerHandler.PlatformView?.InputView is not null)
+				{
+					datePickerHandler.PlatformView.PostAccessibilityFocusNotification(datePickerHandler.PlatformView.InputView);
+				}
+			}
 		}
 
 		static void OnEnded(object? sender)
 		{
 			if (sender is IDatePickerHandler datePickerHandler && datePickerHandler.VirtualView != null)
+			{
 				datePickerHandler.VirtualView.IsFocused = false;
+				
+				// Restore VoiceOver focus to the date picker field when the popup closes
+				datePickerHandler.PlatformView?.PostAccessibilityFocusNotification();
+			}
 		}
 
 		static void OnDoneClicked(object? sender)

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -267,6 +267,12 @@ namespace Microsoft.Maui.Handlers
 			{
 				if (VirtualView is IPicker virtualView)
 					virtualView.IsFocused = true;
+				
+				// Notify VoiceOver that the picker popup has appeared
+				if (sender is MauiPicker platformView && platformView.InputView != null)
+				{
+					platformView.PostAccessibilityFocusNotification(platformView.InputView);
+				}
 #if MACCATALYST
 				if (Handler is not PickerHandler handler)
 					return;
@@ -286,8 +292,17 @@ namespace Microsoft.Maui.Handlers
 				{
 					pickerView.Select(model.SelectedIndex, 0, false);
 				}
+
 				if (VirtualView is IPicker virtualView)
+				{
 					virtualView.IsFocused = false;
+				}
+				
+				// Restore VoiceOver focus to the picker field when the popup closes
+				if (sender is MauiPicker platformView)
+				{
+					platformView.PostAccessibilityFocusNotification();
+				}
 			}
 
 			void OnEditing(object? sender, EventArgs eventArgs)

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -90,6 +90,9 @@ namespace Microsoft.Maui.Handlers
 				if (VirtualView is IPicker virtualView)
 					virtualView.IsFocused = false;
 				uITextField.EditingDidEnd -= editingDidEndHandler;
+				
+				// Restore VoiceOver focus to the picker field when the alert closes
+				uITextField.PostAccessibilityFocusNotification();
 			};
 
 			uITextField.EditingDidEnd += editingDidEndHandler;
@@ -101,9 +104,15 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			var currentViewController = GetCurrentViewController(platformWindow.RootViewController);
-			platformWindow.BeginInvokeOnMainThread(() =>
+			platformWindow.BeginInvokeOnMainThread(async () =>
 			{
-				currentViewController?.PresentViewControllerAsync(pickerController, true);
+				if (currentViewController is not null)
+				{
+					await currentViewController.PresentViewControllerAsync(pickerController, true);
+				}
+
+				// Notify VoiceOver that the picker alert has appeared
+				pickerView?.PostAccessibilityFocusNotification();
 			});
 		}
 
@@ -269,7 +278,7 @@ namespace Microsoft.Maui.Handlers
 					virtualView.IsFocused = true;
 				
 				// Notify VoiceOver that the picker popup has appeared
-				if (sender is MauiPicker platformView && platformView.InputView != null)
+				if (sender is MauiPicker platformView && platformView.InputView is not null)
 				{
 					platformView.PostAccessibilityFocusNotification(platformView.InputView);
 				}

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -103,13 +103,29 @@ namespace Microsoft.Maui.Handlers
 			void OnStarted(object? sender, EventArgs eventArgs)
 			{
 				if (VirtualView is not null)
+				{
 					VirtualView.IsFocused = true;
+					
+					// Notify VoiceOver that the time picker popup has appeared
+					if (sender is MauiTimePicker platformView && platformView.Picker is not null)
+					{
+						platformView.PostAccessibilityFocusNotification(platformView.Picker);
+					}
+				}
 			}
 
 			void OnEnded(object? sender, EventArgs eventArgs)
 			{
 				if (VirtualView is not null)
+				{
 					VirtualView.IsFocused = false;
+					
+					// Restore VoiceOver focus to the time picker field when the popup closes
+					if (sender is MauiTimePicker platformView)
+					{
+						platformView.PostAccessibilityFocusNotification();
+					}
+				}
 			}
 
 			void OnValueChanged(object? sender, EventArgs e)

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -33,7 +33,47 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateSemantics(this UIView platformView, IView view) =>
 			UpdateSemantics(platformView, view?.Semantics);
+		
+		/// <summary>
+		/// Posts a VoiceOver screen changed notification to return focus to the specified view.
+		/// This is typically used when an input view is dismissed and focus should return to the original control.
+		/// </summary>
+		/// <param name="platformView">The platform view that should receive focus</param>
+		internal static void PostAccessibilityFocusNotification(this UIView platformView)
+		{
+			// TODO: Make public for .NET 11.
+			
+			if (UIAccessibility.IsVoiceOverRunning)
+			{
+				UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, platformView);
+			}
+		}
+		
+		/// <summary>
+		/// Posts a VoiceOver screen changed notification for an input view when it becomes visible.
+		/// This ensures VoiceOver shifts focus to the input view (e.g., UIPickerView, UIDatePicker) when it appears.
+		/// </summary>
+		/// <param name="platformView">The platform view that hosts the input view</param>
+		/// <param name="inputView">The input view that should receive focus</param>
+		internal static void PostAccessibilityFocusNotification(this UIView platformView, UIView? inputView)
+		{
+			// TODO: Make public for .NET 11.
+			
+			if (inputView == null)
+			{
+				return;
+			}
 
+			// Post notification with a delay to ensure the InputView is fully displayed in the window hierarchy
+			platformView.BeginInvokeOnMainThread(() =>
+			{
+				if (UIAccessibility.IsVoiceOverRunning && inputView.Window is not null)
+				{
+					UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, inputView);
+				}
+			});
+		}
+		
 		internal static void UpdateSemantics(this UIView platformView, Semantics? semantics)
 		{
 			if (semantics == null)


### PR DESCRIPTION
### Description of Change

This PR include some extension methods to use `UIAccessibility.PostNotification` calls to notify **VoiceOver** when picker popups appear and close for Picker, DatePicker, and TimePicker.
- Open Picker: Posts a VoiceOver notification when an input view becomes visible.
- Close Picker: Posts a VoiceOver notification to return focus to the original control.

Based on the issue description, the picker should:
- When the Picker is opened,  `UIAccessibility.PostNotification(ScreenChanged, inputView)` is called with the `UIPickerView`, VoiceOver focuses on the picker control.
- Once focused on the `UIPickerView`, VoiceOver users can naturally navigate through the individual items. This try to follow iOS accessibility patterns where you first focus on the container control, then navigate within it.
- When closing the picker, restores the VoiceOver focus.

Draft PR until include some related tests.

### Issues Fixed

Fixes #30746