### PR TITLE
fix warnings in templates

### DIFF
--- a/src/Templates/src/templates/maui-mobile/AppShell.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/AppShell.xaml.cs
@@ -50,7 +50,7 @@ public partial class AppShell : Shell
 		await toast.Show(cts.Token);
 	}
 
-	private void SfSegmentedControl_SelectionChanged(object sender, Syncfusion.Maui.Toolkit.SegmentedControl.SelectionChangedEventArgs e)
+	private void SfSegmentedControl_SelectionChanged(object? sender, Syncfusion.Maui.Toolkit.SegmentedControl.SelectionChangedEventArgs e)
     {
 		Application.Current!.UserAppTheme = e.NewIndex == 0 ? AppTheme.Light : AppTheme.Dark;
     }

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml.cs
@@ -22,11 +22,11 @@ public partial class TaskView
 		set => SetValue(TaskCompletedCommandProperty, value);
 	}
 
-	private void CheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+	private void CheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 	{
-		var checkbox = (CheckBox)sender;
-		
-		if (checkbox.BindingContext is not ProjectTask task)
+		var checkbox = (CheckBox?)sender;
+
+		if (checkbox?.BindingContext is not ProjectTask task)
 			return;
 		
 		if (task.IsCompleted == e.Value)


### PR DESCRIPTION
### Description of Change

sample content template has wrong event handlers signatures, triggering warnings with XSG. Fix the signature
