### PR TITLE
[Android] Fixed back button icon selection logic in ShellToolbarTracker

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -416,8 +416,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var command = backButtonHandler.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
 			var backButtonVisibleFromBehavior = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.IsVisibleProperty, true);
 			bool isEnabled = _shell.Toolbar.BackButtonEnabled;
-			//Add the FlyoutIcon only if the FlyoutBehavior is Flyout
-			var image = _flyoutBehavior == FlyoutBehavior.Flyout ? GetFlyoutIcon(backButtonHandler, page) : null;
+			var image = _flyoutBehavior == FlyoutBehavior.Flyout ? GetFlyoutIcon(backButtonHandler, page) : backButtonHandler.GetPropertyIfSet<ImageSource>(BackButtonBehavior.IconOverrideProperty, null);
 			var backButtonVisible = _toolbar.BackButtonVisible;
 
 			DrawerArrowDrawable icon = null;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32050.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32050.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       x:Class="Maui.Controls.Sample.Issues.Issue32050">
+
+    <ShellContent Title="Home">
+        <ContentPage>
+            <Label
+                Text="Issue 32050"
+                AutomationId="Label"
+                VerticalOptions="Center"
+                HorizontalOptions="Center"/>
+        </ContentPage>
+    </ShellContent>
+
+</Shell>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32050.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32050.xaml.cs
@@ -1,0 +1,21 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32050, "IconOverride in Shell.BackButtonBehavior does not work.", PlatformAffected.iOS)]
+public partial class Issue32050 : Shell
+{
+	public Issue32050()
+	{
+		InitializeComponent();
+		Routing.RegisterRoute("Issue32050SubPage", typeof(Issue32050SubPage));
+		GoToAsync("Issue32050SubPage");
+	}
+
+	class Issue32050SubPage : ContentPage
+	{
+		public Issue32050SubPage()
+		{
+			Content = new Label { Text = "Label", AutomationId = "Label" };
+			SetBackButtonBehavior(this, new BackButtonBehavior { IconOverride = "coffee.png" });
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32050.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32050.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32050 : _IssuesUITest
+{
+	public Issue32050(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "IconOverride in Shell.BackButtonBehavior does not work.";
+
+	[Test]
+	[Category(UITestCategories.TitleView)]
+	public void IconOverrideInShellBackButtonBehaviorShouldWork()
+	{
+		App.WaitForElement("Label");
+		VerifyScreenshot();
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Updates the logic for selecting the back button icon to use the IconOverride property when FlyoutBehavior is not Flyout. This ensures the correct icon is displayed based on the current behavior.

Regressing PR: https://github.com/dotnet/maui/pull/29637

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32050

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
