### PR TITLE
[ci] Add variable group MAUI

### DIFF
--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -4,7 +4,7 @@
     <HelixBuild>$(BUILD_BUILDNUMBER)</HelixBuild>
     <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
     <HelixTargetQueues>Windows.10.Amd64.Open;osx.15.arm64.maui.open</HelixTargetQueues>
-    <Creator Condition="'$(HelixAccessToken)' == ''">maui</Creator>
+    <Creator Condition="'$(Creator)' == ''">maui</Creator>
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -33,7 +33,7 @@ variables:
 - name: ApiScanServiceConnectionId
   value: 334a6802-ebad-4fb1-bc3b-105bcc70bda2
 # Produce test-signed build for PR and Public builds
-- ${{ if or(eq(variables['_RunAsPublic'], 'true')) }}:
+- ${{ if eq(variables['_RunAsPublic'], 'true') }}:
   # needed for darc (dependency flow) publishing
   - name: _PublishArgs
     value: ''

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -45,7 +45,7 @@ variables:
   - name: _SignArgs
     value: '/p:DotNetSignType=$(_SignType) /p:TeamName=$(TeamName)'
 # Set up non-PR build from internal project
-- ${{ if and(ne(variables['_RunAsPublic'], 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if or(eq(variables['Build.DefinitionName'], 'dotnet-maui'), eq(variables['Build.DefinitionName'], 'dotnet-maui-build')) }}:
   # needed for darc (dependency flow) publishing
   - name: _PublishArgs
     value: >-

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -25,7 +25,7 @@ variables:
 - name: TreatWarningsAsErrors
   value: false
 - name: _OfficialBuildIdArgs
-  value: /p:OfficialBuildId=$(_BuildOfficalId) /p:_SkipUpdateBuildNumber=true
+  value: ''
 - name: ApiScanAppId
   value: cbde2fca-1ca1-47f7-8212-fcdf1a556eb2
 - name: ApiScanTenantId

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -33,7 +33,7 @@ variables:
 - name: ApiScanServiceConnectionId
   value: 334a6802-ebad-4fb1-bc3b-105bcc70bda2
 # Produce test-signed build for PR and Public builds
-- ${{ if or(eq(variables['_RunAsPublic'], 'true'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if or(eq(variables['_RunAsPublic'], 'true')) }}:
   # needed for darc (dependency flow) publishing
   - name: _PublishArgs
     value: ''

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -46,10 +46,6 @@ variables:
 
 parameters:
 
-  - name: UseProvisionator
-    type: boolean
-    default: false
-
   - name: BuildEverything
     type: boolean
     default: false
@@ -120,10 +116,6 @@ stages:
       ${{ else }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.4' ]
-      ${{ if or(parameters.UseProvisionator, eq(variables['internalProvisioning'],'true') ) }}:
-        skipProvisioning: false
-      ${{ else }}:  
-        skipProvisioning: true
       projects:
         - name: controls
           desc: Controls

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,9 +56,10 @@ variables:
 - name: nugetMultiFeedWarnLevel
   value: none
 
+- group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
+
 # Variable groups required for all builds
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui'),  ne(variables['Build.DefinitionName'], 'maui-pr-devicetests'),  ne(variables['Build.DefinitionName'], 'maui-pr-uitests')) }}:
-  - group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
   - group: maui-provisionator # This is just needed for the provisionator
 
 

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -49,8 +49,6 @@ variables:
   value: true
 - name: _RunAsInternal
   value: false
-- name: _InternalBuildArgs
-  value: ''
 - name: cfsNugetWarnLevel
   value: warn
 - name: nugetMultiFeedWarnLevel
@@ -78,9 +76,7 @@ variables:
 
     - group: DotNetBuilds storage account read tokens
     - group: AzureDevOps-Artifact-Feeds-Pats
-    - name: _InternalBuildArgs
-      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-
+  
 - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-maui') }}:
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,7 +56,7 @@ variables:
 - name: nugetMultiFeedWarnLevel
   value: none
 
-- group: MAUI # This is the main MAUI variable group that contains secret for the apple certificate
+- group: MAUI # This is the main MAUI variable group that contains secrets for the apple certificate
 
 # Variable groups required for all builds
 - ${{ if and(ne(variables['Build.DefinitionName'], 'maui-pr'), ne(variables['Build.DefinitionName'], 'dotnet-maui'),  ne(variables['Build.DefinitionName'], 'maui-pr-devicetests'),  ne(variables['Build.DefinitionName'], 'maui-pr-uitests')) }}:


### PR DESCRIPTION
### Description of Change

We need a couple of variables from this variable group. 
Change other variables to control internal vs public builds. 
Small cleanup 

This pull request updates build and pipeline configuration files to simplify variable handling, improve conditional logic for build stages, and clean up unused parameters. The primary focus is on streamlining how build arguments and variable groups are set for different build scenarios, including official, public, and internal builds.

### Build and variable configuration simplification

* Removed the `_InternalBuildArgs` variable and its assignment from `eng/pipelines/common/variables.yml`, and updated how the `MAUI` variable group is included to always be present, rather than conditionally. [[1]](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL52-L61) [[2]](diffhunk://#diff-257fa339ab6d36b7dd4fc3eada944bea777297cec9f90dcd20fbd6b3e6c6f57dL80-L81)
* Changed the logic for setting `_PublishArgs` in `eng/pipelines/arcade/variables.yml` to use build definition names instead of checking for public/internal builds and pull requests, making the conditions more explicit and maintainable.
* Set `_OfficialBuildIdArgs` to an empty value instead of passing parameters, simplifying the official build argument handling.

### Pipeline cleanup and conditional logic improvements

* Removed the unused `UseProvisionator` parameter and related provisioning logic from `eng/pipelines/ci-uitests.yml`, reducing complexity and potential confusion in test pipeline configuration. [[1]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3L49-L52) [[2]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3L123-L126)

### Minor fix

* Updated the `Creator` property condition in `eng/helix.proj` to check for an existing value before setting a default, preventing unwanted overrides.