### PR TITLE
Fix #19238: Suppress debug output for XAML comments

### DIFF
--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -132,6 +132,9 @@ namespace Microsoft.Maui.Controls.Xaml
 						else
 							node.CollectionItems.Add(new ValueNode(reader.Value.Trim(), (IXmlNamespaceResolver)reader));
 						break;
+					case XmlNodeType.Comment:
+						// Ignore XML comments
+						break;
 					default:
 						Debug.WriteLine("Unhandled node {0} {1} {2}", reader.NodeType, reader.Name, reader.Value);
 						break;
@@ -189,6 +192,9 @@ namespace Microsoft.Maui.Controls.Xaml
 						nodes.Add(node);
 						break;
 					case XmlNodeType.Whitespace:
+						break;
+					case XmlNodeType.Comment:
+						// Ignore XML comments
 						break;
 					default:
 						Debug.WriteLine("Unhandled node {0} {1} {2}", reader.NodeType, reader.Name, reader.Value);


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes #19238 

This PR eliminates the noisy "Unhandled node Comment" debug messages that appear when running locally-built .NET MAUI applications with XAML comments.

### Changes Made

- Added explicit `case XmlNodeType.Comment:` handlers in both `ParseXamlElementFor` and `ReadNode` methods
- XML comments are now silently ignored as they should be
- Kept the `Debug.WriteLine` for the default case to still catch genuinely unhandled node types

### Before
Running a MAUI app with XAML comments would produce debug output like:
```
[0:] Unhandled node Comment   HEADER 
[0:] Unhandled node Comment   FOOTER 
```

### After
XML comments are silently ignored, no debug noise

### Issues Fixed
Fixes #19238