### PR TITLE
Enable XAML SourceGen by default in templates and add per-file default support

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -109,7 +109,7 @@
 	
 	<!-- Inform when XAML source generation is enabled -->
 	<Message 
-		Text="XAML source generation is enabled (MauiXamlInflator=SourceGen). This generates C# code from XAML at compile time for better performance. To disable, remove the MauiXamlInflator line from your .csproj file or set it to Runtime." 
+		Text="XAML source generation is enabled (MauiXamlInflator=SourceGen). This generates C# code from XAML at compile time for better performance. To disable, remove the MauiXamlInflator line from your .csproj file (reverts to configuration-based defaults: Runtime in Debug, XamlC in Release)." 
 		Importance="high" 
 		Condition="'$(MauiXamlInflator)' != '' And $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('sourcegen'))" />
 	

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -116,7 +116,7 @@
 	<!-- Warn when Runtime or XamlC inflator is explicitly set -->
 	<Warning 
 		Code="MAUI1001"
-		Text="MauiXamlInflator is explicitly set to '$(MauiXamlInflator)'. Runtime negatively impacts build performance, and XamlC prevents debugging capabilities like XAML Hot Reload. Consider removing the MauiXamlInflator property to use the recommended defaults, or set it to 'SourceGen' for optimal performance and debugging experience." 
+		Text="MauiXamlInflator is explicitly set to '$(MauiXamlInflator)'. Runtime negatively impacts build performance, and XamlC prevents debugging capabilities like XAML Hot Reload. Consider setting it to 'SourceGen' for optimal performance and debugging experience, or remove it to use configuration-based defaults (Runtime in Debug, XamlC in Release)." 
 		Condition="'$(MauiXamlInflator)' != '' And ($([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('runtime')) Or $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('xamlc')))" />
   </Target>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -116,7 +116,7 @@
 	<!-- Warn when Runtime or XamlC inflator is explicitly set -->
 	<Warning 
 		Code="MAUI1001"
-		Text="MauiXamlInflator is explicitly set to '$(MauiXamlInflator)'. Runtime negatively impacts build performance, and XamlC prevents debugging capabilities like XAML Hot Reload. Consider setting it to 'SourceGen' for optimal performance and debugging experience, or remove it to use configuration-based defaults (Runtime in Debug, XamlC in Release)." 
+		Text="MauiXamlInflator is explicitly set to '$(MauiXamlInflator)'. The 'Runtime' inflator negatively impacts runtime performance and is only recommended for Debug builds. The 'XamlC' inflator prevents debugging capabilities like XAML Hot Reload. Consider setting it to 'SourceGen' for optimal performance and debugging experience, or remove it to use configuration-based defaults (Runtime in Debug, XamlC in Release)." 
 		Condition="'$(MauiXamlInflator)' != '' And ($([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('runtime')) Or $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('xamlc')))" />
   </Target>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -86,8 +86,14 @@
 
   <Target Name="_MauiXamlComputeInflator">
   	<ItemGroup>
+      <!-- Compute the configuration-based default inflator (independent of MauiXamlInflator property) -->
+      <_MauiXamlDefaultInflator Condition=" '$(Configuration)' == 'Debug' " Include="Runtime" />
+      <_MauiXamlDefaultInflator Condition=" '$(Configuration)' != 'Debug' " Include="XamlC" />
+      
       <!-- Assign the default inflator to MauiXaml that don't have any -->
       <!-- there's a roslyn bug that stops parsing value at the first semicolon. replace them all https://github.com/dotnet/roslyn/issues/43970 -->
+      <!-- Special value 'Default' reverts to configuration-based defaults (Runtime in Debug, XamlC in Release) -->
+      <MauiXaml Condition="'%(MauiXaml.Inflator)' == 'Default'" Inflator="@(_MauiXamlDefaultInflator)" />
       <MauiXaml Inflator="$([MSBuild]::ValueOrDefault('%(MauiXaml.Inflator)','$(_MauiXamlInflator)').Replace(';', ','))"/>
       <MauiXaml NoWarn="$([MSBuild]::ValueOrDefault('%(MauiXaml.NoWarn)','').Replace(';', ','))"/>
 
@@ -100,6 +106,18 @@
       <_MauiXaml_AsEmbeddedResource Include="@(_MauiXaml_RT)" />
       <_MauiXaml_AsEmbeddedResource Include="@(_MauiXaml_XC)" KeepDuplicates="false" />      
 	</ItemGroup>
