### PR TITLE
Add demands for Darwin OS in UI tests pipeline

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -57,11 +57,9 @@ variables:
   value: none
 
 # Variable groups required for all builds
-- ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui'),  ne(variables['Build.DefinitionName'], 'maui-pr-devicetests')) }}:
+- ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui'),  ne(variables['Build.DefinitionName'], 'maui-pr-devicetests'),  ne(variables['Build.DefinitionName'], 'maui-pr-uitests')) }}:
   - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
-  
-  - ${{ if ne(variables['Build.DefinitionName'], 'maui-pr-uitests') }}:
-    - group: maui-provisionator # This is just needed for the provisionator
+  - group: maui-provisionator # This is just needed for the provisionator
 
 
 - ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.DefinitionName'], 'dotnet-maui'), eq(variables['Build.DefinitionName'], 'dotnet-maui-build')) }}:

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -70,7 +70,8 @@ parameters:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
       demands:
-        - Agent.OS -equals Darwin
+        - macOS.Name -equals Sequoia
+        - macOS.Architecture -equals x64
   
   - name: androidPoolLinux
     type: object
@@ -86,7 +87,8 @@ parameters:
       name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
       demands:
-        - Agent.OS -equals Darwin
+        - macOS.Name -equals Sequoia
+        - macOS.Architecture -equals x64
   
   - name: windowsBuildPool
     type: object

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -69,6 +69,8 @@ parameters:
     default:
       name: $(androidTestsVmPool)
       vmImage: $(androidTestsVmImage)
+      demands:
+        - Agent.OS -equals Darwin
   
   - name: androidPoolLinux
     type: object
@@ -83,6 +85,8 @@ parameters:
     default:
       name: $(iosTestsVmPool)
       vmImage: $(iosTestsVmImage)
+      demands:
+        - Agent.OS -equals Darwin
   
   - name: windowsBuildPool
     type: object


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

This pull request updates the `eng/pipelines/ui-tests.yml` pipeline configuration to improve agent selection for Android and iOS test pools. The main change is the addition of agent demands to ensure that jobs for these pools only run on macOS (Darwin) agents.

Pipeline configuration improvements:

* Added `demands` for the `androidPoolMac` parameter to restrict jobs to agents with `Agent.OS` set to Darwin, ensuring Android tests run on macOS agents.
* Added `demands` for the `iosPoolMac` parameter to restrict jobs to agents with `Agent.OS` set to Darwin, ensuring iOS tests run on macOS agents.

This PR removed some, but the pool also has some Windoes machines that sometimes get picked: https://github.com/dotnet/maui/pull/32229