### PR TITLE
[iOS][CV2] Fix CollectionView2 on iOS iPad jumps/scrolls randomly when item size changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -233,10 +233,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					{
 						// Use ReconfigureItems (iOS 15+) which is designed for size changes
 						// without full cell recreation - more efficient than ReloadItems
-						if (OperatingSystem.IsIOSVersionAtLeast(15))
-						{
-							collectionView.ReconfigureItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
-						}
+						collectionView.ReconfigureItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
 					});
 
 					return;
@@ -250,7 +247,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		static bool ShouldApplyCellReConfiguration()
         {
-            if (!OperatingSystem.IsIOSVersionAtLeast(18))
+            if (!OperatingSystem.IsIOSVersionAtLeast(15))
             {
                 return false;
             }

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -256,8 +256,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		static bool ShouldApplyCellReConfiguration()
 		{
-			return OperatingSystem.IsIOSVersionAtLeast(15)
-				|| OperatingSystem.IsMacCatalystVersionAtLeast(15);
+			return OperatingSystem.IsIOSVersionAtLeast(15);
 		}
 
 		private void MovedToWindow(object sender, EventArgs e)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -229,6 +229,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				// Self-sizing cells cause scroll position jumps during invalidation
 				if (ShouldApplyCellReConfiguration())
 				{
+					// Wrap in PerformWithoutAnimation to prevent ReconfigureItems from animating
+					// the scroll position adjustment that would otherwise occur during the layout pass.
 					UIView.PerformWithoutAnimation(() =>
 					{
 						// Use ReconfigureItems (iOS 15+) which is designed for size changes

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -225,6 +225,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (invalidatedCells is not null)
 			{
+				var invalidatedIndexPaths = invalidatedCells
+					.Select(collectionView.IndexPathForCell)
+					.ToArray();
+
+				if (invalidatedIndexPaths.Length == 0)
+					return;
+
 				// Workaround for layout issue observed on iPadOS 18+ with UICollectionViewCompositionalLayout
 				// where self-sizing cells can cause scroll position jumps during invalidation
 				if (ShouldApplyCellReConfiguration())

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -225,8 +225,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (invalidatedCells is not null)
 			{
-				// Workaround for Apple bug in iPadOS 18+ with UICollectionViewCompositionalLayout
-				// Self-sizing cells cause scroll position jumps during invalidation
+				// Workaround for layout issue observed on iPadOS 18+ with UICollectionViewCompositionalLayout
+				// where self-sizing cells can cause scroll position jumps during invalidation
 				if (ShouldApplyCellReConfiguration())
 				{
 					// Wrap in PerformWithoutAnimation to prevent ReconfigureItems from animating

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -232,10 +232,32 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (invalidatedIndexPaths is not null)
 			{
+				var indexPathsArray = invalidatedIndexPaths.ToArray();
+
+				// Workaround for layout issue observed on iPadOS 18+ with UICollectionViewCompositionalLayout
+				// where self-sizing cells can cause scroll position jumps during invalidation
+				if (ShouldApplyCellReConfiguration())
+				{
+					// Wrap in PerformWithoutAnimation to prevent ReconfigureItems from animating
+					// the scroll position adjustment that would otherwise occur during the layout pass.
+					UIView.PerformWithoutAnimation(() =>
+					{
+						// Use ReconfigureItems (iOS 15+) which is designed for size changes
+						// without full cell recreation - more efficient than ReloadItems
+						collectionView.ReconfigureItems(indexPathsArray);
+					});
+				}
+
 				var layoutInvalidationContext = new UICollectionViewLayoutInvalidationContext();
-				layoutInvalidationContext.InvalidateItems(invalidatedIndexPaths.ToArray());
+				layoutInvalidationContext.InvalidateItems(indexPathsArray);
 				collectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);
 			}
+		}
+
+		static bool ShouldApplyCellReConfiguration()
+		{
+			return OperatingSystem.IsIOSVersionAtLeast(15)
+				|| OperatingSystem.IsMacCatalystVersionAtLeast(15);
 		}
 
 		private void MovedToWindow(object sender, EventArgs e)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -242,14 +242,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					{
 						// Use ReconfigureItems (iOS 15+) which is designed for size changes
 						// without full cell recreation - more efficient than ReloadItems
-						collectionView.ReconfigureItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
+						collectionView.ReconfigureItems(invalidatedIndexPaths);
 					});
-
-					return;
 				}
 
 				var layoutInvalidationContext = new UICollectionViewLayoutInvalidationContext();
-				layoutInvalidationContext.InvalidateItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
+				layoutInvalidationContext.InvalidateItems(invalidatedIndexPaths);
 				collectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				// Workaround for Apple bug in iPadOS 18+ with UICollectionViewCompositionalLayout
 				// Self-sizing cells cause scroll position jumps during invalidation
-				if (ShouldApplyCompositionalReload())
+				if (ShouldApplyCellReConfiguration())
 				{
 					UIView.PerformWithoutAnimation(() =>
 					{
@@ -249,7 +249,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			}
 		}
 
-		static bool ShouldApplyCompositionalReload()
+		static bool ShouldApplyCellReConfiguration()
         {
             if (!OperatingSystem.IsIOSVersionAtLeast(18))
             {

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -242,7 +242,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					return;
 				}
 
-				// Standard invalidation path for FlowLayout or older iOS versions
 				var layoutInvalidationContext = new UICollectionViewLayoutInvalidationContext();
 				layoutInvalidationContext.InvalidateItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
 				collectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -225,11 +225,39 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (invalidatedCells is not null)
 			{
+				// Workaround for Apple bug in iPadOS 18+ with UICollectionViewCompositionalLayout
+				// Self-sizing cells cause scroll position jumps during invalidation
+				if (ShouldApplyCompositionalReload())
+				{
+					UIView.PerformWithoutAnimation(() =>
+					{
+						// Use ReconfigureItems (iOS 15+) which is designed for size changes
+						// without full cell recreation - more efficient than ReloadItems
+						if (OperatingSystem.IsIOSVersionAtLeast(15))
+						{
+							collectionView.ReconfigureItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
+						}
+					});
+
+					return;
+				}
+
+				// Standard invalidation path for FlowLayout or older iOS versions
 				var layoutInvalidationContext = new UICollectionViewLayoutInvalidationContext();
 				layoutInvalidationContext.InvalidateItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
 				collectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);
 			}
 		}
+
+		static bool ShouldApplyCompositionalReload()
+        {
+            if (!OperatingSystem.IsIOSVersionAtLeast(18))
+            {
+                return false;
+            }
+ 
+            return UIDevice.CurrentDevice?.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad;
+        }
 
 		private void MovedToWindow(object sender, EventArgs e)
 		{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -246,14 +246,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		}
 
 		static bool ShouldApplyCellReConfiguration()
-        {
-            if (!OperatingSystem.IsIOSVersionAtLeast(15))
-            {
-                return false;
-            }
- 
-            return UIDevice.CurrentDevice?.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad;
-        }
+		{
+			return OperatingSystem.IsIOSVersionAtLeast(15);
+		}
 
 		private void MovedToWindow(object sender, EventArgs e)
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
In CollectionView2, when an item’s size changes, the CollectionView jumps or scrolls unexpectedly instead of keeping its current position.

### Description of Change

<!-- Enter description of the fix in this section -->
Replaced the cell update logic from invalidateLayout to reconfigureItems for the affected cell.
reconfigureItems (iOS 15+) is lighter and works correctly on iPad iOS 26.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #32796 
Fixes #33833 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Regarding test case
Since the issue reproduces only on iPadOS 26, I haven’t added a test case.

**Tested the behavior in the following platforms.**
- [ ] Android
- [ ] Windows
- [x] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/6b3d1860-fa1d-4085-a0f9-e57f48eea1ff" width="400" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/89036aa6-010c-4c64-b4de-e7a503579c6f" width="400" height="600"> |
