### PR TITLE
[iOS, macOS] Fixed CollectionView group header size changes with ItemSizingStrategy

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/GroupableItemsViewController2.cs
@@ -127,6 +127,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			var bindingContext = ItemsSource.Group(indexPath);
 
+			// Mark this templated cell as a supplementary view (header/footer)
+			cell.isSupplementaryView = true;
 			cell.isHeaderOrFooterChanged = true;
 			cell.Bind(template, bindingContext, ItemsView);
 			cell.isHeaderOrFooterChanged = false;

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			{
 				TemplatedCell2.ScrollDirection = ScrollDirection;
 
+				// Ensure this cell is treated as a regular item cell (not a supplementary view)
+				TemplatedCell2.isSupplementaryView = false;
 				TemplatedCell2.Bind(ItemsView.ItemTemplate, ItemsSource[indexpathAdjusted], ItemsView);
 			}
 			else if (cell is DefaultCell2 DefaultCell2)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			bool isHeader = elementKind == UICollectionElementKindSectionKey.Header;
 			cell.isHeaderOrFooterChanged = true;
+			cell.isSupplementaryView = true;
 
 			if (isHeader)
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -110,8 +110,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				if (_measureInvalidated || _cachedConstraints != constraints)
 				{
 					// Only use the cached first-item measurement for actual item cells (not headers/footers)
-					// Supplementary views (headers/footers) set the flag `isHeaderOrFooterChanged` during Bind
-					// so we can detect them here and avoid using the item cache for their measurement.
 					if (!isSupplementaryView)
 					{
 						var cachedSize = GetCachedFirstItemSizeFromHandler();

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		Size _measuredSize;
 		Size _cachedConstraints;
 
+		// Indicates the cell is being used as a supplementary view (group header/footer)
+		internal bool isSupplementaryView = false;
 		internal bool MeasureInvalidated => _measureInvalidated;
 
 		// Flags changes confined to the header/footer, preventing unnecessary recycling and revalidation of templated cells.
@@ -110,7 +112,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					// Only use the cached first-item measurement for actual item cells (not headers/footers)
 					// Supplementary views (headers/footers) set the flag `isHeaderOrFooterChanged` during Bind
 					// so we can detect them here and avoid using the item cache for their measurement.
-					if (isHeaderOrFooterChanged)
+					if (!isSupplementaryView)
 					{
 						var cachedSize = GetCachedFirstItemSizeFromHandler();
 						if (cachedSize != CGSize.Empty)
@@ -204,6 +206,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		public override void PrepareForReuse()
 		{
 			//Unbind();
+			isSupplementaryView = false;
 			base.PrepareForReuse();
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml
@@ -2,7 +2,6 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Maui.Controls.Sample.Issues.Issue33130"
-             xmlns:local="clr-namespace:Maui.Controls.Sample"
              Title="Issue33130">
     <Grid Margin="20"
           RowDefinitions="Auto, *">
@@ -17,13 +16,20 @@
                    Text="ItemSizingStrategy: MeasureAllItems"/>
         </StackLayout>
 
-        <local:CollectionView2 Grid.Row="1"
-                               x:Name="TestCollectionView"
-                               ItemsSource="{Binding Animals}"
-                               IsGrouped="true"
-                               AutomationId="TestCollectionView"
-                               ItemSizingStrategy="MeasureAllItems">
-            <local:CollectionView2.ItemTemplate>
+        <CollectionView Grid.Row="1"
+                        x:Name="TestCollectionView"
+                        ItemsSource="{Binding Animals}"
+                        IsGrouped="true"
+                        AutomationId="TestCollectionView"
+                        ItemSizingStrategy="MeasureAllItems">
+            <CollectionView.Header>
+                <Label Text="Animals Collection"
+                       FontSize="24"
+                       AutomationId="CollectionViewHeader"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"/>
+            </CollectionView.Header>
+            <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
                         <Grid.RowDefinitions>
@@ -49,8 +55,8 @@
                                VerticalOptions="End"/>
                     </Grid>
                 </DataTemplate>
-            </local:CollectionView2.ItemTemplate>
-            <local:CollectionView2.GroupHeaderTemplate>
+            </CollectionView.ItemTemplate>
+            <CollectionView.GroupHeaderTemplate>
                 <DataTemplate>
                     <Label x:Name="GroupHeaderLabel"
                            Text="{Binding Name}"
@@ -59,13 +65,13 @@
                            FontAttributes="Bold"
                            AutomationId="GroupHeader"/>
                 </DataTemplate>
-            </local:CollectionView2.GroupHeaderTemplate>
-            <local:CollectionView2.GroupFooterTemplate>
+            </CollectionView.GroupHeaderTemplate>
+            <CollectionView.GroupFooterTemplate>
                 <DataTemplate>
                     <Label Text="{Binding Count, StringFormat='Total animals: {0:D}'}"
                            Margin="0,0,0,10"/>
                 </DataTemplate>
-            </local:CollectionView2.GroupFooterTemplate>
-        </local:CollectionView2>
+            </CollectionView.GroupFooterTemplate>
+        </CollectionView>
     </Grid>
 </ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue33130"
+             xmlns:local="clr-namespace:Maui.Controls.Sample"
+             Title="Issue33130">
+    <Grid Margin="20"
+          RowDefinitions="Auto, *">
+        <StackLayout Grid.Row="0"
+                     Spacing="10"
+                     Margin="0,10">
+            <Button Text="Switch to MeasureFirstItem"
+                    Clicked="OnSwitchToMeasureFirstItem"
+                    AutomationId="SwitchStrategyButton"/>
+            <Label x:Name="StatusLabel"
+                   AutomationId="StatusLabel"
+                   Text="ItemSizingStrategy: MeasureAllItems"/>
+        </StackLayout>
+
+        <local:CollectionView2 Grid.Row="1"
+                               x:Name="TestCollectionView"
+                               ItemsSource="{Binding Animals}"
+                               IsGrouped="true"
+                               AutomationId="TestCollectionView"
+                               ItemSizingStrategy="MeasureAllItems">
+            <local:CollectionView2.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Image Grid.RowSpan="2"
+                               Source="{Binding ImageUrl}"
+                               Aspect="AspectFill"
+                               WidthRequest="80"
+                               HeightRequest="80"/>
+                        <Label Grid.Column="1"
+                               Text="{Binding Name}"
+                               FontAttributes="Bold"/>
+                        <Label Grid.Row="1"
+                               Grid.Column="1"
+                               Text="{Binding Location}"
+                               FontAttributes="Italic"
+                               VerticalOptions="End"/>
+                    </Grid>
+                </DataTemplate>
+            </local:CollectionView2.ItemTemplate>
+            <local:CollectionView2.GroupHeaderTemplate>
+                <DataTemplate>
+                    <Label x:Name="GroupHeaderLabel"
+                           Text="{Binding Name}"
+                           BackgroundColor="LightGray"
+                           FontSize="20"
+                           FontAttributes="Bold"
+                           AutomationId="GroupHeader"/>
+                </DataTemplate>
+            </local:CollectionView2.GroupHeaderTemplate>
+            <local:CollectionView2.GroupFooterTemplate>
+                <DataTemplate>
+                    <Label Text="{Binding Count, StringFormat='Total animals: {0:D}'}"
+                           Margin="0,0,0,10"/>
+                </DataTemplate>
+            </local:CollectionView2.GroupFooterTemplate>
+        </local:CollectionView2>
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml.cs
@@ -10,7 +10,7 @@ public partial class Issue33130 : ContentPage
 	public Issue33130()
 	{
 		InitializeComponent();
-		BindingContext = new GroupedAnimalsViewModel();
+		BindingContext = new Issue33130ViewModel();
 	}
 
 	private void OnSwitchToMeasureFirstItem(object sender, EventArgs e)
@@ -20,45 +20,45 @@ public partial class Issue33130 : ContentPage
 	}
 }
 
-public class GroupedAnimalsViewModel
+public class Issue33130ViewModel
 {
-	public ObservableCollection<GroupHeaderTestAnimalGroup> Animals { get; set; }
+	public ObservableCollection<Issue33130AnimalGroup> Animals { get; set; }
 
-	public GroupedAnimalsViewModel()
+	public Issue33130ViewModel()
 	{
-		Animals = new ObservableCollection<GroupHeaderTestAnimalGroup>
+		Animals = new ObservableCollection<Issue33130AnimalGroup>
 		{
-			new GroupHeaderTestAnimalGroup("Bears")
+			new Issue33130AnimalGroup("Bears")
 			{
-				new GroupHeaderTestAnimal { Name = "Grizzly Bear", Location = "North America", ImageUrl = "bear.jpg" },
-				new GroupHeaderTestAnimal { Name = "Polar Bear", Location = "Arctic", ImageUrl = "bear.jpg" },
+				new Issue33130Animal { Name = "Grizzly Bear", Location = "North America", ImageUrl = "bear.jpg" },
+				new Issue33130Animal { Name = "Polar Bear", Location = "Arctic", ImageUrl = "bear.jpg" },
 			},
-			new GroupHeaderTestAnimalGroup("Monkeys")
+			new Issue33130AnimalGroup("Monkeys")
 			{
-				new GroupHeaderTestAnimal { Name = "Baboon", Location = "Africa", ImageUrl = "monkey.jpg" },
-				new GroupHeaderTestAnimal { Name = "Capuchin Monkey", Location = "South America", ImageUrl = "monkey.jpg" },
-				new GroupHeaderTestAnimal { Name = "Spider Monkey", Location = "Central America", ImageUrl = "monkey.jpg" },
+				new Issue33130Animal { Name = "Baboon", Location = "Africa", ImageUrl = "monkey.jpg" },
+				new Issue33130Animal { Name = "Capuchin Monkey", Location = "South America", ImageUrl = "monkey.jpg" },
+				new Issue33130Animal { Name = "Spider Monkey", Location = "Central America", ImageUrl = "monkey.jpg" },
 			},
-			new GroupHeaderTestAnimalGroup("Elephants")
+			new Issue33130AnimalGroup("Elephants")
 			{
-				new GroupHeaderTestAnimal { Name = "African Elephant", Location = "Africa", ImageUrl = "elephant.jpg" },
-				new GroupHeaderTestAnimal { Name = "Asian Elephant", Location = "Asia", ImageUrl = "elephant.jpg" },
+				new Issue33130Animal { Name = "African Elephant", Location = "Africa", ImageUrl = "elephant.jpg" },
+				new Issue33130Animal { Name = "Asian Elephant", Location = "Asia", ImageUrl = "elephant.jpg" },
 			}
 		};
 	}
 }
 
-public class GroupHeaderTestAnimalGroup : ObservableCollection<GroupHeaderTestAnimal>
+public class Issue33130AnimalGroup : ObservableCollection<Issue33130Animal>
 {
 	public string Name { get; set; }
 
-	public GroupHeaderTestAnimalGroup(string name) : base()
+	public Issue33130AnimalGroup(string name) : base()
 	{
 		Name = name;
 	}
 }
 
-public class GroupHeaderTestAnimal
+public class Issue33130Animal
 {
 	public string Name { get; set; }
 	public string Location { get; set; }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33130.xaml.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33130, "CollectionView group header size changes with ItemSizingStrategy", PlatformAffected.iOS | PlatformAffected.macOS)]
+public partial class Issue33130 : ContentPage
+{
+	public Issue33130()
+	{
+		InitializeComponent();
+		BindingContext = new GroupedAnimalsViewModel();
+	}
+
+	private void OnSwitchToMeasureFirstItem(object sender, EventArgs e)
+	{
+		TestCollectionView.ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem;
+		StatusLabel.Text = $"ItemSizingStrategy: {TestCollectionView.ItemSizingStrategy}";
+	}
+}
+
+public class GroupedAnimalsViewModel
+{
+	public ObservableCollection<GroupHeaderTestAnimalGroup> Animals { get; set; }
+
+	public GroupedAnimalsViewModel()
+	{
+		Animals = new ObservableCollection<GroupHeaderTestAnimalGroup>
+		{
+			new GroupHeaderTestAnimalGroup("Bears")
+			{
+				new GroupHeaderTestAnimal { Name = "Grizzly Bear", Location = "North America", ImageUrl = "bear.jpg" },
+				new GroupHeaderTestAnimal { Name = "Polar Bear", Location = "Arctic", ImageUrl = "bear.jpg" },
+			},
+			new GroupHeaderTestAnimalGroup("Monkeys")
+			{
+				new GroupHeaderTestAnimal { Name = "Baboon", Location = "Africa", ImageUrl = "monkey.jpg" },
+				new GroupHeaderTestAnimal { Name = "Capuchin Monkey", Location = "South America", ImageUrl = "monkey.jpg" },
+				new GroupHeaderTestAnimal { Name = "Spider Monkey", Location = "Central America", ImageUrl = "monkey.jpg" },
+			},
+			new GroupHeaderTestAnimalGroup("Elephants")
+			{
+				new GroupHeaderTestAnimal { Name = "African Elephant", Location = "Africa", ImageUrl = "elephant.jpg" },
+				new GroupHeaderTestAnimal { Name = "Asian Elephant", Location = "Asia", ImageUrl = "elephant.jpg" },
+			}
+		};
+	}
+}
+
+public class GroupHeaderTestAnimalGroup : ObservableCollection<GroupHeaderTestAnimal>
+{
+	public string Name { get; set; }
+
+	public GroupHeaderTestAnimalGroup(string name) : base()
+	{
+		Name = name;
+	}
+}
+
+public class GroupHeaderTestAnimal
+{
+	public string Name { get; set; }
+	public string Location { get; set; }
+	public string ImageUrl { get; set; }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33130.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33130.cs
@@ -16,12 +16,17 @@ public class Issue33130 : _IssuesUITest
 		// Wait for the CollectionView to load
 		App.WaitForElement("TestCollectionView");
 		App.WaitForElement("GroupHeader");
+		App.WaitForElement("CollectionViewHeader");
 
 		// Get the initial header size (before changing ItemSizingStrategy)
 		var headerElementBefore = App.FindElement("GroupHeader");
 		var headerRectBefore = headerElementBefore.GetRect();
 
+		var collectionViewHeaderBefore = App.FindElement("CollectionViewHeader");
+		var collectionViewHeaderRectBefore = collectionViewHeaderBefore.GetRect();
+
 		Assert.That(headerRectBefore.Height, Is.GreaterThan(0), "Header should have a height before strategy change");
+		Assert.That(collectionViewHeaderRectBefore.Height, Is.GreaterThan(0), "CollectionView header should have a height before strategy change");
 
 		// Switch ItemSizingStrategy
 		App.WaitForElement("SwitchStrategyButton");
@@ -30,15 +35,21 @@ public class Issue33130 : _IssuesUITest
 		// Get the header size after changing ItemSizingStrategy
 		var headerElementAfter = App.FindElement("GroupHeader");
 		var headerRectAfter = headerElementAfter.GetRect();
+		var collectionViewHeaderAfter = App.FindElement("CollectionViewHeader");
+		var collectionViewHeaderRectAfter = collectionViewHeaderAfter.GetRect();
 
 		Assert.That(headerRectAfter.Height, Is.GreaterThan(0), "Header should have a height after strategy change");
+		Assert.That(collectionViewHeaderRectAfter.Height, Is.GreaterThan(0), "CollectionView header should have a height after strategy change");
 
 		// The header size should remain the same (within a small tolerance for rendering differences)
 		// Allow for small rounding differences but not significant changes
-		var heightDifference = Math.Abs(headerRectBefore.Height - headerRectAfter.Height);
+		var groupHeaderHeightDifference = Math.Abs(headerRectBefore.Height - headerRectAfter.Height);
+		var collectionViewHeaderHeightDifference = Math.Abs(collectionViewHeaderRectBefore.Height - collectionViewHeaderRectAfter.Height);
 
 		// Assert that the height difference is minimal (less than 5 pixels tolerance)
-		Assert.That(heightDifference, Is.EqualTo(0),
-			$"Header height should not change significantly. Before: {headerRectBefore.Height}, After: {headerRectAfter.Height}, Difference: {heightDifference}");
+		Assert.That(groupHeaderHeightDifference, Is.LessThan(5),
+			$"Header height should not change significantly. Before: {headerRectBefore.Height}, After: {headerRectAfter.Height}, Difference: {groupHeaderHeightDifference}");
+
+		Assert.That(collectionViewHeaderHeightDifference, Is.LessThan(5), $"CollectionView header height should not change significantly. Before: {collectionViewHeaderRectBefore.Height}, After: {collectionViewHeaderRectAfter.Height}, Difference: {collectionViewHeaderHeightDifference}");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33130.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33130.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33130 : _IssuesUITest
+{
+	public override string Issue => "CollectionView group header size changes with ItemSizingStrategy";
+
+	public Issue33130(TestDevice device) : base(device) { }
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void GroupHeaderSizeShouldNotChangeWithItemSizingStrategy()
+	{
+		// Wait for the CollectionView to load
+		App.WaitForElement("TestCollectionView");
+		App.WaitForElement("GroupHeader");
+
+		// Get the initial header size (before changing ItemSizingStrategy)
+		var headerElementBefore = App.FindElement("GroupHeader");
+		var headerRectBefore = headerElementBefore.GetRect();
+
+		Assert.That(headerRectBefore.Height, Is.GreaterThan(0), "Header should have a height before strategy change");
+
+		// Switch ItemSizingStrategy
+		App.WaitForElement("SwitchStrategyButton");
+		App.Tap("SwitchStrategyButton");
+
+		// Get the header size after changing ItemSizingStrategy
+		var headerElementAfter = App.FindElement("GroupHeader");
+		var headerRectAfter = headerElementAfter.GetRect();
+
+		Assert.That(headerRectAfter.Height, Is.GreaterThan(0), "Header should have a height after strategy change");
+
+		// The header size should remain the same (within a small tolerance for rendering differences)
+		// Allow for small rounding differences but not significant changes
+		var heightDifference = Math.Abs(headerRectBefore.Height - headerRectAfter.Height);
+
+		// Assert that the height difference is minimal (less than 5 pixels tolerance)
+		Assert.That(heightDifference, Is.EqualTo(0),
+			$"Header height should not change significantly. Before: {headerRectBefore.Height}, After: {headerRectAfter.Height}, Difference: {heightDifference}");
+	}
+}


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root cause

- When the ItemSizingStrategy is set to measure the first item, the collection view’s grouped item header or footer template size is taken from the first item’s size instead of the actual size of the grouped item header or footer template.

### Description of changes

- I have ignored the first measured item’s size when applying it to the grouped header or footer template, the collection view header or footer view, and the collection view header or footer template in PreferredLayoutAttributesFittingAttributes of TemplatedCell2.

### Issues Fixed

Fixes #33130 

Validated the behaviour in the following platforms
- [x] Android
- [x] Windows ,
- [x]  iOS, 
- [x] MacOS

### Output
**iOS**

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/deb143a4-5df0-463d-915c-16254bad658c" >| <video src="https://github.com/user-attachments/assets/56ba82de-f6d9-4b05-8ea7-2a12031282eb">|

**macOS**
|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/094b3e91-8198-483f-8b87-f3f5777e48b4" >| <video src="https://github.com/user-attachments/assets/5937e5c3-feb5-4138-8c47-9f7a31095a16">|
