### PR TITLE
 Rapid change of selected tab results in crash on Windows

### DIFF
--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
@@ -19,8 +19,10 @@ namespace Microsoft.Maui.Controls
 		NavigationRootManager? _navigationRootManager;
 		WFrame? _navigationFrame;
 		bool _connectedToHandler;
-		bool _isUpdatingSelection;
-		bool _isNavigating;
+		// Volatile ensures visibility of flag changes across async operations
+		// These flags prevent reentrant calls within the UI thread (not multi-threaded access)
+		volatile bool _isUpdatingSelection;
+		volatile bool _isNavigating;
 		WFrame NavigationFrame => _navigationFrame ?? throw new ArgumentNullException(nameof(NavigationFrame));
 		IMauiContext MauiContext => this.Handler?.MauiContext ?? throw new InvalidOperationException("MauiContext cannot be null here");
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
When users rapidly switch tabs in TabbedPage on Windows, concurrent navigation operations cause a crash:
**Stack trace shows crash at line 299** (`UpdateCurrentPageContent`):

   WinRT.Runtime.dll!WinRT.ExceptionHelpers.ThrowExceptionForHR(int hr) Microsoft.W
   inUI.dll!Microsoft.UI.Xaml.Controls.ContentPresenter.Content.set(object value) M
   icrosoft.Maui.Controls.dll!Microsoft.Maui.Controls.TabbedPage.UpdateCurrentPageC
   ontent(WPage page) Line 299

**The Problem Flow**:
     1. User rapidly clicks tabs (Tab 1 → Tab 2 → Tab 3)
     2. First tab change calls `NavigateToPage` → `NavigationFrame.NavigateToType()`
     3. Navigation starts, `OnNavigated` event will fire when complete
     4. **Before first navigation completes**, second tab change triggers another `NavigateToPage`
     5. Second navigation also calls `NavigateToType()` → starts another navigation
     6. Both `OnNavigated` events fire and try to set `presenter.Content`
     7. **WinUI throws**: `ContentPresenter.Content` cannot be modified during active navigation/layout operation

Additionally, setting `SelectedItem` in `MapCurrentPage` triggers `SelectionChanged` events that cause reentrant calls.

### Solution
Implemented two guard flags to prevent race conditions:

1. **`_isNavigating` flag** - Prevents overlapping navigation operations
        - Set before calling `NavigateToType()`
        - Checked at start of `NavigateToPage()` - returns early if navigation in progress
        - Cleared in `OnNavigated()` finally block after content update completes

2. **`_isUpdatingSelection` flag** - Prevents reentrant selection events
        - Set before updating `SelectedItem` in `MapCurrentPage`
        - Checked at start of `OnSelectedMenuItemChanged` - returns early if updating programmatically
        - Cleared in finally block after update completes

This ensures:
     - Only one navigation operation runs at a time
     - Subsequent rapid clicks are queued/ignored until current navigation completes
     - No reentrant selection change events
     - Safe cleanup via try-finally blocks
     
Fixes #32824 