### PR TITLE
Enable CoreCLR iOS and MacCatalyst device tests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <!-- Microsoft.Build.Msix.props" cannot be imported again -->
     <!-- Found version-specific or distribution-specific runtime identifier(s)-->
-    <NoWarn>$(NoWarn);NETSDK1206;NU1702</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;NU1702;IL6001</NoWarn>
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB4011;MSB3277;NETSDK1206;NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -123,4 +123,13 @@
   <!-- Tell typescript to stop deleting everything before building the next TFM -->
   <Target Name="TypeScriptDeleteOutputFromOtherConfigs" />
 
+  <!--
+    Need this until https://github.com/dotnet/sdk/pull/51428 is completed.
+    This allows CoreCLR builds for iOS, tvOS, and Mac Catalyst to find the correct runtime packs.
+  -->
+  <ItemGroup Condition="'$(UseMonoRuntime)' == 'false'">
+    <KnownFrameworkReference Update="Microsoft.NETCore.App"
+        RuntimePackRuntimeIdentifiers="%(RuntimePackRuntimeIdentifiers);ios-arm64;iossimulator-x64;iossimulator-arm64;tvos-arm64;tvossimulator-x64;tvossimulator-arm64;maccatalyst-arm64;maccatalyst-x64" />
+  </ItemGroup>
+
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,14 @@
     <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" protocolVersion="3" />
+   
+    <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
+    <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
+
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rtm.25523.113">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.1.2">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.1.99-ci.main.52">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>01024bb616e7b80417a2c6d320885bfdb956f20a</Sha>
+      <Sha>29f8376059d032c8eb436e757b146148a71d069e</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
     <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.105" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
@@ -54,109 +54,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.0">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-rc.3.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25506.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25523.113">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.25602.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>7b29526f2107416f68578bcb9deaca74fcfcf7f0</Sha>
+      <Sha>6f4c3c9ad695a899e32a91839c1c6d6ad7198c5f</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <MajorVersion>10</MajorVersion>
+    <MajorVersion>11</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>20</PatchVersion>
-    <SdkBandVersion>10.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
+    <PatchVersion>0</PatchVersion>
+    <SdkBandVersion>11.0.100</SdkBandVersion>
+    <PreReleaseVersionLabel>c1.net11</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
@@ -30,30 +30,30 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.120</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.100-rtm.25523.113</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rc.3.25602.101</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <MonoPackageVersion>10.0.100</MonoPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.0</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.0-rc.3.25602.101</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.0</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.0</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.0</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.0</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.0-rc.3.25602.101</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.1.2</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.1.99-ci.main.52</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNETSdkAndroidManifest90100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
@@ -74,19 +74,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.0</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.0-rc.3.25602.101</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.0-rc.3.25602.101</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -136,13 +136,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25523.113</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25523.113</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25523.113</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25523.113</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.25602.101</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.25602.101</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.25602.101</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.25602.101</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25523.113</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25523.113</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.25602.101</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.25602.101</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>
@@ -210,8 +210,8 @@
     <MonoVersionBand>10.0.100</MonoVersionBand>
     <DotNetSdkManifestsFolder>$(DotNetVersionBand)</DotNetSdkManifestsFolder>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
-    <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
+    <DotNetAndroidManifestVersionBand>10.0.100</DotNetAndroidManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>10.0.100</DotNetMaciOSManifestVersionBand>
     <DotNetTizenManifestVersionBand>9.0.100</DotNetTizenManifestVersionBand>
     <MicrosoftMacCatalystSdkPackageVersion>$(MicrosoftMacCatalystSdknet100_260PackageVersion)</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>$(MicrosoftmacOSSdknet100_260PackageVersion)</MicrosoftmacOSSdkPackageVersion>

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -1,7 +1,6 @@
 # This script adds internal feeds required to build commits that depend on internal package sources. For instance,
-# dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. Similarly,
-# dotnet-eng-internal and dotnet-tools-internal are added if dotnet-eng and dotnet-tools are present.
-# In addition, this script also enables disabled internal Maestro (darc-int*) feeds.
+# dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. In addition also enables
+# disabled internal Maestro (darc-int*) feeds.
 #
 # Optionally, this script also adds a credential entry for each of the internal feeds if supplied.
 #
@@ -172,18 +171,6 @@ foreach ($dotnetVersion in $dotnetVersions) {
         AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
         AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal-transport/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
     }
-}
-
-# Check for dotnet-eng and add dotnet-eng-internal if present
-$dotnetEngSource = $sources.SelectSingleNode("add[@key='dotnet-eng']")
-if ($dotnetEngSource -ne $null) {
-    AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "dotnet-eng-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-eng-internal/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
-}
-
-# Check for dotnet-tools and add dotnet-tools-internal if present
-$dotnetToolsSource = $sources.SelectSingleNode("add[@key='dotnet-tools']")
-if ($dotnetToolsSource -ne $null) {
-    AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "dotnet-tools-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
 }
 
 $doc.Save($filename)

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 # This script adds internal feeds required to build commits that depend on internal package sources. For instance,
-# dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. Similarly,
-# dotnet-eng-internal and dotnet-tools-internal are added if dotnet-eng and dotnet-tools are present.
-# In addition, this script also enables disabled internal Maestro (darc-int*) feeds.
+# dotnet6-internal would be added automatically if dotnet6 was found in the nuget.config file. In addition also enables
+# disabled internal Maestro (darc-int*) feeds.
 # 
 # Optionally, this script also adds a credential entry for each of the internal feeds if supplied.
 #
@@ -173,18 +172,6 @@ for DotNetVersion in ${DotNetVersions[@]} ; do
         AddOrEnablePackageSource "$FeedPrefix-internal-transport" "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$FeedPrefix-internal-transport/nuget/$FeedSuffix"
     fi
 done
