### PR TITLE
[Testing] Fixed DoesNotCrash Test case failure

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla39636.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla39636.xaml
@@ -12,6 +12,7 @@
                     <On Platform="iOS" Value="40"/>
                     <On Platform="Android" Value="30"/>
                     <On Platform="UWP" Value="60"/>
+                    <On Platform="MacCatalyst" Value="50"/>
             </OnPlatform>
 
             <x:Double x:Key="SizeLarge">80</x:Double>
@@ -30,6 +31,7 @@
                         <On Platform="iOS" Value="40"/>
                         <On Platform="Android" Value="30"/>
                         <On Platform="UWP" Value="60"/>
+                        <On Platform="MacCatalyst" Value="50"/>
                     </OnPlatform>
         </BoxView.HeightRequest>
       </BoxView>


### PR DESCRIPTION
This PR addresses test failures in the main and inflight/candidate branches and includes updates to improve rendering and test stability across platforms.

- The DoesNotCrash test for Bugzilla39636 was failing and throwing an exception after the HostApp project switched to the XAML Source Generator inflator in PR #32039. The failure occurred because the `<OnPlatform>` resource did not specify a value for MacCatalyst, which is now required by the SourceGen XAML compiler.
- This PR adds an explicit `<On Platform="MacCatalyst" Value="50"/>` resource in Bugzilla39636.xaml, resolving the test failure.

Fixes https://github.com/dotnet/maui/issues/32772

### Tests case:

- DoesNotCrash