### PR TITLE
Add Git workflow rules for Copilot CLI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -239,6 +239,37 @@ When working with public API changes, proper handling of PublicAPI.Unshipped.txt
 
 **Note:** The main branch is always pinned to the latest stable release of the .NET SDK, regardless of whether it's a long-term support (LTS) release. Ensure you have that version installed to build the codebase.
 
+### Git Workflow (Copilot CLI Rules)
+
+**🚨 CRITICAL Git Rules for Copilot CLI:**
+
+1. **NEVER commit directly to `main`** - Always create a feature branch for your work. Direct commits to `main` are strictly prohibited.
+
+2. **Do NOT rebase, squash, or force-push** unless explicitly requested by the user. These operations rewrite git history and can cause problems for other contributors. Default behavior should be regular commits and pushes.
+
+3. **When amending an existing PR, do NOT automatically push** - After making changes to an existing PR branch, ask the user before pushing. This allows the user to review the changes locally first. Exception: If the user's instructions explicitly include pushing, proceed without asking.
+
+**Safe Git Workflow:**
+```bash
+# Create a feature branch (NEVER work directly on main)
+git checkout -b feature/issue-12345
+
+# Make commits normally
+git add .
+git commit -m "Fix: Description of the change"
+
+# Push to remote (for new branches)
+git push -u origin feature/issue-12345
+
+# For subsequent pushes on the same branch
+git push
+```
+
+**When asked to update an existing PR:**
+1. Make the requested changes
+2. Stage and commit the changes
+3. **STOP and ask the user** before pushing: "Changes are committed locally. Would you like me to push these changes to the PR?"
+
 ### Documentation
 - Update XML documentation for public APIs
 - Follow existing code documentation patterns


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds Git workflow instructions for Copilot CLI to the repository instructions (`.github/copilot-instructions.md`).

### Rules added:

1. **Never commit directly to `main`** - Always create a feature branch
2. **No rebase, squash, or force-push** unless explicitly requested by the user
3. **Ask before pushing when amending an existing PR** - Exception: proceed if pushing is explicitly part of the instructions

These rules help prevent accidental history rewrites and ensure users can review changes before they are pushed to remote.