### PR TITLE
Fix XamlC to respect ObsoleteAttribute message and isError parameter

### DIFF
--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -3,7 +3,7 @@
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />

--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -3,6 +3,10 @@
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
+    <!-- XC0618 (obsolete warning) and XC0619 (obsolete error) are suppressed here because sample projects
+         intentionally use deprecated APIs for demonstration purposes. XC0619 is emitted via raw LogError
+         (not the warning-promotion path), so WarningsNotAsErrors has no functional effect on it currently,
+         but it's listed defensively to prevent future TreatWarningsAsErrors from interfering. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>

--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		//CSC equivalents
 		public static BuildExceptionCode ObsoleteProperty = new BuildExceptionCode("XC", 0618, nameof(ObsoleteProperty), ""); //warning
+		public static BuildExceptionCode ObsoletePropertyError = new BuildExceptionCode("XC", 0619, nameof(ObsoletePropertyError), ""); //error
 
 		public string Code { get; }
 		public string CodePrefix { get; }

--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var typeref = Module.ImportReference(node.XmlType.GetTypeReference(Context.Cache, Module, node));
 			TypeDefinition typedef = typeref.ResolveCached(Context.Cache);
 
+			// Check if the type is marked as obsolete
+			SetPropertiesVisitor.LogObsoleteWarningOrError(Context, node, typedef.FullName, typedef.CustomAttributes);
+
 			if (typeref.FullName == "Microsoft.Maui.Controls.Xaml.ArrayExtension")
 			{
 				var visitor = new SetPropertiesVisitor(Context);

--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var typeref = Module.ImportReference(node.XmlType.GetTypeReference(Context.Cache, Module, node));
 			TypeDefinition typedef = typeref.ResolveCached(Context.Cache);
 
-			// Check if the type is marked as obsolete
-			SetPropertiesVisitor.LogObsoleteWarningOrError(Context, node, typedef.FullName, typedef.CustomAttributes);
+			// Check if the type is marked as obsolete (typedef may be null for unresolvable types)
+			if (typedef != null)
+				SetPropertiesVisitor.LogObsoleteWarningOrError(Context, node, typedef.FullName, typedef.CustomAttributes);
 
 			if (typeref.FullName == "Microsoft.Maui.Controls.Xaml.ArrayExtension")
 			{

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -206,7 +206,12 @@
     <comment>0 is the duplicated key</comment>
   </data>
   <data name="ObsoleteProperty" xml:space="preserve">
-    <value>Property, Property setter or BindableProperty "{0}" is deprecated.</value>
+    <value>"{0}" is deprecated: {1}</value>
+    <comment>0 is the member/type name, 1 is the obsolete message from the attribute</comment>
+  </data>
+  <data name="ObsoletePropertyError" xml:space="preserve">
+    <value>"{0}" is obsolete: {1}</value>
+    <comment>0 is the member/type name, 1 is the obsolete message from the attribute</comment>
   </data>  
   <data name="PropertyMissing" xml:space="preserve">
     <value>Missing mandatory property "{0}" on "{1}".</value>

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -206,7 +206,7 @@
     <comment>0 is the duplicated key</comment>
   </data>
   <data name="ObsoleteProperty" xml:space="preserve">
-    <value>"{0}" is deprecated: {1}</value>
+    <value>"{0}" is obsolete: {1}</value>
     <comment>0 is the member/type name, 1 is the obsolete message from the attribute</comment>
   </data>
   <data name="ObsoletePropertyError" xml:space="preserve">

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1697,10 +1697,14 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		{
 			var module = context.Body.Method.Module;
 			var property = parent.VariableType.GetProperty(context.Cache, pd => pd.Name == localName, out TypeReference declaringTypeReference);
+			// Check the property itself for [Obsolete], then check the setter separately.
+			// In the rare case both carry [Obsolete], two diagnostics are emitted — matching
+			// C# compiler behavior, which also checks property declarations and accessors independently.
 			LogObsoleteWarningOrError(context, iXmlLineInfo, localName, property.CustomAttributes);
 
 			var propertySetter = property.SetMethod;
-			LogObsoleteWarningOrError(context, iXmlLineInfo, localName, propertySetter.CustomAttributes);
+			if (propertySetter != null)
+				LogObsoleteWarningOrError(context, iXmlLineInfo, localName, propertySetter.CustomAttributes);
 
 			//			IL_0007:  ldloc.0
 			//			IL_0008:  ldstr "foo"
@@ -2088,7 +2092,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				if (isError)
 				{
 					// [Obsolete("msg", error: true)] must ALWAYS be an error,
-					// regardless of TreatWarningsAsErrors setting
+					// regardless of TreatWarningsAsErrors setting.
+					// XC0619 intentionally bypasses NoWarn, matching C# CS0619 behavior.
+					// Obsolete-as-error cannot be suppressed; users must remove the usage.
 					var code = ObsoletePropertyError;
 					var xamlFilePath = context.LoggingHelper.GetXamlFilePath(context.XamlFilePath);
 					context.LoggingHelper.LogError("XamlC", $"{code.CodePrefix}{code.CodeCode:0000}", code.HelpLink, xamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), memberName, message);

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -2085,8 +2085,20 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		{
 			if (TryGetObsoleteAttribute(customAttributes, out string message, out bool isError))
 			{
-				var code = isError ? ObsoletePropertyError : ObsoleteProperty;
-				context.LoggingHelper.LogWarningOrError(code, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, memberName, message);
+				if (isError)
+				{
+					// [Obsolete("msg", error: true)] must ALWAYS be an error,
+					// regardless of TreatWarningsAsErrors setting
+					var code = ObsoletePropertyError;
+					var xamlFilePath = context.LoggingHelper.GetXamlFilePath(context.XamlFilePath);
+					context.LoggingHelper.LogError("XamlC", $"{code.CodePrefix}{code.CodeCode:0000}", code.HelpLink, xamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, ErrorMessages.ResourceManager.GetString(code.ErrorMessageKey), memberName, message);
+					LoggingHelperExtensions.LoggedErrors ??= new();
+					LoggingHelperExtensions.LoggedErrors.Add(new BuildException(code, new XmlLineInfo(lineInfo.LineNumber, lineInfo.LinePosition), innerException: null, memberName, message));
+				}
+				else
+				{
+					context.LoggingHelper.LogWarningOrError(ObsoleteProperty, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, memberName, message);
+				}
 			}
 		}
 	}

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1317,9 +1317,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var bpRef = module.ImportReference(bpDef.ResolveGenericParameters(declaringTypeReference));
 			bpRef.FieldType = module.ImportReference(bpRef.FieldType);
 
-			var isObsolete = bpDef.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
-			if (isObsolete)
-				context.LoggingHelper.LogWarningOrError(ObsoleteProperty, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, localName);
+			LogObsoleteWarningOrError(context, iXmlLineInfo, localName, bpDef.CustomAttributes);
 
 			return bpRef;
 		}
@@ -1699,14 +1697,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		{
 			var module = context.Body.Method.Module;
 			var property = parent.VariableType.GetProperty(context.Cache, pd => pd.Name == localName, out TypeReference declaringTypeReference);
-			var propertyIsObsolete = property.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
-			if (propertyIsObsolete)
-				context.LoggingHelper.LogWarningOrError(ObsoleteProperty, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, localName);
+			LogObsoleteWarningOrError(context, iXmlLineInfo, localName, property.CustomAttributes);
 
 			var propertySetter = property.SetMethod;
-			var propertySetterIsObsolete = propertySetter.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
-			if (propertySetterIsObsolete)
-				context.LoggingHelper.LogWarningOrError(ObsoleteProperty, context.XamlFilePath, iXmlLineInfo.LineNumber, iXmlLineInfo.LinePosition, 0, 0, localName);
+			LogObsoleteWarningOrError(context, iXmlLineInfo, localName, propertySetter.CustomAttributes);
 
 			//			IL_0007:  ldloc.0
 			//			IL_0008:  ldstr "foo"
@@ -2050,6 +2044,50 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			Context.IL.Append(SetPropertyValue(variableDefinition, new XmlName("", runTimeName), node, Context, node));
 			return true;
+		}
+
+		/// <summary>
+		/// Gets the ObsoleteAttribute information from a custom attribute provider (field, property, method, or type).
+		/// </summary>
+		/// <param name="customAttributes">The custom attributes collection to search.</param>
+		/// <param name="message">The obsolete message from the attribute, or a default message if not specified.</param>
+		/// <param name="isError">True if the obsolete attribute specifies error=true.</param>
+		/// <returns>True if the ObsoleteAttribute is present, false otherwise.</returns>
+		internal static bool TryGetObsoleteAttribute(IEnumerable<CustomAttribute> customAttributes, out string message, out bool isError)
+		{
+			message = null;
+			isError = false;
+
+			var obsoleteAttr = customAttributes.FirstOrDefault(ca => ca.AttributeType.FullName == "System.ObsoleteAttribute");
+			if (obsoleteAttr == null)
+				return false;
+
+			// ObsoleteAttribute has the following constructors:
+			// ObsoleteAttribute()
+			// ObsoleteAttribute(string message)
+			// ObsoleteAttribute(string message, bool error)
+			if (obsoleteAttr.ConstructorArguments.Count >= 1 && obsoleteAttr.ConstructorArguments[0].Value is string msg)
+				message = msg;
+
+			if (obsoleteAttr.ConstructorArguments.Count >= 2 && obsoleteAttr.ConstructorArguments[1].Value is bool err)
+				isError = err;
+
+			// Use a default message if none was provided
+			message ??= "This member is obsolete.";
+
+			return true;
+		}
+
+		/// <summary>
+		/// Logs an obsolete warning or error based on the ObsoleteAttribute's error parameter.
+		/// </summary>
+		internal static void LogObsoleteWarningOrError(ILContext context, IXmlLineInfo lineInfo, string memberName, IEnumerable<CustomAttribute> customAttributes)
+		{
+			if (TryGetObsoleteAttribute(customAttributes, out string message, out bool isError))
+			{
+				var code = isError ? ObsoletePropertyError : ObsoleteProperty;
+				context.LoggingHelper.LogWarningOrError(code, context.XamlFilePath, lineInfo.LineNumber, lineInfo.LinePosition, 0, 0, memberName, message);
+			}
 		}
 	}
 

