### PR TITLE
Add XC0067/MAUIX2015 warning for duplicate implicit content property assignments in XAML

### DIFF
--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public static BuildExceptionCode NamescopeDuplicate = new BuildExceptionCode("XC", 0064, nameof(NamescopeDuplicate), "");
 		public static BuildExceptionCode ContentPropertyAttributeMissing = new BuildExceptionCode("XC", 0065, nameof(ContentPropertyAttributeMissing), "");
 		public static BuildExceptionCode InvalidXaml = new BuildExceptionCode("XC", 0066, nameof(InvalidXaml), "");
+		public static BuildExceptionCode DuplicatePropertyAssignment = new BuildExceptionCode("XC", 0067, nameof(DuplicatePropertyAssignment), ""); //warning
 
 
 		//Extensions

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -270,8 +270,12 @@
   </data>
   <data name="StaticResourceSyntax" xml:space="preserve">
     <value>A key is required in {StaticResource}.</value>
-  </data>  
+  </data>
   <data name="XSharedNotSupported" xml:space="preserve">
     <value>x:Shared is only supported with SourceGen inflator. Remove the attribute or switch to SourceGen.</value>
+  </data>
+  <data name="DuplicatePropertyAssignment" xml:space="preserve">
+    <value>Property '{0}' is being set multiple times. Only the last value will be used.</value>
+    <comment>0 is property name (e.g. "Border.Content" or "Label.Text")</comment>
   </data>
 </root>

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -43,6 +43,31 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		ModuleDefinition Module { get; } = context.Body.Method.Module;
 
+		// Track properties that have been set to detect duplicates
+		readonly Dictionary<ElementNode, HashSet<XmlName>> setProperties = new Dictionary<ElementNode, HashSet<XmlName>>();
+
+		void CheckForDuplicateProperty(ElementNode parentNode, XmlName propertyName, IXmlLineInfo lineInfo)
+		{
+			if (!setProperties.TryGetValue(parentNode, out var props))
+			{
+				props = new HashSet<XmlName>();
+				setProperties[parentNode] = props;
+			}
+
+			if (!props.Add(propertyName))
+			{
+				// Property is being set multiple times
+				Context.LoggingHelper.LogWarningOrError(
+					DuplicatePropertyAssignment,
+					Context.XamlFilePath,
+					lineInfo.LineNumber,
+					lineInfo.LinePosition,
+					0,
+					0,
+					$"{parentNode.XmlType.Name}.{propertyName.LocalName}");
+			}
+		}
+
 		public void Visit(ValueNode node, INode parentNode)
 		{
 			//TODO support Label text as element
@@ -69,6 +94,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				return;
 			if (propertyName.Equals(XmlName.mcIgnorable))
 				return;
+
+			// TODO: Add duplicate implicit content property checking here to match SourceGen behavior
+			// (SourceGen Visit(ValueNode) emits MAUIX2015 when a ValueNode assigns the same implicit
+			// content property that was already assigned by an ElementNode or another ValueNode).
+			// Without this check, <Border>text<Label/></Border> produces MAUIX2015 under SourceGen
+			// but no warning under XamlC.
 			Context.IL.Append(SetPropertyValue(Context.Variables[(ElementNode)parentNode], propertyName, node, Context, node));
 		}
 
@@ -140,8 +171,32 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					var name = new XmlName(node.NamespaceURI, contentProperty);
 					if (skips.Contains(name))
 						return;
-					if (parentNode is ElementNode node2 && node2.SkipProperties.Contains(propertyName))
+					if (parentNode is ElementNode node2 && node2.SkipProperties.Contains(name))
 						return;
