### PR TITLE
Improve templates for GA

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -19,8 +19,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 <!--#if (IncludeSampleContent) -->
-		<!-- https://github.com/CommunityToolkit/Maui/issues/2205 -->
-		<NoWarn>XC0103</NoWarn>
+		<!-- https://github.com/CommunityToolkit/Maui/issues/2921 -->
+		<NoWarn>NU1608</NoWarn>
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 <!--#endif -->
 
@@ -76,6 +76,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="MS_EXT_LOG_DEBUG_VERSION" />
 	</ItemGroup>
 

--- a/src/Templates/src/templates/maui-mobile/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiProgram.cs
@@ -27,15 +27,15 @@ public static class MauiProgram
 					handler.PlatformView.SingleSelectionFollowsFocus = false;
 				});
 
-            	Microsoft.Maui.Handlers.ContentViewHandler.Mapper.AppendToMapping(nameof(Pages.Controls.CategoryChart), (handler, view) =>
-            	{
-	                if (view is Pages.Controls.CategoryChart && handler.PlatformView is Microsoft.Maui.Platform.ContentPanel contentPanel)
-                	{
-                    	contentPanel.IsTabStop = true;
-                	}
-            	});
+				Microsoft.Maui.Handlers.ContentViewHandler.Mapper.AppendToMapping(nameof(Pages.Controls.CategoryChart), (handler, view) =>
+				{
+					if (view is Pages.Controls.CategoryChart && handler.PlatformView is Microsoft.Maui.Platform.ContentPanel contentPanel)
+					{
+						contentPanel.IsTabStop = true;
+					}
+				});
 #endif
-            })
+			})
 //+:cnd:noEmit
 #endif
 			.ConfigureFonts(fonts =>

--- a/src/Templates/src/templates/maui-mobile/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiProgram.cs
@@ -29,7 +29,7 @@ public static class MauiProgram
 
             	Microsoft.Maui.Handlers.ContentViewHandler.Mapper.AppendToMapping(nameof(Pages.Controls.CategoryChart), (handler, view) =>
             	{
-	                if (view is Pages.Controls.CategoryChart && handler.PlatformView is ContentPanel contentPanel)
+	                if (view is Pages.Controls.CategoryChart && handler.PlatformView is Microsoft.Maui.Platform.ContentPanel contentPanel)
                 	{
                     	contentPanel.IsTabStop = true;
                 	}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -11,9 +11,8 @@ public class SimpleTemplateTest : BaseTemplateTests
 	[TestCase("maui", DotNetPrevious, "Release", false, "", "")]
 	[TestCase("maui", DotNetCurrent, "Debug", false, "", "")]
 	[TestCase("maui", DotNetCurrent, "Release", false, "", "TrimMode=partial")]
-	// TODO: Re-enable tests once the Community Toolkit supports .NET 10. More details: https://github.com/dotnet/maui/issues/32151
-	//[TestCase("maui", DotNetCurrent, "Debug", false, "--sample-content", "")]
-	//[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content", "TrimMode=partial")]
+	[TestCase("maui", DotNetCurrent, "Debug", false, "--sample-content", "")]
+	[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content", "TrimMode=partial")]
 	//Debug not ready yet
 	//[TestCase("maui", DotNetCurrent, "Debug", false, "--sample-content", "UseMonoRuntime=false")]
 	//[TestCase("maui", DotNetCurrent, "Release", false, "--sample-content", "UseMonoRuntime=false EnablePreviewFeatures=true")]


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

* Improves https://github.com/dotnet/maui/issues/32198. 
   The issue is that the Maui Community Toolkit specifically excludes .NET 10 stable from the supported versions. This means that until https://github.com/CommunityToolkit/Maui/pull/2902 lands, there will be a warning.  
   This PR just hides the first error with conflicting versions. The warnings of incompatible MCT still exist.
   `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` will still fail the build.
   `<NoWarn>NU1608</NoWarn>` will hide the warnings
See also: https://github.com/CommunityToolkit/Maui/issues/2921 
* Fixes https://github.com/dotnet/maui/issues/32151

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->


Release backport: https://github.com/dotnet/maui/pull/32255