### PR TITLE
[XSG] IndexOutOfRangeException nullable enums

### DIFF
--- a/src/Controls/src/SourceGen/NodeSGExtensions.cs
+++ b/src/Controls/src/SourceGen/NodeSGExtensions.cs
@@ -167,8 +167,9 @@ static class NodeSGExtensions
 		if (converter is not null && stringValue is not null)
 			return true;
 
-		if (toType.NullableAnnotation == NullableAnnotation.Annotated
-			&& toType.SpecialType == SpecialType.None)
+		if (   toType.NullableAnnotation == NullableAnnotation.Annotated
+			&& toType.SpecialType == SpecialType.None
+			&& ((INamedTypeSymbol)toType).TypeArguments.Length == 1)
 		{
 			toType = ((INamedTypeSymbol)toType).TypeArguments[0];
 		}
@@ -271,8 +272,9 @@ static class NodeSGExtensions
 			=> context.ReportDiagnostic(Diagnostic.Create(Descriptors.ConversionFailed, LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, lineInfo, valueString), valueString, toType.ToDisplayString()));
 #pragma warning restore RS0030 // Do not use banned APIs
 
-		if (toType.NullableAnnotation == NullableAnnotation.Annotated
-			&& toType.SpecialType == SpecialType.None)
+		if (   toType.NullableAnnotation == NullableAnnotation.Annotated
+			&& toType.SpecialType == SpecialType.None
+			&& ((INamedTypeSymbol)toType).TypeArguments.Length == 1)
 		{
 			toType = ((INamedTypeSymbol)toType).TypeArguments[0];
 		}