+
+					// Resolve the content property type to determine if it is a collection.
+					// Use CanGet (CLR property resolution) rather than GetBindablePropertyReference+GetValue/Get
+					// to avoid side effects: GetBindablePropertyReference can emit ObsoleteProperty diagnostics
+					// and GetValue/Get generate IL instructions; both would be duplicated by SetPropertyValue.
+					// CanGet covers all content properties because every BP-backed property has a CLR wrapper.
+					var propLocalName = name.LocalName;
+					bool canResolveProperty = CanGet(parentVar, propLocalName, Context, out TypeReference contentPropType);
+
+					// Skip duplicate check when the property cannot be resolved, is System.Object (unresolved
+					// generics would produce false positives), or is a collection type. Matches SourceGen behavior.
+					if (canResolveProperty && contentPropType != null)
+					{
+						bool isObject = contentPropType.FullName == "System.Object";
+						bool isCollection = !isObject
+							&& contentPropType.ImplementsInterface(Context.Cache, Module.ImportReference(Context.Cache, ("mscorlib", "System.Collections", "IEnumerable")))
+							&& contentPropType.GetMethods(Context.Cache, md => md.Name == "Add" && md.Parameters.Count == 1, Module).Any();
+
+						// Use parent namespace for duplicate tracking to match how explicit property assignments are keyed
+						var contentPropertyName = new XmlName(((ElementNode)parentNode).NamespaceURI, contentProperty);
+						if (!isCollection && !isObject)
+							CheckForDuplicateProperty((ElementNode)parentNode, contentPropertyName, node);
+					}
+
 					Context.IL.Append(SetPropertyValue(Context.Variables[(ElementNode)parentNode], name, node, Context, node));
 				}
 				// Collection element, implicit content, or implicit collection element.
@@ -539,7 +594,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				// continue compilation
 			}
 
