### PR TITLE
Add AI-Assisted Development sections to contribution documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,6 +29,10 @@ Follow the style used by the [.NET Foundation](https://github.com/dotnet/runtime
 
 Read and follow our [Pull Request template](/.github/PULL_REQUEST_TEMPLATE.md).
 
+### AI-Assisted Development
+
+We have custom AI agents to help you work on issues more efficiently. See [Using AI to Work on .NET MAUI](https://github.com/dotnet/maui/wiki/Using-AI-to-Work-on-.NET-MAUI) for details.
+
 ### Pull Request Requirements
 
 Please refer to our [Pull Request template](/.github/PULL_REQUEST_TEMPLATE.md).

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -14,7 +14,11 @@ This page contains steps to build and run the .NET MAUI repository from source. 
    ### Mac
    - Install [VSCode](https://code.visualstudio.com/download)
    - Follow the steps for installing the .NET MAUI Dev Kit for VS Code: https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui
-      
+
+## AI-Assisted Development
+
+We have custom AI agents to help you work on issues more efficiently. See [Using AI to Work on .NET MAUI](https://github.com/dotnet/maui/wiki/Using-AI-to-Work-on-.NET-MAUI) for details.
+
 ## Building the Build Tasks
 Before opening the solution in Visual Studio / VS Code you **MUST** build the build tasks.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,8 @@
 <!--
 !!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
+
+💡 TIP: Try our custom agents or just Copilot to help with your contribution!
+https://github.com/dotnet/maui/wiki/Using-AI-to-Work-on-.NET-MAUI
 -->
 
 ### Description of Change


### PR DESCRIPTION
Adds visibility for custom AI agents in contributor documentation to improve discoverability of AI-assisted workflows.

### Changes
- Added "AI-Assisted Development" section to `.github/CONTRIBUTING.md` linking to wiki guide
- Added "AI-Assisted Development" section to `.github/DEVELOPMENT.md` linking to wiki guide

Both sections direct contributors to the [Using AI to Work on .NET MAUI](https://github.com/dotnet/maui/wiki/Using-AI-to-Work-on-.NET-MAUI) wiki page for details on leveraging custom agents when working on issues.

Related to #33148