### PR TITLE
[Testing] Fix for the ProgressSpinnerWorksWhenReEnabled flaky test in CI

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28343.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28343.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		public void ProgressSpinnerWorksWhenReEnabled()
 		{
 			App.WaitForElement("SetToEnabled").Tap();
-			App.ScrollUp("CollectionView");
+			App.ScrollUp("CollectionView", ScrollStrategy.Gesture, swipePercentage:0.99, swipeSpeed:2500);
 			App.WaitForElement("RefreshTriggered");
 		}
 	}


### PR DESCRIPTION
This PR addresses a test failure that occurred in the net10 branch and includes updates to improve test reliability and stability across platforms.

- In the ProgressSpinnerWorksWhenReEnabled test, added ScrollStrategy.Gesture, swipePercentage: 0.99, and swipeSpeed: 2500 in the ScrollUp method to improve CollectionView swiping.

### Test cases:

- ProgressSpinnerWorksWhenReEnabled