### PR TITLE
Disable AppThemeBindingExtension source generation for NET10

### DIFF
--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -674,6 +674,7 @@ internal class KnownMarkups
 	/// Provides value for AppThemeBindingExtension by generating an AppThemeBinding instance
 	/// with Light, Dark, and Default properties set based on the markup extension's properties.
 	/// </summary>
+#if NET11_0_OR_GREATER
 	internal static bool ProvideValueForAppThemeBindingExtension(ElementNode node, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)
 	{
 		returnType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.AppThemeBinding")!;
@@ -779,6 +780,7 @@ internal class KnownMarkups
 		value = $"new global::Microsoft.Maui.Controls.AppThemeBinding {{ {string.Join(", ", parts)} }}";
 		return true;
 	}
+#endif
 
 	//all of this could/should be better, but is already slightly better than XamlC
 	internal static bool ProvideValueForStaticResourceExtension(ElementNode node, IndentedTextWriter writer, SourceGenContext context, NodeSGExtensions.GetNodeValueDelegate? getNodeValue, out ITypeSymbol? returnType, out string value)

--- a/src/Controls/src/SourceGen/NodeSGExtensions.cs
+++ b/src/Controls/src/SourceGen/NodeSGExtensions.cs
@@ -109,7 +109,9 @@ static class NodeSGExtensions
 		{context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.TemplateBindingExtension")!, KnownMarkups.ProvideValueForTemplateBindingExtension},
 		{context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.ReferenceExtension")!, KnownMarkups.ProvideValueForReferenceExtension},
 		{context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.StaticResourceExtension")!, KnownMarkups.ProvideValueForStaticResourceExtension},
+#if NET11_0_OR_GREATER
 		{context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.Xaml.AppThemeBindingExtension")!, KnownMarkups.ProvideValueForAppThemeBindingExtension},
+#endif
 	};
 
 	public static bool TryGetPropertyName(this INode node, INode parentNode, out XmlName name)


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Disables the AppThemeBindingExtension source generation for NET10 by wrapping the code with `#if NET11_0_OR_GREATER` preprocessor directives.

This ensures the feature is only enabled for .NET 11 and later versions.

## Changes

- Wrapped `ProvideValueForAppThemeBindingExtension` method in `KnownMarkups.cs` with `#if NET11_0_OR_GREATER`
- Wrapped the dictionary entry for `AppThemeBindingExtension` in `NodeSGExtensions.cs` with `#if NET11_0_OR_GREATER`