### PR TITLE
[Android] CollectionView selection with drag/drop gestures on Android - fix

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -282,7 +282,37 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			if (e.Event != null)
-				e.Handled = OnTouchEvent(e.Event);
+			{
+				// Process the touch event for this view's gestures
+				OnTouchEvent(e.Event);
+
+				// Allow event bubbling when only drag/drop recognizers are present
+				// For other gestures, allow bubbling so parent behaviors (like item selection) work
+				if (ShouldAllowEventBubbling())
+				{
+					e.Handled = false;
+				}
+			}
+		}
+
+		bool ShouldAllowEventBubbling()
+		{
+			if (View == null)
+				return false;
+
+			var recognizers = View.GetCompositeGestureRecognizers();
+			if (recognizers == null || recognizers.Count == 0)
+				return false;
+
+			// Don't allow bubbling if there are other recognizers than drag and drop
+			foreach (var recognizer in recognizers)
+			{
+				if (recognizer is not DragGestureRecognizer && recognizer is not DropGestureRecognizer)
+					return false;
+			}
+
+			// Only drag/drop recognizers present, allow bubbling
+			return true;
 		}
 
 		void SetupElement(VisualElement? oldElement, VisualElement? newElement)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32702.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32702.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue32702"
+             Title="Issue 32702 - CollectionView Selection with Drag/Drop Gestures">
+    
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <Label Text="Tap items to select them"
+               AutomationId="InstructionLabel"/>
+        
+        <Label x:Name="StatusLabel" 
+               Text="No selection"
+               AutomationId="StatusLabel"/>
+        
+        <CollectionView x:Name="TestCollectionView" 
+                        SelectionMode="Single" 
+                        SelectionChanged="OnSelectionChanged"
+                        AutomationId="TestCollectionView">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Label Text="{Binding .}" 
+                           HeightRequest="50"
+                           Padding="16,8"
+                           BackgroundColor="LightGray"
+                           Margin="4"
+                           AutomationId="{Binding .}">
+                        <Label.GestureRecognizers>
+                            <DropGestureRecognizer AllowDrop="True" />
+                            <DragGestureRecognizer />
+                        </Label.GestureRecognizers>
+                    </Label>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32702.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32702.xaml.cs
@@ -1,0 +1,38 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32702, "CollectionView item selection doesn't work when DragGestureRecognizer or DropGestureRecognizer is attached to item content", PlatformAffected.Android)]
+public partial class Issue32702 : ContentPage
+{
+	public ObservableCollection<string> Items { get; set; }
+
+	public Issue32702()
+	{
+		InitializeComponent();
+
+		Items = new ObservableCollection<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3",
+				"Item 4",
+				"Item 5"
+			};
+
+		TestCollectionView.ItemsSource = Items;
+	}
+
+	private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		if (e.CurrentSelection.Count > 0)
+		{
+			var selectedItem = e.CurrentSelection[0].ToString();
+			StatusLabel.Text = $"Selected: {selectedItem}";
+		}
+		else
+		{
+			StatusLabel.Text = "No selection";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32702.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32702.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32702 : _IssuesUITest
+{
+	public Issue32702(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "CollectionView item selection doesn't work when DragGestureRecognizer or DropGestureRecognizer is attached to item content";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewSelectionWorksWithDragDropGestures()
+	{
+		// Wait for CollectionView to load
+		App.WaitForElement("TestCollectionView");
+
+		// Verify initial state
+		var statusLabel = App.WaitForElement("StatusLabel");
+		Assert.That(statusLabel.GetText(), Is.EqualTo("No selection"));
+
+		// Tap on first item
+		App.Tap("Item 1");
+
+		// Verify selection changed
+		Assert.That(statusLabel.GetText(), Is.EqualTo("Selected: Item 1"));
+
+		// Tap on second item
+		App.Tap("Item 2");
+
+		// Verify selection changed again
+		Assert.That(statusLabel.GetText(), Is.EqualTo("Selected: Item 2"));
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Added logic to allow event bubbling when only DragGestureRecognizer or DropGestureRecognizer are present, enabling CollectionView item selection to work correctly on Android. Includes new test case and UI test to verify the fix for issue #32702.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32702

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