-
-# Check for dotnet-eng and add dotnet-eng-internal if present
-grep -i "<add key=\"dotnet-eng\"" $ConfigFile > /dev/null
-if [ "$?" == "0" ]; then
-    AddOrEnablePackageSource "dotnet-eng-internal" "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-eng-internal/nuget/$FeedSuffix"
-fi
-
-# Check for dotnet-tools and add dotnet-tools-internal if present
-grep -i "<add key=\"dotnet-tools\"" $ConfigFile > /dev/null
-if [ "$?" == "0" ]; then
-    AddOrEnablePackageSource "dotnet-tools-internal" "https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/$FeedSuffix"
-fi
 
 # I want things split line by line
 PrevIFS=$IFS

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -92,7 +92,7 @@ runtime_source_feed=''
 runtime_source_feed_key=''
 
 properties=()
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     -help|-h)

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -19,6 +19,8 @@ parameters:
   # publishing defaults
   artifacts: ''
   enableMicrobuild: false
+  enablePreviewMicrobuild: false
+  microbuildPluginVersion: 'latest'
   enableMicrobuildForMacAndLinux: false
   microbuildUseESRP: true
   enablePublishBuildArtifacts: false
@@ -128,6 +130,8 @@ jobs:
     - template: /eng/common/core-templates/steps/install-microbuild.yml
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
         continueOnError: ${{ parameters.continueOnError }}
@@ -153,6 +157,8 @@ jobs:
     - template: /eng/common/core-templates/steps/cleanup-microbuild.yml
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         continueOnError: ${{ parameters.continueOnError }}
 

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -91,8 +91,8 @@ jobs:
       fetchDepth: 3
       clean: true
 
-    - ${{ if eq(parameters.isAssetlessBuild, 'false') }}: 
-      - ${{ if eq(parameters.publishingVersion, 3) }}: 
+    - ${{ if eq(parameters.isAssetlessBuild, 'false') }}:
+      - ${{ if eq(parameters.publishingVersion, 3) }}:
         - task: DownloadPipelineArtifact@2
           displayName: Download Asset Manifests
           inputs:
@@ -122,9 +122,10 @@ jobs:
 
     # Populate internal runtime variables.
     - template: /eng/common/templates/steps/enable-internal-sources.yml
-      parameters:
-        legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
-    
+      ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+        parameters:
+            legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
+
     - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
     - task: AzureCLI@2
@@ -135,17 +136,16 @@ jobs:
         scriptLocation: scriptPath
         scriptPath: $(System.DefaultWorkingDirectory)/eng/common/sdk-task.ps1
         arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
-          -runtimeSourceFeed https://ci.dot.net/internal 
-          -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
           /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:OfficialBuildId=$(OfficialBuildId)
-
+          -runtimeSourceFeed https://ci.dot.net/internal
+          -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
 
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: powershell@2
       displayName: Create ReleaseConfigs Artifact
       inputs:
@@ -173,7 +173,7 @@ jobs:
             artifactName: AssetManifests
             displayName: 'Publish Merged Manifest'
             retryCountOnTaskFailure: 10 # for any logs being locked
-            sbomEnabled: false  # we don't need SBOM for logs
+            sbomEnabled: false # we don't need SBOM for logs
 
     - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
       parameters:
@@ -190,6 +190,11 @@ jobs:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
+          
+      # Darc is targeting 8.0, so make sure it's installed
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
 
       - task: AzureCLI@2
         displayName: Publish Using Darc
@@ -213,4 +218,4 @@ jobs:
       - template: /eng/common/core-templates/steps/publish-logs.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          JobLabel: 'Publish_Artifacts_Logs'     
+          JobLabel: 'Publish_Artifacts_Logs'

--- a/eng/common/core-templates/job/source-build.yml
+++ b/eng/common/core-templates/job/source-build.yml
@@ -60,10 +60,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore-Svc-Public' ), False, 'NetCore-Public')]
-          demands: ImageOverride -equals build.ubuntu.2004.amd64
+          demands: ImageOverride -equals build.ubuntu.2204.amd64
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-          image: 1es-mariner-2
+          image: 1es-azurelinux-3
           os: linux
     ${{ else }}:
       pool:

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -25,10 +25,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: windows.vs2022.amd64.open
+        image: windows.vs2026preview.scout.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: windows.vs2022.amd64
+        image: windows.vs2026preview.scout.amd64
 
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -1,106 +1,106 @@
 parameters:
-  # Which publishing infra should be used. THIS SHOULD MATCH THE VERSION ON THE BUILD MANIFEST.
-  # Publishing V1 is no longer supported
-  # Publishing V2 is no longer supported
-  # Publishing V3 is the default
-  - name: publishingInfraVersion
-    displayName: Which version of publishing should be used to promote the build definition?
-    type: number
-    default: 3
-    values:
-    - 3
+# Which publishing infra should be used. THIS SHOULD MATCH THE VERSION ON THE BUILD MANIFEST.
+# Publishing V1 is no longer supported
+# Publishing V2 is no longer supported
+# Publishing V3 is the default
+- name: publishingInfraVersion
+  displayName: Which version of publishing should be used to promote the build definition?
+  type: number
+  default: 3
+  values:
+  - 3
 
-  - name: BARBuildId
-    displayName: BAR Build Id
-    type: number
-    default: 0
+- name: BARBuildId
+  displayName: BAR Build Id
+  type: number
+  default: 0
 
-  - name: PromoteToChannelIds
-    displayName: Channel to promote BARBuildId to
-    type: string
-    default: ''
+- name: PromoteToChannelIds
+  displayName: Channel to promote BARBuildId to
+  type: string
+  default: ''
 
