### PR TITLE
Fix race condition in RemoveInnerPage unit test

### DIFF
--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			ContentPage initialPageAppearing = null;
 			ContentPage pageDisappeared = null;
 
-			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
+			var nav = new TestNavigationPage(useMaui, initialPage);
 			_ = new Window(nav);
 			nav.SendAppearing();
 
@@ -153,6 +153,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				=> throw new XunitException("Appearing Fired Incorrectly");
 
 			nav.Navigation.RemovePage(pageToRemove);
+			await nav.NavigatingTask;
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Fixes a race condition in the `RemoveInnerPage` unit test that was causing random failures on CI.

## Issue

The test was failing randomly on CI because it didn't wait for the async navigation to complete after calling `nav.Navigation.RemovePage(pageToRemove)`.

### Root Cause
- The `TestNavigationHandler` simulates async navigation with a 10ms delay
- The test would complete immediately after calling `RemovePage`
- If the navigation completed after the test finished, the `Appearing`/`Disappearing` event handlers would throw exceptions that weren't caught by the test framework
- This created a race condition where the test would pass or fail randomly depending on timing

## Changes

1. Changed `nav` declaration from `NavigationPage` to `var` to preserve the `TestNavigationPage` type
2. Added `await nav.NavigatingTask;` after `RemovePage` call to ensure the test waits for navigation to complete

This matches the pattern used in the `RemoveLastPage` test in the same file (line 122).

## Testing

- Ran the test 50+ times locally - all passed
- The fix ensures deterministic behavior by properly awaiting async operations

## API Changes

None

## Behavioral Changes

None - this only fixes test infrastructure

## PR Checklist

- [x] Has tests (existing test is fixed)
- [x] Focused on a single change
- [x] Follows code style guidelines