### PR TITLE
[XSG] Speed up build times

### DIFF
--- a/src/Controls/src/SourceGen/AssemblyAttributes.cs
+++ b/src/Controls/src/SourceGen/AssemblyAttributes.cs
@@ -1,17 +1,17 @@
-using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 
-class AssemblyCaches(IReadOnlyList<XmlnsDefinitionAttribute> xmlnsDefinitions, IReadOnlyList<XmlnsPrefixAttribute> xmlnsPrefixes, IReadOnlyList<XmlnsDefinitionAttribute> globalGeneratedXmlnsDefinitions, IReadOnlyList<IAssemblySymbol> internalsVisible, bool allowImplicitXmlns)
+class AssemblyAttributes(IReadOnlyList<XmlnsDefinitionAttribute> xmlnsDefinitions, IReadOnlyList<XmlnsPrefixAttribute> xmlnsPrefixes, IReadOnlyList<XmlnsDefinitionAttribute> globalGeneratedXmlnsDefinitions, IReadOnlyList<IAssemblySymbol> internalsVisible, Dictionary<string, List<string>> clrNamespacesForXmlns, bool allowImplicitXmlns)
 {
-	public static readonly AssemblyCaches Empty = new([], [], [], [], false);
+	public static readonly AssemblyAttributes Empty = new([], [], [], [], [], false);
 
 	public IReadOnlyList<XmlnsDefinitionAttribute> XmlnsDefinitions { get; } = xmlnsDefinitions;
 	public IReadOnlyList<XmlnsPrefixAttribute> XmlnsPrefixes { get; } = xmlnsPrefixes;
 	public IReadOnlyList<XmlnsDefinitionAttribute> GlobalGeneratedXmlnsDefinitions { get; } = globalGeneratedXmlnsDefinitions;
 	public IReadOnlyList<IAssemblySymbol> InternalsVisible { get; } = internalsVisible;
+	public Dictionary<string, List<string>> ClrNamespacesForXmlns { get; } = clrNamespacesForXmlns;
 	public bool AllowImplicitXmlns { get; } = allowImplicitXmlns;
 }

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -20,7 +20,7 @@ static class CodeBehindCodeWriter
 
 	internal static readonly string[] accessModifiers = ["private", "public", "internal", "protected"];
 
-	public static string GenerateXamlCodeBehind(XamlProjectItemForCB? xamlItem, Compilation compilation, Action<Diagnostic>? reportDiagnostic, CancellationToken ct, AssemblyCaches xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
+	public static string GenerateXamlCodeBehind(XamlProjectItemForCB? xamlItem, Compilation compilation, Action<Diagnostic>? reportDiagnostic, CancellationToken ct, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
 	{
 		var projItem = xamlItem?.ProjectItem;
 
@@ -273,7 +273,7 @@ static class CodeBehindCodeWriter
 		return sb.ToString();
 	}
 
-	public static bool TryParseXaml(XamlProjectItemForCB parseResult, string uid, Compilation compilation, AssemblyCaches xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic, out string? accessModifier, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out ITypeSymbol? baseType, out IEnumerable<(string, string, string)>? namedFields)
+	public static bool TryParseXaml(XamlProjectItemForCB parseResult, string uid, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic, out string? accessModifier, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out ITypeSymbol? baseType, out IEnumerable<(string, string, string)>? namedFields)
 	{
 		accessModifier = null;
 		rootType = null;
@@ -389,7 +389,7 @@ static class CodeBehindCodeWriter
 		return string.Join(", ", warnings);
 	}
 
-	static IEnumerable<(string name, string type, string accessModifier)> GetNamedFields(XmlNode root, XmlNamespaceManager nsmgr, Compilation compilation, AssemblyCaches xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic)
+	static IEnumerable<(string name, string type, string accessModifier)> GetNamedFields(XmlNode root, XmlNamespaceManager nsmgr, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic)
 	{
 		var xPrefix = nsmgr.LookupPrefix(XamlParser.X2006Uri) ?? nsmgr.LookupPrefix(XamlParser.X2009Uri);
 		if (xPrefix == null)

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -322,7 +322,7 @@ static class CodeBehindCodeWriter
 			var typeArgs = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
 			try
 			{
-				var basetype = new XmlType(root.NamespaceURI, root.LocalName, typeArgs != null ? TypeArgumentsParser.ParseExpression(typeArgs, nsmgr, null) : null).GetTypeSymbol(null, compilation, xmlnsCache);
+				var basetype = new XmlType(root.NamespaceURI, root.LocalName, typeArgs != null ? TypeArgumentsParser.ParseExpression(typeArgs, nsmgr, null) : null).GetTypeSymbol(null, compilation, xmlnsCache, typeCache);
 			}
 			catch
 			{
@@ -348,7 +348,7 @@ static class CodeBehindCodeWriter
 
 		namedFields = GetNamedFields(root, nsmgr, compilation, xmlnsCache, typeCache, cancellationToken, reportDiagnostic);
 		var typeArguments = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
-		baseType = new XmlType(root.NamespaceURI, root.LocalName, typeArguments != null ? TypeArgumentsParser.ParseExpression(typeArguments, nsmgr, null) : null).GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache);
+		baseType = new XmlType(root.NamespaceURI, root.LocalName, typeArguments != null ? TypeArgumentsParser.ParseExpression(typeArguments, nsmgr, null) : null).GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache, typeCache);
 
 		// x:ClassModifier attribute
 		var classModifier = GetAttributeValue(root, "ClassModifier", XamlParser.X2006Uri, XamlParser.X2009Uri);
@@ -419,7 +419,7 @@ static class CodeBehindCodeWriter
 			if (!accessModifiers.Contains(accessModifier)) //quick validation
 				accessModifier = "private";
 
-			yield return (name ?? "", xmlType.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache)?.ToFQDisplayString() ?? "", accessModifier);
+			yield return (name ?? "", xmlType.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache, typeCache)?.ToFQDisplayString() ?? "", accessModifier);
 		}
 	}
 

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -20,7 +20,7 @@ static class CodeBehindCodeWriter
 
 	internal static readonly string[] accessModifiers = ["private", "public", "internal", "protected"];
 
