### PR TITLE
Don't pack .NET Standard

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,6 +2,10 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <PropertyGroup>
+    <IsPackable Condition="$(TargetFramework.Contains('netstandard'))">false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Upgrade xunit's transitive NETStandard.Library dependency to avoid .NET Standard 1.x dependencies. -->
     <!-- <PackageReference Include="NETStandard.Library"


### PR DESCRIPTION
### Description of Change

.NET Standard was never supported, but just remained to help MSBuild tasks.

We don't need to actually ship them.