### PR TITLE
Fix for SwipeView Command Binding Issue in CollectionView Templates

### DIFF
--- a/src/Controls/src/Core/TemplateUtilities.cs
+++ b/src/Controls/src/Core/TemplateUtilities.cs
@@ -59,9 +59,25 @@ namespace Microsoft.Maui.Controls
 			var newElement = (Element)newValue;
 			if (self.ControlTemplate == null)
 			{
-				// For SwipeView, skip child removal to preserve SwipeItems
-				if (bindable is not SwipeView)
+				// Preserve the SwipeItems in logical tree during content changes
+				if (bindable is SwipeView swipeView)
 				{
+					// Remove all children except SwipeItems
+					for (int i = self.InternalChildren.Count - 1; i >= 0; i--)
+					{
+						var child = self.InternalChildren[i];
+						bool isSwipeItems = child == swipeView.RightItems ||
+										   child == swipeView.LeftItems ||
+										   child == swipeView.TopItems ||
+										   child == swipeView.BottomItems;
+
+						if (!isSwipeItems)
+							self.RemoveAt(i);
+					}
+				}
+				else
+				{
+					// For other controls, remove all children
 					while (self.InternalChildren.Count > 0)
 					{
 						self.RemoveAt(self.InternalChildren.Count - 1);

--- a/src/Controls/src/Core/TemplateUtilities.cs
+++ b/src/Controls/src/Core/TemplateUtilities.cs
@@ -59,9 +59,13 @@ namespace Microsoft.Maui.Controls
 			var newElement = (Element)newValue;
 			if (self.ControlTemplate == null)
 			{
-				while (self.InternalChildren.Count > 0)
+				// For SwipeView, skip child removal to preserve SwipeItems
+				if (bindable is not SwipeView)
 				{
-					self.RemoveAt(self.InternalChildren.Count - 1);
+					while (self.InternalChildren.Count > 0)
+					{
+						self.RemoveAt(self.InternalChildren.Count - 1);
+					}
 				}
 
 				if (newValue != null)

--- a/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SwipeViewTests.cs
@@ -413,5 +413,78 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.NotNull(swipeItemView.Content);
 			Assert.NotEmpty(swipeView.LeftItems);
 		}
+
+		[Fact]
+		public void SwipeItemsRemainInLogicalTreeWhenContentIsSet()
+		{
+			var swipeView = new SwipeView();
+			var testCommand = new Command(() => { });
+			var viewModel = new TestViewModel { TestCommand = testCommand };
+
+			var rightSwipeItem = new SwipeItem { Text = "Action" };
+			rightSwipeItem.SetBinding(SwipeItem.CommandProperty,
+				new Binding("TestCommand",
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext,
+						ancestorType: typeof(TestViewModel))));
+
+			var leftSwipeItem = new SwipeItem { Text = "Delete" };
+			leftSwipeItem.SetBinding(SwipeItem.CommandProperty,
+				new Binding("TestCommand",
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext,
+						ancestorType: typeof(TestViewModel))));
+
+			var topSwipeItem = new SwipeItem { Text = "Top" };
+			topSwipeItem.SetBinding(SwipeItem.CommandProperty,
+				new Binding("TestCommand",
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext,
+						ancestorType: typeof(TestViewModel))));
+
+			var bottomSwipeItem = new SwipeItem { Text = "Bottom" };
+			bottomSwipeItem.SetBinding(SwipeItem.CommandProperty,
+				new Binding("TestCommand",
+					source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestorBindingContext,
+						ancestorType: typeof(TestViewModel))));
+
+			swipeView.RightItems = new SwipeItems { rightSwipeItem };
+			swipeView.LeftItems = new SwipeItems { leftSwipeItem };
+			swipeView.TopItems = new SwipeItems { topSwipeItem };
+			swipeView.BottomItems = new SwipeItems { bottomSwipeItem };
+
+			swipeView.BindingContext = viewModel;
+			swipeView.Content = new Grid();
+
+			// Verify SwipeItems remain in logical tree
+			Assert.Contains(swipeView.RightItems, swipeView.LogicalChildrenInternal);
+			Assert.Contains(swipeView.LeftItems, swipeView.LogicalChildrenInternal);
+			Assert.Contains(swipeView.TopItems, swipeView.LogicalChildrenInternal);
+			Assert.Contains(swipeView.BottomItems, swipeView.LogicalChildrenInternal);
+
+			// Verify parent relationships
+			Assert.Equal(swipeView, swipeView.RightItems.Parent);
+			Assert.Equal(swipeView, swipeView.LeftItems.Parent);
+			Assert.Equal(swipeView, swipeView.TopItems.Parent);
+			Assert.Equal(swipeView, swipeView.BottomItems.Parent);
+
+			// Verify BindingContext propagation
+			Assert.Equal(viewModel, swipeView.RightItems.BindingContext);
+			Assert.Equal(viewModel, swipeView.LeftItems.BindingContext);
+			Assert.Equal(viewModel, swipeView.TopItems.BindingContext);
+			Assert.Equal(viewModel, swipeView.BottomItems.BindingContext);
+			Assert.Equal(viewModel, ((BindableObject)swipeView.RightItems[0]).BindingContext);
+			Assert.Equal(viewModel, ((BindableObject)swipeView.LeftItems[0]).BindingContext);
+			Assert.Equal(viewModel, ((BindableObject)swipeView.TopItems[0]).BindingContext);
+			Assert.Equal(viewModel, ((BindableObject)swipeView.BottomItems[0]).BindingContext);
+
+			// Verify RelativeSource bindings resolved correctly
+			Assert.Equal(testCommand, rightSwipeItem.Command);
+			Assert.Equal(testCommand, leftSwipeItem.Command);
+			Assert.Equal(testCommand, topSwipeItem.Command);
+			Assert.Equal(testCommand, bottomSwipeItem.Command);
+		}
+
+		class TestViewModel
+		{
+			public Command TestCommand { get; set; }
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SwipeView/SwipeViewTests.cs
@@ -67,7 +67,9 @@ namespace Microsoft.Maui.DeviceTests
 #pragma warning disable CS0618 // Type or member is obsolete
 					var logicalChildrenCount = swipeView.LogicalChildren.Count;
 #pragma warning restore CS0618 // Type or member is obsolete
-					Assert.Equal(1, logicalChildrenCount);
+
+					// Verify SwipeView maintains Content and all four SwipeItems as logical children
+					Assert.Equal(5, logicalChildrenCount);
 				});
 			});
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause:

The issue is caused by a change to TemplateUtilities.OnContentChanged() that switched from using self.InternalChildren.RemoveAt()to self.RemoveAt(). This change removes all SwipeItems (RightItems, LeftItems, TopItems, BottomItems) from the logical children tree when the SwipeView template is applied. When SwipeItems are removed from the logical tree, RelativeSource bindings cannot traverse the parent chain to find ancestor ViewModels, causing command bindings to fail. 

**Regression PR:** https://github.com/dotnet/maui/pull/30672


### Fix Description:

The fix involves modifying TemplateUtilities.OnContentChanged to preserve SwipeItems when SwipeView content changes. When a SwipeView's Content property changes, the method selectively removes only the old content while preserving SwipeItems (RightItems, LeftItems, TopItems, BottomItems) in the logical tree using reference equality checks. This prevents SwipeItems from losing their binding context when content changes, ensuring RelativeSource bindings and commands continue to function correctly.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/32332

### Tested the behaviour in the following platforms
- [x] Mac
- [x] Windows
- [x] iOS
- [x] Android

### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/5b72ad4a-c882-4e0c-98ca-e04f048671cc">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/8f1715df-d25c-4e31-b205-b787beb4631f">|