### PR TITLE
Duplicated the Empty option for backwards compat

### DIFF
--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/dotnetcli.host.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/dotnetcli.host.json
@@ -27,7 +27,7 @@
       "isHidden": true
     },
     "Empty": {
-      "longName": "empty"
+      "isHidden": true
     },
     "IncludeSampleContent": {
       "isHidden": true

--- a/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor-solution/.template.config/template.json
@@ -410,6 +410,12 @@
       "defaultValue": "false",
       "description": "Configures whether to omit sample pages and styling that demonstrate basic usage patterns."
     },
+    "empty": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Configures whether to omit sample pages and styling that demonstrate basic usage patterns."
+    },
     "auth": {
       "type": "generated",
       "generator": "constant",
@@ -426,7 +432,7 @@
     },
     "SampleContent": {
       "type": "computed",
-      "value": "(((IncludeSampleContent && (HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\"))) || ((!Empty && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))))"
+      "value": "(((IncludeSampleContent && (HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\"))) || ((!Empty && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\")) && (!empty && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))))"
     },
     "AllInteractive": {
       "type": "parameter",

--- a/src/Templates/src/templates/maui-blazor/.template.config/dotnetcli.host.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/dotnetcli.host.json
@@ -11,7 +11,7 @@
       "isHidden": true
     },
     "Empty": {
-      "longName": "empty"
+      "isHidden": true
     }
   },
   "usageExamples": [

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -172,9 +172,15 @@
       "defaultValue": "false",
       "description": "Configures whether to omit sample pages and styling that demonstrate basic usage patterns."
     },
+    "empty": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Configures whether to omit sample pages and styling that demonstrate basic usage patterns."
+    },
     "SampleContent": {
       "type": "computed",
-      "value": "(((IncludeSampleContent && (HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\"))) || ((!Empty && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))))"
+      "value": "(((IncludeSampleContent && (HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\"))) || ((!Empty && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\")) && (!empty && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))))"
     }
   },
   "forms": {


### PR DESCRIPTION
### Description of Change

As a side-effect of improving the CLI options in #31849, the CLI forces the TFM to be the older one if you use older template options.

An example is that in net9.0, there is a `--Empty` option. In .NET 10 we switched to `--empty`. If you use the former, it forces the template to be .NET 9. This change adds a hidden `--Empty` that allows old things to work if you use it, but still only shows the new ones.

There are several options that are still going to have issues, but some are not meant to be used by a user and should have been hidden since the start. Also, this is more of a convenience sine you can always override the template by passing `-f net10.0` if bad things happen.

The `--Empty` just is more common and has a higher chance of being used. 

Any issues that arise in future can be solved the same way and hopefully in .NET 11 we can start removing the duplicates. since they are hidden.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32197

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
