### PR TITLE
[Android] NET10 - Exception on quit - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
@@ -37,14 +37,5 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			((IShellContentController)ShellContentTab).RecyclePage(_page);
 			_page = null;
 		}
-
-		public override void OnDestroy()
-		{
-			_mauiContext
-				.GetDispatcher()
-				.Dispatch(Dispose);
-
-			base.OnDestroy();
-		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

`ShellFragmentContainer.OnDestroy()` attempts to dispatch `Dispose()` via the dispatcher during app shutdown. The `MauiContext` service provider is already disposed at this point, causing `ObjectDisposedException` → `JavaProxyThrowable`.

**Fix:** Remove the `OnDestroy()` override entirely.

**Why safe:**
- `OnDestroyView()` already handles cleanup (page recycling, null references)
- No custom `Destroy()` logic exists (unlike `ShellContentFragment`/`ShellItemRenderer`)
- Android framework manages fragment disposal

**Root cause:** Commit 0e86703d38 (PR #5064) switched from `Activity.RunOnUiThread(Dispose)` to dispatcher-based disposal, introducing a dependency on the service provider being available—not guaranteed during shutdown.

### Issues Fixed

Fixes #32600

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> pr-reviewer please review
> @dotnet/maui/pull/32647


</details>