### PR TITLE
[Windows] Fix for PickPhotosAsync throws exception if image is modified

### DIFF
--- a/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
+++ b/src/Essentials/src/MediaPicker/ImageProcessor.shared.cs
@@ -125,7 +125,14 @@ internal static partial class ImageProcessor
             if (preserveMetaData && originalMetadata != null)
             {
                 var finalStream = await ApplyMetadataAsync(outputStream, originalMetadata, originalFileName);
-                outputStream.Dispose();
+                
+                // Only dispose outputStream if finalStream is a different object
+                // On Windows, ApplyMetadataAsync returns the same stream, so we shouldn't dispose it
+                if (finalStream != outputStream)
+                {
+                    outputStream.Dispose();
+                }
+                
                 return finalStream;
             }
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- PickPhotosAsync throws an ObjectDisposedException when size or compression options are used.

### Root Cause of the issue

- The method ApplyMetadataAsync in ImageProcessor.windows.cs returns the same stream that was passed in. However, on iOS and Android, it returns a new stream. After ApplyMetadataAsync completes, the old stream is disposed. On Android and iOS, this is fine because a new stream is returned, so disposing the old one has no effect. But on Windows, since the same stream is returned and then disposed, accessing it afterward causes an exception.

### Description of Change
* Resource management improvement:
  * In `ImageProcessor.shared.cs`, updated the logic to only dispose `outputStream` if `ApplyMetadataAsync` returns a different stream, preventing unintended disposal on platforms (like Windows) where the same stream may be returned.
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #32408 

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/0bf833a9-dd97-4acb-a42d-3d27bbe5a808"> | <video src="https://github.com/user-attachments/assets/283e6006-e310-4886-8f29-f0394e36a27b"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