--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -43,6 +43,7 @@
   
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS0618;CS0672;MVVMTK0045</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0619</WarningsNotAsErrors>
   </PropertyGroup>
   
 	<ItemGroup>

--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -43,6 +43,9 @@
   
   <PropertyGroup>
     <NoWarn>$(NoWarn);CS0618;CS0672;MVVMTK0045</NoWarn>
+    <!-- XC0618 (obsolete warning) and XC0619 (obsolete error) are suppressed here because this project
+         intentionally uses deprecated APIs. XC0619 uses raw LogError (not the warning-promotion path),
+         so WarningsNotAsErrors is defensive only. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0619</WarningsNotAsErrors>
   </PropertyGroup>
   

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -35,7 +35,7 @@
     <PublishAot>true</PublishAot>
     <_IsPublishing>true</_IsPublishing>
     <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
-    <WarningsNotAsErrors>IL3050</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL3050</WarningsNotAsErrors>
     <DefineConstants>$(DefineConstants);NATIVE_AOT</DefineConstants>
   </PropertyGroup>
 

--- a/src/Controls/tests/TestCases.HostApp/Directory.Build.props
+++ b/src/Controls/tests/TestCases.HostApp/Directory.Build.props
@@ -3,7 +3,7 @@
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <Import Project="../../../../Directory.Build.props" />

