### PR TITLE
[XC] Fix XamlC null key error in CanAddToResourceDictionary

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1705,6 +1705,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		static bool CanAddToResourceDictionary(VariableDefinition parent, TypeReference collectionType, ElementNode node, IXmlLineInfo lineInfo, ILContext context)
 		{
+			if (parent is null)
+				return false;
+
 			if (collectionType.FullName != "Microsoft.Maui.Controls.ResourceDictionary"
 				&& !collectionType.InheritsFromOrImplements(context.Cache, context.Module.ImportReference(context.Cache, ("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "ResourceDictionary"))))
 				return false;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24472.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24472.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui24472">
+    <!-- 
+        This test reproduces issue #24472 where XamlC throws 
+        "Value cannot be null. (Parameter 'key')" when compiling XAML 
+        with x:Array containing custom objects and a DataTemplate with a nested view.
+        
+        The issue is triggered by the combination of:
+        1. x:Array with items in CollectionView.ItemsSource
+        2. DataTemplate in ItemTemplate
+        3. CollectionView.Header with nested content
+    -->
+    <CollectionView>
+        <CollectionView.ItemsSource>
+            <x:Array Type="{x:Type local:Maui24472Item}">
+                <local:Maui24472Item Name="Test1" />
+                <local:Maui24472Item Name="Test2" />
+                <local:Maui24472Item />
+                <local:Maui24472Item />
+            </x:Array>
+        </CollectionView.ItemsSource>
+        <CollectionView.Header>
+            <Grid RowDefinitions="Auto,*">
+                <Label Text="Header" />
+                <Border Grid.Row="1" StrokeShape="RoundRectangle 30">
+                    <Grid>
+                        <Image Source="dotnet_bot.png" />
+                        <Button Text="Test" />
+                    </Grid>
+                </Border>
+            </Grid>
+        </CollectionView.Header>
+        <CollectionView.ItemTemplate>
+            <DataTemplate >
+                <Border StrokeThickness="1">
+                    <Grid ColumnDefinitions="Auto,*,*">
+                        <Border Background="#AA333333" WidthRequest="40" HeightRequest="40" Grid.RowSpan="2" />
+                        <Label Text="{Binding Name}" Grid.Column="1" />
+                    </Grid>
+                </Border>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui24472.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui24472.xaml.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+// Simple item class for the test
+public class Maui24472Item
+{
+	public string Name { get; set; }
+}
+
+public partial class Maui24472 : ContentPage
+{
+	public Maui24472() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[Test]
+		// https://github.com/dotnet/maui/issues/24472
+		// XamlC was throwing "Value cannot be null. (Parameter 'key')" when compiling
+		// XAML with x:Array containing custom objects in CollectionView.ItemsSource
+		public void XArrayInCollectionViewItemsSourceDoesNotCrash([Values] XamlInflator inflator)
+		{
+			var page = new Maui24472(inflator);
+			Assert.That(page, Is.Not.Null);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #24472

When processing XAML with complex nested structures (e.g., `CollectionView` with `x:Array` items and `DataTemplate`), XamlC could throw `Value cannot be null. (Parameter 'key')` because `CanAddToResourceDictionary` was called with a null `parent` parameter.

### Root Cause

The error occurs when `context.Cache.GetResourceNamesInUse(parent)` is called with a null `VariableDefinition`. This happens because `GetResourceNamesInUse` internally uses a `Dictionary<VariableDefinition, ICollection<string>>`, and accessing a dictionary with a null key throws `ArgumentNullException("key")`.

### Fix

Added an early null check in `CanAddToResourceDictionary` to return `false` if `parent` is null. This is safe because:
1. If `parent` is null, we cannot add to a ResourceDictionary anyway
2. Returning `false` allows the compiler to try other property-setting methods

### Changes
- **src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs**: Added null check for `parent` parameter
- **src/Controls/tests/Xaml.UnitTests/Issues/Maui24472.xaml/.cs**: Added unit test with `CollectionView`, `x:Array`, and `DataTemplate`

### Testing
- All 1755 XAML unit tests pass
- New test `Maui24472` verifies the fix works for all XamlInflator modes (Runtime, XamlC, SourceGen)