### PR TITLE
[Net10] CV2 - Disable scrolling and bouncing when empty view is shown

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -35,6 +35,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
+		bool _scrollEnabled;
+		bool _bounceVertical;
+		bool _bounceHorizontal;
+
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
@@ -572,6 +576,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				return;
 			}
 
+			if (CollectionView is not null)
+			{
+				_scrollEnabled = CollectionView.ScrollEnabled;
+				_bounceVertical = CollectionView.AlwaysBounceVertical;
+				_bounceHorizontal = CollectionView.AlwaysBounceHorizontal;
+
+				// Disable all forms of user-driven movement
+				// When no items are visible, scroll/bounce serve no purpose and cause visual glitches
+				CollectionView.ScrollEnabled = false;
+				CollectionView.AlwaysBounceVertical = false;
+				CollectionView.AlwaysBounceHorizontal = false;
+			}
+
 			_emptyUIView.Tag = EmptyTag;
 			CollectionView.AddSubview(_emptyUIView);
 
@@ -594,6 +611,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			}
 
 			_emptyUIView.RemoveFromSuperview();
+
+			if (CollectionView is not null)
+			{
+				CollectionView.ScrollEnabled = _scrollEnabled;
+				CollectionView.AlwaysBounceVertical = _bounceVertical;
+				CollectionView.AlwaysBounceHorizontal = _bounceHorizontal;
+			}
 
 			_emptyViewDisplayed = false;
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Introduces logic to store and temporarily disable scroll and bounce behaviors on the CollectionView when the empty view is displayed, preventing visual glitches. Restores the original settings when the empty view is removed.

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/ff70dd21-f231-4a15-b52c-e7ffdab9c541" width="300px"></video>|<video src="https://github.com/user-attachments/assets/c49c4048-f3f0-45b8-a4dd-461c2c09e5c8" width="300px"></video>|

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/31960
Fixes https://github.com/dotnet/maui/issues/31465

```xaml
<Grid RowDefinitions="auto,200">
    <Button Text="Modify ItemsSource"
            Clicked="OnModifyItemsSourceClicked"
            HorizontalOptions="Center"
            VerticalOptions="Center"
            Grid.Row="0"/>
    <CollectionView
        Grid.Row="1"
        BackgroundColor="Red"
        x:Name="collectionView"
        WidthRequest="200"
        VerticalScrollBarVisibility="Always">
        <CollectionView.EmptyView>
            <Grid BackgroundColor="Green">
                <Label  Text="Empty CollectionView"/>
            </Grid>
        </CollectionView.EmptyView>
    </CollectionView>
</Grid>
```

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