-			if (   dataTypeNode is ElementNode enode
+			if (dataTypeNode is ElementNode enode
 				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
 				&& enode.XmlType.Name == nameof(Xaml.NullExtension))
 			{

--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -30,3 +30,4 @@ MAUIX2010 | XamlParsing | Info | ExpressionNotSettable
 MAUIX2011 | XamlParsing | Warning | AmbiguousMemberWithStaticType
 MAUIX2012 | XamlParsing | Error | CSharpExpressionsRequirePreviewFeatures
 MAUIX2013 | XamlParsing | Error | AsyncLambdaNotSupported
+MAUIX2015 | XamlInflation | Warning | DuplicatePropertyAssignment

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -325,6 +325,14 @@ namespace Microsoft.Maui.Controls.SourceGen
 			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true);
 
+		public static DiagnosticDescriptor DuplicatePropertyAssignment = new DiagnosticDescriptor(
+			id: "MAUIX2015",
+			title: new LocalizableResourceString(nameof(MauiGResources.DuplicatePropertyAssignmentTitle), MauiGResources.ResourceManager, typeof(MauiGResources)),
+			messageFormat: new LocalizableResourceString(nameof(MauiGResources.DuplicatePropertyAssignmentMessage), MauiGResources.ResourceManager, typeof(MauiGResources)),
+			category: "XamlInflation",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+
 		// public static BuildExceptionCode TypeResolution = new BuildExceptionCode("XC", 0000, nameof(TypeResolution), "");
 		// public static BuildExceptionCode PropertyResolution = new BuildExceptionCode("XC", 0001, nameof(PropertyResolution), "");
 		// public static BuildExceptionCode MissingEventHandler = new BuildExceptionCode("XC", 0002, nameof(MissingEventHandler), "");

--- a/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
+++ b/src/Controls/src/SourceGen/InitializeComponentCodeWriter.cs
@@ -130,7 +130,8 @@ $$"""
 			return;
 		}
 
-""");
+"""
+);
 					}
 					Visit(root, sgcontext);
 

--- a/src/Controls/src/SourceGen/MauiGResources.resx
+++ b/src/Controls/src/SourceGen/MauiGResources.resx
@@ -240,4 +240,11 @@
     <value>Event handler '{0}' with correct signature not found in type '{1}'.</value>
     <comment>0 is handler name, 1 is type name</comment>
   </data>
+  <data name="DuplicatePropertyAssignmentTitle" xml:space="preserve">
+    <value>Property set multiple times</value>
+  </data>
+  <data name="DuplicatePropertyAssignmentMessage" xml:space="preserve">
+    <value>Property '{0}' is being set multiple times. Only the last value will be used.</value>
+    <comment>0 is a property name (e.g., "Border.Content", "Label.Text")</comment>
+  </data>
 </root>

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -534,7 +534,7 @@ static class SetPropertyHelpers
 		}
 	}
 
-	static bool CanGet(ILocalValue parentVar, string localName, SourceGenContext context, out ITypeSymbol? propertyType, out IPropertySymbol? propertySymbol)
+	internal static bool CanGet(ILocalValue parentVar, string localName, SourceGenContext context, out ITypeSymbol? propertyType, out IPropertySymbol? propertySymbol)
 	{
 		propertyType = null;
 		if ((propertySymbol = parentVar.Type.GetAllProperties(localName, context).FirstOrDefault()) == null)
@@ -546,7 +546,7 @@ static class SetPropertyHelpers
 		return true;
 	}
 
-	static bool CanGetValue(ILocalValue parentVar, IFieldSymbol? bpFieldSymbol, bool attached, SourceGenContext context, out ITypeSymbol? propertyType)
+	internal static bool CanGetValue(ILocalValue parentVar, IFieldSymbol? bpFieldSymbol, bool attached, SourceGenContext context, out ITypeSymbol? propertyType)
 	{
 		propertyType = null;
 		if (bpFieldSymbol == null)

--- a/src/Controls/src/SourceGen/SourceGenContext.cs
+++ b/src/Controls/src/SourceGen/SourceGenContext.cs
@@ -38,10 +38,14 @@ class SourceGenContext(IndentedTextWriter writer, Compilation compilation, Sourc
 		var noWarn = ProjectItem?.NoWarn;
 		if (!string.IsNullOrEmpty(noWarn))
 		{
-			var suppressedIds = noWarn!.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+			var suppressedIds = noWarn!.Split(new[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
 			foreach (var id in suppressedIds)
 			{
-				if (diagnostic.Id.Equals(id.Trim(), StringComparison.OrdinalIgnoreCase))
+				var code = id.Trim();
+				// Match full ID (e.g., "MAUIX2015") or bare numeric suffix (e.g., "2015")
+				if (code.Equals(diagnostic.Id, StringComparison.OrdinalIgnoreCase) ||
+					(diagnostic.Id.StartsWith("MAUIX", StringComparison.OrdinalIgnoreCase) &&
+					 code == diagnostic.Id.Substring("MAUIX".Length)))
 				{
 					return; // Suppress this diagnostic
 				}

--- a/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,11 +36,59 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 	public bool SkipChildren(INode node, INode parentNode) => node is ElementNode en && en.IsLazyResource(parentNode, Context);
 	public bool IsResourceDictionary(ElementNode node) => node.IsResourceDictionary(Context);
 
+	// Track properties that have been set to detect duplicates
+	readonly Dictionary<ElementNode, HashSet<XmlName>> setProperties = new Dictionary<ElementNode, HashSet<XmlName>>();
+
+	void CheckForDuplicateProperty(ElementNode parentNode, XmlName propertyName, IXmlLineInfo lineInfo)
+	{
+		if (!setProperties.TryGetValue(parentNode, out var props))
+		{
+			props = new HashSet<XmlName>();
+			setProperties[parentNode] = props;
+		}
+
+		if (!props.Add(propertyName))
+		{
+			var propertyDisplayName = $"{parentNode.XmlType.Name}.{propertyName.LocalName}";
+			var location = LocationCreate(Context.ProjectItem.RelativePath!, lineInfo, propertyDisplayName);
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.DuplicatePropertyAssignment, location, propertyDisplayName));
+		}
+	}
+
+	/// <summary>
+	/// Resolves the type of an implicit content property and, when the property is a non-collection
+	/// non-Object type, calls <see cref="CheckForDuplicateProperty"/> to emit a diagnostic if it has
+	/// already been assigned.
+	/// </summary>
+	/// <param name="lookupName">XmlName used for the <c>GetBindableProperty</c> lookup (namespace may differ from <paramref name="trackingName"/>).</param>
+	/// <param name="trackingName">XmlName used as the deduplication key (always uses the parent element's namespace).</param>
+	void CheckImplicitContentForDuplicate(
+		ILocalValue parentVar,
+		ElementNode parentNode,
+		XmlName lookupName,
+		XmlName trackingName,
+		IXmlLineInfo lineInfo)
+	{
+		bool attached = false;
+		var localName = lookupName.LocalName;
+		var bpFieldSymbol = parentVar.Type.GetBindableProperty(lookupName.NamespaceURI, ref localName, out attached, context, lineInfo);
+		ITypeSymbol? propertyType = null;
+
+		bool hasProperty = (bpFieldSymbol != null && SetPropertyHelpers.CanGetValue(parentVar, bpFieldSymbol, attached, context, out propertyType))
+			|| SetPropertyHelpers.CanGet(parentVar, localName, context, out propertyType, out _);
+
+		bool isObject = propertyType != null && propertyType.SpecialType == SpecialType.System_Object;
+		if (hasProperty && propertyType != null && !isObject && !propertyType.CanAdd(context))
+			CheckForDuplicateProperty(parentNode, trackingName, lineInfo);
+	}
+
 	public void Visit(ValueNode node, INode parentNode)
 	{
 		//TODO support Label text as element
 
 		// if it's implicit content property, get the content property name
+		bool isImplicitContentProperty = false;
+		ILocalValue? parentVar = null;
 		if (!node.TryGetPropertyName(parentNode, out XmlName propertyName))
 		{
 			if (!parentNode.IsCollectionItem(node))
@@ -47,9 +96,12 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 			string? contentProperty;
 			if (!Context.Variables.ContainsKey((ElementNode)parentNode))
 				return;
-			var parentVariable = Context.Variables[(ElementNode)parentNode];
-			if ((contentProperty = parentVariable.Type.GetContentPropertyName(context)) != null)
+			parentVar = Context.Variables[(ElementNode)parentNode];
+			if ((contentProperty = parentVar.Type.GetContentPropertyName(context)) != null)
+			{
 				propertyName = new XmlName(((ElementNode)parentNode).NamespaceURI, contentProperty);
+				isImplicitContentProperty = true;
+			}
 			else
 				return;
 		}
@@ -63,13 +115,12 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 		if (propertyName.Equals(XmlName.mcIgnorable))
 			return;
 
-		// Check that parent has a variable before accessing
-		var parentElement = (ElementNode)parentNode;
-		if (!Context.Variables.TryGetValue(parentElement, out var parentVar))
-		{
-			var parentKey = parentElement.Properties.TryGetValue(XmlName.xKey, out var keyNode) && keyNode is ValueNode vn ? vn.Value?.ToString() : "(none)";
-			throw new System.InvalidOperationException($"SetPropertiesVisitor.Visit(ValueNode): Parent '{parentElement.XmlType.Name}' x:Key='{parentKey}' not in Variables for propertyName='{propertyName}'");
-		}
+		parentVar ??= Context.Variables.TryGetValue((ElementNode)parentNode, out var pv) ? pv : null;
+		// Parent element not yet in Variables — can occur for markup extensions or nodes
+		// processed before their parent is fully initialized. Silently skip; the assignment
+		// will be handled through another visitor pass.
+		if (parentVar == null)
+			return;
 
 		// Try to set runtime name (for x:Name with RuntimeNameProperty attribute)
 		if (TrySetRuntimeName(propertyName, parentVar, node))
@@ -78,6 +129,10 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 		// Skip x:Name after TrySetRuntimeName has had a chance to process it
 		if (propertyName == XmlName.xName)
 			return;
+
+		// Check for duplicate property assignment for implicit content properties
+		if (isImplicitContentProperty)
+			CheckImplicitContentForDuplicate(parentVar, (ElementNode)parentNode, propertyName, propertyName, node);
 
 		SetPropertyHelpers.SetPropertyValue(Writer, parentVar, propertyName, node, Context);
 	}
@@ -207,6 +262,7 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 				var key1 = ((ElementNode)parentNode).Properties.TryGetValue(XmlName.xKey, out var kn1) && kn1 is ValueNode vn1 ? vn1.Value?.ToString() : "(none)";
 				throw new System.InvalidOperationException($"SetPropertiesVisitor.Visit(ElementNode) propertyName != Empty: Parent '{((ElementNode)parentNode).XmlType.Name}' x:Key='{key1}' not in Variables");
 			}
+
 			SetPropertyHelpers.SetPropertyValue(Writer, pVar1, propertyName, node, Context);
 		}
 		else if (parentNode.IsCollectionItem(node) && parentNode is ElementNode)
@@ -225,8 +281,14 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 				var name = new XmlName(node.NamespaceURI, contentProperty);
 				if (skips.Contains(name))
 					return;
-				if (parentNode is ElementNode node1 && node1.SkipProperties.Contains(propertyName))
+				if (parentNode is ElementNode node1 && node1.SkipProperties.Contains(name))
 					return;
+
+				// Only check for duplicate property assignment if the property is not a collection
+				// Use parent namespace for duplicate tracking to match how explicit property assignments are keyed
+				var contentPropertyName = new XmlName(((ElementNode)parentNode).NamespaceURI, contentProperty);
+				CheckImplicitContentForDuplicate(parentVar, (ElementNode)parentNode, name, contentPropertyName, node);
+
 				SetPropertyHelpers.SetPropertyValue(Writer, parentVar, name, node, Context);
 			}
 			else if (parentVar.Type.CanAdd(context))

--- a/src/Controls/src/SourceGen/xlf/MauiGResources.Designer.cs
+++ b/src/Controls/src/SourceGen/xlf/MauiGResources.Designer.cs
@@ -267,9 +267,10 @@ namespace Microsoft.Maui.Controls.SourceGen {
 		// Namescope diagnostics
 		internal static string NamescopeError => ResourceManager.GetString("NamescopeError", resourceCulture);
 		internal static string NamescopeDuplicate => ResourceManager.GetString("NamescopeDuplicate", resourceCulture);
-
 		// Event handler diagnostics
 		internal static string MissingEventHandlerTitle => ResourceManager.GetString("MissingEventHandlerTitle", resourceCulture);
 		internal static string MissingEventHandler => ResourceManager.GetString("MissingEventHandler", resourceCulture);
+		internal static string DuplicatePropertyAssignmentTitle => ResourceManager.GetString("DuplicatePropertyAssignmentTitle", resourceCulture);
+		internal static string DuplicatePropertyAssignmentMessage => ResourceManager.GetString("DuplicatePropertyAssignmentMessage", resourceCulture);
 	}
 }

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/MultipleChildrenWarningTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/MultipleChildrenWarningTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+public class MultipleChildrenWarningTests : SourceGenXamlInitializeComponentTestBase
+{
+	[Fact]
+	public void BorderWithMultipleChildren_EmitsWarning()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Border>
+		<Label Text="First" />
+		<Label Text="Second" />
+	</Border>
+</ContentPage>
+"""
+;
+
+		var code =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+"""
+;
+
+		var (result, generated) = RunGenerator(xaml, code);
+		
+		// Verify that a warning diagnostic was emitted
+		var warnings = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToArray();
+		Assert.True(warnings.Length > 0, "Expected at least one warning diagnostic");
+		
+		var multipleChildrenWarning = warnings.FirstOrDefault(d => d.Id == "MAUIX2015");
+		Assert.NotNull(multipleChildrenWarning);
+		Assert.Contains("Border.Content", multipleChildrenWarning.GetMessage(), StringComparison.Ordinal);
+		Assert.Contains("multiple times", multipleChildrenWarning.GetMessage(), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ContentPageWithMultipleChildren_EmitsWarning()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Label Text="First" />
+	<Label Text="Second" />
+</ContentPage>
+"""
+;
+
+		var code =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+"""
+;
+
+		var (result, generated) = RunGenerator(xaml, code);
+		
+		// Verify that a warning diagnostic was emitted
+		var warnings = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToArray();
+		Assert.True(warnings.Length > 0, "Expected at least one warning diagnostic");
+		
+		var multipleChildrenWarning = warnings.FirstOrDefault(d => d.Id == "MAUIX2015");
+		Assert.NotNull(multipleChildrenWarning);
+		Assert.Contains("ContentPage.Content", multipleChildrenWarning.GetMessage(), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void BorderWithSingleChild_NoWarning()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Border>
+		<Label Text="Only Child" />
+	</Border>
+</ContentPage>
+"""
+;
+
+		var code =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+"""
+;
+
+		var (result, generated) = RunGenerator(xaml, code);
+		
+		// Verify that NO warning diagnostic was emitted for single child
+		var multipleChildrenWarning = result.Diagnostics.FirstOrDefault(d => d.Id == "MAUIX2015");
+		Assert.Null(multipleChildrenWarning);
+	}
+
+	[Fact]
+	public void StackLayoutWithMultipleChildren_NoWarning()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<VerticalStackLayout>
+		<Label Text="First" />
+		<Label Text="Second" />
+		<Label Text="Third" />
+	</VerticalStackLayout>
+</ContentPage>
+"""
+;
+
+		var code =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+"""
+;
+
+		var (result, generated) = RunGenerator(xaml, code);
+		
+		// VerticalStackLayout is a collection type, so multiple children are valid
+		var multipleChildrenWarning = result.Diagnostics.FirstOrDefault(d => d.Id == "MAUIX2015");
+		Assert.Null(multipleChildrenWarning);
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618;CA2252</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0025;XC0045;MAUIG2045;MAUID1000;MAUIX2005</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0025;XC0045;XC0067;MAUIG2045;MAUID1000;MAUIX2005;MAUIX2015</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
@@ -76,6 +76,13 @@
     <MauiXaml Update="Issues\Issue1438.xaml" NoWarn="0612" />
     <MauiXaml Update="Issues\Issue2578.xaml" NoWarn="0612" />
     <MauiXaml Update="Issues\Issue2659.xaml" NoWarn="0612" />
+    
+    <!-- Suppress XC0067/MAUIX2015 (property set multiple times) for test files that intentionally test this scenario -->
+    <MauiXaml Update="Issues\Bz40906.xaml" NoWarn="67;2015" />
+    <MauiXaml Update="Issues\Maui3059.xaml" NoWarn="67;2015" />
+    <MauiXaml Update="Issues\Maui20616.xaml" NoWarn="67;2015" />
+    <MauiXaml Update="Issues\Maui20818.xaml" NoWarn="67;2015" />
+    <MauiXaml Update="TestSharedResourceDictionary.xaml" NoWarn="67;2015" />
 
     <!-- LazyRD feature test -->
     <MauiXaml Update="Issues\LazyResourceDictionary.sgen.xaml" LazyRD="true" />

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh5095.rt.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh5095.rt.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.Maui.Controls.Build.Tasks;
 using Xunit;
 
@@ -35,8 +36,8 @@ public partial class Gh5095 : ContentPage
 """)
 					.RunMauiSourceGenerator(typeof(Gh5095));
 