-  - name: enableSourceLinkValidation
-    displayName: Enable SourceLink validation
-    type: boolean
-    default: false
+- name: enableSourceLinkValidation
+  displayName: Enable SourceLink validation
+  type: boolean
+  default: false
 
-  - name: enableSigningValidation
-    displayName: Enable signing validation
-    type: boolean
-    default: true
+- name: enableSigningValidation
+  displayName: Enable signing validation
+  type: boolean
+  default: true
 
-  - name: enableSymbolValidation
-    displayName: Enable symbol validation
-    type: boolean
-    default: false
+- name: enableSymbolValidation
+  displayName: Enable symbol validation
+  type: boolean
+  default: false
 
-  - name: enableNugetValidation
-    displayName: Enable NuGet validation
-    type: boolean
-    default: true
-    
-  - name: publishInstallersAndChecksums
-    displayName: Publish installers and checksums
-    type: boolean
-    default: true
-    
-  - name: requireDefaultChannels
-    displayName: Fail the build if there are no default channel(s) registrations for the current build
-    type: boolean
-    default: false
+- name: enableNugetValidation
+  displayName: Enable NuGet validation
+  type: boolean
+  default: true
 
-  - name: SDLValidationParameters
-    type: object
-    default:
-      enable: false
-      publishGdn: false
-      continueOnError: false
-      params: ''
-      artifactNames: ''
-      downloadArtifacts: true
+- name: publishInstallersAndChecksums
+  displayName: Publish installers and checksums
+  type: boolean
+  default: true
 
-  - name: isAssetlessBuild
-    type: boolean
-    displayName: Is Assetless Build
-    default: false
+- name: requireDefaultChannels
+  displayName: Fail the build if there are no default channel(s) registrations for the current build
+  type: boolean
+  default: false
 
-  # These parameters let the user customize the call to sdk-task.ps1 for publishing
-  # symbols & general artifacts as well as for signing validation
-  - name: symbolPublishingAdditionalParameters
-    displayName: Symbol publishing additional parameters
-    type: string
-    default: ''
+- name: SDLValidationParameters
+  type: object
+  default:
+    enable: false
+    publishGdn: false
+    continueOnError: false
+    params: ''
+    artifactNames: ''
+    downloadArtifacts: true
 
-  - name: artifactsPublishingAdditionalParameters
-    displayName: Artifact publishing additional parameters
-    type: string
-    default: ''
+- name: isAssetlessBuild
+  type: boolean
+  displayName: Is Assetless Build
+  default: false
 
-  - name: signingValidationAdditionalParameters
-    displayName: Signing validation additional parameters
-    type: string
-    default: ''
+# These parameters let the user customize the call to sdk-task.ps1 for publishing
+# symbols & general artifacts as well as for signing validation
+- name: symbolPublishingAdditionalParameters
+  displayName: Symbol publishing additional parameters
+  type: string
+  default: ''
 
-  # Which stages should finish execution before post-build stages start
-  - name: validateDependsOn
-    type: object
-    default:
-    - build
+- name: artifactsPublishingAdditionalParameters
+  displayName: Artifact publishing additional parameters
+  type: string
+  default: ''
 
-  - name: publishDependsOn
-    type: object
-    default:
-    - Validate
+- name: signingValidationAdditionalParameters
+  displayName: Signing validation additional parameters
+  type: string
+  default: ''
 
-  # Optional: Call asset publishing rather than running in a separate stage
-  - name: publishAssetsImmediately
-    type: boolean
-    default: false
+# Which stages should finish execution before post-build stages start
+- name: validateDependsOn
+  type: object
+  default:
+  - build
 
-  - name: is1ESPipeline
-    type: boolean
-    default: false
+- name: publishDependsOn
+  type: object
+  default:
+  - Validate
+
+# Optional: Call asset publishing rather than running in a separate stage
+- name: publishAssetsImmediately
+  type: boolean
+  default: false
+
+- name: is1ESPipeline
+  type: boolean
+  default: false
 
 stages:
 - ${{ if or(eq( parameters.enableNugetValidation, 'true'), eq(parameters.enableSigningValidation, 'true'), eq(parameters.enableSourceLinkValidation, 'true'), eq(parameters.SDLValidationParameters.enable, 'true')) }}:
@@ -108,10 +108,10 @@ stages:
     dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Validate Build Assets
     variables:
-      - template: /eng/common/core-templates/post-build/common-variables.yml
-      - template: /eng/common/core-templates/variables/pool-providers.yml
-        parameters:
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+    - template: /eng/common/core-templates/post-build/common-variables.yml
+    - template: /eng/common/core-templates/variables/pool-providers.yml
+      parameters:
+        is1ESPipeline: ${{ parameters.is1ESPipeline }}
     jobs:
     - job:
       displayName: NuGet Validation
@@ -127,35 +127,35 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
-            image: windows.vs2022.amd64
+            image: windows.vs2026preview.scout.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
 
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Package Artifacts
-          inputs:
-            buildType: specific
-            buildVersionToDownload: specific
-            project: $(AzDOProjectName)
-            pipeline: $(AzDOPipelineId)
-            buildId: $(AzDOBuildId)
-            artifactName: PackageArtifacts
-            checkDownloadedFiles: true
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Artifacts
+        inputs:
+          buildType: specific
+          buildVersionToDownload: specific
+          project: $(AzDOProjectName)
+          pipeline: $(AzDOPipelineId)
+          buildId: $(AzDOBuildId)
+          artifactName: PackageArtifacts
+          checkDownloadedFiles: true
 
-        - task: PowerShell@2
-          displayName: Validate
-          inputs:
-            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
-            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
+      - task: PowerShell@2
+        displayName: Validate
+        inputs:
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
+          arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:
       displayName: Signing Validation
