### PR TITLE
[testing] Skip failing test for now

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.iOS.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(100, updatedSize.Height);
 		}
 
-		[Fact, Category(TestCategory.Layout)]
+		[Fact(Skip="Failing https://github.com/dotnet/maui/issues/32368"), Category(TestCategory.Layout)]
 		public async Task ContentViewRespondsWhenViewRemoved()
 		{
 			var contentView = new ContentView();


### PR DESCRIPTION
### Description of Change

Skip this failing test `ContentViewRespondsWhenViewRemoved` on catalyst to make build green 


Issue to track this work to reenable - https://github.com/dotnet/maui/issues/32368 
