### PR TITLE
Enable CoreCLR iOS and MacCatalyst device tests

### DIFF
--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -70,7 +70,7 @@ RunTarget(TARGET);
 void ExecuteBuild(string project, string binDir, string config, string rid, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-    bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
+	bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
 	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
 	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-catalyst.binlog";
 	DotNetBuild(project, new DotNetBuildSettings

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -70,8 +70,7 @@ RunTarget(TARGET);
 void ExecuteBuild(string project, string binDir, string config, string rid, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-	bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
-	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
+	var monoRuntime = useCoreClr ? "coreclr" : "mono";
 	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-catalyst.binlog";
 	DotNetBuild(project, new DotNetBuildSettings
 	{

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -12,6 +12,7 @@ var testAppProjectPath = Argument("appproject", EnvironmentVariable("MAC_TEST_AP
 var testResultsPath = Argument("results", EnvironmentVariable("MAC_TEST_RESULTS") ?? GetTestResultsDirectory().FullPath);
 var runtimeIdentifier = Argument("rid", EnvironmentVariable("MAC_RUNTIME_IDENTIFIER") ?? GetDefaultRuntimeIdentifier());
 var deviceCleanupEnabled = Argument("cleanup", true);
+var useCoreClr = Argument("coreclr", false);
 
 // Directory setup
 var binlogDirectory = DetermineBinlogDirectory(projectPath, binlogArg).FullPath;
@@ -25,12 +26,13 @@ Information($"Build Runtime Identifier: {runtimeIdentifier}");
 Information($"Build Target Framework: {targetFramework}");
 Information($"Test Device: {testDevice}");
 Information($"Test Results Path: {testResultsPath}");
+Information("Use CoreCLR: {0}", useCoreClr);
 
 Task("buildOnly")
 	.WithCriteria(!string.IsNullOrEmpty(projectPath))
 	.Does(() =>
 	{
-		ExecuteBuild(projectPath, binlogDirectory, configuration, runtimeIdentifier, targetFramework, dotnetToolPath);
+		ExecuteBuild(projectPath, binlogDirectory, configuration, runtimeIdentifier, targetFramework, dotnetToolPath, useCoreClr);
 	});
 
 Task("testOnly")
@@ -65,10 +67,12 @@ Task("uitest")
 
 RunTarget(TARGET);
 
-void ExecuteBuild(string project, string binDir, string config, string rid, string tfm, string toolPath)
+void ExecuteBuild(string project, string binDir, string config, string rid, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-	var binlog = $"{binDir}/{projectName}-{config}-catalyst.binlog";
+    bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
+	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
+	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-catalyst.binlog";
 	DotNetBuild(project, new DotNetBuildSettings
 	{
 		Configuration = config,
@@ -78,10 +82,19 @@ void ExecuteBuild(string project, string binDir, string config, string rid, stri
 			MaxCpuCount = 0
 		},
 		ToolPath = toolPath,
-		ArgumentCustomization = args => args
-			.Append("/p:BuildIpa=true")
-			.Append($"/p:RuntimeIdentifier={rid}")
-			.Append($"/bl:{binlog}")
+		ArgumentCustomization = args =>
+		{
+			args
+				.Append("/p:BuildIpa=true")
+				.Append($"/p:RuntimeIdentifier={rid}")
+				.Append($"/bl:{binlog}");
+
+			if (isUsingCoreClr)
+			{
+				args.Append("/p:UseMonoRuntime=false");
+			}
+			return args;
+		}
 	});
 }
 

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -135,7 +135,7 @@ RunTarget(TARGET);
 void ExecuteBuild(string project, string device, string binDir, string config, string rid, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-    bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
+	bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
 	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
 	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-ios.binlog";
 
@@ -156,10 +156,10 @@ void ExecuteBuild(string project, string device, string binDir, string config, s
 				.Append("/bl:" + binlog)
 				.Append("/tl");
 
-            if (isUsingCoreClr)
-            {
-                args.Append("/p:UseMonoRuntime=false");
-            }
+			if (isUsingCoreClr)
+			{
+				args.Append("/p:UseMonoRuntime=false");
+			}
 
 			return args;
 		}

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -16,6 +16,7 @@ var testResultsPath = Argument("results", EnvironmentVariable("IOS_TEST_RESULTS"
 var platform = testDevice.ToLower().Contains("simulator") ? "iPhoneSimulator" : "iPhone";
 var runtimeIdentifier = Argument("rid", EnvironmentVariable("IOS_RUNTIME_IDENTIFIER") ?? GetDefaultRuntimeIdentifier(testDevice));
 var deviceCleanupEnabled = Argument("cleanup", true);
+var useCoreClr = Argument("coreclr", false);
 
 // Device details
 var udid = Argument("udid", EnvironmentVariable("IOS_SIMULATOR_UDID") ?? "");
@@ -38,6 +39,7 @@ Information($"Build Runtime Identifier: {runtimeIdentifier}");
 Information($"Build Target Framework: {targetFramework}");
 Information($"Test Device: {testDevice}");
 Information($"Test Results Path: {testResultsPath}");
+Information("Use CoreCLR: {0}", useCoreClr);
 Information("Runtime Variant: {0}", RUNTIME_VARIANT);
 
 var dotnetToolPath = GetDotnetToolPath();
@@ -85,7 +87,7 @@ Task("buildOnly")
 	.WithCriteria(!string.IsNullOrEmpty(projectPath))
 	.Does(() =>
 	{
-		ExecuteBuild(projectPath, testDevice, binlogDirectory, configuration, runtimeIdentifier, targetFramework, dotnetToolPath);
+		ExecuteBuild(projectPath, testDevice, binlogDirectory, configuration, runtimeIdentifier, targetFramework, dotnetToolPath, useCoreClr);
 	});
 
 Task("testOnly")
@@ -130,10 +132,12 @@ Task("uitest")
 
 RunTarget(TARGET);
 
-void ExecuteBuild(string project, string device, string binDir, string config, string rid, string tfm, string toolPath)
+void ExecuteBuild(string project, string device, string binDir, string config, string rid, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-	var binlog = $"{binDir}/{projectName}-{config}-ios.binlog";
+    bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
+	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
+	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-ios.binlog";
 
 	DotNetBuild(project, new DotNetBuildSettings
 	{
@@ -151,6 +155,11 @@ void ExecuteBuild(string project, string device, string binDir, string config, s
 				.Append($"/p:RuntimeIdentifier={rid}")
 				.Append("/bl:" + binlog)
 				.Append("/tl");
+
+            if (isUsingCoreClr)
+            {
+                args.Append("/p:UseMonoRuntime=false");
+            }
 
 			return args;
 		}

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -135,8 +135,7 @@ RunTarget(TARGET);
 void ExecuteBuild(string project, string device, string binDir, string config, string rid, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-	bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
-	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
+	var monoRuntime = useCoreClr ? "coreclr" : "mono";
 	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-ios.binlog";
 
 	DotNetBuild(project, new DotNetBuildSettings

--- a/eng/pipelines/common/device-tests-jobs.yml
+++ b/eng/pipelines/common/device-tests-jobs.yml
@@ -10,7 +10,7 @@ parameters:
   useArtifacts: false
   cakeArgs: ''
   buildAndTest: true
-  useCoreClr: false # Use CoreCLR for Android builds
+  useCoreClr: false # Use CoreCLR for Android, iOS, and Catalyst builds
   targetFrameworkVersion:
     tfm: ''
     dependsOn: ''

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -17,7 +17,7 @@ parameters:
   poolName: 'Azure Pipelines'
   skipDotNet: false
   buildType: 'buildAndTest' # [ buildAndTest, buildOnly, testOnly ]
-  useCoreClr: false # Use CoreCLR for Android builds
+  useCoreClr: false # Use CoreCLR for Android, iOS, and Catalyst builds
 
 steps:
 

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -114,6 +114,31 @@ stages:
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
 
+    - ${{ if eq(platform, 'ios') }}:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.ios, '') }}:
+          - template: device-tests-jobs.yml
+            parameters:
+              platform: ios
+              timeoutInMinutes: 120
+              pool: ${{ parameters.iOSPool }}
+              versions: ${{ parameters.iosVersions }}
+              targetFrameworkVersion: ${{ parameters.targetFrameworkVersion }}
+              checkoutDirectory: ${{ parameters.checkoutDirectory }}
+              project:
+                name: ${{ project.name }}
+                desc: ${{ project.desc }}
+                path: ${{ project.ios }}
+                versionsExclude: ${{ project.iosVersionsCoreClrExclude }}
+                configuration: ${{ project.iOSConfiguration }}
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipProvisioning: ${{ parameters.skipProvisioning }}
+              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+              artifactName: ${{ parameters.artifactName }}
+              artifactItemPattern: ${{ parameters.artifactItemPattern }}
+              useArtifacts: ${{ parameters.useArtifacts }}
+              useCoreClr: true
+
     - ${{ if eq(platform, 'catalyst') }}:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.catalyst, '') }}:
@@ -136,6 +161,31 @@ stages:
               artifactName: ${{ parameters.artifactName }}
               artifactItemPattern: ${{ parameters.artifactItemPattern }}
               useArtifacts: ${{ parameters.useArtifacts }}
+
+    - ${{ if eq(platform, 'catalyst') }}:
+      - ${{ each project in parameters.projects }}:
+        - ${{ if ne(project.catalyst, '') }}:
+          - template: device-tests-jobs.yml
+            parameters:
+              platform: catalyst
+              timeoutInMinutes: 240
+              pool: ${{ parameters.catalystPool }}
+              versions: ${{ parameters.catalystVersions }}
+              targetFrameworkVersion: ${{ parameters.targetFrameworkVersion }}
+              checkoutDirectory: ${{ parameters.checkoutDirectory }}
+              project:
+                name: ${{ project.name }}
+                desc: ${{ project.desc }}
+                path: ${{ project.catalyst }}
+                versionsExclude: ${{ project.catalystVersionsCoreClrExclude }}
+                configuration: ${{ project.iOSConfiguration }}
+              provisionatorChannel: ${{ parameters.provisionatorChannel }}
+              skipProvisioning: ${{ parameters.skipProvisioning }}
+              agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+              artifactName: ${{ parameters.artifactName }}
+              artifactItemPattern: ${{ parameters.artifactItemPattern }}
+              useArtifacts: ${{ parameters.useArtifacts }}
+              useCoreClr: true
 
     - ${{ if eq(platform, 'windows') }}:
       - ${{ each project in parameters.projects }}:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -171,6 +171,9 @@ stages:
         desc: Controls
         androidApiLevelsExclude: [ 27, 25 ] # Ignore for now API25 since the runs's are not stable
         androidApiLevelsCoreClrExclude: [ 27, 25, 23]
+        # Tracking issue: https://github.com/dotnet/runtime/issues/122219
+        iosVersionsCoreClrExclude: [ 'simulator-18.4' ] # Disable Controls tests on CoreCLR for iOS as they are failing
+        catalystVersionsCoreClrExclude: [ 'latest' ] # Disable Controls tests on CoreCLR for Catalyst as they are failing
         androidConfiguration: 'Debug'
         iOSConfiguration: 'Debug'
         windowsConfiguration: 'Debug'


### PR DESCRIPTION
## Description

This PR enables CoreCLR iOS and MacCatalyst device tests, mirroring the existing Android CoreCLR device tests implementation.

## Changes:
 - Added useCoreClr and /p:UseMonoRuntime=false when building with CoreCLR
 - Enabled device tests