### PR TITLE
Remove Android environment variable file handling for Aspire

### DIFF
--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -43,27 +43,6 @@ namespace Microsoft.Maui.Hosting
 
 			IDictionary environmentVariables = Environment.GetEnvironmentVariables();
 
-#if ANDROID
-			const string androidEnvVarFilePath = "/data/local/tmp/ide-launchenv.txt";
-
-			// For Android we read the environment variables from a text file that is written to the device/emulator
-			// If the file not exists, we will use the default environment variables which is less stable
-			if (OperatingSystem.IsAndroid() && System.IO.File.Exists(androidEnvVarFilePath))
-			{
-				var envVarLines = System.IO.File.ReadAllLines(androidEnvVarFilePath);
-
-				var fileEnvironmentVariables = envVarLines
-					.Select(line => line.Split('=', 2))
-					.ToDictionary(parts => parts[0], parts => parts[1]);
-
-				// Merge file environment variables into the existing environment variables
-				foreach (var kvp in fileEnvironmentVariables)
-				{
-					environmentVariables[kvp.Key] = kvp.Value;
-				}
-			}
-#endif
-
 			string devTunnelId = environmentVariables["DEVTUNNEL_ID"]?.ToString() ?? string.Empty;
 
 			var variablesToInclude = new HashSet<string>


### PR DESCRIPTION
### Description of Change

Removes the Android specific environment variable I added for Aspire in #31494. Since this implementation of the Aspire+MAUI integration is broken atm anyway, we can just remove this code since its also not needed for the native Aspire integration (see https://github.com/dotnet/aspire/pull/11942). 

This code wasn't great to begin with, let's remove it. I did leave the feature toggle intact in case we might want to use that in other scenarios.

### Issues Fixed

Closes #32119

Closes #32120 
