### PR TITLE
[iOS] RTL column mirroring in UICollectionView - fix

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -108,6 +108,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public static void MapFlowDirection(ItemsViewHandler2<TItemsView> handler, ItemsView itemsView)
 		{
 			handler.Controller?.UpdateFlowDirection();
+
+			// UIKit does not automatically mirror or reflow UICollectionView layouts when the flow direction
+			// (semanticContentAttribute) changes at runtime. To ensure correct RTL/LTR behavior, we explicitly
+			// notify the controller to rebuild or reassign its layout. Without this, UICollectionViewCompositionalLayout
+			// and other layouts will keep their previous geometry and ignore the new direction.
+			handler.UpdateLayout();
 		}
 
 		public static void MapIsVisible(ItemsViewHandler2<TItemsView> handler, ItemsView itemsView)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -312,6 +312,29 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 						}
 					}
 				}
+
+				// Explicitly apply semantic content attribute to the native UICollectionView so
+				// compositional layout mirrors columns in RTL. The platform view's semantic attribute
+				// does not automatically propagate to native children which are not backed by IView.
+				UISemanticContentAttribute desiredAttr = UISemanticContentAttribute.Unspecified;
+				switch (ItemsView.FlowDirection)
+				{
+					case FlowDirection.LeftToRight:
+						desiredAttr = UISemanticContentAttribute.ForceLeftToRight;
+						break;
+					case FlowDirection.RightToLeft:
+						desiredAttr = UISemanticContentAttribute.ForceRightToLeft;
+						break;
+					case FlowDirection.MatchParent:
+						// Let it inherit from the parent view we just updated
+						desiredAttr = UISemanticContentAttribute.Unspecified;
+						break;
+				}
+
+				if (CollectionView.SemanticContentAttribute != desiredAttr)
+				{
+					CollectionView.SemanticContentAttribute = desiredAttr;
+				}
 			}
 
 			if (_emptyViewDisplayed)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -312,29 +312,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 						}
 					}
 				}
-
-				// Explicitly apply semantic content attribute to the native UICollectionView so
-				// compositional layout mirrors columns in RTL. The platform view's semantic attribute
-				// does not automatically propagate to native children which are not backed by IView.
-				UISemanticContentAttribute desiredAttr = UISemanticContentAttribute.Unspecified;
-				switch (ItemsView.FlowDirection)
-				{
-					case FlowDirection.LeftToRight:
-						desiredAttr = UISemanticContentAttribute.ForceLeftToRight;
-						break;
-					case FlowDirection.RightToLeft:
-						desiredAttr = UISemanticContentAttribute.ForceRightToLeft;
-						break;
-					case FlowDirection.MatchParent:
-						// Let it inherit from the parent view we just updated
-						desiredAttr = UISemanticContentAttribute.Unspecified;
-						break;
-				}
-
-				if (CollectionView.SemanticContentAttribute != desiredAttr)
-				{
-					CollectionView.SemanticContentAttribute = desiredAttr;
-				}
+	
+				CollectionView.UpdateFlowDirection(ItemsView);
 			}
 
 			if (_emptyViewDisplayed)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32359.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32359.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue32359"
