### PR TITLE
predictive back gesture support for Android 13+

### DIFF
--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -27,18 +27,7 @@ namespace Microsoft.Maui
 		public override void OnBackPressed()
 #pragma warning restore 809
 		{
-			var preventBackPropagation = false;
-			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
-			{
-				preventBackPropagation = del(this) || preventBackPropagation;
-			});
-
-			if (!preventBackPropagation)
-#pragma warning disable CA1416 // Validate platform compatibility
-#pragma warning disable CA1422 // Validate platform compatibility
-				base.OnBackPressed();
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416 // Validate platform compatibility
+			HandleBackNavigation();
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)
@@ -144,6 +133,22 @@ namespace Microsoft.Maui
 			});
 
 			return handled || base.OnKeyUp(keyCode, e);
+		}
+
+		/// <summary>
+		/// Central handler used by both legacy <see cref="OnBackPressed"/> and the Android 13+ predictive back gesture callback.
+		/// Implements lifecycle event invocation and default back stack propagation unless explicitly prevented.
+		/// </summary>
+		void HandleBackNavigation()
+		{
+			var preventBackPropagation = false;
+			IPlatformApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
+			{
+				preventBackPropagation = del(this) || preventBackPropagation;
+			});
+
+			if (!preventBackPropagation)
+				base.OnBackPressed();
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -38,15 +38,11 @@ namespace Microsoft.Maui
 			// Guidance: route custom back handling through AndroidX OnBackPressedDispatcher so
 			// predictive back works correctly:
 			// https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#update-custom
-			if (OperatingSystem.IsAndroidVersionAtLeast(33))
+			if (OperatingSystem.IsAndroidVersionAtLeast(33) && _predictiveBackCallback is null)
 			{
-				var dispatcher = OnBackInvokedDispatcher;
-				if (_predictiveBackCallback is null)
-				{
-					_predictiveBackCallback = new PredictiveBackCallback(this);
-					// Priority 0 = PRIORITY_DEFAULT: callback invoked only when no higher-priority callback handles the event
-					dispatcher?.RegisterOnBackInvokedCallback(0, _predictiveBackCallback);
-				}
+				_predictiveBackCallback = new PredictiveBackCallback(this);
+				// Priority 0 = PRIORITY_DEFAULT: callback invoked only when no higher-priority callback handles the event
+				OnBackInvokedDispatcher?.RegisterOnBackInvokedCallback(0, _predictiveBackCallback);
 			}
 		}
 

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -41,8 +41,12 @@ namespace Microsoft.Maui
 			if (OperatingSystem.IsAndroidVersionAtLeast(33))
 			{
 				var dispatcher = OnBackInvokedDispatcher;
-				_predictiveBackCallback ??= new PredictiveBackCallback(this);
-				dispatcher?.RegisterOnBackInvokedCallback(0, _predictiveBackCallback);
+				if (_predictiveBackCallback is null)
+				{
+					_predictiveBackCallback = new PredictiveBackCallback(this);
+					// Priority 0 = PRIORITY_DEFAULT: callback invoked only when no higher-priority callback handles the event
+					dispatcher?.RegisterOnBackInvokedCallback(0, _predictiveBackCallback);
+				}
 			}
 		}
 
@@ -51,6 +55,7 @@ namespace Microsoft.Maui
 			if (OperatingSystem.IsAndroidVersionAtLeast(33) && _predictiveBackCallback is not null)
 			{
 				OnBackInvokedDispatcher?.UnregisterOnBackInvokedCallback(_predictiveBackCallback);
+				_predictiveBackCallback.Dispose();
 				_predictiveBackCallback = null;
 			}
 			base.OnDestroy();
@@ -72,7 +77,7 @@ namespace Microsoft.Maui
 			return handled || implHandled;
 		}
 
-		IOnBackInvokedCallback? _predictiveBackCallback;
+		PredictiveBackCallback? _predictiveBackCallback;
 
 		sealed class PredictiveBackCallback : Java.Lang.Object, IOnBackInvokedCallback
 		{

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -1,5 +1,7 @@
+using System;
 using Android.OS;
 using Android.Views;
+using Android.Window;
 using AndroidX.Activity;
 using AndroidX.AppCompat.App;
 using AndroidX.Core.Content.Resources;
@@ -30,10 +32,27 @@ namespace Microsoft.Maui
 			{
 				this.CreatePlatformWindow(IPlatformApplication.Current.Application, savedInstanceState);
 			}
+
+			// Register predictive back callback (Android 13+/API 33+) if available.
+			// This integrates MAUI lifecycle OnBackPressed events with the system back gesture animation.
+			// Guidance: route custom back handling through AndroidX OnBackPressedDispatcher so
+			// predictive back works correctly:
+			// https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#update-custom
+			if (OperatingSystem.IsAndroidVersionAtLeast(33))
+			{
+				var dispatcher = OnBackInvokedDispatcher;
+				_predictiveBackCallback ??= new PredictiveBackCallback(this);
+				dispatcher?.RegisterOnBackInvokedCallback(0, _predictiveBackCallback);
+			}
 		}
 
 		protected override void OnDestroy()
 		{
+			if (OperatingSystem.IsAndroidVersionAtLeast(33) && _predictiveBackCallback is not null)
+			{
+				OnBackInvokedDispatcher?.UnregisterOnBackInvokedCallback(_predictiveBackCallback);
+				_predictiveBackCallback = null;
+			}
 			base.OnDestroy();
 		}
 
@@ -51,6 +70,23 @@ namespace Microsoft.Maui
 				(this.GetWindow() as IPlatformEventsListener)?.DispatchTouchEvent(e) == true;
 
 			return handled || implHandled;
+		}
+
+		IOnBackInvokedCallback? _predictiveBackCallback;
+
+		sealed class PredictiveBackCallback : Java.Lang.Object, IOnBackInvokedCallback
+		{
+			readonly MauiAppCompatActivity _activity;
+			public PredictiveBackCallback(MauiAppCompatActivity activity)
+			{
+				_activity = activity;
+			}
+
+			public void OnBackInvoked()
+			{
+				// Reuse unified handling (will invoke lifecycle events and conditionally propagate).
+				_activity.HandleBackNavigation();
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This PR introduces a unified HandleBackNavigation method to centralize and standardize back navigation logic across platforms.

On Android 13 (API 33) and above, it integrates predictive back gesture callbacks with the MAUI lifecycle, ensuring that custom back navigation seamlessly participates in the system’s predictive back animations.

For more information on predictive back navigation, see the official Android documentation:
https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#update-custom

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32458
Fixes https://github.com/dotnet/maui/issues/32750

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
