### PR TITLE
Fix CollectionView selection color persisting incorrectly after scrolling on iOS 26.1

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -163,6 +163,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_bound = false;
 			base.PrepareForReuse();
+			
+			// Ensure visual state is reset when cell is reused
+			// This prevents the previous selection state from persisting
+			UpdateVisualStates();
+			
+			// Reset SelectedBackgroundView to ensure it's re-evaluated in Bind
+			// This fixes an issue on iOS 26.1 where the color persists incorrectly
+			if (SelectedBackgroundView != null && PlatformHandler?.VirtualView is View view && IsUsingVSMForSelectionColor(view))
+			{
+				SelectedBackgroundView.BackgroundColor = UIKit.UIColor.Clear;
+			}
 		}
 
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32493.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32493.xaml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             x:Class="Maui.Controls.Sample.Issues.Issue32493"
+             Title="Issue 32493">
+    <ContentPage.Resources>
+        <Style TargetType="Grid">
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Selected">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" 
+                                        Value="LightSkyBlue" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
+    <Grid Margin="20" RowDefinitions="Auto, *">
+        <StackLayout Grid.Row="0">
+            <Label AutomationId="Instructions" Text="1. Select an item (should turn LightSkyBlue)"/>
+            <Label Text="2. Scroll the list up or down"/>
+            <Label Text="3. Verify the selected item remains LightSkyBlue (not LightGray)"/>
+        </StackLayout>
+        <CollectionView Grid.Row="1"
+                        AutomationId="CollectionView"
+                        ItemsSource="{Binding Items}"
+                        SelectionMode="Single">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label Grid.Row="0" 
+                               Text="{Binding Title}" 
+                               FontAttributes="Bold" />
+                        <Label Grid.Row="1"
+                               Text="{Binding Description}"
+                               FontAttributes="Italic" 
+                               VerticalOptions="End" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32493.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32493.xaml.cs
@@ -1,0 +1,32 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32493, "Selected item color changes from lightskyblue to lightgray after scrolling on iOS 26.1", PlatformAffected.iOS)]
+public partial class Issue32493 : ContentPage
+{
+	public ObservableCollection<TestItem> Items { get; set; }
+
+	public Issue32493()
+	{
+		InitializeComponent();
+
+		Items = new ObservableCollection<TestItem>();
+		for (int i = 0; i < 50; i++)
+		{
+			Items.Add(new TestItem
+			{
+				Title = $"Item {i}",
+				Description = $"Description for item {i}"
+			});
+		}
+
+		BindingContext = this;
+	}
+
+	public class TestItem
+	{
+		public string Title { get; set; }
+		public string Description { get; set; }
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32493.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32493.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue32493 : _IssuesUITest
+	{
+		public override string Issue => "Selected item color changes from lightskyblue to lightgray after scrolling on iOS 26.1";
+
+		public Issue32493(TestDevice device) : base(device) { }
+
+		[Test]
+		[Category(UITestCategories.CollectionView)]
+		public void SelectionColorShouldPersistAfterScrolling()
+		{
+			// Wait for CollectionView to be ready
+			App.WaitForElement("CollectionView");
+
+			// Tap on the first item to select it
+			// Look for "Item 0" text in the collection view
+			App.Tap("Item 0");
+
+			// Wait a moment for selection to apply
+			Task.Delay(500).Wait();
+
+			// Scroll down to trigger cell reuse
+			App.ScrollDown("CollectionView", ScrollStrategy.Gesture, swipeSpeed: 500);
+			Task.Delay(500).Wait();
+
+			// Scroll back up to see the selected item again
+			App.ScrollUp("CollectionView", ScrollStrategy.Gesture, swipeSpeed: 500);
+			Task.Delay(500).Wait();
+
+			// Verify screenshot to check if color is still correct
+			// The selected item should still be LightSkyBlue, not LightGray
+			VerifyScreenshot();
+		}
+	}
+}


### PR DESCRIPTION
<- iOS 26+: Uses autoresizing masks (new behavior) Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes #32493

When using VisualStateManager to customize CollectionView selection colors, the selected item would change from the custom color (e.g., LightSkyBlue) back to the default gray color after scrolling on iOS 26.1.

### Root Cause

The `PrepareForReuse()` method in `TemplatedCell.cs` was not properly resetting the visual state and `SelectedBackgroundView` color when cells were reused during scrolling. This caused the default gray selection color to persist instead of respecting the VSM-defined custom color.

### Changes Made

1. **Updated `PrepareForReuse()`** in `src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs`:
   - Call `UpdateVisualStates()` to reset the visual state based on current selection status
   - Reset `SelectedBackgroundView.BackgroundColor` to `UIColor.Clear` for cells using VSM for selection colors
   
2. **Added UI test case** `Issue32493` to prevent regression:
   - Reproduces the scenario with 50 items and custom selection color
   - Tests selection persistence after scrolling (cell reuse)
   - Includes screenshot verification

### Testing

- ✅ Built and tested on iPhone 17 Pro simulator with iOS 26.1
- ✅ Automated UI test passes with fix applied
- ✅ Selection color (LightSkyBlue) now persists correctly after scrolling
- ✅ No impact on cells not using VSM for selection

### Issues Resolved

- Fixes #32493