### PR TITLE
[Android] Fixed Shell flyout does not disable scrolling when FlyoutVerticalScrollMode is set to Disabled

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			var container = new ContainerView(parent.Context, content, MauiContext);
 			container.MatchWidth = true;
+			container.MeasureHeight = true; // Force height to be measured, not matched to parent
 			container.LayoutParameters = new LP(LP.MatchParent, LP.WrapContent);
 			linearLayout.AddView(container);
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -149,7 +149,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				container.MeasureHeight = true;
 			}
 
-			container.MeasureHeight = true; // Force height to be measured, not matched to parent
 			container.LayoutParameters = new LP(LP.MatchParent, LP.WrapContent);
 			linearLayout.AddView(container);
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -139,6 +139,16 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			var container = new ContainerView(parent.Context, content, MauiContext);
 			container.MatchWidth = true;
+
+			// In Auto or Disabled scroll modes, RecyclerView passes an EXACTLY heightMeasureSpec,
+			// causing items to be measured to the full RecyclerView height.
+			// Setting MeasureHeight = true forces UNSPECIFIED mode, allowing items to use their natural height (~48dp).
+			// This enables RecyclerView to detect when scrolling is needed and to create all required view holders.
+			if (_shellContext.Shell.FlyoutVerticalScrollMode != ScrollMode.Enabled)
+			{
+				container.MeasureHeight = true;
+			}
+
 			container.MeasureHeight = true; // Force height to be measured, not matched to parent
 			container.LayoutParameters = new LP(LP.MatchParent, LP.WrapContent);
 			linearLayout.AddView(container);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -310,6 +310,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_rootView.AddView(_flyoutContentView, index);
 			UpdateContentPadding();
+			UpdateVerticalScrollMode();
 		}
 
 
@@ -932,7 +933,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			SetClipToPadding(false);
 			SetLayoutManager(_layoutManager = new ScrollLayoutManager(context, (int)Orientation.Vertical, false));
-			SetLayoutManager(new LinearLayoutManager(context, (int)Orientation.Vertical, false));
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32477.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32477.cs
@@ -1,0 +1,52 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32477, "[Android] Shell flyout does not disable scrolling when FlyoutVerticalScrollMode is set to Disabled", PlatformAffected.Android)]
+public class Issue32477 : TestShell
+{
+	protected override void Init()
+	{
+		FlyoutVerticalScrollMode = ScrollMode.Disabled;
+		FlyoutBehavior = FlyoutBehavior.Locked;
+		var flyoutItem = new FlyoutItem
+		{
+			Title = "Menu"
+		};
+
+		// Add a ShellContent
+		flyoutItem.Items.Add(new ShellContent
+		{
+			Title = "Home",
+			ContentTemplate = new DataTemplate(typeof(Issue32477ContentPage))
+		});
+
+		// Add FlyoutItem to the Shell
+		Items.Add(flyoutItem);
+
+		// Add MenuItems (static links in flyout)
+		for (int i = 1; i <= 30; i++)
+		{
+			Items.Add(new MenuItem
+			{
+				Text = $"Item {i}"
+			});
+		}
+	}
+
+	class Issue32477ContentPage : ContentPage
+	{
+		public Issue32477ContentPage()
+		{
+			Content = new StackLayout
+			{
+				Children =
+			{
+				new Label
+				{
+					Text = "The flyout menu items should not be scrollable when the scroll mode is disabled."
+				}
+			}
+			};
+		}
+	}
+
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32477.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32477.cs
@@ -1,0 +1,30 @@
+
+#if TEST_FAILS_ON_WINDOWS // Issue Link - https://github.com/dotnet/maui/issues/32416
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32477 : _IssuesUITest
+{
+	public Issue32477(TestDevice testDevice) : base(testDevice)
+	{
+	}
+	public override string Issue => "[Android] Shell flyout does not disable scrolling when FlyoutVerticalScrollMode is set to Disabled";
+
+	[Test]
+	[Category(UITestCategories.FlyoutPage)]
+	public void VerifyFlyoutVerticalScrollModeDisabledOnAndroid()
+	{
+		App.WaitForElement("Item 1");
+
+		for (int i = 0; i < 5; i++)
+		{
+			App.ScrollDown("Item 5", ScrollStrategy.Gesture);
+		}
+
+		App.WaitForElement("Item 1");
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause

- The Shell Flyout’s LinearLayoutManager configuration was overriding the ScrollLayoutManager settings, preventing the Shell.FlyoutVerticalScrollMode property from being correctly applied to the RecyclerView.


### Description of Change

- The LinearLayoutManager assignment for the Shell Flyout RecyclerView was removed so that the ScrollLayoutManager can correctly control scrolling behavior.
- In Auto or Disabled scroll modes, the ScrollLayoutManager passed an EXACTLY heightMeasureSpec to the RecyclerView, causing first item to expand to the full height of the RecyclerView instead of using its natural height.
- By setting measureHeight = true, the heightMeasureSpec switches to UNSPECIFIED, allowing items to measure at their natural height (~48dp). This ensures accurate scrolling behavior and allows the RecyclerView to create all required view holders properly.


Validated the behaviour in the following platforms
- [x] Android
- [x] Windows ,
- [x]  iOS, 
- [x] MacOS

### Issues Fixed

Fixes #32477 

### Output

**Android**
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/1293ae32-af0c-42af-a0b4-96f26228721a" >| <video src="https://github.com/user-attachments/assets/37f037bd-8634-41bf-9f31-43f50b617eda">|

