### PR TITLE
Return stub IAlertManagerSubscription for standard AlertManager

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Standard.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Standard.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		private partial IAlertManagerSubscription CreateSubscription(IMauiContext mauiContext)
 		{
-			throw new NotImplementedException();
+			return new AlertRequestHelper();
 		}
 
 		internal partial class AlertRequestHelper


### PR DESCRIPTION
.NET 10 MAUI introduced a new internal implementation of IAlertManagerSubscription. This includes a standard implementation with a NotImplementedException for CreateSubscription.

https://github.com/dotnet/maui/blob/3680b04dfa836df7c475fdaa1f636b08d0b4f054/src/Controls/src/Core/Platform/AlertManager/AlertManager.Standard.cs#L8-L11

This creates a problem if you are using .NET implementations of the controls from outside the standard .NET MAUI UI TFMs (Such as test cases for controls outside of the MAUI repo). Window calls on an internal AlertManager implementation, 

https://github.com/dotnet/maui/blob/3680b04dfa836df7c475fdaa1f636b08d0b4f054/src/Controls/src/Core/Window/Window.cs#L696-L700

This calls on that standard AlertManager, which then fails with a not implemented exception. in .NET 9 and previous, this would no-op.

Returning the stub AlertManagerHelper fixes this and lets it continue. For 99.999% of users (scientifically speaking), they shouldn't notice a difference in behavior.