### PR TITLE
[release/10.0.1xx] Update warning to ignore in SimpleTemplateTest

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -46,7 +46,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 		{
 			warningsToIgnore = new string[]
 			{
-				"XC0103", // https://github.com/CommunityToolkit/Maui/issues/2205
+				"NU1608", // https://github.com/CommunityToolkit/Maui/issues/2921
 			};
 		}
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/maui/pull/32320

This pull request makes a minor update to the `SimpleTemplateTest.cs` integration test. The change updates the list of warnings to ignore during test execution.

* Testing configuration: Replaces the ignored warning code from `"XC0103"` to `"NU1608"` in the `warningsToIgnore` array, referencing a new related issue.