### PR TITLE
Check when to re-layout subviews - fix #25174

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -806,11 +806,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					if (vc.IsBeingDismissed ||
 					    (vc.PresentationController != null && vc.PresentationController.PresentedViewController == vc))
 						continue;
-
-					if (vc.View?.Superview != View)
-						continue;
-
+					
 					if (vc.View == null)
+						continue;
+					
+					if (vc.View?.Superview != View)
 						continue;
 
 					vc.View.Frame = View.Bounds;

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -802,7 +802,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			public override void ViewDidLayoutSubviews()
 			{
 				foreach (var vc in ChildViewControllers)
+				{
+					if (vc.IsBeingDismissed ||
+					    (vc.PresentationController != null && vc.PresentationController.PresentedViewController == vc))
+						continue;
+
+					if (vc.View?.Superview != View)
+						continue;
+
+					if (vc.View == null)
+						continue;
+
 					vc.View.Frame = View.Bounds;
+				}
 			}
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25174.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25174.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics;
+
+namespace Maui.Controls.Sample.Issues
+{
+
+	[Issue(IssueTracker.Github, 25174, "Camera preview is freezing when rotating and using FlyoutPage on iOS #25174", PlatformAffected.iOS)]
+	public class Issue25174 : FlyoutPage
+	{
+		public Issue25174()
+		{
+			Flyout = new ContentPage()
+			{
+				Title = "Menu",
+				Content = new Label() { Text = "This is a menu" }
+			};
+			Detail = new NavigationPage(new ContentPage()
+			{
+				Content = new Button()
+				{
+					Text = "CapturePhotoAsync",
+					AutomationId = "CapturePhotoAsync",
+					Command = new RelayCommand(async () =>
+					{
+						await MediaPicker.CapturePhotoAsync();
+					})
+				},
+			});
+
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Platforms/iOS/Info.plist
+++ b/src/Controls/tests/TestCases.HostApp/Platforms/iOS/Info.plist
@@ -30,5 +30,8 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Access to your location is required for cool things to happen!</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Access to your camera is required for cool things to happen!</string>
+	
 </dict>
 </plist>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25174.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25174.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue25174 : _IssuesUITest
+	{
+		const string CapturePhotoAsync = "CapturePhotoAsync";
+		const string Allow = "Allow";
+		
+
+		public Issue25174(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "Camera preview is freezing when rotating and using FlyoutPage on iOS #25174";
+
+		[Test]
+		[Category(UITestCategories.Navigation)]
+		public void ScrollViewInHeaderDisposesProperly()
+		{
+			App.SetOrientationLandscape();
+			App.WaitForElement(CapturePhotoAsync);
+			App.Tap(CapturePhotoAsync);
+			App.WaitForElement(Allow);
+			App.Tap(Allow);
+			App.SetOrientationPortrait();
+
+			//TODO tap X button in camera screen
+			
+
+			App.WaitForElement(CapturePhotoAsync);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

| After | Before |
| ------------- | ------------- |
|  ![after](https://github.com/user-attachments/assets/81711d57-861d-422c-b8c3-eb22d0978d9a) |![before](https://github.com/user-attachments/assets/29e20f1a-0b0a-4467-9b63-1f1b0c582be5) |





### Description of Change

When closing a MediaPicker (or any modal) from the Detail page in a FlyoutPage, the FlyoutPage could enter an infinite layout loop in ViewDidLayoutSubviews().

This fix ensures that any UIViewController currently presented modally (PresentationController.PresentedViewController == vc) or being dismissed (IsBeingDismissed) is skipped during layout. This prevents the infinite loop while allowing normal child controllers to layout correctly.



### Issues Fixed

Fixes #25174 