### PR TITLE
Switch to using POST for .NET method invoke

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeDotNetFails.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_InvokeDotNetFails.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.HybridWebView)]
+#if WINDOWS
+[Collection(WebViewsCollection)]
+#endif
+public class HybridWebViewTests_InvokeDotNet : HybridWebViewTestsBase
+{
+	[Fact]
+	public Task GetRequestsAreBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that GET requests to the __hwvInvokeDotNet endpoint are blocked
+			// This should return a 400 Bad Request response because it is ALSO missing the token header.
+			Assert.Equal("400", target.TestResult);
+		});
+
+	[Fact]
+	public Task GetRequestWithHeaderIsBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that GET requests to the __hwvInvokeDotNet endpoint are blocked
+			// This should return a 405 Method Not Allowed response
+			Assert.Equal("405", target.TestResult);
+		});
+
+	[Fact]
+	public Task MissingTokenHeaderIsBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that POST requests without the X-Maui-Invoke-Token header are blocked
+			// This should return a 400 Bad Request response
+			Assert.Equal("400", target.TestResult);
+		});
+
+	[Fact]
+	public Task InvalidTokenHeaderIsBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that POST requests with an incorrect X-Maui-Invoke-Token header value are blocked
+			// This should return a 400 Bad Request response
+			Assert.Equal("400", target.TestResult);
+		});
+
+#if ANDROID
+	[Fact]
+	public Task MissingBodyHeaderIsBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that POST requests without the X-Maui-Request-Body header are blocked on Android
+			// This should return a 400 Bad Request response
+			Assert.Equal("400", target.TestResult);
+		});
+#endif
+
+	[Fact]
+	public Task EmptyBodyIsBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that POST requests with an empty body are blocked
+			// This should return a 400 Bad Request response
+			Assert.Equal("400", target.TestResult);
+		});
+
+	[Fact]
+	public Task ValidRequestIsNotBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that valid POST requests with proper headers and body are not blocked
+			// Valid requests should get a 200 status or possibly 404 if the method doesn't exist
+			// but should not get blocked with 400/403/405
+			Assert.True(target.TestResult != "400" && target.TestResult != "403" && target.TestResult != "405",
+				$"Valid request was unexpectedly blocked with status: {target.TestResult}");
+		});
+
+	[Fact]
+	public Task IframeRequestIsBlocked() =>
+		RunJavaScriptTest(async (hybridWebView, target) =>
+		{
+			// Test that requests from iframe contexts are blocked
+			// iframe requests should be blocked or result in an error
+#if IOS || MACCATALYST
+			var error = "iframe:error:app://0.0.0.1:Load failed";
+#else
+			var error = "iframe:error:https://0.0.0.1:Failed to fetch";
+#endif
+			Assert.Equal(error, target.TestResult);
+		});
+
+	private Task RunJavaScriptTest(Func<HybridWebView, InvokeTarget, Task> validateResult, [CallerMemberName] string? jsMethodName = null) =>
+		RunTest("invokedotnetfails.html", async (hybridWebView) =>
+		{
+			var target = new InvokeTarget();
+
+			hybridWebView.SetInvokeJavaScriptTarget(target);
+
+			// Execute the JavaScript test method
+			await hybridWebView.EvaluateJavaScriptAsync($"Test{jsMethodName}()");
+
+			// Wait for the test to complete
+			await WebViewHelpers.WaitForHtmlStatusSet(hybridWebView);
+
+			// Get the result and let the caller validate it
+			var result = await hybridWebView.EvaluateJavaScriptAsync("GetTestResult()");
+
+			target.TestResult = result;
+
+			await validateResult(hybridWebView, target);
+		});
+
+	private class InvokeTarget
+	{
+		public List<string> ParamValues { get; private set; } = new();
+
+		public string? TestResult { get; set; }
+
+        public void TestMethod(string param)
+        {
+			ParamValues.Add(param);
+        }
+    }
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_SetInvokeJavaScriptTarget.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_SetInvokeJavaScriptTarget.cs
@@ -21,8 +21,6 @@ public partial class HybridWebViewTests_SetInvokeJavaScriptTarget : HybridWebVie
 			var invokeJavaScriptTarget = new TestDotNetMethods();
 			hybridWebView.SetInvokeJavaScriptTarget(invokeJavaScriptTarget);
 
