### PR TITLE
Fix Project Icon and Tag Selection Issues in Project template (DeveloperBalance Sample)

### DIFF
--- a/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
@@ -141,7 +141,14 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 			Description = _project.Description;
 			Tasks = _project.Tasks;
 
-			Icon.Icon = _project.Icon;
+			foreach (var icon in Icons)
+			{
+				if (icon.Icon == _project.Icon)
+				{
+					Icon = icon;
+					break;
+				}
+			}
 
 			Categories = await _categoryRepository.ListAsync();
 			Category = Categories?.FirstOrDefault(c => c.ID == _project.CategoryID);

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -118,20 +118,19 @@
                             <Border StrokeShape="RoundRectangle 22" 
                                 HeightRequest="44" 
                                 VerticalOptions="Center"
-                                BackgroundColor="Transparent"
                                 Padding="{OnPlatform '18,0,18,8',Android='18,0,18,0'}"
                                 SemanticProperties.Description="{Binding Title}">
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
                                         <VisualState x:Name="Normal">
                                             <VisualState.Setters>
-                                                <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightSecondaryBackground},Dark={StaticResource DarkSecondaryBackground}}"/>
+                                                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightSecondaryBackground},Dark={StaticResource DarkSecondaryBackground}}"/>
                                                 <Setter TargetName="TagLabel" Property="Label.TextColor" Value="{AppThemeBinding Light={StaticResource DarkOnLightBackground},Dark={StaticResource LightOnDarkBackground}}"/>
                                             </VisualState.Setters>
                                         </VisualState>
                                         <VisualState x:Name="Selected">
                                             <VisualState.Setters>
-                                                <Setter Property="Background" Value="{Binding DisplayColor}"/>
+                                                <Setter Property="BackgroundColor" Value="{Binding DisplayColor}"/>
                                                 <Setter TargetName="TagLabel" Property="Label.TextColor" Value="{AppThemeBinding Light={StaticResource LightBackground},Dark={StaticResource DarkBackground}}"/>
                                             </VisualState.Setters>
                                         </VisualState>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -31,7 +31,9 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:Project">
-                    <Border SemanticProperties.Description="{Binding Name, StringFormat='{0}'}">
+                    <Border 
+                        Background="{AppThemeBinding Light={StaticResource LightSecondaryBackground},Dark={StaticResource DarkSecondaryBackground}}"
+                        SemanticProperties.Description="{Binding Name, StringFormat='{0}'}">
                         <VerticalStackLayout Padding="10">
                             <Label Text="{Binding Name}" FontSize="24" />
                             <Label Text="{Binding Description}" />

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/AppStyles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/AppStyles.xaml
@@ -252,7 +252,6 @@
 
     <Style TargetType="Border">
         <Setter Property="StrokeShape" Value="RoundRectangle 20"/>
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource LightSecondaryBackground},Dark={StaticResource DarkSecondaryBackground}}"/>
         <Setter Property="StrokeThickness" Value="0"/>
         <Setter Property="Padding" Value="{OnIdiom 15, Desktop=20}"/>
     </Style>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
Icon Selection:
When navigating to a ProjectDetailPage, modifying the icon selection, and saving, the selected icon repeats when navigating back to the ProjectPage.

Tag Selection:
When selecting tags, the gray background extends outside the item area.

### Root Cause
Icon Selection:
Previously, only the Icon property of the existing IconData object was updated. This approach modified the wrong object's property instead of selecting the correct IconData from the list, causing the UI to display an incorrect icon selection.

Tag Selection:
The Background property was used, which fills the entire container space, causing the gray color to overflow.

### Description of Change
Icon Selection:
Updated the code to assign the matching IconData object directly from the Icons list. This ensures the correct icon is selected, and the UI consistently reflects the chosen icon after saving and navigation.

Tag Selection:
Replaced Background with BackgroundColor to ensure the color is applied only to the intended item area.

### Associated Pull Requests
https://github.com/dotnet/maui-samples/pull/698

### Screenshots

Icon Selection:

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/0827495c-89e5-4d5e-b8c7-3823f6cd5710"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/04613422-4f91-4fb0-ab78-f427f6938fc5">) |

Tag Selection:

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="300" height="600"  src="https://github.com/user-attachments/assets/8d1b24f4-2495-4c0a-b00e-3cf2862c4820"> | <img width="300" height="600"  src="https://github.com/user-attachments/assets/f44b2915-3e3a-4b37-9012-4fa351966f42">) |