### PR TITLE
[Testing] Fix for flaky test(TwoPaneView_Pane1Priority) in CI

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/TwoPaneViewFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/TwoPaneViewFeatureTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 #if MACCATALYST || WINDOWS
 
-        [Test]
+        [Test, Order(16)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_RTLFlowDirection()
         {
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.TestCases.Tests
             VerifyScreenshot();
         }
 
-        [Test]
+        [Test, Order(1)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_WideMode()
         {
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.TestCases.Tests
             VerifyScreenshot();
         }
 
-        [Test]
+        [Test, Order(2)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_IsTall_UsingRect()
         {
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.TestCases.Tests
             Assert.That(App.WaitForElement("CurrentModeLabel").GetText(), Is.EqualTo("Tall Mode"), "CurrentModeLabel should display 'Tall Mode'");
         }
 
-        [Test]
+        [Test, Order(3)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_Wide_UsingRect()
         {
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.TestCases.Tests
             Assert.That(App.WaitForElement("CurrentModeLabel").GetText(), Is.EqualTo("Wide Mode"));
         }
 
-        [Test]
+        [Test, Order(17)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_IsWideWithRTL_UsingRect()
         {
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.TestCases.Tests
             Assert.That(App.WaitForElement("CurrentModeLabel").GetText(), Is.EqualTo("Wide Mode"), "CurrentModeLabel should display 'Wide Mode'");
         }
 
-        [Test]
+        [Test, Order(4)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_TallMode()
         {
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.TestCases.Tests
             VerifyScreenshot();
         }
 
-        [Test]
+        [Test, Order(5)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_Pane1Priority()
         {
@@ -164,7 +164,7 @@ namespace Microsoft.Maui.TestCases.Tests
             VerifyScreenshot();
         }
 
-        [Test]
+        [Test, Order(6)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_Pane2Priority()
         {
@@ -186,7 +186,7 @@ namespace Microsoft.Maui.TestCases.Tests
             VerifyScreenshot();
         }
 
-        [Test]
+        [Test, Order(7)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_Pane1SizeIncrease_WithTallMode()
         {
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.TestCases.Tests
             VerifyScreenshot();
         }
 
-        [Test]
+        [Test, Order(8)]
         [Category(UITestCategories.Layout)]
         public void TwoPaneView_Pane2SizeIncrease_WithTallMode()
         {
@@ -225,7 +225,7 @@ namespace Microsoft.Maui.TestCases.Tests
         }
 
 #endif
-		[Test]
+		[Test, Order(15)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_IsVisible()
 		{
@@ -241,7 +241,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(14)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_ZIsShadowEnabled()
 		{
@@ -257,7 +257,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(13)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_Pane1SizeIncrease()
 		{
@@ -275,7 +275,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(12)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_Pane2SizeIncrease()
 		{
@@ -295,7 +295,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 #if ANDROID || IOS
 
-		[Test]
+		[Test, Order(1)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_IsTall_UsingRect()
 		{
@@ -307,7 +307,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			Assert.That(App.WaitForElement("CurrentModeLabel").GetText(), Is.EqualTo("Tall Mode"), "CurrentModeLabel should display 'Tall Mode'");
 		}
 
-		[Test]
+		[Test, Order(2)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_IsWide_UsingRect()
 		{
@@ -331,7 +331,7 @@ namespace Microsoft.Maui.TestCases.Tests
 
 		}
 
-		[Test]
+		[Test, Order(3)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_IsWideWithRTL_UsingRect()
 		{
@@ -357,7 +357,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			Assert.That(App.WaitForElement("CurrentModeLabel").GetText(), Is.EqualTo("Wide Mode"), "CurrentModeLabel should display 'Wide Mode'");
 		}
 
-		[Test]
+		[Test, Order(4)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_TallMode()
 		{
@@ -370,7 +370,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(5)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_WideMode()
 		{
@@ -388,7 +388,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(6)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_Pane1SizeIncrease_WithWideMode()
 		{
@@ -411,7 +411,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(7)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_Pane2SizeIncrease_WithWideMode()
 		{
@@ -434,7 +434,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(8)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_ShadowWithWideMode()
 		{
@@ -455,7 +455,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(9)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_RTLFlowDirection()
 		{
@@ -477,7 +477,7 @@ namespace Microsoft.Maui.TestCases.Tests
 		}
 
 
-		[Test]
+		[Test, Order(10)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_Pane1Priority()
 		{
@@ -493,7 +493,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			VerifyScreenshot();
 		}
 
-		[Test]
+		[Test, Order(11)]
 		[Category(UITestCategories.Layout)]
 		public void TwoPaneView_Pane2Priority()
 		{


### PR DESCRIPTION
 
This pull request updates the test order in the ``TwoPaneViewFeatureTests`` class. The TwoPaneView_Pane1Priority test was occasionally failing in CI due to RTL state carried over from earlier tests. Setting a clear execution order ensures tests run in the correct sequence and resolves the flaky behavior.
