### PR TITLE
[Android] Fixed soft input inconsistency

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986.cs
@@ -97,7 +97,6 @@ public class Issue28986 : _IssuesUITest
 		Assert.That(finalAllPosition.Y, Is.EqualTo(allPosition.Y), "Final All position should match initial All position");
 	}
 
-#if TEST_FAILS_ON_ANDROID
 	[Test]
 	[Category(UITestCategories.SafeAreaEdges)]
 	public void SafeAreaPerEdgeValidation()
@@ -128,6 +127,5 @@ public class Issue28986 : _IssuesUITest
 			Assert.That(containerPositionWithoutSoftInput.Height, Is.EqualTo(containerPosition.Height), "ContentGrid height should return to original when Soft Input is dismissed with Container edges");
 		});
 	}
-	#endif
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ContentPage.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_ContentPage.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue28986_ContentPage : _IssuesUITest
 {
-    public override string Issue => "Test SafeArea ContentPage for per-edge safe area control";
+	public override string Issue => "Test SafeArea ContentPage for per-edge safe area control";
 
-    public Issue28986_ContentPage(TestDevice device) : base(device)
-    {
-    }
+	public Issue28986_ContentPage(TestDevice device) : base(device)
+	{
+	}
 
-    [Test]
+	[Test]
 	[Category(UITestCategories.SafeAreaEdges)]
 	public void SafeAreaMainGridBasicFunctionality()
 	{
@@ -97,8 +97,6 @@ public class Issue28986_ContentPage : _IssuesUITest
 		Assert.That(finalAllPosition.Y, Is.EqualTo(allPosition.Y), "Final All position should match initial All position");
 	}
 
-
-	#if TEST_FAILS_ON_ANDROID
 	[Test]
 	[Category(UITestCategories.SafeAreaEdges)]
 	public void SafeAreaPerEdgeValidation()
@@ -129,6 +127,5 @@ public class Issue28986_ContentPage : _IssuesUITest
 			Assert.That(containerPositionWithoutSoftInput.Height, Is.EqualTo(containerPosition.Height), "ContentGrid height should return to original when Soft Input is dismissed with Container edges");
 		});
 	}
-	#endif
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
@@ -224,7 +224,6 @@ public class Issue28986_SafeAreaBorderOrientation : _IssuesUITest
             "Dimensions should still differ between portrait and landscape after multiple changes");
     }
 
-#if TEST_FAILS_ON_ANDROID 
     [Test]
     [Category(UITestCategories.SafeAreaEdges)]
     public void SafeAreaBorderSoftInputBehavior()
@@ -320,116 +319,5 @@ public class Issue28986_SafeAreaBorderOrientation : _IssuesUITest
         Assert.That(borderHeightChanged || safeAreaChanged, Is.True,
             "Test should demonstrate that keyboard interaction affects either safe area or border layout");
     }
