### PR TITLE
Removed Value property coercion in RadioButton

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="Value"/>.</summary>
 		public static readonly BindableProperty ValueProperty =
 			BindableProperty.Create(nameof(Value), typeof(object), typeof(RadioButton), null,
-			propertyChanged: (b, o, n) => ((RadioButton)b).OnValuePropertyChanged(),
-			coerceValue: (b, o) => o ?? b);
+			propertyChanged: (b, o, n) => ((RadioButton)b).OnValuePropertyChanged());
 
 		/// <summary>Bindable property for <see cref="IsChecked"/>.</summary>
 		public static readonly BindableProperty IsCheckedProperty = BindableProperty.Create(
@@ -210,9 +209,6 @@ namespace Microsoft.Maui.Controls
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<RadioButton>>(() =>
 				new PlatformConfigurationRegistry<RadioButton>(this));
-
-			//initialize Value to prevent null value
-			Value = this;
 		}
 
 		/// <inheritdoc/>

--- a/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
@@ -305,15 +305,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void ValuePropertyCoercedToItselfIfSetToNull()
+		public void ValuePropertyCanBeSetToNull()
 		{
 			var radioButton = new RadioButton();
 
-			Assert.Equal(radioButton, radioButton.Value);
+			Assert.Null(radioButton.Value);
+
+			radioButton.Value = 1;
+
+			Assert.Equal(1, radioButton.Value);
 
 			radioButton.Value = null;
 
-			Assert.Equal(radioButton, radioButton.Value);
+			Assert.Null(radioButton.Value);
 		}
 	}
 }


### PR DESCRIPTION
Eliminated the coercion logic that set RadioButton.Value to the instance when null, allowing Value to be explicitly set to null. Updated related unit test to reflect the new behavior.

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Eliminated the coercion logic that set RadioButton.Value to the instance when null, allowing Value to be explicitly set to null. Updated related unit test to reflect the new behavior.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32466

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
