### PR TITLE
Changed the visibility of the _dialog field in the PickerHandler

### DIFF
--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class PickerHandler : ViewHandler<IPicker, MauiPicker>
 	{
-		AppCompatAlertDialog? _dialog;
+		protected AppCompatAlertDialog? _dialog;
 
 		protected override MauiPicker CreatePlatformView() =>
 			new MauiPicker(Context);

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(string! value) -> Microsoft.Maui.GridLength
+Microsoft.Maui.Handlers.PickerHandler._dialog -> AndroidX.AppCompat.App.AlertDialog?


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This pull request makes a small change to the visibility of the `_dialog` field in the `PickerHandler` class and updates the public API documentation accordingly.

- Changed the `_dialog` field in `PickerHandler` from private to protected, allowing subclasses to access it.
- Updated the public API file to reflect the new protected member `_dialog` in `PickerHandler`.

This is primarily required to customize the picker dialog at the application level. Currently, this field can only be accessed through reflection, as demonstrated in this PR.

https://github.com/dotnet/maui-samples/pull/706/files#diff-57238c4856e2b7f228f25afd45ceff1a3d5202163770664b2e7214197ee0490dR31

