### PR TITLE
[Mac, iOS, Windows] Fix for inconsistent Text-to-Speech rate behavior

### DIFF
--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Media
 					speechUtterance.Volume = options.Volume.Value;
 
 				if (options.Rate.HasValue)
-					speechUtterance.Rate = options.Rate.Value;
+					speechUtterance.Rate = NormalizeRate(options.Rate.Value);
 			}
 
 			return speechUtterance;
@@ -79,6 +79,21 @@ namespace Microsoft.Maui.Media
 				if (speechUtterance == args.Utterance)
 					tcsUtterance?.TrySetResult(true);
 			}
+		}
+
+		static float NormalizeRate(float rate)
+		{
+			float iosMin = AVSpeechUtterance.MinimumSpeechRate;
+			float iosMax = AVSpeechUtterance.MaximumSpeechRate;
+			float iosNormal = AVSpeechUtterance.DefaultSpeechRate;
+
+			if (rate == 1.0f)
+				return iosNormal; // "Normal" - exact mapping
+
+			// Linear interpolation (lerp) from MAUI range [0.1, 2.0] to iOS range [iosMin, iosMax]
+			// Formula: targetMin + (input - inputMin) / (inputMax - inputMin) * (targetMax - targetMin)
+			// Optimized: no intermediate variables, direct calculation
+			return iosMin + ((rate - 0.1f) / (2.0f - 0.1f)) * (iosMax - iosMin);
 		}
 #pragma warning restore CA1416
 	}

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -87,25 +87,12 @@ namespace Microsoft.Maui.Media
 			float iosMax = AVSpeechUtterance.MaximumSpeechRate;
 			float iosNormal = AVSpeechUtterance.DefaultSpeechRate;
 
+			const float min = 0.1f, normal = 1f, max = 2f;
 
-			if (rate == 0.1f)
-			{
-				return iosMin; // Minimum - exact mapping
-			}
-
-			if (rate == 1.0f)
-			{
-				return iosNormal; // "Normal" - exact mapping
-			}
-
-			if (rate == 2.0f)
-			{
-				return iosMax; // Maximum - exact mapping
-			}
-
-			// Linear interpolation (lerp) from MAUI range [0.1, 2.0] to iOS range [iosMin, iosMax]
-			// Formula: targetMin + (input - inputMin) / (inputMax - inputMin) * (targetMax - targetMin)
-			return iosMin + ((rate - 0.1f) / (2.0f - 0.1f)) * (iosMax - iosMin);
+			return rate <= min ? iosMin :
+				   rate == normal ? iosNormal :
+				   rate >= max ? iosMax :
+				   iosMin + ((rate - min) / (max - min)) * (iosMax - iosMin); // Linear interpolation (lerp) from MAUI range [0.1, 2.0] to iOS range [iosMin, iosMax]
 		}
 #pragma warning restore CA1416
 	}

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -87,12 +87,24 @@ namespace Microsoft.Maui.Media
 			float iosMax = AVSpeechUtterance.MaximumSpeechRate;
 			float iosNormal = AVSpeechUtterance.DefaultSpeechRate;
 
+
+			if (rate == 0.1f)
+			{
+				return iosMin; // Minimum - exact mapping
+			}
+
 			if (rate == 1.0f)
+			{
 				return iosNormal; // "Normal" - exact mapping
+			}
+
+			if (rate == 2.0f)
+			{
+				return iosMax; // Maximum - exact mapping
+			}
 
 			// Linear interpolation (lerp) from MAUI range [0.1, 2.0] to iOS range [iosMin, iosMax]
 			// Formula: targetMin + (input - inputMin) / (inputMax - inputMin) * (targetMax - targetMin)
-			// Optimized: no intermediate variables, direct calculation
 			return iosMin + ((rate - 0.1f) / (2.0f - 0.1f)) * (iosMax - iosMin);
 		}
 #pragma warning restore CA1416

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.ios.tvos.watchos.cs
@@ -81,19 +81,11 @@ namespace Microsoft.Maui.Media
 			}
 		}
 
