### PR TITLE
Enable CoreCLR iOS and MacCatalyst device tests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -123,4 +123,13 @@
   <!-- Tell typescript to stop deleting everything before building the next TFM -->
   <Target Name="TypeScriptDeleteOutputFromOtherConfigs" />
 
+  <!--
+    Need this until https://github.com/dotnet/sdk/pull/51428 is completed.
+    This allows CoreCLR builds for iOS, tvOS, and Mac Catalyst to find the correct runtime packs.
+  -->
+  <ItemGroup Condition="'$(UseMonoRuntime)' == 'false'">
+    <KnownFrameworkReference Update="Microsoft.NETCore.App"
+        RuntimePackRuntimeIdentifiers="%(RuntimePackRuntimeIdentifiers);ios-arm64;iossimulator-x64;iossimulator-arm64;tvos-arm64;tvossimulator-x64;tvossimulator-arm64;maccatalyst-arm64;maccatalyst-x64" />
+  </ItemGroup>
+
 </Project>

--- a/eng/pipelines/common/device-tests-jobs.yml
+++ b/eng/pipelines/common/device-tests-jobs.yml
@@ -10,7 +10,7 @@ parameters:
   useArtifacts: false
   cakeArgs: ''
   buildAndTest: true
-  useCoreClr: false # Use CoreCLR for Android builds
+  useCoreClr: false # Use CoreCLR for Android, iOS, and Catalyst builds
   targetFrameworkVersion:
     tfm: ''
     dependsOn: ''

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -17,7 +17,7 @@ parameters:
   poolName: 'Azure Pipelines'
   skipDotNet: false
   buildType: 'buildAndTest' # [ buildAndTest, buildOnly, testOnly ]
-  useCoreClr: false # Use CoreCLR for Android builds
+  useCoreClr: false # Use CoreCLR for Android, iOS, and Catalyst builds
 
 steps:
 

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -114,6 +114,31 @@ stages:
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
 
+    - ${{ if eq(platform, 'ios') }}:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.ios, '') }}:
+          - template: device-tests-jobs.yml
+            parameters:
+              platform: ios
+              timeoutInMinutes: 120
+              pool: ${{ parameters.iOSPool }}
+              versions: ${{ parameters.iosVersions }}
+              targetFrameworkVersion: ${{ parameters.targetFrameworkVersion }}
+              checkoutDirectory: ${{ parameters.checkoutDirectory }}
+              project:
+                name: ${{ project.name }}
+                desc: ${{ project.desc }}
+                path: ${{ project.ios }}
+                versionsExclude: ${{ project.iosVersionsCoreClrExclude }}
+                configuration: ${{ project.iOSConfiguration }}
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipProvisioning: ${{ parameters.skipProvisioning }}
+              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+              artifactName: ${{ parameters.artifactName }}
+              artifactItemPattern: ${{ parameters.artifactItemPattern }}
+              useArtifacts: ${{ parameters.useArtifacts }}
+              useCoreClr: true
+
     - ${{ if eq(platform, 'catalyst') }}:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.catalyst, '') }}:
@@ -136,6 +161,31 @@ stages:
               artifactName: ${{ parameters.artifactName }}
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
+
+    - ${{ if eq(platform, 'catalyst') }}:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.catalyst, '') }}:
+          - template: device-tests-jobs.yml
+            parameters:
+              platform: catalyst
+              timeoutInMinutes: 240
+              pool: ${{ parameters.catalystPool }}
+              versions: ${{ parameters.catalystVersions }}
+              targetFrameworkVersion: ${{ parameters.targetFrameworkVersion }}
+              checkoutDirectory: ${{ parameters.checkoutDirectory }}
+              project:
+                name: ${{ project.name }}
+                desc: ${{ project.desc }}
+                path: ${{ project.catalyst }}
+                versionsExclude: ${{ project.catalystVersionsCoreClrExclude }}
+                configuration: ${{ project.iOSConfiguration }}
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipProvisioning: ${{ parameters.skipProvisioning }}
+              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+              artifactName: ${{ parameters.artifactName }}
+              artifactItemPattern: ${{ parameters.artifactItemPattern }}
+              useArtifacts: ${{ parameters.useArtifacts }}
+              useCoreClr: true
 
     - ${{ if eq(platform, 'windows') }}:
       - ${{ each project in parameters.projects }}:


### PR DESCRIPTION
## Description

This PR enables CoreCLR iOS and MacCatalyst device tests, mirroring the existing Android CoreCLR device tests implementation.

## Changes:
 - Added useCoreClr and /p:UseMonoRuntime=false when building with CoreCLR
 - Enabled device tests