-#endif
-
-#if TEST_FAILS_ON_ANDROID // Landscape orientation causes keyboard to occupy  fullview
-    [Test]
-    [Category(UITestCategories.SafeAreaEdges)]
-    public void SafeAreaBorderSoftInputWithOrientationChange()
-    {
-        var borderContent = App.WaitForElement("BorderContent");
-
-        // 1. Set bottom edge to SoftInput mode for keyboard behavior
-        App.Tap("SetBottomSoftInputButton");
-
-        // Wait for the test status to confirm the change
-        var softInputSet = App.WaitForTextToBePresentInElement("TestStatus", "SoftInput", TimeSpan.FromSeconds(3));
-        Assert.That(softInputSet, Is.True, "Bottom edge should be set to SoftInput mode");
-
-        // 2. Show keyboard in portrait mode
-        App.Tap("TestEntry");
-
-        Thread.Sleep(1000);
-
-        Assert.That(App.IsKeyboardShown(), Is.True, "Keyboard should become visible in portrait mode");
-
-        // 3. Record portrait state with keyboard visible
-        var portraitWithKeyboardBounds = borderContent.GetRect();
-        var portraitWithKeyboardSafeArea = App.WaitForElement("SafeAreaInsets").GetText();
-
-        Assert.That(App.IsKeyboardShown(), Is.True, "IsKeyboardShown should confirm keyboard is visible");
-
-        // Verify we start in portrait with keyboard
-        Assert.That(portraitWithKeyboardBounds.Height, Is.GreaterThan(portraitWithKeyboardBounds.Width * 0.6),
-            "Should be in portrait orientation even with keyboard visible");
-
-        // 4. Change orientation to landscape while keyboard is still visible
-        App.SetOrientationLandscape();
-        Thread.Sleep(2000); // Wait for orientation change and layout to settle
-
-        // 5. Record landscape state with keyboard visible
-        var landscapeWithKeyboardBounds = borderContent.GetRect();
-        var landscapeWithKeyboardSafeArea = App.WaitForElement("SafeAreaInsets").GetText();
-
-        Assert.That(App.IsKeyboardShown(), Is.True, "Keyboard should remain visible after orientation change");
-
-        // Verify orientation changed to landscape
-        Assert.That(landscapeWithKeyboardBounds.Width, Is.GreaterThan(landscapeWithKeyboardBounds.Height * 0.6),
-            "Should now be in landscape orientation with keyboard visible");
-
-        // 6. Verify border maintains visibility in landscape with keyboard
-        Assert.That(landscapeWithKeyboardBounds.Width, Is.GreaterThan(0),
-            "Border should remain visible in landscape with keyboard");
-        Assert.That(landscapeWithKeyboardBounds.Height, Is.GreaterThan(0),
-            "Border should remain visible in landscape with keyboard");
-
-        // 7. Verify dimensions differ between orientations even with keyboard visible
-        Assert.That(portraitWithKeyboardBounds.Width, Is.Not.EqualTo(landscapeWithKeyboardBounds.Width).Within(10),
-            "Border width should differ between portrait and landscape with keyboard visible");
-        Assert.That(portraitWithKeyboardBounds.Height, Is.Not.EqualTo(landscapeWithKeyboardBounds.Height).Within(10),
-            "Border height should differ between portrait and landscape with keyboard visible");
-
-        // 8. Verify landscape has wider aspect ratio even with keyboard
-        var portraitAspectRatio = portraitWithKeyboardBounds.Height / portraitWithKeyboardBounds.Width;
-        var landscapeAspectRatio = landscapeWithKeyboardBounds.Height / landscapeWithKeyboardBounds.Width;
-
-        Assert.That(portraitAspectRatio, Is.GreaterThan(landscapeAspectRatio),
-            "Portrait should still have higher aspect ratio than landscape, even with keyboard visible");
-
-        // 9. Verify safe area insets adapted to landscape with keyboard
-        Assert.That(portraitWithKeyboardSafeArea, Is.Not.EqualTo(landscapeWithKeyboardSafeArea),
-            "Safe area insets should be different between portrait and landscape with keyboard");
-
-        // 10. Hide keyboard in landscape mode using proper dismiss method
-        App.DismissKeyboard();
-        Thread.Sleep(1000);
-
-        Assert.That(App.IsKeyboardShown(), Is.False, "Keyboard should be hidden in landscape mode");
-
-        // 11. Record landscape state with keyboard hidden
-        var landscapeWithoutKeyboardBounds = borderContent.GetRect();
-
-        Assert.That(App.IsKeyboardShown(), Is.False, "IsKeyboardShown should confirm keyboard is hidden");
-
-        // 12. Verify border expanded when keyboard was dismissed in landscape
-        Assert.That(landscapeWithoutKeyboardBounds.Height, Is.GreaterThan(landscapeWithKeyboardBounds.Height),
-            "Border should expand when keyboard is hidden in landscape mode");
-
-        // 13. Change back to portrait without keyboard
-        App.SetOrientationPortrait();
-        Thread.Sleep(2000); // Wait for orientation change and layout to settle
-
-        // 14. Record final portrait state without keyboard
-        var finalPortraitBounds = borderContent.GetRect();
-
-        // Verify back in portrait
-        Assert.That(finalPortraitBounds.Height, Is.GreaterThan(finalPortraitBounds.Width * 0.8),
-            "Should be back in portrait orientation");
-
-        // 15. Verify overall stability - border should be functional in final state
-        Assert.That(finalPortraitBounds.Width, Is.GreaterThan(0),
-            "Border should be visible in final portrait state");
-        Assert.That(finalPortraitBounds.Height, Is.GreaterThan(0),
-            "Border should be visible in final portrait state");
-
-        // 16. Verify no errors occurred during complex interaction
-        var testStatus = App.WaitForElement("TestStatus");
-        Assert.That(testStatus.GetText(), Does.Not.Contain("Error"),
-            "No errors should occur during orientation change with keyboard interaction");
-
-        // 17. Verify final state is stable (keyboard hidden)
-        Assert.That(App.IsKeyboardShown(), Is.False, "Keyboard should remain hidden in final state");
-    }
-#endif
 }
 #endif

--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -223,7 +223,7 @@ internal static class SafeAreaExtensions
         }
         else
         {
-            newWindowInsets = windowInsets;            
+            newWindowInsets = windowInsets;
         }
 
         // Fallback: return the base safe area for legacy views
