### PR TITLE
[XSG] disable #line info by default

### DIFF
--- a/src/Controls/src/SourceGen/ProjectItem.cs
+++ b/src/Controls/src/SourceGen/ProjectItem.cs
@@ -23,7 +23,8 @@ record ProjectItem(AdditionalText AdditionalText, AnalyzerConfigOptions Options)
 				return true;
 			if (Options.IsDisabled("build_property.MauiXamlLineInfo"))
 				return false;
-			return Configuration.Equals("Debug", StringComparison.OrdinalIgnoreCase);
+			//return Configuration.Equals("Debug", StringComparison.OrdinalIgnoreCase);
+			return false; //default to False due to roslyn issues with large pdbs https://github.com/dotnet/roslyn/issues/80952
 		}
 	}
 

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/LineInfoTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/LineInfoTests.cs
@@ -58,10 +58,6 @@ public class LineInfoTests : SourceGenXamlInitializeComponentTestBase
 
         var generatedCode = result.GeneratedTrees.Single(tree => Path.GetFileName(tree.FilePath) == "Test.xaml.xsg.cs").ToString();
         var expectedFilePath = Path.Combine(Environment.CurrentDirectory, "Test.xaml");
-#if RELEASE
         Assert.False(generatedCode.Contains(@$"#line 9 ""{expectedFilePath}""", StringComparison.Ordinal));        
-#else
-		Assert.True(generatedCode.Contains(@$"#line 9 ""{expectedFilePath}""", StringComparison.Ordinal));
-#endif
     }
 }


### PR DESCRIPTION
### Description of Change

there are too many situation where it cause or might cause issues with wrong pdbs. disable it for now.

