### PR TITLE
Fix XAML files being embedded as resources when using SourceGen inflator

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -179,7 +179,7 @@
   <Target Name="_MauiAddXamlEmbeddedResources"
           DependsOnTargets="$(_MauiAddXamlEmbeddedResourcesDependsOn)">
     <ItemGroup>
-      <EmbeddedResource Include="@(MauiXaml)" />
+      <EmbeddedResource Include="@(_MauiXaml_AsEmbeddedResource)" />
       <EmbeddedResource Include="@(MauiCss)" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
### Description of Change

When `MauiXamlInflator` is set to `SourceGen`, XAML files should **not** be embedded as resources in the assembly since they're handled by source generators at compile time. However, XAML files were still being embedded, causing unnecessary resource bloat.

### Root Cause

In `Microsoft.Maui.Controls.targets`:

1. The `_MauiXamlComputeInflator` target (lines 87-103) correctly identifies which XAML files need to be embedded by creating:
   - `_MauiXaml_RT` - Runtime inflation files  
   - `_MauiXaml_XC` - XamlC files
   - `_MauiXaml_AsEmbeddedResource` - Combined list of files that should be embedded (lines 100-101)

2. The `_MauiAddXamlEmbeddedResources` target (line 182) was incorrectly adding **ALL** `@(MauiXaml)` files as embedded resources, instead of only the filtered `@(_MauiXaml_AsEmbeddedResource)` list.

### The Fix

Changed line 182 in `_MauiAddXamlEmbeddedResources` target from:
```xml
<EmbeddedResource Include="@(MauiXaml)" />
```

To:
```xml
<EmbeddedResource Include="@(_MauiXaml_AsEmbeddedResource)" />
```

This ensures that only XAML files using Runtime or XamlC inflators are embedded as resources, while SourceGen files are correctly excluded.

### Validation

Tested with a sample app where `MauiXamlInflator=SourceGen`:

**Before the fix:**
- Debug build: 6 XAML files embedded as resources
- Release build: 4 XAML files embedded as resources

**After the fix:**
- Debug build: 0 XAML files embedded ✅
- Release build: 0 XAML files embedded ✅

### Issues Fixed

Fixes #32747
Fixes #30893

### Platforms Affected
- iOS
- Android  
- Windows
- macOS / Mac Catalyst