-				//FIXME check the diagnostic code
-				Assert.Single(result.Diagnostics);
+				Assert.Contains(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+				Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2015");
 			}
 		}
 	}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui3059">
+	<Border>
+		<Label Text="First" />
+		<Label Text="Second" />
+	</Border>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059.xaml.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui3059 : ContentPage
+{
+	public Maui3059()
+	{
+		InitializeComponent();
+	}
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		public void Dispose() => DispatcherProvider.SetCurrent(null);
+
+		[Theory]
+		[XamlInflatorData]
+		internal void BorderWithMultipleChildren_OnlyLastChildIsUsed(XamlInflator inflator)
+		{
+			var page = new Maui3059(inflator);
+
+			Assert.NotNull(page.Content);
+			Assert.IsType<Microsoft.Maui.Controls.Border>(page.Content);
+
+			var border = (Microsoft.Maui.Controls.Border)page.Content;
+			Assert.NotNull(border.Content);
+			Assert.IsType<Label>(border.Content);
+
+			var label = (Label)border.Content;
+			Assert.Equal("Second", label.Text);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059VisualStates.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059VisualStates.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui3059VisualStates">
+	<ContentPage.Resources>
+		<Style TargetType="Grid">
+			<Setter Property="VisualStateManager.VisualStateGroups">
+				<VisualStateGroupList>
+					<VisualStateGroup x:Name="CommonStates">
+						<VisualState x:Name="Normal" />
+						<VisualState x:Name="Selected">
+							<VisualState.Setters>
+								<Setter Property="BackgroundColor" Value="LightSkyBlue" />
+							</VisualState.Setters>
+						</VisualState>
+					</VisualStateGroup>
+				</VisualStateGroupList>
+			</Setter>
+		</Style>
+	</ContentPage.Resources>
+	<Grid>
+		<Label Text="Test" />
+	</Grid>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059VisualStates.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3059VisualStates.xaml.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui3059VisualStates : ContentPage
+{
+	public Maui3059VisualStates()
+	{
+		InitializeComponent();
+	}
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		public void Dispose() => DispatcherProvider.SetCurrent(null);
+
+		[Theory]
+		[XamlInflatorData]
+		internal void VisualStateGroupList_MultipleChildren_NoWarning(XamlInflator inflator)
+		{
+			var page = new Maui3059VisualStates(inflator);
+			Assert.NotNull(page.Content);
+			Assert.IsType<Grid>(page.Content);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #3059

## Description of Change

Adds XC0067/MAUIX2006 warning diagnostic to detect when XAML **implicit content properties** are set multiple times (e.g., `<Border><Label/><Label/></Border>`).

This implementation specifically targets the issue described in #3059: detecting multiple children in single-child content properties.

## Key Changes

- **Focused implementation**: Only warns for implicit content property duplicates
- **Does NOT warn for**: Explicit attribute duplicates like `<Label Text="A" Text="B" />` (XAML parser already rejects these at parse time)
- **Collection-aware**: Correctly handles collection properties (e.g., `Style.Setters`, `VisualStateGroup.States`) - no warnings when adding multiple items
- **Works for both implicit and explicit content property syntax**:
  - `<Border><Label/><Label/></Border>` → warns about `Border.Content`
  - `<Border><Border.Content><Label/><Label/></Border.Content></Border>` → warns about `Border.Content`

## Implementation Details

- Duplicate detection only in `Visit(ElementNode)` for implicit content properties
- Removed checks for explicit attribute assignments (ValueNode) - not needed
- Added property type inspection to detect collection properties
- Collections use `Add()` method, so multiple children are expected and don't trigger warnings
- Improved NoWarn parsing to properly handle comma/semicolon-delimited codes
- Implemented in both Build.Tasks and SourceGen

## Testing

- Added comprehensive unit tests in SourceGen.UnitTests
- Tests verify warnings for single-value content properties
- Tests verify NO warnings for collection properties
- Tests verify NO warnings for single children
- Removed unnecessary tests for explicit attribute duplicates

## Issues Fixed

Fixes #3059
