### PR TITLE
[XSG] Fix NaN and Infinity value generation in Setter

### DIFF
--- a/src/Controls/src/SourceGen/NodeSGExtensions.cs
+++ b/src/Controls/src/SourceGen/NodeSGExtensions.cs
@@ -354,7 +354,17 @@ static class NodeSGExtensions
 			if (string.IsNullOrEmpty(valueString))
 				return "default";
 			if (float.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out var floatValue))
+			{
+				// Handle special values that don't need a suffix
+				if (float.IsNaN(floatValue))
+					return "float.NaN";
+				if (float.IsPositiveInfinity(floatValue))
+					return "float.PositiveInfinity";
+				if (float.IsNegativeInfinity(floatValue))
+					return "float.NegativeInfinity";
+				// Regular values need the F suffix
 				return $"{SymbolDisplay.FormatPrimitive(floatValue, true, false)}F";
+			}
 			else
 				reportDiagnostic();
 		}
@@ -363,7 +373,17 @@ static class NodeSGExtensions
 			if (string.IsNullOrEmpty(valueString))
 				return "default";
 			if (double.TryParse(valueString, NumberStyles.Number, CultureInfo.InvariantCulture, out var doubleValue))
+			{
+				// Handle special values that don't need a suffix
+				if (double.IsNaN(doubleValue))
+					return "double.NaN";
+				if (double.IsPositiveInfinity(doubleValue))
+					return "double.PositiveInfinity";
+				if (double.IsNegativeInfinity(doubleValue))
+					return "double.NegativeInfinity";
+				// Regular values need the D suffix
 				return $"{SymbolDisplay.FormatPrimitive(doubleValue, true, false)}D";
+			}
 			else
 				reportDiagnostic();
 		}

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterWithNaN.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterWithNaN.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+public class SetterWithNaN : SourceGenXamlInitializeComponentTestBase
+{
+	[Fact]
+	public void SetterPropertyWithNaNValue()
+	{
+		// Issue: Setter with Value="NaN" generates incorrect code "Value = NaND" instead of "Value = double.NaN"
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+    <ContentPage.Resources>
+        <Style TargetType="Label" x:Key="LabelStyle">
+            <Setter Property="HeightRequest" Value="NaN" />
+            <Setter Property="WidthRequest" Value="NaN" />
+        </Style>
+    </ContentPage.Resources>
+</ContentPage>
+""";
+
+		var code =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify that NaN is correctly generated as double.NaN, not NaND
+		Assert.Contains("double.NaN", generated, StringComparison.Ordinal);
+		Assert.DoesNotContain("NaND", generated, StringComparison.Ordinal);
+		
+		// Verify both HeightRequest and WidthRequest setters use double.NaN
+		Assert.Contains("HeightRequestProperty", generated, StringComparison.Ordinal);
+		Assert.Contains("WidthRequestProperty", generated, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void SetterPropertyWithNaNValueInObjectInitializer()
+	{
+		// Verify the generated Setter uses double.NaN in its object initializer
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+    <ContentPage.Resources>
+        <Style TargetType="Button" x:Key="ButtonStyle">
+            <Setter Property="HeightRequest" Value="NaN" />
+        </Style>
+    </ContentPage.Resources>
+</ContentPage>
+""";
+
+		var code =
+"""
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify the Setter is created with Value = double.NaN in object initializer syntax
+		Assert.Contains("new global::Microsoft.Maui.Controls.Setter", generated, StringComparison.Ordinal);
+		Assert.Contains("Property = global::Microsoft.Maui.Controls.VisualElement.HeightRequestProperty", generated, StringComparison.Ordinal);
+		Assert.Contains("Value = double.NaN", generated, StringComparison.Ordinal);
+		
+		// Ensure incorrect code is not generated
+		Assert.DoesNotContain("Value = NaND", generated, StringComparison.Ordinal);
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui32697.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui32697.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui32697">
+	<ContentPage.Resources>
+		<Style x:Key="TestStyle" TargetType="Label">
+			<Setter Property="HeightRequest" Value="NaN" />
+			<Setter Property="WidthRequest" Value="NaN" />
+		</Style>
+	</ContentPage.Resources>
+	<VerticalStackLayout>
+		<Label x:Name="TestLabel" Style="{StaticResource TestStyle}" Text="Test" />
+	</VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui32697.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui32697.xaml.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui32697 : ContentPage
+{
+	public Maui32697() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[Test]
+		public void SetterWithNaNValueWorksWithAllInflators([Values] XamlInflator inflator)
+		{
+			var page = new Maui32697(inflator);
+
+			// Verify the style was applied
+			Assert.That(page.TestLabel, Is.Not.Null);
+			Assert.That(page.TestLabel.Style, Is.Not.Null);
+
+			// Verify NaN values are correctly applied
+			Assert.That(double.IsNaN(page.TestLabel.HeightRequest), Is.True, "HeightRequest should be NaN");
+			Assert.That(double.IsNaN(page.TestLabel.WidthRequest), Is.True, "WidthRequest should be NaN");
+		}
+
+		[Test]
+		public void SetterWithNaNValueInStyleResourceWorksWithAllInflators([Values] XamlInflator inflator)
+		{
+			var page = new Maui32697(inflator);
+
+			// Verify the style exists in resources
+			Assert.That(page.Resources.ContainsKey("TestStyle"), Is.True);
+
+			var style = page.Resources["TestStyle"] as Style;
+			Assert.That(style, Is.Not.Null);
+			Assert.That(style.Setters.Count, Is.EqualTo(2));
+
+			// Verify the setters have NaN values
+			var heightSetter = style.Setters.FirstOrDefault(s => s.Property == VisualElement.HeightRequestProperty);
+			Assert.That(heightSetter, Is.Not.Null);
+			Assert.That(heightSetter.Value, Is.TypeOf<double>());
+			Assert.That(double.IsNaN((double)heightSetter.Value), Is.True, "HeightRequest setter value should be NaN");
+
+			var widthSetter = style.Setters.FirstOrDefault(s => s.Property == VisualElement.WidthRequestProperty);
+			Assert.That(widthSetter, Is.Not.Null);
+			Assert.That(widthSetter.Value, Is.TypeOf<double>());
+			Assert.That(double.IsNaN((double)widthSetter.Value), Is.True, "WidthRequest setter value should be NaN");
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Fixes #32697

When using `Value="NaN"` or `Value="Infinity"` in XAML Setters, the XAML SourceGenerator generated invalid code like `Value = NaND` instead of `Value = double.NaN`, causing compilation errors.

### Root Cause

The `ValueForLanguagePrimitive` method in `NodeSGExtensions.cs` blindly appended type suffixes (`D` for double, `F` for float) to all numeric values, including special values like NaN and Infinity. When `SymbolDisplay.FormatPrimitive(double.NaN, ...)` returned `"NaN"`, the code appended `D`, resulting in the invalid identifier `NaND`.

### Solution

Added explicit checks for special values (NaN, PositiveInfinity, NegativeInfinity) in both float and double handling:
- Special values return fully-qualified names: `double.NaN`, `float.NaN`, `double.PositiveInfinity`, etc.
- Regular numeric values still get their type suffixes: `123.45D`, `123.45F`

## Before/After

### Before (Bug)
```csharp
var setter = new global::Microsoft.Maui.Controls.Setter {
    Property = global::Microsoft.Maui.Controls.VisualElement.HeightRequestProperty, 
    Value = NaND  // ❌ Compilation error - NaND is undefined
};
```

### After (Fixed)
```csharp
var setter = new global::Microsoft.Maui.Controls.Setter {
    Property = global::Microsoft.Maui.Controls.VisualElement.HeightRequestProperty, 
    Value = double.NaN  // ✅ Correct
};
```

## Issues Fixed

- `Value="NaN"` for double → now generates `double.NaN` (was `NaND`)
- `Value="NaN"` for float → now generates `float.NaN` (was `NaNF`)
- `Value="Infinity"` for double → now generates `double.PositiveInfinity` (was `InfinityD`)
- `Value="-Infinity"` for double → now generates `double.NegativeInfinity` (was `-InfinityD`)
- Same fixes for float types

## Test Coverage

### SourceGen Unit Tests
Added `src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterWithNaN.cs`:
- 2 test methods verifying correct code generation
- Validates generated code contains `double.NaN` and not `NaND`

### Xaml Unit Tests
Added `src/Controls/tests/Xaml.UnitTests/Issues/Maui32697.xaml[.cs]`:
- 2 test methods × 3 inflators (Runtime, XamlC, SourceGen) = 6 test cases
- Validates NaN values work correctly at runtime with all inflators

### Test Results
✅ **All 65 SourceGen tests pass** (63 existing + 2 new)
✅ **All 6 Xaml unit tests pass** (all 3 inflators validated)
✅ **No regressions**

## Platforms Affected
- All (issue was in source generator, not platform-specific code)

## Behavioral Changes
None for correctly-written XAML. This fix enables previously-broken XAML to compile and work correctly.

## PR Checklist
- [x] Has tests (6 new tests added)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard