### PR TITLE
[ci] Update Xcode and correct simulator

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -86,7 +86,7 @@ steps:
       xcrun xcode-select --print-path
       xcodebuild -version
       sudo xcodebuild -license accept
-      sudo xcodebuild -downloadPlatform iOS
+      sudo xcodebuild -downloadPlatform iOS -buildVersion 26.0 -architectureVariant universal
       sudo xcodebuild -runFirstLaunch
     displayName: Select Xcode Version
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 10.0.100-preview.2.25164.34
 - name: REQUIRED_XCODE
-  value: 26.0.0
+  value: 26.0.1
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 26.0.0
+  value: 26.0.1
 - name: POWERSHELL_VERSION
   value: 7.4.0
 # Localization variables


### PR DESCRIPTION
### Description of Change

Update to XCODE 26.0.1
- Fix issue for failing builds not finding correct iOS runtime