### PR TITLE
Add tooltip text for Add button in Developer Balance template sample

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -97,6 +97,7 @@
         <controls:AddButton 
             IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
             Command="{Binding AddTaskCommand}"
+            ToolTipProperties.Text="Add task"
             SemanticProperties.Description="Add task" />
     </Grid>
 </ContentPage>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -184,7 +184,8 @@
         </ScrollView>
 
         <controls:AddButton Command="{Binding AddTaskCommand}" 
-                            SemanticProperties.Description="Add task" />
+                            SemanticProperties.Description="Add task" 
+                            ToolTipProperties.Text="Add task" />
     </Grid>
     
 </ContentPage>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -42,7 +42,8 @@
         </CollectionView>
 
         <controls:AddButton
-        Command="{Binding AddProjectCommand}" 
+        Command="{Binding AddProjectCommand}"
+        SemanticProperties.Description="Add project" 
         ToolTipProperties.Text="Add project" />
     </Grid>
 </ContentPage>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -42,6 +42,7 @@
         </CollectionView>
 
         <controls:AddButton
-        Command="{Binding AddProjectCommand}" />
+        Command="{Binding AddProjectCommand}" 
+        ToolTipProperties.Text="Add project" />
     </Grid>
 </ContentPage>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
No tooltip was shown for the Add Button in the Developer Balance sample. 

### Description of Change
Added tooltip text for the Add buttons in the Project and Tasks sections.

**MAUI-samples PR:** https://github.com/dotnet/maui-samples/pull/703

### Screenshots

| Mac | Windows |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/345e5754-01b1-49d6-8a76-84cb478a9e05"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/88d28356-ee17-47ec-b2df-6f826fc89ab8">) |