@@ -169,54 +169,54 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:        
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
             image: 1es-windows-2022
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64          
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Package Artifacts
-          inputs:
-            buildType: specific
-            buildVersionToDownload: specific
-            project: $(AzDOProjectName)
-            pipeline: $(AzDOPipelineId)
-            buildId: $(AzDOBuildId)
-            artifactName: PackageArtifacts
-            checkDownloadedFiles: true
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Artifacts
+        inputs:
+          buildType: specific
+          buildVersionToDownload: specific
+          project: $(AzDOProjectName)
+          pipeline: $(AzDOPipelineId)
+          buildId: $(AzDOBuildId)
+          artifactName: PackageArtifacts
+          checkDownloadedFiles: true
 
-        # This is necessary whenever we want to publish/restore to an AzDO private feed
-        # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
-        # otherwise it'll complain about accessing a private feed.
-        - task: NuGetAuthenticate@1
-          displayName: 'Authenticate to AzDO Feeds'
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate to AzDO Feeds'
 
-        # Signing validation will optionally work with the buildmanifest file which is downloaded from
-        # Azure DevOps above.
-        - task: PowerShell@2
-          displayName: Validate
-          inputs:
-            filePath: eng\common\sdk-task.ps1
-            arguments: -task SigningValidation -restore -msbuildEngine vs
-              /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
-              ${{ parameters.signingValidationAdditionalParameters }}
+      # Signing validation will optionally work with the buildmanifest file which is downloaded from
+      # Azure DevOps above.
+      - task: PowerShell@2
+        displayName: Validate
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task SigningValidation -restore -msbuildEngine vs
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
+            /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
+            ${{ parameters.signingValidationAdditionalParameters }}
 
-        - template: /eng/common/core-templates/steps/publish-logs.yml
-          parameters:
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
-            StageLabel: 'Validation'
-            JobLabel: 'Signing'
-            BinlogToolVersion: $(BinlogToolVersion)
+      - template: /eng/common/core-templates/steps/publish-logs.yml
+        parameters:
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+          StageLabel: 'Validation'
+          JobLabel: 'Signing'
+          BinlogToolVersion: $(BinlogToolVersion)
 
     - job:
       displayName: SourceLink Validation
@@ -230,41 +230,41 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:          
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
             image: 1es-windows-2022
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64          
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Blob Artifacts
-          inputs:
-            buildType: specific
-            buildVersionToDownload: specific
-            project: $(AzDOProjectName)
-            pipeline: $(AzDOPipelineId)
-            buildId: $(AzDOBuildId)
-            artifactName: BlobArtifacts
-            checkDownloadedFiles: true
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Blob Artifacts
+        inputs:
+          buildType: specific
+          buildVersionToDownload: specific
+          project: $(AzDOProjectName)
+          pipeline: $(AzDOPipelineId)
+          buildId: $(AzDOBuildId)
+          artifactName: BlobArtifacts
+          checkDownloadedFiles: true
 
-        - task: PowerShell@2
-          displayName: Validate
-          inputs:
-            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
-            arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
-              -ExtractPath $(Agent.BuildDirectory)/Extract/ 
-              -GHRepoName $(Build.Repository.Name) 
-              -GHCommit $(Build.SourceVersion)
-              -SourcelinkCliVersion $(SourceLinkCLIVersion)
-          continueOnError: true
+      - task: PowerShell@2
+        displayName: Validate
+        inputs:
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
+          arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
+            -ExtractPath $(Agent.BuildDirectory)/Extract/ 
+            -GHRepoName $(Build.Repository.Name) 
+            -GHCommit $(Build.SourceVersion)
+            -SourcelinkCliVersion $(SourceLinkCLIVersion)
+        continueOnError: true
 
 - ${{ if ne(parameters.publishAssetsImmediately, 'true') }}:
   - stage: publish_using_darc
@@ -274,10 +274,10 @@ stages:
       dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Publish using Darc
     variables:
-      - template: /eng/common/core-templates/post-build/common-variables.yml
-      - template: /eng/common/core-templates/variables/pool-providers.yml
-        parameters:
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+    - template: /eng/common/core-templates/post-build/common-variables.yml
+    - template: /eng/common/core-templates/variables/pool-providers.yml
+      parameters:
+        is1ESPipeline: ${{ parameters.is1ESPipeline }}
     jobs:
     - job:
       displayName: Publish Using Darc
@@ -291,37 +291,41 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:          
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: NetCore1ESPool-Publishing-Internal
             image: windows.vs2019.amd64
             os: windows
           ${{ else }}:
             name: NetCore1ESPool-Publishing-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64          
+            demands: ImageOverride -equals windows.vs2019.amd64
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: NuGetAuthenticate@1
+      - task: NuGetAuthenticate@1
 
-        # Populate internal runtime variables.
-        - template: /eng/common/templates/steps/enable-internal-sources.yml
-          parameters:
-            legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
+      # Populate internal runtime variables.
+      - template: /eng/common/templates/steps/enable-internal-sources.yml
+        parameters:
+          legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
 
-        - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
-        - task: AzureCLI@2
-          displayName: Publish Using Darc
-          inputs:
-            azureSubscription: "Darc: Maestro Production"
-            scriptType: ps
-            scriptLocation: scriptPath
-            scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
-            arguments: >
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
+
+      - task: AzureCLI@2
+        displayName: Publish Using Darc
+        inputs:
+          azureSubscription: "Darc: Maestro Production"
+          scriptType: ps
+          scriptLocation: scriptPath
+          scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
+          arguments: >
               -BuildId $(BARBuildId)
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
               -AzdoToken '$(System.AccessToken)'
@@ -330,5 +334,5 @@ stages:
               -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
               -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
               -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
-              -runtimeSourceFeed https://ci.dot.net/internal
+              -runtimeSourceFeed https://ci.dot.net/internal 
               -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'

