### PR TITLE
[XSG] Fix CS8601 error in XAML SourceGen setter for nullable reference types

### DIFF
--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/CompiledBindings.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/CompiledBindings.cs
@@ -421,6 +421,10 @@ public partial class TestPage
 		{
 			global::System.Action<global::Test.TestPage, string?>? setter = static (source, value) =>
 			{
+				if (value is null)
+				{
+					return;
+				}
 				if (source.Product is {} p0)
 				{
 					p0.Name = value;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

When binding path contains nullable access (e.g., `Child.Message` where `Child` is nullable), the XAML SourceGen was generating a setter that assigns a nullable value to a non-nullable property, causing CS8601 "Possible null reference assignment" error.

### Before (generated code):
```csharp
global::System.Action<MainPageVm, string?>? setter = static (source, value) =>
{
    if (source.Child is {} p0)
    {
        p0.Message = value;  // CS8601: value is string? but Message is string
    }
};
```

### After (generated code):
```csharp
global::System.Action<MainPageVm, string?>? setter = static (source, value) =>
{
    if (value is null)  // NEW: early return for null values
    {
        return;
    }
    if (source.Child is {} p0)
    {
        p0.Message = value;  // Now safe: value is not null
    }
};
```

## Changes

- Added early return for null values in `AppendSetterLambda` when:
  - `PropertyType.IsNullable` is true (the binding path involves nullable access)
  - `SetterOptions.AcceptsNullValue` is false (the target property does not accept null)
- This mirrors the existing logic in `BindingCodeWriter.cs` used for C# binding interceptors
- Updated the `CorrectlyDetectsNullableReferenceTypes` test to expect the new null-check

## Reproduction

The issue was reproduced using the test project from [this comment](https://github.com/dotnet/maui/issues/32893#issuecomment-3596725822).
