### PR TITLE
Fix #32670: Generate fully qualified Row/ColumnDefinition types in SourceGen

### DIFF
--- a/src/Controls/src/SourceGen/TypeConverters/ColumnDefinitionCollectionConverter.cs
+++ b/src/Controls/src/SourceGen/TypeConverters/ColumnDefinitionCollectionConverter.cs
@@ -13,6 +13,7 @@ class ColumnDefinitionCollectionConverter : ISGTypeConverter
 	public string Convert(string value, BaseNode node, ITypeSymbol toType, IndentedTextWriter writer, SourceGenContext context, ILocalValue? parentVar = null)
 	{
 		var xmlLineInfo = (IXmlLineInfo)node;
+		var columnDefinitionType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ColumnDefinition")!;
 		if (!string.IsNullOrEmpty(value))
 		{
 			var lengths = value.Split([',']);
@@ -22,7 +23,7 @@ class ColumnDefinitionCollectionConverter : ISGTypeConverter
 			foreach (var length in lengths)
 			{
 				var gridLength = gridLengthConverter.Convert(length, node, toType, writer, context);
-				columnDefinitions.Add($"new ColumnDefinition({gridLength})");
+				columnDefinitions.Add($"new {columnDefinitionType.ToFQDisplayString()}({gridLength})");
 			}
 
 			var columnDefinitionCollectionType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ColumnDefinitionCollection")!;

--- a/src/Controls/src/SourceGen/TypeConverters/RowDefinitionCollectionConverter.cs
+++ b/src/Controls/src/SourceGen/TypeConverters/RowDefinitionCollectionConverter.cs
@@ -13,6 +13,7 @@ class RowDefinitionCollectionConverter : ISGTypeConverter
 	public string Convert(string value, BaseNode node, ITypeSymbol toType, IndentedTextWriter writer, SourceGenContext context, ILocalValue? parentVar = null)
 	{
 		var xmlLineInfo = (IXmlLineInfo)node;
+		var rowDefinitionType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.RowDefinition")!;
 		if (!string.IsNullOrEmpty(value))
 		{
 			var lengths = value.Split([',']);
@@ -22,7 +23,7 @@ class RowDefinitionCollectionConverter : ISGTypeConverter
 			foreach (var length in lengths)
 			{
 				var gridLength = gridLengthConverter.Convert(length, node, toType, writer, context);
-				rowDefinitions.Add($"new RowDefinition({gridLength})");
+				rowDefinitions.Add($"new {rowDefinitionType.ToFQDisplayString()}({gridLength})");
 			}
 
 			var rowDefinitionCollectionType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.RowDefinitionCollection")!;

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/StaticResourceWithTypeConversion.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/StaticResourceWithTypeConversion.cs
@@ -108,7 +108,7 @@ public partial class TestPage
 #line 8 "{{testXamlFilePath}}"
 		staticResourceExtension.Key = "GridRowDef";
 #line default
-		var rowDefinitionCollection = new global::Microsoft.Maui.Controls.RowDefinitionCollection([new RowDefinition(new global::Microsoft.Maui.GridLength(10, global::Microsoft.Maui.GridUnitType.Absolute)), new RowDefinition(global::Microsoft.Maui.GridLength.Star), new RowDefinition(global::Microsoft.Maui.GridLength.Star), new RowDefinition(global::Microsoft.Maui.GridLength.Auto)]);
+		var rowDefinitionCollection = new global::Microsoft.Maui.Controls.RowDefinitionCollection([new global::Microsoft.Maui.Controls.RowDefinition(new global::Microsoft.Maui.GridLength(10, global::Microsoft.Maui.GridUnitType.Absolute)), new global::Microsoft.Maui.Controls.RowDefinition(global::Microsoft.Maui.GridLength.Star), new global::Microsoft.Maui.Controls.RowDefinition(global::Microsoft.Maui.GridLength.Star), new global::Microsoft.Maui.Controls.RowDefinition(global::Microsoft.Maui.GridLength.Auto)]);
 		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(rowDefinitionCollection!) == null)
 			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(rowDefinitionCollection!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 8);
 #line 8 "{{testXamlFilePath}}"


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes #32670

The SourceGen TypeConverters for RowDefinitionCollection and ColumnDefinitionCollection were generating unqualified `new RowDefinition()` and `new ColumnDefinition()` calls, which could cause ambiguity issues in generated code.

### Changes Made

1. **ColumnDefinitionCollectionConverter.cs**: Now uses `GetTypeByMetadataName` and `ToFQDisplayString()` to generate fully qualified `global::Microsoft.Maui.Controls.ColumnDefinition` type references
2. **RowDefinitionCollectionConverter.cs**: Same fix for RowDefinition types
3. **Updated existing test expectations** in `StaticResourceWithTypeConversion.cs` to match new fully qualified output

### Example

**Before:**
```csharp
new RowDefinitionCollection([new RowDefinition(global::Microsoft.Maui.GridLength.Star)])
```

**After:**
```csharp
new RowDefinitionCollection([new global::Microsoft.Maui.Controls.RowDefinition(global::Microsoft.Maui.GridLength.Star)])
```

### Testing

- ✅ All SourceGen.UnitTests pass (66 tests)
- ✅ All Xaml.UnitTests pass (1713 tests)