### PR TITLE
Disable MAUI telemetry for Aspire ServiceDefaults by default

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
@@ -53,7 +53,7 @@ public static class Extensions
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
-                // Uncomment the following line to enable reporting metrics coming from the .NET MAUI SDK, this might cause for a lot of added telemetry
+                // Uncomment the following line to enable reporting metrics coming from the .NET MAUI SDK, this might cause a lot of added telemetry
                 //metrics.AddMeter("Microsoft.Maui");
                 
                 metrics.AddHttpClientInstrumentation()
@@ -61,7 +61,7 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                // Uncomment the following line to enable reporting tracing coming from the .NET MAUI SDK, this might cause for a lot of added telemetry
+                // Uncomment the following line to enable reporting tracing coming from the .NET MAUI SDK, this might cause a lot of added telemetry
                 //tracing.AddSource("Microsoft.Maui");
                 
                 tracing.AddSource(builder.Environment.ApplicationName)

--- a/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/Extensions.cs
@@ -53,16 +53,16 @@ public static class Extensions
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
-                // Enable reporting metrics coming from the .NET MAUI SDK
-                metrics.AddMeter("Microsoft.Maui");
+                // Uncomment the following line to enable reporting metrics coming from the .NET MAUI SDK, this might cause for a lot of added telemetry
+                //metrics.AddMeter("Microsoft.Maui");
                 
                 metrics.AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>
             {
-                // Enable reporting tracing coming from the .NET MAUI SDK
-                tracing.AddSource("Microsoft.Maui");
+                // Uncomment the following line to enable reporting tracing coming from the .NET MAUI SDK, this might cause for a lot of added telemetry
+                //tracing.AddSource("Microsoft.Maui");
                 
                 tracing.AddSource(builder.Environment.ApplicationName)
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)


### PR DESCRIPTION
Comment out the telemetry configuration for Aspire by default for the MAUI SDK.

This might cause a lot of extra data which a) might make things unclear for the user and b) can maybe overload the dev tunnel/OTEL server

Let's only enable this when the developer specifically does that to figure out something on the MAUI side.