### PR TITLE
Shell Flyout appears in Release builds even when FlyoutBehavior="Disabled" - fix

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			PanGestureRecognizer.ShouldReceiveTouch += (sender, touch) =>
 			{
+				if (_flyoutBehavior == FlyoutBehavior.Disabled)
+					return false;
+					
 				if (!context.AllowFlyoutGesture || _flyoutBehavior != FlyoutBehavior.Flyout)
 					return false;
 				var view = View;
@@ -117,6 +120,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				IsOpen = true;
 			else if (behavior == FlyoutBehavior.Disabled)
 				IsOpen = false;
+			
+			UpdatePanGestureEnabled();
+			
 			LayoutSidebar(false);
 			UpdateFlyoutAccessibility();
 		}
@@ -240,6 +246,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			((IShellController)Shell).AddFlyoutBehaviorObserver(this);
 			UpdateFlowDirection();
 			UpdateFlyoutAccessibility();
+			UpdatePanGestureEnabled();
+		}
+		
+		void UpdatePanGestureEnabled()
+		{
+			if (PanGestureRecognizer != null)
+			{
+				PanGestureRecognizer.Enabled = _flyoutBehavior != FlyoutBehavior.Disabled;
+			}
 		}
 
 		public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32616.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32616.cs
@@ -1,0 +1,76 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32616, "Shell Flyout appears in Release builds even when FlyoutBehavior=\"Disabled\" (MacCatalyst)", PlatformAffected.macOS)]
+public class Issue32616 : Shell
+{
+	public Issue32616()
+	{
+		this.FlyoutBehavior = FlyoutBehavior.Disabled;
+		
+		var label = new Label 
+		{ 
+			Text = "Flyout is DISABLED. Try to swipe from left edge - flyout should NOT appear.",
+			AutomationId = "StatusLabel",
+			Margin = new Thickness(20)
+		};
+		
+		var enableButton = new Button 
+		{ 
+			Text = "Enable Flyout", 
+			AutomationId = "EnableButton",
+			Margin = new Thickness(20)
+		};
+		
+		var disableButton = new Button 
+		{ 
+			Text = "Disable Flyout", 
+			AutomationId = "DisableButton",
+			Margin = new Thickness(20),
+			IsEnabled = false
+		};
+		
+		enableButton.Clicked += (s, e) => 
+		{
+			this.FlyoutBehavior = FlyoutBehavior.Flyout;
+			label.Text = "Flyout is ENABLED. Swipe from left edge - flyout SHOULD appear.";
+			enableButton.IsEnabled = false;
+			disableButton.IsEnabled = true;
+		};
+		
+		disableButton.Clicked += (s, e) => 
+		{
+			this.FlyoutBehavior = FlyoutBehavior.Disabled;
+			label.Text = "Flyout is DISABLED. Try to swipe from left edge - flyout should NOT appear.";
+			enableButton.IsEnabled = true;
+			disableButton.IsEnabled = false;
+		};
+		
+		var stack = new StackLayout
+		{
+			Children = { label, enableButton, disableButton }
+		};
+		
+		var contentPage = new ContentPage
+		{
+			Title = "Issue 32616",
+			Content = stack
+		};
+		
+		// Add flyout items so there's something to display when enabled
+		var flyoutItem = new FlyoutItem
+		{
+			Title = "Main",
+			Items =
+			{
+				new ShellContent
+				{
+					Title = "Page 1",
+					Route = "Page1",
+					Content = contentPage
+				}
+			}
+		};
+		
+		Items.Add(flyoutItem);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32616.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32616.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue32616 : _IssuesUITest
+	{
+		public Issue32616(TestDevice testDevice) : base(testDevice) { }
+
+		public override string Issue => "Shell Flyout appears in Release builds even when FlyoutBehavior=\"Disabled\" (MacCatalyst)";
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void FlyoutShouldNotAppearWhenDisabled()
+		{
+			// Initial state: flyout is disabled
+			App.WaitForElement("StatusLabel");
+			App.WaitForElement("EnableButton");
+			
+			// Verify flyout icon is not present when disabled
+			App.WaitForNoFlyoutIcon();
+			
+			// Enable flyout
+			App.Tap("EnableButton");
+			
+			// Verify flyout icon appears when enabled
+			App.WaitForFlyoutIcon();
+			
+			// Disable flyout again
+			App.Tap("DisableButton");
+			
+			// Verify flyout icon disappears when disabled
+			App.WaitForNoFlyoutIcon();
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Added logic to disable the pan gesture recognizer when FlyoutBehavior is set to Disabled. This prevents unintended gesture interactions when the flyout is not available.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32616

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
