### PR TITLE
Fix command dependency reentrancy

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -432,6 +432,25 @@ namespace Microsoft.Maui.Controls
 			return bpcontext != null && bpcontext.Bindings.Count > 0;
 		}
 
+		/// <summary>
+		/// Forces the binding for the specified property to apply immediately.
+		/// This is used when one property depends on another and needs the dependent
+		/// property's binding to resolve before proceeding.
+		/// See https://github.com/dotnet/maui/issues/31939
+		/// </summary>
+		internal void ForceBindingApply(BindableProperty targetProperty)
+		{
+			if (targetProperty == null)
+				throw new ArgumentNullException(nameof(targetProperty));
+
+			BindablePropertyContext bpcontext = GetContext(targetProperty);
+			if (bpcontext == null || bpcontext.Bindings.Count == 0)
+				return;
+
+			// Force the binding to apply now
+			ApplyBinding(bpcontext, fromBindingContextChanged: false);
+		}
+
 		internal virtual void OnRemoveDynamicResource(BindableProperty property)
 		{
 		}

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -252,6 +252,21 @@ namespace Microsoft.Maui.Controls
 
 		internal ValidateValueDelegate ValidateValue { get; private set; }
 
+		// Properties that this property depends on - when getting this property's value,
+		// if the dependency has a pending binding, return the default value instead.
+		// This is used to fix timing issues where one property binding resolves before another.
+		// See https://github.com/dotnet/maui/issues/31939
+		internal BindableProperty[] Dependencies { get; private set; }
+
+		/// <summary>
+		/// Registers a dependency on another BindableProperty. When this property's value is retrieved,
+		/// if the dependency has a binding that hasn't resolved yet (value is null), return null.
+		/// </summary>
+		internal void DependsOn(params BindableProperty[] dependencies)
+		{
+			Dependencies = dependencies;
+		}
+
 		/// <summary>Creates a new instance of the BindableProperty class.</summary>
 		/// <param name="propertyName">The name of the BindableProperty.</param>
 		/// <param name="returnType">The type of the property.</param>

--- a/src/Controls/src/Core/Button/Button.cs
+++ b/src/Controls/src/Core/Button/Button.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Maui.Controls
 			RefreshIsEnabledProperty();
 
 		protected override bool IsEnabledCore =>
-			base.IsEnabledCore && CommandElement.GetCanExecute(this);
+			base.IsEnabledCore && CommandElement.GetCanExecute(this, CommandProperty);
 
 		bool _wasImageLoading;
 

--- a/src/Controls/src/Core/Button/ButtonElement.cs
+++ b/src/Controls/src/Core/Button/ButtonElement.cs
@@ -10,16 +10,27 @@ namespace Microsoft.Maui.Controls
 		/// <summary>
 		/// The backing store for the <see cref="ICommandElement.Command" /> bindable property.
 		/// </summary>
-		public static readonly BindableProperty CommandProperty = BindableProperty.Create(
-			nameof(IButtonElement.Command), typeof(ICommand), typeof(IButtonElement), null,
-			propertyChanging: CommandElement.OnCommandChanging, propertyChanged: CommandElement.OnCommandChanged);
+		public static readonly BindableProperty CommandProperty;
 
 		/// <summary>
 		/// The backing store for the <see cref="ICommandElement.CommandParameter" /> bindable property.
 		/// </summary>
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
-			nameof(IButtonElement.CommandParameter), typeof(object), typeof(IButtonElement), null,
-			propertyChanged: CommandElement.OnCommandParameterChanged);
+		public static readonly BindableProperty CommandParameterProperty;
+
+		static ButtonElement()
+		{
+			CommandParameterProperty = BindableProperty.Create(
+				nameof(IButtonElement.CommandParameter), typeof(object), typeof(IButtonElement), null,
+				propertyChanged: CommandElement.OnCommandParameterChanged);
+
+			CommandProperty = BindableProperty.Create(
+				nameof(IButtonElement.Command), typeof(ICommand), typeof(IButtonElement), null,
+				propertyChanging: CommandElement.OnCommandChanging, propertyChanged: CommandElement.OnCommandChanged);
+
+			// Register dependency: Command depends on CommandParameter for CanExecute evaluation
+			// See https://github.com/dotnet/maui/issues/31939
+			CommandProperty.DependsOn(CommandParameterProperty);
+		}
 
 		/// <summary>
 		/// The string identifier for the pressed visual state of this control.