-		static float NormalizeRate(float rate)
-		{
-			float iosMin = AVSpeechUtterance.MinimumSpeechRate;
-			float iosMax = AVSpeechUtterance.MaximumSpeechRate;
-			float iosNormal = AVSpeechUtterance.DefaultSpeechRate;
-
-			const float min = 0.1f, normal = 1f, max = 2f;
-
-			return rate <= min ? iosMin :
-				   rate == normal ? iosNormal :
-				   rate >= max ? iosMax :
-				   iosMin + ((rate - min) / (max - min)) * (iosMax - iosMin); // Linear interpolation (lerp) from MAUI range [0.1, 2.0] to iOS range [iosMin, iosMax]
-		}
+		static float NormalizeRate(float rate) =>
+			NormalizeRate(rate,
+				AVSpeechUtterance.MinimumSpeechRate,
+				AVSpeechUtterance.MaximumSpeechRate,
+				AVSpeechUtterance.DefaultSpeechRate);
 #pragma warning restore CA1416
 	}
 }

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
@@ -152,6 +152,52 @@ namespace Microsoft.Maui.Media
 		internal const float RateDefault = 1.0f;
 		internal const float RateMin = 0.1f;
 
+		internal static float NormalizeRate(float rate, float platformMin, float platformMax, float platformNormal)
+		{
+			const float min = RateMin, normal = RateDefault, max = RateMax;
+
+			if (rate <= min)
+			{
+				return platformMin;
+			}
+
+			if (rate >= max)
+			{
+				return platformMax;
+			}
+
+			return rate <= normal
+				? platformMin + ((rate - min) / (normal - min)) * (platformNormal - platformMin)
+				: platformNormal + ((rate - normal) / (max - normal)) * (platformMax - platformNormal);
+		}
+
+		internal static string ProsodyRate(float rate)
+		{
+			// Map MAUI rate range [0.1, 2.0] to Windows SSML rate constants
+			// 1.0 should be "medium" (normal speed)
+			if (rate <= 0.25f)
+			{
+				return "x-slow";
+			}
+
+			if (rate <= 0.75f)
+			{
+				return "slow";
+			}
+
+			if (rate <= 1.25f)
+			{
+				return "medium";
+			}
+
+			if (rate <= 1.75f)
+			{
+				return "fast";
+			}
+
+			return "x-fast";
+		}
+
 		SemaphoreSlim? semaphore;
 
 		public Task<IEnumerable<Locale>> GetLocalesAsync() =>

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.windows.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.windows.cs
@@ -102,24 +102,19 @@ namespace Microsoft.Maui.Media
 			{
 				return "x-slow";
 			}
-			else if (rate > 0.25f && rate <= 0.75f)
+			if (rate <= 0.75f)
 			{
 				return "slow";
 			}
-			else if (rate > 0.75f && rate <= 1.25f)
+			if (rate <= 1.25f)
 			{
 				return "medium";
 			}
-			else if (rate > 1.25f && rate <= 1.75f)
+			if (rate <= 1.75f)
 			{
 				return "fast";
 			}
-			else if (rate > 1.75f)
-			{
-				return "x-fast";
-			}
-
-			return "medium"; // Default fallback
+			return "x-fast";
 		}
 
 		static string ProsodyPitch(float? pitch)

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.windows.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.windows.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Media
 				pitch = ProsodyPitch(options.Pitch);
 
 			if (options?.Rate.HasValue ?? false)
-				rate = (options.Rate.Value * 100f).ToString(CultureInfo.InvariantCulture) + "%";
+				rate = ProsodyRate(options.Rate.Value);
 
 			// SSML generation
 			var ssml = new StringBuilder();
@@ -92,6 +92,34 @@ namespace Microsoft.Maui.Media
 			ssml.AppendLine($"</speak>");
 
 			return ssml.ToString();
