### PR TITLE
CursorPosition not calculated correctly on behaviors events for iOS devices

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32483.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32483.cs
@@ -15,25 +15,15 @@ public class Issue32483 : ContentPage
 		label.HeightRequest = 100;
 		var entry = new Entry();
 		entry.Keyboard = Keyboard.Numeric;
-		entry.Behaviors.Add(new Issue32483Behavior());
+		entry.TextChanged += (s, e) =>
+		{
+			label.Text = "CursorPosition : " + entry.CursorPosition;
+		};
 		entry.AutomationId = "TestEntry";
 		entry.HeightRequest = 100;
 		stackLayout.Children.Add(label);
 		stackLayout.Children.Add(entry);
 		Content = stackLayout;
-	}
-}
-
- public class Issue32483Behavior : Behavior<Entry>
-{
-    protected override void OnAttachedTo(Entry bindable)
-    {
-        base.OnAttachedTo(bindable);
-        bindable.TextChanged += OnTextChanged;
-    }
-    private void OnTextChanged(object sender, TextChangedEventArgs e)
-    {
-        (((sender as Entry).Parent as StackLayout).Children[0] as Label).Text = "CursorPosition : " + (sender as Entry).CursorPosition;
 	}
 }
 	

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32483.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32483.cs
@@ -1,0 +1,39 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32483, "CursorPosition not calculated correctly on behaviors events for iOS devices", PlatformAffected.iOS)]
+
+public class Issue32483 : ContentPage
+{
+	public Issue32483()
+	{
+		var stackLayout = new StackLayout();
+		var label = new Label
+		{
+			Text = "CursorPosition :",
+		};
+		label.AutomationId = "CursorLabel";
+		label.HeightRequest = 100;
+		var entry = new Entry();
+		entry.Keyboard = Keyboard.Numeric;
+		entry.Behaviors.Add(new Issue32483Behavior());
+		entry.AutomationId = "TestEntry";
+		entry.HeightRequest = 100;
+		stackLayout.Children.Add(label);
+		stackLayout.Children.Add(entry);
+		Content = stackLayout;
+	}
+}
+
+ public class Issue32483Behavior : Behavior<Entry>
+{
+    protected override void OnAttachedTo(Entry bindable)
+    {
+        base.OnAttachedTo(bindable);
+        bindable.TextChanged += OnTextChanged;
+    }
+    private void OnTextChanged(object sender, TextChangedEventArgs e)
+    {
+        (((sender as Entry).Parent as StackLayout).Children[0] as Label).Text = "CursorPosition : " + (sender as Entry).CursorPosition;
+	}
+}
+	

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32483.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32483.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32483 : _IssuesUITest
+{
+	public Issue32483(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "CursorPosition not calculated correctly on behaviors events for iOS devices";
+
+	[Test]
+	[Category(UITestCategories.Entry)]
+	public void Issue32483Test()
+	{
+		// Tap the button to push the FlyoutPage modally
+		App.WaitForElement("TestEntry");
+		App.Tap("TestEntry");
+		App.EnterText("TestEntry","12345");
+		App.WaitForElement("CursorPosition : 5");
+	}
+}

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -192,6 +192,15 @@ namespace Microsoft.Maui.Handlers
 			{
 				if (sender is MauiTextField platformView)
 				{
+					// Update cursor position BEFORE updating text so that when TextChanged event fires,
+					// the CursorPosition property reflects the current native cursor position
+					var cursorPosition = platformView.GetCursorPosition();
+					
+					if (VirtualView?.CursorPosition != cursorPosition)
+					{
+						VirtualView?.CursorPosition = cursorPosition;
+					}
+
 					VirtualView?.UpdateText(platformView.Text);
 				}
 			}


### PR DESCRIPTION
### Issue Details:

The CursorPosition property value is not calculated correctly on TextChanged event of the Entry in iOS platform but it calculated correctly in Android platform.
       
### Root Cause:

Analysed the issue how it works in android platform, then saw that when enter text on entry, the selectionchanged event is triggered from native level and we updated the VirtualView.CursorPosition by getting the cursorposition of native platformview on SelectionChanged event. So, it works fine in android platform. Then checked in iOS platform, the SelectionChanged event is not triggered from iOS when enter text on entry.

### Description of Change:

I retrieved the cursor position using platformView.GetCursorPosition() and assigned it to VirtualView.CursorPosition in the OnEditingChanged event within EntryHandler.iOS.cs.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #32483  

### Screenshots
| Before  | After  |
|---------|--------|
| <video width="1080" height="2400" src="https://github.com/user-attachments/assets/7185167b-835c-41ec-bacc-4713b463e912"/> | <video width="1080" height="2400" src="https://github.com/user-attachments/assets/272ea156-32c7-4e14-8e00-a73084ae1944" /> |
