### PR TITLE
[iOS 26] Navigation hangs after rapidly open and closing new page using Navigation.PushAsync - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			// Bounds check: ensure we have a valid index for pages array
 			int targetIndex = NavigationBar.Items.Length - 1;
-			if (targetIndex < 0 || targetIndex >= pages.Count)
+			if (targetIndex < 0 || targetIndex >= pages.Count || pages[targetIndex] is null)
 				return true;
 
 			_shellSection.SyncStackDownTo(pages[targetIndex]);
@@ -577,10 +577,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			foreach (var child in ShellSection.Stack)
 			{
-				if (child == null)
-					continue;
-				var renderer = (IPlatformViewHandler)child.Handler;
-				if (viewController == renderer.ViewController)
+				if (child?.Handler is IPlatformViewHandler { ViewController: var vc } && viewController == vc)
 					return child;
 			}
 


### PR DESCRIPTION
Added additional null checks for page and renderer references in ShellSectionRenderer to prevent potential null reference exceptions during navigation and view controller handling.

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Add null checks in ShellSectionRenderer
Added additional null checks for page and renderer references in ShellSectionRenderer to prevent potential null reference exceptions during navigation and view controller handling.

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/d63c59c1-8559-4d10-87d1-f1c8b67f8ea8" width="300px"></video>|<video src="https://github.com/user-attachments/assets/b5b6cf6c-29fb-4953-a9d7-f1f30988a3dc" width="300px"></video>|

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32425

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