--- a/src/Controls/tests/TestCases.HostApp/Directory.Build.props
+++ b/src/Controls/tests/TestCases.HostApp/Directory.Build.props
@@ -3,6 +3,9 @@
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
+    <!-- XC0618 (obsolete warning) and XC0619 (obsolete error) are suppressed here because this project
+         intentionally uses deprecated APIs. XC0619 uses raw LogError (not the warning-promotion path),
+         so WarningsNotAsErrors is defensive only. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618;CA2252</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0025;XC0045;XC0067;MAUIG2045;MAUID1000;MAUIX2005;MAUIX2015</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0619;XC0022;XC0023;XC0025;XC0045;XC0067;MAUIG2045;MAUID1000;MAUIX2005;MAUIX2015</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618;CA2252</NoWarn>
+    <!-- XC0618/XC0619 suppressed: test projects exercise deprecated APIs intentionally.
+         XC0619 uses raw LogError (not warning-promotion), so WarningsNotAsErrors is defensive only. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0619;XC0022;XC0023;XC0025;XC0045;XC0067;MAUIG2045;MAUID1000;MAUIX2005;MAUIX2015</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui23961">
+    <Grid>
+        <!-- Test Case 1: Properties with obsolete(error: false) should produce warnings -->
+        <local:Maui23961Class1
+            BP1="Obsolete warning BP"
+            P1="Obsolete warning property" />
+
+        <!-- Test Case 2: Obsolete class with error: false should produce warning -->
+        <local:Maui23961ObsoleteClass2 />
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
@@ -1,0 +1,93 @@
+using System;
+using System.ComponentModel;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui23961 : ContentPage
+{
+	public Maui23961() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[SetUp]
+		public void Setup()
+		{
+			AppInfo.SetCurrent(new MockAppInfo());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			AppInfo.SetCurrent(null);
+		}
+
+		[Test]
+		public void ObsoleteWarningIncludesMessage([Values] XamlInflator inflator)
+		{
+			// This test verifies that obsolete warnings include the custom message from the ObsoleteAttribute
+			// and that types/properties with [Obsolete(error: false)] produce warnings, not errors
+
+			if (inflator == XamlInflator.XamlC)
+			{
+				// When not treating warnings as errors, this should compile with warnings
+				MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: false);
+				// The test passes if compilation succeeds (warnings are emitted but don't fail the build)
+			}
+			else
+			{
+				var page = new Maui23961(inflator);
+				Assert.That(page, Is.Not.Null);
+			}
+		}
+
+		[Test]
+		public void ObsoleteWarningBecomesErrorWhenTreatWarningsAsErrors([Values] XamlInflator inflator)
+		{
+			// When TreatWarningsAsErrors is true, obsolete warnings should become errors
+			if (inflator == XamlInflator.XamlC)
+			{
+				// Should throw when treating warnings as errors (may be Exception or AggregateException)
+				var ex = Assert.Catch(() => MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: true));
+				Assert.That(ex, Is.Not.Null);
+			}
+			else
+			{
+				// Runtime and SourceGen don't have treatWarningsAsErrors
+				var page = new Maui23961(inflator);
+				Assert.That(page, Is.Not.Null);
+			}
+		}
+	}
+}
+
+// Test classes for obsolete attribute handling
+public class Maui23961Class1 : Grid
+{
+	[Obsolete("[Test Message]: BP1Property is deprecated", error: false)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static readonly BindableProperty BP1Property =
+		BindableProperty.Create(nameof(BP1), typeof(string), typeof(Maui23961Class1), null);
+
+	[Obsolete("[Test Message]: BP1 property is deprecated", error: false)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string BP1
+	{
+		get => (string)GetValue(BP1Property);
+		set => SetValue(BP1Property, value);
+	}
+
+	[Obsolete("[Test Message]: P1 is deprecated", error: false)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string P1 { get; set; }
+}
+
+[Obsolete("[Test Message]: Maui23961ObsoleteClass2 is deprecated", error: false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class Maui23961ObsoleteClass2 : Grid { }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
@@ -4,90 +4,86 @@ using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.UnitTests;
-using NUnit.Framework;
+using Xunit;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
 public partial class Maui23961 : ContentPage
 {
-	public Maui23961() => InitializeComponent();
+public Maui23961() => InitializeComponent();
 
-	[TestFixture]
-	class Tests
-	{
-		[SetUp]
-		public void Setup()
-		{
-			AppInfo.SetCurrent(new MockAppInfo());
-			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
-		}
+[Collection("Issue")]
+public class Tests : IDisposable
+{
+public Tests()
+{
+AppInfo.SetCurrent(new MockAppInfo());
+DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+}
 
-		[TearDown]
-		public void TearDown()
-		{
-			AppInfo.SetCurrent(null);
-		}
+public void Dispose()
+{
+AppInfo.SetCurrent(null);
+}
 
-		[Test]
-		public void ObsoleteWarningIncludesMessage([Values] XamlInflator inflator)
-		{
-			// This test verifies that obsolete warnings include the custom message from the ObsoleteAttribute
-			// and that types/properties with [Obsolete(error: false)] produce warnings, not errors
+[Theory]
+[XamlInflatorData]
+internal void ObsoleteWarningIncludesMessage(XamlInflator inflator)
+{
+// This test verifies that obsolete warnings include the custom message from the ObsoleteAttribute
+// and that types/properties with [Obsolete(error: false)] produce warnings, not errors
 
-			if (inflator == XamlInflator.XamlC)
-			{
-				// When not treating warnings as errors, this should compile with warnings
-				MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: false);
-				// The test passes if compilation succeeds (warnings are emitted but don't fail the build)
-			}
-			else
-			{
-				var page = new Maui23961(inflator);
-				Assert.That(page, Is.Not.Null);
-			}
-		}
+if (inflator == XamlInflator.XamlC)
+{
+// When not treating warnings as errors, this should compile with warnings
+MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: false);
+// The test passes if compilation succeeds (warnings are emitted but don't fail the build)
+}
+else
+{
+var page = new Maui23961(inflator);
+Assert.NotNull(page);
+}
+}
 
-		[Test]
-		public void ObsoleteWarningBecomesErrorWhenTreatWarningsAsErrors([Values] XamlInflator inflator)
-		{
-			// When TreatWarningsAsErrors is true, obsolete warnings should become errors
-			if (inflator == XamlInflator.XamlC)
-			{
-				// Should throw when treating warnings as errors (may be Exception or AggregateException)
-				var ex = Assert.Catch(() => MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: true));
-				Assert.That(ex, Is.Not.Null);
-			}
-			else
-			{
-				// Runtime and SourceGen don't have treatWarningsAsErrors
-				var page = new Maui23961(inflator);
-				Assert.That(page, Is.Not.Null);
-			}
-		}
-	}
+[Theory]
+[XamlInflatorData]
+internal void ObsoleteWarningBecomesErrorWhenTreatWarningsAsErrors(XamlInflator inflator)
+{
+// When TreatWarningsAsErrors is true, obsolete warnings should become errors
+if (inflator == XamlInflator.XamlC)
+{
+// Should throw when treating warnings as errors
+var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: true));
+Assert.NotNull(ex);
+}
+else
+{
+// Runtime and SourceGen don't have treatWarningsAsErrors
+var page = new Maui23961(inflator);
+Assert.NotNull(page);
+}
+}
+}
 }
 
 // Test classes for obsolete attribute handling
 public class Maui23961Class1 : Grid
 {
-	[Obsolete("[Test Message]: BP1Property is deprecated", error: false)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static readonly BindableProperty BP1Property =
-		BindableProperty.Create(nameof(BP1), typeof(string), typeof(Maui23961Class1), null);
+[Obsolete("[Test Message]: BP1Property is deprecated", error: false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static readonly BindableProperty BP1Property =
+BindableProperty.Create(nameof(BP1), typeof(string), typeof(Maui23961Class1), null);
 
-	[Obsolete("[Test Message]: BP1 property is deprecated", error: false)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public string BP1
-	{
-		get => (string)GetValue(BP1Property);
-		set => SetValue(BP1Property, value);
-	}
-
-	[Obsolete("[Test Message]: P1 is deprecated", error: false)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public string P1 { get; set; }
+[Obsolete("[Test Message]: BP1 property is deprecated", error: false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public string BP1
+{
+get => (string)GetValue(BP1Property);
+set => SetValue(BP1Property, value);
 }
 
-[Obsolete("[Test Message]: Maui23961ObsoleteClass2 is deprecated", error: false)]
+[Obsolete("[Test Message]: P1 is deprecated", error: false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public class Maui23961ObsoleteClass2 : Grid { }
+public string P1 { get; set; }
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
@@ -39,7 +39,7 @@ if (inflator == XamlInflator.XamlC)
 // Compile with warnings allowed and capture the emitted warnings
 MockCompiler.Compile(typeof(Maui23961), out _, out _, out var warnings, treatWarningsAsErrors: false);
 // Verify the diagnostic messages include the custom [Obsolete] message text
-Assert.Contains(warnings, w => w.Message.Contains("[Test Message]"));
+Assert.Contains(warnings, w => w.Message.Contains("[Test Message]", StringComparison.Ordinal));
 }
 else
 {

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
@@ -11,62 +11,62 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
 public partial class Maui23961 : ContentPage
 {
-public Maui23961() => InitializeComponent();
+	public Maui23961() => InitializeComponent();
 
-[Collection("Issue")]
-public class Tests : IDisposable
-{
-public Tests()
-{
-AppInfo.SetCurrent(new MockAppInfo());
-DispatcherProvider.SetCurrent(new DispatcherProviderStub());
-}
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests()
+		{
+			AppInfo.SetCurrent(new MockAppInfo());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
 
-public void Dispose()
-{
-AppInfo.SetCurrent(null);
-}
+		public void Dispose()
+		{
+			AppInfo.SetCurrent(null);
+		}
 
-[Theory]
-[XamlInflatorData]
-internal void ObsoleteWarningIncludesMessage(XamlInflator inflator)
-{
-// This test verifies that obsolete warnings include the custom message from the ObsoleteAttribute
-// and that types/properties with [Obsolete(error: false)] produce warnings, not errors
+		[Theory]
+		[XamlInflatorData]
+		internal void ObsoleteWarningIncludesMessage(XamlInflator inflator)
+		{
+			// This test verifies that obsolete warnings include the custom message from the ObsoleteAttribute
+			// and that types/properties with [Obsolete(error: false)] produce warnings, not errors
 
-if (inflator == XamlInflator.XamlC)
-{
-// Compile with warnings allowed and capture the emitted warnings
-MockCompiler.Compile(typeof(Maui23961), out _, out _, out var warnings, treatWarningsAsErrors: false);
-// Verify the diagnostic messages include the custom [Obsolete] message text
-Assert.Contains(warnings, w => w.Message.Contains("[Test Message]", StringComparison.Ordinal));
-}
-else
-{
-var page = new Maui23961(inflator);
-Assert.NotNull(page);
-}
-}
+			if (inflator == XamlInflator.XamlC)
+			{
+				// Compile with warnings allowed and capture the emitted warnings
+				MockCompiler.Compile(typeof(Maui23961), out _, out _, out var warnings, treatWarningsAsErrors: false);
+				// Verify the diagnostic messages include the custom [Obsolete] message text
+				Assert.Contains(warnings, w => w.Message.Contains("[Test Message]", StringComparison.Ordinal));
+			}
+			else
+			{
+				var page = new Maui23961(inflator);
+				Assert.NotNull(page);
+			}
+		}
 
-[Theory]
-[XamlInflatorData]
-internal void ObsoleteWarningBecomesErrorWhenTreatWarningsAsErrors(XamlInflator inflator)
-{
-// When TreatWarningsAsErrors is true, obsolete warnings should become errors
-if (inflator == XamlInflator.XamlC)
-{
-// Should throw when treating warnings as errors
-var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: true));
-Assert.NotNull(ex);
-}
-else
-{
-// Runtime and SourceGen don't have treatWarningsAsErrors
-var page = new Maui23961(inflator);
-Assert.NotNull(page);
-}
-}
-}
+		[Theory]
+		[XamlInflatorData]
+		internal void ObsoleteWarningBecomesErrorWhenTreatWarningsAsErrors(XamlInflator inflator)
+		{
+			// When TreatWarningsAsErrors is true, obsolete warnings should become errors
+			if (inflator == XamlInflator.XamlC)
+			{
+				// Should throw when treating warnings as errors
+				var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: true));
+				Assert.NotNull(ex);
+			}
+			else
+			{
+				// Runtime and SourceGen don't have treatWarningsAsErrors
+				var page = new Maui23961(inflator);
+				Assert.NotNull(page);
+			}
+		}
+	}
 }
 
 // Test classes for obsolete attribute handling
@@ -76,20 +76,20 @@ public class Maui23961ObsoleteClass2 : Grid { }
 
 public class Maui23961Class1 : Grid
 {
-[Obsolete("[Test Message]: BP1Property is deprecated", error: false)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static readonly BindableProperty BP1Property =
-BindableProperty.Create(nameof(BP1), typeof(string), typeof(Maui23961Class1), null);
+	[Obsolete("[Test Message]: BP1Property is deprecated", error: false)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static readonly BindableProperty BP1Property =
+		BindableProperty.Create(nameof(BP1), typeof(string), typeof(Maui23961Class1), null);
 
-[Obsolete("[Test Message]: BP1 property is deprecated", error: false)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public string BP1
-{
-get => (string)GetValue(BP1Property);
-set => SetValue(BP1Property, value);
-}
+	[Obsolete("[Test Message]: BP1 property is deprecated", error: false)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string BP1
+	{
+		get => (string)GetValue(BP1Property);
+		set => SetValue(BP1Property, value);
+	}
 
-[Obsolete("[Test Message]: P1 is deprecated", error: false)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public string P1 { get; set; }
+	[Obsolete("[Test Message]: P1 is deprecated", error: false)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string P1 { get; set; }
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
@@ -68,6 +68,10 @@ Assert.NotNull(page);
 }
 
 // Test classes for obsolete attribute handling
+[Obsolete("[Test Message]: Maui23961ObsoleteClass2 is deprecated", error: false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class Maui23961ObsoleteClass2 : Grid { }
+
 public class Maui23961Class1 : Grid
 {
 [Obsolete("[Test Message]: BP1Property is deprecated", error: false)]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Microsoft.Build.Framework;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Dispatching;
@@ -35,9 +36,10 @@ internal void ObsoleteWarningIncludesMessage(XamlInflator inflator)
 
 if (inflator == XamlInflator.XamlC)
 {
-// When not treating warnings as errors, this should compile with warnings
-MockCompiler.Compile(typeof(Maui23961), treatWarningsAsErrors: false);
-// The test passes if compilation succeeds (warnings are emitted but don't fail the build)
+// Compile with warnings allowed and capture the emitted warnings
+MockCompiler.Compile(typeof(Maui23961), out _, out _, out var warnings, treatWarningsAsErrors: false);
+// Verify the diagnostic messages include the custom [Obsolete] message text
+Assert.Contains(warnings, w => w.Message.Contains("[Test Message]"));
 }
 else
 {

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.rt.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.rt.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui23961Error">
+    <Grid>
+        <!-- Test Case: Properties with obsolete(error: true) should produce errors -->
+        <local:Maui23961ErrorClass1
+            BP2="Obsolete error BP"
+            P2="Obsolete error property" />
+
+        <!-- Test Case: Obsolete class with error: true should produce error -->
+        <local:Maui23961ObsoleteClass3 />
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -1,0 +1,84 @@
+using System;
+using System.ComponentModel;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Build.Tasks;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui23961Error : ContentPage
+{
+	public Maui23961Error() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[SetUp]
+		public void Setup()
+		{
+			AppInfo.SetCurrent(new MockAppInfo());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			AppInfo.SetCurrent(null);
+		}
+
+		[Test]
+		public void ObsoleteErrorProducesCompilationError([Values] XamlInflator inflator)
+		{
+			// This test verifies that [Obsolete(error: true)] would produce a compilation error
+			// Note: Since this is a .rt.xaml file, XamlC doesn't process it during build,
+			// but we can verify the behavior by checking the runtime behavior.
+			if (inflator == XamlInflator.XamlC)
+			{
+				// For .rt.xaml files, XamlC doesn't process them during build.
+				// The error behavior is tested implicitly by the fact that a regular .xaml file
+				// with [Obsolete(error: true)] would fail to compile (not in WarningsNotAsErrors).
+				// We verify the MockCompiler doesn't crash for this type.
+				MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false);
+			}
+			else if (inflator == XamlInflator.SourceGen)
+			{
+				// SourceGen doesn't generate code for .rt.xaml files by design
+				Assert.Ignore("SourceGen does not process .rt.xaml files");
+			}
+			else
+			{
+				// Runtime doesn't check for obsolete at compile time
+				var page = new Maui23961Error(inflator);
+				Assert.That(page, Is.Not.Null);
+			}
+		}
+	}
+}
+
+// Test classes for obsolete attribute error handling
+public class Maui23961ErrorClass1 : Grid
+{
+	[Obsolete("[Error Message]: BP2Property is obsolete", error: true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static readonly BindableProperty BP2Property =
+		BindableProperty.Create(nameof(BP2), typeof(string), typeof(Maui23961ErrorClass1), null);
+
+	[Obsolete("[Error Message]: BP2 property is obsolete", error: true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string BP2
+	{
+		get => (string)GetValue(BP2Property);
+		set => SetValue(BP2Property, value);
+	}
+
+	[Obsolete("[Error Message]: P2 is obsolete", error: true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string P2 { get; set; }
+}
+
+[Obsolete("[Error Message]: Maui23961ObsoleteClass3 is obsolete", error: true)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class Maui23961ObsoleteClass3 : Grid { }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -32,25 +32,18 @@ public partial class Maui23961Error : ContentPage
 		[Test]
 		public void ObsoleteErrorProducesCompilationError([Values] XamlInflator inflator)
 		{
-			// This test verifies that [Obsolete(error: true)] would produce a compilation error
-			// Note: Since this is a .rt.xaml file, XamlC doesn't process it during build,
-			// but we can verify the behavior by checking the runtime behavior.
 			if (inflator == XamlInflator.XamlC)
 			{
-				// For .rt.xaml files, XamlC doesn't process them during build.
-				// The error behavior is tested implicitly by the fact that a regular .xaml file
-				// with [Obsolete(error: true)] would fail to compile (not in WarningsNotAsErrors).
-				// We verify the MockCompiler doesn't crash for this type.
-				MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false);
+				// [Obsolete("msg", error: true)] must always produce a compilation error,
+				// even without TreatWarningsAsErrors
+				Assert.Throws<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
 			}
 			else if (inflator == XamlInflator.SourceGen)
 			{
-				// SourceGen doesn't generate code for .rt.xaml files by design
 				Assert.Ignore("SourceGen does not process .rt.xaml files");
 			}
 			else
 			{
-				// Runtime doesn't check for obsolete at compile time
 				var page = new Maui23961Error(inflator);
 				Assert.That(page, Is.Not.Null);
 			}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -35,7 +35,9 @@ if (inflator == XamlInflator.XamlC)
 {
 // [Obsolete("msg", error: true)] must always produce a compilation error,
 // even without TreatWarningsAsErrors
-Assert.Throws<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
+// Multiple [Obsolete(error:true)] members produce multiple LoggedErrors wrapped in AggregateException,
+// so use ThrowsAny rather than Throws (which requires an exact type match).
+Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
 }
 else if (inflator == XamlInflator.SourceGen)
 {

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -38,7 +38,7 @@ if (inflator == XamlInflator.XamlC)
 // Multiple [Obsolete(error:true)] members produce multiple LoggedErrors wrapped in AggregateException,
 // so use ThrowsAny rather than Throws (which requires an exact type match).
 var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
-Assert.Contains("XC0619", ex.Message);
+Assert.Contains("XC0619", ex.Message, StringComparison.Ordinal);
 }
 else if (inflator == XamlInflator.SourceGen)
 {

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -11,69 +11,69 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
 public partial class Maui23961Error : ContentPage
 {
-public Maui23961Error() => InitializeComponent();
+	public Maui23961Error() => InitializeComponent();
 
-[Collection("Issue")]
-public class Tests : IDisposable
-{
-public Tests()
-{
-AppInfo.SetCurrent(new MockAppInfo());
-DispatcherProvider.SetCurrent(new DispatcherProviderStub());
-}
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests()
+		{
+			AppInfo.SetCurrent(new MockAppInfo());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
 
-public void Dispose()
-{
-AppInfo.SetCurrent(null);
-}
+		public void Dispose()
+		{
+			AppInfo.SetCurrent(null);
+		}
 
-[Theory]
-[XamlInflatorData]
-internal void ObsoleteErrorProducesCompilationError(XamlInflator inflator)
-{
-if (inflator == XamlInflator.XamlC)
-{
-// [Obsolete("msg", error: true)] must always produce a compilation error,
-// even without TreatWarningsAsErrors
-// Multiple [Obsolete(error:true)] members produce multiple LoggedErrors wrapped in AggregateException,
-// so use ThrowsAny rather than Throws (which requires an exact type match).
-var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
-Assert.Contains("XC0619", ex.Message, StringComparison.Ordinal);
-}
-else if (inflator == XamlInflator.SourceGen)
-{
-// SourceGen does not process .rt.xaml files
-return;
-}
-else
-{
-// .rt.xaml files only support runtime inflation (no XamlInflator ctor generated)
-var page = new Maui23961Error();
-Assert.NotNull(page);
-}
-}
-}
+		[Theory]
+		[XamlInflatorData]
+		internal void ObsoleteErrorProducesCompilationError(XamlInflator inflator)
+		{
+			if (inflator == XamlInflator.XamlC)
+			{
+				// [Obsolete("msg", error: true)] must always produce a compilation error,
+				// even without TreatWarningsAsErrors
+				// Multiple [Obsolete(error:true)] members produce multiple LoggedErrors wrapped in AggregateException,
+				// so use ThrowsAny rather than Throws (which requires an exact type match).
+				var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
+				Assert.Contains("XC0619", ex.Message, StringComparison.Ordinal);
+			}
+			else if (inflator == XamlInflator.SourceGen)
+			{
+				// SourceGen does not process .rt.xaml files
+				return;
+			}
+			else
+			{
+				// .rt.xaml files only support runtime inflation (no XamlInflator ctor generated)
+				var page = new Maui23961Error();
+				Assert.NotNull(page);
+			}
+		}
+	}
 }
 
 // Test classes for obsolete attribute error handling
 public class Maui23961ErrorClass1 : Grid
 {
-[Obsolete("[Error Message]: BP2Property is obsolete", error: true)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static readonly BindableProperty BP2Property =
-BindableProperty.Create(nameof(BP2), typeof(string), typeof(Maui23961ErrorClass1), null);
+	[Obsolete("[Error Message]: BP2Property is obsolete", error: true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static readonly BindableProperty BP2Property =
+		BindableProperty.Create(nameof(BP2), typeof(string), typeof(Maui23961ErrorClass1), null);
 
-[Obsolete("[Error Message]: BP2 property is obsolete", error: true)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public string BP2
-{
-get => (string)GetValue(BP2Property);
-set => SetValue(BP2Property, value);
-}
+	[Obsolete("[Error Message]: BP2 property is obsolete", error: true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string BP2
+	{
+		get => (string)GetValue(BP2Property);
+		set => SetValue(BP2Property, value);
+	}
 
-[Obsolete("[Error Message]: P2 is obsolete", error: true)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public string P2 { get; set; }
+	[Obsolete("[Error Message]: P2 is obsolete", error: true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public string P2 { get; set; }
 }
 
 [Obsolete("[Error Message]: Maui23961ObsoleteClass3 is obsolete", error: true)]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -44,7 +44,8 @@ return;
 }
 else
 {
-var page = new Maui23961Error(inflator);
+// .rt.xaml files only support runtime inflation (no XamlInflator ctor generated)
+var page = new Maui23961Error();
 Assert.NotNull(page);
 }
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -37,7 +37,8 @@ if (inflator == XamlInflator.XamlC)
 // even without TreatWarningsAsErrors
 // Multiple [Obsolete(error:true)] members produce multiple LoggedErrors wrapped in AggregateException,
 // so use ThrowsAny rather than Throws (which requires an exact type match).
-Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
+var ex = Assert.ThrowsAny<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
+Assert.Contains("XC0619", ex.Message);
 }
 else if (inflator == XamlInflator.SourceGen)
 {

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23961Error.xaml.cs
@@ -5,71 +5,71 @@ using Microsoft.Maui.Controls.Build.Tasks;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.UnitTests;
-using NUnit.Framework;
+using Xunit;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
 public partial class Maui23961Error : ContentPage
 {
-	public Maui23961Error() => InitializeComponent();
+public Maui23961Error() => InitializeComponent();
 
-	[TestFixture]
-	class Tests
-	{
-		[SetUp]
-		public void Setup()
-		{
-			AppInfo.SetCurrent(new MockAppInfo());
-			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
-		}
+[Collection("Issue")]
+public class Tests : IDisposable
+{
+public Tests()
+{
+AppInfo.SetCurrent(new MockAppInfo());
+DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+}
 
-		[TearDown]
-		public void TearDown()
-		{
-			AppInfo.SetCurrent(null);
-		}
+public void Dispose()
+{
+AppInfo.SetCurrent(null);
+}
 
-		[Test]
-		public void ObsoleteErrorProducesCompilationError([Values] XamlInflator inflator)
-		{
-			if (inflator == XamlInflator.XamlC)
-			{
-				// [Obsolete("msg", error: true)] must always produce a compilation error,
-				// even without TreatWarningsAsErrors
-				Assert.Throws<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
-			}
-			else if (inflator == XamlInflator.SourceGen)
-			{
-				Assert.Ignore("SourceGen does not process .rt.xaml files");
-			}
-			else
-			{
-				var page = new Maui23961Error(inflator);
-				Assert.That(page, Is.Not.Null);
-			}
-		}
-	}
+[Theory]
+[XamlInflatorData]
+internal void ObsoleteErrorProducesCompilationError(XamlInflator inflator)
+{
+if (inflator == XamlInflator.XamlC)
+{
+// [Obsolete("msg", error: true)] must always produce a compilation error,
+// even without TreatWarningsAsErrors
+Assert.Throws<Exception>(() => MockCompiler.Compile(typeof(Maui23961Error), treatWarningsAsErrors: false));
+}
+else if (inflator == XamlInflator.SourceGen)
+{
+// SourceGen does not process .rt.xaml files
+return;
+}
+else
+{
+var page = new Maui23961Error(inflator);
+Assert.NotNull(page);
+}
+}
+}
 }
 
 // Test classes for obsolete attribute error handling
 public class Maui23961ErrorClass1 : Grid
 {
-	[Obsolete("[Error Message]: BP2Property is obsolete", error: true)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static readonly BindableProperty BP2Property =
-		BindableProperty.Create(nameof(BP2), typeof(string), typeof(Maui23961ErrorClass1), null);
+[Obsolete("[Error Message]: BP2Property is obsolete", error: true)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static readonly BindableProperty BP2Property =
+BindableProperty.Create(nameof(BP2), typeof(string), typeof(Maui23961ErrorClass1), null);
 
-	[Obsolete("[Error Message]: BP2 property is obsolete", error: true)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public string BP2
-	{
-		get => (string)GetValue(BP2Property);
-		set => SetValue(BP2Property, value);
-	}
+[Obsolete("[Error Message]: BP2 property is obsolete", error: true)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public string BP2
+{
+get => (string)GetValue(BP2Property);
+set => SetValue(BP2Property, value);
+}
 
-	[Obsolete("[Error Message]: P2 is obsolete", error: true)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public string P2 { get; set; }
+[Obsolete("[Error Message]: P2 is obsolete", error: true)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public string P2 { get; set; }
 }
 
 [Obsolete("[Error Message]: Maui23961ObsoleteClass3 is obsolete", error: true)]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml
@@ -4,9 +4,8 @@
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
 		xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui23989" >
-    <cmp:StackLayout x:DataType="local:MockViewModel">
+    <StackLayout x:DataType="local:MockViewModel">
         <Picker
             ItemsSource="{Binding Items}"
             ItemDisplayBinding="{Binding Title}"
@@ -15,5 +14,5 @@
             ItemsSource="{Binding Items}"
             ItemDisplayBinding="{Binding Title, x:DataType=local:MockItemViewModel}"
             x:Name="picker1" />
-    </cmp:StackLayout>
+    </StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -27,7 +27,15 @@ public partial class Maui23989
 		internal void ItemDisplayBindingWithoutDataTypeFails(XamlInflator inflator)
 		{
 			if (inflator == XamlInflator.XamlC)
-				XamlExceptionAssert.ThrowsBuildException(12, 13, s => s.Contains("0022", StringComparison.Ordinal), () => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
+			{
+				// May throw AggregateException if multiple warnings are promoted to errors
+				// (e.g., obsolete type warning + binding warning)
+				var ex = Assert.Catch(() => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
+				Assert.That(ex, Is.Not.Null);
+				// Verify at least one error contains the expected XC0022 binding warning
+				var message = ex.ToString();
+				Assert.That(message, Does.Contain("0022"));
+			}
 
 			var layout = new Maui23989(inflator);
 			//without x:DataType, bindings aren't compiled

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -27,7 +27,7 @@ public partial class Maui23989
 		internal void ItemDisplayBindingWithoutDataTypeFails(XamlInflator inflator)
 		{
 			if (inflator == XamlInflator.XamlC)
-				XamlExceptionAssert.ThrowsBuildException(12, 13, s => s.Contains("0022", StringComparison.Ordinal), () => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
+				XamlExceptionAssert.ThrowsBuildException(11, 13, s => s.Contains("0022", StringComparison.Ordinal), () => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
 
 			var layout = new Maui23989(inflator);
 			//without x:DataType, bindings aren't compiled

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -27,13 +27,7 @@ public partial class Maui23989
 		internal void ItemDisplayBindingWithoutDataTypeFails(XamlInflator inflator)
 		{
 			if (inflator == XamlInflator.XamlC)
-			{
-				// With treatWarningsAsErrors, both XC0022 (binding without DataType) and
-				// XC0618 (obsolete Compatibility.StackLayout) become errors, causing AggregateException
-				var ex = Assert.Catch(() => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
-				Assert.That(ex, Is.Not.Null);
-				Assert.That(ex.ToString(), Does.Contain("0022"));
-			}
+				XamlExceptionAssert.ThrowsBuildException(12, 13, s => s.Contains("0022", StringComparison.Ordinal), () => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
 
 			var layout = new Maui23989(inflator);
 			//without x:DataType, bindings aren't compiled

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui23989.xaml.cs
@@ -28,13 +28,11 @@ public partial class Maui23989
 		{
 			if (inflator == XamlInflator.XamlC)
 			{
-				// May throw AggregateException if multiple warnings are promoted to errors
-				// (e.g., obsolete type warning + binding warning)
+				// With treatWarningsAsErrors, both XC0022 (binding without DataType) and
+				// XC0618 (obsolete Compatibility.StackLayout) become errors, causing AggregateException
 				var ex = Assert.Catch(() => MockCompiler.Compile(typeof(Maui23989), treatWarningsAsErrors: true));
 				Assert.That(ex, Is.Not.Null);
-				// Verify at least one error contains the expected XC0022 binding warning
-				var message = ex.ToString();
-				Assert.That(message, Does.Contain("0022"));
+				Assert.That(ex.ToString(), Does.Contain("0022"));
 			}
 
 			var layout = new Maui23989(inflator);

--- a/src/Controls/tests/Xaml.UnitTests/MockCompiler.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MockCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Build.Framework;
 using Microsoft.Maui.Controls.Build.Tasks;
 using Microsoft.Maui.Controls.MSBuild.UnitTests;
 using Mono.Cecil;
@@ -36,13 +37,26 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			bool treatWarningsAsErrors = false,
 			bool compileBindingsWithSource = true,
 			bool generateFullIl = true)
+			=> Compile(type, out methodDefinition, out hasLoggedErrors, out _, targetFramework, treatWarningsAsErrors, compileBindingsWithSource, generateFullIl);
+
+		public static void Compile(
+			Type type,
+			out MethodDefinition methodDefinition,
+			out bool hasLoggedErrors,
+			out IReadOnlyList<BuildWarningEventArgs> loggedWarnings,
+			string targetFramework = null,
+			bool treatWarningsAsErrors = false,
+			bool compileBindingsWithSource = true,
+			bool generateFullIl = true)
 		{
 			methodDefinition = null;
+			loggedWarnings = null;
 			var assembly = type.Assembly.Location;
 			var refs = from an in type.Assembly.GetReferencedAssemblies()
 					   let a = System.Reflection.Assembly.Load(an)
 					   select a.Location;
 
+			var dummyEngine = new MSBuild.UnitTests.DummyBuildEngine();
 			var xamlc = new XamlCTask
 			{
 				Assembly = assembly,
@@ -56,7 +70,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				TargetFramework = targetFramework,
 				TreatWarningsAsErrors = treatWarningsAsErrors,
 				CompileBindingsWithSource = compileBindingsWithSource,
-				BuildEngine = new MSBuild.UnitTests.DummyBuildEngine(),
+				BuildEngine = dummyEngine,
 				MockCompile = true,
 
 			};
@@ -65,8 +79,10 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			{
 				methodDefinition = xamlc.InitCompForType;
 				hasLoggedErrors = xamlc.LoggingHelper.HasLoggedErrors;
+				loggedWarnings = dummyEngine.Warnings;
 				return;
 			}
+			loggedWarnings = dummyEngine.Warnings;
 			if (exceptions.Count > 1)
 				throw new AggregateException(exceptions);
 			throw exceptions[0];

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -3,7 +3,7 @@
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -3,6 +3,9 @@
     <SampleProject>true</SampleProject>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
     <DefaultXamlRuntime Condition=" '$(UseWorkload)' != 'true' ">Maui</DefaultXamlRuntime>
+    <!-- XC0618 (obsolete warning) and XC0619 (obsolete error) are suppressed here because this project
+         intentionally uses deprecated APIs. XC0619 uses raw LogError (not the warning-promotion path),
+         so WarningsNotAsErrors is defensive only. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>

--- a/src/ProfiledAot/src/Directory.Build.props
+++ b/src/ProfiledAot/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <AndroidNeedsInternetPermission>true</AndroidNeedsInternetPermission>
     <AndroidEnableAotProfiler>true</AndroidEnableAotProfiler>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0618;XC0619</WarningsNotAsErrors>
   </PropertyGroup>
   
   <Import Project="../../../Directory.Build.props" />

--- a/src/ProfiledAot/src/Directory.Build.props
+++ b/src/ProfiledAot/src/Directory.Build.props
@@ -4,6 +4,9 @@
     <AndroidNeedsInternetPermission>true</AndroidNeedsInternetPermission>
     <AndroidEnableAotProfiler>true</AndroidEnableAotProfiler>
     <RunAOTCompilation>false</RunAOTCompilation>
+    <!-- XC0618 (obsolete warning) and XC0619 (obsolete error) are suppressed here because this project
+         intentionally uses deprecated APIs. XC0619 uses raw LogError (not the warning-promotion path),
+         so WarningsNotAsErrors is defensive only. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0618;XC0619</WarningsNotAsErrors>
   </PropertyGroup>
   

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn);CA1416;XC0022;XC0023</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -7,6 +7,9 @@
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
     <NoWarn>$(NoWarn);CA1416;XC0022;XC0023</NoWarn>
+    <!-- XC0618 (obsolete warning) and XC0619 (obsolete error) are suppressed here because this project
+         intentionally uses deprecated APIs. XC0619 uses raw LogError (not the warning-promotion path),
+         so WarningsNotAsErrors is defensive only. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0022;XC0023;XC0618;XC0619</WarningsNotAsErrors>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #23961

This PR fixes XamlC to properly handle the `ObsoleteAttribute` by:

1. **Extracting and displaying the custom message** from `[Obsolete("message")]` instead of a generic deprecation message
2. **Respecting the `isError` parameter** - when `[Obsolete("message", error: true)]` is used, XamlC now emits an error (XC0619) instead of a warning (XC0618)
3. **Adding obsolete type detection** for classes marked with `[Obsolete]` when used in XAML

### Changes

- **`ErrorMessages.resx`**: Updated `ObsoleteProperty` message format to include the custom message: `"{0}" is deprecated: {1}`
- **`BuildException.cs`**: Added `XC0619` (ObsoletePropertyError) for error cases when `isError=true`
- **`SetPropertiesVisitor.cs`**: 
  - Added `TryGetObsoleteAttribute()` helper to extract message and isError from the attribute
  - Added `LogObsoleteWarningOrError()` helper that logs the appropriate warning or error based on the attribute
  - Updated property/field obsolete checking to use these helpers
- **`CreateObjectVisitor.cs`**: Added obsolete type detection when XAML elements are created

### Before
```
XamlC warning XC0618: Property, Property setter or BindableProperty "MyProperty" is deprecated.
```

### After
```
XamlC warning XC0618: "MyProperty" is deprecated: Use NewProperty instead.
XamlC error XC0619: "MyProperty" is obsolete: This property will be removed in the next version.
```

## Testing

- Added `Maui23961.xaml` / `.cs` - tests for warnings with `error: false`
- Added `Maui23961Error.rt.xaml` / `.cs` - tests for errors with `error: true`
- All 1780+ existing Xaml.UnitTests pass
- Samples build successfully