### PR TITLE
Fix TitleView covering content in iOS 26+ Shell

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -306,8 +306,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				if (titleView.Parent != null)
 				{
-					var view = new TitleViewContainer(titleView);
-					NavigationItem.TitleView = view;
+					// For iOS 26+ and pre-iOS 11, we use autoresizing masks and need to adjust the frame manually
+					if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+					{
+						if (ViewController?.NavigationController?.NavigationBar.Frame is CGRect frame)
+						{
+							var view = new TitleViewContainer(titleView, frame);
+							NavigationItem.TitleView = view;
+						}
+					}
+					else
+					{
+						var view = new TitleViewContainer(titleView);
+						NavigationItem.TitleView = view;
+					}
 				}
 				else
 				{
@@ -684,7 +696,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				MatchHeight = true;
 
-				if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))
+				// For iOS 26+, we need to use autoresizing masks instead of constraints to ensure proper TitleView display
+				if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				{
+					TranslatesAutoresizingMaskIntoConstraints = true;
+					AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
+				}
+				else if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))
 				{
 					TranslatesAutoresizingMaskIntoConstraints = false;
 				}
@@ -692,6 +710,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					TranslatesAutoresizingMaskIntoConstraints = true;
 					AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
+				}
+			}
+
+			internal TitleViewContainer(View view, CGRect? navigationBarFrame) : this(view)
+			{
+				if (navigationBarFrame is CGRect navigationBarFrameValue)
+				{
+					Frame = new CGRect(Frame.X, Frame.Y, navigationBarFrameValue.Width, navigationBarFrameValue.Height);
 				}
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32287.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32287.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       xmlns:ns="clr-namespace:Maui.Controls.Sample.Issues"
+       x:Class="Maui.Controls.Sample.Issues.Issue32287">
+
+  <Shell.TitleView>
+    <Label Text="I'm a custom title"
+           FontSize="20"
+           BackgroundColor="Green"
+           HorizontalTextAlignment="Center"
+           VerticalTextAlignment="Center"/>
+  </Shell.TitleView>
+
+  <ShellContent Title="Home page"
+                Route="MainPage">
+    <ShellContent.ContentTemplate>
+      <DataTemplate>
+        <ContentPage>
+          <Label Text="Hello, World!"
+                 VerticalOptions="Center"
+                 HorizontalOptions="Center"
+                 AutomationId="Label"/>
+        </ContentPage>
+      </DataTemplate>
+    </ShellContent.ContentTemplate>
+  </ShellContent>
+</Shell>
+  

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32287.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32287.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32287, "Using custom TitleView in AppShell causes shell content to be covered in iOS 26", PlatformAffected.iOS)]
+public partial class Issue32287 : Shell
+{
+	public Issue32287()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32287.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32287.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32287 : _IssuesUITest
+{
+	public Issue32287(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "Using custom TitleView in AppShell causes shell content to be covered in iOS 26";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void CustomTitleViewDoesNotCoverContent()
+	{
+		App.WaitForElement("Label");
+		VerifyScreenshot();
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Adjusts TitleViewContainer to use autoresizing masks and sets the frame for iOS 26+ and Mac Catalyst 26+ to prevent the custom TitleView from covering Shell content. Adds a test case and UI test for Issue 32287 to verify the fix.

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/bcc22b2c-c62e-4b06-836e-d0812c098370" width="300px"/>|<img src="https://github.com/user-attachments/assets/34b07af6-b9c0-4084-a0fd-14970481489b" width="300px"/>|

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32287

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
