### PR TITLE
[windows] Workaround for EmitCompilerGeneratedFiles issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -277,4 +277,9 @@
     <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
   </PropertyGroup>
+
+   <!-- Workaround for EmitCompilerGeneratedFiles issue https://microsoft.visualstudio.com/OS/_workitems/edit/57204991 -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CreateCompilerGeneratedFilesOutputPath</CoreCompileDependsOn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description of Change

This tries to workaround a issue with Microsoft.Windowsappsdk failing sometimes  https://microsoft.visualstudio.com/OS/_workitems/edit/57204991

Fixes #32503 