### PR TITLE
[ci] Try fix RuniOS tests

### DIFF
--- a/eng/pipelines/common/maui-templates.yml
+++ b/eng/pipelines/common/maui-templates.yml
@@ -161,7 +161,7 @@ jobs:
         displayName: Reset iOS simulators
         # TODO: pass properly device type/version from top-level yml
         env:
-          IOS_TEST_DEVICE: ios-simulator-64_18.0
+          IOS_TEST_DEVICE: ios-simulator-64_18.4
 
     - pwsh: ./build.ps1 --target=dotnet-integration-test --filter="Category=${{ RunPlatform.testName }}" --resultsfilename="integration-run-${{ RunPlatform.testName }}" --verbosity=diagnostic
       displayName: Run ${{ RunPlatform.testName }} templates run tests
@@ -169,7 +169,7 @@ jobs:
       # TODO: pass properly device type/version from top-level yml
       ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
         env:
-          IOS_TEST_DEVICE: ios-simulator-64_18.0
+          IOS_TEST_DEVICE: ios-simulator-64_18.4
 
     - ${{ if eq(RunPlatform.testName, 'RunOniOS') }}:
       - pwsh: ./build.ps1 --target=Cleanup -Script eng/devices/ios.cake ---results="$(TestResultsDirectory)" ${{ parameters.cakeArgs }}


### PR DESCRIPTION
### Description of Change

These integration tests are failing

```
Failed to boot simulator with UDID '\u001b[41m\u001b[30mfail\u001b[39m\u001b[22m\u001b[49m: Microsoft.DotNet.XHarness.Common.CLI.NoDeviceFoundException: Failed to find/create suitable simulator
---> Microsoft.DotNet.XHarness.Common.CLI.NoDeviceFoundException: Could not create device
runtime: com.apple.CoreSimulator.SimRuntime.iOS-18-0
device type: com.apple.CoreSimulator.SimDeviceType.iPhone-XS
at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.FindOrCreateDevicesAsync(ILog log, String runtime, String devicetype, Boolean force, CancellationToken cancellationToken) in //src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:line 232
at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.FindSimulators(TestTargetOs target, ILog log, Boolean createIfNeeded, Boolean minVersion, CancellationToken cancellationToken) in //src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:line 412
at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.FindSimulators(TestTargetOs target, ILog log, Int32 retryCount, Boolean createIfNeeded, Boolean minVersion, CancellationToken cancellationToken) in //src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:line 517
--- End of inner exception stack trace ---
at Microsoft.DotNet.XHarness.iOS.Shared.Hardware.SimulatorLoader.FindSimulators(TestTargetOs target, ILog log, Int32 retryCount, Boolean createIfNeeded, Boolean minVersion, CancellationToken cancellationToken) in //src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs:line 525
at Microsoft.DotNet.XHarness.Apple.DeviceFinder.FindDevice(TestTargetOs target, String deviceName, ILog log, Boolean includeWirelessDevices, Boolean pairedDevicesOnly, CancellationToken cancellationToken) in //src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs:line 60
at Microsoft.DotNet.XHarness.CLI.Commands.Apple.AppleDeviceCommand.Invoke(ILogger logger) in //src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleDeviceCommand.cs:line 59'.
Expected: True
But was:  False
```