### PR TITLE
[XSG] Report binding diagnostics instead of propagating exceptions

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -155,7 +155,14 @@ namespace Microsoft.Maui.Controls
 		async void ApplyRelativeSourceBinding(RelativeBindingSource relativeSource, Element relativeSourceTarget, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
 #pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
 		{
-			await relativeSource.Apply(_expression, relativeSourceTarget, targetObject, targetProperty, specificity);
+			try
+			{
+				await relativeSource.Apply(_expression, relativeSourceTarget, targetObject, targetProperty, specificity);
+			}
+			catch (Exception ex)
+			{
+				BindingDiagnostics.SendBindingFailure(this, relativeSource, targetObject, targetProperty, "Binding", BindingExpression.ApplyingRelativeSourceBindingErrorMessage, relativeSource.Mode, ex.Message);
+			}
 		}
 
 		internal override BindingBase Clone()

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Controls
 		internal const string PropertyNotFoundErrorMessage = "'{0}' property not found on '{1}', target property: '{2}.{3}'";
 		internal const string CannotConvertTypeErrorMessage = "'{0}' cannot be converted to type '{1}'";
 		internal const string ParseIndexErrorMessage = "'{0}' could not be parsed as an index for a '{1}'";
+		internal const string ApplyingRelativeSourceBindingErrorMessage = "Applying relative source binding ('{0}') failed due to {1}";
 		static readonly char[] ExpressionSplit = new[] { '.' };
 
 		readonly List<BindingExpressionPart> _parts = new List<BindingExpressionPart>();

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -205,7 +205,14 @@ namespace Microsoft.Maui.Controls.Internals
 			RelativeBindingSource relativeSource, Element relativeSourceTarget, BindableObject targetObject, BindableProperty targetProperty, SetterSpecificity specificity)
 #pragma warning restore RECS0165 // Asynchronous methods should return a Task instead of void
 		{
-			await relativeSource.Apply(this, relativeSourceTarget, targetObject, targetProperty, specificity);
+			try
+			{
+				await relativeSource.Apply(this, relativeSourceTarget, targetObject, targetProperty, specificity);
+			}
+			catch (Exception ex)
+			{
+				BindingDiagnostics.SendBindingFailure(this, relativeSource, targetObject, targetProperty, "Binding", BindingExpression.ApplyingRelativeSourceBindingErrorMessage, relativeSource.Mode, ex.Message);
+			}
 		}
 
 		internal override BindingBase Clone()
@@ -316,6 +323,10 @@ namespace Microsoft.Maui.Controls.Internals
 					catch (Exception ex) when (ex is NullReferenceException || ex is KeyNotFoundException || ex is IndexOutOfRangeException || ex is ArgumentOutOfRangeException)
 					{
 					}
+					catch (Exception ex)
+					{
+						BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, "Binding", $"Exception thrown from getter: {ex.Message}");
+					}
 				}
 				if (!BindingExpressionHelper.TryConvert(ref value, property, property.ReturnType, true))
 				{
@@ -345,6 +356,10 @@ namespace Microsoft.Maui.Controls.Internals
 					// Ignore exceptions that are thrown when the source object is null or the property
 					// cannot be found. This can happen when the source object is a collection and the
 					// property is not found in the collection item.
+				}
+				catch (Exception ex)
+				{
+					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, "Binding", $"Exception thrown from setter: {ex.Message}");
 				}
 			}
 		}

