### PR TITLE
Update logic for large title display mode on iOS - shell

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -421,7 +421,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (SelectedViewController is UINavigationController navigationController)
 			{
-				navigationController.NavigationBar.PrefersLargeTitles = largeTitleDisplayMode == LargeTitleDisplayMode.Always;
+				navigationController.NavigationBar.PrefersLargeTitles = largeTitleDisplayMode != LargeTitleDisplayMode.Never;
 				var top = navigationController.TopViewController;
 				if (top is not null)
 				{


### PR DESCRIPTION
Changed the condition for setting PrefersLargeTitles to enable large titles unless the display mode is set to Never, improving compatibility with different display modes.