### PR TITLE
[windows] Fixed Rapid change of selected tab results in crash.

### DIFF
--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
@@ -265,7 +265,6 @@ namespace Microsoft.Maui.Controls
 				oldPresenter.Content = null;
 
 			CurrentPage = page;
-
 			FrameNavigationOptions navOptions = new FrameNavigationOptions();
 			navOptions.IsNavigationStackEnabled = false;
 			NavigationFrame.NavigateToType(typeof(WPage), null, navOptions);

--- a/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/TabbedPage/TabbedPage.Windows.cs
@@ -280,10 +280,7 @@ namespace Microsoft.Maui.Controls
 
 		void UpdateCurrentPageContent(WPage page)
 		{
-			if (MauiContext == null)
-				return;
-
-			if (_displayedPage == CurrentPage)
+			if (MauiContext == null || _displayedPage == CurrentPage)
 				return;
 
 			WContentPresenter? presenter;

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -12,7 +12,10 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
+using WContentPresenter = Microsoft.UI.Xaml.Controls.ContentPresenter;
+using WFrame = Microsoft.UI.Xaml.Controls.Frame;
 using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
+using WPage = Microsoft.UI.Xaml.Controls.Page;
 using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 
 namespace Microsoft.Maui.DeviceTests
@@ -196,6 +199,40 @@ namespace Microsoft.Maui.DeviceTests
 					GetMauiNavigationView(tabbedPage),
 					tabText, iconColor, tabbedPage.FindMauiContext());
 			}
+		}
+
+		[Fact(DisplayName = "Issue 32824 - Tab Switch Clears Old Content To Prevent Crash")]
+		public async Task TabSwitchClearsOldContentToPreventCrash()
+		{
+			// https://github.com/dotnet/maui/issues/32824
+			// When switching tabs, the old ContentPresenter.Content must be cleared
+			// before navigation to prevent "Element is already the child of another element" crash.
+			SetupBuilder();
+
+			var page1 = new ContentPage { Title = "Tab 1", Content = new Label { Text = "Page 1" } };
+			var page2 = new ContentPage { Title = "Tab 2", Content = new Label { Text = "Page 2" } };
+			var tabbedPage = new TabbedPage { Children = { page1, page2 } };
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
+			{
+				var frame = typeof(TabbedPage)
+					.GetField("_navigationFrame", BindingFlags.NonPublic | BindingFlags.Instance)
+					?.GetValue(tabbedPage) as WFrame;
+
+				Assert.NotNull(frame);
+
+				var oldPresenter = (frame.Content as WPage)?.Content as WContentPresenter;
+				Assert.NotNull(oldPresenter);
+				Assert.NotNull(oldPresenter.Content);
+
+				// Switch tabs - oldPresenter.Content should be cleared before navigation
+				tabbedPage.CurrentPage = page2;
+
+				//old presenter content must be null to prevent crash
+				Assert.Null(oldPresenter.Content);
+
+				return Task.CompletedTask;
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Root Cause
On Windows, `TabbedPage` uses WinUI `Frame` navigation to display each tab’s content. Each tab’s platform view (native UI element) is hosted inside a WinUI `Page` through a `ContentPresenter`.
During rapid tab switching, the platform view is reassigned to a new WinUI `Page` while still attached to the previous one. WinUI does not allow a UI element to exist in two visual trees simultaneously, which causes the crash.
 
### Description of Change
Added a `_displayedPage` tracking field to maintain the correct displayed MAUI Page during navigation, allowing `NavigateToPage` to skip early if the requested page is already displayed and avoid redundant navigation. The method also now clears the previous WinUI Page’s `ContentPresenter` to explicitly detach the platform view and prevent the “element already has a parent” WinUI error. In `UpdateCurrentPageContent`, a skip guard avoids reassigning content that is already set, while `_displayedPage` is updated only after successful content assignment. Finally, OnHandlerDisconnected resets `_displayedPage` to null to ensure proper cleanup and prevent stale references.

### Issues Fixed
Fixes #32824 
Fixes #14572 
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Video
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/4ae17a81-a399-4cd6-856d-ca4938cb683b" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/5927a164-22d8-45bc-a910-003bfbc1927a" /> |