+	
+	<!-- Inform when XAML source generation is enabled -->
+	<Message 
+		Text="XAML source generation is enabled (MauiXamlInflator=SourceGen). This generates C# code from XAML at compile time for better performance. To disable, remove the MauiXamlInflator line from your .csproj file or set it to Runtime." 
+		Importance="high" 
+		Condition="'$(MauiXamlInflator)' != '' And $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('sourcegen'))" />
+	
+	<!-- Warn when Runtime or XamlC inflator is explicitly set -->
+	<Warning 
+		Code="MAUI1001"
+		Text="MauiXamlInflator is explicitly set to '$(MauiXamlInflator)'. Runtime negatively impacts build performance, and XamlC prevents debugging capabilities like XAML Hot Reload. Consider removing the MauiXamlInflator property to use the recommended defaults, or set it to 'SourceGen' for optimal performance and debugging experience." 
+		Condition="'$(MauiXamlInflator)' != '' And ($([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('runtime')) Or $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('xamlc')))" />
   </Target>
 
   <!-- Inject MauiXaml and MauiCss as AdditionalFiles for partial type generation-->

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
@@ -20,6 +20,14 @@
     <EnableDefaultCssItems>false</EnableDefaultCssItems>
     <Nullable>enable</Nullable>
 
+    <!-- Enable XAML source generation for faster build times and improved performance.
+         This generates C# code from XAML at compile time instead of runtime inflation.
+         To disable, remove this line.
+         For individual files, you can override by setting Inflator metadata:
+           <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+           <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+    <MauiXamlInflator>SourceGen</MauiXamlInflator>
+
     <!-- Display name -->
     <ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -20,6 +20,14 @@
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
         <Nullable>enable</Nullable>
 
+        <!-- Enable XAML source generation for faster build times and improved performance.
+             This generates C# code from XAML at compile time instead of runtime inflation.
+             To disable, remove this line.
+             For individual files, you can override by setting Inflator metadata:
+               <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+               <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+        <MauiXamlInflator>SourceGen</MauiXamlInflator>
+
         <!-- Display name -->
         <ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -11,6 +11,14 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
+
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -18,6 +18,14 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 <!--#if (IncludeSampleContent) -->
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 <!--#endif -->

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
@@ -8,6 +8,14 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
+
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
@@ -8,6 +8,14 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
+
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
@@ -14,6 +14,15 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
+
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
+
 		<!-- We do not want XAML files to be processed as .NET MAUI XAML, but rather WinUI XAML. -->
 		<EnableDefaultMauiItems>false</EnableDefaultMauiItems>
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
@@ -8,6 +8,14 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
+
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/MainPage.xaml.cs
@@ -9,7 +9,7 @@ public partial class MainPage : ContentPage
 		InitializeComponent();
 	}
 
-	private void OnCounterClicked(object sender, EventArgs e)
+	private void OnCounterClicked(object? sender, EventArgs e)
 	{
 		count++;
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
@@ -7,6 +7,14 @@
 		<RootNamespace>MauiApp._1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<Nullable>enable</Nullable>
+
+		<!-- Enable XAML source generation for faster build times and improved performance.
+		     This generates C# code from XAML at compile time instead of runtime inflation.
+		     To disable, remove this line.
+		     For individual files, you can override by setting Inflator metadata:
+		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
+		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

This PR enables XAML source generation by default in all .NET MAUI templates and adds support for reverting individual files to configuration-based defaults.

## Changes Made

### 1. Templates (9 files)

Added `<MauiXamlInflator>SourceGen</MauiXamlInflator>` to all template projects with inline documentation:
- maui-mobile
- maui-blazor
- maui-blazor-solution
- maui-lib
- maui-multiproject (all platforms: iOS, Android, Mac, WinUI)

Each template includes comments explaining:
- What SourceGen does (generates C# from XAML at compile time)
- How to disable (remove the line)
- How to override per-file with metadata
- What `Inflator="Default"` means (Runtime for Debug, XamlC for Release)

### 2. Build System (Microsoft.Maui.Controls.targets)

**New Feature: Per-file Default Support**
- Computes configuration-based defaults independently
- Allows `<MauiXaml Update="MyPage.xaml" Inflator="Default" />` to revert individual files to config-based defaults (Runtime for Debug, XamlC for Release)

**Informational Message**
- Displays when SourceGen is enabled: "XAML source generation is enabled..."
- Reminds users how to disable

**Warning on Legacy Settings**
- Warns when `MauiXamlInflator` is set to Runtime or XamlC
- Explains trade-offs:
  - Runtime: negatively impacts runtime performance, only recommended for Debug builds
  - XamlC: prevents debugging capabilities like XAML Hot Reload
- Recommends setting to SourceGen or removing the property

## Benefits

1. **Better Performance**: SourceGen avoids Runtime's overhead in all configurations
2. **Better Debugging**: Unlike XamlC, SourceGen maintains Hot Reload and debugging capabilities
3. **Consistency**: Same behavior across Debug and Release builds
4. **User Guidance**: New developers get the recommended configuration by default
5. **Flexibility**: Per-file overrides available when needed

## Usage Examples

Global setting (in template by default):
```xml
<MauiXamlInflator>SourceGen</MauiXamlInflator>
```

Per-file overrides:
```xml
<ItemGroup>
  <!-- Revert to defaults for this file -->
  <MauiXaml Update="MyPage.xaml" Inflator="Default" />
  
  <!-- Force runtime inflation for this file -->
  <MauiXaml Update="OtherPage.xaml" Inflator="Runtime" />
</ItemGroup>
```

## Issues Fixed

Fixes #32732  
Fixes #32644  
Fixes #32640
