### PR TITLE
[iOS 26] NavigationPage.TitleView resizing on iOS 26+ rotation - Fix

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32722.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32722.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue32722"
+             Title="Issue 32722">
+    
+    <NavigationPage.TitleView>
+        <Grid x:Name="TitleViewGrid" 
+              BackgroundColor="LightBlue" 
+              HorizontalOptions="FillAndExpand"
+              AutomationId="TitleViewGrid">
+            <Label Text="TitleView Test" 
+                   x:Name="TitleLabel"
+                   AutomationId="TitleLabel"
+                   TextColor="White"
+                   FontSize="18"
+                   FontAttributes="Bold"
+                   VerticalOptions="Center"
+                   HorizontalOptions="Center"/>
+        </Grid>
+    </NavigationPage.TitleView>
+    
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <Label Text="Issue #32722 Test"
+               FontSize="20"
+               FontAttributes="Bold"
+               AutomationId="HeaderLabel"
+               HorizontalOptions="Center"/>
+        
+        <Label Text="This test verifies that NavigationPage.TitleView expands when the window/orientation changes on iOS 26+."
+               FontSize="14"
+               AutomationId="DescriptionLabel"/>
+        
+        <Label x:Name="StatusLabel"
+               Text="Rotate device to test"
+               AutomationId="StatusLabel"
+               FontSize="16"
+               TextColor="Gray"
+               Margin="0,20,0,0"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32722.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32722.xaml.cs
@@ -1,0 +1,17 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32722, "NavigationPage.TitleView does not expand with host window in iPadOS 26+", PlatformAffected.iOS)]
+public class Issue32722NavPage : NavigationPage
+{
+	public Issue32722NavPage() : base(new Issue32722())
+	{
+	}
+}
+
+public partial class Issue32722 : ContentPage
+{
+	public Issue32722()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32722.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32722.cs
@@ -1,0 +1,54 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue32722 : _IssuesUITest
+	{
+		public override string Issue => "NavigationPage.TitleView does not expand with host window in iPadOS 26+";
+
+		public Issue32722(TestDevice device) : base(device) { }
+
+		[Test]
+		[Category(UITestCategories.Navigation)]
+		public void TitleViewExpandsOnRotation()
+		{
+			// Wait for page to load
+			App.WaitForElement("TitleViewGrid");
+			App.WaitForElement("StatusLabel");
+
+			// Get initial orientation and TitleView bounds
+			var titleViewInitial = App.WaitForElement("TitleViewGrid").GetRect();
+			var initialWidth = titleViewInitial.Width;
+			
+			App.SetOrientationLandscape();
+
+			// Wait for rotation to complete
+			System.Threading.Thread.Sleep(2000);
+
+			// Get TitleView bounds after rotation
+			var titleViewAfterRotation = App.WaitForElement("TitleViewGrid").GetRect();
+			var newWidth = titleViewAfterRotation.Width;
+
+			// On iOS 26+, the TitleView should expand/contract with the rotation
+			// The bug was that it would stay at the original width
+			// After fix, the width should change to match the new navigation bar width
+			Assert.That(newWidth, Is.Not.EqualTo(initialWidth).Within(100), 
+				"TitleView width should change after rotation");
+
+			// Verify TitleView is still visible and has reasonable dimensions
+			Assert.That(newWidth, Is.GreaterThan(100), 
+				"TitleView should have a reasonable width after rotation");
+
+			// Rotate back to original orientation
+			App.SetOrientationPortrait();
+			System.Threading.Thread.Sleep(2000);
+
+			// Verify TitleView returns to approximately original width
+			var titleViewFinal = App.WaitForElement("TitleViewGrid").GetRect();
+			Assert.That(titleViewFinal.Width, Is.EqualTo(initialWidth).Within(5),
+				"TitleView should return to original width after rotating back");
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

Adds logic to update the TitleView frame during orientation changes for iOS 26+ and Mac Catalyst 26+, ensuring the TitleView expands to fill the navigation bar after rotation. Includes new test case and UI test to verify TitleView resizing behavior.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/32722

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/0537ab48-4f36-47ce-bdaa-0e75a79db8d0" width="300px"></video>|<video src="https://github.com/user-attachments/assets/2d1ba2da-01f0-439a-b030-b0bb38a03708" width="300px"></video>|
