### PR TITLE
Fix ContentViewRespondsWhenViewRemoved test fails on Catalyst 

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.iOS.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(100, updatedSize.Height);
 		}
 
-		[Fact(Skip="Failing https://github.com/dotnet/maui/issues/32368"), Category(TestCategory.Layout)]
+		[Fact, Category(TestCategory.Layout)]
 		public async Task ContentViewRespondsWhenViewRemoved()
 		{
 			var contentView = new ContentView();

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -63,10 +63,11 @@ namespace Microsoft.Maui.Handlers
 					}
 					handler.PlatformView.InvalidateAncestorsMeasures();
 				}
-			
+
 			}
-		}		
-	public static partial void MapContent(IContentViewHandler handler, IContentView page)
+		}
+
+		public static partial void MapContent(IContentViewHandler handler, IContentView page)
 		{
 			UpdateContent(handler);
 		}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Maui.Platform;
 using PlatformView = UIKit.UIView;
 
 namespace Microsoft.Maui.Handlers
@@ -49,9 +50,18 @@ namespace Microsoft.Maui.Handlers
 				// so that it can walk up the hierarchy
 				platformView.InvalidateAncestorsMeasures();
 			}
-		}
-
-		public static partial void MapContent(IContentViewHandler handler, IContentView page)
+			else
+			{
+				// When content is removed, we need to invalidate measures so the ContentView can resize to 0x0
+				// We need to invalidate both the ContentView itself and its ancestors
+				if (handler.PlatformView is IPlatformMeasureInvalidationController controller)
+				{
+					controller.InvalidateMeasure(false);
+				}
+				handler.PlatformView.InvalidateAncestorsMeasures();
+			}
+		}		
+	public static partial void MapContent(IContentViewHandler handler, IContentView page)
 		{
 			UpdateContent(handler);
 		}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -51,10 +51,11 @@ namespace Microsoft.Maui.Handlers
 			}
 			else
 			{
-				if (handler.VirtualView.PresentedContent is null)
+				var bounds = handler.PlatformView.Bounds;
+				if (handler.VirtualView.PresentedContent is null && (bounds.Width > 0 || bounds.Height > 0))
 				{
 					// When content is removed, we need to invalidate measures so the ContentView can resize to 0x0
-					// Only invalidate if the ContentView previously had content (optimization to avoid unnecessary invalidation)
+					// Only invalidate if the ContentView actually had a non-zero size (optimization to avoid unnecessary invalidation)
 					// Invalidate both the ContentView itself and its ancestors
 					if (handler.PlatformView is IPlatformMeasureInvalidationController controller)
 					{

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -54,14 +54,10 @@ namespace Microsoft.Maui.Handlers
 				var bounds = handler.PlatformView.Bounds;
 				if (handler.VirtualView.PresentedContent is null && (bounds.Width > 0 || bounds.Height > 0))
 				{
-					// When content is removed, we need to invalidate measures so the ContentView can resize to 0x0
-					// Only invalidate if the ContentView actually had a non-zero size (optimization to avoid unnecessary invalidation)
-					// Invalidate both the ContentView itself and its ancestors
-					if (handler.PlatformView is IPlatformMeasureInvalidationController controller)
-					{
-						controller.InvalidateMeasure(false);
-					}
-					handler.PlatformView.InvalidateAncestorsMeasures();
+					// // When content is removed, we need to invalidate measures so the ContentView can resize to 0x0
+					// // Only invalidate if the ContentView actually had a non-zero size (optimization to avoid unnecessary invalidation)
+					// // Invalidate both the ContentView itself and its ancestors
+					handler.PlatformView.InvalidateMeasure();
 				}
 
 			}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Maui.Platform;
 using PlatformView = UIKit.UIView;
 
 namespace Microsoft.Maui.Handlers
@@ -52,13 +51,18 @@ namespace Microsoft.Maui.Handlers
 			}
 			else
 			{
-				// When content is removed, we need to invalidate measures so the ContentView can resize to 0x0
-				// We need to invalidate both the ContentView itself and its ancestors
-				if (handler.PlatformView is IPlatformMeasureInvalidationController controller)
+				if (handler.VirtualView.PresentedContent is null)
 				{
-					controller.InvalidateMeasure(false);
+					// When content is removed, we need to invalidate measures so the ContentView can resize to 0x0
+					// Only invalidate if the ContentView previously had content (optimization to avoid unnecessary invalidation)
+					// Invalidate both the ContentView itself and its ancestors
+					if (handler.PlatformView is IPlatformMeasureInvalidationController controller)
+					{
+						controller.InvalidateMeasure(false);
+					}
+					handler.PlatformView.InvalidateAncestorsMeasures();
 				}
-				handler.PlatformView.InvalidateAncestorsMeasures();
+			
 			}
 		}		
 	public static partial void MapContent(IContentViewHandler handler, IContentView page)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Description
When content is removed from a ContentView, its height remains cached, leading to layout inconsistencies.

### Root Cause
To improve performance, measure caching was introduced in #[31485](https://github.com/dotnet/maui/pull/31485), which reuses previously measured sizes to avoid redundant layout passes. However, when content is removed, the cached size isn’t automatically invalidated. This causes parent layouts to rely on stale measurements. While invalidation was already handled for content updates (#[30991](https://github.com/dotnet/maui/pull/30991/files#diff-d182926911414e5cf952f0e0fe884c33fb86c6a96001019edaa6f97e355412c6)), it wasn’t addressed for content removal.

### Description of Change
Added InvalidateMeasure calls for both ContentView and its parent when content is set to null and the cached size remains. This ensures proper re-measurement and layout refresh.

### Regression PR 
PR #31485
PR #30991 

### Issues Fixed
Fixes #32368

### Tested the behaviour on the following platforms
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac
 
### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<image width="300" height="150" alt="Before Fix" src="https://github.com/user-attachments/assets/fc9444fd-1bfb-422d-b13c-3a598804bcd3">|<image width="300" height="150" alt="After Fix" src="https://github.com/user-attachments/assets/fce3c114-495e-43c6-b271-caca2b1be29d">|