--- a/eng/common/core-templates/steps/generate-sbom.yml
+++ b/eng/common/core-templates/steps/generate-sbom.yml
@@ -5,7 +5,7 @@
 # IgnoreDirectories - Directories to ignore for SBOM generation. This will be passed through to the CG component detector.
 
 parameters:
-  PackageVersion: 10.0.0
+  PackageVersion: 11.0.0
   BuildDropPath: '$(System.DefaultWorkingDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom

--- a/eng/common/core-templates/steps/install-microbuild-impl.yml
+++ b/eng/common/core-templates/steps/install-microbuild-impl.yml
@@ -1,0 +1,34 @@
+parameters:
+  - name: microbuildTaskInputs
+    type: object
+    default: {}
+
+  - name: microbuildEnv
+    type: object
+    default: {}
+
+  - name: enablePreviewMicrobuild
+    type: boolean
+    default: false
+
+  - name: condition
+    type: string
+
+  - name: continueOnError
+    type: boolean
+
+steps:
+- ${{ if eq(parameters.enablePreviewMicrobuild, 'true') }}:
+    - task: MicroBuildSigningPluginPreview@4
+      displayName: Install Preview MicroBuild plugin
+      inputs: ${{ parameters.microbuildTaskInputs }}
+      env: ${{ parameters.microbuildEnv }}
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: ${{ parameters.condition }}
+- ${{ else }}:
+  - task: MicroBuildSigningPlugin@4
+    displayName: Install MicroBuild plugin
+    inputs: ${{ parameters.microbuildTaskInputs }}
+    env: ${{ parameters.microbuildEnv }}
+    continueOnError: ${{ parameters.continueOnError }}
+    condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -4,6 +4,8 @@ parameters:
   # Enable install tasks for MicroBuild on Mac and Linux
   # Will be ignored if 'enableMicrobuild' is false or 'Agent.Os' is 'Windows_NT'
   enableMicrobuildForMacAndLinux: false
+  # Enable preview version of MB signing plugin
+  enablePreviewMicrobuild: false
   # Determines whether the ESRP service connection information should be passed to the signing plugin.
   # This overlaps with _SignType to some degree. We only need the service connection for real signing.
   # It's important that the service connection not be passed to the MicroBuildSigningPlugin task in this place.
@@ -11,22 +13,43 @@ parameters:
   # Unfortunately, _SignType can't be used to exclude the use of the service connection in non-real sign scenarios. The
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
+  # Microbuild installation directory
+  microBuildOutputFolder: $(Agent.TempDirectory)/MicroBuild
+  # Microbuild version
+  microbuildPluginVersion: 'latest'
 
   continueOnError: false
 
 steps:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-      # Installing .NET 8 is required to use the MicroBuild signing plugin on non-Windows platforms
+      # Needed to download the MicroBuild plugin nupkgs on Mac and Linux when nuget.exe is unavailable
       - task: UseDotNet@2
         displayName: Install .NET 8.0 SDK for MicroBuild Plugin
         inputs:
           packageType: sdk
           version: 8.0.x
-          # Installing the SDK in a '.dotnet-microbuild' directory is required for signing.
-          # See target FindDotNetPathForMicroBuild in arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
-          # Do not remove '.dotnet-microbuild' from the path without changing the corresponding logic.
-          installationPath: $(Agent.TempDirectory)/.dotnet-microbuild
+          installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet-microbuild
+        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+
+      - script: |
+          set -euo pipefail
+
+          # UseDotNet@2 prepends the dotnet executable path to the PATH variable, so we can call dotnet directly
+          version=$(dotnet --version)
+          cat << 'EOF' > ${{ parameters.microBuildOutputFolder }}/global.json
+          {
+            "sdk": {
+              "version": "$version",
+              "paths": [
+                "${{ parameters.microBuildOutputFolder }}/.dotnet-microbuild"
+              ],
+              "errorMessage": "The .NET SDK version $version is required to install the MicroBuild signing plugin."
+            }
+          }
+          EOF
+        displayName: 'Add global.json to MicroBuild Installation path'
+        workingDirectory: ${{ parameters.microBuildOutputFolder }}
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     - script: |
@@ -50,41 +73,46 @@ steps:
     # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
     # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
     # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
-    - task: MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild plugin (Windows)
-      inputs:
-        signType: $(_SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
-          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-            ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-          ${{ else }}:
-            ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
-      env:
-        TeamName: $(_TeamName)
-        MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      continueOnError: ${{ parameters.continueOnError }}
-      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
-
-    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
-      - task: MicroBuildSigningPlugin@4
-        displayName: Install MicroBuild plugin (non-Windows)
-        inputs:
+    - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+      parameters:
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildTaskInputs:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          version: ${{ parameters.microbuildPluginVersion }}
           ${{ if eq(parameters.microbuildUseESRP, true) }}:
             ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
             ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-              ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+              ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
             ${{ else }}:
-              ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
-        env:
+              ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+        microbuildEnv:
           TeamName: $(_TeamName)
-          MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
+          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
-        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))
+        condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
+
+    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
+      - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+        parameters:
+          enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+          microbuildTaskInputs:
+            signType: $(_SignType)
+            zipSources: false
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            version: ${{ parameters.microbuildPluginVersion }}
+            workingDirectory: ${{ parameters.microBuildOutputFolder }}
+            ${{ if eq(parameters.microbuildUseESRP, true) }}:
+              ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+              ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+                ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+              ${{ else }}:
+                ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+          microbuildEnv:
+            TeamName: $(_TeamName)
+            MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          continueOnError: ${{ parameters.continueOnError }}
+          condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -26,7 +26,7 @@ steps:
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
     arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