--- a/src/Controls/src/Core/Cells/TextCell.cs
+++ b/src/Controls/src/Core/Cells/TextCell.cs
@@ -11,18 +11,27 @@ namespace Microsoft.Maui.Controls
 	public class TextCell : Cell, ICommandElement
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
-		public static readonly BindableProperty CommandProperty =
-			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TextCell),
-			propertyChanging: CommandElement.OnCommandChanging,
-			propertyChanged: CommandElement.OnCommandChanged);
+		public static readonly BindableProperty CommandProperty;
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
-		public static readonly BindableProperty CommandParameterProperty =
-			BindableProperty.Create(nameof(CommandParameter),
+		public static readonly BindableProperty CommandParameterProperty;
+
+		static TextCell()
+		{
+			CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter),
 				typeof(object),
 				typeof(TextCell),
 				null,
 				propertyChanged: CommandElement.OnCommandParameterChanged);
+
+			CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TextCell),
+				propertyChanging: CommandElement.OnCommandChanging,
+				propertyChanged: CommandElement.OnCommandChanged);
+
+			// Register dependency: Command depends on CommandParameter for CanExecute evaluation
+			// See https://github.com/dotnet/maui/issues/31939
+			CommandProperty.DependsOn(CommandParameterProperty);
+		}
 
 		/// <summary>Bindable property for <see cref="Text"/>.</summary>
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(TextCell), default(string));
@@ -95,10 +104,7 @@ namespace Microsoft.Maui.Controls
 
 		void ICommandElement.CanExecuteChanged(object sender, EventArgs eventArgs)
 		{
-			if (Command is null)
-				return;
-
-			IsEnabled = Command.CanExecute(CommandParameter);
+			IsEnabled = CommandElement.GetCanExecute(this, CommandProperty);
 		}
 
 		WeakCommandSubscription ICommandElement.CleanupTracker { get; set; }

--- a/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.Mapper.cs
@@ -9,7 +9,13 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class CheckBox
 	{
-		static CheckBox() => RemapForControls();
+		static CheckBox()
+		{
+			// Register dependency: Command depends on CommandParameter for CanExecute evaluation
+			// See https://github.com/dotnet/maui/issues/31939
+			CommandProperty.DependsOn(CommandParameterProperty);
+			RemapForControls();
+		}
 
 		private new static void RemapForControls()
 		{

--- a/src/Controls/src/Core/CheckBox/CheckBox.cs
+++ b/src/Controls/src/Core/CheckBox/CheckBox.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Maui.Controls
 			RefreshIsEnabledProperty();
 
 		protected override bool IsEnabledCore =>
-			base.IsEnabledCore && CommandElement.GetCanExecute(this);
+			base.IsEnabledCore && CommandElement.GetCanExecute(this, CommandProperty);
 		public Paint Foreground => Color?.AsPaint();
 
 		bool ICheckBox.IsChecked

--- a/src/Controls/src/Core/CommandElement.cs
+++ b/src/Controls/src/Core/CommandElement.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls
 			commandElement.CanExecuteChanged(bo, EventArgs.Empty);
 		}
 
-		public static bool GetCanExecute(ICommandElement commandElement)
+		public static bool GetCanExecute(ICommandElement commandElement, BindableProperty? commandProperty = null)
 		{
 			if (commandElement.Command == null)
 				return true;

--- a/src/Controls/src/Core/CommandElement.cs
+++ b/src/Controls/src/Core/CommandElement.cs
@@ -42,6 +42,29 @@ namespace Microsoft.Maui.Controls
 			if (commandElement.Command == null)
 				return true;
 
+			// If there are dependencies (e.g., CommandParameter for Command), force their bindings
+			// to apply before evaluating CanExecute. This fixes timing issues where Command binding
+			// resolves before CommandParameter binding during reparenting.
+			// See https://github.com/dotnet/maui/issues/31939
+			if (commandProperty?.Dependencies is not null && commandElement is BindableObject bo)
+			{
+				foreach (var dependency in commandProperty.Dependencies)
+				{
+					// Only force bindings to apply when the dependency is actually pending.
+					// Unconditionally forcing can cause re-entrancy/feedback loops in cases where
+					// CanExecute evaluation triggers binding reapplication.
+					if (!bo.GetIsBound(dependency))
+						continue;
+
+					// For command parameter dependencies, 'null' is the common "not resolved yet" state.
+					// If it's already non-null, avoid forcing a re-apply.
+					if (bo.GetValue(dependency) is not null)
+						continue;
+
+					bo.ForceBindingApply(dependency);
+				}
+			}
+
 			return commandElement.Command.CanExecute(commandElement.CommandParameter);
 		}
 	}

