### PR TITLE
Update WindowsAppSDK to 1.8

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -122,7 +122,8 @@
 
   <!-- Tell typescript to stop deleting everything before building the next TFM -->
   <Target Name="TypeScriptDeleteOutputFromOtherConfigs" />
-  <!-- Don't include any JS files in the Content, we will embed it -->
+  <!-- Don't add any outputs to any item group, we are embedding things manually -->
   <Target Name="GetTypeScriptOutputForPublishing" />
+  <Target Name="GetTypeScriptCopyToOutputDirectoryItems" />
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.8.250916003</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.8.251003001</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,8 +69,8 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.7.250909003</MicrosoftWindowsAppSDKPackageVersion>
-    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.8.250916003</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
-    <MicrosoftWindowsAppSDKPackageVersion>1.8.251003001</MicrosoftWindowsAppSDKPackageVersion>
+    <MicrosoftWindowsAppSDKPackageVersion>1.8.251106002</MicrosoftWindowsAppSDKPackageVersion>
     <MicrosoftWindowsSDKBuildToolsPackageVersion>10.0.26100.4654</MicrosoftWindowsSDKBuildToolsPackageVersion>
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>

--- a/eng/devices/windows.cake
+++ b/eng/devices/windows.cake
@@ -80,7 +80,6 @@ Task("GenerateMsixCert")
 	var currentUserMyStore = new X509Store("My", StoreLocation.CurrentUser);
 	currentUserMyStore.Open(OpenFlags.ReadWrite);
 	certificateThumbprint = localTrustedPeopleStore.Certificates.FirstOrDefault(c => c.Subject.Contains(certCN))?.Thumbprint;
-	Information("Cert thumbprint: " + certificateThumbprint ?? "null");
 
 	if (string.IsNullOrEmpty(certificateThumbprint))
 	{
@@ -100,7 +99,7 @@ Task("GenerateMsixCert")
 		req.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
 		req.CertificateExtensions.Add(
 			new X509KeyUsageExtension(
-				X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.NonRepudiation,
+				X509KeyUsageFlags.DigitalSignature,
 				false));
 
 		req.CertificateExtensions.Add(
@@ -120,6 +119,8 @@ Task("GenerateMsixCert")
 
 	localTrustedPeopleStore.Close();
 	currentUserMyStore.Close();
+
+	Information("Cert thumbprint: " + certificateThumbprint ?? "null");
 });
 
 Task("buildOnly")

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -13,9 +13,6 @@
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
 		<NoWarn>$(NoWarn);CA1416</NoWarn>
-		<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-		<!-- Disable PRI generation to avoid conflicts with Core project's PRI file -->
-		<AppxGeneratePriEnabled>false</AppxGeneratePriEnabled>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -39,6 +39,7 @@
     <Compile Include="**\*.windows.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.windows.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <PackageReference Include="Microsoft.Web.WebView2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

--- a/src/Graphics/src/Graphics.Skia/Graphics.Skia.csproj
+++ b/src/Graphics/src/Graphics.Skia/Graphics.Skia.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <PackageReference Include="SkiaSharp.Views.WinUI" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -40,7 +40,6 @@
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
@@ -167,8 +167,8 @@ public class WindowsTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.Publish(projectFile, config, framework: $"{framework}-windows10.0.19041.0", properties: BuildProps),
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
-		var rid = usesRidGraph ? "win10-x64" : "win-x64";
-		var assetsRoot = Path.Combine(projectDir, $"bin/{config}/{framework}-windows10.0.19041.0/{rid}/AppPackages/{name}_1.0.0.1_Test");
+		var rid = usesRidGraph ? "win10-x64/" : "";
+		var assetsRoot = Path.Combine(projectDir, $"bin/{config}/{framework}-windows10.0.19041.0/{rid}AppPackages/{name}_1.0.0.1_Test");
 
 		AssetExists($"{name}_1.0.0.1_x64.msix");
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/WindowsTemplateTest.cs
@@ -168,7 +168,10 @@ public class WindowsTemplateTest : BaseTemplateTests
 			$"Project {Path.GetFileName(projectFile)} failed to build. Check test output/attachments for errors.");
 
 		var rid = usesRidGraph ? "win10-x64/" : "";
-		var assetsRoot = Path.Combine(projectDir, $"bin/{config}/{framework}-windows10.0.19041.0/{rid}AppPackages/{name}_1.0.0.1_Test");
+		var prefix = framework == DotNetCurrent
+			? ""
+			: $"bin/{config}/{framework}-windows10.0.19041.0/";
+		var assetsRoot = Path.Combine(projectDir, $"{prefix}{rid}AppPackages/{name}_1.0.0.1_Test");
 
 		AssetExists($"{name}_1.0.0.1_x64.msix");
 


### PR DESCRIPTION
This pull request updates several project files to improve Windows platform support and modernize dependencies. The main changes involve updating Windows SDK package versions, adding the `Microsoft.WindowsAppSDK` package to relevant projects, and making adjustments for publishing and output handling.

Fixes https://github.com/dotnet/maui/issues/30858

Attempt 1 https://github.com/dotnet/maui/pull/30665
Attempt 2 https://github.com/dotnet/maui/pull/31281

**Dependency updates:**

* Updated `MicrosoftWindowsAppSDKPackageVersion` to `1.8.251003001` and `MicrosoftWindowsSDKBuildToolsPackageVersion` to `10.0.26100.4654` in `eng/Versions.props`, ensuring projects use the latest Windows SDKs.

**Project file improvements for Windows support:**

* Added `Microsoft.WindowsAppSDK` as a `PackageReference` to `Essentials.csproj`, `Graphics.Skia.csproj`, `Graphics.Win2D.csproj`, and duplicated in `Graphics.csproj` to ensure consistent Windows App SDK usage across graphics and essentials projects. [[1]](diffhunk://#diff-f243c2b1e6b28c505c27e07d7cb7a99764386669ce229c6b856c32ca67faaf00R42) [[2]](diffhunk://#diff-f23bffcd581d332998a68c42c65149fa447d2d3bed3d3c0ebf458e279f51e8dfR37) [[3]](diffhunk://#diff-dc41b78aa310aeed937c387045a62fb5f2ae3ce0ce3bb304a7c21782d30c25a6R30) [[4]](diffhunk://#diff-008ec03ba4c24598765341193edb331fec925e36d0f68e4d1bcbbea940790f9dR43)
* Removed Windows-specific property settings from `Controls.Xaml.csproj`, simplifying project configuration for Windows builds.

**Build and publishing process adjustments:**

* Added new MSBuild targets (`GetTypeScriptOutputForPublishing`, `GetTypeScriptCopyToOutputDirectoryItems`) in `Directory.Build.targets` to improve TypeScript output handling during publishing.
* Updated asset path logic in `WindowsTemplateTest.cs` to better handle runtime identifier (RID) directories when publishing packaged Windows apps.