### PR TITLE
[test] Try to upload test coverage

### DIFF
--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
-  <DataCollectionRunSettings>
-    <DataCollectionProviders>
-      <DataCollectionProvider friendlyName="Code Coverage">
-        <Configuration>
-          <Module>
-            <Exclude>
-              <Module name="*" />
-            </Exclude>
-            <Include>
-              <Module name="Microsoft.Maui*.dll" />
-            </Include>
-          </Module>
-        </Configuration>
-      </DataCollectionProvider>
-    </DataCollectionProviders>
-  </DataCollectionRunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0">
+                <Configuration>
+                    <CodeCoverage>
+                        <Format>cobertura</Format>
+                        <ModulePaths>
+                            <Include>
+                                <ModulePath>.*Microsoft\.Maui.*\.dll</ModulePath>
+                            </Include>
+                            <Exclude>
+                                <ModulePath>.*Tests.dll</ModulePath>
+                                <ModulePath>.*Test.*\.dll</ModulePath>
+                                <ModulePath>.*\.UnitTests\.dll</ModulePath>
+                                <ModulePath>.*\.DeviceTests\.dll</ModulePath>
+                            </Exclude>
+                        </ModulePaths>
+                    </CodeCoverage>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
 </RunSettings>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,7 +153,7 @@
     <XUnitAnalyzersPackageVersion>1.15.0</XUnitAnalyzersPackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <NSubstitutePackageVersion>5.1.0</NSubstitutePackageVersion>
-    <CoverletCollectorPackageVersion>6.0.0</CoverletCollectorPackageVersion>
+  <MicrosoftCodeCoveragePackageVersion>17.6.3</MicrosoftCodeCoveragePackageVersion>
     <!-- Additional packages for cgmanifest.json -->
     <SyncfusionMauiToolkitPackageVersion>1.0.4</SyncfusionMauiToolkitPackageVersion>
     <MicrosoftDataSqliteCorePackageVersion>8.0.8</MicrosoftDataSqliteCorePackageVersion>

--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -184,5 +184,10 @@ jobs:
         testRunner: VSTest
         testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
         testRunTitle: ${{ RunPlatform.testName }} templates run tests
+
+    - task: PublishCodeCoverageResults@2
+      displayName: "Publish code coverage"
+      inputs:
+        summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
     # - template: /eng/pipelines/common/fail-on-issue.yml
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -189,6 +189,10 @@ stages:
           inputs:
             testRunner: VSTest
             testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
+        - task: PublishCodeCoverageResults@2
+          displayName: "Publish code coverage"
+          inputs:
+            summaryFileLocation: '$(build.artifactstagingdirectory)/**/*.cobertura.xml'
         - task: PublishBuildArtifacts@1
           condition: always()
           displayName: Publish Artifacts (${{ BuildPlatform.artifact }})
@@ -308,6 +312,10 @@ stages:
           testRunner: VSTest
           testResultsFiles: '$(build.artifactstagingdirectory)/**/*.trx'
           testRunTitle: ${{ BuildPlatform.name }} sample build tests
+      - task: PublishCodeCoverageResults@2
+        displayName: "Publish code coverage"
+        inputs:
+          summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
       - task: PublishBuildArtifacts@1
         condition: always()
         displayName: publish artifacts

--- a/eng/scripts/update-cgmanifest.ps1
+++ b/eng/scripts/update-cgmanifest.ps1
@@ -42,7 +42,7 @@ $packageVersionMappings = @{
     'xunit' = 'XunitPackageVersion'
     'xunit.runner.visualstudio' = 'XunitRunnerVisualStudioPackageVersion'
     'xunit.analyzer' = 'XUnitAnalyzersPackageVersion'
-    'coverlet.collector' = 'CoverletCollectorPackageVersion'
+    'Microsoft.CodeCoverage' = 'MicrosoftCodeCoveragePackageVersion'
     
     # Microsoft Extensions packages
     'Microsoft.Extensions.Logging.Debug' = 'MicrosoftExtensionsLoggingDebugVersion'

--- a/src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj
@@ -10,21 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" Publish="true"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" Publish="true"/>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../src/BindingSourceGen/Controls.BindingSourceGen.csproj" />
     <ProjectReference Include="../../src/Core/Controls.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Controls/tests/Core.Design.UnitTests/Controls.Core.Design.UnitTests.csproj
+++ b/src/Controls/tests/Core.Design.UnitTests/Controls.Core.Design.UnitTests.csproj
@@ -10,6 +10,10 @@
     <Reference Include="System.Xaml" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.DesignTools.Extensibility" Version="17.5.33428.366" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <ProjectReference Include="..\..\src\Core.Design\Controls.Core.Design.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj
+++ b/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj
@@ -9,7 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)"/>
+	  <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="NSubstitute" Version="$(NSubstitutePackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj
@@ -21,6 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -39,6 +39,10 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/tests/UnitTests/Core.UnitTests.csproj
+++ b/src/Core/tests/UnitTests/Core.UnitTests.csproj
@@ -24,7 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)"/>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="NSubstitute" Version="$(NSubstitutePackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
   </ItemGroup>

--- a/src/Essentials/test/UnitTests/Essentials.UnitTests.csproj
+++ b/src/Essentials/test/UnitTests/Essentials.UnitTests.csproj
@@ -14,6 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)"/>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+    </PackageReference>  
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
+++ b/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
@@ -11,12 +11,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
-		<PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)">
+		<PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.Extended" />
+    	<PackageReference Include="SkiaSharp" />
+    	<PackageReference Include="SkiaSharp.Extended" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.Extended" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPackageVersion)" />
+  <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePackageVersion)" />
     <PackageReference Include="Svg.Skia" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

This pull request introduces automated code coverage collection and reporting to the test pipelines. The main changes add code coverage collection to the test execution process and publish the results as part of the build pipeline outputs.

**Code Coverage Integration**

* Added code coverage collection to test runs by appending the `--collect "Code Coverage"` argument in `RunTestWithLocalDotNet` within `dotnet.cake`.

**Pipeline Updates for Coverage Reporting**

* Updated `maui-templates.yml` pipeline to include a `PublishCodeCoverageResults@2` task, publishing coverage results from Cobertura files.
* Added `PublishCodeCoverageResults@2` tasks to the test stages in `handlers.yml`, ensuring coverage results are published for both build and sample test pipelines. [[1]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394R205-R208) [[2]](diffhunk://#diff-5c9b6f86c989bb9415ea86f38f9e127f8dadf3a8516e9d027c7ee6289f10c394R328-R331)
