### PR TITLE
Add tests for CSS styles with IsEnabled=false

### DIFF
--- a/src/Controls/tests/Core.UnitTests/StyleSheets/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleSheets/StyleTests.cs
@@ -152,5 +152,21 @@ namespace Microsoft.Maui.Controls.StyleSheets.UnitTests
 			Assert.Equal((page.Content as Label).TextColor, Colors.Yellow);
 		}
 
+		[Fact]
+		public void CSSStyleAppliedAfterReEnablingInitiallyDisabledButton_Issue12550()
+		{
+			// https://github.com/dotnet/maui/issues/12550
+			var app = new MockApplication();
+			app.Resources.Add(StyleSheet.FromString("button{ background-color: green; }"));
+
+			var button = new Button { IsEnabled = false };
+			var page = new ContentPage { Content = button };
+			app.LoadPage(page);
+
+			button.IsEnabled = true;
+
+			Assert.Equal(Colors.Green, button.BackgroundColor);
+		}
+
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui12550.css
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui12550.css
@@ -1,0 +1,1 @@
+button { background-color: green; }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui12550.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui12550.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui12550">
+    <ContentPage.Resources>
+        <StyleSheet Source="Maui12550.css"/>
+    </ContentPage.Resources>
+    <VerticalStackLayout>
+        <!-- Button with IsEnabled=false on initialization -->
+        <Button x:Name="DisabledButton" Text="Initially Disabled" IsEnabled="False" />
+        <!-- Button with IsEnabled=true (default) for comparison -->
+        <Button x:Name="EnabledButton" Text="Initially Enabled" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui12550.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui12550.xaml.cs
@@ -1,0 +1,46 @@
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui12550 : ContentPage
+{
+	public Maui12550() => InitializeComponent();
+
+	[TestFixture]
+	class Tests
+	{
+		[Test]
+		public void CSSStyleAppliedToInitiallyEnabledButton([Values] XamlInflator inflator)
+		{
+			var page = new Maui12550(inflator);
+			Assert.That(page.EnabledButton.BackgroundColor, Is.EqualTo(Colors.Green));
+		}
+
+		[Test]
+		public void CSSStyleAppliedAfterReEnablingInitiallyDisabledButton([Values] XamlInflator inflator)
+		{
+			var page = new Maui12550(inflator);
+			Assert.That(page.DisabledButton.IsEnabled, Is.False);
+
+			page.DisabledButton.IsEnabled = true;
+
+			// https://github.com/dotnet/maui/issues/12550
+			Assert.That(page.DisabledButton.BackgroundColor, Is.EqualTo(Colors.Green),
+				"CSS background-color should be applied after re-enabling a button that was initially disabled");
+		}
+
+		[Test]
+		public void CSSStyleAppliedAfterDisableEnableCycle([Values] XamlInflator inflator)
+		{
+			var page = new Maui12550(inflator);
+			Assert.That(page.EnabledButton.BackgroundColor, Is.EqualTo(Colors.Green));
+
+			page.EnabledButton.IsEnabled = false;
+			page.EnabledButton.IsEnabled = true;
+
+			Assert.That(page.EnabledButton.BackgroundColor, Is.EqualTo(Colors.Green),
+				"CSS background-color should be preserved after disable/enable cycle");
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds unit tests for issue #12550 - CSS styles are ignored when element's IsEnabled=false on initialization.

## Tests Added

- **XAML Unit Tests** (`Maui12550.xaml` / `.xaml.cs` / `.css`):
  - `CSSStyleAppliedToInitiallyEnabledButton` - verifies CSS works on enabled buttons
  - `CSSStyleAppliedAfterReEnablingInitiallyDisabledButton` - verifies CSS is applied after re-enabling a button that started disabled
  - `CSSStyleAppliedAfterDisableEnableCycle` - verifies CSS is preserved through disable/enable cycle

- **Core Unit Test** (`StyleTests.cs`):
  - `CSSStyleAppliedAfterReEnablingInitiallyDisabledButton_Issue12550` - basic scenario test

## Test Results

All tests pass, indicating the core CSS/VSM specificity logic is working correctly. The tests serve as regression tests to ensure this behavior continues to work.

Closes #12550