@@ -234,33 +234,28 @@ internal static class SafeAreaExtensions
     {
         // Edge-to-edge content - no safe area padding
         if (safeAreaRegion == SafeAreaRegions.None)
-        {
             return 0;
-        }
 
-        // Handle SoftInput specifically - only apply keyboard insets for bottom edge when keyboard is showing
-        if (isKeyboardShowing && edge == 3)
+        // Handle SoftInput specifically for bottom edge when keyboard is showing
+        if (edge == 3 && SafeAreaEdges.IsSoftInput(safeAreaRegion))
         {
-            // Always apply keyboard insets when keyboard is showing to prevent content overlap
-            // Use keyboard height or original safe area, whichever is larger
-            var keyboardInset = keyBoardInsets.Bottom;
-            if (SafeAreaEdges.IsSoftInput(safeAreaRegion))
-                return Math.Max(keyboardInset, originalSafeArea);
-
-            // For non-SoftInput regions, still apply keyboard padding to prevent overlap
-            // unless explicitly set to None region
-            if (safeAreaRegion != SafeAreaRegions.None)
-                return Math.Max(keyboardInset, originalSafeArea);
-
-            return keyboardInset;
+            return HandleSoftInputRegion(safeAreaRegion, originalSafeArea, isKeyboardShowing, keyBoardInsets);
         }
 
-        // All other regions respect safe area in some form
-        // This includes:
-        // - Default: Platform default behavior
-        // - All: Obey all safe area insets  
-        // - Container: Content flows under keyboard but stays out of bars/notch
-        // - Any combination of the above flags
+        // All other regions respect safe area (Default, All, Container, etc.)
         return originalSafeArea;
+    }
+
+    static double HandleSoftInputRegion(SafeAreaRegions safeAreaRegion, double originalSafeArea, bool isKeyboardShowing, SafeAreaPadding keyBoardInsets)
+    {
+        if (!isKeyboardShowing)
+        {
+            // When keyboard is hidden, only apply safe area for "All" regions
+            return safeAreaRegion == SafeAreaRegions.All ? originalSafeArea : 0;
+        }
+
+        // When keyboard is showing, use the larger of keyboard inset or original safe area
+        var keyboardInset = keyBoardInsets.Bottom;
+        return Math.Max(keyboardInset, originalSafeArea);
     }
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request primarily removes Android-specific test exclusion directives (`#if TEST_FAILS_ON_ANDROID` and related `#endif`) from several test files, making previously excluded tests run on Android. Additionally, it refactors the safe area logic for handling keyboard insets on Android, simplifying and improving the calculation for the bottom edge when the keyboard is visible.

**Test coverage improvements:**

* Removed `#if TEST_FAILS_ON_ANDROID` preprocessor directives from `Issue28986.cs`, `Issue28986_ContentPage.cs`, and `Issue28986_SafeAreaBorderOrientation.cs`, enabling tests that were previously skipped on Android to now run on that platform. [[1]](diffhunk://#diff-66b7183bd94ed13552dfccd919d52c49526ab42bdf7dc6b01a014199eb2a6c52L100) [[2]](diffhunk://#diff-66b7183bd94ed13552dfccd919d52c49526ab42bdf7dc6b01a014199eb2a6c52L131) [[3]](diffhunk://#diff-8df106d1f95d28d5ad94b37f88eee64e50def8284bdf837ed8154444c51cbc9aL100-L101) [[4]](diffhunk://#diff-8df106d1f95d28d5ad94b37f88eee64e50def8284bdf837ed8154444c51cbc9aL132) [[5]](diffhunk://#diff-fae5a575c10e19df39bb4e9b8ffb2ac29073acc20c317197edbc0cb3995aa612L227) [[6]](diffhunk://#diff-fae5a575c10e19df39bb4e9b8ffb2ac29073acc20c317197edbc0cb3995aa612L323-L433)

**Safe area logic refactoring:**

* Simplified the logic in `SafeAreaExtensions.cs` by removing a special case for `SoftInput.AdjustPan` and refactoring how the bottom safe area is calculated when the keyboard is showing, delegating to a new helper method for clarity and correctness. [[1]](diffhunk://#diff-87ce5a154873af90beed753b747eb597ff054c452499562b7b519988c12ee897L65-L78) [[2]](diffhunk://#diff-87ce5a154873af90beed753b747eb597ff054c452499562b7b519988c12ee897L251-R260)
* Introduced the `HandleSoftInputRegion` helper method to ensure the bottom safe area uses the larger of the keyboard inset or the original safe area when the keyboard is visible, and applies safe area only for "All" regions when the keyboard is hidden.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

## Output
| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/7ef609f5-5d8f-46ba-802f-c0ea9dab3fad"> | <video src="https://github.com/user-attachments/assets/02c3b0a4-729f-4bc8-ae6e-6e460f785639">|



