### PR TITLE
[Android] Fix ShellFlyout footer area not cleared after removing footer view

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -427,7 +427,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var footer = ((IShellController)_shellContext.Shell).FlyoutFooter;
 
 			if (footer == null)
+			{
+				UpdateContentPadding();
 				return;
+			}
 
 			if (_flyoutWidth == 0)
 				return;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellFlyoutContent.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/ShellFlyoutContent.cs
@@ -34,4 +34,28 @@ public class ShellFlyoutContent : _IssuesUITest
 		App.TapInShellFlyout(ResetButton);
 		App.Tap(FlyoutItem);
 	}
+
+	// https://github.com/dotnet/maui/issues/32883
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void FlyoutFooterAreaClearedAfterRemoval()
+	{
+		App.WaitForElement("PageLoaded");
+
+		// Open flyout and get the position of the bottom flyout item before adding footer
+		App.TapInShellFlyout("Flyout Item Bottom");
+
+		// Add header and footer
+		App.Tap("ToggleHeaderFooter");
+
+		// Open the flyout and verify footer is visible
+		App.TapInShellFlyout("Footer View");
+
+		// Remove header and footer
+		App.Tap("ToggleHeaderFooter");
+
+		// Open flyout and verify the footer area is cleared by checking "Flyout Item Bottom" is still accessible
+		// If the padding wasn't cleared, the bottom flyout item would be pushed up and inaccessible
+		App.TapInShellFlyout("Flyout Item Bottom");
+	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

When the flyout footer is removed (set to null), the `UpdateContentPadding()` method was not being called, which left the bottom padding on the flyout content. This caused the footer area to remain visible even after the footer view was removed.

## Visual Representation

**Before (Bug):**
```
┌─────────────────────────┐
│      Shell Flyout       │
├─────────────────────────┤
│ ▶ Flyout Item Top       │
│ ▶ Flyout Item :1        │
│ ...                     │
│ ▶ Flyout Item Bottom    │
│                         │
│ [After removing footer] │
│ ┌───────────────────┐   │
│ │ (Empty space)     │   │ ← BUG: Padding remains!
│ └───────────────────┘   │
└─────────────────────────┘
```

**After (Fix):**
```
┌─────────────────────────┐
│      Shell Flyout       │
├─────────────────────────┤
│ ▶ Flyout Item Top       │
│ ▶ Flyout Item :1        │
│ ...                     │
│ ▶ Flyout Item Bottom    │ ← Correct position
└─────────────────────────┘
  No extra space at bottom!
```

## Root Cause

In `ShellFlyoutTemplatedContentRenderer.UpdateFlyoutFooter()`, when `footer == null`, the method returned early without calling `UpdateContentPadding()`. This is inconsistent with `UpdateFlyoutHeader()` which correctly calls `UpdateContentPadding()` regardless of whether the header is null.

## Solution

Added a call to `UpdateContentPadding()` before the early return when the footer is null. This ensures the bottom margin/padding on the flyout content is reset when the footer is removed.

## Testing

Added UI test `FlyoutFooterAreaClearedAfterRemoval()` that:
1. Opens flyout and taps bottom flyout item
2. Adds header/footer via Toggle button
3. Verifies footer is visible  
4. Removes header/footer
5. Verifies the footer area is cleared by checking bottom flyout item is still accessible

## Issues Fixed

Fixes #32883