### PR TITLE
[ci] Don t batch runs on public ci

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -1,5 +1,5 @@
 trigger:
-  batch: true
+  batch: false
   branches:
     include:
     - main


### PR DESCRIPTION
### Description of Change

This pull request makes a minor configuration change to the CI pipeline. The batching behavior for pipeline triggers has been disabled.

* Set `batch` to `false` in `eng/pipelines/ci.yml` to ensure that CI runs are triggered immediately for each push to the `main` branch, rather than being batched together.