### PR TITLE
[NET11.0][Editor] Implemented Completed command

### DIFF
--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using static Microsoft.Maui.Primitives.Dimension;
@@ -57,6 +58,12 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="VerticalTextAlignment"/>.</summary>
 		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(Editor), TextAlignment.Start);
 
+		/// <summary>Bindable property for <see cref="ReturnCommand"/>.</summary>
+		public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(nameof(ReturnCommand), typeof(ICommand), typeof(Editor), default(ICommand));
+
+		/// <summary>Bindable property for <see cref="ReturnCommandParameter"/>.</summary>
+		public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(nameof(ReturnCommandParameter), typeof(object), typeof(Editor), default(object));
+
 		readonly Lazy<PlatformConfigurationRegistry<Editor>> _platformConfigurationRegistry;
 
 		/// <summary>Gets or sets a value that controls whether the editor will change size to accommodate input as the user enters it. This is a bindable property.</summary>
@@ -86,6 +93,26 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (TextAlignment)GetValue(VerticalTextAlignmentProperty); }
 			set { SetValue(VerticalTextAlignmentProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the command to run when the editor text is completed.
+		/// This is a bindable property.
+		/// </summary>
+		public ICommand ReturnCommand
+		{
+			get => (ICommand)GetValue(ReturnCommandProperty);
+			set => SetValue(ReturnCommandProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets the parameter object for the <see cref="ReturnCommand" /> that can be used to provide extra information.
+		/// This is a bindable property.
+		/// </summary>
+		public object ReturnCommandParameter
+		{
+			get => GetValue(ReturnCommandParameterProperty);
+			set => SetValue(ReturnCommandParameterProperty, value);
 		}
 
 
@@ -128,7 +155,17 @@ namespace Microsoft.Maui.Controls
 		/// <remarks>For internal use only. This API can be changed or removed without notice at any time.</remarks>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendCompleted()
-			=> Completed?.Invoke(this, EventArgs.Empty);
+		{
+			if (IsEnabled)
+			{
+				Completed?.Invoke(this, EventArgs.Empty);
+
+				if (ReturnCommand != null && ReturnCommand.CanExecute(ReturnCommandParameter))
+				{
+					ReturnCommand.Execute(ReturnCommandParameter);
+				}
+			}
+		}
 
 		protected override void OnTextChanged(string oldValue, string newValue)
 		{

--- a/src/Controls/src/Core/Editor/Editor.cs
+++ b/src/Controls/src/Core/Editor/Editor.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Maui.Controls
 			{
 				Completed?.Invoke(this, EventArgs.Empty);
 
-				if (ReturnCommand != null && ReturnCommand.CanExecute(ReturnCommandParameter))
+				if (ReturnCommand is not null && ReturnCommand.CanExecute(ReturnCommandParameter))
 				{
 					ReturnCommand.Execute(ReturnCommandParameter);
 				}

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -70,3 +70,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionBadge(Microsoft.Maui.Controls.ShellSection shellSection, int index) -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -70,3 +70,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -70,3 +70,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -71,3 +71,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -67,3 +67,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -67,3 +67,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -58,3 +58,9 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/tests/Core.UnitTests/EditorTests.cs
+++ b/src/Controls/tests/Core.UnitTests/EditorTests.cs
@@ -1,3 +1,4 @@
+using System.Windows.Input;
 using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -48,6 +49,64 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			Editor editor = new Editor();
 			Assert.False(editor.IsReadOnly);
+		}
+
+		[Fact]
+		public void CompletedCommandTest()
+		{
+			var editor = new Editor();
+			var parameter = new object();
+			object commandExecuted = null;
+			ICommand cmd = new Command(() => commandExecuted = parameter);
+
+			editor.ReturnCommand = cmd;
+			editor.ReturnCommandParameter = parameter;
+			editor.SendCompleted();
+
+			Assert.Equal(commandExecuted, parameter);
+		}
+
+		[Fact]
+		public void CompletedCommandNotExecutedWhenDisabled()
+		{
+			int counter = 0;
+			var editor = new Editor();
+			Command cmd = new Command(() => counter++);
+
+			editor.ReturnCommand = cmd;
+			editor.IsEnabled = false;
+			editor.SendCompleted();
+
+			Assert.Equal(0, counter);
+		}
+
+		[Fact]
+		public void CompletedCommandNotExecutedWhenCanExecuteReturnsFalse()
+		{
+			int counter = 0;
+			var editor = new Editor();
+			Command cmd = new Command(() => counter++, () => false);
+
+			editor.ReturnCommand = cmd;
+			editor.SendCompleted();
+
+			Assert.Equal(0, counter);
+		}
+
+		[Fact]
+		public void CompletedEventAndCommandBothFire()
+		{
+			var editor = new Editor();
+			int eventFired = 0;
+			int commandFired = 0;
+
+			editor.Completed += (s, e) => eventFired++;
+			editor.ReturnCommand = new Command(() => commandFired++);
+
+			editor.SendCompleted();
+
+			Assert.Equal(1, eventFired);
+			Assert.Equal(1, commandFired);
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request adds new command support to the `Editor` control, allowing developers to bind an `ICommand` that will be executed when the editor's text is completed (e.g., when the user presses the return key). It introduces new bindable properties for the command and its parameter, updates the completion logic to execute the command, and adds unit tests to ensure the new functionality works as expected.

**New Editor Command Support:**

* Added two new bindable properties to `Editor`: `ReturnCommand` (of type `ICommand`) and `ReturnCommandParameter` (of type `object`). These allow developers to bind a command and an optional parameter that will be executed when the editor completes input. [[1]](diffhunk://#diff-e1e01bd8d7674e0d2b75effc62926da199a7dd860ddf89326477c2ea061dff15R61-R66) [[2]](diffhunk://#diff-e1e01bd8d7674e0d2b75effc62926da199a7dd860ddf89326477c2ea061dff15R89-R108)
* Updated the `SendCompleted` method in `Editor` to execute the bound `ReturnCommand` (with its parameter) if it is set, the editor is enabled, and the command can execute. The original `Completed` event still fires as before.

**Public API and Platform Support:**

* Registered the new properties and accessors in the public API files for all supported platforms, ensuring the new command functionality is available and discoverable in the public API surface. [[1]](diffhunk://#diff-4731d7bdf78f0e9d2a7a64d6f56502e3d2095313d039e7f09c0e7d1552471f8eR2-R7) [[2]](diffhunk://#diff-793476570313a2965972f9be2c01f3eaaf5eec16dfab1b6b7e34cd5473af4277R2-R7) [[3]](diffhunk://#diff-b98fb401b945e281e04d9aabd0695677c639da1423ae935f1e521e88e8cae021R2-R7) [[4]](diffhunk://#diff-923a9c83577000b182ef448083ba67a73bd622126eafbd11d265afe0e2387a68R2-R7) [[5]](diffhunk://#diff-3324c5c5383447dd9cdd61dcbf1d33296a6c74dbcacacbb137989fc7f349845fR2-R7) [[6]](diffhunk://#diff-a4c05859d4a21178412f770adceb3ecec389283dee69e54a035f6768a5b54f24R235-R238) [[7]](diffhunk://#diff-a4c05859d4a21178412f770adceb3ecec389283dee69e54a035f6768a5b54f24R465-R466)

**Unit Testing:**

* Added comprehensive unit tests for the new command functionality, including tests for command execution, command not executing when the editor is disabled, command not executing when `CanExecute` returns false, and ensuring both the `Completed` event and the command fire when appropriate. [[1]](diffhunk://#diff-670678b0d04fa4a48fe8bd5b05698746a9d594f40285718b51e3c4040f87ed80R1) [[2]](diffhunk://#diff-670678b0d04fa4a48fe8bd5b05698746a9d594f40285718b51e3c4040f87ed80R53-R110)

Reference: https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Entry/Entry.cs

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #7775

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
