### PR TITLE
Enable XAML Source Generator on ManualTests project

### DIFF
--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -36,6 +36,9 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+
+		<!-- Use XAML Source Generator for better performance and debugging -->
+		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
   
   <PropertyGroup>
@@ -85,7 +88,12 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
-  
+
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
+
+  <ItemGroup>
+    <!-- Suppress CS0612 (obsolete) for XAML files using deprecated NamedSize FontSize values -->
+    <MauiXaml Update="Views\HeadersAndFooters\HeaderFooterAddClearPage.xaml" NoWarn="0612" />
+  </ItemGroup>
   
 </Project>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Enables XAML Source Generator (XSG) on the `Controls.ManualTests` project by setting `MauiXamlInflator=SourceGen`.

## Changes

- Added `<MauiXamlInflator>SourceGen</MauiXamlInflator>` to enable XAML Source Generator for better performance and debugging
- Added `NoWarn="0612"` for `HeaderFooterAddClearPage.xaml` which uses deprecated `NamedSize` (`FontSize="Title"`)

## Testing

- Built and ran on MacCatalyst successfully
