### PR TITLE
[XSG] fix generatedpath, rename generator

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -18,7 +18,7 @@ using static GeneratorHelpers;
 using static LocationHelpers;
 
 [Generator(LanguageNames.CSharp)]
-public class CodeBehindGenerator : IIncrementalGenerator
+public class XamlGenerator : IIncrementalGenerator
 {
 	public void Initialize(IncrementalGeneratorInitializationContext initContext)
 	{
@@ -201,6 +201,8 @@ $"""
 		}
 
 		var prefix = Path.GetDirectoryName(relativePath).Replace(Path.DirectorySeparatorChar, '_').Replace(':', '_');
+		if (!string.IsNullOrEmpty(prefix))
+			prefix += "_";
 		var fileNameNoExtension = Path.GetFileNameWithoutExtension(relativePath);
 		var kind = projectItem.Kind.ToLowerInvariant() ?? "unknown-kind";
 		return $"{prefix}{fileNameNoExtension}.{kind}.{suffix}.cs";

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SourceGenXamlInitializeComponentTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SourceGenXamlInitializeComponentTests.cs
@@ -22,7 +22,7 @@ public class SourceGenXamlInitializeComponentTestBase : SourceGenTestsBase
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
 		var workingDirectory = Environment.CurrentDirectory;
 		var xamlFile = new AdditionalXamlFile(Path.Combine(workingDirectory, path ?? "Test.xaml"), xaml, RelativePath: path ?? "Test.xaml", TargetFramework: targetFramework, NoWarn: noWarn, ManifestResourceName: $"{compilation.AssemblyName}.Test.xaml", Lineinfo: lineinfo);
-		var result = RunGenerator<CodeBehindGenerator>(compilation, xamlFile);
+		var result = RunGenerator<XamlGenerator>(compilation, xamlFile);
 		var generated = result.Results.SingleOrDefault().GeneratedSources.SingleOrDefault(gs => gs.HintName.EndsWith(".xsg.cs")).SourceText?.ToString();
 
 		return (result, generated);

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGenCssTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGenCssTests.cs
@@ -26,7 +26,7 @@ h1 {color: purple;
 """;
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
 		var cssFile = new AdditionalCssFile("Test.css", css);
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, cssFile);
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, cssFile);
 
 		Assert.False(result.Diagnostics.Any());
 
