### PR TITLE
Update warning to ignore in SimpleTemplateTest

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -46,7 +46,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 		{
 			warningsToIgnore = new string[]
 			{
-				"XC0103", // https://github.com/CommunityToolkit/Maui/issues/2205
+				"NU1608", // https://github.com/CommunityToolkit/Maui/issues/2921
 			};
 		}
 


### PR DESCRIPTION
This pull request makes a minor update to the list of warnings to ignore during the build process in the integration test suite.

* Updated the ignored warning code from `"XC0103"` to `"NU1608"` in the `Build` method of `SimpleTemplateTest.cs`, referencing a new related issue.