-      -BinlogToolVersion ${{parameters.BinlogToolVersion}}
+      -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
       -runtimeSourceFeed https://ci.dot.net/internal 
       -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -1,6 +1,6 @@
 parameters:
-  sourceIndexUploadPackageVersion: 2.0.0-20250818.1
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250818.1
+  sourceIndexUploadPackageVersion: 2.0.0-20250906.1
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20250906.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   binlogPath: artifacts/log/Debug/Build.binlog
 
@@ -14,8 +14,8 @@ steps:
     workingDirectory: $(Agent.TempDirectory)
 
 - script: |
-    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
   displayName: "Source Index: Download netsourceindex Tools"
   # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
   workingDirectory: $(Agent.TempDirectory)

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -5,7 +5,7 @@ darcVersion=''
 versionEndpoint='https://maestro.dot.net/api/assets/darc-version?api-version=2020-02-20'
 verbosity='minimal'
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     --darcversion)

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -18,7 +18,7 @@ architecture=''
 runtime='dotnet'
 runtimeSourceFeed=''
 runtimeSourceFeedKey=''
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     -version|-v)

--- a/eng/common/dotnet.sh
+++ b/eng/common/dotnet.sh
@@ -19,7 +19,7 @@ source $scriptroot/tools.sh
 InitializeDotNetCli true # install
 
 # Invoke acquired SDK with args if they are provided
