### PR TITLE
[ci] Bump to new Xcode to 26.0.1 and .NET default version

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -8,9 +8,9 @@ variables:
 - name: DOTNET_VERSION
   value: 10.0.100-preview.2.25164.34
 - name: REQUIRED_XCODE
-  value: 26.0.0
+  value: 26.0.1
 - name: DEVICETESTS_REQUIRED_XCODE
-  value: 26.0.0
+  value: 26.0.1
 - name: XCODE
   value: 26.0.1
 - name: POWERSHELL_VERSION

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -6,7 +6,7 @@ variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: DOTNET_VERSION
-  value: 10.0.100-preview.2.25164.34
+  value: 10.0.100
 - name: REQUIRED_XCODE
   value: 26.0.1
 - name: DEVICETESTS_REQUIRED_XCODE


### PR DESCRIPTION
### Description of Change

This pull request updates key toolchain versions in the pipeline configuration to ensure the build uses the latest stable releases.

Toolchain version updates:

* Updated the `DOTNET_VERSION` variable to use the stable release `10.0.100` instead of the previous preview version.

Environment configuration updates:

* Updated `REQUIRED_XCODE` and `DEVICETESTS_REQUIRED_XCODE` variables to version `26.0.1` to match the current `XCODE` version, ensuring consistency across build and test environments.