### PR TITLE
[C] Fix binding to interface-inherited properties like IReadOnlyList<T>.Count

### DIFF
--- a/src/Controls/tests/SourceGen.UnitTests/Maui32879Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/Maui32879Tests.cs
@@ -60,6 +60,7 @@ $$"""
 // </auto-generated>
 //------------------------------------------------------------------------------
 #nullable enable
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
 
 namespace Test;
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui13872.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui13872.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui13872">
+    <VerticalStackLayout>
+	<Label x:Name="label0" Text="{Binding List.Count}"/>
+	<Label x:Name="label1" Text="{Binding ListCount}"/> 
+        <Label x:Name="label2" Text="{Binding List.Count}" x:DataType="local:Maui13872ViewModel"/>
+        <Label x:Name="label3" Text="{Binding ListCount}" x:DataType="local:Maui13872ViewModel"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui13872.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui13872.xaml.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui13872 : ContentPage
+{
+	public Maui13872() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[Test]
+		public void CompiledBindingToIReadOnlyListCount([Values] XamlInflator inflator)
+		{
+			var page = new Maui13872(inflator);
+			page.BindingContext = new Maui13872ViewModel();
+
+			// Uncompiled bindings (no x:DataType) - should work with all inflators
+			Assert.That(page.label0.Text, Is.EqualTo("3"), "Uncompiled binding to List.Count");
+			Assert.That(page.label1.Text, Is.EqualTo("3"), "Uncompiled binding to ListCount");
+
+			// Compiled bindings (with x:DataType) - IReadOnlyList<T>.Count should resolve correctly.
+			// Count is defined on IReadOnlyCollection<T> which IReadOnlyList<T> inherits.
+			Assert.That(page.label2.Text, Is.EqualTo("3"), "Compiled binding to List.Count");
+			Assert.That(page.label3.Text, Is.EqualTo("3"), "Compiled binding to ListCount");
+		}
+	}
+}
+
+public class Maui13872ViewModel
+{
+	private readonly string[] _list = ["Bill", "Steve", "John"];
+
+	public IReadOnlyList<string> List => _list;
+
+	public int ListCount => _list.Length;
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #13872

Runtime bindings were not resolving properties inherited from parent interfaces. For example, `IReadOnlyList<T>.Count` would return `null` because `Count` is defined on `IReadOnlyCollection<T>`, not directly on `IReadOnlyList<T>`.

## Changes

- Added `GetProperty()` method in `BindingExpression.cs` that searches both base classes and implemented interfaces recursively (similar to how `GetIndexer()` already handles this case)
- Updated `SetupPart()` to use the new `GetProperty()` method
- Added unit test `Maui13872` that verifies bindings to `IReadOnlyList<T>.Count` work correctly with all XAML inflators (Runtime, XamlC, SourceGen)

## Test Results

All 1790 XAML unit tests pass:
- **Passed:** 1764
- **Skipped:** 26
- **Failed:** 0