### PR TITLE
Refactor device test stages in pipeline configuration

### DIFF
--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -48,7 +48,7 @@ parameters:
   default: $(System.DefaultWorkingDirectory)
 
 stages:
-- stage: devicetests_ios_catalyst_android
+- stage: devicetests_build
   displayName: ${{ parameters.TargetFrameworkVersion }} ios/catalyst/android Helix Tests
   dependsOn: []
   jobs:
@@ -102,6 +102,11 @@ stages:
           condition: not(succeeded())
           artifact: ${{ parameters.appArtifactName }}_failed_$(System.JobAttempt)
 
+- stage: devicetests_ios
+  displayName: ${{ parameters.TargetFrameworkVersion }} iOS Helix Tests
+  dependsOn: 
+    - devicetests_build
+  jobs:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
     parameters:
       helixRepo: dotnet/maui
@@ -120,8 +125,6 @@ stages:
         clean: all
       jobs:
       - job: device_tests_ios
-        dependsOn:
-        - builddevice_tests
         displayName: Run DeviceTests iOS
         timeoutInMinutes: 240
         variables:
@@ -147,9 +150,12 @@ stages:
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsIOS
 
+- stage: devicetests_ios_catalyst_android
+  displayName: ${{ parameters.TargetFrameworkVersion }} MacCatalyst Helix Tests
+  dependsOn: 
+    - devicetests_build
+  jobs:
       - job: device_tests_maccatalyst
-        dependsOn:
-        - builddevice_tests
         displayName: Run DeviceTests MacCatalyst
         timeoutInMinutes: 240
         variables:
@@ -175,9 +181,12 @@ stages:
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsMacCatalyst
 
+- stage: devicetests_ios_catalyst_android
+  displayName: ${{ parameters.TargetFrameworkVersion }} Android Helix Tests
+  dependsOn: 
+    - devicetests_build
+  jobs:
       - job: device_tests_android
-        dependsOn:
-        - builddevice_tests
         displayName: Run DeviceTests Android
         timeoutInMinutes: 240
         variables:

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -150,7 +150,7 @@ stages:
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsIOS
 
-- stage: devicetests_ios_catalyst_android
+- stage: devicetests_catalyst
   displayName: ${{ parameters.TargetFrameworkVersion }} MacCatalyst Helix Tests
   dependsOn: 
     - devicetests_build
@@ -198,7 +198,7 @@ stages:
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsMacCatalyst
 
-- stage: devicetests_ios_catalyst_android
+- stage: devicetests_android
   displayName: ${{ parameters.TargetFrameworkVersion }} Android Helix Tests
   dependsOn: 
     - devicetests_build

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -155,6 +155,23 @@ stages:
   dependsOn: 
     - devicetests_build
   jobs:
+  - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
+    parameters:
+      helixRepo: dotnet/maui
+      pool: ${{ parameters.buildPool }}
+      enableMicrobuild: ${{ parameters.enableMicrobuild }}
+      enablePublishUsingPipelines: true
+      enablePublishBuildAssets: ${{ parameters.publishAssets }}
+      enableTelemetry: true
+      enableSourceBuild: ${{ parameters.enableSourceBuild }}
+      enableSourceIndex: ${{ parameters.enableSourceIndex }}
+      sourceIndexParams: ${{ parameters.sourceIndexParams }}
+      publishAssetsImmediately: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: false
+      workspace:
+        clean: all
+      jobs:
       - job: device_tests_maccatalyst
         displayName: Run DeviceTests MacCatalyst
         timeoutInMinutes: 240
@@ -186,6 +203,23 @@ stages:
   dependsOn: 
     - devicetests_build
   jobs:
+  - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
+    parameters:
+      helixRepo: dotnet/maui
+      pool: ${{ parameters.buildPool }}
+      enableMicrobuild: ${{ parameters.enableMicrobuild }}
+      enablePublishUsingPipelines: true
+      enablePublishBuildAssets: ${{ parameters.publishAssets }}
+      enableTelemetry: true
+      enableSourceBuild: ${{ parameters.enableSourceBuild }}
+      enableSourceIndex: ${{ parameters.enableSourceIndex }}
+      sourceIndexParams: ${{ parameters.sourceIndexParams }}
+      publishAssetsImmediately: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: false
+      workspace:
+        clean: all
+      jobs:
       - job: device_tests_android
         displayName: Run DeviceTests Android
         timeoutInMinutes: 240

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -71,7 +71,7 @@ stages:
       jobs:
       - job: builddevice_tests
         displayName: Build Device Tests
-        timeoutInMinutes: 240
+        timeoutInMinutes: 60
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}
@@ -149,6 +149,8 @@ stages:
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsIOS
+            WorkItemTimeout: 04:00:00
+            XUnitWorkItemTimeout: 04:00:00
 
 - stage: devicetests_catalyst
   displayName: ${{ parameters.TargetFrameworkVersion }} MacCatalyst Helix Tests
@@ -174,7 +176,7 @@ stages:
       jobs:
       - job: device_tests_maccatalyst
         displayName: Run DeviceTests MacCatalyst
-        timeoutInMinutes: 240
+        timeoutInMinutes: 60
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}
@@ -222,7 +224,7 @@ stages:
       jobs:
       - job: device_tests_android
         displayName: Run DeviceTests Android
-        timeoutInMinutes: 240
+        timeoutInMinutes: 60
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}


### PR DESCRIPTION
This pull request reorganizes the device test stages in the `eng/pipelines/arcade/stage-device-tests.yml` pipeline to improve clarity and maintainability. The main changes include splitting combined test stages into dedicated stages for iOS, MacCatalyst, and Android, and updating dependencies to ensure proper build and test sequencing.

Pipeline stage restructuring:

* Renamed the initial test stage from `devicetests_ios_catalyst_android` to `devicetests_build` to clarify its purpose as the build stage.
* Added a new `devicetests_ios` stage specifically for running iOS Helix Tests, with an explicit dependency on the build stage.
* Removed unnecessary job dependencies on `builddevice_tests` within the iOS device test job, as these are now handled by the stage-level dependency.

Separation of test stages:

* Split the previous combined `devicetests_ios_catalyst_android` stage into two distinct stages: `devicetests_ios_catalyst_android` for MacCatalyst tests and another for Android tests, each with their own jobs and a dependency on the build stage. [[1]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL150-R158) [[2]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL178-R189)