### PR TITLE
[Testing] Fix for flaky test(CollectionViewHeaderShouldNotScroll) in CI

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue10947.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue10947.xaml
@@ -7,8 +7,7 @@
              Title="Issue10947">
 
     <ContentPage.Resources>
-        <x:Array x:Key="stringArray"
-                Type="{x:Type x:String}">
+        <x:Array x:Key="stringArray" Type="{x:Type x:String}">
             <x:String>First Item</x:String>
             <x:String>Second Item</x:String>
             <x:String>Third Item</x:String>
@@ -18,8 +17,6 @@
         </x:Array>
     </ContentPage.Resources>
     <Grid>
-
-
         <CollectionView x:Name="CollectionView1"
                 ItemsSource="{StaticResource stringArray}"
                 Background="aliceblue">

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue10947.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue10947.xaml
@@ -16,29 +16,34 @@
             <x:String>Sixth Item</x:String>
         </x:Array>
     </ContentPage.Resources>
-    <Grid>
-        <CollectionView x:Name="CollectionView1"
-                ItemsSource="{StaticResource stringArray}"
-                Background="aliceblue">
-            <CollectionView.Header>
-                <StackLayout Background="Pink">
-                    <Entry AutomationId="HeaderEntry"
-                           Background="LightGray"
-                           Placeholder="Header Entry"/>
-                </StackLayout>
-            </CollectionView.Header>
-            <CollectionView.Footer>
-                <StackLayout Background="Pink">
-                    <Entry AutomationId="FooterEntry"
-                           Background="LightGray"
-                           Placeholder="Footer Entry"/>
-                </StackLayout>
-            </CollectionView.Footer>
-            <CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <Entry Text="{Binding .}"/>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-    </Grid>
+    <CollectionView
+        x:Name="CollectionView1"
+        ItemsSource="{StaticResource stringArray}"
+        Background="aliceblue">
+        <CollectionView.Margin>
+            <OnPlatform x:TypeArguments="Thickness">
+                <On Platform="iOS"
+                        Value="0,50,0,0"/>
+            </OnPlatform>
+        </CollectionView.Margin>
+        <CollectionView.Header>
+            <StackLayout Background="Pink">
+                <Entry AutomationId="HeaderEntry"
+                       Background="LightGray"
+                       Placeholder="Header Entry"/>
+            </StackLayout>
+        </CollectionView.Header>
+        <CollectionView.Footer>
+            <StackLayout Background="Pink">
+                <Entry AutomationId="FooterEntry"
+                       Background="LightGray"
+                       Placeholder="Footer Entry"/>
+            </StackLayout>
+        </CollectionView.Footer>
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <Entry Text="{Binding .}"/>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue10947.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue10947.xaml
@@ -7,7 +7,8 @@
              Title="Issue10947">
 
     <ContentPage.Resources>
-        <x:Array x:Key="stringArray" Type="{x:Type x:String}">
+        <x:Array x:Key="stringArray"
+                Type="{x:Type x:String}">
             <x:String>First Item</x:String>
             <x:String>Second Item</x:String>
             <x:String>Third Item</x:String>
@@ -16,26 +17,31 @@
             <x:String>Sixth Item</x:String>
         </x:Array>
     </ContentPage.Resources>
+    <Grid>
 
-    <CollectionView x:Name="CollectionView1" ItemsSource="{StaticResource stringArray}" Background="aliceblue">
-        <CollectionView.Header>
-            <StackLayout Background="Pink">
-                <Entry AutomationId="HeaderEntry"
-                    Background="LightGray"
-                    Placeholder="Header Entry"/>
-            </StackLayout>
-        </CollectionView.Header>
-        <CollectionView.Footer>
-            <StackLayout Background="Pink">
-                <Entry AutomationId="FooterEntry"
-                    Background="LightGray"
-                    Placeholder="Footer Entry" />
-            </StackLayout>
-        </CollectionView.Footer>
-        <CollectionView.ItemTemplate>
-            <DataTemplate>
-                <Entry Text="{Binding .}"/>
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-    </CollectionView>
+
+        <CollectionView x:Name="CollectionView1"
+                ItemsSource="{StaticResource stringArray}"
+                Background="aliceblue">
+            <CollectionView.Header>
+                <StackLayout Background="Pink">
+                    <Entry AutomationId="HeaderEntry"
+                           Background="LightGray"
+                           Placeholder="Header Entry"/>
+                </StackLayout>
+            </CollectionView.Header>
+            <CollectionView.Footer>
+                <StackLayout Background="Pink">
+                    <Entry AutomationId="FooterEntry"
+                           Background="LightGray"
+                           Placeholder="Footer Entry"/>
+                </StackLayout>
+            </CollectionView.Footer>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Entry Text="{Binding .}"/>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10947.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10947.cs
@@ -22,18 +22,18 @@ public class Issue10947 : _IssuesUITest
 		var headerEntry = App.WaitForElement(HeaderEntry);
 		var headerLocation = headerEntry.GetRect();
 		var footerEntry = App.WaitForElement(FooterEntry);
-		var footerLocation = headerEntry.GetRect();
+		var footerLocation = footerEntry.GetRect();
 
 		App.Tap(HeaderEntry);
 
 		var newHeaderEntry = App.WaitForElement(HeaderEntry);
-		var newHeaderLocation = headerEntry.GetRect();
+		var newHeaderLocation = newHeaderEntry.GetRect();
 		ClassicAssert.AreEqual(headerLocation, newHeaderLocation);
 
 		App.Tap(FooterEntry);
 
 		var newFooterEntry = App.WaitForElement(FooterEntry);
-		var newFooterLocation = headerEntry.GetRect();
+		var newFooterLocation = newFooterEntry.GetRect();
 
 		ClassicAssert.AreEqual(footerLocation, newFooterLocation);
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10947.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue10947.cs
@@ -26,14 +26,12 @@ public class Issue10947 : _IssuesUITest
 
 		App.Tap(HeaderEntry);
 
-		var newHeaderEntry = App.WaitForElement(HeaderEntry);
-		var newHeaderLocation = newHeaderEntry.GetRect();
+		var newHeaderLocation = headerEntry.GetRect();
 		ClassicAssert.AreEqual(headerLocation, newHeaderLocation);
 
 		App.Tap(FooterEntry);
 
-		var newFooterEntry = App.WaitForElement(FooterEntry);
-		var newFooterLocation = newFooterEntry.GetRect();
+		var newFooterLocation = footerEntry.GetRect();
 
 		ClassicAssert.AreEqual(footerLocation, newFooterLocation);
 	}


### PR DESCRIPTION
This pull request addresses layout and test correctness issues in the Issue10947 test case, specifically related to the CollectionView header and footer interaction on iOS.

**UI improvements:**

- This change was necessary because the Entry control in the header was not tappable due to layout constraints — it was likely being overlapped or not rendered in an interactable area.
- After applying the margin, the Entry became fully visible and interactable, and taps are now recognized correctly. This behavior was only problematic on iOS, and the platform-specific margin ensures consistent layout and functionality across platforms.

**Test logic corrections:**

- Fixed the test in Issue10947.cs to correctly locate the footer and header Entry elements, ensuring the test checks the correct elements positions before and after user interaction.