### PR TITLE
Fix Picker layout on Mac Catalyst 26+

### DIFF
--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -2,7 +2,6 @@
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using UIKit;
-using RectangleF = CoreGraphics.CGRect;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -50,8 +49,7 @@ namespace Microsoft.Maui.Handlers
 				paddingTitle += 25;
 
 			var pickerHeight = 240;
-			var frame = new RectangleF(0, paddingTitle, 269, pickerHeight);
-			var pickerView = new UIPickerView(frame);
+			var pickerView = new UIPickerView();
 			pickerView.Model = new PickerSource(this);
 			pickerView?.ReloadAllComponents();
 

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -83,6 +83,17 @@ namespace Microsoft.Maui.Handlers
 			if (_pickerController.View != null && pickerView != null)
 			{
 				_pickerController.View.AddSubview(pickerView);
+				
+				var container = _pickerController.View;
+				pickerView.TranslatesAutoresizingMaskIntoConstraints = false;
+				NSLayoutConstraint.ActivateConstraints(
+				[
+					pickerView.CenterXAnchor.ConstraintEqualTo(container.CenterXAnchor),
+					pickerView.WidthAnchor.ConstraintEqualTo(container.WidthAnchor),
+					pickerView.TopAnchor.ConstraintEqualTo(container.TopAnchor, paddingTitle),
+					pickerView.HeightAnchor.ConstraintEqualTo(pickerHeight),
+				]);
+
 				var doneButtonHeight = 90;
 				var height = NSLayoutConstraint.Create(_pickerController.View, NSLayoutAttribute.Height, NSLayoutRelation.Equal, null, NSLayoutAttribute.NoAttribute, 1, pickerHeight + doneButtonHeight);
 				_pickerController.View.AddConstraint(height);


### PR DESCRIPTION
On Mac Catalyst 26+, the Picker view was incorrectly positioned, appearing visually shifted within the picker controller.
This PR centers UIPickerView using NSLayoutConstraint when added to the pickerController’s view. This ensures correct alignment, predictable sizing, and consistent layout behavior across Mac Catalyst versions.

Fixes https://github.com/dotnet/maui/issues/33229

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/d55949ec-3f78-4836-a18c-778e240f2a1f" width="300px"/>|<img src="https://github.com/user-attachments/assets/7fb709ba-b1cd-490e-b093-7dd79f48ea08" width="300px"/>|
