### PR TITLE
Fix SolidColorBrush.Equals to compare Color values instead of references

### DIFF
--- a/src/Controls/src/Core/SolidColorBrush.cs
+++ b/src/Controls/src/Core/SolidColorBrush.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls
 			if (!(obj is SolidColorBrush dest))
 				return false;
 
-			return Color == dest.Color;
+			return Equals(Color, dest.Color);
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='GetHashCode']/Docs/*" />

--- a/src/Controls/tests/Core.UnitTests/SolidColorBrushTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SolidColorBrushTests.cs
@@ -53,5 +53,30 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.NotNull(white.Color);
 			Assert.Equal(white.Color, Colors.White);
 		}
+
+		[Fact]
+		// https://github.com/dotnet/maui/issues/27281
+		public void SolidColorBrushEqualsComparesColorValues()
+		{
+			// Create two Color instances with identical RGBA values but different object references
+			// This simulates what happens with OnPlatform<Color> which creates new Color instances
+			var color1 = new Color(1.0f, 0.0f, 0.0f, 1.0f);
+			var color2 = new Color(1.0f, 0.0f, 0.0f, 1.0f);
+
+			// Verify these are different instances
+			Assert.False(ReferenceEquals(color1, color2));
+
+			// Verify the Color.Equals method returns true for same values
+			Assert.True(color1.Equals(color2));
+
+			// Create SolidColorBrush instances with these colors
+			var brush1 = new SolidColorBrush(color1);
+			var brush2 = new SolidColorBrush(color2);
+
+			// This is the bug from issue #27281: SolidColorBrush.Equals uses '==' for Color comparison
+			// which compares references instead of values, causing infinite loops with DynamicResource
+			// and OnPlatform<Color> because OnPlatform creates new Color instances each time
+			Assert.True(brush1.Equals(brush2));
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #27281

The issue was that `SolidColorBrush.Equals` used `==` to compare `Color` objects, which compares references instead of values. This caused infinite loops when using `DynamicResource` with `OnPlatform<Color>` because `OnPlatform` creates new `Color` instances each time, and the equality check would always return false even for identical color values.

## Changes

- Changed `SolidColorBrush.Equals` to use `Equals(Color, dest.Color)` instead of `Color == dest.Color`
- Added unit test `SolidColorBrushEqualsComparesColorValues` to verify the fix

## Root Cause

`Color` is a class, and `OnPlatform<Color>` creates a new `Color` instance each time it is evaluated. When `SolidColorBrush.Equals` compared colors using `==`, it was doing reference comparison instead of value comparison. This caused `VisualElement.OnParentResourcesChanged` to detect a "change" every time (even when the color values were identical), leading to an infinite loop.

## Fix

Use `Equals()` which delegates to `Color.Equals()`, which compares colors by their RGBA values (via `ToInt()`).