-	public static string GenerateXamlCodeBehind(XamlProjectItemForCB? xamlItem, Compilation compilation, Action<Diagnostic>? reportDiagnostic, CancellationToken ct, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
+	public static string GenerateXamlCodeBehind(XamlProjectItemForCB? xamlItem, Compilation compilation, Action<Diagnostic>? reportDiagnostic, CancellationToken ct, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache)
 	{
 		var projItem = xamlItem?.ProjectItem;
 
@@ -273,7 +273,7 @@ static class CodeBehindCodeWriter
 		return sb.ToString();
 	}
 
-	public static bool TryParseXaml(XamlProjectItemForCB parseResult, string uid, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic, out string? accessModifier, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out ITypeSymbol? baseType, out IEnumerable<(string, string, string)>? namedFields)
+	public static bool TryParseXaml(XamlProjectItemForCB parseResult, string uid, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic, out string? accessModifier, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out INamedTypeSymbol? baseType, out IEnumerable<(string, string, string)>? namedFields)
 	{
 		accessModifier = null;
 		rootType = null;
@@ -389,7 +389,7 @@ static class CodeBehindCodeWriter
 		return string.Join(", ", warnings);
 	}
 
-	static IEnumerable<(string name, string type, string accessModifier)> GetNamedFields(XmlNode root, XmlNamespaceManager nsmgr, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic)
+	static IEnumerable<(string name, string type, string accessModifier)> GetNamedFields(XmlNode root, XmlNamespaceManager nsmgr, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache, CancellationToken cancellationToken, Action<Diagnostic>? reportDiagnostic)
 	{
 		var xPrefix = nsmgr.LookupPrefix(XamlParser.X2006Uri) ?? nsmgr.LookupPrefix(XamlParser.X2009Uri);
 		if (xPrefix == null)

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -94,7 +94,7 @@ public class CodeBehindGenerator : IIncrementalGenerator
 			.WithTrackingName(TrackingNames.XmlnsDefinitionsProviderForIC);
 
 		var xamlSourceProviderForIC = xamlProjectItemProviderForIC
-			.Combine(xmlnsDefinitionsProviderForIC, referenceTypeCacheProvider, compilationWithCodeBehindProvider)
+			.Combine(xmlnsDefinitionsProviderForIC, compilationWithCodeBehindProvider.Select(GetTypeCache), compilationWithCodeBehindProvider)
 			.WithTrackingName(TrackingNames.XamlSourceProviderForIC);
 
 		// Register the XAML pipeline for CodeBehind

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -273,7 +273,7 @@ $"""
 		return true;
 	}
 
-	static bool CanSourceGenXaml(XamlProjectItemForIC? xamlItem, Compilation compilation, SourceProductionContext context, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
+	static bool CanSourceGenXaml(XamlProjectItemForIC? xamlItem, Compilation compilation, SourceProductionContext context, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache)
 	{
 		ProjectItem? projItem;
 		if (xamlItem == null || (projItem = xamlItem.ProjectItem) == null)

--- a/src/Controls/src/SourceGen/Controls.SourceGen.csproj
+++ b/src/Controls/src/SourceGen/Controls.SourceGen.csproj
@@ -45,7 +45,6 @@
     <Compile Include="..\Xaml\XmlName.cs" Link="XmlName.cs" />
     <Compile Include="..\Xaml\XmlType.cs" Link="XmlType.cs" />
     <Compile Include="..\Xaml\XmlnsHelper.cs" Link="XmlnsHelper.cs" />
-    <Compile Include="..\Xaml\XmlTypeXamlExtensions.cs" Link="XmlTypeXamlExtensions.cs" />
     <Compile Include="..\..\..\Core\src\Services\Crc64.cs">
       <Link>Crc64.cs</Link>
     </Compile>

--- a/src/Controls/src/SourceGen/GeneratorHelpers.cs
+++ b/src/Controls/src/SourceGen/GeneratorHelpers.cs
@@ -369,9 +369,9 @@ static class GeneratorHelpers
 		}
 	}
 
-	public static IDictionary<XmlType, ITypeSymbol> GetTypeCache(Compilation compilation, CancellationToken cancellationToken) => new Dictionary<XmlType, ITypeSymbol>();
+	public static IDictionary<XmlType, INamedTypeSymbol> GetTypeCache(Compilation compilation, CancellationToken cancellationToken) => new Dictionary<XmlType, INamedTypeSymbol>();
 
-	public static (string? source, XamlProjectItemForCB? xamlItem, IList<Diagnostic>? diagnostics) GetSource((XamlProjectItemForCB? xamlItem, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, Compilation compilation) tuple, CancellationToken cancellationToken)
+	public static (string? source, XamlProjectItemForCB? xamlItem, IList<Diagnostic>? diagnostics) GetSource((XamlProjectItemForCB? xamlItem, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache, Compilation compilation) tuple, CancellationToken cancellationToken)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
 		var (xamlItem, xmlnsCache, typeCache, compilation) = tuple;

--- a/src/Controls/src/SourceGen/GeneratorHelpers.cs
+++ b/src/Controls/src/SourceGen/GeneratorHelpers.cs
@@ -45,7 +45,7 @@ static class GeneratorHelpers
 		return projectItem.Kind == "None" ? null : projectItem;
 	}
 
-    public static XamlProjectItemForIC? ComputeXamlProjectItemForIC((ProjectItem?, AssemblyCaches) itemAndCaches, CancellationToken cancellationToken)
+    public static XamlProjectItemForIC? ComputeXamlProjectItemForIC((ProjectItem?, AssemblyAttributes) itemAndCaches, CancellationToken cancellationToken)
 	{
 		var (projectItem, assemblyCaches) = itemAndCaches;
 		var text = projectItem?.AdditionalText.GetText(cancellationToken);
@@ -63,7 +63,7 @@ static class GeneratorHelpers
 		}
 	}
 
-	static SGRootNode? ParseXaml(string xaml, AssemblyCaches assemblyCaches)
+	static SGRootNode? ParseXaml(string xaml, AssemblyAttributes assemblyCaches)
 	{
 		List<string> warningDisableList = [];
 		var nsmgr = new XmlNamespaceManager(new NameTable());
@@ -112,9 +112,9 @@ static class GeneratorHelpers
 		return null;
 	}
 
-	public static XamlProjectItemForCB? ComputeXamlProjectItemForCB((ProjectItem?, AssemblyCaches) itemAndCaches, CancellationToken cancellationToken)
+	public static XamlProjectItemForCB? ComputeXamlProjectItemForCB((ProjectItem?, AssemblyAttributes) itemAndCaches, CancellationToken cancellationToken)
 	{
-		(ProjectItem? projectItem, AssemblyCaches xmlnsCache) = itemAndCaches;
+		(ProjectItem? projectItem, AssemblyAttributes xmlnsCache) = itemAndCaches;
 
 		if (projectItem == null)
 			return null;
@@ -156,7 +156,7 @@ static class GeneratorHelpers
 		return new XamlProjectItemForCB(projectItem, root, nsmgr);
 	}
 
-	public static (XmlNode?, XmlNamespaceManager) LoadXmlDocument(SourceText text, AssemblyCaches assemblyCaches, CancellationToken cancellationToken)
+	public static (XmlNode?, XmlNamespaceManager) LoadXmlDocument(SourceText text, AssemblyAttributes assemblyCaches, CancellationToken cancellationToken)
 	{
 		var nsmgr = new XmlNamespaceManager(new NameTable());
 		nsmgr.AddNamespace("__f__", XamlParser.MauiUri);
@@ -187,27 +187,26 @@ static class GeneratorHelpers
 		return (root, nsmgr);
 	}
 
-	public static AssemblyCaches GetAssemblyAttributes(Compilation compilation, CancellationToken cancellationToken)
+	public static AssemblyAttributes GetAssemblyAttributes(Compilation compilation, CancellationToken cancellationToken)
 	{
 		// [assembly: XmlnsDefinition]
 		INamedTypeSymbol? xmlnsDefinitonAttribute = compilation.GetTypesByMetadataName(typeof(XmlnsDefinitionAttribute).FullName)
-			.SingleOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
+			.FirstOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
 
 		// [assembly: InternalsVisibleTo]
 		INamedTypeSymbol? internalsVisibleToAttribute = compilation.GetTypeByMetadataName(typeof(InternalsVisibleToAttribute).FullName);
 
 		// [assembly: XmlnsPrefix]
 		INamedTypeSymbol? xmlnsPrefixAttribute = compilation.GetTypesByMetadataName(typeof(XmlnsPrefixAttribute).FullName)
-			.SingleOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
+			.FirstOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
 
 		// [assembly: AllowImplicitXmlnsDeclaration]
 		INamedTypeSymbol? allowImplicitXmlnsAttribute = compilation.GetTypesByMetadataName(typeof(Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute).FullName)
-			.SingleOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
+			.FirstOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
 
-		if (xmlnsDefinitonAttribute is null || internalsVisibleToAttribute is null)
-		{
-			return AssemblyCaches.Empty;
-		}
+		if (xmlnsDefinitonAttribute is null || internalsVisibleToAttribute is null)		
+			return AssemblyAttributes.Empty;
+		
 
 		var xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
 		var internalsVisible = new List<IAssemblySymbol>();
@@ -242,20 +241,15 @@ static class GeneratorHelpers
 					// [assembly: XmlnsDefinition]
 					var xmlnsDef = new XmlnsDefinitionAttribute(attr.ConstructorArguments[0].Value as string, attr.ConstructorArguments[1].Value as string);
 					if (attr.NamedArguments.Length == 1 && attr.NamedArguments[0].Key == nameof(XmlnsDefinitionAttribute.AssemblyName))
-					{
+
 						xmlnsDef.AssemblyName = attr.NamedArguments[0].Value.Value as string;
-					}
 					else
-					{
 						xmlnsDef.AssemblyName = assembly.Name;
-					}
 
 					//only add globalxmlns definition from the current assembly
 					if (xmlnsDef.XmlNamespace == XamlParser.MauiGlobalUri
 						&& !SymbolEqualityComparer.Default.Equals(assembly, compilation.Assembly))
-					{
 						continue;
-					}
 
 					xmlnsDefinitions.Add(xmlnsDef);
 				}
@@ -263,9 +257,7 @@ static class GeneratorHelpers
 				{
 					// [assembly: InternalsVisibleTo]
 					if (attr.ConstructorArguments[0].Value is string assemblyName && new AssemblyName(assemblyName).Name == compilation.Assembly.Identity.Name)
-					{
 						internalsVisible.Add(assembly);
-					}
 				}
 				else if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, xmlnsPrefixAttribute))
 				{
@@ -287,8 +279,22 @@ static class GeneratorHelpers
 				globalGeneratedXmlnsDefinitions.Add(new XmlnsDefinitionAttribute(global.XmlNamespace, pointed.Target) { AssemblyName = pointed.AssemblyName });
 			}
 		}
+		IReadOnlyList<XmlnsDefinitionAttribute> xmlnsDefinitionsList = [.. xmlnsDefinitions.Distinct()];
+		Dictionary<string, List<string>> clrNamespacesForXmlns = [];
+		foreach (var xmlnsDef in xmlnsDefinitionsList)
+		{
+			if (!clrNamespacesForXmlns.TryGetValue(xmlnsDef.XmlNamespace, out var list))
+			{
+				list = new List<string>();
+				clrNamespacesForXmlns[xmlnsDef.XmlNamespace] = list;
+			}
+			if (!xmlnsDef.Target.StartsWith("http://") && !list.Contains(xmlnsDef.Target))
+			{
+				list.Add(xmlnsDef.Target);
+			}
+		}
 
-		return new AssemblyCaches([.. xmlnsDefinitions.Distinct()], xmlnsPrefixes, [.. globalGeneratedXmlnsDefinitions.Distinct()], internalsVisible, allowImplicitXmlns);
+		return new AssemblyAttributes(xmlnsDefinitionsList, xmlnsPrefixes, [.. globalGeneratedXmlnsDefinitions.Distinct()], internalsVisible, clrNamespacesForXmlns, allowImplicitXmlns);
 	}
 
 	static void ApplyTransforms(XmlNode node, string? targetFramework, XmlNamespaceManager nsmgr)
@@ -365,7 +371,7 @@ static class GeneratorHelpers
 
 	public static IDictionary<XmlType, ITypeSymbol> GetTypeCache(Compilation compilation, CancellationToken cancellationToken) => new Dictionary<XmlType, ITypeSymbol>();
 
-	public static (string? source, XamlProjectItemForCB? xamlItem, IList<Diagnostic>? diagnostics) GetSource((XamlProjectItemForCB? xamlItem, AssemblyCaches xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, Compilation compilation) tuple, CancellationToken cancellationToken)
+	public static (string? source, XamlProjectItemForCB? xamlItem, IList<Diagnostic>? diagnostics) GetSource((XamlProjectItemForCB? xamlItem, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, Compilation compilation) tuple, CancellationToken cancellationToken)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
 		var (xamlItem, xmlnsCache, typeCache, compilation) = tuple;

--- a/src/Controls/src/SourceGen/ITypeSymbolExtensions.Maui.cs
+++ b/src/Controls/src/SourceGen/ITypeSymbolExtensions.Maui.cs
@@ -35,7 +35,7 @@ static partial class ITypeSymbolExtensions
 		{
 			var typename = localname.Substring(0, dotIdx);
 			localname = localname.Substring(dotIdx + 1);
-			elementType = new XmlType(namespaceURI, typename, null).GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache)!;
+			elementType = new XmlType(namespaceURI, typename, null).GetTypeSymbol(context)!;
 			return true;
 		}
 		return false;

--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -17,7 +17,7 @@ static class InitializeComponentCodeWriter
 
 	public static string GeneratedCodeAttribute => $"[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"{typeof(InitializeComponentCodeWriter).Assembly.FullName}\", \"{typeof(InitializeComponentCodeWriter).Assembly.GetName().Version}\")]";
 
-	public static string GenerateInitializeComponent(XamlProjectItemForIC xamlItem, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyCaches xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
+	public static string GenerateInitializeComponent(XamlProjectItemForIC xamlItem, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
 	{
 		using (var codeWriter = new IndentedTextWriter(new StringWriter(CultureInfo.InvariantCulture), "\t") { NewLine = NewLine })
 		{

--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -89,7 +89,7 @@ static class InitializeComponentCodeWriter
 			{
 				var methodName = genSwitch ? "InitializeComponentSourceGen" : "InitializeComponent";
 				codeWriter.WriteLine($"private partial void {methodName}()");
-				xamlItem.Root!.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, out var baseType);
+				xamlItem.Root!.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, typeCache, out var baseType);
 				var sgcontext = new SourceGenContext(codeWriter, compilation, sourceProductionContext, xmlnsCache, typeCache, rootType!, baseType, xamlItem.ProjectItem);
 				using (newblock())
 				{

--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -17,7 +17,7 @@ static class InitializeComponentCodeWriter
 
 	public static string GeneratedCodeAttribute => $"[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"{typeof(InitializeComponentCodeWriter).Assembly.FullName}\", \"{typeof(InitializeComponentCodeWriter).Assembly.GetName().Version}\")]";
 
-	public static string GenerateInitializeComponent(XamlProjectItemForIC xamlItem, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
+	public static string GenerateInitializeComponent(XamlProjectItemForIC xamlItem, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache)
 	{
 		using (var codeWriter = new IndentedTextWriter(new StringWriter(CultureInfo.InvariantCulture), "\t") { NewLine = NewLine })
 		{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -34,7 +34,7 @@ internal class KnownMarkups
 		var typename = member.Substring(0, dotIdx);
 		var membername = member.Substring(dotIdx + 1);
 
-		var typeSymbol = typename.GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache, markupNode);
+		var typeSymbol = typename.GetTypeSymbol(context, markupNode);
 		if (typeSymbol == null)
 		{
 			//FIXME
@@ -91,7 +91,7 @@ internal class KnownMarkups
 			return null;
 		}
 
-		var typeSymbol = typeName!.GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache, xTypeNode);
+		var typeSymbol = typeName!.GetTypeSymbol(context, xTypeNode);
 		if (typeSymbol == null)
 		{
 			context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, null, $"Type not found {typeSymbol}"));
@@ -426,7 +426,7 @@ internal class KnownMarkups
 				return false;
 			}
 
-			if (!dataType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, out INamedTypeSymbol? symbol) && symbol is not null)
+			if (!dataType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out INamedTypeSymbol? symbol) && symbol is not null)
 			{
 				// TODO report the right diagnostic
 				context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, location, "Cannot resolve x:DataType type"));
@@ -482,7 +482,7 @@ internal class KnownMarkups
 		static bool DoesNotInheritDataType(ElementNode node, SourceGenContext context)
 		{
 			return GetParent(node) is ElementNode parentNode
-				&& parentNode.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, out INamedTypeSymbol? parentTypeSymbol)
+				&& parentNode.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out INamedTypeSymbol? parentTypeSymbol)
 				&& parentTypeSymbol is not null
 				&& node.TryGetPropertyName(parentNode, out XmlName propertyName)
 				&& parentTypeSymbol.GetAllProperties(propertyName.LocalName, context).FirstOrDefault() is IPropertySymbol propertySymbol

--- a/src/Controls/src/SourceGen/NodeSGExtensions.cs
+++ b/src/Controls/src/SourceGen/NodeSGExtensions.cs
@@ -576,7 +576,7 @@ static class NodeSGExtensions
 			var ttnode = (node as ElementNode)?.Properties[new XmlName("", "TargetType")];
 			//it's either a value
 			if (ttnode is ValueNode { Value: string tt })
-				return XmlTypeExtensions.GetTypeSymbol(tt, context.ReportDiagnostic, context.Compilation, context.XmlnsCache, node);
+				return XmlTypeExtensions.GetTypeSymbol(tt, context, node);
 			//or a x:Type that we parsed earlier
 			if (context.Types.TryGetValue(ttnode!, out var typeSymbol))
 				return typeSymbol;
@@ -604,7 +604,7 @@ static class NodeSGExtensions
 		}
 		else if (parts.Length == 2)
 		{
-			var typeSymbol = XmlTypeExtensions.GetTypeSymbol(parts[0], context.ReportDiagnostic, context.Compilation, context.XmlnsCache, node);
+			var typeSymbol = XmlTypeExtensions.GetTypeSymbol(parts[0], context, node);
 			string propertyName = parts[1];
 			return typeSymbol!.GetBindableProperty("", ref propertyName, out _, context, node)!;
 		}
@@ -640,7 +640,7 @@ static class NodeSGExtensions
 		else
 			typeName = target.XmlType;
 
-		return typeName!.GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache);
+		return typeName!.GetTypeSymbol(context);
 	}
 
 	public static bool RepresentsType(this INode node, string namespaceUri, string name)

--- a/src/Controls/src/SourceGen/SourceGenContext.cs
+++ b/src/Controls/src/SourceGen/SourceGenContext.cs
@@ -9,7 +9,7 @@ using static Microsoft.Maui.Controls.SourceGen.NodeSGExtensions;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 
-class SourceGenContext(IndentedTextWriter writer, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyAttributes assemblyCaches, IDictionary<XmlType, ITypeSymbol> typeCache, ITypeSymbol rootType, ITypeSymbol? baseType, ProjectItem projectItem)
+class SourceGenContext(IndentedTextWriter writer, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyAttributes assemblyCaches, IDictionary<XmlType, INamedTypeSymbol> typeCache, ITypeSymbol rootType, ITypeSymbol? baseType, ProjectItem projectItem)
 {
 	public SourceProductionContext SourceProductionContext => sourceProductionContext;
 	public IndentedTextWriter Writer => writer;
@@ -19,7 +19,7 @@ class SourceGenContext(IndentedTextWriter writer, Compilation compilation, Sourc
 	public Compilation Compilation => compilation;
 	public AssemblyAttributes XmlnsCache => assemblyCaches;
 	public ITypeSymbol RootType => rootType;
-	public IDictionary<XmlType, ITypeSymbol> TypeCache => typeCache;
+	public IDictionary<XmlType, INamedTypeSymbol> TypeCache => typeCache;
 	public IDictionary<INode, object> Values { get; } = new Dictionary<INode, object>();
 	public IDictionary<INode, ILocalValue> Variables { get; } = new Dictionary<INode, ILocalValue>();
 	public void ReportDiagnostic(Diagnostic diagnostic) => sourceProductionContext.ReportDiagnostic(diagnostic);

--- a/src/Controls/src/SourceGen/SourceGenContext.cs
+++ b/src/Controls/src/SourceGen/SourceGenContext.cs
@@ -9,7 +9,7 @@ using static Microsoft.Maui.Controls.SourceGen.NodeSGExtensions;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 
-class SourceGenContext(IndentedTextWriter writer, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyCaches assemblyCaches, IDictionary<XmlType, ITypeSymbol> typeCache, ITypeSymbol rootType, ITypeSymbol? baseType, ProjectItem projectItem)
+class SourceGenContext(IndentedTextWriter writer, Compilation compilation, SourceProductionContext sourceProductionContext, AssemblyAttributes assemblyCaches, IDictionary<XmlType, ITypeSymbol> typeCache, ITypeSymbol rootType, ITypeSymbol? baseType, ProjectItem projectItem)
 {
 	public SourceProductionContext SourceProductionContext => sourceProductionContext;
 	public IndentedTextWriter Writer => writer;
@@ -17,7 +17,7 @@ class SourceGenContext(IndentedTextWriter writer, Compilation compilation, Sourc
 	public IndentedTextWriter? RefStructWriter { get; set; }
 
 	public Compilation Compilation => compilation;
-	public AssemblyCaches XmlnsCache => assemblyCaches;
+	public AssemblyAttributes XmlnsCache => assemblyCaches;
 	public ITypeSymbol RootType => rootType;
 	public IDictionary<XmlType, ITypeSymbol> TypeCache => typeCache;
 	public IDictionary<INode, object> Values { get; } = new Dictionary<INode, object>();

--- a/src/Controls/src/SourceGen/TypeConverters/TypeTypeConverter.cs
+++ b/src/Controls/src/SourceGen/TypeConverters/TypeTypeConverter.cs
@@ -24,7 +24,7 @@ class TypeTypeConverter : ISGTypeConverter
 			xmlType = new XmlType(node.NamespaceResolver.LookupNamespace(split[0]), split[1], null);
 		else
 			xmlType = new XmlType(node.NamespaceResolver.LookupNamespace(""), split[0], null);
-		var typeRef = xmlType.GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache);
+		var typeRef = xmlType.GetTypeSymbol(context);
 		if (typeRef != null)
 			return $"typeof({typeRef.ToFQDisplayString()})";
 		error:

--- a/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
@@ -35,7 +35,7 @@ class CreateValuesVisitor : IXamlNodeVisitor
 
 	public static void CreateValue(ElementNode node, IndentedTextWriter writer, IDictionary<INode, ILocalValue> variables, Compilation compilation, AssemblyAttributes xmlnsCache, SourceGenContext Context, Func<INode, ITypeSymbol, ILocalValue>? getNodeValue = null)
 	{
-		if (!node.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, out var type) || type is null)
+		if (!node.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, Context.TypeCache, out var type) || type is null)
 			return;
 
 		//x:Array

--- a/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
@@ -33,7 +33,7 @@ class CreateValuesVisitor : IXamlNodeVisitor
 		//At this point, all MarkupNodes are expanded to ElementNodes
 	}
 
-	public static void CreateValue(ElementNode node, IndentedTextWriter writer, IDictionary<INode, ILocalValue> variables, Compilation compilation, AssemblyCaches xmlnsCache, SourceGenContext Context, Func<INode, ITypeSymbol, ILocalValue>? getNodeValue = null)
+	public static void CreateValue(ElementNode node, IndentedTextWriter writer, IDictionary<INode, ILocalValue> variables, Compilation compilation, AssemblyAttributes xmlnsCache, SourceGenContext Context, Func<INode, ITypeSymbol, ILocalValue>? getNodeValue = null)
 	{
 		if (!node.XmlType.TryResolveTypeSymbol(null, compilation, xmlnsCache, out var type) || type is null)
 			return;

--- a/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
@@ -196,7 +196,7 @@ class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 
 			var xmltype = new XmlType(namespaceuri, name + "Extension", typeArguments);
 
-			if (!xmltype.TryResolveTypeSymbol(null, contextProvider!.Context.Compilation, contextProvider!.Context.XmlnsCache, out _))
+			if (!xmltype.TryResolveTypeSymbol(null, contextProvider!.Context.Compilation, contextProvider!.Context.XmlnsCache, contextProvider!.Context.TypeCache, out _))
 				xmltype = new XmlType(namespaceuri, name, typeArguments);
 
 			if (xmltype == null)

--- a/src/Controls/src/SourceGen/XmlTypeExtensions.cs
+++ b/src/Controls/src/SourceGen/XmlTypeExtensions.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Maui.Controls.SourceGen;
 
 static class XmlTypeExtensions
 {
-	public static ITypeSymbol? GetTypeSymbol(this XmlType xmlType, SourceGenContext context)
+	public static INamedTypeSymbol? GetTypeSymbol(this XmlType xmlType, SourceGenContext context)
 		=> xmlType.GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache, context.TypeCache);
 
-	public static ITypeSymbol? GetTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
+	public static INamedTypeSymbol? GetTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache)
 	{
 		if (TryResolveTypeSymbol(xmlType, reportDiagnostic, compilation, xmlnsCache, typeCache, out var symbol))
 			return symbol!;
@@ -26,25 +26,22 @@ static class XmlTypeExtensions
 		throw new Exception($"Unable to resolve {xmlType.NamespaceUri}:{xmlType.Name}");
 	}
 
-	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, SourceGenContext context, INode node)
+	public static INamedTypeSymbol? GetTypeSymbol(this string nameAndPrefix, SourceGenContext context, INode node)
 		=> GetTypeSymbol(nameAndPrefix, context.ReportDiagnostic, context.Compilation, context.XmlnsCache, context.TypeCache, node);
 
-	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, INode node)
+	public static INamedTypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache, INode node)
 		=> GetTypeSymbol(nameAndPrefix, reportDiagnostic, compilation, xmlnsCache, typeCache, node.NamespaceResolver, (IXmlLineInfo)node);
 
-	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, IXmlNamespaceResolver resolver, IXmlLineInfo lineInfo)
+	public static INamedTypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache, IXmlNamespaceResolver resolver, IXmlLineInfo lineInfo)
 	{
 		XmlType xmlType = TypeArgumentsParser.ParseSingle(nameAndPrefix, resolver, lineInfo);
 		return xmlType.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache, typeCache);
 	}
 
-	public static bool TryResolveTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, out INamedTypeSymbol? symbol)
+	public static bool TryResolveTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, INamedTypeSymbol> typeCache, out INamedTypeSymbol? symbol)
 	{
-		if (typeCache.TryGetValue(xmlType, out var s))
-		{
-			symbol = s as INamedTypeSymbol;
+		if (typeCache.TryGetValue(xmlType, out symbol))			
 			return true;
-		}
 
 		var name = xmlType.Name.Split(':').Last(); //strip prefix
 		var genericSuffix = xmlType.TypeArguments is not null ? $"`{xmlType.TypeArguments.Count}" : string.Empty;
@@ -84,7 +81,5 @@ static class XmlTypeExtensions
 	}
 
 	public static bool RepresentsType(this XmlType xmlType, string namespaceUri, string name)
-	{
-		return xmlType.Name == name && xmlType.NamespaceUri == namespaceUri;
-	}
+		=> xmlType.Name == name && xmlType.NamespaceUri == namespaceUri;
 }

--- a/src/Controls/src/SourceGen/XmlTypeExtensions.cs
+++ b/src/Controls/src/SourceGen/XmlTypeExtensions.cs
@@ -1,13 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 using Microsoft.Maui.Controls.Xaml;
 
@@ -15,9 +10,12 @@ namespace Microsoft.Maui.Controls.SourceGen;
 
 static class XmlTypeExtensions
 {
-	public static ITypeSymbol? GetTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache)
+	public static ITypeSymbol? GetTypeSymbol(this XmlType xmlType, SourceGenContext context)
+		=> xmlType.GetTypeSymbol(context.ReportDiagnostic, context.Compilation, context.XmlnsCache, context.TypeCache);
+
+	public static ITypeSymbol? GetTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache)
 	{
-		if (TryResolveTypeSymbol(xmlType, reportDiagnostic, compilation, xmlnsCache, out var symbol))
+		if (TryResolveTypeSymbol(xmlType, reportDiagnostic, compilation, xmlnsCache, typeCache, out var symbol))
 			return symbol!;
 		if (reportDiagnostic is not null)
 		{
@@ -28,17 +26,25 @@ static class XmlTypeExtensions
 		throw new Exception($"Unable to resolve {xmlType.NamespaceUri}:{xmlType.Name}");
 	}
 
-	static Dictionary<Compilation, Dictionary<XmlType, INamedTypeSymbol>> s_typeSymbolCache = new();
-	public static bool TryResolveTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, out INamedTypeSymbol? symbol)
-	{
-		if (!s_typeSymbolCache.TryGetValue(compilation, out var xmlTypeCache))
-		{
-			xmlTypeCache = [];
-			s_typeSymbolCache[compilation] = xmlTypeCache;
-		}
+	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, SourceGenContext context, INode node)
+		=> GetTypeSymbol(nameAndPrefix, context.ReportDiagnostic, context.Compilation, context.XmlnsCache, context.TypeCache, node);
 
-		if (xmlTypeCache.TryGetValue(xmlType, out symbol))
+	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, INode node)
+		=> GetTypeSymbol(nameAndPrefix, reportDiagnostic, compilation, xmlnsCache, typeCache, node.NamespaceResolver, (IXmlLineInfo)node);
+
+	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, IXmlNamespaceResolver resolver, IXmlLineInfo lineInfo)
+	{
+		XmlType xmlType = TypeArgumentsParser.ParseSingle(nameAndPrefix, resolver, lineInfo);
+		return xmlType.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache, typeCache);
+	}
+
+	public static bool TryResolveTypeSymbol(this XmlType xmlType, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IDictionary<XmlType, ITypeSymbol> typeCache, out INamedTypeSymbol? symbol)
+	{
+		if (typeCache.TryGetValue(xmlType, out var s))
+		{
+			symbol = s as INamedTypeSymbol;
 			return true;
+		}
 
 		var name = xmlType.Name.Split(':').Last(); //strip prefix
 		var genericSuffix = xmlType.TypeArguments is not null ? $"`{xmlType.TypeArguments.Count}" : string.Empty;
@@ -66,10 +72,10 @@ static class XmlTypeExtensions
 				symbol = types[0];
 				if (symbol.IsGenericType && xmlType.TypeArguments is not null)
 				{
-					var typeArgs = xmlType.TypeArguments.Select(typeArg => typeArg.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache)!).ToArray();
+					var typeArgs = xmlType.TypeArguments.Select(typeArg => typeArg.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache, typeCache)!).ToArray();
 					symbol = symbol.Construct(typeArgs);
 				}
-				xmlTypeCache[xmlType] = symbol;
+				typeCache[xmlType] = symbol;
 				return true;
 			}
         }
@@ -77,73 +83,8 @@ static class XmlTypeExtensions
 		return false;
 	}
 
-	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, INode node)
-		=> GetTypeSymbol(nameAndPrefix, reportDiagnostic, compilation, xmlnsCache, node.NamespaceResolver, (IXmlLineInfo)node);
-
-	public static ITypeSymbol? GetTypeSymbol(this string nameAndPrefix, Action<Diagnostic>? reportDiagnostic, Compilation compilation, AssemblyAttributes xmlnsCache, IXmlNamespaceResolver resolver, IXmlLineInfo lineInfo)
-	{
-		XmlType xmlType = TypeArgumentsParser.ParseSingle(nameAndPrefix, resolver, lineInfo);
-		return xmlType.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache);
-	}
-
-	static string? GetClrNamespace(string namespaceuri)
-	{
-		if (namespaceuri == XamlParser.X2009Uri)
-			return "System";
-
-		if (namespaceuri != XamlParser.X2006Uri &&
-			!namespaceuri.StartsWith("clr-namespace", StringComparison.InvariantCulture) &&
-			!namespaceuri.StartsWith("using:", StringComparison.InvariantCulture))
-			return null;
-
-		return XmlnsHelper.ParseNamespaceFromXmlns(namespaceuri);
-	}
-
 	public static bool RepresentsType(this XmlType xmlType, string namespaceUri, string name)
 	{
 		return xmlType.Name == name && xmlType.NamespaceUri == namespaceUri;
 	}
-
-	// 	static string GetTypeNameFromCustomNamespace(XmlType xmlType, Compilation compilation, AssemblyCaches xmlnsCache)
-	// 	{
-	// #nullable disable
-	// 		string typeName = xmlType.GetTypeReference<string>(xmlnsCache.XmlnsDefinitions, null,
-	// 			(typeInfo) =>
-	// 			{
-	// 				string typeName = typeInfo.typeName.Replace('+', '/'); //Nested types
-	// 				string fullName = $"{typeInfo.clrNamespace}.{typeInfo.typeName}";
-	// 				IList<INamedTypeSymbol> types = compilation.GetTypesByMetadataName(fullName);
-
-	// 				if (types.Count == 0)
-	// 				{
-	// 					return null;
-	// 				}
-
-	// 				foreach (INamedTypeSymbol type in types)
-	// 				{
-	// 					// skip over types that are not in the correct assemblies
-	// 					if (type.ContainingAssembly.Identity.Name != typeInfo.assemblyName)
-	// 					{
-	// 						continue;
-	// 					}
-
-	// 					if (!type.IsPublicOrVisibleInternal(xmlnsCache.InternalsVisible))
-	// 					{
-	// 						continue;
-	// 					}
-
-	// 					int i = fullName.IndexOf('`');
-	// 					if (i > 0)
-	// 					{
-	// 						fullName = fullName.Substring(0, i);
-	// 					}
-	// 					return fullName;
-	// 				}
-
-	// 				return null;
-	// 			});
-
-	// 		return typeName;
-	// #nullable enable
-	// 	}
 }

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -409,6 +409,8 @@ namespace Microsoft.Maui.Controls.Xaml
 #if !NETSTANDARD
 		[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 #endif
+
+#if !__SOURCEGEN__
 		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly, bool expandToExtension,
 			out XamlParseException exception)
 		{
@@ -505,5 +507,6 @@ namespace Microsoft.Maui.Controls.Xaml
 		public static bool IsVisibleInternal(this Assembly from, Assembly to) =>
 			from.GetCustomAttributes<InternalsVisibleToAttribute>().Any(ca =>
 				ca.AssemblyName.StartsWith(to.GetName().Name, StringComparison.InvariantCulture));
+#endif
 	}
 }

--- a/src/Controls/src/Xaml/XmlnsHelper.cs
+++ b/src/Controls/src/Xaml/XmlnsHelper.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public static void ParseXmlns(string xmlns, out string typeName, out string ns, out string asm, out string targetPlatform)
 		{
-			typeName = ns = asm = targetPlatform = null;
-
 			xmlns = xmlns.Trim();
 
 			if (xmlns.StartsWith("using:", StringComparison.Ordinal))

--- a/src/Controls/tests/Xaml.Benchmarks/Program.cs
+++ b/src/Controls/tests/Xaml.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
 
 namespace Microsoft.Maui.Controls.Xaml.Benchmarks;
 
@@ -27,6 +28,7 @@ class Program
 {
 	static void Main(string[] args)
 	{		
-		BenchmarkDotNet.Running.BenchmarkRunner.Run<LayoutBenchmark>();
+		BenchmarkSwitcher.FromAssembly (typeof (Program).Assembly).Run (args);
+
 	}
 }


### PR DESCRIPTION
### Description of Change

fix symbol logic resolution to avoid looping too much

building the Xaml.UnitTests, sourcegen times
Oct 27: 24,163s
Oct 29: 16,139s (#32242)
today :  1,363s

That's a speedup of 95%, and it now takes less time to sourcegen than to XamlC

