### PR TITLE
Fix Maui32879Tests expected output to include pragma warning disable

### DIFF
--- a/src/Controls/tests/SourceGen.UnitTests/Maui32879Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/Maui32879Tests.cs
@@ -60,6 +60,7 @@ $$"""
 // </auto-generated>
 //------------------------------------------------------------------------------
 #nullable enable
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
 
 namespace Test;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes a merge conflict in `Maui32879Tests.cs` where the expected generated output was missing the `#pragma warning disable CS0219` line that was added to the source generator in a separate change.

## Changes

Updated the expected output in `StyleSetterWithAttachedPropertyContentSyntax` test to include the pragma warning disable directive after `#nullable enable`.

## Testing

- [x] `dotnet test src/Controls/tests/SourceGen.UnitTests/` passes (116 tests, 0 failures)