+		}
+
+		static string ProsodyRate(float rate)
+		{
+			// Map MAUI rate range [0.1, 2.0] to Windows SSML rate constants
+			// 1.0 should be "medium" (normal speed)
+			if (rate <= 0.25f)
+			{
+				return "x-slow";
+			}
+			else if (rate > 0.25f && rate <= 0.75f)
+			{
+				return "slow";
+			}
+			else if (rate > 0.75f && rate <= 1.25f)
+			{
+				return "medium";
+			}
+			else if (rate > 1.25f && rate <= 1.75f)
+			{
+				return "fast";
+			}
+			else if (rate > 1.75f)
+			{
+				return "x-fast";
+			}
+
+			return "medium"; // Default fallback
 		}
 
 		static string ProsodyPitch(float? pitch)

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.windows.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.windows.cs
@@ -94,29 +94,6 @@ namespace Microsoft.Maui.Media
 			return ssml.ToString();
 		}
 
-		static string ProsodyRate(float rate)
-		{
-			// Map MAUI rate range [0.1, 2.0] to Windows SSML rate constants
-			// 1.0 should be "medium" (normal speed)
-			if (rate <= 0.25f)
-			{
-				return "x-slow";
-			}
-			if (rate <= 0.75f)
-			{
-				return "slow";
-			}
-			if (rate <= 1.25f)
-			{
-				return "medium";
-			}
-			if (rate <= 1.75f)
-			{
-				return "fast";
-			}
-			return "x-fast";
-		}
-
 		static string ProsodyPitch(float? pitch)
 		{
 			if (!pitch.HasValue)

--- a/src/Essentials/test/UnitTests/TextToSpeech_Tests.cs
+++ b/src/Essentials/test/UnitTests/TextToSpeech_Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Media;
@@ -10,6 +11,98 @@ namespace Tests
 		[Fact]
 		public async Task TextToSpeech_Speak_Fail_On_NetStandard() =>
 			await Assert.ThrowsAsync<NotImplementedInReferenceAssemblyException>(() => TextToSpeech.SpeakAsync("Xamarin Essentials!"));
+
+		// NormalizeRate tests — use arbitrary platform constants to verify math
+		const float PlatMin = 0.0f;
+		const float PlatMax = 1.0f;
+		const float PlatNormal = 0.5f;
+
+		[Fact]
+		public void NormalizeRate_MinRate_ReturnsPlatformMin()
+		{
+			var result = TextToSpeechImplementation.NormalizeRate(0.1f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(PlatMin, result);
+		}
+
+		[Fact]
+		public void NormalizeRate_BelowMinRate_ReturnsPlatformMin()
+		{
+			var result = TextToSpeechImplementation.NormalizeRate(0.05f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(PlatMin, result);
+		}
+
+		[Fact]
+		public void NormalizeRate_MaxRate_ReturnsPlatformMax()
+		{
+			var result = TextToSpeechImplementation.NormalizeRate(2.0f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(PlatMax, result);
+		}
+
+		[Fact]
+		public void NormalizeRate_AboveMaxRate_ReturnsPlatformMax()
+		{
+			var result = TextToSpeechImplementation.NormalizeRate(3.0f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(PlatMax, result);
+		}
+
+		[Fact]
+		public void NormalizeRate_DefaultRate_ReturnsPlatformNormal()
+		{
+			var result = TextToSpeechImplementation.NormalizeRate(1.0f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(PlatNormal, result, precision: 5);
+		}
+
+		[Fact]
+		public void NormalizeRate_MidLow_InterpolatesCorrectly()
+		{
+			// 0.55 is halfway between 0.1 and 1.0 → should be halfway between PlatMin and PlatNormal
+			var result = TextToSpeechImplementation.NormalizeRate(0.55f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(0.25f, result, precision: 5);
+		}
+
+		[Fact]
+		public void NormalizeRate_MidHigh_InterpolatesCorrectly()
+		{
+			// 1.5 is halfway between 1.0 and 2.0 → should be halfway between PlatNormal and PlatMax
+			var result = TextToSpeechImplementation.NormalizeRate(1.5f, PlatMin, PlatMax, PlatNormal);
+			Assert.Equal(0.75f, result, precision: 5);
+		}
+
+		[Fact]
+		public void NormalizeRate_IsContinuousAtNormal()
+		{
+			// Values just below and above 1.0 should produce results close to PlatNormal
+			var belowNormal = TextToSpeechImplementation.NormalizeRate(0.999f, PlatMin, PlatMax, PlatNormal);
+			var aboveNormal = TextToSpeechImplementation.NormalizeRate(1.001f, PlatMin, PlatMax, PlatNormal);
+			Assert.True(Math.Abs(belowNormal - aboveNormal) < 0.01f,
+				$"Discontinuity at normal: below={belowNormal}, above={aboveNormal}");
+		}
+
+		// ProsodyRate tests
+		[Theory]
+		[InlineData(0.1f, "x-slow")]
+		[InlineData(0.25f, "x-slow")]
+		[InlineData(0.26f, "slow")]
+		[InlineData(0.5f, "slow")]
+		[InlineData(0.75f, "slow")]
+		[InlineData(0.76f, "medium")]
+		[InlineData(1.0f, "medium")]
+		[InlineData(1.25f, "medium")]
+		[InlineData(1.26f, "fast")]
+		[InlineData(1.5f, "fast")]
+		[InlineData(1.75f, "fast")]
+		[InlineData(1.76f, "x-fast")]
+		[InlineData(2.0f, "x-fast")]
+		public void ProsodyRate_MapsCorrectly(float rate, string expected)
+		{
+			Assert.Equal(expected, TextToSpeechImplementation.ProsodyRate(rate));
+		}
+
+		[Fact]
+		public void ProsodyRate_DefaultRate_ReturnsMedium()
+		{
+			Assert.Equal("medium", TextToSpeechImplementation.ProsodyRate(1.0f));
+		}
 
 		[Fact]
 		public void TextToSpeech_Slit_Text()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- If the rate is set to 1.0 (within the 0.1–2.0 range) in the SpeechOptions, the speech output is too fast on Windows, iOS, and macOS. A rate of 1.0 behaves as ‘normal’ only on Android.

### Root Cause of the issue

- On iOS and macOS, AVSpeechUtterance expects rates in the range 0.1–1.0, with 0.5 representing the normal speed. MAUI currently forwards the rate value directly (such as 1.0) without mapping it to the iOS/macOS scale, which results in speech that is significantly faster than the intended ‘normal’ rate.”
- On Windows, MAUI uses SpeechSynthesizer with SSML to control speech parameters. When the MAUI rate is set to 1.0, it is converted to "100%" in SSML.
* **According to the SSML specification:**
  - 100% → Speak at the default speed of that specific voice
  - 200% → Speak twice as fast as the default speed
  - 50% → Speak half as fast as the default speed
- However, every Windows voice has its own built-in default speaking speed, which can vary widely between devices, systems, and installed voices.
- Because of this, using percentages (like 100%, 150%, or 50%) produces inconsistent and unpredictable speech rates.

### Description of Change

**Platform-specific speech rate normalization:**

* **iOS/tvOS/watchOS rate normalization:**
  - Added a new `NormalizeRate` method that linearly interpolates the MAUI rate range `[0.1, 2.0]` to match the iOS `AVSpeechUtterance` rate range, ensuring that user-specified rates are accurately reflected in speech output. 

* **Windows SSML rate mapping:**
  - Introduced the `ProsodyRate` function to map the MAUI rate range `[0.1, 2.0]` to Windows SSML prosody rate constants (`x-slow`, `slow`, `medium`, `fast`, `x-fast`), providing a more predictable and natural speech rate experience for users.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #32492 

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/f6aabc41-9cd5-4d39-9274-2d9e387a8be5"> | <video src="https://github.com/user-attachments/assets/eacba7a8-b240-4951-a22a-0bca17743b70"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