--- a/src/Controls/tests/Xaml.UnitTests/BindingDiagnosticsInvalidTwoWayBinding.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/BindingDiagnosticsInvalidTwoWayBinding.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BindingDiagnosticsInvalidTwoWayBinding"
+             x:DataType="local:BindingDiagnosticsInvalidTwoWayBindingViewModel"
+             Title="BindingDiagnosticsInvalidTwoWayBinding">
+    <Entry Text="{Binding Text, Mode=TwoWay}" x:Name="Entry" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/BindingDiagnosticsInvalidTwoWayBinding.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BindingDiagnosticsInvalidTwoWayBinding.xaml.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class BindingDiagnosticsInvalidTwoWayBindingViewModel(string text)
+{
+	public string Text { get; } = text; // Read-only property
+}
+
+public partial class BindingDiagnosticsInvalidTwoWayBinding : ContentPage
+{
+	public BindingDiagnosticsInvalidTwoWayBinding() => InitializeComponent();
+
+	[TestFixture]
+#if !DEBUG
+	[Ignore("This test runs only in debug")]
+#endif
+	class Tests
+	{
+		bool enableDiagnosticsInitialState;
+
+		[SetUp]
+		public void Setup()
+		{
+			enableDiagnosticsInitialState = RuntimeFeature.EnableDiagnostics;
+			RuntimeFeature.EnableMauiDiagnostics = true;
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			RuntimeFeature.EnableMauiDiagnostics = enableDiagnosticsInitialState;
+		}
+
+		[Test]
+		public void TestSourceGen()
+		{
+			List<BindingBaseErrorEventArgs> failures = new();
+			BindingDiagnostics.BindingFailed += (o, e) => failures.Add(e);
+
+			var layout = new BindingDiagnosticsInvalidTwoWayBinding(XamlInflator.SourceGen)
+			{
+				BindingContext = new BindingDiagnosticsInvalidTwoWayBindingViewModel("Hello, World!")
+			};
+
+			// after the binding context is set, the Entry will try to push its value to the target through
+			// the two way binding
+			Assert.That(failures.Count, Is.EqualTo(1));
+			Assert.That(layout.Entry.Text, Is.EqualTo("Hello, World!"));
+			var failure = failures[0] as BindingErrorEventArgs;
+			Assert.That(failure.XamlSourceInfo.LineNumber, Is.EqualTo(8));
+			Assert.That(failure.Target, Is.TypeOf<Entry>());
+			Assert.That(failure.TargetProperty, Is.EqualTo(Entry.TextProperty));
+
+
+			layout.Entry.Text = "New Text";
+
+			// after the Entry's Text is changed, it will again try to push its value to the target through
+			// the two way binding
+			Assert.That(failures.Count, Is.EqualTo(2));
+			failure = failures[1] as BindingErrorEventArgs;
+			Assert.That(failure.XamlSourceInfo.LineNumber, Is.EqualTo(8));
+			Assert.That(failure.Target, Is.TypeOf<Entry>());
+			Assert.That(failure.TargetProperty, Is.EqualTo(Entry.TextProperty));
+		}
+
+		[Test]
+		public void Test()
+		{
+			List<BindingBaseErrorEventArgs> failures = new();
+			BindingDiagnostics.BindingFailed += (o, e) => failures.Add(e);
+
+			var layout = new BindingDiagnosticsInvalidTwoWayBinding(XamlInflator.XamlC)
+			{
+				BindingContext = new BindingDiagnosticsInvalidTwoWayBindingViewModel("Hello, World!")
+			};
+
+			// XamlC doesn't will not throw any exception or report any binding failures
+			// the binding will simply pull the value from the VM
+			Assert.That(failures.Count, Is.EqualTo(0));
+			Assert.That(layout.Entry.Text, Is.EqualTo("Hello, World!"));
+
+			layout.Entry.Text = "New Text";
+
+			// after the Entry's Text is changed, it will again try to push its value to the target through
+			// the two way binding - but nothing will happen
+			Assert.That(failures.Count, Is.EqualTo(0));
+			Assert.That(layout.Entry.Text, Is.EqualTo("New Text"));
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Bindings targetting read-only properties/fields compiled into `TypedBinding` through BindingSourceGen or through XamlSourceGen have setters which throw an exception because there is no way to set the value of the read-only binding. This chagne makes sure this exception is caught and transformed into `BindingDiagnostic` report.

Alternatively, we could  change the codegen to more closely match XamlC - a setter with empty body which doesn't report anything. Discussion in comments is welcome.

### Issues Fixed

Fixes erros reported in https://github.com/dotnet/maui/pull/32039