--- a/src/Controls/src/Core/ImageButton/ImageButton.cs
+++ b/src/Controls/src/Core/ImageButton/ImageButton.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Maui.Controls
 		bool IImageController.GetLoadAsAnimation() => false;
 
 		protected override bool IsEnabledCore =>
-			base.IsEnabledCore && CommandElement.GetCanExecute(this);
+			base.IsEnabledCore && CommandElement.GetCanExecute(this, CommandProperty);
 
 		void ICommandElement.CanExecuteChanged(object sender, EventArgs e) =>
 			RefreshIsEnabledProperty();

--- a/src/Controls/src/Core/Menu/MenuItem.cs
+++ b/src/Controls/src/Core/Menu/MenuItem.cs
@@ -12,15 +12,26 @@ namespace Microsoft.Maui.Controls
 	public partial class MenuItem : BaseMenuItem, IMenuItemController, ICommandElement, IMenuElement, IPropertyPropagationController
 	{
 		/// <summary>Bindable property for <see cref="Command"/>.</summary>
-		public static readonly BindableProperty CommandProperty = BindableProperty.Create(
-			nameof(Command), typeof(ICommand), typeof(MenuItem), null,
-			propertyChanging: CommandElement.OnCommandChanging,
-			propertyChanged: CommandElement.OnCommandChanged);
+		public static readonly BindableProperty CommandProperty;
 
 		/// <summary>Bindable property for <see cref="CommandParameter"/>.</summary>
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
-			nameof(CommandParameter), typeof(object), typeof(MenuItem), null,
-			propertyChanged: CommandElement.OnCommandParameterChanged);
+		public static readonly BindableProperty CommandParameterProperty;
+
+		static MenuItem()
+		{
+			CommandParameterProperty = BindableProperty.Create(
+				nameof(CommandParameter), typeof(object), typeof(MenuItem), null,
+				propertyChanged: CommandElement.OnCommandParameterChanged);
+
+			CommandProperty = BindableProperty.Create(
+				nameof(Command), typeof(ICommand), typeof(MenuItem), null,
+				propertyChanging: CommandElement.OnCommandChanging,
+				propertyChanged: CommandElement.OnCommandChanged);
+
+			// Register dependency: Command depends on CommandParameter for CanExecute evaluation
+			// See https://github.com/dotnet/maui/issues/31939
+			CommandProperty.DependsOn(CommandParameterProperty);
+		}
 
 		/// <summary>Bindable property for <see cref="IsDestructive"/>.</summary>
 		public static readonly BindableProperty IsDestructiveProperty = BindableProperty.Create(nameof(IsDestructive), typeof(bool), typeof(MenuItem), false);
@@ -122,7 +133,7 @@ namespace Microsoft.Maui.Controls
 				return false;
 			}
 
