### PR TITLE
Fix for Shell back navigation using GoToAsync not triggering page transition to the previous page

### DIFF
--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -550,9 +550,9 @@ namespace Microsoft.Maui.Controls
 			if (globalRoutes == null || globalRoutes.Count == 0)
 			{
 				if (_navStack.Count == 2)
-					await OnPopAsync(animate ?? false);
+					await OnPopAsync(animate ?? true);
 				else
-					await OnPopToRootAsync(animate ?? false);
+					await OnPopToRootAsync(animate ?? true);
 
 				return;
 			}

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -446,6 +446,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task BackNavigationDefaultsToAnimatedWhenNotSpecified()
+		{
+			Routing.RegisterRoute(nameof(BackNavigationDefaultsToAnimatedWhenNotSpecified), typeof(ContentPage));
+			var shellContent = new ShellContent();
+			var shell = new TestShell(new TestFlyoutItem(new TestShellSection(shellContent)));
+			await shell.GoToAsync(nameof(BackNavigationDefaultsToAnimatedWhenNotSpecified));
+			
+			// Navigate back without specifying animate parameter (null)
+			await shell.GoToAsync("..");
+			
+			// Should default to animated (true) to match other navigation methods
+			Assert.True(shell.LastPopWasAnimated);
+		}
+
+		[Fact]
 		public async Task DefaultRoutesMaintainedIfThatsAllThereIs()
 		{
 			Routing.RegisterRoute(nameof(DefaultRoutesMaintainedIfThatsAllThereIs), typeof(ContentPage));


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- When navigating back from a page in Shell to the root page using GoToAsync(".."), the page transition animation is not visible.

### Root Cause

- The issue was caused by incorrect defaulting logic for the animate parameter in ShellSection.cs. When GoToAsync("..") was called without explicitly specifying the animate argument, the code used [animate ?? false](https://github.com/dotnet/maui/blob/12b049528a204874f2c44cde96ce32763943b88a/src/Controls/src/Core/Shell/ShellSection.cs#L552-L556), which incorrectly defaulted to no animation.

- This behavior was inconsistent with other navigation methods such as:

1. **PopAsync** () → defaults to true

https://github.com/dotnet/maui/blob/12b049528a204874f2c44cde96ce32763943b88a/src/Controls/src/Core/NavigationProxy.cs#L95-L98

2. **PopToRootAsync**() → defaults to true

https://github.com/dotnet/maui/blob/12b049528a204874f2c44cde96ce32763943b88a/src/Controls/src/Core/NavigationPage/NavigationPage.cs#L263-L266

3. **PushAsync**() → defaults to true

https://github.com/dotnet/maui/blob/12b049528a204874f2c44cde96ce32763943b88a/src/Controls/src/Core/NavigationPage/NavigationPage.cs#L297-L300


### Description of Change

- Changed the default value of the animate parameter to true for both OnPopAsync and OnPopToRootAsync methods in the navigation stack logic in ShellSection.cs, so that navigation transitions are now animated by default.


### Issues Fixed
Fixes #19074 

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output

| Platform | Before | After |
|----------|----------|----------|
| Android | <video src="https://github.com/user-attachments/assets/aa8f809b-54c0-4eab-9ec0-0e0ce54af3d6"> | <video src="https://github.com/user-attachments/assets/d5f90cd4-3d22-4164-98eb-ed46789ce1a9"> |
| iOS | <video src="https://github.com/user-attachments/assets/e6a40555-c052-4e09-8e89-26bc149177dd"> | <video src="https://github.com/user-attachments/assets/7ecccf7a-c39c-403c-9a3f-20ea9adffb5d"> |