-			//await Task.Delay(15_000);
-
 			// Tell JavaScript to invoke the method
 			hybridWebView.SendRawMessage(methodName);
 

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/invokedotnetfails.html
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/invokedotnetfails.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <link rel="icon" href="data:,">
+    <script src="_framework/hybridwebview.js"></script>
+    <script>
+
+        // Test helper functions that will be called from C# tests
+        var testResult = null;
+
+        function GetTestResult() {
+            var result = testResult;
+            testResult = null;
+            return result;
+        }
+
+        function SetStatusDone() {
+            document.getElementById('status').innerHTML = "Done!";
+        }
+
+        const RequestMessage = JSON.stringify({
+            methodName: 'TestMethod',
+            parameters: ['Test Value']
+        });
+
+        // Test functions
+
+        function TestGetRequestsAreBlocked() {
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'GET'
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        function TestGetRequestWithHeaderIsBlocked() {
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'GET',
+                headers: {
+                    'X-Maui-Invoke-Token': 'HybridWebView',
+                    'X-Maui-Request-Body': RequestMessage
+                }
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        function TestMissingTokenHeaderIsBlocked() {
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'POST',
+                body: RequestMessage
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        function TestInvalidTokenHeaderIsBlocked() {
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'POST',
+                headers: {
+                    'X-Maui-Invoke-Token': 'InvalidValue',
+                    'X-Maui-Request-Body': RequestMessage
+                },
+                body: RequestMessage
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        // Android specific test
+        function TestMissingBodyHeaderIsBlocked() {
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'POST',
+                headers: {
+                    'X-Maui-Invoke-Token': 'HybridWebView'
+                }
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        function TestEmptyBodyIsBlocked() {
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'POST',
+                headers: {
+                    'X-Maui-Invoke-Token': 'HybridWebView',
+                    'X-Maui-Request-Body': ''
+                },
+                body: ''
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        function TestValidRequestIsNotBlocked() {
+
+            fetch(`${window.location.origin}/__hwvInvokeDotNet`, {
+                method: 'POST',
+                headers: {
+                    'X-Maui-Invoke-Token': 'HybridWebView',
+                    'X-Maui-Request-Body': RequestMessage
+                },
+                body: RequestMessage
+            }).then(response => {
+                testResult = response.status.toString();
+                SetStatusDone();
+            }).catch(error => {
+                testResult = `error: ${error.message}`;
+                SetStatusDone();
+            });
+        }
+
+        function TestIframeRequestIsBlocked() {
+            // Create an iframe and load JSFiddle embed
+            const iframe = document.createElement('iframe');
+            iframe.width = '100%';
+            iframe.height = '300';
+            iframe.src = 'https://mattleibow.github.io/maui-test-host/maui/hybridwebview/iframe-content-v1.html';
+            // iframe.frameBorder = '0';
+            // iframe.loading = 'lazy';
+            // iframe.allowTransparency = 'true';
+            // iframe.allowFullscreen = 'true';
+            document.body.appendChild(iframe);
+            
+            // Listen for messages from iframe
+            const messageHandler = (event) => {
+                if (event.data && event.data.type === 'iframe-test-result') {
+                    if (event.data.success) {
+                        testResult = `iframe:success:${event.data.origin}:${event.data.status}`;
+                    } else {
+                        testResult = `iframe:error:${event.data.origin}:${event.data.error}`;
+                    }
+                    SetStatusDone();
+                    
+                    // Cleanup
+                    window.removeEventListener('message', messageHandler);
+                    if (iframe.parentNode) {
+                        iframe.parentNode.removeChild(iframe);
+                    }
+                }
+            };
+            
+            window.addEventListener('message', messageHandler);
+        }
+
+    </script>
+</head>
+<body>
+    <div>
+        Hybrid fails test!
+    </div>
+    <div id="htmlLoaded"></div>
+    <div id="status"></div>
+</body>
+</html>

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -82,7 +82,7 @@
     <TypeScriptSourceMap>false</TypeScriptSourceMap>
     <TypeScriptNoImplicitAny>true</TypeScriptNoImplicitAny>
     <TypeScriptCompileOnSaveEnabled>true</TypeScriptCompileOnSaveEnabled>
-    <TypeScriptCompileBlocked Condition=" '$(CI)' != 'true' and '$(TF_BUILD)' != 'true' ">true</TypeScriptCompileBlocked>
+    <TypeScriptCompileBlocked Condition=" '$(TypeScriptCompileBlocked)' == '' and '$(CI)' != 'true' and '$(TF_BUILD)' != 'true' ">true</TypeScriptCompileBlocked>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.7.1">

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.js
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.js
@@ -143,14 +143,20 @@
             }
         }
         const message = JSON.stringify(body);
-        const requestUrl = `${window.location.origin}/__hwvInvokeDotNet?data=${encodeURIComponent(message)}`;
+        // send the request to .NET
+        const requestUrl = `${window.location.origin}/__hwvInvokeDotNet`;
         const rawResponse = await fetch(requestUrl, {
-            method: 'GET',
+            method: 'POST',
             headers: {
-                'Accept': 'application/json'
-            }
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-Maui-Invoke-Token': 'HybridWebView',
+                'X-Maui-Request-Body': message // Some platforms (Android) do not expose the POST body
+            },
+            body: message
         });
         const response = await rawResponse.json();
+        // a null response is a null response
         if (!response) {
             return null;
         }
@@ -165,9 +171,11 @@
             }
             throw error;
         }
+        // deserialize if there is JSON data
         if (response.IsJson) {
             return JSON.parse(response.Result);
         }
+        // otherwise return the primitive
         return response.Result;
     }
     /*

--- a/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebView.ts
@@ -48,8 +48,8 @@ interface JSInvokeError {
     StackTrace?: string;
 }
 interface DotNetInvokeResult {
-    IsJson: boolean;
-    Result: any;
+    IsJson?: boolean;
+    Result?: any;
     IsError?: boolean;
     ErrorMessage?: string;
     ErrorType?: string;
@@ -205,16 +205,22 @@ interface DotNetInvokeResult {
 
         const message = JSON.stringify(body);
 
-        const requestUrl = `${window.location.origin}/__hwvInvokeDotNet?data=${encodeURIComponent(message)}`;
-
+        // send the request to .NET
+        const requestUrl = `${window.location.origin}/__hwvInvokeDotNet`;
         const rawResponse = await fetch(requestUrl, {
-            method: 'GET',
+            method: 'POST',
             headers: {
-                'Accept': 'application/json'
-            }
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-Maui-Invoke-Token': 'HybridWebView',
+                'X-Maui-Request-Body': message // Some platforms (Android) do not expose the POST body
+            },
+            body: message
         });
+
         const response: DotNetInvokeResult = await rawResponse.json();
 
+        // a null response is a null response
         if (!response) {
             return null;
         }
@@ -231,10 +237,12 @@ interface DotNetInvokeResult {
             throw error;
         }
 
+        // deserialize if there is JSON data
         if (response.IsJson) {
             return JSON.parse(response.Result);
         }
 
+        // otherwise return the primitive
         return response.Result;
     }
 

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Handlers
 				using var deferral = eventArgs.GetDeferral();
 
 				// 2.b. Check if the request is for a local resource
-				var (stream, contentType, statusCode, reason) = await GetResponseStreamAsync(eventArgs.Request.Uri, logger);
+				var (stream, contentType, statusCode, reason) = await GetResponseStreamAsync(url, eventArgs.Request, logger);
 
 				// 2.c. Create the response header
 				var headers = "";
@@ -161,7 +161,7 @@ namespace Microsoft.Maui.Handlers
 			logger?.LogDebug("Request for {Url} was not handled.", url);
 		}
 
-		private async Task<(IRandomAccessStream? Stream, string? ContentType, int StatusCode, string Reason)> GetResponseStreamAsync(string url, ILogger? logger)
+		private async Task<(IRandomAccessStream? Stream, string? ContentType, int StatusCode, string Reason)> GetResponseStreamAsync(string url, CoreWebView2WebResourceRequest request, ILogger? logger)
 		{
 			var requestUri = WebUtils.RemovePossibleQueryString(url);
 
@@ -186,9 +186,34 @@ namespace Microsoft.Maui.Handlers
 				{
 					logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", url);
 
-					var fullUri = new Uri(url);
-					var invokeQueryString = HttpUtility.ParseQueryString(fullUri.Query);
-					var contentBytes = await InvokeDotNetAsync(invokeQueryString);
+					// Only accept requests that have the expected headers
+					if (!HasExpectedHeaders(request.Headers))
+					{
+						logger?.LogError("InvokeDotNet endpoint missing or invalid request header");
+						return (Stream: null, ContentType: null, StatusCode: 400, Reason: "Bad Request");
+					}
+
+					// Only accept POST requests
+					if (!string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase))
+					{
+						logger?.LogError("InvokeDotNet endpoint only accepts POST requests. Received: {Method}", request.Method);
+						return (Stream: null, ContentType: null, StatusCode: 405, Reason: "Method Not Allowed");
+					}
+
+					// Read the request body
+					Stream requestBody;
+					if (request.Content is { } bodyStream && bodyStream.Size > 0)
+					{
+						requestBody = bodyStream.AsStreamForRead();
+					}
+					else
+					{
+						logger?.LogError("InvokeDotNet request body is empty");
+						return (Stream: null, ContentType: null, StatusCode: 400, Reason: "Bad Request");
+					}
+
+					// Invoke the method
+					var contentBytes = await InvokeDotNetAsync(streamBody: requestBody);
 					if (contentBytes is not null)
 					{
 						var ras = await CopyContentToRandomAccessStreamAsync(contentBytes.AsBuffer());

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.cs
@@ -1,14 +1,20 @@
 ﻿#if __IOS__ || MACCATALYST
 using PlatformView = WebKit.WKWebView;
+using HeaderPairType = Foundation.NSObject;
 #elif MONOANDROID
 using PlatformView = Android.Webkit.WebView;
+using HeaderPairType = System.String;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
+using HeaderPairType = System.String;
 #elif TIZEN
 using PlatformView = Tizen.NUI.BaseComponents.View;
+using HeaderPairType = System.String;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0_OR_GREATER && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
+using HeaderPairType = System.String;
 #endif
+
 #if __ANDROID__
 using Android.Webkit;
 #elif __IOS__
@@ -18,6 +24,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.Storage;
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Threading;
 using Microsoft.Maui.Devices;
@@ -68,6 +75,11 @@ namespace Microsoft.Maui.Handlers
 
 		internal const string InvokeDotNetPath = "__hwvInvokeDotNet";
 		internal const string HybridWebViewDotJsPath = "_framework/hybridwebview.js";
+
+		internal const string InvokeDotNetTokenHeaderName = "X-Maui-Invoke-Token";
+		internal const string InvokeDotNetTokenHeaderValue = "HybridWebView";
+		internal const string InvokeDotNetBodyHeaderName = "X-Maui-Request-Body";
+
 
 		public static IPropertyMapper<IHybridWebView, IHybridWebViewHandler> Mapper = new PropertyMapper<IHybridWebView, IHybridWebViewHandler>(ViewHandler.ViewMapper)
 		{
@@ -172,23 +184,26 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		internal async Task<byte[]?> InvokeDotNetAsync(NameValueCollection invokeQueryString)
+		internal async Task<byte[]?> InvokeDotNetAsync(Stream? streamBody = null, string? stringBody = null)
 		{
 			try
 			{
 				var invokeTarget = VirtualView.InvokeJavaScriptTarget ?? throw new InvalidOperationException($"The {nameof(IHybridWebView)}.{nameof(IHybridWebView.InvokeJavaScriptTarget)} property must have a value in order to invoke a .NET method from JavaScript.");
 				var invokeTargetType = VirtualView.InvokeJavaScriptType ?? throw new InvalidOperationException($"The {nameof(IHybridWebView)}.{nameof(IHybridWebView.InvokeJavaScriptType)} property must have a value in order to invoke a .NET method from JavaScript.");
 
-				var invokeDataString = invokeQueryString["data"];
-				if (string.IsNullOrEmpty(invokeDataString))
+				JSInvokeMethodData? invokeData = null;
+				if (streamBody is not null)
 				{
-					throw new ArgumentException("The 'data' query string parameter is required.", nameof(invokeQueryString));
+					invokeData = await JsonSerializer.DeserializeAsync<JSInvokeMethodData>(streamBody, HybridWebViewHandlerJsonContext.Default.JSInvokeMethodData);
+				}
+				else if (stringBody is not null && !string.IsNullOrWhiteSpace(stringBody))
+				{
+					invokeData = JsonSerializer.Deserialize<JSInvokeMethodData>(stringBody, HybridWebViewHandlerJsonContext.Default.JSInvokeMethodData);
 				}
 
-				var invokeData = JsonSerializer.Deserialize<JSInvokeMethodData>(invokeDataString, HybridWebViewHandlerJsonContext.Default.JSInvokeMethodData);
 				if (invokeData?.MethodName is null)
 				{
-					throw new ArgumentException("The invoke data did not provide a method name.", nameof(invokeQueryString));
+					throw new InvalidOperationException("The invoke data did not provide a method name.");
 				}
 
 				var invokeResultRaw = await InvokeDotNetMethodAsync(invokeTargetType, invokeTarget, invokeData);
@@ -201,7 +216,7 @@ namespace Microsoft.Maui.Handlers
 			catch (Exception ex)
 			{
 				MauiContext?.CreateLogger<HybridWebViewHandler>()?.LogError(ex, "An error occurred while invoking a .NET method from JavaScript: {ErrorMessage}", ex.Message);
-				
+
 				// Return error response instead of null so JavaScript can handle the error
 				var errorResult = CreateErrorResult(ex);
 				var errorJson = JsonSerializer.Serialize(errorResult, HybridWebViewHandlerJsonContext.Default.DotNetInvokeResult);
@@ -514,6 +529,46 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			return assembly.GetManifestResourceStream(resourceName);
+		}
+
+		private static bool IsExpectedHeader((string? Name, string? Value) header, (string Name, string Value) expected) =>
+			string.Equals(header.Name, expected.Name, StringComparison.OrdinalIgnoreCase) &&
+			string.Equals(header.Value, expected.Value, StringComparison.OrdinalIgnoreCase);
+
+		internal static bool HasExpectedHeaders(IEnumerable<KeyValuePair<HeaderPairType, HeaderPairType>>? headers)
+		{
+			if (headers is null)
+				return false;
+
+			var expectedOrigin = AppOrigin.TrimEnd('/');
+
+			var hasExpectedToken = false;
+			var hasExpectedOrigin = false;
+			var hasExpectedReferer = false;
+
+			foreach (var header in headers)
+			{
+#if IOS || MACCATALYST
+				var name = header.Key?.ToString();
+				var value = header.Value?.ToString();
+#else
+				var name = header.Key;
+				var value = header.Value;
+#endif
+
+				// Is this from the script
+				hasExpectedToken = hasExpectedToken || IsExpectedHeader((name, value), (InvokeDotNetTokenHeaderName, InvokeDotNetTokenHeaderValue));
+
+				// Is this from a local script
+				var urlValue = value?.TrimEnd('/');
+				hasExpectedOrigin = hasExpectedOrigin || IsExpectedHeader((name, urlValue), ("Origin", expectedOrigin));
+				hasExpectedReferer = hasExpectedReferer || IsExpectedHeader((name, urlValue), ("Referer", expectedOrigin));
+
+				if (hasExpectedToken && (hasExpectedOrigin || hasExpectedReferer))
+					return true;
+			}
+
+			return false;
 		}
 
 #if !NETSTANDARD

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Maui.Handlers
 					logger?.LogDebug("Request for {Url} will be handled by .NET MAUI.", url);
 
 					// 2.a. Check if the request is for a local resource
-					var (bytes, contentType, statusCode) = await GetResponseBytesAsync(url, logger);
+					var (bytes, contentType, statusCode) = await GetResponseBytesAsync(url, urlSchemeTask.Request, logger);
 
 					// 2.b. Return the response header
 					using var dic = new NSMutableDictionary<NSString, NSString>();
@@ -216,14 +216,13 @@ namespace Microsoft.Maui.Handlers
 				logger?.LogDebug("Request for {Url} was not handled.", url);
 			}
 
-			private async Task<(NSData? ResponseBytes, string? ContentType, int StatusCode)> GetResponseBytesAsync(string url, ILogger? logger)
+			private async Task<(NSData? ResponseBytes, string? ContentType, int StatusCode)> GetResponseBytesAsync(string url, NSUrlRequest request, ILogger? logger)
 			{
 				if (Handler is null)
 				{
 					return (null, ContentType: null, StatusCode: 404);
 				}
 
-				var fullUrl = url;
 				url = WebUtils.RemovePossibleQueryString(url);
 
 				if (new Uri(url) is Uri uri && AppOriginUri.IsBaseOf(uri))
@@ -248,9 +247,34 @@ namespace Microsoft.Maui.Handlers
 					{
 						logger?.LogDebug("Request for {Url} will be handled by the .NET method invoker.", url);
 
-						var fullUri = new Uri(fullUrl!);
-						var invokeQueryString = HttpUtility.ParseQueryString(fullUri.Query);
-						var contentBytes = await Handler.InvokeDotNetAsync(invokeQueryString);
+						// Only accept requests that have the expected headers
+						if (!HasExpectedHeaders(request.Headers))
+						{
+							logger?.LogError("InvokeDotNet endpoint missing or invalid request header");
+							return (null, null, StatusCode: 400);
+						}
+
+						// Only accept POST requests
+						if (!string.Equals(request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase))
+						{
+							logger?.LogError("InvokeDotNet endpoint only accepts POST requests. Received: {Method}", request.HttpMethod);
+							return (null, null, StatusCode: 405);
+						}
+
+						// Read the request body
+						Stream requestBody;
+						if (request.Body is NSData bodyData && bodyData.Length > 0)
+						{
+							requestBody = bodyData.AsStream();
+						}
+						else
+						{
+							logger?.LogError("InvokeDotNet request body is empty");
+							return (null, null, StatusCode: 400);
+						}
+
+						// Invoke the method
+						var contentBytes = await Handler.InvokeDotNetAsync(streamBody: requestBody);
 						if (contentBytes is not null)
 						{
 							return (NSData.FromArray(contentBytes), "application/json", StatusCode: 200);


### PR DESCRIPTION


This pull request introduces significant improvements to the HybridWebView's .NET invocation security and request handling, as well as updates to the related test infrastructure and JavaScript interop logic. The changes enforce stricter validation of incoming requests to the `__hwvInvokeDotNet` endpoint, ensuring only properly formed POST requests with required headers and bodies are processed. Comprehensive device tests and supporting HTML/JS files have been added to verify these behaviors across platforms.

**HybridWebView .NET Invocation Security & Request Handling**

* The HybridWebView handler now strictly validates requests to the `__hwvInvokeDotNet` endpoint: only POST requests with the correct `X-Maui-Invoke-Token` and `X-Maui-Request-Body` headers and a non-empty body are accepted; others are blocked with appropriate HTTP status codes (400 Bad Request, 405 Method Not Allowed). [[1]](diffhunk://#diff-9adaedb7571e93283664d8e3db8d34930d748bbe1207eb004f53e25e08eaaaeaL189-R216) [[2]](diffhunk://#diff-de0e019f17984afe73ae3cc64fe8381c003dfc168873034fee4f5c97937cc6a6R79-R83) [[3]](diffhunk://#diff-de0e019f17984afe73ae3cc64fe8381c003dfc168873034fee4f5c97937cc6a6L175-R206)
* Refactored the .NET invocation logic to deserialize request data from the POST body or header, removing reliance on query strings and improving platform compatibility. [[1]](diffhunk://#diff-9adaedb7571e93283664d8e3db8d34930d748bbe1207eb004f53e25e08eaaaeaL164-R164) [[2]](diffhunk://#diff-9adaedb7571e93283664d8e3db8d34930d748bbe1207eb004f53e25e08eaaaeaL132-R132) [[3]](diffhunk://#diff-de0e019f17984afe73ae3cc64fe8381c003dfc168873034fee4f5c97937cc6a6L175-R206)

**JavaScript Interop and API Updates**

* Updated the JavaScript and TypeScript logic to send POST requests with the required headers and body to the `__hwvInvokeDotNet` endpoint, matching the new server-side requirements. The request and response handling code was also improved for better error handling and data deserialization. [[1]](diffhunk://#diff-c67a5341f466f16fb9bf82ce6b217b8e1575141e34fd6be0412af34ff687330aL146-R159) [[2]](diffhunk://#diff-c67a5341f466f16fb9bf82ce6b217b8e1575141e34fd6be0412af34ff687330aR174-R178) [[3]](diffhunk://#diff-08a062a075719e4712bde55f65795a01123b43135ede4b2694be2bc862dcf400L208-R223) [[4]](diffhunk://#diff-08a062a075719e4712bde55f65795a01123b43135ede4b2694be2bc862dcf400R240-R245) [[5]](diffhunk://#diff-08a062a075719e4712bde55f65795a01123b43135ede4b2694be2bc862dcf400L51-R52)

**Device Test Infrastructure**

* Added a new device test suite (`HybridWebViewTests_InvokeDotNetFails.cs`) and corresponding HTML test page (`invokedotnetfails.html`) to verify that invalid requests (wrong method, missing/invalid headers, empty body, iframe context) are blocked and only valid requests succeed. [[1]](diffhunk://#diff-2f6b656bc58d3aa55e82394806d29fdda0a004a72091725c7f567247efc07007R1-R130) [[2]](diffhunk://#diff-04ae8ecc3e06241fb8e0dc199db7189f02aa0c806ecafd02dbcef8989c61f0adR1-R182)

**Cross-Platform and Build System Improvements**

* Refactored handler code to use a platform-agnostic `HeaderPairType` for header handling, improving maintainability and cross-platform support. [[1]](diffhunk://#diff-de0e019f17984afe73ae3cc64fe8381c003dfc168873034fee4f5c97937cc6a6R3-R17) [[2]](diffhunk://#diff-de0e019f17984afe73ae3cc64fe8381c003dfc168873034fee4f5c97937cc6a6R27)
* Improved TypeScript build configuration to allow overriding the compile block condition via the `TypeScriptCompileBlocked` property.

**Future Improvements**

* Right now, Windows, iOS and Mac Catalyst use a POST with a body, but Android is limited and has to use a header. In future, switching to a [JavascriptInterface] may be worth investigation.
* This could also be expanded into a non-HTTP request and just use the same messaging system that the other invokes use.