-			var canExecute = CommandElement.GetCanExecute(menuItem);
+			var canExecute = CommandElement.GetCanExecute(menuItem, CommandProperty);
 			if (!canExecute)
 			{
 				return false;

--- a/src/Controls/src/Core/RefreshView/RefreshView.Mapper.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.Mapper.cs
@@ -6,6 +6,13 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class RefreshView
 	{
+		static RefreshView()
+		{
+			// Register dependency: Command depends on CommandParameter for CanExecute evaluation
+			// See https://github.com/dotnet/maui/issues/31939
+			CommandProperty.DependsOn(CommandParameterProperty);
+		}
+
 		internal static new void RemapForControls()
 		{
 			// Adjust the mappings to preserve Controls.RefreshView legacy behaviors

--- a/src/Controls/src/Core/RefreshView/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView/RefreshView.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Controls
 			if (bindable is RefreshView refreshView)
 			{
 				refreshView._isRefreshEnabledExplicit = (bool)value;
-				return refreshView._isRefreshEnabledExplicit && CommandElement.GetCanExecute(refreshView);
+				return refreshView._isRefreshEnabledExplicit && CommandElement.GetCanExecute(refreshView, CommandProperty);
 			}
 
 			return false;

--- a/src/Controls/src/Core/SearchBar/SearchBar.Mapper.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.Mapper.cs
@@ -6,6 +6,13 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class SearchBar
 	{
+		static SearchBar()
+		{
+			// Register dependency: SearchCommand depends on SearchCommandParameter for CanExecute evaluation
+			// See https://github.com/dotnet/maui/issues/31939
+			SearchCommandProperty.DependsOn(SearchCommandParameterProperty);
+		}
+
 		internal static new void RemapForControls()
 		{
 			// Adjust the mappings to preserve Controls.SearchBar legacy behaviors

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Maui.Controls
 		object ICommandElement.CommandParameter => SearchCommandParameter;
 
 		protected override bool IsEnabledCore =>
-			base.IsEnabledCore && CommandElement.GetCanExecute(this);
+			base.IsEnabledCore && CommandElement.GetCanExecute(this, SearchCommandProperty);
 
 		void ICommandElement.CanExecuteChanged(object sender, EventArgs e) =>
 			RefreshIsEnabledProperty();

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31939.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31939.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui31939">
+    <local:Maui31939Control x:Name="TestControl"
+                            TestCommand="{Binding TestCommand}"
+                            TestCommandParameter="TestValue">
+        <local:Maui31939Control.ControlTemplate>
+            <ControlTemplate>
+                <Grid x:Name="MainLayout">
+                    <Button x:Name="TestButton"
+                            Text="Test"
+                            Command="{TemplateBinding TestCommand}"
+                            CommandParameter="{TemplateBinding TestCommandParameter}" />
+                </Grid>
+            </ControlTemplate>
+        </local:Maui31939Control.ControlTemplate>
+    </local:Maui31939Control>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31939.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31939.xaml.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Windows.Input;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+// Regression test for https://github.com/dotnet/maui/issues/31939
+// CommandParameter TemplateBinding is lost during ControlTemplate reparenting,
+// causing CanExecute to be called with null parameter before CommandParameter is resolved.
+public partial class Maui31939 : ContentPage
+{
+	public Maui31939() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		public void Dispose() => DispatcherProvider.SetCurrent(null);
+		[Theory]
+		[XamlInflatorData]
+		internal void CommandParameterTemplateBindingShouldNotBeNullWhenCanExecuteIsCalled(XamlInflator inflator)
+		{
+			// Verify initial template binding works correctly: CommandParameter should be resolved
+			// before CanExecute is called when template is first applied.
+			var viewModel = new Maui31939ViewModel();
+			var page = new Maui31939(inflator);
+			page.BindingContext = viewModel;
+
+			Assert.False(viewModel.CanExecuteCalledWithNullParameter, 
+				"CanExecute was called with null parameter during template binding application");
+
+			var button = (Button)page.TestControl.GetTemplateChild("TestButton");
+			Assert.NotNull(button);
+			Assert.Equal("TestValue", button.CommandParameter);
+			Assert.NotNull(button.Command);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void CommandParameterTemplateBindingWorksAfterReparenting(XamlInflator inflator)
+		{
+			// Regression test: when elements are reparented within a ControlTemplate, bindings
+			// are re-applied. Due to the async void ApplyRelativeSourceBinding path, Command may
+			// be applied before CommandParameter, causing CanExecute(null) to be called.
+			var viewModel = new Maui31939ViewModel();
+			var page = new Maui31939(inflator);
+			page.BindingContext = viewModel;
+
+			var grid = (Grid)page.TestControl.GetTemplateChild("MainLayout");
+			var button = (Button)page.TestControl.GetTemplateChild("TestButton");
+
+			Assert.NotNull(button);
+			Assert.Equal("TestValue", button.CommandParameter);
+
+			// Simulate reparenting operation (like the issue describes)
+			viewModel.ResetCanExecuteTracking();
+			grid.Children.Clear();
+			grid.Children.Add(button);
+
+			// After reparenting, CommandParameter should still be bound correctly
+			// and CanExecute should not have been called with null
+			Assert.False(viewModel.CanExecuteCalledWithNullParameter,
+				"CanExecute was called with null parameter after reparenting");
+			Assert.Equal("TestValue", button.CommandParameter);
+		}
+	}
+}
+
+/// <summary>
+/// Custom control with Command and CommandParameter bindable properties
+/// for testing TemplateBinding scenarios.
+/// </summary>
+public class Maui31939Control : ContentView
+{
+	public static readonly BindableProperty TestCommandProperty =
+		BindableProperty.Create(nameof(TestCommand), typeof(ICommand), typeof(Maui31939Control), null);
+
+	public static readonly BindableProperty TestCommandParameterProperty =
+		BindableProperty.Create(nameof(TestCommandParameter), typeof(object), typeof(Maui31939Control), null);
+
+	public ICommand TestCommand
+	{
+		get => (ICommand)GetValue(TestCommandProperty);
+		set => SetValue(TestCommandProperty, value);
+	}
+
+	public object TestCommandParameter
+	{
+		get => GetValue(TestCommandParameterProperty);
+		set => SetValue(TestCommandParameterProperty, value);
+	}
+}
+
+/// <summary>
+/// ViewModel with a Command that tracks whether CanExecute was called with null parameter.
+/// This simulates the real-world scenario where apps have commands that expect non-null parameters.
+/// </summary>
+public class Maui31939ViewModel
+{
+	public bool CanExecuteCalledWithNullParameter { get; private set; }
+	private bool _isEnabled = true;
+
+	public Maui31939ViewModel()
+	{
+		TestCommand = new Maui31939Command(
+			execute: parameter => { /* Do nothing */ },
+			canExecute: parameter =>
+			{
+				if (parameter is null)
+				{
+					CanExecuteCalledWithNullParameter = true;
+				}
+				return _isEnabled;
+			});
+	}
+
+	public ICommand TestCommand { get; }
+
+	public void ResetCanExecuteTracking()
+	{
+		CanExecuteCalledWithNullParameter = false;
+	}
+}
+
+/// <summary>
+/// Custom command implementation that allows tracking CanExecute calls.
+/// </summary>
+public class Maui31939Command : ICommand
+{
+	private readonly Action<object> _execute;
+	private readonly Func<object, bool> _canExecute;
+
+	public event EventHandler CanExecuteChanged;
+
+	public Maui31939Command(Action<object> execute, Func<object, bool> canExecute = null)
+	{
+		_execute = execute ?? throw new ArgumentNullException(nameof(execute));
+		_canExecute = canExecute;
+	}
+
+	public bool CanExecute(object parameter) => _canExecute?.Invoke(parameter) ?? true;
+
+	public void Execute(object parameter) => _execute(parameter);
+
+	public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}


### PR DESCRIPTION
### What
Prevents a re-entrant/feedback-loop scenario during CanExecute evaluation where forcing dependency bindings to apply (e.g., CommandParameter) can recursively trigger further CanExecute refreshes and lead to hangs.

### Why
GetCanExecute currently forces binding application for dependent properties on every evaluation. In scenarios involving frequent command refresh (e.g., MultiBinding-driven CommandParameter updates), this can cause repeated binding reapplication and re-entrant CanExecute calls.

### How
Only force dependency binding application when it appears pending:
- dependency is bound
- dependency value is currently null

This keeps the original dependency ordering intent while avoiding unnecessary re-application.

### Tests
- dotnet test ./src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
- dotnet test ./src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj --blame-hang --blame-hang-timeout 10s --filter FullyQualifiedName~Maui18123