### PR TITLE
Enable CoreCLR Apple template tests

### DIFF
--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -150,8 +150,7 @@ RunTarget(TARGET);
 void ExecuteBuild(string project, string device, string binDir, string config, string tfm, string toolPath, bool useCoreClr)
 {
 	var projectName = System.IO.Path.GetFileNameWithoutExtension(project);
-	bool isUsingCoreClr = useCoreClr.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
-	var monoRuntime = isUsingCoreClr ? "coreclr" : "mono";
+	var monoRuntime = useCoreClr ? "coreclr" : "mono";
 	var binlog = $"{binDir}/{projectName}-{config}-{monoRuntime}-android.binlog";
 
 	DotNetBuild(project, new DotNetBuildSettings
@@ -168,7 +167,7 @@ void ExecuteBuild(string project, string device, string binDir, string config, s
 			args.Append("/p:EmbedAssembliesIntoApk=true")
 				.Append("/bl:" + binlog);
 
-			if (isUsingCoreClr)
+			if (useCoreClr)
 			{
 				args.Append("/p:UseMonoRuntime=false");
 			}

--- a/eng/devices/catalyst.cake
+++ b/eng/devices/catalyst.cake
@@ -88,7 +88,7 @@ void ExecuteBuild(string project, string binDir, string config, string rid, stri
 				.Append($"/p:RuntimeIdentifier={rid}")
 				.Append($"/bl:{binlog}");
 
-			if (isUsingCoreClr)
+			if (useCoreClr)
 			{
 				args.Append("/p:UseMonoRuntime=false");
 			}

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -155,7 +155,7 @@ void ExecuteBuild(string project, string device, string binDir, string config, s
 				.Append("/bl:" + binlog)
 				.Append("/tl");
 
-			if (isUsingCoreClr)
+			if (useCoreClr)
 			{
 				args.Append("/p:UseMonoRuntime=false");
 			}

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Simulator.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Apple/Simulator.cs
@@ -1,9 +1,13 @@
-﻿
+﻿using System.Text.RegularExpressions;
+
 namespace Microsoft.Maui.IntegrationTests.Apple
 {
 	public class Simulator
 	{
 		readonly string XCRunTool = "xcrun";
+
+		// Regex pattern for valid simulator UDID (UUID format: 8-4-4-4-12 hex characters)
+		static readonly Regex UdidPattern = new Regex(@"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$", RegexOptions.Compiled);
 
 		public string XHarnessID { get; set; } = System.Environment.GetEnvironmentVariable("IOS_TEST_DEVICE") ?? "ios-simulator-64";
 
@@ -13,7 +17,23 @@ namespace Microsoft.Maui.IntegrationTests.Apple
 			if (!string.IsNullOrEmpty(_udid))
 				return _udid;
 
-			return _udid = XHarness.GetSimulatorUDID(XHarnessID).Trim();
+			var output = XHarness.GetSimulatorUDID(XHarnessID);
+
+			// The output may contain error messages before the actual UDID.
+			// Search for a valid UDID pattern in the output.
+			foreach (var line in output.Split('\n', '\r'))
+			{
+				var trimmedLine = line.Trim();
+				if (UdidPattern.IsMatch(trimmedLine))
+				{
+					_udid = trimmedLine;
+					return _udid;
+				}
+			}
+
+			// If no valid UDID found, return the trimmed output (will likely cause a meaningful error downstream)
+			TestContext.WriteLine($"Warning: Could not find valid UDID in xharness output. Full output:\n{output}");
+			return _udid = output.Trim();
 		}
 
 		public bool Launch()

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -37,6 +37,10 @@ namespace Microsoft.Maui.IntegrationTests
 		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, null)]
 		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, "full")]
 		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.NativeAOT, null)]
+		[TestCase("maui", "Debug", DotNetCurrent, "iossimulator-x64", RuntimeVariant.CoreCLR, null)]
+		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.CoreCLR, null)]
+		[TestCase("maui-blazor", "Debug", DotNetCurrent, "iossimulator-x64", RuntimeVariant.CoreCLR, null)]
+		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.CoreCLR, null)]
 		public void RunOniOS(string id, string config, string framework, string runtimeIdentifier, RuntimeVariant runtimeVariant, string trimMode)
 		{
 			var projectDir = TestDirectory;
@@ -46,13 +50,17 @@ namespace Microsoft.Maui.IntegrationTests
 				$"Unable to create template {id}. Check test output for errors.");
 
 			var buildProps = BuildProps;
+			buildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
 			if (runtimeVariant == RuntimeVariant.NativeAOT)
 			{
 				buildProps.Add("PublishAot=true");
 				buildProps.Add("PublishAotUsingRuntimePack=true"); // TODO: This parameter will become obsolete https://github.com/dotnet/runtime/issues/87060
 				buildProps.Add("_IsPublishing=true"); // using dotnet build with -p:_IsPublishing=true enables targeting simulators
-				buildProps.Add($"RuntimeIdentifier={runtimeIdentifier}");
 				buildProps.Add("IlcTreatWarningsAsErrors=false"); // TODO: Remove this once all warnings are fixed https://github.com/dotnet/maui/issues/19397
+			}
+			else if (runtimeVariant == RuntimeVariant.CoreCLR)
+			{
+				buildProps.Add("UseMonoRuntime=false");
 			}
 
 			if (!string.IsNullOrEmpty(trimMode))

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -5,7 +5,8 @@ namespace Microsoft.Maui.IntegrationTests
 	public enum RuntimeVariant
 	{
 		Mono,
-		NativeAOT
+		NativeAOT,
+		CoreCLR
 	}
 
 	public abstract class BaseBuildTest


### PR DESCRIPTION
## Description

This PR enables CoreCLR Apple template tests, mirroring the existing Android CoreCLR tests implementation.

Contributes to https://github.com/dotnet/runtime/issues/120056