### PR TITLE
[XSG] Fix x:Static to support inherited static members from base classes

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/XStaticInheritance.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/XStaticInheritance.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.XStaticInheritance">
+	<StackLayout>
+		<!-- Test accessing const from base class -->
+		<Label x:Name="baseConstant"
+			   Text="{x:Static local:DerivedClassForStaticTest.BaseClassString}" />
+		<!-- Test accessing static property from base class -->
+		<Label x:Name="baseProperty"
+			   Text="{x:Static local:DerivedClassForStaticTest.BaseStaticProperty}" />
+		<!-- Test accessing static field from base class -->
+		<Label x:Name="baseField"
+			   Text="{x:Static local:DerivedClassForStaticTest.BaseStaticField}" />
+		<!-- Test accessing derived class member (should work) -->
+		<Label x:Name="derivedConstant"
+			   Text="{x:Static local:DerivedClassForStaticTest.DerivedClassString}" />
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/XStaticInheritance.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/XStaticInheritance.xaml.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class BaseClassForStaticTest
+{
+	public const string BaseClassString = "base class string";
+	public static string BaseStaticProperty { get; } = "base static property";
+	public static string BaseStaticField = "base static field";
+}
+
+public class DerivedClassForStaticTest : BaseClassForStaticTest
+{
+	public const string DerivedClassString = "derived class string";
+}
+
+public partial class XStaticInheritance : ContentPage
+{
+	public XStaticInheritance() => InitializeComponent();
+
+	public XStaticInheritance(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[TestFixture]
+	class Tests
+	{
+		[Test]
+		public void XStaticCanAccessInheritedConstant([Values] XamlInflator inflator)
+		{
+			var layout = new XStaticInheritance(inflator);
+			Assert.That(layout.baseConstant.Text, Is.EqualTo("base class string"));
+		}
+
+		[Test]
+		public void XStaticCanAccessInheritedStaticProperty([Values] XamlInflator inflator)
+		{
+			var layout = new XStaticInheritance(inflator);
+			Assert.That(layout.baseProperty.Text, Is.EqualTo("base static property"));
+		}
+
+		[Test]
+		public void XStaticCanAccessInheritedStaticField([Values] XamlInflator inflator)
+		{
+			var layout = new XStaticInheritance(inflator);
+			Assert.That(layout.baseField.Text, Is.EqualTo("base static field"));
+		}
+
+		[Test]
+		public void XStaticCanAccessDerivedClassMember([Values] XamlInflator inflator)
+		{
+			var layout = new XStaticInheritance(inflator);
+			Assert.That(layout.derivedConstant.Text, Is.EqualTo("derived class string"));
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes #15286

The x:Static markup extension now correctly resolves static members (constants, properties, and fields) inherited from base classes.

### Issue

Previously, x:Static only searched for members on the exact type specified, causing `XamlParseException` when trying to access inherited static members via a derived class reference. For example:

```csharp
public class BaseClass
{
    public const string BaseClassString = "base class string";
}

public class TestClass : BaseClass
{
    public const string TestClassString = "test class string";
}
```

```xaml
<Label Text="{x:Static local:TestClass.TestClassString}"/> <!-- worked -->
<Label Text="{x:Static local:TestClass.BaseClassString}"/> <!-- threw exception -->
```

### Changes

- Modified `StaticExtension.ProvideValue()` to walk the type hierarchy using `GetTypeInfo().DeclaredProperties` and `DeclaredFields`
- Added while loop to traverse `BaseType` chain until member is found or hierarchy is exhausted
- Aligns runtime XAML behavior with compiled XAML (which already had correct behavior) and WPF

### Testing

- Added comprehensive unit tests in `XStaticInheritance.xaml/cs`
- Tests verify access to inherited const, static property, and static field
- All 12 new tests pass (runtime + compiled variants)
- All 51 existing XStatic tests still pass (no regressions)

### API Changes

None - this is a bug fix that restores expected behavior

### Backward Compatibility

This change is fully backward compatible. It only adds support for previously broken scenarios.
