### PR TITLE
Fix VoiceOver doesnot announces the State of the ComboBox 

### DIFF
--- a/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
@@ -45,6 +45,9 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	bool _isBusy;
 
 	[ObservableProperty]
+	private bool _isCategoryPickerExpanded;
+
+	[ObservableProperty]
 	private List<IconData> _icons =	new List<IconData>
 	{
 		new IconData { Icon = FluentUI.ribbon_24_regular, Description = "Ribbon Icon" },
@@ -182,6 +185,18 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	{
 		await _taskRepository.SaveItemAsync(task);
 		OnPropertyChanged(nameof(HasCompletedTasks));
+	}
+
+	partial void  OnIsCategoryPickerExpandedChanged(bool value)
+	{
+		if (value)
+		{
+			SemanticScreenReader.Announce("State Expanded");
+		}
+		else
+		{
+			SemanticScreenReader.Announce("State Collapsed");
+		}
 	}
 
 	[RelayCommand]

--- a/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
@@ -191,11 +191,11 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	{
 		if (value)
 		{
-			SemanticScreenReader.Announce("State Expanded");
+			SemanticScreenReader.Announce("Category ComboBox, State Expanded");
 		}
 		else
 		{
-			SemanticScreenReader.Announce("State Collapsed");
+			SemanticScreenReader.Announce("Category ComboBox, State Collapsed");
 		}
 	}
 

--- a/src/Templates/src/templates/maui-mobile/PageModels/TaskDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/TaskDetailPageModel.cs
@@ -125,11 +125,11 @@ public partial class TaskDetailPageModel : ObservableObject, IQueryAttributable
 	{
 		if (value)
 		{
-			SemanticScreenReader.Announce("State Expanded");
+			SemanticScreenReader.Announce("Project ComboBox, State Expanded");
 		}
 		else
 		{
-			SemanticScreenReader.Announce("State Collapsed");
+			SemanticScreenReader.Announce("Project ComboBox, State Collapsed");
 		}
 	}
 

--- a/src/Templates/src/templates/maui-mobile/PageModels/TaskDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/TaskDetailPageModel.cs
@@ -34,6 +34,9 @@ public partial class TaskDetailPageModel : ObservableObject, IQueryAttributable
 	[ObservableProperty]
 	private bool _isExistingProject;
 
+	[ObservableProperty]
+	private bool _isProjectPickerExpanded;
+
 	public TaskDetailPageModel(ProjectRepository projectRepository, TaskRepository taskRepository, ModalErrorHandler errorHandler)
 	{
 		_projectRepository = projectRepository;
@@ -115,6 +118,18 @@ public partial class TaskDetailPageModel : ObservableObject, IQueryAttributable
 		{
 			_canDelete = value;
 			DeleteCommand.NotifyCanExecuteChanged();
+		}
+	}
+
+	partial void OnIsProjectPickerExpandedChanged(bool value)
+	{
+		if (value)
+		{
+			SemanticScreenReader.Announce("State Expanded");
+		}
+		else
+		{
+			SemanticScreenReader.Announce("State Collapsed");
 		}
 	}
 

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -36,15 +36,13 @@
                         Text="{Binding Description}" SemanticProperties.Description="Description" />
                 </sf:SfTextInputLayout>
 
-               <sf:SfTextInputLayout
+              <sf:SfTextInputLayout
                     Hint="Category"
-                    SemanticProperties.Description="ComboBox to Select Category"
-                    SemanticProperties.Hint="State Collapsed">
-                    <Picker SemanticProperties.Hint="Select the category for the project"
-                            ItemsSource="{Binding Categories}"
+                    SemanticProperties.Description="ComboBox to select a category. Activate to browse and select a category">
+                    <Picker ItemsSource="{Binding Categories}"
                             SelectedItem="{Binding Category}"
                             SelectedIndex="{Binding CategoryIndex}"
-                            SemanticProperties.Description="Category State Expanded"/>
+                            IsOpen="{Binding IsCategoryPickerExpanded, Mode=TwoWay}"/>
                 </sf:SfTextInputLayout>
 
                 <Label 

--- a/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
@@ -35,18 +35,16 @@
                         SemanticProperties.Hint="Indicates if this task is completed" />
                 </sf:SfTextInputLayout>
 
-                 <sf:SfTextInputLayout
+              <sf:SfTextInputLayout
                     IsVisible="{Binding IsExistingProject}"
-                    SemanticProperties.Description="ComboBox to select Project"
-                    SemanticProperties.Hint="State Collapsed"
+                    SemanticProperties.Description="ComboBox to select a project. Activate to browse and select a project"
                     Hint="Project">
                     <Picker 
                         ItemsSource="{Binding Projects}"
                         ItemDisplayBinding="{Binding Name, x:DataType=models:Project}"
                         SelectedItem="{Binding Project}"
                         SelectedIndex="{Binding SelectedProjectIndex}"
-                        SemanticProperties.Description="Project State Expanded"
-                        SemanticProperties.Hint="Which project this task belongs to"/>
+                        IsOpen="{Binding IsProjectPickerExpanded, Mode=TwoWay}"/>
                 </sf:SfTextInputLayout>
 
                 <Button 


### PR DESCRIPTION
### Issue Description:

VoiceOver does not read the ComboBox State correctly,  In the sample, the ComboBox behavior is implemented using SfTextInputLayout with a Picker. However, I have already implemented the semantic properties for picker , it was overriden by SfTextInputLayout,  the expectation is for VoiceOver to recognise and announce it as a ComboBox state.

### Description of change :
Update SemanticProperties using property changed on IsOpen property in picker to achieve the expected output.

> Note:
net9.0 PR - https://github.com/dotnet/maui-samples/pull/651

### Issues Fixed
Fixes [#30899 ](https://github.com/dotnet/maui/issues/30899)

### Tested the behaviour in the following platforms
- [ ] Android
- [ ] Windows
- [ ] iOS
- [x] Mac