--- a/src/Controls/src/SourceGen/TypeConverters/RDSourceConverter.cs
+++ b/src/Controls/src/SourceGen/TypeConverters/RDSourceConverter.cs
@@ -45,6 +45,11 @@ class RDSourceConverter : ISGTypeConverter
 		if (value.Contains(";assembly="))
 		{
 			var parts = value.Split([";assembly="], StringSplitOptions.RemoveEmptyEntries);
+			if (parts.Length < 2)
+			{
+				// Invalid format: missing assembly name after ;assembly=
+				return "default";
+			}
 			value = parts[0];
 			var asmName = parts[1];
 			asm = context.Compilation.GetAssembly(asmName)!;

--- a/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
@@ -71,7 +71,7 @@ class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 		if (expression.StartsWith("{}", StringComparison.Ordinal))
 			return new ValueNode(expression.Substring(2), null, xmlLineInfo?.LineNumber ?? -1, xmlLineInfo?.LinePosition ?? -1);
 
-		if (expression[expression.Length - 1] != '}')
+		if (expression.Length == 0 || expression[expression.Length - 1] != '}')
 		{
 			//FIXME fix location
 			var location = Context.ProjectItem.RelativePath is not null ? Location.Create(Context.ProjectItem.RelativePath, new TextSpan(), new LinePositionSpan()) : null;

--- a/src/Controls/src/Xaml/MarkupExpressionParser.cs
+++ b/src/Controls/src/Xaml/MarkupExpressionParser.cs
@@ -223,6 +223,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (end == 0)
 				throw new XamlParseException("Empty value string in markup expression", serviceProvider);
 
+			if (end >= remaining.Length)
+				throw new XamlParseException("Unexpected end of markup expression", serviceProvider);
+
 			next = remaining[end];
 			remaining = remaining.Substring(end + 1);
 

--- a/src/Controls/tests/SourceGen.UnitTests/Maui32658Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/Maui32658Tests.cs
@@ -1,0 +1,122 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Maui.Controls.SourceGen;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.SourceGen.SourceGeneratorDriver;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests.SourceGen;
+
+public class Maui32658Tests : SourceGenTestsBase
+{
+	private record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, string? NoWarn = null)
+		: AdditionalFile(Text: SourceGeneratorDriver.ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, NoWarn: NoWarn);
+
+	[Fact]
+	public void MarkupExtensionWithCustomXmlnsNoThirdParty()
+	{
+		// Test reproducing MauiIcons pattern: generic abstract base class that returns BindingBase
+		// This more closely matches the actual MauiIcons implementation
+		var markupExtensionCode =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using System;
+
+[assembly: XmlnsDefinition("http://test.example.com/markup", "TestMarkup")]
+
+namespace TestMarkup
+{
+	public enum TestIcons
+	{
+		None,
+		Home,
+		Settings,
+		AccessAlarm
+	}
+
+	// Simulate MauiIcons BaseIcon class
+	public abstract class BaseIcon : BindableObject
+	{
+		public static readonly BindableProperty IconColorProperty = 
+			BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(BaseIcon), null);
+
+		public Color IconColor
+		{
+			get => (Color)GetValue(IconColorProperty);
+			set => SetValue(IconColorProperty, value);
+		}
+	}
+
+	// Simulate MauiIcons generic BaseIconExtension<TEnum>
+	[ContentProperty(nameof(Icon))]
+	public abstract class BaseIconExtension<TEnum> : BaseIcon, IMarkupExtension<BindingBase> where TEnum : Enum
+	{
+		public static new readonly BindableProperty IconProperty = 
+			BindableProperty.Create(nameof(Icon), typeof(TEnum?), typeof(BaseIconExtension<TEnum>), null);
+
+		public TEnum? Icon
+		{
+			get => (TEnum?)GetValue(IconProperty);
+			set => SetValue(IconProperty, value);
+		}
+
+		public BindingBase ProvideValue(IServiceProvider serviceProvider)
+		{
+			// Return a binding that would produce a FontImageSource
+			return new Binding 
+			{ 
+				Source = new FontImageSource 
+				{ 
+					Glyph = Icon?.ToString() ?? "",
+					FontFamily = "TestFont",
+					Size = 24
+				},
+				Path = "."
+			};
+		}
+
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) 
+			=> ProvideValue(serviceProvider);
+	}
+
+	// Concrete implementation like MaterialOutlinedExtension
+	public class TestIconExtension : BaseIconExtension<TestIcons>
+	{
+	}
+}
+""";
+
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:test="http://test.example.com/markup"
+	x:Class="Test.TestPage">
+	<ImageButton Source="{test:TestIcon Icon=AccessAlarm}"/>
+</ContentPage>
+""";
+
+		var compilation = CreateMauiCompilation();
+		
+		// Add the markup extension code to the compilation
+		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(markupExtensionCode));
+
+		var result = RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
+
+		// This should NOT produce "Index was outside the bounds of the array" error
+		var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+		
+		// Output diagnostics for debugging
+		foreach (var diag in errors)
+		{
+			System.Console.WriteLine($"Error: {diag.GetMessage()}");
+		}
+		
+		Assert.False(errors.Any(e => e.GetMessage().Contains("Index was outside the bounds of the array", System.StringComparison.Ordinal)), 
+			$"Found IndexOutOfRangeException: {string.Join(", ", errors.Select(e => e.GetMessage()))}");
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui32658.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui32658.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui32658">
+	<ImageButton x:Name="imageButton" Source="{local:TestIcon Icon=AccessAlarm}"/>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui32658.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui32658.xaml.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+// Reproduce MauiIcons pattern: enum for icon selection
+public enum TestIcons
+{
+	None,
+	Home,
+	Settings,
+	AccessAlarm
+}
+
+// Simulate MauiIcons BaseIcon class
+public abstract class BaseTestIcon : BindableObject
+{
+	public static readonly BindableProperty IconColorProperty = 
+		BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(BaseTestIcon), null);
+
+	public Color IconColor
+	{
+		get => (Color)GetValue(IconColorProperty);
+		set => SetValue(IconColorProperty, value);
+	}
+}
+
+// Simulate MauiIcons generic BaseIconExtension<TEnum>
+[ContentProperty(nameof(Icon))]
+[AcceptEmptyServiceProvider]
+public abstract class BaseTestIconExtension<TEnum> : BaseTestIcon, IMarkupExtension<BindingBase> where TEnum : Enum
+{
+	public static readonly BindableProperty IconExtensionProperty = 
+		BindableProperty.Create(nameof(Icon), typeof(TEnum), typeof(BaseTestIconExtension<TEnum>), default(TEnum));
+
+	public TEnum Icon
+	{
+		get => (TEnum)GetValue(IconExtensionProperty);
+		set => SetValue(IconExtensionProperty, value);
+	}
+
+	public BindingBase ProvideValue(IServiceProvider serviceProvider)
+	{
+		// Return a binding that would produce a FontImageSource
+		return new Binding 
+		{ 
+			Source = new FontImageSource 
+			{ 
+				Glyph = Icon?.ToString() ?? "",
+				FontFamily = "TestFont",
+				Size = 24
+			},
+			Path = "."
+		};
+	}
+
+	object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) 
+		=> ProvideValue(serviceProvider);
+}
+
+// Concrete implementation like MaterialOutlinedExtension
+public class TestIconExtension : BaseTestIconExtension<TestIcons>
+{
+}
+
+public partial class Maui32658 : ContentPage
+{
+	public Maui32658() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[Test]
+		public void MarkupExtensionWithGenericBaseClassAndEnumProperty([Values] XamlInflator inflator)
+		{
+			// This test reproduces issue #32658
+			// The bug was an IndexOutOfRangeException when parsing markup extensions
+			// with a generic abstract base class pattern (like MauiIcons)
+			var page = new Maui32658(inflator);
+			
+			// Just verifying the page loads without throwing is sufficient
+			// The original bug would throw "Index was outside the bounds of the array"
+			// during XAML parsing when using generic markup extensions
+			Assert.That(page, Is.Not.Null);
+			Assert.That(page.imageButton, Is.Not.Null);
+		}
+	}
+}


### PR DESCRIPTION

## Description of Change

bug while trying to underlying type of a nullable enum

## Main Fix

**NodeSGExtensions.cs**: Added bounds check `TypeArguments.Length == 1` before accessing `TypeArguments[0]` when unwrapping nullable types.

## Additional Defensive Fixes

- **ExpandMarkupsVisitor.cs**: Check string is not empty before accessing `expression[Length-1]`
- **MarkupExpressionParser.cs**: Add bounds check before accessing `remaining[end]`
- **RDSourceConverter.cs**: Validate array has 2+ elements after `Split` before accessing indices

## Tests Added

- **SourceGen.UnitTests/Maui32658Tests**: Verifies source generation succeeds without throwing
- **Xaml.UnitTests/Maui32658**: Tests runtime loading with all inflators (Runtime/XamlC/SourceGen)

Both tests reproduce the MauiIcons pattern (generic abstract base class with enum property, inheriting from BindableObject, returning BindingBase) without requiring third-party dependencies.

## Issues Fixed

Fixes #32658 