### PR TITLE
Fix the Aspire ServiceDefaults project template

### DIFF
--- a/src/Templates/src/templates/maui-aspire-servicedefaults/MauiAspire.1.ServiceDefaults.csproj
+++ b/src/Templates/src/templates/maui-aspire-servicedefaults/MauiAspire.1.ServiceDefaults.csproj
@@ -5,6 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsAspireSharedProject>true</IsAspireSharedProject>
+		<UseMauiCore>true</UseMauiCore>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -324,6 +324,10 @@ public class SimpleTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.New("maui-aspire-servicedefaults", projectDir, additionalDotNetNewParams: $"-n \"{projectName}\""),
 			$"Unable to create template maui-aspire-servicedefaults. Check test output for errors.");
 
+		// Verify the project actually builds
+		Assert.IsTrue(DotnetInternal.Build(expectedProjectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),
+			$"Project {Path.GetFileName(expectedProjectFile)} failed to build. Check test output/attachments for errors.");
+
 		// Verify the project file was created with the correct name (this was the bug)
 		Assert.IsTrue(File.Exists(expectedProjectFile),
 			$"Expected project file '{expectedProjectFile}' was not created. This indicates the template naming issue.");
@@ -340,9 +344,11 @@ public class SimpleTemplateTest : BaseTemplateTests
 		Assert.IsTrue(File.Exists(Path.Combine(projectDir, "Extensions.cs")),
 			"Expected Extensions.cs file was not created.");
 
-		// Verify we can build it (even if restore fails due to placeholder tokens, the project structure should be valid)
+		// Verify the project file contains required properties
 		var projectContent = File.ReadAllText(expectedProjectFile);
 		Assert.IsTrue(projectContent.Contains("<IsAspireSharedProject>true</IsAspireSharedProject>", StringComparison.Ordinal),
 			"Project file should contain Aspire-specific properties.");
+		Assert.IsTrue(projectContent.Contains("<UseMauiCore>true</UseMauiCore>", StringComparison.Ordinal),
+			"Project file should contain UseMauiCore property.");
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -324,10 +324,6 @@ public class SimpleTemplateTest : BaseTemplateTests
 		Assert.IsTrue(DotnetInternal.New("maui-aspire-servicedefaults", projectDir, additionalDotNetNewParams: $"-n \"{projectName}\""),
 			$"Unable to create template maui-aspire-servicedefaults. Check test output for errors.");
 
-		// Verify the project actually builds
-		Assert.IsTrue(DotnetInternal.Build(expectedProjectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),
-			$"Project {Path.GetFileName(expectedProjectFile)} failed to build. Check test output/attachments for errors.");
-
 		// Verify the project file was created with the correct name (this was the bug)
 		Assert.IsTrue(File.Exists(expectedProjectFile),
 			$"Expected project file '{expectedProjectFile}' was not created. This indicates the template naming issue.");
@@ -350,5 +346,9 @@ public class SimpleTemplateTest : BaseTemplateTests
 			"Project file should contain Aspire-specific properties.");
 		Assert.IsTrue(projectContent.Contains("<UseMauiCore>true</UseMauiCore>", StringComparison.Ordinal),
 			"Project file should contain UseMauiCore property.");
+
+		// Verify the project actually builds
+		Assert.IsTrue(DotnetInternal.Build(expectedProjectFile, "Debug", properties: BuildProps, msbuildWarningsAsErrors: true),
+			$"Project {Path.GetFileName(expectedProjectFile)} failed to build. Check test output/attachments for errors.");
 	}
 }


### PR DESCRIPTION
This pull request improves the integration test for the Aspire Service Defaults template by adding more thorough validation of the generated project. The changes focus on ensuring the template produces a buildable project and that the project file contains all required properties.

Enhancements to integration test coverage:

* Added a build verification step to ensure the generated project from the `maui-aspire-servicedefaults` template can be successfully built, catching issues early in the test process.
* Added an assertion to verify that the generated project file includes the `<UseMauiCore>true</UseMauiCore>` property, in addition to the existing Aspire-specific properties check.