### PR TITLE
[CarouselViewHandler2] Fir fox CurrentItem does not work when ItemSpacing is set

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -347,6 +347,12 @@ internal static class LayoutFactory2
 				var itemSpacing = itemsView.ItemsLayout is LinearItemsLayout linearLayout ? linearLayout.ItemSpacing : 0;
 
 				var effectiveItemWidth = env.Container.ContentSize.Width - sectionMargin * 2 + itemSpacing;
+
+				if (effectiveItemWidth <= 0)
+				{
+					return;
+				}
+
 				double page = (offset.X + sectionMargin) / effectiveItemWidth;
 
 				if (Math.Abs(page % 1) > (double.Epsilon * 100) || cv2Controller.ItemsSource.ItemCount <= 0)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -343,7 +343,19 @@ internal static class LayoutFactory2
 					return;
 				}
 
-				var page = (offset.X + sectionMargin) / (env.Container.ContentSize.Width - sectionMargin * 2);
+				// Calculate page index accounting for ItemSpacing
+				var itemSpacing = itemsView.ItemsLayout is LinearItemsLayout linearLayout ? linearLayout.ItemSpacing : 0;
+				double page;
+				if (isHorizontal)
+				{
+					var effectiveItemWidth = env.Container.ContentSize.Width - sectionMargin * 2 + itemSpacing;
+					page = (offset.X + sectionMargin) / effectiveItemWidth;
+				}
+				else
+				{
+					var effectiveItemHeight = env.Container.ContentSize.Height - sectionMargin * 2 + itemSpacing;
+					page = (offset.Y + sectionMargin) / effectiveItemHeight;
+				}
 
 				if (Math.Abs(page % 1) > (double.Epsilon * 100) || cv2Controller.ItemsSource.ItemCount <= 0)
 				{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -345,17 +345,9 @@ internal static class LayoutFactory2
 
 				// Calculate page index accounting for ItemSpacing
 				var itemSpacing = itemsView.ItemsLayout is LinearItemsLayout linearLayout ? linearLayout.ItemSpacing : 0;
-				double page;
-				if (isHorizontal)
-				{
-					var effectiveItemWidth = env.Container.ContentSize.Width - sectionMargin * 2 + itemSpacing;
-					page = (offset.X + sectionMargin) / effectiveItemWidth;
-				}
-				else
-				{
-					var effectiveItemHeight = env.Container.ContentSize.Height - sectionMargin * 2 + itemSpacing;
-					page = (offset.Y + sectionMargin) / effectiveItemHeight;
-				}
+
+				var effectiveItemWidth = env.Container.ContentSize.Width - sectionMargin * 2 + itemSpacing;
+				double page = (offset.X + sectionMargin) / effectiveItemWidth;
 
 				if (Math.Abs(page % 1) > (double.Epsilon * 100) || cv2Controller.ItemsSource.ItemCount <= 0)
 				{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32048.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32048.cs
@@ -1,0 +1,78 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32048, "CurrentItem does not update when ItemSpacing is set", PlatformAffected.iOS)]
+public class Issue32048 : ContentPage
+{
+    CarouselView2 carouselView;
+    Label currentItemLabel;
+    string firstItem = "Baboon";
+
+    public Issue32048()
+    {
+        carouselView = new CarouselView2
+        {
+            AutomationId = "CarouselViewWithItemSpacing",
+            HeightRequest = 400,
+            BackgroundColor = Colors.LightGray,
+            ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+            {
+                ItemSpacing = 10,
+                SnapPointsType = SnapPointsType.MandatorySingle,
+            },
+            ItemTemplate = new DataTemplate(() =>
+            {
+                Label label = new Label
+                {
+                    HorizontalOptions = LayoutOptions.Center,
+                    VerticalOptions = LayoutOptions.Center
+                };
+                label.SetBinding(Label.TextProperty, ".");
+
+                return new Grid
+                {
+                    Children = { label }
+                };
+            }),
+            ItemsSource = new string[]
+            {
+                "Baboon",
+                "Capuchin Monkey",
+                "Blue Monkey",
+                "Squirrel Monkey",
+                "Golden Lion Tamarin"
+            }
+        };
+
+        carouselView.CurrentItemChanged += OnCurrentItemChanged;
+
+        currentItemLabel = new Label
+        {
+            AutomationId = "Issue32048StatusLabel",
+            Text = "Failure"
+        };
+
+        Grid grid = new Grid
+        {
+            Padding = 25,
+            RowSpacing = 10,
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto)
+            }
+        };
+
+        grid.Add(carouselView);
+        grid.Add(currentItemLabel, row: 1);
+
+        Content = grid;
+    }
+
+    void OnCurrentItemChanged(object sender, CurrentItemChangedEventArgs e)
+    {
+        if (e.CurrentItem is not null && e.CurrentItem.ToString() != firstItem)
+        {
+            currentItemLabel.Text = "Success";
+        }
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32048.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32048.cs
@@ -1,0 +1,30 @@
+#if TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/31670
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32048 : _IssuesUITest
+{
+	public Issue32048(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "CurrentItem does not update when ItemSpacing is set";
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void VerifyCurrentItemUpdatesWithItemSpacing()
+	{
+		App.WaitForElement("CarouselViewWithItemSpacing");
+		App.ScrollRight("CarouselViewWithItemSpacing");
+
+#if MACCATALYST
+		Thread.Sleep(1000);
+#endif
+		var resultLabel = App.WaitForElement("Issue32048StatusLabel").GetText();
+		Assert.That(resultLabel, Is.EqualTo("Success"));
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- CurrentItem does not update when ItemSpacing is set.

### Root Cause

- When ItemSpacing is set on a CarouselView using CV2 (CarouselViewHandler2), the page calculation logic was only considering the container size but ignoring the additional space consumed by ItemSpacing.


### Description of Change

- Updated the page index calculation in LayoutFactory2.cs to include ItemSpacing when determining the current page in the carousel layout. This ensures that CurrentItem updates correctly when spacing is present.


### Issues Fixed
Fixes #32048 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/81a4529b-049b-4662-be87-90a83cd94a70"> | <video src="https://github.com/user-attachments/assets/9448e421-a065-44aa-846f-3d0af0696de0"> |