-if [[ $# > 0 ]]; then
+if [[ $# -gt 0 ]]; then
   __dotnetDir=${_InitializeDotNetCli}
   dotnetPath=${__dotnetDir}/dotnet
   ${dotnetPath} "$@"

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -100,7 +100,7 @@ operation=''
 authToken=''
 repoName=''
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     --operation)

--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -27,9 +27,11 @@ case "$os" in
                 libssl-dev libkrb5-dev pigz cpio
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ]; then
+        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ] || [ "$ID" = "centos"]; then
             pkg_mgr="$(command -v tdnf 2>/dev/null || command -v dnf)"
             $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
+        elif [ "$ID" = "amzn" ]; then
+            dnf install -y cmake llvm lld lldb clang python libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "alpine" ]; then
             apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev openssl-dev pigz cpio
         else

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -70,7 +70,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.13.0" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "18.0.0" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -394,8 +394,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.13.0
-  $defaultXCopyMSBuildVersion = '17.13.0'
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/18.0.0
+  $defaultXCopyMSBuildVersion = '18.0.0'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -3,8 +3,8 @@ trigger:
     include:
     - main
     - release/*
-    - net9.0
     - net10.0
+    - net11.0
     - inflight/*
   tags:
     include:
@@ -28,8 +28,8 @@ pr:
     include:
     - main
     - release/*
-    - net9.0
     - net10.0
+    - net11.0
     - inflight/*
   paths:
     include:

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -3,6 +3,7 @@ trigger:
     include:
     - main
     - net10.0
+    - net11.0
     - release/*
     - internal/release/*
   tags:

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -4,6 +4,7 @@ trigger:
     - main
     - release/*
     - net10.0
+    - net11.0
   tags:
     include:
     - '*'
@@ -27,6 +28,7 @@ pr:
     - main
     - release/*
     - net10.0
+    - net11.0
   paths:
     include:
     - '*'

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -4,6 +4,7 @@ trigger:
     include:
     - main
     - net10.0
+    - net11.0
     - release/*
     - inflight/*
   paths:
@@ -23,6 +24,7 @@ pr:
     include:
     - main
     - net10.0
+    - net11.0
     - release/*
     - inflight/*
   paths:

--- a/eng/pipelines/common/device-tests-jobs.yml
+++ b/eng/pipelines/common/device-tests-jobs.yml
@@ -10,7 +10,7 @@ parameters:
   useArtifacts: false
   cakeArgs: ''
   buildAndTest: true
-  useCoreClr: false # Use CoreCLR for Android builds
+  useCoreClr: false # Use CoreCLR for Android, iOS, and Catalyst builds
   targetFrameworkVersion:
     tfm: ''
     dependsOn: ''

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -17,7 +17,7 @@ parameters:
   poolName: 'Azure Pipelines'
   skipDotNet: false
   buildType: 'buildAndTest' # [ buildAndTest, buildOnly, testOnly ]
-  useCoreClr: false # Use CoreCLR for Android builds
+  useCoreClr: false # Use CoreCLR for Android, iOS, and Catalyst builds
 
 steps:
 

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -114,6 +114,31 @@ stages:
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
 
+    - ${{ if eq(platform, 'ios') }}:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.ios, '') }}:
+          - template: device-tests-jobs.yml
+            parameters:
+              platform: ios
+              timeoutInMinutes: 120
+              pool: ${{ parameters.iOSPool }}
+              versions: ${{ parameters.iosVersions }}
+              targetFrameworkVersion: ${{ parameters.targetFrameworkVersion }}
+              checkoutDirectory: ${{ parameters.checkoutDirectory }}
+              project:
+                name: ${{ project.name }}
+                desc: ${{ project.desc }}
+                path: ${{ project.ios }}
+                versionsExclude: ${{ project.iosVersionsCoreClrExclude }}
+                configuration: ${{ project.iOSConfiguration }}
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipProvisioning: ${{ parameters.skipProvisioning }}
+              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+              artifactName: ${{ parameters.artifactName }}
+              artifactItemPattern: ${{ parameters.artifactItemPattern }}
+              useArtifacts: ${{ parameters.useArtifacts }}
+              useCoreClr: true
+
     - ${{ if eq(platform, 'catalyst') }}:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.catalyst, '') }}:
@@ -136,6 +161,31 @@ stages:
               artifactName: ${{ parameters.artifactName }}
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
+
+    - ${{ if eq(platform, 'catalyst') }}:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.catalyst, '') }}:
+          - template: device-tests-jobs.yml
+            parameters:
+              platform: catalyst
+              timeoutInMinutes: 240
+              pool: ${{ parameters.catalystPool }}
+              versions: ${{ parameters.catalystVersions }}
+              targetFrameworkVersion: ${{ parameters.targetFrameworkVersion }}
+              checkoutDirectory: ${{ parameters.checkoutDirectory }}
+              project:
+                name: ${{ project.name }}
+                desc: ${{ project.desc }}
+                path: ${{ project.catalyst }}
+                versionsExclude: ${{ project.catalystVersionsCoreClrExclude }}
+                configuration: ${{ project.iOSConfiguration }}
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipProvisioning: ${{ parameters.skipProvisioning }}
+              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+              artifactName: ${{ parameters.artifactName }}
+              artifactItemPattern: ${{ parameters.artifactItemPattern }}
+              useArtifacts: ${{ parameters.useArtifacts }}
+              useCoreClr: true
 
     - ${{ if eq(platform, 'windows') }}:
       - ${{ each project in parameters.projects }}:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net9.0
     - net10.0
+    - net11.0
   tags:
     include:
     - '*'
@@ -29,6 +30,7 @@ pr:
     - release/*
     - net9.0
     - net10.0
+    - net11.0
   paths:
     include:
     - '*'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net9.0
     - net10.0
+    - net11.0
   tags:
     include:
     - '*'
@@ -28,6 +29,7 @@ pr:
     - release/*
     - net9.0
     - net10.0
+    - net11.0
   paths:
     include:
     - '*'

--- a/eng/pipelines/ui-tests.yml
+++ b/eng/pipelines/ui-tests.yml
@@ -4,6 +4,7 @@ trigger:
     - main
     - release/*
     - net10.0
+    - net11.0
   tags:
     include:
     - '*'
@@ -27,6 +28,7 @@ pr:
     - main
     - release/*
     - net10.0
+    - net11.0
   paths:
     include:
     - '*'

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "tools": {
-    "dotnet": "10.0.100-rtm.25523.113"
+    "dotnet": "10.0.100-rc.3.25602.101"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25555.106",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25555.106"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25602.101",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25602.101"
   }
 }

--- a/src/BlazorWebView/src/Maui/Windows/StaticContentProvider.cs
+++ b/src/BlazorWebView/src/Maui/Windows/StaticContentProvider.cs
@@ -464,24 +464,24 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				return Mappings.TryGetValue(extension, out contentType);
 			}
 
-			private static string GetExtension(string path)
+		private static string GetExtension(string path)
+		{
+			// Don't use Path.GetExtension as that may throw an exception if there are
+			// invalid characters in the path. Invalid characters should be handled
+			// by the FileProviders
+
+			if (string.IsNullOrWhiteSpace(path))
 			{
-				// Don't use Path.GetExtension as that may throw an exception if there are
-				// invalid characters in the path. Invalid characters should be handled
-				// by the FileProviders
+				return null;
+			}
 
-				if (string.IsNullOrWhiteSpace(path))
-				{
-					return null;
-				}
-
-				int index = path.LastIndexOf('.');
-				if (index < 0)
-				{
-					return null;
-				}
-
-				return path.Substring(index);
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
+			int index = path.LastIndexOf('.');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
+			if (index < 0)
+			{
+				return null;
+			}				return path.Substring(index);
 			}
 		}
 	}

--- a/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Build.Tasks/CompiledMarkupExtensions/StaticExtension.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			if (IsNullOrEmpty(member) || !member.Contains("."))
 				throw new BuildException(BuildExceptionCode.XStaticSyntax, node as IXmlLineInfo, null);
 
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 			var dotIdx = member.LastIndexOf('.');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 			var typename = member.Substring(0, dotIdx);
 			var membername = member.Substring(dotIdx + 1);
 

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -670,7 +670,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				var lbIndex = p.IndexOf('[');
 				if (lbIndex != -1)
 				{
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 					var rbIndex = p.LastIndexOf(']');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 					if (rbIndex == -1)
 						throw new BuildException(BindingIndexerNotClosed, lineInfo, null);
 

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -37,7 +37,9 @@ internal class KnownMarkups
 			return false;
 		}
 
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 		var dotIdx = member.LastIndexOf('.');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 		var typename = member.Substring(0, dotIdx);
 		var membername = member.Substring(dotIdx + 1);
 

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (string.IsNullOrEmpty(Member) || Member.IndexOf(".", StringComparison.Ordinal) == -1)
 				throw new XamlParseException("Syntax for x:Static is [Member=][prefix:]typeName.staticMemberName", serviceProvider);
 
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 			var dotIdx = Member.LastIndexOf('.');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 			var typename = Member.Substring(0, dotIdx);
 			var membername = Member.Substring(dotIdx + 1);
 

--- a/src/Controls/tests/Xaml.Benchmarks/Microsoft.Maui.Controls.Xaml.Benchmarks.csproj
+++ b/src/Controls/tests/Xaml.Benchmarks/Microsoft.Maui.Controls.Xaml.Benchmarks.csproj
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <DefineConstants>$(DefineConstants);_MAUIXAML_SG_NAMESCOPE_DISABLE</DefineConstants>
+    <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/src/Fonts/FontFile.cs
+++ b/src/Core/src/Fonts/FontFile.cs
@@ -107,7 +107,9 @@ namespace Microsoft.Maui
 
 			string currentString = "";
 			char lastCharacter = ' ';
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 			var index = fontFamily.LastIndexOf('-');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 			bool multipleCaps = false;
 			var cleansedString = index > 0 ? fontFamily.Substring(0, index) : fontFamily;
 			foreach (var c in cleansedString)

--- a/src/Core/src/Fonts/FontManager.Tizen.cs
+++ b/src/Core/src/Fonts/FontManager.Tizen.cs
@@ -43,12 +43,14 @@ namespace Microsoft.Maui
 			if (string.IsNullOrEmpty(fontFamily))
 				return "";
 
-			var cleansedFont = CleanseFontName(fontFamily ?? string.Empty);
-			if (cleansedFont == null)
-				return "";
+		var cleansedFont = CleanseFontName(fontFamily ?? string.Empty);
+		if (cleansedFont == null)
+			return "";
 
-			int index = cleansedFont.LastIndexOf('-');
-			if (index != -1)
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
+		int index = cleansedFont.LastIndexOf('-');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
+		if (index != -1)
 			{
 				string font = cleansedFont.Substring(0, index);
 				return $"{font}";
@@ -69,13 +71,15 @@ namespace Microsoft.Maui
 			if (string.IsNullOrEmpty(fontKey.family))
 				return "";
 
-			var cleansedFont = CleanseFontName(fontKey.family ?? string.Empty);
+		var cleansedFont = CleanseFontName(fontKey.family ?? string.Empty);
 
-			if (cleansedFont == null)
-				return "";
+		if (cleansedFont == null)
+			return "";
 
-			int index = cleansedFont.LastIndexOf('-');
-			if (index != -1)
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
+		int index = cleansedFont.LastIndexOf('-');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
+		if (index != -1)
 			{
 				string font = cleansedFont.Substring(0, index);
 				return $"{font}";

--- a/src/Core/src/Handlers/HybridWebView/FileExtensionContentTypeProvider.cs
+++ b/src/Core/src/Handlers/HybridWebView/FileExtensionContentTypeProvider.cs
@@ -457,8 +457,9 @@ internal sealed class FileExtensionContentTypeProvider
 		{
 			return null;
 		}
-
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 		int index = path.LastIndexOf('.');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 		if (index < 0)
 		{
 			return null;

--- a/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
+++ b/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
@@ -10,6 +10,7 @@
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <PublishTrimmed>false</PublishTrimmed>
+    <PublishReadyToRun>false</PublishReadyToRun>
     <RunAOTCompilation>false</RunAOTCompilation>
     <!-- Physical device is recommended -->
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>

--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Maui.Controls.Generated</InterceptorsPreviewNamespaces>
+    <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics/ColorUtils.cs
+++ b/src/Graphics/src/Graphics/ColorUtils.cs
@@ -361,7 +361,9 @@ internal static class ColorUtils
 		out ReadOnlySpan<char> quad3)
 	{
 		var op = value.IndexOf('(');
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 		var cp = value.LastIndexOf(')');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 		if (op < 0 || cp < 0 || cp < op)
 			goto ReturnFalse;
 
@@ -403,7 +405,9 @@ internal static class ColorUtils
 		out ReadOnlySpan<char> triplet2)
 	{
 		var op = value.IndexOf('(');
+#pragma warning disable CA1307 // Specify StringComparison for clarity - char overload doesn't support StringComparison
 		var cp = value.LastIndexOf(')');
+#pragma warning restore CA1307 // Specify StringComparison for clarity
 		if (op < 0 || cp < 0 || cp < op)
 			goto ReturnFalse;
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -121,25 +121,7 @@ namespace Microsoft.Maui.IntegrationTests
 		#region Expected warning messages
 
 		// IMPORTANT: Always store expected File information as a relative path to the repo ROOT
-		private static readonly List<WarningsPerFile> expectedNativeAOTWarnings = new()
-		{
-			// Example of expected warning
-			new WarningsPerFile
-			{
-				File = "src\\Controls\\samples\\Controls.Sample\\Maui.Controls.Sample.csproj",
-				WarningsPerCode = new List<WarningsPerCode>
-				{
-					new WarningsPerCode
-					{
-						Code = "IL6001",
-						Messages = new List<string>
-						{
-							"ILLink : error IL6001: Assembly 'Xamarin.GooglePlayServices.Tasks' contains reference to obsolete attribute 'Android.Runtime.PreserveAttribute'. Members with this attribute may be trimmed. Please use System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute instead.",
-						}
-					}
-				}
-			}	
-		};
+		private static readonly List<WarningsPerFile> expectedNativeAOTWarnings = new();
 
 		// Windows-specific expected warnings (if any)
 		// These might be different from iOS/Mac warnings due to platform-specific implementations

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -121,7 +121,25 @@ namespace Microsoft.Maui.IntegrationTests
 		#region Expected warning messages
 
 		// IMPORTANT: Always store expected File information as a relative path to the repo ROOT
-		private static readonly List<WarningsPerFile> expectedNativeAOTWarnings = new();
+		private static readonly List<WarningsPerFile> expectedNativeAOTWarnings = new()
+		{
+			// Example of expected warning
+			new WarningsPerFile
+			{
+				File = "src\\Controls\\samples\\Controls.Sample\\Maui.Controls.Sample.csproj",
+				WarningsPerCode = new List<WarningsPerCode>
+				{
+					new WarningsPerCode
+					{
+						Code = "IL6001",
+						Messages = new List<string>
+						{
+							"ILLink : error IL6001: Assembly 'Xamarin.GooglePlayServices.Tasks' contains reference to obsolete attribute 'Android.Runtime.PreserveAttribute'. Members with this attribute may be trimmed. Please use System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute instead.",
+						}
+					}
+				}
+			}	
+		};
 
 		// Windows-specific expected warnings (if any)
 		// These might be different from iOS/Mac warnings due to platform-specific implementations


### PR DESCRIPTION
## Description

This PR enables CoreCLR iOS and MacCatalyst device tests, mirroring the existing Android CoreCLR device tests implementation.

## Changes:
 - Added useCoreClr and /p:UseMonoRuntime=false when building with CoreCLR
 - Enabled device tests