### PR TITLE
[Android] Fixed ShellFlyout Footer area not cleared after removing footer view

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -427,7 +427,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var footer = ((IShellController)_shellContext.Shell).FlyoutFooter;
 
 			if (footer == null)
+			{
+				UpdateContentPadding();
 				return;
+			}
 
 			if (_flyoutWidth == 0)
 				return;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request makes a minor update to the `UpdateFlyoutFooter` method in `ShellFlyoutTemplatedContentRenderer.cs`. Now, when the `FlyoutFooter` is `null`, the method also calls `UpdateContentPadding()` before returning. This ensures that the content padding is updated even when there is no footer present.

* Call `UpdateContentPadding()` when `FlyoutFooter` is `null` in the `UpdateFlyoutFooter` method of `ShellFlyoutTemplatedContentRenderer.cs` to ensure correct padding.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #32883

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output
| Before | After |
|--|--|
|<video src="https://github.com/user-attachments/assets/04474cd6-6b90-4082-a30d-026f5b6ca98d" width=300 height=60> | <video src="https://github.com/user-attachments/assets/258389ae-1f54-44ed-aeb4-0a3bce23633f" width=300 height=600>|







