### PR TITLE
[iOS26][NavigationPage] Updated nav bar appearance logic for iOS26

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -589,6 +589,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			bool shouldHide = NavPage.OnThisPlatform().HideNavigationBarSeparator();
 
+			if (OperatingSystem.IsIOSVersionAtLeast(26))
+			{
+				bool isStatusBarHiddenExplicitlySet = NavPage.IsSet(PrefersStatusBarHiddenProperty);
+				if(!isStatusBarHiddenExplicitlySet)
+                {
+                    shouldHide = true;
+                }
+			}
+
 			// Just setting the ShadowImage is good for iOS11
 			if (_defaultNavBarShadowImage == null)
 				_defaultNavBarShadowImage = NavigationBar.ShadowImage;
@@ -646,7 +655,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void UpdateTranslucent()
 		{
 #pragma warning disable CS0618 // Type or member is obsolete
-			NavigationBar.Translucent = NavPage.OnThisPlatform().IsNavigationBarTranslucent();
+			if (OperatingSystem.IsIOSVersionAtLeast(26))
+			{
+				bool isNavigationBarTranslucentExplicitlySet = NavPage.IsSet(IsNavigationBarTranslucentProperty);
+				if (isNavigationBarTranslucentExplicitlySet)
+				{
+					NavigationBar.Translucent = NavPage.OnThisPlatform().IsNavigationBarTranslucent();
+				}
+			}
+			else
+			{
+				NavigationBar.Translucent = NavPage.OnThisPlatform().IsNavigationBarTranslucent();
+			}
 #pragma warning restore CS0618 // Type or member is obsolete
 		}
 
@@ -800,8 +820,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				var navigationBarAppearance = NavigationBar.StandardAppearance;
 				if (_currentBarBackgroundColor is null)
 				{
-					navigationBarAppearance.ConfigureWithOpaqueBackground();
-					navigationBarAppearance.BackgroundColor = Maui.Platform.ColorExtensions.BackgroundColor;
+					if (!OperatingSystem.IsIOSVersionAtLeast(26))
+					{
+						navigationBarAppearance.ConfigureWithOpaqueBackground();
+						navigationBarAppearance.BackgroundColor = Maui.Platform.ColorExtensions.BackgroundColor;
+					}
 
 					var parentingViewController = GetParentingViewController();
 					parentingViewController?.SetupDefaultNavigationBarAppearance();
@@ -1064,7 +1087,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				// We only check height because the navigation bar constrains vertical space (44pt height),
 				// but allows horizontal flexibility. Width can vary based on icon design and content,
 				// while height must fit within the fixed navigation bar bounds to avoid clipping.
-				
+
 				// if the image is bigger than the default available size, resize it
 				if (icon is not null)
 				{

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -592,10 +592,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (OperatingSystem.IsIOSVersionAtLeast(26))
 			{
 				bool isStatusBarHiddenExplicitlySet = NavPage.IsSet(PrefersStatusBarHiddenProperty);
-				if(!isStatusBarHiddenExplicitlySet)
-                {
-                    shouldHide = true;
-                }
+				if (!isStatusBarHiddenExplicitlySet)
+				{
+					shouldHide = true;
+				}
 			}
 
 			// Just setting the ShadowImage is good for iOS11
@@ -657,6 +657,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 #pragma warning disable CS0618 // Type or member is obsolete
 			if (OperatingSystem.IsIOSVersionAtLeast(26))
 			{
+				// iOS 26 introduced Liquid Glass design with translucent nav bars by default.
+				// Only force opaque appearance if background color is explicitly set.
 				bool isNavigationBarTranslucentExplicitlySet = NavPage.IsSet(IsNavigationBarTranslucentProperty);
 				if (isNavigationBarTranslucentExplicitlySet)
 				{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Introduces conditional logic for iOS 26 and above to handle navigation bar separator visibility and translucency based on whether properties are explicitly set. Also updates navigation bar appearance configuration to skip certain steps on iOS 26+.

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/a525b9cc-68ff-4b5f-9eb5-a98e9b717763" width="300px"></video>|<video src="https://github.com/user-attachments/assets/402c2ab7-a46a-4452-90f0-19c62ae5cea2" width="300px"></video>|

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
