### PR TITLE
[ci] Update Integration tests with $(_MauiDotNetTfm)

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
### Description of Change

Some machines could not have net8.0 

This pull request updates the target framework for the `Microsoft.Maui.IntegrationTests` project to use a variable instead of a hardcoded value, making the project configuration more flexible and consistent with other Maui projects.

Project configuration update:

* Changed the `TargetFramework` property in `Microsoft.Maui.IntegrationTests.csproj` to use the `$(_MauiDotNetTfm)` variable instead of the hardcoded `net8.0` value, allowing the target framework to be set dynamically.