### PR TITLE
[Windows]Fix for Custom TitleBar Errors During App Closure with Modal Navigation

### DIFF
--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -197,7 +197,12 @@ namespace Microsoft.Maui.Platform
 
 		internal void UpdateTitleBarContentSize()
 		{
-			if (AppTitleBarContentControl is null)
+			if (!AppWindowId.HasValue || AppTitleBarContentControl is null)
+				return;
+
+			// Get the AppWindow and validate it exists
+			var appWindow = AppWindow.GetFromWindowId(AppWindowId.Value);
+			if (appWindow is null)
 				return;
 
 			if (_appTitleBarHeight != AppTitleBarContentControl.ActualHeight &&
@@ -205,11 +210,8 @@ namespace Microsoft.Maui.Platform
 			{
 				UpdateRootNavigationViewMargins(AppTitleBarContentControl.ActualHeight);
 
-				if (AppWindowId.HasValue)
-				{
-					AppWindow.GetFromWindowId(AppWindowId.Value).TitleBar.PreferredHeightOption =
-						_appTitleBarHeight >= 48 ? TitleBarHeightOption.Tall : TitleBarHeightOption.Standard;
-				}
+				appWindow.TitleBar.PreferredHeightOption =
+					_appTitleBarHeight >= 48 ? TitleBarHeightOption.Tall : TitleBarHeightOption.Standard;
 
 				this.RefreshThemeResources();
 			}
@@ -224,19 +226,15 @@ namespace Microsoft.Maui.Platform
 				rectArray.Add(rect);
 			}
 
-			if (AppWindowId.HasValue)
-			{
-				var nonClientInputSrc =
-					InputNonClientPointerSource.GetForWindowId(AppWindowId.Value);
+			var nonClientInputSrc = InputNonClientPointerSource.GetForWindowId(AppWindowId.Value);
 
-				if (rectArray.Count > 0)
-				{
-					nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, [.. rectArray]);
-				}
-				else
-				{
-					nonClientInputSrc.ClearRegionRects(NonClientRegionKind.Passthrough);
-				}
+			if (rectArray.Count > 0)
+			{
+				nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, [.. rectArray]);
+			}
+			else
+			{
+				nonClientInputSrc.ClearRegionRects(NonClientRegionKind.Passthrough);
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause:

The issue occurs because of a change in the TitleBar management process that moved the cleanup call from NavigationRootManager.Disconnect() to WindowHandler.DisconnectHandler(), which unintentionally introduced a race condition during application shutdown. When the window closes, WindowHandler.DisconnectHandler() disposes of the TitleBar before NavigationRootManager.Disconnect() triggers layout updates. 

These layout updates cause UpdateTitleBarContentSize() to run, which attempts to access WinUI APIs InputNonClientPointerSource.GetForWindowId(). Because the window is in the process of closing, these APIs can fail and raise exception “Value does not fall within the expected range.” The absence of proper window state validation before these API calls resulted in unhandled exceptions during shutdown.

**Regression PR:** https://github.com/dotnet/maui/pull/27192

### Fix Description:

The fix involves adding window state validation at the start of UpdateTitleBarContentSize() before calling any window-specific APIs. The method now verifies that AppWindowId is valid, AppTitleBarContentControl exists, and AppWindow.GetFromWindowId()does not return null. If any of these checks fail, the method exits gracefully. This prevents exceptions during shutdown and allows the cleanup process to complete smoothly without extra state tracking.

When the window is being disposed, AppWindow.GetFromWindowId() returns null, causing the method to terminate safely before invoking APIs like InputNonClientPointerSource.GetForWindowId(), thereby avoiding exceptions and eliminating the need for additional error handling.

**Note:** This issue occurs when closing the window, so it is not possible to add a test case for it.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/32331
Fixes https://github.com/dotnet/maui/issues/32194

### Tested the behaviour in the following platforms
- [x] Mac
- [x] Windows
- [ ] iOS
- [ ] Android

Currently, the TitleBar control is only available on the Windows and Mac Catalyst.

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/313bbe48-8eb6-414d-b8bd-63458fb75e26">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/46b411d1-0977-47dd-84eb-fb2557333c31">|