### PR TITLE
[Android]Fix deadlock on modal navigation

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -8,7 +8,6 @@ using Android.OS;
 using Android.Views;
 using Android.Views.Animations;
 using AndroidX.Activity;
-using AndroidX.Core.View;
 using AndroidX.Fragment.App;
 using Microsoft.Maui.LifecycleEvents;
 using AAnimation = Android.Views.Animations.Animation;
@@ -215,6 +214,7 @@ namespace Microsoft.Maui.Controls.Platform
 			NavigationRootManager? _navigationRootManager;
 			static readonly ColorDrawable TransparentColorDrawable = new(AColor.Transparent);
 			bool _pendingAnimation = true;
+			bool _pendingNavigation = true;
 
 			public event EventHandler? AnimationEnded;
 
@@ -392,6 +392,13 @@ namespace Microsoft.Maui.Controls.Platform
 			public override void OnResume()
 			{
 				base.OnResume();
+
+				if (!_pendingNavigation)
+				{
+					return;
+				}
+
+				_pendingNavigation = false;
 				Navigated?.Invoke(this, EventArgs.Empty);
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32310.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32310.cs
@@ -1,0 +1,42 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32310, "App hangs if PopModalAsync is called after PushModalAsync with single await Task.Yield()", PlatformAffected.Android)]
+public class Issue32310 : ContentPage
+{
+	public Issue32310()
+	{
+		var navigateButton = new Button
+		{
+			Text = "Perform Modal Navigation",
+			AutomationId = "NavigateButton",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		navigateButton.Clicked += (s, e) =>
+		{
+			Dispatcher.DispatchAsync(async () =>
+			{
+				await Navigation.PushModalAsync(new ContentPage() { Content = new Label() { Text = "Hello!" } }, false);
+
+				await Task.Yield();
+
+				await Navigation.PopModalAsync(false);
+			});
+		};
+
+		var layout = new VerticalStackLayout
+		{
+			Padding = new Thickness(30, 0),
+			Spacing = 25,
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			Children =
+			{
+				navigateButton
+			}
+		};
+
+		Content = layout;
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32310.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32310.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32310 : _IssuesUITest
+{
+	public Issue32310(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "App hangs if PopModalAsync is called after PushModalAsync with single await Task.Yield()";
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void ModalNavigationShouldNotHang()
+	{
+		App.WaitForElement("NavigateButton");
+		App.Tap("NavigateButton");
+
+		// If the fix works, the modal should push and pop quickly,
+		// and we should be back to the same page with the button visible
+		App.WaitForElement("NavigateButton", timeout: TimeSpan.FromSeconds(5));
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change
This PR adds the `Navigated` event inside `DialogFragment`. The issue happens because the Push/PopModal navigation returns too early and causes the hanging since it gets lost.

Also added `TaskCreationOptions.RunContinuationsAsynchronously` to both `TaskCompletionSource` in Pop and Push modal navigations. This will make the continuations run in the expected order.

I kept the `AnimationEnded` event because they fire in different moments, so I believe it's better to keep it for animated navigations.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

This is a follow up of: #32853

Fixes #32310

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
