### PR TITLE
Make MAUI instantly compilable on Linux

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>DOTNET_TFM-android</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 
     <!-- Note for MacCatalyst:

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>DOTNET_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 
         <!-- Note for MacCatalyst:

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>DOTNET_TFM-android</TargetFrameworks>
+		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 
 		<RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MauiLib1</RootNamespace>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>DOTNET_TFM-android</TargetFrameworks>
+		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 
 		<!-- Note for MacCatalyst:


### PR DESCRIPTION
This pull request updates the target framework selection logic in several MAUI project templates to improve cross-platform compatibility. The main change is to ensure that iOS and MacCatalyst targets are only included on platforms that support them, specifically excluding them when building on Linux.

Fixes #14088

**Cross-platform build logic updates:**

* In `MauiApp.1.csproj` (both `maui-blazor-solution` and `maui-blazor` templates), `MauiLib1.csproj`, and `MauiApp.1.csproj` (`maui-mobile` template), the default target frameworks are set to only Android. Additional target frameworks for iOS and MacCatalyst are now conditionally added only if the build is not running on Linux. [[1]](diffhunk://#diff-e6df9bb27d052339368a3cc2da336d27ecd3f5ea066e9713431667e7c995df44L4-R5) [[2]](diffhunk://#diff-e8e993df19d218df708567ef9344e43b923fb4c13bbec27a7b57c9b3653efaeeL4-R5) [[3]](diffhunk://#diff-5ce941f8cda449994a41056896936305152d7cd634ce40907a2c2463f164ff68L4-R5) [[4]](diffhunk://#diff-89619ac038b59e0a1637d71c540fb17308cae3fbbf85d6f185598f6b4650cd5eL4-R5)
* The Windows target framework is still conditionally added if the build is running on Windows, preserving existing Windows compatibility logic. [[1]](diffhunk://#diff-e6df9bb27d052339368a3cc2da336d27ecd3f5ea066e9713431667e7c995df44L4-R5) [[2]](diffhunk://#diff-e8e993df19d218df708567ef9344e43b923fb4c13bbec27a7b57c9b3653efaeeL4-R5) [[3]](diffhunk://#diff-5ce941f8cda449994a41056896936305152d7cd634ce40907a2c2463f164ff68L4-R5) [[4]](diffhunk://#diff-89619ac038b59e0a1637d71c540fb17308cae3fbbf85d6f185598f6b4650cd5eL4-R5)