### PR TITLE
[ci] Device tests using MAUI pool for build

### DIFF
--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -55,7 +55,7 @@ stages:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
     parameters:
       helixRepo: dotnet/maui
-      buildPool: ${{ parameters.buildPool }}
+      pool: ${{ parameters.buildPool }}
       enableMicrobuild: ${{ parameters.enableMicrobuild }}
       enablePublishUsingPipelines: true
       enablePublishBuildAssets: ${{ parameters.publishAssets }}

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -6,7 +6,9 @@ parameters:
 - name: postSteps
   type: stepList
   default: []
-- name: pool
+- name: buildPool
+  type: object
+- name: testPool
   type: object
 - name: enableSourceBuild
   type: boolean
@@ -53,7 +55,7 @@ stages:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
     parameters:
       helixRepo: dotnet/maui
-      pool: ${{ parameters.pool }}
+      buildPool: ${{ parameters.buildPool }}
       enableMicrobuild: ${{ parameters.enableMicrobuild }}
       enablePublishUsingPipelines: true
       enablePublishBuildAssets: ${{ parameters.publishAssets }}
@@ -103,7 +105,7 @@ stages:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
     parameters:
       helixRepo: dotnet/maui
-      pool: ${{ parameters.pool }}
+      pool: ${{ parameters.testPool }}
       enableMicrobuild: false
       enablePublishUsingPipelines: true
       enablePublishBuildAssets: ${{ parameters.publishAssets }}

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -58,6 +58,12 @@ parameters:
     name: Azure Pipelines
     vmImage: windows-2022
 
+- name: macOSTestPool
+  type: object
+  default:
+    name: Azure Pipelines
+    vmImage: macOS-15
+
 - name: macOSPool
   type: object
   default:
@@ -75,7 +81,8 @@ stages:
   # Use Helix for iOS / Android and MacCatalyst Device Tests
   - template: /eng/pipelines/arcade/stage-device-tests.yml@self
     parameters:
-      pool: ${{ parameters.macOSPool }}
+      buildPool: ${{ parameters.macOSPool }}
+      testPool: ${{ parameters.macOSTestPool }}
       runAsPublic: true
       TargetFrameworkVersion: ${{ targetFrameworkVersion.tfm }}
       prepareSteps:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -116,7 +116,8 @@ stages:
     # Use Helix for iOS / Android and MacCatalyst Device Tests
     - template: /eng/pipelines/arcade/stage-device-tests.yml@self
       parameters:
-        pool: ${{ parameters.macOSHelixPool }}
+        buildPool: ${{ parameters.macOSHelixPool }}
+        testPool: ${{ parameters.macOSPool }}
         runAsPublic: true
         TargetFrameworkVersion: ${{ targetFrameworkVersion.tfm }}
         prepareSteps:


### PR DESCRIPTION
### Description of Change

Make build of device tests  faster by using our own pool.

This pull request refactors how build and test agent pools are specified and used in device test pipelines. The main change is splitting the previous single `pool` parameter into separate `buildPool` and `testPool` parameters, allowing greater flexibility in selecting agents for build and test stages. This improves pipeline configuration clarity and makes it easier to use different agent images for building and testing.

**Pipeline parameter refactoring:**

* Split the `pool` parameter into `buildPool` and `testPool` in `eng/pipelines/arcade/stage-device-tests.yml`, updating their types to `object` for better agent specification.
* Updated all pipeline templates and stage invocations to use the new `buildPool` and `testPool` parameters instead of the old `pool` parameter, ensuring builds and tests can run on different agents. [[1]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL56-R58) [[2]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL106-R108) [[3]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bL78-R85) [[4]](diffhunk://#diff-d2d1c388a0fb3196dbfcdab96421bc88336637a3d44480c96717f92d000facaeL119-R120)

**Agent pool improvements:**

* Added a new `macOSTestPool` parameter to `eng/pipelines/ci-device-tests.yml` for specifying a distinct macOS agent pool for tests, with a default image of `macOS-15`.

These changes make the pipeline configuration more flexible and maintainable, especially for scenarios where builds and tests require different environments.

