### PR TITLE
Only emit compiler generated files in Debug configuration

### DIFF
--- a/src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj
+++ b/src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj
@@ -10,7 +10,7 @@
     <ApplicationId>com.microsoft.maui.profiling</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <IsPackable>false</IsPackable>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
     <NoWarn>$(NoWarn);XC0022</NoWarn>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>

--- a/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
+++ b/src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -16,7 +16,7 @@
     <DefineConstants>$(DefineConstants);_MAUIXAML_SG_NAMESCOPE_DISABLE</DefineConstants>
     -->
     
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
@@ -62,7 +62,7 @@
     <Compile Include="..\Core.UnitTests\MockServiceProvider.cs" />
     <Compile Include="..\Core.UnitTests\MockFontManager.cs" />
     <Compile Include="..\Core.UnitTests\MockDeviceDisplay.cs" />
-    <Compile Remove="$(CompilerGeneratedFilesOutputPath)\**\*.cs" />
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)\**\*.cs" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />

--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Maui.Controls.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

`EmitCompilerGeneratedFiles` is a debug-only feature that can cause CI issues in Release builds. This PR restricts it to Debug configuration only.

## Changes

Added `Condition="'$(Configuration)' == 'Debug'"` to `EmitCompilerGeneratedFiles` in:
- `src/Core/tests/Benchmarks/Core.Benchmarks.csproj`
- `src/Controls/src/BindingSourceGen/Controls.BindingSourceGen.csproj`
- `src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj`
- `src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj`

Also made the `Compile Remove` directive for generated files conditional on Debug in `Controls.Xaml.UnitTests.csproj`.