### PR TITLE
Add longPathAware to Windows app manifest in templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/Platforms/Windows/app.manifest
@@ -10,6 +10,8 @@
       -->
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/app.manifest
@@ -10,6 +10,8 @@
       -->
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/app.manifest
@@ -10,6 +10,8 @@
       -->
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/app.manifest
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/app.manifest
@@ -15,6 +15,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
### Description of Change

The error in #25837 seems to be caused by the fact that the WinUI app is not "long path aware", adding this setting to the default templates should mitigate this problem.

Also see: https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#application-manifest-updates-to-declare-long-path-capability

### Issues Fixed

Fixes #25837
