### PR TITLE
[Android] Fix WebView scrolling inside ScrollView

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32971.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32971.cs
@@ -8,7 +8,8 @@ public class Issue32971 : ContentPage
         var webView = new WebView
         {
             Source = "https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/",
-            HeightRequest = 1000,
+            HeightRequest = 600,
+            VerticalOptions = LayoutOptions.Start,
         };
 
         var scrollView = new ScrollView

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32971.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32971.cs
@@ -5,17 +5,66 @@ public class Issue32971 : ContentPage
 {
     public Issue32971()
     {
-        var webView = new WebView
+        Label _scrollStateLabel = new Label
         {
-            Source = "https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/",
+            Text = "NotScrolled",
+            AutomationId = "ScrollStateLabel",
+            FontSize = 20,
+            HorizontalTextAlignment = TextAlignment.Center,
+        };
+
+        WebView _webView = new WebView
+        {
+            AutomationId = "TestWebView",
             HeightRequest = 600,
             VerticalOptions = LayoutOptions.Start,
+        };
+
+        _webView.Source = new HtmlWebViewSource
+        {
+            Html = @"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+                <style>
+                    body { font-family: Arial; padding: 20px; margin: 0; }
+                    .section { border: 2px solid #0066cc; padding: 20px; margin: 10px 0; background: #f0f8ff; min-height: 300px; }
+                </style>
+            </head>
+            <body>
+                <h1>WebView Scrolling Test</h1>
+                <div class='section'><h2>Section 1</h2><p>Scroll down to test...</p></div>
+                <div class='section'><h2>Section 2</h2><p>Keep scrolling...</p></div>
+                <div class='section'><h2>Section 3</h2><p>More content...</p></div>
+                <div class='section'><h2>Section 4</h2><p>Almost there...</p></div>
+                <div class='section'><h2>Section 5</h2><p>Bottom reached!</p></div>
+            </body>
+            </html>"
+        };
+
+        var checkButton = new Button
+        {
+            Text = "Check Scroll State",
+            AutomationId = "CheckButton",
+        };
+
+        checkButton.Clicked += async (s, e) =>
+        {
+            var result = await _webView.EvaluateJavaScriptAsync("Math.round(window.pageYOffset);");
+            if (int.TryParse(result, out int scrollPos) && scrollPos > 50)
+            {
+                _scrollStateLabel.Text = "Scrolled";
+            }
         };
 
         var scrollView = new ScrollView
         {
             AutomationId = "TestScrollView",
-            Content = webView,
+            Content = new VerticalStackLayout
+            {
+                Children = { _scrollStateLabel, checkButton, _webView }
+            }
         };
 
         Content = scrollView;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32971.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32971.cs
@@ -1,0 +1,22 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32971, "WebView content does not scroll when placed inside a ScrollView", PlatformAffected.Android)]
+public class Issue32971 : ContentPage
+{
+    public Issue32971()
+    {
+        var webView = new WebView
+        {
+            Source = "https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/",
+            HeightRequest = 1000,
+        };
+
+        var scrollView = new ScrollView
+        {
+            AutomationId = "TestScrollView",
+            Content = webView,
+        };
+
+        Content = scrollView;
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32971.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32971.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32971 : _IssuesUITest
+{
+	public override string Issue => "WebView content does not scroll when placed inside a ScrollView";
+
+	public Issue32971(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void WebViewShouldScrollInsideScrollView()
+	{
+		VerifyInternetConnectivity();
+		App.WaitForElement("TestScrollView");
+
+		// The test passes if we can scroll the WebView content inside a ScrollView.
+		App.ScrollDown("TestScrollView");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32971.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32971.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using UITest.Appium;
 using UITest.Core;
 
@@ -17,10 +16,10 @@ public class Issue32971 : _IssuesUITest
 	[Category(UITestCategories.WebView)]
 	public void WebViewShouldScrollInsideScrollView()
 	{
-		VerifyInternetConnectivity();
 		App.WaitForElement("TestScrollView");
-
-		// The test passes if we can scroll the WebView content inside a ScrollView.
 		App.ScrollDown("TestScrollView");
+		App.Tap("CheckButton");
+		var scrollStateLabel = App.FindElement("ScrollStateLabel").GetText();
+		Assert.That(scrollStateLabel, Is.EqualTo("Scrolled"));
 	}
 }

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Android.Content;
 using Android.Graphics;
+using Android.Views;
 using Android.Webkit;
 
 namespace Microsoft.Maui.Platform

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Platform
 		public override bool OnTouchEvent(MotionEvent? e)
 		{
 			if (e == null)
-				return base.OnTouchEvent(e);
+				return false;
 
 			switch (e.Action)
 			{

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -42,6 +42,30 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public override bool OnTouchEvent(MotionEvent? e)
+		{
+			if (e == null)
+				return base.OnTouchEvent(e);
+
+			switch (e.Action)
+			{
+				case MotionEventActions.Down:
+					Parent?.RequestDisallowInterceptTouchEvent(true);
+					break;
+
+				case MotionEventActions.Move:
+					Parent?.RequestDisallowInterceptTouchEvent(true);
+					break;
+
+				case MotionEventActions.Up:
+				case MotionEventActions.Cancel:
+					Parent?.RequestDisallowInterceptTouchEvent(false);
+					break;
+			}
+
+			return base.OnTouchEvent(e);
+		}
+
 		void IWebViewDelegate.LoadHtml(string? html, string? baseUrl)
 		{
 			_handler?.CurrentNavigationEvent = WebNavigationEvent.NewPage;

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -51,9 +51,6 @@ namespace Microsoft.Maui.Platform
 			switch (e.Action)
 			{
 				case MotionEventActions.Down:
-					Parent?.RequestDisallowInterceptTouchEvent(true);
-					break;
-
 				case MotionEventActions.Move:
 					Parent?.RequestDisallowInterceptTouchEvent(true);
 					break;

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -14,3 +14,4 @@ override Microsoft.Maui.Platform.LayoutViewGroup.HasOverlappingRendering.get -> 
 override Microsoft.Maui.Platform.WrapperView.HasOverlappingRendering.get -> bool
 override Microsoft.Maui.Platform.MauiHybridWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
 override Microsoft.Maui.Platform.MauiWebView.OnSizeChanged(int width, int height, int oldWidth, int oldHeight) -> void
+override Microsoft.Maui.Platform.MauiWebView.OnTouchEvent(Android.Views.MotionEvent? e) -> bool


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
WebView does not scroll when placed inside a ScrollView. The parent ScrollView intercepts vertical touch gestures, preventing the WebView from scrolling its internal content.

### Root Cause
The parent ScrollView was intercepting all touch events without checking if the child WebView needed to scroll. This prevented the WebView from receiving touch events and handling its own scrolling.

### Description of Change
Added touch event handling to prevent parent interception when WebView scrolls. When touch begins or continues, WebView requests exclusive control from parent. When touch ends or cancels, control returns to parent. This enables WebView scrolling while preserving normal parent-child interaction.
 
Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #32971  

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/12b3ca6e-582d-4a50-9ea1-f49027f2d907" >| <video src="https://github.com/user-attachments/assets/2fbfd03c-4432-49e9-8b2d-6e7643f57487">|