@@ -54,7 +54,7 @@ h1 {color: red;
 """;
 		var cssFile = new AdditionalCssFile("Test.css", css);
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		var result = SourceGeneratorDriver.RunGeneratorWithChanges<CodeBehindGenerator>(compilation, ApplyChanges, cssFile);
+		var result = SourceGeneratorDriver.RunGeneratorWithChanges<XamlGenerator>(compilation, ApplyChanges, cssFile);
 
 		var result1 = result.result1.Results.Single();
 		var result2 = result.result2.Results.Single();

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGenXamlCodeBehindTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGenXamlCodeBehindTests.cs
@@ -29,7 +29,7 @@ public class SourceGenXamlCodeBehindTests : SourceGenTestsBase
 </ContentPage>
 """;
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
 
@@ -52,7 +52,7 @@ public class SourceGenXamlCodeBehindTests : SourceGenTestsBase
 """;
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]"));
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
 
@@ -82,7 +82,7 @@ using Microsoft.Maui.Controls;
 """;
 		var compilation = CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
-		var result = RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
 
@@ -112,7 +112,7 @@ using Microsoft.Maui.Controls;
 """;
 		var compilation = CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
-		var result = RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
 
@@ -164,7 +164,7 @@ public class TestControl : ContentView
 		if (resolvedType)
 			compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
 
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		if (resolvedType)
 		{
@@ -195,7 +195,7 @@ public class TestControl : ContentView
 """;
 		var xamlFile = new AdditionalXamlFile("Test.xaml", xaml);
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		var result = SourceGeneratorDriver.RunGeneratorWithChanges<CodeBehindGenerator>(compilation, ApplyChanges, xamlFile);
+		var result = SourceGeneratorDriver.RunGeneratorWithChanges<XamlGenerator>(compilation, ApplyChanges, xamlFile);
 
 		var result1 = result.result1.Results.Single();
 		var result2 = result.result2.Results.Single();
@@ -238,7 +238,7 @@ public class TestControl : ContentView
 """;
 		var xamlFile = new AdditionalXamlFile("Test.xaml", xaml);
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		var result = SourceGeneratorDriver.RunGeneratorWithChanges<CodeBehindGenerator>(compilation, ApplyChanges, xamlFile);
+		var result = SourceGeneratorDriver.RunGeneratorWithChanges<XamlGenerator>(compilation, ApplyChanges, xamlFile);
 
 		var result1 = result.result1.Results.Single();
 		var result2 = result.result2.Results.Single();
@@ -292,7 +292,7 @@ public class TestControl : ContentView
 """;
 		var xamlFile = new AdditionalXamlFile("Test.xaml", xaml);
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		var result = SourceGeneratorDriver.RunGeneratorWithChanges<CodeBehindGenerator>(compilation, ApplyChanges, xamlFile);
+		var result = SourceGeneratorDriver.RunGeneratorWithChanges<XamlGenerator>(compilation, ApplyChanges, xamlFile);
 
 		var result1 = result.result1.Results.Single();
 		var result2 = result.result2.Results.Single();
@@ -338,7 +338,7 @@ public class TestControl : ContentView
 """;
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]"));
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		var generated = result.Results.Single().GeneratedSources.Single(gs => gs.HintName.EndsWith(".sg.cs")).SourceText.ToString();
 		Assert.True(result.Diagnostics.Any() || string.IsNullOrWhiteSpace(generated));
@@ -379,7 +379,7 @@ namespace Ns2
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
 
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.True(result.Diagnostics.Any());
 
@@ -473,7 +473,7 @@ internal class InternalWithSuffix : Button { }
 				SourceGeneratorDriver.CreateMauiCompilation("external2.Generated").AddSyntaxTrees(CSharpSyntaxTree.ParseText(externaltwo)).ToMetadataReference(),
 				SourceGeneratorDriver.CreateMauiCompilation("external3.Generated").AddSyntaxTrees(CSharpSyntaxTree.ParseText(externalthree)).ToMetadataReference());
 
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
 
@@ -539,7 +539,7 @@ internal class InternalButVisible : Label { }
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation().AddSyntaxTrees(CSharpSyntaxTree.ParseText(code)).AddReferences(externalCompilation.ToMetadataReference());
 
 
-		var result = SourceGeneratorDriver.RunGenerator<CodeBehindGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
 

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Save(projectFile);
 			Build(projectFile, additionalArgs: $"-c {configuration} -p:MauiXamlInflator=SourceGen -p:EmitCompilerGeneratedFiles=True -p:CompilerGeneratedFilesOutputPath=Generated");
 
-			var generatorDirectory = IOPath.Combine(tempDirectory, "Generated", "Microsoft.Maui.Controls.SourceGen", "Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator");
+			var generatorDirectory = IOPath.Combine(tempDirectory, "Generated", "Microsoft.Maui.Controls.SourceGen", "Microsoft.Maui.Controls.SourceGen.XamlGenerator");
 			AssertExists(IOPath.Combine(generatorDirectory, "MainPage.xaml.sg.cs"), nonEmpty: true);
 			AssertExists(IOPath.Combine(generatorDirectory, "MainPage.xaml.xsg.cs"), nonEmpty: true);
 			

--- a/src/Controls/tests/Xaml.UnitTests/MockSourceGenerator.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MockSourceGenerator.cs
@@ -73,7 +73,7 @@ public static class MockSourceGenerator
 		var path = System.IO.Path.Combine(top, "artifacts", "bin", "Controls.SourceGen", config, "netstandard2.0", "Microsoft.Maui.Controls.SourceGen.dll");
 		var analyzerAssembly = Assembly.LoadFrom(path);
 
-		var generatorType = analyzerAssembly?.GetType("Microsoft.Maui.Controls.SourceGen.CodeBehindGenerator")!;
+		var generatorType = analyzerAssembly?.GetType("Microsoft.Maui.Controls.SourceGen.XamlGenerator")!;
 		var generator = (generatorType?.GetConstructor([])?.Invoke([]) as IIncrementalGenerator)?.AsSourceGenerator();
 
 		if (generator is null)


### PR DESCRIPTION
### Description of Change

generated paths were using _ as directory separator, except for the last one. fix that. also rename the generator type