### PR TITLE
Fixed Exception should throw on value fails on validation

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Maui.Controls
 			if (property.ValidateValue != null && !property.ValidateValue(this, value))
 			{
 				Application.Current?.FindMauiContext()?.CreateLogger<BindableObject>()?.LogWarning($"Value is an invalid value for {property.PropertyName}");
-				return;
+				throw new ArgumentException($"Value is an invalid value for {property.PropertyName}", nameof(value));
 			}
 
 			if (property.CoerceValue != null)

--- a/src/Controls/tests/Core.UnitTests/BindablePropertyUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindablePropertyUnitTests.cs
@@ -191,5 +191,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(1, ((TestStruct)bindable.GetValue(prop)).IntValue);
 		}
 
+		[Fact]
+		public void SetValueThrowsExceptionWhenValidationFails()
+		{
+			var propertyName = "foo";
+			var prop = BindableProperty.Create(
+				propertyName,
+				typeof(int),
+				typeof(MockBindable),
+				defaultValue: 0,
+				validateValue: (b, v) => (int)v >= 0);
+
+			var bindable = new MockBindable();
+			var exception = Assert.Throws<ArgumentException>(() => bindable.SetValue(prop, -1));
+			Assert.Equal($"Value is an invalid value for {propertyName} (Parameter 'value')", exception.Message);
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### RootCause : 
The current implementation of `BindableObject.SetValueCore` does not throw an exception when a value fails on validation.  
Instead, it logs a warning and returns early.
### Description of Change :

<!-- Enter description of the fix in this section -->
* Updated the behavior in `SetValueCore` (in `BindableObject.cs`) to throw an `ArgumentException` when the `ValidateValue` callback returns `false`, instead of silently returning without setting the value.
### Reference :

> An exception will be raised if a validation callback returns false

Source : [Microsoft Docs — Validation Callbacks](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/bindable-properties?view=net-maui-10.0&viewFallbackFrom=net-maui-8.0#validation-callbacks)
Xamarin : [Reference](https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Core/BindableObject.cs#L415)
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #25823 

### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/cc2307d5-8419-408e-9b89-c19ff56cc4a8"> | <video src="https://github.com/user-attachments/assets/c4e8604a-99fb-46e1-afd7-24e11fbec4a3"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