+             Title="Issue 32359">
+    
+    <Grid RowDefinitions="Auto,Auto,*" Padding="10">
+        <Label Grid.Row="0" 
+               Text="CollectionView RTL - VerticalGrid 4 Columns" 
+               FontSize="16" 
+               FontAttributes="Bold" 
+               Margin="0,0,0,10"/>
+        
+        <HorizontalStackLayout Grid.Row="1" Spacing="10" Margin="0,0,0,10">
+            <Button x:Name="SetRtlButton" 
+                    Text="Set RTL"
+                    AutomationId="SetRtlButton"/>
+            <Button x:Name="SetLtrButton" 
+                    Text="Set LTR"
+                    AutomationId="SetLtrButton"/>
+            <Label x:Name="StatusLabel" 
+                   Text="Current: LTR" 
+                   AutomationId="StatusLabel"
+                   VerticalOptions="Center"/>
+        </HorizontalStackLayout>
+        
+        <CollectionView x:Name="TestCollectionView" 
+                        Grid.Row="2"
+                        AutomationId="TestCollectionView">
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Orientation="Vertical" Span="4"/>
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid BackgroundColor="LightBlue" 
+                          Margin="2" 
+                          HeightRequest="60"
+                          WidthRequest="80">
+                        <Label Text="{Binding .}" 
+                               HorizontalOptions="Center" 
+                               VerticalOptions="Center"
+                               FontSize="14"
+                               TextColor="Black"/>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+    
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32359.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32359.xaml.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 32359, 
+		"FlowDirection RightToLeft not applied to CollectionView with VerticalGrid multi-column layout",
+		PlatformAffected.iOS)]
+	public partial class Issue32359 : ContentPage
+	{
+		private ObservableCollection<string> _items;
+
+		public Issue32359()
+		{
+			InitializeComponent();
+			
+			// Create test data - using numbers to make column order clearly visible
+			_items = new ObservableCollection<string>();
+			for (int i = 1; i <= 20; i++)
+			{
+				_items.Add($"{i}");
+			}
+			
+			TestCollectionView.ItemsSource = _items;
+			
+			// Wire up buttons
+			SetRtlButton.Clicked += OnSetRtlClicked;
+			SetLtrButton.Clicked += OnSetLtrClicked;
+		}
+
+		private void OnSetRtlClicked(object? sender, EventArgs e)
+		{
+			this.FlowDirection = FlowDirection.RightToLeft;
+			StatusLabel.Text = "Current: RTL";
+		}
+
+		private void OnSetLtrClicked(object? sender, EventArgs e)
+		{
+			this.FlowDirection = FlowDirection.LeftToRight;
+			StatusLabel.Text = "Current: LTR";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32359.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32359.xaml.cs
@@ -27,15 +27,17 @@ namespace Maui.Controls.Sample.Issues
 			SetLtrButton.Clicked += OnSetLtrClicked;
 		}
 
-		private void OnSetRtlClicked(object? sender, EventArgs e)
+		private void OnSetRtlClicked(object sender, EventArgs e)
 		{
-			this.FlowDirection = FlowDirection.RightToLeft;
+
+			TestCollectionView.FlowDirection = FlowDirection.RightToLeft;
 			StatusLabel.Text = "Current: RTL";
 		}
 
-		private void OnSetLtrClicked(object? sender, EventArgs e)
+		private void OnSetLtrClicked(object sender, EventArgs e)
 		{
-			this.FlowDirection = FlowDirection.LeftToRight;
+
+			TestCollectionView.FlowDirection = FlowDirection.LeftToRight;
 			StatusLabel.Text = "Current: LTR";
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32359.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32359.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue32359 : _IssuesUITest
+	{
+		public override string Issue => "FlowDirection RightToLeft not applied to CollectionView with VerticalGrid multi-column layout";
+
+		public Issue32359(TestDevice device) : base(device)
+		{
+		}
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void VerticalGridCollectionViewRTLColumnMirroringShouldWork()
+		{
+			// Wait for CollectionView to load
+			App.WaitForElement("TestCollectionView");
+			App.WaitForElement("SetRtlButton");
+			
+			// Set to RTL - this should mirror the column order
+			// In a 4-column grid, items should appear: 4, 3, 2, 1 (right to left)
+			// instead of: 1, 2, 3, 4 (left to right)
+			App.Tap("SetRtlButton");
+			
+			// Wait for layout to update
+			App.WaitForElement("StatusLabel");
+			
+			// Verify screenshot shows RTL column mirroring
+			// The first row should show: "4  3  2  1" (from right to left)
+			// instead of: "1  2  3  4" (from left to right)
+			VerifyScreenshot();
+		}
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void VerticalGridCollectionViewLTRToRTLToggleShouldWork()
+		{
+			// Start in LTR (default)
+			App.WaitForElement("TestCollectionView");
+			App.WaitForElement("SetLtrButton");
+			
+			// Verify LTR layout first (optional baseline)
+			App.Tap("SetLtrButton");
+			App.WaitForElement("StatusLabel");
+			
+			// Toggle to RTL
+			App.Tap("SetRtlButton");
+			App.WaitForElement("StatusLabel");
+			
+			// Toggle back to LTR
+			App.Tap("SetLtrButton");
+			App.WaitForElement("StatusLabel");
+			
+			// Toggle to RTL again - ensure it still works
+			App.Tap("SetRtlButton");
+			App.WaitForElement("StatusLabel");
+			
+			// Final verification in RTL mode
+			VerifyScreenshot();
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Explicitly sets the semantic content attribute on the native UICollectionView to ensure compositional layouts mirror columns correctly in right-to-left (RTL) scenarios. This addresses an issue where the platform view's semantic attribute does not propagate to native children not backed by IView.

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/fb0784f5-7c7f-4b15-b2ab-ccdb2a7b8833" width="300px"></video>|<video src="https://github.com/user-attachments/assets/74a5180e-e7f5-45fc-bb88-ceb329fb2e4a" width="300px"></video>|


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32359

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
