### PR TITLE
[ci] Always install the universal iOS simulator.

### DIFF
--- a/eng/pipelines/arcade/setup-test-env.yml
+++ b/eng/pipelines/arcade/setup-test-env.yml
@@ -28,7 +28,11 @@ steps:
     xcrun xcode-select --print-path
     xcodebuild -version
     sudo xcodebuild -license accept
-    sudo xcodebuild -downloadPlatform iOS
+    if [[ ${XCODE_VERSION/\.*/} -ge 26 ]]; then
+      sudo xcodebuild -downloadPlatform iOS -architectureVariant universal
+    else
+      sudo xcodebuild -downloadPlatform iOS
+    fi
     sudo xcodebuild -runFirstLaunch
   displayName: Select Xcode Version
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -86,7 +86,11 @@ steps:
       xcrun xcode-select --print-path
       xcodebuild -version
       sudo xcodebuild -license accept
-      sudo xcodebuild -downloadPlatform iOS
+      if [[ ${XCODE_VERSION/\.*/} -ge 26 ]]; then
+        sudo xcodebuild -downloadPlatform iOS -architectureVariant universal
+      else
+        sudo xcodebuild -downloadPlatform iOS
+      fi
       sudo xcodebuild -runFirstLaunch
     displayName: Select Xcode Version
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
### Description of Change

Always install the universal iOS simulators.

Otherwise:

1. The arm64 iOS simulator isn't able to run x64 apps.
2. We run x64 apps in the iOS simulator in dotnet/macios (even on arm64 bots).
3. If MAUI installs the arm64 iOS simulator, it'll make our x64 tests apps fail to launch.

So fix this by installing the universal iOS simulator when using Xcode 26+
(earlier versions of Xcode doesn't support the '-architectureVariant'
argument).

<!-- Please let the below note in for people that find this PR -->

> [!NOTE]
> Are you waiting for the changes in this PR to be merged?

Yes!

> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

N/A