### PR TITLE
[Windows]Fix for AdaptiveTrigger Not Firing When Changing Window Width Programmatically

### DIFF
--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -44,11 +44,13 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>Bindable property for <see cref="Width"/>.</summary>
 		public static readonly BindableProperty WidthProperty = BindableProperty.Create(
-			nameof(Width), typeof(double), typeof(Window), Primitives.Dimension.Unset);
+			nameof(Width), typeof(double), typeof(Window), Primitives.Dimension.Unset,
+			propertyChanged: OnSizePropertyChanged);
 
 		/// <summary>Bindable property for <see cref="Height"/>.</summary>
 		public static readonly BindableProperty HeightProperty = BindableProperty.Create(
-			nameof(Height), typeof(double), typeof(Window), Primitives.Dimension.Unset);
+			nameof(Height), typeof(double), typeof(Window), Primitives.Dimension.Unset,
+			propertyChanged: OnSizePropertyChanged);        
 
 		/// <summary>Bindable property for <see cref="MaximumWidth"/>.</summary>
 		public static readonly BindableProperty MaximumWidthProperty = BindableProperty.Create(
@@ -227,6 +229,16 @@ namespace Microsoft.Maui.Controls
 		}
 
 		int _batchFrameUpdate = 0;
+
+		static void OnSizePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var window = (Window)bindable;
+			// Only trigger SizeChanged if not being updated from platform (FrameChanged)
+			if (window._batchFrameUpdate == 0)
+			{
+				window.SizeChanged?.Invoke(window, EventArgs.Empty);
+			}
+		}
 
 		void IWindow.FrameChanged(Rect frame)
 		{

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for <see cref="Height"/>.</summary>
 		public static readonly BindableProperty HeightProperty = BindableProperty.Create(
 			nameof(Height), typeof(double), typeof(Window), Primitives.Dimension.Unset,
-			propertyChanged: OnSizePropertyChanged);        
+			propertyChanged: OnSizePropertyChanged);
 
 		/// <summary>Bindable property for <see cref="MaximumWidth"/>.</summary>
 		public static readonly BindableProperty MaximumWidthProperty = BindableProperty.Create(

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue27646.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue27646.cs
@@ -1,0 +1,99 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 27646, "AdaptiveTrigger not firing when changing window width programmatically only", PlatformAffected.UWP)]
+public class Issue27646 : ContentPage
+{
+	Label indicatorLabel;
+	Label statusLabel;
+
+	public Issue27646()
+	{
+		var stackLayout = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10
+		};
+
+		var instructionLabel = new Label
+		{
+			Text = "Click button to resize window. Label text should change at 600px window width.",
+			AutomationId = "InstructionLabel"
+		};
+		stackLayout.Add(instructionLabel);
+
+		statusLabel = new Label
+		{
+			Text = "Window width: Unknown",
+			AutomationId = "StatusLabel",
+			FontAttributes = FontAttributes.Bold
+		};
+		stackLayout.Add(statusLabel);
+
+		var resizeButton = new Button
+		{
+			Text = "Resize Window",
+			AutomationId = "ResizeButton"
+		};
+		resizeButton.Clicked += OnResizeClicked;
+		stackLayout.Add(resizeButton);
+
+		indicatorLabel = new Label
+		{
+			Text = "Initial",
+			WidthRequest = 200,
+			HeightRequest = 100,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+			AutomationId = "IndicatorLabel"
+		};
+		stackLayout.Add(indicatorLabel);
+
+		Content = stackLayout;
+
+		VisualStateManager.SetVisualStateGroups(indicatorLabel, new VisualStateGroupList
+		{
+			new VisualStateGroup
+			{
+				Name = "WindowWidthStates",
+				States =
+				{
+					new VisualState
+					{
+						Name = "Narrow",
+						StateTriggers =
+						{
+							new AdaptiveTrigger { MinWindowWidth = 0 }
+						},
+						Setters =
+						{
+							new Setter { Property = Label.TextProperty, Value = "Narrow Window" }
+						}
+					},
+					new VisualState
+					{
+						Name = "Wide",
+						StateTriggers =
+						{
+							new AdaptiveTrigger { MinWindowWidth = 600 }
+						},
+						Setters =
+						{
+							new Setter { Property = Label.TextProperty, Value = "Wide Window" }
+						}
+					}
+				}
+			}
+		});
+	}
+
+	void OnResizeClicked(object sender, EventArgs e)
+	{
+		if (Window is not null)
+		{
+			double newWidth = Window.Width >= 600 ? 550 : 650;
+			Window.Width = newWidth;
+
+			statusLabel.Text = $"Window width: {newWidth}px";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27646.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27646.cs
@@ -1,0 +1,33 @@
+#if WINDOWS // MacCatalyst don't support programmatic window resizing. So, ignored test on MacCatalyst.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue27646 : _IssuesUITest
+{
+	public override string Issue => "AdaptiveTrigger not firing when changing window width programmatically only";
+
+	public Issue27646(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.Window)]
+	public void AdaptiveTriggerShouldFireWhenWindowWidthChangedProgrammatically()
+	{
+		App.WaitForElement("ResizeButton");
+
+		App.Tap("ResizeButton");
+		
+		var indicatorAfterFirstClick = App.FindElement("IndicatorLabel");
+		Assert.That(indicatorAfterFirstClick.GetText(), Is.EqualTo("Narrow Window"),
+			"Label should show 'Narrow Window' after resizing to 550px");
+
+		App.Tap("ResizeButton");
+		
+		var indicatorAfterSecondClick = App.FindElement("IndicatorLabel");
+		Assert.That(indicatorAfterSecondClick.GetText(), Is.EqualTo("Wide Window"),
+			"Label should show 'Wide Window' after resizing to 650px");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27646.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue27646.cs
@@ -1,4 +1,4 @@
-#if WINDOWS // MacCatalyst don't support programmatic window resizing. So, ignored test on MacCatalyst.
+#if WINDOWS // MacCatalyst doesn't support programmatic window resizing. So, ignored test on MacCatalyst.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause

The issue occurs because of the order of operations when window dimensions are changed programmatically versus manually. The FrameChanged() method determines whether to fire the SizeChanged event by comparing current property values against incoming frame values. During manual resize operations, the platform invokes FrameChanged() first, which then updates the Width and Height properties, successfully detecting the change and firing the event.
 
However, during programmatic resize, the Width and Height properties update immediately upon assignment. When the platform subsequently invokes FrameChanged(), the property values already match the incoming frame values, causing the comparison to fail and preventing the SizeChanged event from firing. This breaks AdaptiveTrigger functionality, which depends on the SizeChanged event to update visual states.

### Description of Issue Fix

The fix involves adding propertyChanged callbacks to WidthProperty and HeightProperty that fire the SizeChanged event immediately when properties change from user code. The existing _batchFrameUpdate flag distinguishes between user-initiated changes (flag equals zero) and platform-initiated changes (flag greater than zero), preventing duplicate event firing. When user code sets Width or Height programmatically, the callback fires SizeChanged directly.
 
When the platform updates properties through FrameChanged(), the callback is suppressed and the existing event logic handles notification. This ensures AdaptiveTrigger receives notifications for both programmatic and manual resizes without duplicates, following the established pattern used by ColumnDefinition and RowDefinition in MAUI's Grid layout system.

Tested the behavior in the following platforms.
 
- [x] Windows
- [x] Mac
- [ ] iOS
- [ ] Android

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/27646

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="270" height="600"  src="https://github.com/user-attachments/assets/ec51b57d-09b0-4275-ac82-ee8f512baad3"> | <video width="270" height="600"  src="https://github.com/user-attachments/assets/0259d3e6-4154-4a2a-92cb-91448d846f0c"> |