### PR TITLE
[Android] Refactor selection limit handling in MediaPicker

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -247,7 +247,8 @@ namespace Microsoft.Maui.Media
 			// Android has a limitation that you need to use a different request for single and multiple picks.
 			// If the selection limit is 1, we can use the single pick method,
 			// otherwise we need to use the multiple pick method.
-			if (options.SelectionLimit == 1)
+			int selectionLimit = options?.SelectionLimit ?? 1;
+			if (selectionLimit == 1)
 			{
 				var singleResult = await PickUsingPhotoPicker(options, photo);
 				return singleResult is not null ? [singleResult] : [];
@@ -258,9 +259,9 @@ namespace Microsoft.Maui.Media
 
 			// Only set the limit for 2 and up. For single selection (limit == 1) is handled above,
 			// and limit == 0 should be treated as unlimited.
-			if (options.SelectionLimit >= 2)
+			if (selectionLimit >= 2)
 			{
-				pickVisualMediaRequestBuilder.SetMaxItems(options.SelectionLimit);
+				pickVisualMediaRequestBuilder.SetMaxItems(selectionLimit);
 			}
 
 			var pickVisualMediaRequest = pickVisualMediaRequestBuilder.Build();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

I think we should add a null check and a default value on Android - similar to how it’s already handled on iOS.

https://github.com/dotnet/maui/blob/73ae2c9dd0d7d3b798d255e1ddb34c3234232ff4/src/Essentials/src/MediaPicker/MediaPicker.ios.cs#L211

Replaces direct access to options.SelectionLimit with a local variable that defaults to 1 if options is null. Updates all relevant checks and method calls to use the new variable, improving null safety and code clarity.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32535

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
