### PR TITLE
Fix crash when TimePicker.Time is set to null

### DIFF
--- a/src/Controls/src/Core/TimePicker/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker/TimePicker.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Maui.Controls
 		static void TimePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (bindable is TimePicker timePicker)
-				timePicker.TimeSelected?.Invoke(timePicker, new TimeChangedEventArgs((TimeSpan)oldValue, (TimeSpan)newValue));
+				timePicker.TimeSelected?.Invoke(timePicker, new TimeChangedEventArgs((TimeSpan?)oldValue, (TimeSpan?)newValue));
 		}
 
 		private protected override string GetDebuggerDisplay()


### PR DESCRIPTION
### Description of Change

Since TimePicker now supports nullable, the casts need to be nullable to match the TimeChangedEventArgs properties. 

### Issues Fixed

`timeSpan.Time = null` throws a NullReferenceException. (This PR is also the reporting issue.)

#32709