### PR TITLE
Fix HybridWebView HybridRoot initialization for multi-RID builds

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/HybridWebView/HybridWebViewControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/HybridWebView/HybridWebViewControlPage.xaml.cs
@@ -17,6 +17,7 @@ public partial class HybridWebViewControlPage : ContentPage
 		// Explicitly set HybridRoot to ensure it's properly initialized
 		// This is needed especially for multi-RID builds where binding might not trigger immediately
 		MyHybridWebView.HybridRoot = _viewModel.HybridRoot;
+		MyHybridWebView.DefaultFile = _viewModel.DefaultFile;
 	}
 
 	private async void OnEvaluateJavaScriptClicked(object sender, EventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/HybridWebView/HybridWebViewControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/HybridWebView/HybridWebViewControlPage.xaml.cs
@@ -13,6 +13,10 @@ public partial class HybridWebViewControlPage : ContentPage
 		_viewModel = new HybridWebViewViewModel();
 		MyHybridWebView.RawMessageReceived += OnRawMessageReceived;
 		BindingContext = _viewModel;
+		
+		// Explicitly set HybridRoot to ensure it's properly initialized
+		// This is needed especially for multi-RID builds where binding might not trigger immediately
+		MyHybridWebView.HybridRoot = _viewModel.HybridRoot;
 	}
 
 	private async void OnEvaluateJavaScriptClicked(object sender, EventArgs e)


### PR DESCRIPTION
The HybridWebView feature test was failing in CI after PR #32229 which changed from RuntimeIdentifier to RuntimeIdentifiers for MacCatalyst builds. This enabled multi-RID builds (maccatalyst-x64;maccatalyst-arm64) which exposed a timing issue where the XAML binding for HybridRoot didn't trigger properly during initialization.

Root Cause:
- With multi-RID builds, the HybridRoot property binding from XAML wasn't being set before the control attempted to load its content
- This caused the HybridWebView to not find the correct HTML resources path

Fix:
- Explicitly set MyHybridWebView.HybridRoot in the constructor after setting BindingContext to ensure immediate initialization
- Kept the XAML binding in place for consistency with other property bindings
- This makes the code robust against binding timing variations between different build configurations

Fixes test failures related to PR #32229

Fixes #32721

