### PR TITLE
Add smart UI test category detection to skip irrelevant test jobs

### DIFF
--- a/.github/pr-review/pr-preflight.md
+++ b/.github/pr-review/pr-preflight.md
@@ -12,6 +12,7 @@
 4. **Classify files** — separate fix files from test files, identify test type (UI / Device / Unit)
 5. **Document edge cases** — from comments mentioning "what about...", "does this work with..."
 6. **Record PR's fix** in Fix Candidates table (pending validation)
+7. **Identify impacted UI test categories** — analyze which UI controls could be affected by this PR (see below)
 
 ```bash
 # Fetch PR metadata
@@ -35,13 +36,41 @@ gh pr view XXXXX --json comments --jq '.comments[] | select(.body | contains("Fi
 
 ---
 
-## Part B: Code Review (Step 7)
+## Step 7: Identify Impacted UI Test Categories
+
+After classifying files, determine which UI test categories could be affected by the PR changes. This enables targeted UI test runs instead of running the full matrix (~2h).
+
+**How to identify categories:**
+1. Look at the **controls modified** in the PR (e.g., changes to `Button` handler → `Button` category)
+2. Consider **indirect impacts** (e.g., a layout change could affect `Layout`, `CollectionView`, `ListView`)
+3. Check the **issue description** for mentions of specific controls
+4. Consider **platform-specific impacts** (e.g., iOS SafeArea changes → `SafeAreaEdges`)
+
+**Available categories** (from `UITestCategories.cs`):
+`Accessibility`, `ActionSheet`, `ActivityIndicator`, `Animation`, `Border`, `BoxView`, `Brush`, `Button`, `CarouselView`, `Cells`, `CheckBox`, `CollectionView`, `ContextActions`, `DatePicker`, `Dispatcher`, `DisplayAlert`, `DragAndDrop`, `Editor`, `Effects`, `Entry`, `Essentials`, `FlyoutPage`, `Focus`, `Fonts`, `Frame`, `Gestures`, `GraphicsView`, `Image`, `ImageButton`, `IndicatorView`, `InputTransparent`, `IsEnabled`, `IsVisible`, `Label`, `Layout`, `Lifecycle`, `ListView`, `ManualReview`, `Maps`, `Navigation`, `Page`, `Performance`, `Picker`, `ProgressBar`, `RadioButton`, `RefreshView`, `SafeAreaEdges`, `ScrollView`, `SearchBar`, `Shadow`, `Shape`, `Shell`, `Slider`, `SoftInput`, `Stepper`, `Switch`, `SwipeView`, `TabbedPage`, `TableView`, `TimePicker`, `TitleView`, `ToolbarItem`, `Triggers`, `ViewBaseTests`, `VisualStateManager`, `WebView`, `Window`
+
+**Output file:**
+```bash
+mkdir -p CustomAgentLogsTmp/PRState/{PRNumber}/PRAgent/uitests
+```
+
+Write `ai-categories.md`:
+```markdown
+Button — PR modifies ButtonHandler click event logic
+Layout — Changes to StackLayout could affect child arrangement
+```
+
+One category per line, followed by ` — ` and a brief justification. Write `NONE` if the PR has no UI impact (e.g., docs-only, build scripts, backend-only changes).
+
+---
+
+## Part B: Code Review (Step 8)
 
 > **Purpose:** Perform deep code analysis using the `code-review` skill to surface correctness issues, safety concerns, and MAUI convention violations BEFORE Try-Fix explores alternatives. These findings guide Try-Fix models toward higher-quality fixes.
 
-> **🚨 Independence-first requirement:** Step 7 MUST be invoked as a **separate sub-agent** (via the `task` tool with `agent_type: "general-purpose"`) so the code-review skill can form its assessment from the code BEFORE reading any PR narrative. The sub-agent receives ONLY the PR number — not the context gathered in Part A. This prevents anchoring bias.
+> **🚨 Independence-first requirement:** Step 8 MUST be invoked as a **separate sub-agent** (via the `task` tool with `agent_type: "general-purpose"`) so the code-review skill can form its assessment from the code BEFORE reading any PR narrative. The sub-agent receives ONLY the PR number — not the context gathered in Part A. This prevents anchoring bias.
 >
-> **Validation constraint:** The Step 7 prompt MUST NOT contain issue titles, root-cause descriptions, bug summaries, or any Part A content — only `PR #XXXXX`. If you find yourself adding context "to help" the sub-agent, you are violating independence-first.
+> **Validation constraint:** The Step 8 prompt MUST NOT contain issue titles, root-cause descriptions, bug summaries, or any Part A content — only `PR #XXXXX`. If you find yourself adding context "to help" the sub-agent, you are violating independence-first.
 
 7. **Invoke the code-review skill as a sub-agent:**
 
@@ -69,7 +98,7 @@ gh pr view XXXXX --json comments --jq '.comments[] | select(.body | contains("Fi
    5. Check CI status
    6. Blast radius, failure-mode probing, and verdict
 
-**If Step 7 fails, times out, or returns malformed output:**
+**If Step 8 fails, times out, or returns malformed output:**
 - Write `pre-flight/code-review.md` with: `## Code Review: SKIPPED\n\nReason: {failure description}`
 - Set verdict to `SKIPPED` in the Code Review Summary section of `content.md`
 - Omit `hints` from Try-Fix prompts (the `hints` field becomes optional when code review is unavailable)

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -50,6 +50,9 @@ param(
     [switch]$UseCurrentBranch,
 
     [Parameter(Mandatory = $false)]
+    [switch]$SkipUITests,
+
+    [Parameter(Mandatory = $false)]
     [switch]$DryRun,
 
     [Parameter(Mandatory = $false)]
@@ -438,6 +441,52 @@ function Invoke-CopilotStep {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
+#  STEP 0.5: TRIGGER UI Test Pipeline (non-blocking — runs in parallel)
+# ═════════════════════════════════════════════════════════════════════════════
+
+Write-Host ""
+Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+Write-Host "║  STEP 0.5: TRIGGER UI TESTS (non-blocking)                 ║" -ForegroundColor Cyan
+Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+
+$uitestResult = "SKIPPED"
+$uitestCategories = ""
+$uitestBuildId = ""
+
+if ($SkipUITests) {
+    Write-Host "  ⏭️ Skipped (SkipUITests flag)" -ForegroundColor Yellow
+} else {
+    $triggerScript = Join-Path $PSScriptRoot "trigger-uitest-pipeline.ps1"
+    if (Test-Path $triggerScript) {
+        try {
+            # SkipMonitor: queue the build but don't wait — gate + PR review run in parallel
+            $triggerArgs = @{ PRNumber = $PRNumber; SkipMonitor = $true }
+            if ($DryRun) { $triggerArgs['DryRun'] = $true }
+
+            $triggerOutput = & $triggerScript @triggerArgs 2>&1
+            $triggerOutput | ForEach-Object { Write-Host "  $_" }
+
+            foreach ($line in $triggerOutput) {
+                $lineStr = $line.ToString()
+                if ($lineStr -match '^UITEST_RESULT=(.+)$') { $uitestResult = $Matches[1] }
+                if ($lineStr -match '^UITEST_BUILD_ID=(.+)$') { $uitestBuildId = $Matches[1] }
+                if ($lineStr -match '^UITEST_CATEGORIES=(.+)$') { $uitestCategories = $Matches[1] }
+            }
+
+            if ($uitestBuildId) {
+                Write-Host "  🚀 UI tests running in background (build #$uitestBuildId)" -ForegroundColor Green
+                Write-Host "  ⏩ Continuing with gate + review while tests run..." -ForegroundColor Cyan
+            }
+        } catch {
+            Write-Host "  ⚠️ UI test trigger failed (non-fatal): $_" -ForegroundColor Yellow
+            $uitestResult = "ERROR"
+        }
+    } else {
+        Write-Host "  ⚠️ trigger-uitest-pipeline.ps1 not found — skipping" -ForegroundColor Yellow
+    }
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
 #  STEP 1: Gate - Test Before and After Fix (script, no copilot agent)
 # ═════════════════════════════════════════════════════════════════════════════
 
@@ -574,6 +623,69 @@ Invoke-CopilotStep -StepName "STEP 2: PR REVIEW" -Prompt $step2Prompt | Out-Null
 
 # Restore review branch — the Copilot agent may have switched branches (e.g. via gh pr checkout)
 git checkout $reviewBranch 2>$null | Out-Null
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  STEP 2.5: COLLECT UI Test Results (wait for build triggered in Step 0.5)
+# ═════════════════════════════════════════════════════════════════════════════
+
+if ($uitestBuildId -and $uitestResult -eq 'QUEUED' -and -not $SkipUITests -and -not $DryRun) {
+    Write-Host ""
+    Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "║  STEP 2.5: COLLECT UI TEST RESULTS                        ║" -ForegroundColor Cyan
+    Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+
+    $AzdoOrg = "dnceng-public"
+    $AzdoProject = "public"
+    $PollInterval = 300  # 5 minutes
+    $Timeout = 10800     # 3 hours
+    $startWait = Get-Date
+
+    Write-Host "  ⏳ Checking UI test build #$uitestBuildId..." -ForegroundColor Cyan
+
+    while ($true) {
+        $elapsed = (Get-Date) - $startWait
+        if ($elapsed.TotalSeconds -gt $Timeout) {
+            Write-Host "  ⚠️ Timeout waiting for UI tests ($([math]::Round($elapsed.TotalMinutes))m)" -ForegroundColor Yellow
+            $uitestResult = "TIMEOUT"
+            break
+        }
+
+        try {
+            $buildStatus = Invoke-RestMethod -Uri "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/build/builds/${uitestBuildId}?api-version=7.1"
+            if ($buildStatus.status -eq 'completed') {
+                $uitestResult = $buildStatus.result
+                Write-Host "  ✅ UI tests completed: $uitestResult ($([math]::Round($elapsed.TotalMinutes, 1))m)" -ForegroundColor $(if ($uitestResult -eq 'succeeded') { 'Green' } else { 'Yellow' })
+                break
+            }
+            Write-Host "  ⏳ [$($elapsed.ToString('hh\:mm\:ss'))] Still running... (next check in 5m)" -ForegroundColor DarkGray
+        } catch {
+            Write-Host "  ⚠️ Poll error: $($_.Exception.Message)" -ForegroundColor DarkGray
+        }
+
+        Start-Sleep -Seconds $PollInterval
+    }
+
+    # Write UI test results to content.md for AI summary (no separate comment)
+    Write-Host "  📝 Generating UI test results for AI summary..." -ForegroundColor Cyan
+    $uitestOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests"
+    $uitestContentFile = Join-Path $uitestOutputDir "content.md"
+    $commentScript = Join-Path $PSScriptRoot "post-uitest-categories-comment.ps1"
+    if (Test-Path $commentScript) {
+        try {
+            & $commentScript -PRNumber $PRNumber -BuildId $uitestBuildId -OutputFile $uitestContentFile 2>&1 | ForEach-Object { Write-Host "    $_" }
+        } catch {
+            Write-Host "  ⚠️ Failed to generate UI test content (non-fatal): $_" -ForegroundColor Yellow
+            # Write minimal fallback content
+            New-Item -ItemType Directory -Force -Path $uitestOutputDir | Out-Null
+            $resultIcon = switch ($uitestResult) { "succeeded" { "✅" } "failed" { "❌" } "TIMEOUT" { "⏱️" } default { "⚠️" } }
+            $buildUrl = "https://dev.azure.com/dnceng-public/public/_build/results?buildId=$uitestBuildId"
+            "**Build:** [#$uitestBuildId]($buildUrl) | $resultIcon $uitestResult`n**Categories:** ``$uitestCategories``" |
+                Set-Content $uitestContentFile -Encoding UTF8
+        }
+    }
+
+    Write-Host "  📊 UI Test final result: $uitestResult" -ForegroundColor $(if ($uitestResult -eq 'succeeded') { 'Green' } else { 'Yellow' })
+}
 
 # ═════════════════════════════════════════════════════════════════════════════
 #  STEP 3: Post AI Summary Comment (direct script invocation)

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -50,9 +50,6 @@ param(
     [switch]$UseCurrentBranch,
 
     [Parameter(Mandatory = $false)]
-    [switch]$SkipUITests,
-
-    [Parameter(Mandatory = $false)]
     [switch]$DryRun,
 
     [Parameter(Mandatory = $false)]
@@ -441,49 +438,48 @@ function Invoke-CopilotStep {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  STEP 0.5: TRIGGER UI Test Pipeline (non-blocking — runs in parallel)
+#  STEP 0.5: DETECT UI Test Categories (detection only — no pipeline trigger)
 # ═════════════════════════════════════════════════════════════════════════════
 
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║  STEP 0.5: TRIGGER UI TESTS (non-blocking)                 ║" -ForegroundColor Cyan
+Write-Host "║  STEP 0.5: DETECT UI TEST CATEGORIES                       ║" -ForegroundColor Cyan
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
 
-$uitestResult = "SKIPPED"
 $uitestCategories = ""
-$uitestBuildId = ""
 
-if ($SkipUITests) {
-    Write-Host "  ⏭️ Skipped (SkipUITests flag)" -ForegroundColor Yellow
-} else {
-    $triggerScript = Join-Path $PSScriptRoot "trigger-uitest-pipeline.ps1"
-    if (Test-Path $triggerScript) {
-        try {
-            # SkipMonitor: queue the build but don't wait — gate + PR review run in parallel
-            $triggerArgs = @{ PRNumber = $PRNumber; SkipMonitor = $true }
-            if ($DryRun) { $triggerArgs['DryRun'] = $true }
+$detectScript = Join-Path $RepoRoot "eng/scripts/detect-ui-test-categories.ps1"
+if (Test-Path $detectScript) {
+    try {
+        $detectOutput = & pwsh -NoProfile -File $detectScript -PrNumber "$PRNumber" 2>&1
+        $detectOutput | ForEach-Object { Write-Host "  $_" }
 
-            $triggerOutput = & $triggerScript @triggerArgs 2>&1
-            $triggerOutput | ForEach-Object { Write-Host "  $_" }
-
-            foreach ($line in $triggerOutput) {
-                $lineStr = $line.ToString()
-                if ($lineStr -match '^UITEST_RESULT=(.+)$') { $uitestResult = $Matches[1] }
-                if ($lineStr -match '^UITEST_BUILD_ID=(.+)$') { $uitestBuildId = $Matches[1] }
-                if ($lineStr -match '^UITEST_CATEGORIES=(.+)$') { $uitestCategories = $Matches[1] }
+        foreach ($line in $detectOutput) {
+            $lineStr = $line.ToString()
+            if ($lineStr -match 'UITestCategoryList;isOutput=true\](.+)$') {
+                $uitestCategories = $Matches[1]
             }
-
-            if ($uitestBuildId) {
-                Write-Host "  🚀 UI tests running in background (build #$uitestBuildId)" -ForegroundColor Green
-                Write-Host "  ⏩ Continuing with gate + review while tests run..." -ForegroundColor Cyan
-            }
-        } catch {
-            Write-Host "  ⚠️ UI test trigger failed (non-fatal): $_" -ForegroundColor Yellow
-            $uitestResult = "ERROR"
         }
-    } else {
-        Write-Host "  ⚠️ trigger-uitest-pipeline.ps1 not found — skipping" -ForegroundColor Yellow
+
+        if ([string]::IsNullOrWhiteSpace($uitestCategories) -or $uitestCategories -eq 'NONE') {
+            Write-Host "  ℹ️ No UI test categories detected" -ForegroundColor DarkGray
+        } else {
+            Write-Host "  🎯 Detected categories: $uitestCategories" -ForegroundColor Green
+        }
+
+        # Write detection result for AI summary
+        $uitestOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests"
+        New-Item -ItemType Directory -Force -Path $uitestOutputDir | Out-Null
+        if ([string]::IsNullOrWhiteSpace($uitestCategories) -or $uitestCategories -eq 'NONE') {
+            "No UI test categories detected for this PR." | Set-Content (Join-Path $uitestOutputDir "content.md") -Encoding UTF8
+        } else {
+            "**Detected UI test categories:** ``$uitestCategories``" | Set-Content (Join-Path $uitestOutputDir "content.md") -Encoding UTF8
+        }
+    } catch {
+        Write-Host "  ⚠️ Category detection failed (non-fatal): $_" -ForegroundColor Yellow
     }
+} else {
+    Write-Host "  ⚠️ detect-ui-test-categories.ps1 not found" -ForegroundColor Yellow
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -654,69 +650,6 @@ Invoke-CopilotStep -StepName "STEP 2: PR REVIEW" -Prompt $step2Prompt | Out-Null
 
 # Restore review branch — the Copilot agent may have switched branches (e.g. via gh pr checkout)
 git checkout $reviewBranch 2>$null | Out-Null
-
-# ═════════════════════════════════════════════════════════════════════════════
-#  STEP 2.5: COLLECT UI Test Results (wait for build triggered in Step 0.5)
-# ═════════════════════════════════════════════════════════════════════════════
-
-if ($uitestBuildId -and $uitestResult -eq 'QUEUED' -and -not $SkipUITests -and -not $DryRun) {
-    Write-Host ""
-    Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-    Write-Host "║  STEP 2.5: COLLECT UI TEST RESULTS                        ║" -ForegroundColor Cyan
-    Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
-
-    $AzdoOrg = "dnceng-public"
-    $AzdoProject = "public"
-    $PollInterval = 300  # 5 minutes
-    $Timeout = 10800     # 3 hours
-    $startWait = Get-Date
-
-    Write-Host "  ⏳ Checking UI test build #$uitestBuildId..." -ForegroundColor Cyan
-
-    while ($true) {
-        $elapsed = (Get-Date) - $startWait
-        if ($elapsed.TotalSeconds -gt $Timeout) {
-            Write-Host "  ⚠️ Timeout waiting for UI tests ($([math]::Round($elapsed.TotalMinutes))m)" -ForegroundColor Yellow
-            $uitestResult = "TIMEOUT"
-            break
-        }
-
-        try {
-            $buildStatus = Invoke-RestMethod -Uri "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/build/builds/${uitestBuildId}?api-version=7.1"
-            if ($buildStatus.status -eq 'completed') {
-                $uitestResult = $buildStatus.result
-                Write-Host "  ✅ UI tests completed: $uitestResult ($([math]::Round($elapsed.TotalMinutes, 1))m)" -ForegroundColor $(if ($uitestResult -eq 'succeeded') { 'Green' } else { 'Yellow' })
-                break
-            }
-            Write-Host "  ⏳ [$($elapsed.ToString('hh\:mm\:ss'))] Still running... (next check in 5m)" -ForegroundColor DarkGray
-        } catch {
-            Write-Host "  ⚠️ Poll error: $($_.Exception.Message)" -ForegroundColor DarkGray
-        }
-
-        Start-Sleep -Seconds $PollInterval
-    }
-
-    # Write UI test results to content.md for AI summary (no separate comment)
-    Write-Host "  📝 Generating UI test results for AI summary..." -ForegroundColor Cyan
-    $uitestOutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests"
-    $uitestContentFile = Join-Path $uitestOutputDir "content.md"
-    $commentScript = Join-Path $PSScriptRoot "post-uitest-categories-comment.ps1"
-    if (Test-Path $commentScript) {
-        try {
-            & $commentScript -PRNumber $PRNumber -BuildId $uitestBuildId -OutputFile $uitestContentFile 2>&1 | ForEach-Object { Write-Host "    $_" }
-        } catch {
-            Write-Host "  ⚠️ Failed to generate UI test content (non-fatal): $_" -ForegroundColor Yellow
-            # Write minimal fallback content
-            New-Item -ItemType Directory -Force -Path $uitestOutputDir | Out-Null
-            $resultIcon = switch ($uitestResult) { "succeeded" { "✅" } "failed" { "❌" } "TIMEOUT" { "⏱️" } default { "⚠️" } }
-            $buildUrl = "https://dev.azure.com/dnceng-public/public/_build/results?buildId=$uitestBuildId"
-            "**Build:** [#$uitestBuildId]($buildUrl) | $resultIcon $uitestResult`n**Categories:** ``$uitestCategories``" |
-                Set-Content $uitestContentFile -Encoding UTF8
-        }
-    }
-
-    Write-Host "  📊 UI Test final result: $uitestResult" -ForegroundColor $(if ($uitestResult -eq 'succeeded') { 'Green' } else { 'Yellow' })
-}
 
 # ═════════════════════════════════════════════════════════════════════════════
 #  STEP 3: Post AI Summary Comment (direct script invocation)

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -548,30 +548,38 @@ $gateResult = switch ($gateExitCode) {
 $gateColor = switch ($gateResult) { "PASSED" { "Green" } "SKIPPED" { "Yellow" } default { "Red" } }
 Write-Host "  📁 Gate result: $gateResult" -ForegroundColor $gateColor
 
-# Copy the verification report to gate/content.md if it exists
+# Copy the verification report to gate/content.md (always overwrite — the report is the source of truth)
 $verificationReport = Join-Path $gateOutputDir "verify-tests-fail/verification-report.md"
 if (Test-Path $verificationReport) {
-    Copy-Item $verificationReport (Join-Path $gateOutputDir "content.md") -Force
+    $reportContent = Get-Content $verificationReport -Raw -ErrorAction SilentlyContinue
+    # Validate report has proper format (not the old "Test Summary" / "Passed: False" format)
+    if ($reportContent -and $reportContent -match 'Gate Result:' -and $reportContent -notmatch 'Passed: False') {
+        Copy-Item $verificationReport (Join-Path $gateOutputDir "content.md") -Force
+    } else {
+        # Report exists but has bad format — generate clean fallback
+        Write-Host "  ⚠️ Verification report has invalid format — using fallback" -ForegroundColor Yellow
+        $resultIcon = switch ($gateResult) { "PASSED" { "✅" } "SKIPPED" { "⚠️" } default { "❌" } }
+        @"
+### Gate Result: $resultIcon $gateResult
+
+**Platform:** $($gatePlatform.ToUpper())
+
+The gate verification completed with result: **$gateResult**.
+"@ | Set-Content (Join-Path $gateOutputDir "content.md") -Encoding UTF8
+    }
 } elseif (-not (Test-Path (Join-Path $gateOutputDir "content.md"))) {
-    # Create gate content based on result
     if ($gateResult -eq "SKIPPED") {
-        $skipContent = @"
+        @"
 ### Gate Result: ⚠️ SKIPPED
 
 No tests were detected in this PR.
 
-**Recommendation:** Add tests to verify the fix using the ``write-tests-agent``:
-
-``````
-@copilot write tests for this PR
-``````
-
-The agent will analyze the issue, determine the appropriate test type (UI test, device test, unit test, or XAML test), and create tests that verify the fix.
-"@
-        $skipContent | Set-Content (Join-Path $gateOutputDir "content.md")
+**Recommendation:** Add tests to verify the fix using the ``write-tests-agent``.
+"@ | Set-Content (Join-Path $gateOutputDir "content.md") -Encoding UTF8
     } else {
-        "### Gate Result: $(if ($gateExitCode -eq 0) { '✅ PASSED' } else { '❌ FAILED' })`n`n**Platform:** $gatePlatform" |
-            Set-Content (Join-Path $gateOutputDir "content.md")
+        $resultIcon = switch ($gateResult) { "PASSED" { "✅" } default { "❌" } }
+        "### Gate Result: $resultIcon $gateResult`n`n**Platform:** $($gatePlatform.ToUpper())" |
+            Set-Content (Join-Path $gateOutputDir "content.md") -Encoding UTF8
     }
 }
 

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -508,9 +508,40 @@ $gatePlatform = if ($Platform) { $Platform } else { "android" }
 Write-Host "  🧪 Running gate on platform: $gatePlatform" -ForegroundColor Cyan
 
 $verifyScript = Join-Path $PSScriptRoot "../skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1"
-$gateOutput = & pwsh -NoProfile -File "$verifyScript" -Platform $gatePlatform -PRNumber $PRNumber -RequireFullVerification 2>&1
-$gateExitCode = $LASTEXITCODE
-$gateOutput | ForEach-Object { Write-Host "    $_" }
+$maxGateAttempts = 3
+$gateExitCode = 1
+$gateOutput = @()
+
+for ($gateAttempt = 1; $gateAttempt -le $maxGateAttempts; $gateAttempt++) {
+    if ($gateAttempt -gt 1) {
+        Write-Host "  🔄 Retry $gateAttempt/$maxGateAttempts — previous attempt hit environment error" -ForegroundColor Yellow
+    }
+    $gateOutput = & pwsh -NoProfile -File "$verifyScript" -Platform $gatePlatform -PRNumber $PRNumber -RequireFullVerification 2>&1
+    $gateExitCode = $LASTEXITCODE
+    $gateOutput | ForEach-Object { Write-Host "    $_" }
+
+    # Check if this was an ENV ERROR (emulator timeout, ADB failure, etc.)
+    $gateContentFile = Join-Path $gateOutputDir "verify-tests-fail/verification-report.md"
+    $isEnvError = $false
+    if ($gateExitCode -ne 0 -and (Test-Path $gateContentFile)) {
+        $gateContent = Get-Content $gateContentFile -Raw -ErrorAction SilentlyContinue
+        if ($gateContent -match 'ENV ERROR') {
+            $isEnvError = $true
+            Write-Host "  ⚠️ Environment error detected (attempt $gateAttempt/$maxGateAttempts)" -ForegroundColor Yellow
+        }
+    }
+
+    if ($gateExitCode -eq 0 -or -not $isEnvError) {
+        break  # Real pass or real failure — don't retry
+    }
+    if ($gateAttempt -lt $maxGateAttempts) {
+        Write-Host "  ⏳ Waiting 30s before retry..." -ForegroundColor DarkGray
+        Start-Sleep -Seconds 30
+    }
+}
+if ($isEnvError) {
+    Write-Host "  ⚠️ All $maxGateAttempts gate attempts hit environment errors" -ForegroundColor Yellow
+}
 
 # Exit code: 0 = passed, 1 = verification failed, 2 = no tests detected
 $gateResult = switch ($gateExitCode) {

--- a/.github/scripts/post-ai-summary-comment.ps1
+++ b/.github/scripts/post-ai-summary-comment.ps1
@@ -67,11 +67,11 @@ if (-not (Test-Path $PRAgentDir)) {
 }
 
 $phases = [ordered]@{
+    "uitests"     = @{ File = "uitests/content.md";        Icon = "🧪"; Title = "UI Tests — Category Detection" }
     "pre-flight"  = @{ File = "pre-flight/content.md";     Icon = "🔍"; Title = "Pre-Flight — Context & Validation" }
     "code-review" = @{ File = "pre-flight/code-review.md"; Icon = "🔬"; Title = "Code Review — Deep Analysis" }
     "try-fix"     = @{ File = "try-fix/content.md";        Icon = "🔧"; Title = "Fix — Analysis & Comparison" }
     "report"      = @{ File = "report/content.md";         Icon = "📋"; Title = "Report — Final Recommendation" }
-    "uitests"     = @{ File = "uitests/content.md";        Icon = "🧪"; Title = "UI Tests — Category Detection & Results" }
 }
 
 # ─── Gate content (rendered first, always open) ───

--- a/.github/scripts/post-ai-summary-comment.ps1
+++ b/.github/scripts/post-ai-summary-comment.ps1
@@ -71,6 +71,7 @@ $phases = [ordered]@{
     "code-review" = @{ File = "pre-flight/code-review.md"; Icon = "🔬"; Title = "Code Review — Deep Analysis" }
     "try-fix"     = @{ File = "try-fix/content.md";        Icon = "🔧"; Title = "Fix — Analysis & Comparison" }
     "report"      = @{ File = "report/content.md";         Icon = "📋"; Title = "Report — Final Recommendation" }
+    "uitests"     = @{ File = "uitests/content.md";        Icon = "🧪"; Title = "UI Tests — Category Detection & Results" }
 }
 
 # ─── Gate content (rendered first, always open) ───

--- a/.github/scripts/post-uitest-categories-comment.ps1
+++ b/.github/scripts/post-uitest-categories-comment.ps1
@@ -1,0 +1,590 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Posts UI test results summary on a PR after maui-pr-uitests pipeline completes.
+
+.DESCRIPTION
+    Maintains ONE comment per PR identified by <!-- UI Test Categories -->.
+    Fetches test run results from AzDO, groups failures by error pattern,
+    classifies them as snapshot/timeout/crash/assertion, and provides
+    actionable information for maintainers.
+
+    Each invocation adds an expandable session keyed by the PR HEAD SHA.
+    - Same SHA  -> replaces that session in-place.
+    - New SHA   -> prepends a new session (latest first; older collapsed).
+
+.PARAMETER PRNumber
+    The pull request number (required).
+
+.PARAMETER BuildId
+    The Azure DevOps build ID to summarise (required).
+
+.PARAMETER Repo
+    Repo in owner/name form. Defaults to dotnet/maui.
+
+.PARAMETER AzdoOrg
+    Azure DevOps org. Defaults to dnceng-public.
+
+.PARAMETER AzdoProject
+    Azure DevOps project. Defaults to public.
+
+.PARAMETER DryRun
+    Print the comment instead of posting.
+
+.EXAMPLE
+    ./post-uitest-categories-comment.ps1 -PRNumber 35015 -BuildId 1386834
+
+.EXAMPLE
+    ./post-uitest-categories-comment.ps1 -PRNumber 35015 -BuildId 1386834 -DryRun
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$PRNumber,
+
+    [Parameter(Mandatory = $true)]
+    [int]$BuildId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Repo = "dotnet/maui",
+
+    [Parameter(Mandatory = $false)]
+    [string]$AzdoOrg = "dnceng-public",
+
+    [Parameter(Mandatory = $false)]
+    [string]$AzdoProject = "public",
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputFile,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$MARKER = "<!-- UI Test Categories -->"
+$BuildUrl = "https://dev.azure.com/$AzdoOrg/$AzdoProject/_build/results?buildId=$BuildId"
+$ApiBase = "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/build/builds/$BuildId"
+
+# ============================================================================
+# HELPER: classify a test failure
+# ============================================================================
+
+function Get-FailureType {
+    param([string]$ErrorMsg)
+    if ([string]::IsNullOrWhiteSpace($ErrorMsg)) { return "unknown" }
+    if ($ErrorMsg -match 'Snapshot different|VisualTestFailedException|difference\)') { return "snapshot" }
+    if ($ErrorMsg -match 'Timeout|timed out|TimeoutException') { return "timeout" }
+    if ($ErrorMsg -match 'NullReferenceException|ObjectDisposedException|crashed|SIGABRT|SIGSEGV') { return "crash" }
+    if ($ErrorMsg -match 'Assert\.|Expected|actual|Is\.EqualTo|Is\.Not') { return "assertion" }
+    return "other"
+}
+
+function Get-FailureIcon {
+    param([string]$Type)
+    switch ($Type) {
+        "snapshot"  { return "🖼️" }
+        "timeout"   { return "⏱️" }
+        "crash"     { return "💥" }
+        "assertion" { return "❌" }
+        default     { return "❓" }
+    }
+}
+
+function Format-RunName {
+    param([string]$Name)
+    # _ios_ui_tests_mono_controls_latest -> iOS Mono (latest)
+    # _android_ui_tests_controls_30 -> Android (API 30)
+    # _winui_ui_tests_controls -> WinUI
+    # _mac_ui_tests_controls -> macOS
+    # Material3_M3_android_ui_tests_controls_36 -> Material3 Android (API 36)
+    # CarouselView_CARV1_ios_ui_tests_mono_controls_latest -> CarouselView iOS Mono (latest)
+    $n = $Name -replace '^_', ''
+    # Extract prefix (CarouselView, CollectionView, Material3, etc.)
+    $prefix = ''
+    if ($n -match '^(CarouselView|CollectionView|Material3)[_]') {
+        $prefix = $Matches[1] + ' '
+        $n = $n -replace '^[^_]+_', ''
+    }
+    # Strip intermediate noise
+    $n = $n -replace 'CARV1_', '' -replace 'CV1_', '' -replace 'M3_', ''
+    # Parse platform
+    $platform = ''
+    if ($n -match 'ios_ui_tests_mono') { $platform = 'iOS Mono' }
+    elseif ($n -match 'android_ui_tests') { $platform = 'Android' }
+    elseif ($n -match 'winui_ui_tests') { $platform = 'WinUI' }
+    elseif ($n -match 'mac_ui_tests') { $platform = 'macOS' }
+    else { return "$prefix$Name" }
+    # Parse version suffix
+    $version = ''
+    if ($n -match '_(\d+_\d+)$') { $version = $Matches[1] -replace '_', '.' }
+    elseif ($n -match '_(\d+)$') { $version = "API $($Matches[1])" }
+    elseif ($n -match '_(latest)$') { $version = $Matches[1] }
+    if ($version) { return "$prefix$platform ($version)" }
+    return "$prefix$platform"
+}
+
+# ============================================================================
+# FETCH BUILD + TIMELINE
+# ============================================================================
+
+Write-Host "Fetching build $BuildId..." -ForegroundColor Cyan
+$build = Invoke-RestMethod -Uri "$ApiBase`?api-version=7.1"
+$timeline = Invoke-RestMethod -Uri "$ApiBase/timeline?api-version=7.1"
+
+# ----------------------------------------------------------------------------
+# Detected categories (from "Check if category should run" logs)
+# ----------------------------------------------------------------------------
+
+$checkRecords = @($timeline.records |
+    Where-Object { $_.name -eq "Check if category should run" -and $_.log -and $_.log.id })
+
+$detectedCategories = $null
+$filterEngaged = $false
+$ranCount = 0
+$totalCount = 0
+
+if ($checkRecords.Count -gt 0) {
+    foreach ($rec in $checkRecords) {
+        $log = Invoke-RestMethod -Uri "$ApiBase/logs/$($rec.log.id)?api-version=7.1"
+        if ($log -match "Detected Categories:\s*'([^']*)'\s*\(filter engaged:\s*(True|False)") {
+            $val = $Matches[1]
+            $eng = $Matches[2] -eq "True"
+            if (-not $val.StartsWith('$(')) {
+                $detectedCategories = $val
+                $filterEngaged = $eng
+                break
+            }
+        }
+    }
+    # Count ran vs skipped
+    foreach ($rec in $checkRecords) {
+        $totalCount++
+        $log = Invoke-RestMethod -Uri "$ApiBase/logs/$($rec.log.id)?api-version=7.1"
+        if ($log -match "Should run tests:\s*True") { $ranCount++ }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($detectedCategories)) {
+    $detectedCategories = "all (full matrix)"
+}
+$noneDetected = $detectedCategories -eq 'NONE'
+$skippedCount = $totalCount - $ranCount
+
+Write-Host "Detected categories: $detectedCategories" -ForegroundColor Green
+Write-Host "Filter engaged: $filterEngaged" -ForegroundColor Green
+
+# ============================================================================
+# FETCH TEST RESULTS (requires auth — try az CLI first, then AZURE_DEVOPS_EXT_PAT)
+# ============================================================================
+
+$allRuns = @()
+$testApiHeaders = $null
+
+# Try az CLI token first (works locally)
+try {
+    $azToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv 2>$null)
+    if (-not [string]::IsNullOrWhiteSpace($azToken)) {
+        $testApiHeaders = @{ Authorization = "Bearer $azToken" }
+        Write-Host "Using az CLI token for test API" -ForegroundColor DarkGray
+    }
+} catch { }
+
+# Fall back to AZURE_DEVOPS_EXT_PAT (available in CI)
+if (-not $testApiHeaders) {
+    $azdoPat = $env:AZURE_DEVOPS_EXT_PAT
+    if (-not [string]::IsNullOrWhiteSpace($azdoPat) -and -not $azdoPat.StartsWith('$(') -and $azdoPat.Length -ge 40) {
+        $base64 = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$azdoPat"))
+        $testApiHeaders = @{ Authorization = "Basic $base64" }
+        Write-Host "Using AZURE_DEVOPS_EXT_PAT for test API" -ForegroundColor DarkGray
+    }
+}
+
+if ($testApiHeaders) {
+    Write-Host "Fetching test results..." -ForegroundColor Cyan
+    $buildUri = "vstfs:///Build/Build/$BuildId"
+    try {
+        $runsResp = Invoke-RestMethod -Headers $testApiHeaders -Uri "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/test/runs?buildUri=$buildUri&api-version=7.1"
+        foreach ($run in $runsResp.value) {
+            if ($run.totalTests -eq 0) { continue }
+            $failedTests = @()
+            if ($run.passedTests -lt $run.totalTests) {
+                try {
+                    $failedResp = Invoke-RestMethod -Headers $testApiHeaders `
+                        -Uri "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/test/Runs/$($run.id)/results?outcomes=Failed&`$top=200&api-version=7.1"
+                    $failedTests = @($failedResp.value)
+                } catch { }
+            }
+            $allRuns += [pscustomobject]@{
+                Name        = $run.name
+                Total       = $run.totalTests
+                Passed      = $run.passedTests
+                FailedCount = $failedTests.Count
+                FailedTests = $failedTests
+            }
+        }
+    } catch {
+        Write-Host "⚠️ Could not fetch test results: $_" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "⚠️ No az token — test details unavailable (public org requires auth for test API)" -ForegroundColor Yellow
+}
+
+# ============================================================================
+# CLASSIFY AND GROUP FAILURES
+# ============================================================================
+
+$totalTests = ($allRuns | Measure-Object -Property Total -Sum).Sum
+$totalPassed = ($allRuns | Measure-Object -Property Passed -Sum).Sum
+$totalFailed = ($allRuns | Measure-Object -Property FailedCount -Sum).Sum
+
+$failedRuns = @($allRuns | Where-Object { $_.FailedCount -gt 0 })
+$passedRuns = @($allRuns | Where-Object { $_.FailedCount -eq 0 -and $_.Total -gt 0 })
+
+# Build a flat list of all failures with classification
+$allFailures = @()
+foreach ($run in $failedRuns) {
+    # Parse platform from run name (e.g., _ios_ui_tests_mono_controls_latest -> iOS Mono latest)
+    $platform = $run.Name -replace '^_', '' -replace '_ui_tests_', ' ' -replace '_controls_', ' ' -replace '_', ' '
+    foreach ($t in $run.FailedTests) {
+        $errRaw = if ($t.errorMessage) { $t.errorMessage } else { '' }
+        $errOneLine = ($errRaw -replace '\r?\n', ' ' -replace '\s+', ' ').Trim()
+        $ftype = Get-FailureType -ErrorMsg $errOneLine
+
+        # Extract key detail based on type
+        $detail = switch ($ftype) {
+            "snapshot" {
+                if ($errOneLine -match '(\d+\.\d+)%\s*difference') { "$($Matches[1])% diff" }
+                else { "snapshot mismatch" }
+            }
+            "timeout" { "timed out" }
+            "crash" {
+                if ($errOneLine -match '(NullReferenceException|ObjectDisposedException|SIGABRT|SIGSEGV)') { $Matches[1] }
+                else { "crash" }
+            }
+            "assertion" {
+                if ($errOneLine.Length -gt 120) { $errOneLine.Substring(0, 120) + "..." }
+                else { $errOneLine }
+            }
+            default {
+                if ($errOneLine.Length -gt 120) { $errOneLine.Substring(0, 120) + "..." }
+                else { $errOneLine }
+            }
+        }
+
+        $allFailures += [pscustomobject]@{
+            TestName = $t.testCase.name
+            RunName  = $run.Name
+            Platform = $platform
+            Type     = $ftype
+            Detail   = $detail
+            Error    = if ($errOneLine.Length -gt 300) { $errOneLine.Substring(0, 300) + "..." } else { $errOneLine }
+        }
+    }
+}
+
+# Group by failure type
+$failuresByType = $allFailures | Group-Object -Property Type | Sort-Object Count -Descending
+
+Write-Host "Total: $totalTests tests, $totalPassed passed, $totalFailed failed across $($allRuns.Count) runs" -ForegroundColor $(if ($totalFailed -gt 0) { "Yellow" } else { "Green" })
+
+# ============================================================================
+# STAGE RESULTS (only failed/issues stages)
+# ============================================================================
+
+$stages = @($timeline.records | Where-Object { $_.type -eq "Stage" } | Sort-Object name -Unique)
+$failedStages = @($stages | Where-Object { $_.result -eq "failed" -or $_.result -eq "canceled" })
+$passedStages = @($stages | Where-Object { $_.result -eq "succeeded" -or $_.result -eq "succeededWithIssues" })
+
+# ============================================================================
+# FETCH PR METADATA
+# ============================================================================
+
+try {
+    $commitJson = gh api "repos/$Repo/pulls/$PRNumber/commits" --jq '.[-1] | {message: .commit.message, sha: .sha}' 2>$null | ConvertFrom-Json
+} catch {
+    Write-Host "⚠️ Could not fetch commits: $_" -ForegroundColor Yellow
+    $commitJson = $null
+}
+$commitTitle = if ($commitJson) { ($commitJson.message -split "`n")[0] } else { "Unknown" }
+$commitTitle = $commitTitle -replace '&','&amp;' -replace '<','&lt;' -replace '>','&gt;'
+$commitSha7  = if ($commitJson) { $commitJson.sha.Substring(0, 7) } else { "unknown" }
+$commitFull  = if ($commitJson) { $commitJson.sha } else { "" }
+$commitUrl   = if ($commitJson) { "https://github.com/$Repo/commit/$commitFull" } else { "#" }
+
+try { $prAuthor = gh api "repos/$Repo/pulls/$PRNumber" --jq '.user.login' 2>$null } catch { $prAuthor = $null }
+
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm UTC")
+
+# ============================================================================
+# BUILD COMMENT
+# ============================================================================
+
+$buildBadge = switch ($build.result) {
+    "succeeded"           { "✅ passed" }
+    "succeededWithIssues" { "⚠️ passed with issues" }
+    "failed"              { "❌ failed" }
+    "canceled"            { "🚫 canceled" }
+    default               { "🔄 $($build.status)" }
+}
+
+$passRate = if ($totalTests -gt 0) { [math]::Round(($totalPassed / $totalTests) * 100, 1) } else { 0 }
+
+# Header line with key stats
+if ($noneDetected -and $totalTests -eq 0) {
+    $headerLine = "**$buildBadge** | No UI test categories detected"
+} else {
+    $headerLine = "**$buildBadge** | $totalPassed/$totalTests passed ($passRate%)"
+    if ($totalFailed -gt 0) { $headerLine += " | **$totalFailed failed**" }
+}
+
+# Filter info line
+$filterLine = if ($noneDetected) {
+    "⏭️ No UI test categories detected — skipped $skippedCount of $totalCount matrix cells"
+} elseif ($filterEngaged) {
+    "🎯 **Detected categories:** ``$detectedCategories`` — ran $ranCount of $totalCount matrix cells (skipped $skippedCount)"
+} else {
+    "📦 **Full matrix** — all $totalCount matrix cells ran"
+}
+
+# --- Failed tests section (the main content) ---
+$failedSection = ""
+if ($totalFailed -gt 0) {
+    $parts = @()
+
+    # Platform summary table
+    $parts += "### Results by Platform"
+    $parts += ""
+    $parts += "| Platform | Passed | Failed | Total |"
+    $parts += "|---|---|---|---|"
+    foreach ($run in ($allRuns | Sort-Object Name)) {
+        $displayName = Format-RunName -Name $run.Name
+        $icon = if ($run.FailedCount -eq 0) { "✅" } else { "❌" }
+        $parts += "| $icon $displayName | $($run.Passed) | $($run.FailedCount) | $($run.Total) |"
+    }
+    $parts += ""
+
+    # Failure breakdown by type
+    $parts += "### Failures ($totalFailed)"
+    $parts += ""
+    $typeSummary = @($failuresByType | ForEach-Object {
+        $icon = Get-FailureIcon -Type $_.Name
+        "$icon **$($_.Name)**: $($_.Count)"
+    })
+    $parts += ($typeSummary -join " | ")
+    $parts += ""
+
+    # Per-run breakdown — cap at 15 runs and 25 tests per run to stay under GitHub comment limit
+    $maxRuns = 15
+    $maxTestsPerRun = 25
+    $sortedFailedRuns = @($failedRuns | Sort-Object FailedCount -Descending)
+    $shownRuns = @($sortedFailedRuns | Select-Object -First $maxRuns)
+    $hiddenRunCount = $sortedFailedRuns.Count - $shownRuns.Count
+
+    foreach ($run in $shownRuns) {
+        $displayName = Format-RunName -Name $run.Name
+        $passedPct = if ($run.Total -gt 0) { [math]::Round(($run.Passed / $run.Total) * 100, 0) } else { 0 }
+
+        $parts += "<details>"
+        $parts += "<summary>❌ <strong>$displayName</strong> — $($run.FailedCount) failed, $($run.Passed)/$($run.Total) passed ($passedPct%)</summary>"
+        $parts += "<br>"
+        $parts += ""
+        $parts += "| | Test | Detail |"
+        $parts += "|---|---|---|"
+
+        $runFailures = @($allFailures | Where-Object { $_.RunName -eq $run.Name } | Sort-Object Type, TestName)
+        $shownTests = @($runFailures | Select-Object -First $maxTestsPerRun)
+        $hiddenTestCount = $runFailures.Count - $shownTests.Count
+        foreach ($f in $shownTests) {
+            $icon = Get-FailureIcon -Type $f.Type
+            $name = $f.TestName -replace '\|', '\|'
+            $det = $f.Detail -replace '\|', '\|' -replace '`', "'"
+            if ($det.Length -gt 150) { $det = $det.Substring(0, 150) + "..." }
+            $parts += "| $icon | ``$name`` | $det |"
+        }
+        if ($hiddenTestCount -gt 0) {
+            $parts += "| | _...and $hiddenTestCount more_ | |"
+        }
+        $parts += ""
+        $parts += "</details>"
+        $parts += ""
+    }
+    if ($hiddenRunCount -gt 0) {
+        $parts += "_...and $hiddenRunCount more runs with failures (see [build]($BuildUrl))_"
+        $parts += ""
+    }
+
+    $failedSection = $parts -join "`n"
+} elseif (-not $noneDetected -and $totalTests -gt 0) {
+    $parts = @()
+    $parts += "### Results by Platform"
+    $parts += ""
+    $parts += "| Platform | Passed | Total |"
+    $parts += "|---|---|---|"
+    foreach ($run in ($allRuns | Sort-Object Name)) {
+        $displayName = Format-RunName -Name $run.Name
+        $parts += "| ✅ $displayName | $($run.Passed) | $($run.Total) |"
+    }
+    $parts += ""
+    $failedSection = $parts -join "`n"
+}
+
+# --- Failed stages (compact) ---
+$stageSection = ""
+if ($failedStages.Count -gt 0) {
+    $stageLines = @()
+    $stageLines += "<details>"
+    $stageLines += "<summary>🔴 <strong>Failed stages ($($failedStages.Count))</strong> of $($stages.Count) total</summary>"
+    $stageLines += "<br>"
+    $stageLines += ""
+    foreach ($s in $failedStages) {
+        $stageLines += "- ❌ $($s.name)"
+    }
+    $stageLines += ""
+    $stageLines += "</details>"
+    $stageSection = $stageLines -join "`n"
+}
+
+$sessionStart = "<!-- SESSION:$commitSha7 START -->"
+$sessionEnd   = "<!-- SESSION:$commitSha7 END -->"
+
+$sessionBody = @"
+$sessionStart
+<details open>
+<summary>🧪 <a href="$commitUrl"><code>$commitSha7</code></a> · $commitTitle · <em>$timestamp</em></summary>
+<br>
+
+[Build #$BuildId]($BuildUrl) | $headerLine
+
+$filterLine
+
+$failedSection
+
+$stageSection
+
+</details>
+$sessionEnd
+"@
+
+# ============================================================================
+# OUTPUT: either write to file (-OutputFile) or post as PR comment
+# ============================================================================
+
+if ($OutputFile) {
+    # Write content for embedding in AI summary (no session markers, no comment wrapper)
+    $contentBody = @"
+[Build #$BuildId]($BuildUrl) | $headerLine
+
+$filterLine
+
+$failedSection
+
+$stageSection
+"@
+    $contentBody = $contentBody -replace "`n{4,}", "`n`n`n"
+    $outputDir = Split-Path $OutputFile -Parent
+    if ($outputDir -and -not (Test-Path $outputDir)) {
+        New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+    }
+    $contentBody | Set-Content -Path $OutputFile -Encoding UTF8
+    Write-Host "✅ Written to $OutputFile" -ForegroundColor Green
+    return
+}
+
+# ============================================================================
+# POST AS SEPARATE PR COMMENT (standalone mode)
+# ============================================================================
+
+function Merge-Sessions {
+    param([string]$ExistingBody, [string]$NewSession, [string]$Sha7)
+
+    $pattern = '(?s)<!-- SESSION:([a-f0-9]+) START -->.*?<!-- SESSION:\1 END -->'
+    $matches = [regex]::Matches($ExistingBody, $pattern)
+
+    $sessions = [ordered]@{}
+    foreach ($m in $matches) { $sessions[$m.Groups[1].Value] = $m.Value }
+    $sessions[$Sha7] = $NewSession
+
+    $orderedKeys = @($Sha7) + @($sessions.Keys | Where-Object { $_ -ne $Sha7 })
+    $blocks = @()
+    $first = $true
+    foreach ($k in $orderedKeys) {
+        $b = $sessions[$k]
+        # Ensure <br> after every </summary> (normalize old sessions)
+        $b = $b -replace '</summary>\s*(?!<br>)', "</summary>`n<br>"
+        if ($first) {
+            $b = $b -replace '<details(?:\s+open)?>', '<details open>'
+            $first = $false
+        } else {
+            $b = $b -replace '<details\s+open>', '<details>'
+        }
+        $blocks += $b
+    }
+    return ($blocks -join "`n`n---`n`n")
+}
+
+Write-Host "Looking for existing comment on $Repo#$PRNumber..." -ForegroundColor Cyan
+$existingId = $null
+$existingBody = $null
+
+$existingRaw = gh api "repos/$Repo/issues/$PRNumber/comments" --paginate 2>$null
+if ($existingRaw) {
+    try {
+        $all = $existingRaw | ConvertFrom-Json
+        $existing = @($all | Where-Object { $_.body -and $_.body.Contains($MARKER) }) | Select-Object -Last 1
+        if ($existing) {
+            $existingId = $existing.id
+            $existingBody = $existing.body
+            Write-Host "Found existing comment (ID: $existingId)" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "⚠️ Could not parse comments: $_" -ForegroundColor Yellow
+    }
+}
+
+if ($existingBody) {
+    $merged = Merge-Sessions -ExistingBody $existingBody -NewSession $sessionBody -Sha7 $commitSha7
+    $commentBody = @"
+$MARKER
+
+## 🧪 UI Test Results
+
+$merged
+"@
+} else {
+    $commentBody = @"
+$MARKER
+
+## 🧪 UI Test Results
+
+$sessionBody
+"@
+}
+
+$commentBody = $commentBody -replace "`n{4,}", "`n`n`n"
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Host "=== COMMENT PREVIEW ===" -ForegroundColor Cyan
+    Write-Host $commentBody
+    Write-Host "=== END PREVIEW ===" -ForegroundColor Cyan
+    exit 0
+}
+
+$tempFile = [System.IO.Path]::GetTempFileName()
+try {
+    @{ body = $commentBody } | ConvertTo-Json -Depth 10 | Set-Content -Path $tempFile -Encoding UTF8
+    if ($existingId) {
+        Write-Host "Updating comment $existingId..." -ForegroundColor Yellow
+        gh api --method PATCH "repos/$Repo/issues/comments/$existingId" --input $tempFile | Out-Null
+        Write-Host "✅ Updated" -ForegroundColor Green
+        Write-Output "COMMENT_ID=$existingId"
+    } else {
+        Write-Host "Creating new comment..." -ForegroundColor Yellow
+        $resp = gh api --method POST "repos/$Repo/issues/$PRNumber/comments" --input $tempFile | ConvertFrom-Json
+        Write-Host "✅ Posted (ID: $($resp.id))" -ForegroundColor Green
+        Write-Output "COMMENT_ID=$($resp.id)"
+    }
+} finally {
+    Remove-Item $tempFile -ErrorAction SilentlyContinue
+}

--- a/.github/scripts/trigger-uitest-pipeline.ps1
+++ b/.github/scripts/trigger-uitest-pipeline.ps1
@@ -16,7 +16,7 @@
     The GitHub PR number (required).
 
 .PARAMETER SourceBranch
-    AzDO pipeline source branch. Defaults to main.
+    AzDO pipeline source branch. Defaults to the PR merge ref (pull/N/merge).
 
 .PARAMETER DryRun
     Show what would be done without queuing or posting.
@@ -34,7 +34,7 @@ param(
     [int]$PRNumber,
 
     [Parameter(Mandatory = $false)]
-    [string]$SourceBranch = "main",
+    [string]$SourceBranch,
 
     [Parameter(Mandatory = $false)]
     [switch]$DryRun,
@@ -60,6 +60,12 @@ Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
 Write-Host "║  UI TEST PIPELINE — PR #$PRNumber                              ║" -ForegroundColor Cyan
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+
+# Default SourceBranch to the PR's merge ref so tests run the PR's actual code
+if ([string]::IsNullOrWhiteSpace($SourceBranch)) {
+    $SourceBranch = "pull/$PRNumber/merge"
+    Write-Host "  📌 Source branch: refs/$SourceBranch (PR merge ref)" -ForegroundColor Cyan
+}
 
 # ============================================================================
 # STEP 1: Read AI categories (Tier 3) from pre-flight output
@@ -137,9 +143,11 @@ if ($detectedCategories) {
     $templateParams['categories'] = $detectedCategories
 }
 
+$sourceBranchRef = if ($SourceBranch -like "pull/*") { "refs/$SourceBranch" } else { "refs/heads/$SourceBranch" }
+
 $buildBody = @{
     definition = @{ id = $PipelineDefId }
-    sourceBranch = "refs/heads/$SourceBranch"
+    sourceBranch = $sourceBranchRef
     templateParameters = $templateParams
 } | ConvertTo-Json -Depth 5
 

--- a/.github/scripts/trigger-uitest-pipeline.ps1
+++ b/.github/scripts/trigger-uitest-pipeline.ps1
@@ -16,7 +16,7 @@
     The GitHub PR number (required).
 
 .PARAMETER SourceBranch
-    AzDO pipeline source branch. Defaults to feature/detect-uitest-categories.
+    AzDO pipeline source branch. Defaults to main.
 
 .PARAMETER DryRun
     Show what would be done without queuing or posting.
@@ -34,7 +34,7 @@ param(
     [int]$PRNumber,
 
     [Parameter(Mandatory = $false)]
-    [string]$SourceBranch = "feature/detect-uitest-categories",
+    [string]$SourceBranch = "main",
 
     [Parameter(Mandatory = $false)]
     [switch]$DryRun,

--- a/.github/scripts/trigger-uitest-pipeline.ps1
+++ b/.github/scripts/trigger-uitest-pipeline.ps1
@@ -1,0 +1,320 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Detects UI test categories, queues AzDO pipeline, monitors, and posts results.
+
+.DESCRIPTION
+    Orchestrates the full UI test flow for a PR:
+    1. Read AI-suggested categories from uitests/ai-categories.md (if available)
+    2. Detect categories via source-path mapping + test file analysis
+    3. Queue maui-pr-uitests pipeline (def 313) on AzDO with detected categories
+    4. Poll until build completes (timeout 3h)
+    5. Post results comment via post-uitest-categories-comment.ps1
+    6. Write uitests/content.md for AI summary integration
+
+.PARAMETER PRNumber
+    The GitHub PR number (required).
+
+.PARAMETER SourceBranch
+    AzDO pipeline source branch. Defaults to feature/detect-uitest-categories.
+
+.PARAMETER DryRun
+    Show what would be done without queuing or posting.
+
+.PARAMETER SkipMonitor
+    Queue the build but don't wait for it to complete.
+
+.EXAMPLE
+    ./trigger-uitest-pipeline.ps1 -PRNumber 35015
+    ./trigger-uitest-pipeline.ps1 -PRNumber 35015 -DryRun
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$PRNumber,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SourceBranch = "feature/detect-uitest-categories",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipMonitor
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $RepoRoot) { $RepoRoot = $PSScriptRoot | Split-Path | Split-Path }
+
+$AzdoOrg = "dnceng-public"
+$AzdoProject = "public"
+$PipelineDefId = 313
+$PollIntervalSec = 120
+$TimeoutMinutes = 180
+$OutputDir = Join-Path $RepoRoot "CustomAgentLogsTmp/PRState/$PRNumber/PRAgent/uitests"
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+Write-Host ""
+Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+Write-Host "║  UI TEST PIPELINE — PR #$PRNumber                              ║" -ForegroundColor Cyan
+Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+
+# ============================================================================
+# STEP 1: Read AI categories (Tier 3) from pre-flight output
+# ============================================================================
+
+$aiCategories = $null
+$aiCategoriesFile = Join-Path $OutputDir "ai-categories.md"
+if (Test-Path $aiCategoriesFile) {
+    $aiContent = Get-Content $aiCategoriesFile -Raw -Encoding UTF8
+    if (-not [string]::IsNullOrWhiteSpace($aiContent) -and $aiContent.Trim() -ne 'NONE') {
+        # Extract category names (lines like "Button — justification")
+        $aiCatLines = @($aiContent -split "`n" | ForEach-Object {
+            if ($_ -match '^([A-Za-z]+)') { $Matches[1] }
+        } | Where-Object { $_ })
+        if ($aiCatLines.Count -gt 0) {
+            $aiCategories = $aiCatLines -join ','
+            Write-Host "  🤖 AI categories (from pre-flight): $aiCategories" -ForegroundColor Green
+        }
+    }
+} else {
+    Write-Host "  ℹ️ No AI categories file found (pre-flight may not have run yet)" -ForegroundColor DarkGray
+}
+
+# ============================================================================
+# STEP 2: Detect categories using the detect script (Tier 1 + 2 + 3)
+# ============================================================================
+
+Write-Host "  🔍 Running category detection for PR #$PRNumber..." -ForegroundColor Cyan
+
+$detectScript = Join-Path $RepoRoot "eng/scripts/detect-ui-test-categories.ps1"
+$detectArgs = @("-PrNumber", "$PRNumber")
+if ($aiCategories) { $detectArgs += @("-AiCategories", $aiCategories) }
+
+# Capture the output to extract detected categories
+$detectOutput = & pwsh -NoProfile -File $detectScript @detectArgs 2>&1
+$detectOutput | ForEach-Object { Write-Host "    $_" }
+
+# Parse detected categories from the script output
+$detectedCategories = $null
+foreach ($line in $detectOutput) {
+    $lineStr = $line.ToString()
+    if ($lineStr -match 'UITestCategoryList;isOutput=true\](.+)$') {
+        $detectedCategories = $Matches[1]
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($detectedCategories)) {
+    Write-Host "  📦 No specific categories detected — full matrix would run" -ForegroundColor Yellow
+    $detectedCategories = $null
+} elseif ($detectedCategories -eq 'NONE') {
+    Write-Host "  ⏭️ No UI-relevant changes detected — skipping UI test pipeline" -ForegroundColor Yellow
+
+    # Write skip result
+    @"
+### UI Tests: ⏭️ Skipped
+
+No UI-relevant changes detected for this PR. UI test pipeline was not triggered.
+"@ | Set-Content (Join-Path $OutputDir "content.md") -Encoding UTF8
+
+    Write-Output "UITEST_RESULT=SKIPPED"
+    Write-Output "UITEST_CATEGORIES=NONE"
+    return
+} else {
+    Write-Host "  🎯 Detected categories: $detectedCategories" -ForegroundColor Green
+}
+
+# ============================================================================
+# STEP 3: Queue AzDO build
+# ============================================================================
+
+Write-Host "  🚀 Queueing maui-pr-uitests pipeline..." -ForegroundColor Cyan
+
+$templateParams = @{ prNumber = "$PRNumber" }
+if ($detectedCategories) {
+    $templateParams['categories'] = $detectedCategories
+}
+
+$buildBody = @{
+    definition = @{ id = $PipelineDefId }
+    sourceBranch = "refs/heads/$SourceBranch"
+    templateParameters = $templateParams
+} | ConvertTo-Json -Depth 5
+
+if ($DryRun) {
+    Write-Host "  [DRY RUN] Would queue build with:" -ForegroundColor Magenta
+    Write-Host "    Source: $SourceBranch" -ForegroundColor Gray
+    Write-Host "    Categories: $($detectedCategories ?? 'all')" -ForegroundColor Gray
+    Write-Host "    PR: $PRNumber" -ForegroundColor Gray
+
+    @"
+### UI Tests: 🏗️ Dry Run
+
+**Detected categories:** ``$($detectedCategories ?? 'all')``
+**Source branch:** ``$SourceBranch``
+
+Build was not queued (dry run mode).
+"@ | Set-Content (Join-Path $OutputDir "content.md") -Encoding UTF8
+
+    Write-Output "UITEST_RESULT=DRYRUN"
+    Write-Output "UITEST_CATEGORIES=$($detectedCategories ?? 'all')"
+    return
+}
+
+# Queue via AzDO REST API
+$build = $null
+$queueMethod = "none"
+
+$azdoPat = $env:AZURE_DEVOPS_EXT_PAT
+if ($azdoPat -and $azdoPat -notmatch '^\$\(' -and $azdoPat.Length -ge 40) {
+    $patLen = $azdoPat.Length
+    $maskedPat = $azdoPat.Substring(0, [Math]::Min(4, $patLen)) + "****"
+    Write-Host "  📡 Queueing via AzDO REST API (Basic auth, token: $maskedPat, length: $patLen)..." -ForegroundColor Gray
+    $ErrorActionPreference = "Continue"
+    try {
+        $base64 = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$azdoPat"))
+        $headers = @{
+            Authorization  = "Basic $base64"
+            'Content-Type' = 'application/json'
+        }
+        $queueUrl = "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/build/builds?api-version=7.1"
+        Write-Host "    URL: $queueUrl" -ForegroundColor DarkGray
+        $response = Invoke-RestMethod -Uri $queueUrl -Method POST -Headers $headers -Body $buildBody -ErrorAction Stop
+        if ($response.id) {
+            $build = $response
+            $queueMethod = "rest-api"
+            Write-Host "  ✅ Build queued via REST API (build #$($response.id))" -ForegroundColor Green
+        }
+    } catch {
+        $errMsg = $_.Exception.Message
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        Write-Host "  ❌ REST API failed (HTTP $statusCode): $errMsg" -ForegroundColor Red
+        if ($_.ErrorDetails.Message) {
+            Write-Host "    Details: $($_.ErrorDetails.Message)" -ForegroundColor Red
+        }
+    }
+    $ErrorActionPreference = "Stop"
+} else {
+    Write-Host "  ⚠️ AZURE_DEVOPS_EXT_PAT not set, unresolved, or too short (need PAT ≥40 chars)" -ForegroundColor Yellow
+    if ($azdoPat) { Write-Host "    (got length $($azdoPat.Length) — expected ≥40 for a PAT. Check DNCENG_PUBLIC_PAT pipeline variable.)" -ForegroundColor Yellow }
+}
+
+if (-not $build -or -not $build.id) {
+    Write-Host "  ❌ Could not queue build on $AzdoOrg/$AzdoProject" -ForegroundColor Red
+    Write-Host "  💡 Detected categories: $($detectedCategories ?? 'all')" -ForegroundColor Yellow
+
+    @"
+### UI Tests: ❌ Failed to Queue
+
+**Detected categories:** ``$($detectedCategories ?? 'all')``
+
+Could not queue build on $AzdoOrg/$AzdoProject. Check DNCENG_PUBLIC_PAT pipeline variable.
+"@ | Set-Content (Join-Path $OutputDir "content.md") -Encoding UTF8
+
+    Write-Output "UITEST_RESULT=QUEUE_FAILED"
+    Write-Output "UITEST_CATEGORIES=$($detectedCategories ?? 'all')"
+    return
+}
+
+Write-Host "  📡 Queued via: $queueMethod" -ForegroundColor Gray
+
+$buildId = $build.id
+$buildUrl = "https://dev.azure.com/$AzdoOrg/$AzdoProject/_build/results?buildId=$buildId"
+Write-Host "  ✅ Build queued: #$buildId" -ForegroundColor Green
+Write-Host "  🔗 $buildUrl" -ForegroundColor Cyan
+
+if ($SkipMonitor) {
+    Write-Host "  ⏭️ Skipping monitoring (SkipMonitor flag)" -ForegroundColor Yellow
+
+    @"
+### UI Tests: 🔄 In Progress
+
+**Detected categories:** ``$($detectedCategories ?? 'all')``
+**Build:** [#$buildId]($buildUrl) — queued, not yet complete
+
+Monitoring was skipped. Check the build link for results.
+"@ | Set-Content (Join-Path $OutputDir "content.md") -Encoding UTF8
+
+    Write-Output "UITEST_RESULT=QUEUED"
+    Write-Output "UITEST_BUILD_ID=$buildId"
+    Write-Output "UITEST_CATEGORIES=$($detectedCategories ?? 'all')"
+    return
+}
+
+# ============================================================================
+# STEP 4: Monitor build until completion
+# ============================================================================
+
+Write-Host "  ⏳ Monitoring build #$buildId (poll every ${PollIntervalSec}s, timeout ${TimeoutMinutes}m)..." -ForegroundColor Cyan
+
+$startTime = Get-Date
+$buildResult = $null
+
+while ($true) {
+    $elapsed = (Get-Date) - $startTime
+    if ($elapsed.TotalMinutes -gt $TimeoutMinutes) {
+        Write-Host "  ⚠️ Timeout after $TimeoutMinutes minutes" -ForegroundColor Yellow
+        $buildResult = "TIMEOUT"
+        break
+    }
+
+    try {
+        $status = Invoke-RestMethod -Uri "https://dev.azure.com/$AzdoOrg/$AzdoProject/_apis/build/builds/${buildId}?api-version=7.1"
+        if ($status.status -eq 'completed') {
+            $buildResult = $status.result
+            Write-Host "  ✅ Build completed: $buildResult ($([math]::Round($elapsed.TotalMinutes, 1))m)" -ForegroundColor $(if ($buildResult -eq 'succeeded') { 'Green' } else { 'Yellow' })
+            break
+        }
+        Write-Host "    [$($elapsed.ToString('hh\:mm\:ss'))] $($status.status)..." -ForegroundColor DarkGray
+    } catch {
+        Write-Host "    [$($elapsed.ToString('hh\:mm\:ss'))] Poll error: $($_.Exception.Message)" -ForegroundColor DarkGray
+    }
+
+    Start-Sleep -Seconds $PollIntervalSec
+}
+
+# ============================================================================
+# STEP 5: Post results comment
+# ============================================================================
+
+Write-Host "  📝 Posting results comment..." -ForegroundColor Cyan
+
+$commentScript = Join-Path $PSScriptRoot "post-uitest-categories-comment.ps1"
+if (Test-Path $commentScript) {
+    try {
+        $commentOutput = & $commentScript -PRNumber $PRNumber -BuildId $buildId
+        $commentIdLine = $commentOutput | Where-Object { $_ -match '^COMMENT_ID=' } | Select-Object -Last 1
+        if ($commentIdLine -match '^COMMENT_ID=(\d+)$') {
+            Write-Host "  ✅ Comment posted (ID: $($Matches[1]))" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "  ⚠️ Failed to post comment (non-fatal): $_" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "  ⚠️ post-uitest-categories-comment.ps1 not found" -ForegroundColor Yellow
+}
+
+# ============================================================================
+# STEP 6: Write content.md for AI summary
+# ============================================================================
+
+$resultIcon = switch ($buildResult) {
+    "succeeded" { "✅" }
+    "failed"    { "❌" }
+    "TIMEOUT"   { "⏱️" }
+    default     { "⚠️" }
+}
+
+@"
+### UI Tests: $resultIcon $buildResult
+
+**Detected categories:** ``$($detectedCategories ?? 'all')``
+**Build:** [#$buildId]($buildUrl)
+**Duration:** $([math]::Round(((Get-Date) - $startTime).TotalMinutes, 1)) minutes
+"@ | Set-Content (Join-Path $OutputDir "content.md") -Encoding UTF8
+
+Write-Output "UITEST_RESULT=$buildResult"
+Write-Output "UITEST_BUILD_ID=$buildId"
+Write-Output "UITEST_CATEGORIES=$($detectedCategories ?? 'all')"

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -649,6 +649,7 @@ stages:
               COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
               GH_TOKEN: $(GH_COMMENT_TOKEN)
               DEVICE_UDID: $(DEVICE_UDID)
+              AZURE_DEVOPS_EXT_PAT: $(DNCENG_PUBLIC_PAT)
 
           # Publish Copilot logs and session artifacts
           - task: PublishPipelineArtifact@1

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -62,6 +62,43 @@ stages:
   - stage: ReviewPR
     displayName: 'Review Pull Request'
     jobs:
+      # Lightweight job: detect UI test categories and trigger maui-pr-uitests ASAP
+      - job: TriggerUITests
+        displayName: 'Detect & Trigger UI Tests'
+        pool:
+          name: Azure Pipelines
+          vmImage: ubuntu-22.04
+        timeoutInMinutes: 10
+        steps:
+          - checkout: self
+            fetchDepth: 1
+
+          - bash: |
+              if [ -z "${{ parameters.PRNumber }}" ]; then
+                echo "##vso[task.logissue type=error]PRNumber parameter is required"
+                exit 1
+              fi
+            displayName: 'Validate Parameters'
+
+          - bash: |
+              echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null || true
+            displayName: 'Setup gh CLI'
+            env:
+              GH_TOKEN: $(GH_COMMENT_TOKEN)
+
+          - bash: |
+              set +e
+              echo "Running trigger-uitest-pipeline.ps1 (SkipMonitor)..."
+              pwsh -NoProfile .github/scripts/trigger-uitest-pipeline.ps1 \
+                -PRNumber ${{ parameters.PRNumber }} \
+                -SkipMonitor
+              echo "Exit code: $?"
+              exit 0
+            displayName: 'Detect Categories & Queue UI Tests'
+            env:
+              GH_TOKEN: $(GH_COMMENT_TOKEN)
+              AZURE_DEVOPS_EXT_PAT: $(DNCENG_PUBLIC_PAT)
+
       - job: CopilotReview
         displayName: 'Run Copilot PR Reviewer Agent'
         ${{ if eq(parameters.Platform, 'android') }}:

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -62,43 +62,6 @@ stages:
   - stage: ReviewPR
     displayName: 'Review Pull Request'
     jobs:
-      # Lightweight job: detect UI test categories and trigger maui-pr-uitests ASAP
-      - job: TriggerUITests
-        displayName: 'Detect & Trigger UI Tests'
-        pool:
-          name: Azure Pipelines
-          vmImage: ubuntu-22.04
-        timeoutInMinutes: 10
-        steps:
-          - checkout: self
-            fetchDepth: 1
-
-          - bash: |
-              if [ -z "${{ parameters.PRNumber }}" ]; then
-                echo "##vso[task.logissue type=error]PRNumber parameter is required"
-                exit 1
-              fi
-            displayName: 'Validate Parameters'
-
-          - bash: |
-              echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null || true
-            displayName: 'Setup gh CLI'
-            env:
-              GH_TOKEN: $(GH_COMMENT_TOKEN)
-
-          - bash: |
-              set +e
-              echo "Running trigger-uitest-pipeline.ps1 (SkipMonitor)..."
-              pwsh -NoProfile .github/scripts/trigger-uitest-pipeline.ps1 \
-                -PRNumber ${{ parameters.PRNumber }} \
-                -SkipMonitor
-              echo "Exit code: $?"
-              exit 0
-            displayName: 'Detect Categories & Queue UI Tests'
-            env:
-              GH_TOKEN: $(GH_COMMENT_TOKEN)
-              AZURE_DEVOPS_EXT_PAT: $(DNCENG_PUBLIC_PAT)
-
       - job: CopilotReview
         displayName: 'Run Copilot PR Reviewer Agent'
         ${{ if eq(parameters.Platform, 'android') }}:

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -64,6 +64,16 @@ parameters:
     type: boolean
     default: false
 
+  - name: prNumber
+    displayName: 'PR number (run UI tests for a specific PR)'
+    type: string
+    default: ' '
+
+  - name: categories
+    displayName: 'UI test categories to run (comma-separated, e.g. "Button,Label"). Leave empty for all.'
+    type: string
+    default: ' '
+
   # Internal pools (dnceng)
   - name: androidPoolInternal
     type: object
@@ -168,6 +178,8 @@ stages:
       # BuildNativeAOT is false by default, but true in devdiv environment
       BuildNativeAOT: ${{ or(parameters.BuildNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
+      prNumber: ${{ parameters.prNumber }}
+      categories: ${{ parameters.categories }}
       ${{ if or(parameters.BuildEverything, ne(variables['Build.Reason'], 'PullRequest')) }}:
         androidApiLevels: [ 30 ]
         iosVersions: [ '18.5', 'latest' ]

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -17,28 +17,112 @@ parameters:
   checkoutDirectory: $(System.DefaultWorkingDirectory)
 
 steps:
+# EARLY CHECK: Determine if this category group should run tests
+# This runs FIRST to avoid wasting time on provisioning if no tests will run
+# Also calculates matching categories to avoid duplicating this logic later
+- pwsh: |
+    $testFilterParam = $env:CATEGORY_GROUP
+    $testFilterFallback = $env:TEST_FILTER_PARAM
+    $detectedCategories = $env:DETECTED_CATEGORIES
+    # Engage filtering whenever discovery actually emitted detected categories.
+    # That happens for real PR builds AND for manual queues that pass -PrNumber.
+    # When no upstream stage produced the variable, AzDO leaves the literal
+    # placeholder '$(DETECTED_CATEGORIES)' in the env value — detect that via
+    # StartsWith. We can't compare against the literal placeholder in a
+    # single-quoted string here because AzDO pre-expands $(...) macros in the
+    # entire script body before pwsh runs.
+    $detectedCategoriesSet = -not [string]::IsNullOrWhiteSpace($detectedCategories) -and -not $detectedCategories.StartsWith('$(')
+    $isPR = $env:BUILD_REASON -eq "PullRequest"
+    $shouldFilter = $isPR -or $detectedCategoriesSet
+
+    # When detection ran but found NOTHING relevant, UITestCategoryList is set to 'NONE'.
+    # In that case skip ALL jobs — there are no categories to test.
+    $noneDetected = $detectedCategoriesSet -and $detectedCategories -eq 'NONE'
+
+    Write-Host "=== Early Category Check ==="
+    Write-Host "Build Reason: $env:BUILD_REASON"
+    Write-Host "Category Group (from matrix): '$testFilterParam'"
+    Write-Host "Test Filter (from parameter): '$testFilterFallback'"
+    Write-Host "Detected Categories: '$detectedCategories' (filter engaged: $shouldFilter, none detected: $noneDetected)"
+    
+    # Use testFilter parameter as fallback when CATEGORYGROUP is not set or not expanded
+    # When CATEGORYGROUP variable doesn't exist, it shows as literal '$(CATEGORYGROUP)'
+    $categoryGroupNotSet = [string]::IsNullOrWhiteSpace($testFilterParam) -or $testFilterParam -eq '$(CATEGORYGROUP)'
+    if ($categoryGroupNotSet -and -not [string]::IsNullOrWhiteSpace($testFilterFallback)) {
+        $testFilterParam = $testFilterFallback
+        Write-Host "Using testFilter parameter as category: '$testFilterParam'"
+    }
+    
+    $shouldRun = $true
+    $matchingCategoriesResult = $testFilterParam  # Default: use all categories from this group
+
+    # NONE means detection ran successfully but no categories matched — skip everything
+    if ($noneDetected) {
+        $shouldRun = $false
+        $matchingCategoriesResult = ""
+        Write-Host "##[warning]No UI test categories detected for this PR — SKIPPING all tests"
+    }
+    # For builds with detected categories, check if this category group has any matches
+    elseif ($shouldFilter -and $detectedCategoriesSet -and -not [string]::IsNullOrWhiteSpace($testFilterParam)) {
+        $categoryList = $testFilterParam -split ","
+        $detectedList = $detectedCategories -split ","
+        $matchingCategories = @()
+        
+        foreach ($cat in $categoryList) {
+            $cat = $cat.Trim()
+            foreach ($det in $detectedList) {
+                $det = $det.Trim()
+                if ($cat -ieq $det) {
+                    $matchingCategories += $cat
+                    Write-Host "Match found: '$cat'"
+                    break
+                }
+            }
+        }
+        
+        if ($matchingCategories.Count -eq 0) {
+            $shouldRun = $false
+            $matchingCategoriesResult = ""
+            Write-Host "##[warning]No matching categories - SKIPPING all steps for this job"
+            Write-Host "Category group '$testFilterParam' does not contain any detected categories: $detectedCategories"
+        } else {
+            $matchingCategoriesResult = $matchingCategories -join ","
+            Write-Host "Matching categories for this job: $matchingCategoriesResult"
+        }
+    }
+    
+    Write-Host "Should run tests: $shouldRun"
+    Write-Host "##vso[task.setvariable variable=SHOULD_RUN_TESTS]$shouldRun"
+    Write-Host "##vso[task.setvariable variable=MATCHING_CATEGORIES]$matchingCategoriesResult"
+  displayName: 'Check if category should run'
+  env:
+    CATEGORY_GROUP: $(CATEGORYGROUP)
+    TEST_FILTER_PARAM: ${{ parameters.testFilter }}
+    DETECTED_CATEGORIES: $(DETECTED_CATEGORIES)
+    BUILD_REASON: $(Build.Reason)
+
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'false'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'false'))
   inputs:
     artifact: ui-tests-samples
 
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'true'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'Mono'), eq('${{ parameters.useMaterial3 }}', 'true'))
   inputs:
     artifact: ui-tests-samples-material3
 
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'NativeAOT'))
   inputs:
     artifact: ui-tests-samples-nativeaot
 
 - task: DownloadPipelineArtifact@2
-  condition: and(ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'CoreCLR'), eq('${{ parameters.useMaterial3 }}', 'false'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}' , 'windows'), eq('${{ parameters.runtimeVariant }}' , 'CoreCLR'), eq('${{ parameters.useMaterial3 }}', 'false'))
   inputs:
     artifact: ui-tests-samples-coreclr
 
 - task: DownloadPipelineArtifact@2
-  condition: eq('${{ parameters.platform }}' , 'windows')
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), eq('${{ parameters.platform }}' , 'windows'))
   inputs:
     artifact: ui-tests-samples-windows
 
@@ -47,17 +131,21 @@ steps:
       chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
       $(System.DefaultWorkingDirectory)/eng/scripts/clean-bot.sh
     displayName: 'Clean bot'
+    condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
     continueOnError: true
     timeoutInMinutes: 60
 
 - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
   - template: enable-kvm.yml
+    parameters:
+      extraCondition: eq(variables['SHOULD_RUN_TESTS'], 'True')
 
 - ${{ if eq(parameters.platform, 'catalyst')}}:
   - bash: |
       chmod +x $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
       $(System.DefaultWorkingDirectory)/eng/scripts/disable-notification-center.sh
     displayName: 'Disable Notification Center'
+    condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
     continueOnError: true
     timeoutInMinutes: 60
 
@@ -81,7 +169,7 @@ steps:
       openSslArgs: '' # Do not use legacy openssl for Catalyst builds
 
 - task: PowerShell@2
-  condition: and(ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), ne('${{ parameters.platform }}', 'windows'), ne('${{ parameters.platform }}', 'android'))
   inputs:
     targetType: 'inline'
     script: |
@@ -93,6 +181,7 @@ steps:
 
 - pwsh: ./build.ps1 --target=dotnet --configuration="${{ parameters.configuration }}" --verbosity=diagnostic
   displayName: 'Install .NET'
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   retryCountOnTaskFailure: 2
   env:
     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
@@ -100,15 +189,17 @@ steps:
 
 - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
   displayName: 'Add .NET to PATH'
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
 
 # AzDO hosted agents default to 1024x768; set something bigger for Windows UI tests
 - pwsh: |
     $scriptPath = Join-Path "$(System.DefaultWorkingDirectory)" "eng" "scripts" "Set-ScreenResolution.ps1"
     & $scriptPath -Width 1920 -Height 1080
-  condition: eq('${{ parameters.platform }}' , 'windows')
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'), eq('${{ parameters.platform }}' , 'windows'))
   displayName: "Set screen resolution"
 
 - task: UseNode@1
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   inputs:
     version: "20.3.1"
   displayName: "Install node"
@@ -117,6 +208,7 @@ steps:
     $skipAppiumDoctor = if ($IsMacOS -or $IsLinux) { "true" } else { "false" }
     dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -bl:"$(LogDirectory)/provision-appium.binlog"
   displayName: "Install Appium"
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   continueOnError: false
   retryCountOnTaskFailure: 2
   timeoutInMinutes: 10
@@ -138,12 +230,18 @@ steps:
 
     $testFilter = ""
     $testConfigrationArgs = "${{ parameters.testConfigurationArgs }}"
-
-    "${{ parameters.testFilter }}".Split(",") | ForEach {
-      $testFilter += "TestCategory=" + $_ + "|"
+    
+    # Use MATCHING_CATEGORIES from early check (already filtered for PR category detection)
+    $testFilterParam = $env:MATCHING_CATEGORIES
+    
+    Write-Host "Categories to run (from early check): '$testFilterParam'"
+    
+    if ($testFilterParam) {
+      $testFilterParam.Split(",") | ForEach {
+        $testFilter += "TestCategory=" + $_ + "|"
+      }
+      $testFilter = $testFilter.TrimEnd("|")
     }
-
-    $testFilter = $testFilter.TrimEnd("|")
 
     # Cake does not allow empty parameters, so check if our filter is empty before adding it
     if ($testConfigrationArgs) {
@@ -162,10 +260,12 @@ steps:
 
     Invoke-Expression $command  
   displayName: $(Agent.JobName)
+  condition: and(succeeded(), eq(variables['SHOULD_RUN_TESTS'], 'True'))
   ${{ if ne(parameters.platform, 'android')}}:
     retryCountOnTaskFailure: 1
   env:
     APPIUM_HOME: $(APPIUM_HOME)
+    MATCHING_CATEGORIES: $(MATCHING_CATEGORIES)
 
 - bash: |
     cat ${BASH_SOURCE[0]}

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -14,6 +14,8 @@ parameters:
   skipProvisioning: true
   BuildNativeAOT: false # Parameter to control whether NativeAOT artifacts should be built
   RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
+  prNumber: ' ' # Optional: PR number for testing category detection from a manual queue
+  categories: ' ' # Optional: comma-separated categories to run (bypasses auto-detection). Empty = all.
   categoryGroupsToTest:
     # Make sure that this list is always up-to-date with src/Controls/tests/TestCases.Shared.Tests/UITestCategories.cs
     # we might want to improve this somehow depending on how much the categories change over time
@@ -52,9 +54,42 @@ parameters:
       app: /optional/path/to/app.csproj
 
 stages:
+  - stage: discover_ui_test_categories
+    displayName: Discover UI Test Categories
+    condition: |
+      or(
+        eq(variables['Build.Reason'], 'PullRequest'),
+        ne(trim('${{ parameters.prNumber }}'), '')
+      )
+    jobs:
+      - job: detect
+        displayName: Detect category filters
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            fetchDepth: 200
+          - task: PowerShell@2
+            name: DetectCategories
+            displayName: Determine UI test categories for PRs
+            env:
+              SYSTEM_PULLREQUEST_TARGETBRANCH: $(System.PullRequest.TargetBranch)
+              MANUAL_PR_NUMBER: ${{ parameters.prNumber }}
+              MANUAL_CATEGORIES: ${{ parameters.categories }}
+            inputs:
+              pwsh: true
+              filePath: $(System.DefaultWorkingDirectory)/eng/scripts/detect-ui-test-categories.ps1
+              arguments: '-TargetBranch "$env:SYSTEM_PULLREQUEST_TARGETBRANCH" -PrNumber "$env:MANUAL_PR_NUMBER" -Categories "$env:MANUAL_CATEGORIES"'
+
   - stage: build_ui_tests
     displayName: Build UITests Sample App
-    dependsOn: []
+    dependsOn:
+      - discover_ui_test_categories
+    condition: |
+      or(
+        ne(variables['Build.Reason'], 'PullRequest'),
+        in(dependencies.discover_ui_test_categories.result, 'Succeeded', 'Skipped')
+      )
     jobs:
       - job: build_ui_tests
         displayName: Build Sample App
@@ -141,7 +176,9 @@ stages:
 
   - stage: android_ui_tests
     displayName: Android UITests
-    dependsOn: build_ui_tests
+    dependsOn:
+      - build_ui_tests
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
@@ -161,6 +198,8 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  # Access detected categories directly from stage dependency
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -173,7 +212,6 @@ stages:
                       ${{ if not(eq(api, 27)) }}:
                         device: android-emulator-64_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
                   # Collect and publish Android snapshot diffs
@@ -185,7 +223,9 @@ stages:
 
   - stage: android_ui_tests_coreclr
     displayName: Android UITests CoreClr
-    dependsOn: build_ui_tests_coreclr
+    dependsOn:
+      - build_ui_tests_coreclr
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
@@ -205,6 +245,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -218,7 +259,6 @@ stages:
                         device: android-emulator-64_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
-                      testFilter: $(CATEGORYGROUP)
                       headless: ${{ parameters.headless }}
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                       runtimeVariant: "CoreCLR"
@@ -271,7 +311,9 @@ stages:
 
   - stage: ios_ui_tests_mono
     displayName: iOS UITests Mono
-    dependsOn: build_ui_tests
+    dependsOn:
+      - build_ui_tests
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
@@ -291,6 +333,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -307,7 +350,6 @@ stages:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
                       runtimeVariant : "Mono"
-                      testFilter: $(CATEGORYGROUP)
                       headless: ${{ parameters.headless }}
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
@@ -319,7 +361,19 @@ stages:
 
   - stage: ios_ui_tests_mono_cv1
     displayName: iOS UITests Mono CollectionView1
-    dependsOn: build_ui_tests
+    dependsOn:
+      - discover_ui_test_categories
+      - build_ui_tests
+    condition: |
+      and(
+        succeeded('build_ui_tests'),
+        or(
+          ne(variables['Build.Reason'], 'PullRequest'),
+          eq(dependencies.discover_ui_test_categories.result, 'Skipped'),
+          eq(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], ''),
+          contains(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], 'CollectionView')
+        )
+      )
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
@@ -334,6 +388,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -363,7 +418,19 @@ stages:
 
   - stage: ios_ui_tests_mono_carv1
     displayName: iOS UITests Mono CarouselView1
-    dependsOn: build_ui_tests
+    dependsOn:
+      - discover_ui_test_categories
+      - build_ui_tests
+    condition: |
+      and(
+        succeeded('build_ui_tests'),
+        or(
+          ne(variables['Build.Reason'], 'PullRequest'),
+          eq(dependencies.discover_ui_test_categories.result, 'Skipped'),
+          eq(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], ''),
+          contains(stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'], 'CarouselView')
+        )
+      )
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
@@ -378,6 +445,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -408,7 +476,9 @@ stages:
   - ${{ if and(eq(parameters.BuildNativeAOT, true), eq(parameters.RunNativeAOT, true)) }}:
     - stage: ios_ui_tests_nativeaot
       displayName: iOS UITests NativeAOT
-      dependsOn: build_ui_tests_nativeaot
+      dependsOn:
+        - build_ui_tests_nativeaot
+        - discover_ui_test_categories
       jobs:
         - ${{ each project in parameters.projects }}:
           - ${{ if ne(project.ios, '') }}:
@@ -428,6 +498,7 @@ stages:
                   variables:
                     REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                    DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                   steps:
                     - template: ui-tests-steps.yml
                       parameters:
@@ -444,13 +515,14 @@ stages:
                           device: ios-simulator-64_${{ version }}
                         provisionatorChannel: ${{ parameters.provisionatorChannel }}
                         runtimeVariant : "NativeAOT"
-                        testFilter: $(CATEGORYGROUP)
                         headless: ${{ parameters.headless }}
                         skipProvisioning: ${{ parameters.skipProvisioning }}
 
   - stage: winui_ui_tests
     displayName: WinUI UITests
-    dependsOn: build_ui_tests_windows
+    dependsOn:
+      - build_ui_tests_windows
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.winui, '') }}:
@@ -467,6 +539,7 @@ stages:
                 pool: ${{ parameters.windowsPool }}
                 variables:
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)\.appium\
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -476,7 +549,6 @@ stages:
                       path: ${{ project.winui }}
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
                   # Collect and publish Windows snapshot diffs
@@ -487,7 +559,9 @@ stages:
 
   - stage: mac_ui_tests
     displayName: macOS UITests
-    dependsOn: build_ui_tests
+    dependsOn:
+      - build_ui_tests
+      - discover_ui_test_categories
     jobs:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.mac, '') }}:
@@ -505,6 +579,7 @@ stages:
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
+                  DETECTED_CATEGORIES: $[ stageDependencies.discover_ui_test_categories.detect.outputs['DetectCategories.UITestCategoryList'] ]
                 steps:
                   - template: ui-tests-steps.yml
                     parameters:
@@ -514,7 +589,6 @@ stages:
                       path: ${{ project.mac }}
                       app: ${{ project.app }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      testFilter: $(CATEGORYGROUP)
                       skipProvisioning: ${{ parameters.skipProvisioning }}
                   
                   # Collect and publish Mac snapshot diffs

--- a/eng/scripts/detect-ui-test-categories.ps1
+++ b/eng/scripts/detect-ui-test-categories.ps1
@@ -1,0 +1,402 @@
+[CmdletBinding()]
+param(
+    [string]$TargetBranch,
+    [string]$PrNumber,
+    [string]$Categories,
+    [string]$AiCategories,
+    [string]$TestRoot = "src/Controls/tests/TestCases.Shared.Tests"
+)
+
+# Normalize PrNumber: strip whitespace; AzDO often passes a placeholder space when the parameter is unset.
+if (-not [string]::IsNullOrWhiteSpace($PrNumber)) {
+    $PrNumber = $PrNumber.Trim()
+} else {
+    $PrNumber = $null
+}
+
+# Normalize Categories parameter
+if (-not [string]::IsNullOrWhiteSpace($Categories)) {
+    $Categories = $Categories.Trim()
+} else {
+    $Categories = $null
+}
+
+# Normalize AiCategories parameter (from AI reasoning during pre-flight)
+if (-not [string]::IsNullOrWhiteSpace($AiCategories)) {
+    $AiCategories = $AiCategories.Trim()
+} else {
+    $AiCategories = $null
+}
+
+$buildReason = $env:BUILD_REASON
+if ([string]::IsNullOrWhiteSpace($buildReason)) {
+    $buildReason = $env:SYSTEM_REASON
+}
+
+$isManualPrTest = -not [string]::IsNullOrWhiteSpace($PrNumber)
+
+# When categories are explicitly provided, skip auto-detection entirely.
+# This lets triage/maintainers run specific categories via manual queue.
+if (-not [string]::IsNullOrWhiteSpace($Categories)) {
+    $catList = @($Categories -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    Write-Host "##[section]Categories provided via parameter: $($catList -join ', '). Skipping auto-detection." -ForegroundColor Green
+    $matrix = [ordered]@{}
+    $index = 0
+    foreach ($cat in ($catList | Sort-Object)) {
+        $matrix["Category_$index"] = @{ CATEGORYGROUP = $cat }
+        $index++
+    }
+    $matrixJson = $matrix | ConvertTo-Json -Depth 5
+    Write-Host "##vso[task.setvariable variable=UITestCategoryMatrix;isOutput=true]$matrixJson"
+    Write-Host "##vso[task.setvariable variable=UITestCategoryList;isOutput=true]$($catList -join ',')"
+    return
+}
+
+if ($buildReason -ne 'PullRequest' -and -not $isManualPrTest) {
+    Write-Host "Build reason '$buildReason' is not PullRequest and no -PrNumber override was provided. Running all categories." -ForegroundColor Cyan
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($TargetBranch)) {
+    $TargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+}
+
+# Determine the PR number for label / API lookups.
+$prNumberForLookup = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+if ([string]::IsNullOrWhiteSpace($prNumberForLookup) -and $isManualPrTest) {
+    $prNumberForLookup = $PrNumber
+}
+$repoName = $env:BUILD_REPOSITORY_NAME
+if ([string]::IsNullOrWhiteSpace($repoName)) {
+    $repoName = 'dotnet/maui'
+}
+
+# Helper: build authenticated GitHub API headers.
+function Get-GitHubHeaders {
+    $h = @{ 'User-Agent' = 'maui-ui-test-detector' }
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+        $h['Authorization'] = "Bearer $env:GH_TOKEN"
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:SYSTEM_ACCESSTOKEN)) {
+        $h['Authorization'] = "Bearer $env:SYSTEM_ACCESSTOKEN"
+    }
+    return $h
+}
+
+# Helper: invoke a REST call with retries for transient failures.
+function Invoke-WithRetry {
+    param([string]$Uri, [hashtable]$Headers, [int]$MaxRetries = 3, [int]$DelaySeconds = 10)
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            return Invoke-RestMethod -Uri $Uri -Headers $Headers -Method Get -TimeoutSec 30
+        } catch {
+            Write-Host "##[warning]Attempt $attempt/$MaxRetries failed: $($_.Exception.Message)"
+            if ($attempt -lt $MaxRetries) {
+                Write-Host "Retrying in ${DelaySeconds}s..."
+                Start-Sleep -Seconds $DelaySeconds
+            } else {
+                throw
+            }
+        }
+    }
+}
+
+# Manual-test override: when -PrNumber is provided, fetch the PR's base/head from GitHub
+# and replay the same diff that a normal PR build would see.
+if ($isManualPrTest) {
+    try {
+        $prUrl = "https://api.github.com/repos/$repoName/pulls/$PrNumber"
+        Write-Host "##[section]Manual PR test mode (PrNumber=$PrNumber). Fetching PR metadata from $prUrl" -ForegroundColor Yellow
+        $pr = Invoke-WithRetry -Uri $prUrl -Headers (Get-GitHubHeaders)
+        $TargetBranch = $pr.base.ref
+        $headRef = $pr.head.ref
+        $headSha = $pr.head.sha
+        $baseRepoCloneUrl = $pr.base.repo.clone_url
+        $headRepoCloneUrl = $pr.head.repo.clone_url
+        Write-Host "PR #$PrNumber : $($pr.head.repo.full_name)/$headRef ($headSha) -> $($pr.base.repo.full_name)/$TargetBranch" -ForegroundColor Cyan
+
+        # Fetch base branch from the base repo.
+        git remote remove _detect_base 2>$null | Out-Null
+        git remote add _detect_base $baseRepoCloneUrl
+        git fetch _detect_base "$TargetBranch" --no-tags --prune --depth=200 | Out-Null
+        git update-ref refs/remotes/origin/$TargetBranch _detect_base/$TargetBranch | Out-Null
+
+        # Fetch head commit (works for forks too) and check it out so the diff reflects the PR changes.
+        git remote remove _detect_head 2>$null | Out-Null
+        git remote add _detect_head $headRepoCloneUrl
+        git fetch _detect_head "$headSha" --no-tags --depth=200 | Out-Null
+        git checkout --quiet $headSha | Out-Null
+    } catch {
+        Write-Host "##[warning]Manual PR test setup failed: $($_.Exception.Message). Falling back to running ALL categories."
+        return
+    }
+}
+
+# Escape hatch: PR label "run-all-uitests" forces the full category matrix to run.
+if (-not [string]::IsNullOrWhiteSpace($prNumberForLookup)) {
+    try {
+        $labelsUrl = "https://api.github.com/repos/$repoName/issues/$prNumberForLookup/labels"
+        Write-Host "Checking PR labels at $labelsUrl" -ForegroundColor Cyan
+        $labels = Invoke-WithRetry -Uri $labelsUrl -Headers (Get-GitHubHeaders)
+        $labelNames = @($labels | ForEach-Object { $_.name })
+        Write-Host "PR labels: $([string]::Join(', ', $labelNames))" -ForegroundColor Cyan
+        if ($labelNames -contains 'run-all-uitests') {
+            Write-Host "##[section]Label 'run-all-uitests' present. Running ALL UI test categories (detection bypassed)." -ForegroundColor Yellow
+            return
+        }
+    } catch {
+        Write-Host "##[warning]Failed to query PR labels: $($_.Exception.Message). Continuing with category detection."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($TargetBranch)) {
+    Write-Host "##[warning]Unable to determine target branch for comparison."
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+$targetBranch = $TargetBranch -replace '^refs/heads/', ''
+
+Write-Host "Fetching target branch 'origin/${targetBranch}' for diff analysis..." -ForegroundColor Cyan
+try {
+    git fetch origin "${targetBranch}" --no-tags --prune --depth=200 | Out-Null
+} catch {
+    Write-Host "##[warning]Failed to fetch origin/${targetBranch}: $($_.Exception.Message)"
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+$mergeBase = $null
+try {
+    $mergeBase = (git merge-base HEAD "origin/${targetBranch}").Trim()
+} catch {
+    Write-Host "##[warning]Could not determine merge base with origin/${targetBranch}: $($_.Exception.Message)"
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($mergeBase)) {
+    Write-Host "##[warning]Merge base calculation returned empty result."
+    Write-Host "##[section]FALLBACK: All UI test categories will run for this PR."
+    return
+}
+
+Write-Host "Calculating diff between $mergeBase and HEAD limited to '$TestRoot'..." -ForegroundColor Cyan
+$diff = git diff --diff-filter=AMR --unified=0 $mergeBase HEAD -- "$TestRoot"
+
+# Also get the full file list for Tier 2 source-path mapping
+$allChangedFiles = @(git diff --diff-filter=AMR --name-only $mergeBase HEAD)
+Write-Host "Total changed files in PR: $($allChangedFiles.Count)" -ForegroundColor Cyan
+
+# ============================================================================
+# TIER 2: Source-path-to-category mapping table
+# Maps product code paths to UI test categories by naming conventions.
+# ============================================================================
+
+$pathToCategoryMap = @(
+    @{ Pattern = 'src/Controls/src/Core/Button';              Category = 'Button' }
+    @{ Pattern = 'src/Controls/src/Core/Border';              Category = 'Border' }
+    @{ Pattern = 'src/Controls/src/Core/BoxView';             Category = 'BoxView' }
+    @{ Pattern = 'src/Controls/src/Core/CarouselView';        Category = 'CarouselView' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Items';      Category = 'CollectionView' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Items2';     Category = 'CollectionView' }
+    @{ Pattern = 'src/Controls/src/Core/CheckBox';            Category = 'CheckBox' }
+    @{ Pattern = 'src/Controls/src/Core/DatePicker';          Category = 'DatePicker' }
+    @{ Pattern = 'src/Controls/src/Core/Editor';              Category = 'Editor' }
+    @{ Pattern = 'src/Controls/src/Core/Entry';               Category = 'Entry' }
+    @{ Pattern = 'src/Controls/src/Core/FlyoutPage';          Category = 'FlyoutPage' }
+    @{ Pattern = 'src/Controls/src/Core/Frame';               Category = 'Frame' }
+    @{ Pattern = 'src/Controls/src/Core/GestureRecognizer';   Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/PanGesture';          Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/PinchGesture';        Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/SwipeGesture';        Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/TapGesture';          Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/PointerGesture';      Category = 'Gestures' }
+    @{ Pattern = 'src/Controls/src/Core/DragGesture';         Category = 'DragAndDrop' }
+    @{ Pattern = 'src/Controls/src/Core/DropGesture';         Category = 'DragAndDrop' }
+    @{ Pattern = 'src/Controls/src/Core/Image.';              Category = 'Image' }
+    @{ Pattern = 'src/Controls/src/Core/ImageButton';         Category = 'ImageButton' }
+    @{ Pattern = 'src/Controls/src/Core/IndicatorView';       Category = 'IndicatorView' }
+    @{ Pattern = 'src/Controls/src/Core/Label';               Category = 'Label' }
+    @{ Pattern = 'src/Controls/src/Core/Layout';              Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/Grid';                Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/StackLayout';         Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/FlexLayout';          Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/AbsoluteLayout';      Category = 'Layout' }
+    @{ Pattern = 'src/Controls/src/Core/ListView';            Category = 'ListView' }
+    @{ Pattern = 'src/Controls/src/Core/NavigationPage';      Category = 'Navigation' }
+    @{ Pattern = 'src/Controls/src/Core/Page';                Category = 'Page' }
+    @{ Pattern = 'src/Controls/src/Core/ContentPage';         Category = 'Page' }
+    @{ Pattern = 'src/Controls/src/Core/Picker';              Category = 'Picker' }
+    @{ Pattern = 'src/Controls/src/Core/ProgressBar';         Category = 'ProgressBar' }
+    @{ Pattern = 'src/Controls/src/Core/RadioButton';         Category = 'RadioButton' }
+    @{ Pattern = 'src/Controls/src/Core/RefreshView';         Category = 'RefreshView' }
+    @{ Pattern = 'src/Controls/src/Core/ScrollView';          Category = 'ScrollView' }
+    @{ Pattern = 'src/Controls/src/Core/SearchBar';           Category = 'SearchBar' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Shapes';     Category = 'Shape' }
+    @{ Pattern = 'src/Controls/src/Core/Shapes';              Category = 'Shape' }
+    @{ Pattern = 'src/Controls/src/Core/Shell';               Category = 'Shell' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/Shell';      Category = 'Shell' }
+    @{ Pattern = 'src/Controls/src/Core/Slider';              Category = 'Slider' }
+    @{ Pattern = 'src/Controls/src/Core/Stepper';             Category = 'Stepper' }
+    @{ Pattern = 'src/Controls/src/Core/Switch';              Category = 'Switch' }
+    @{ Pattern = 'src/Controls/src/Core/SwipeView';           Category = 'SwipeView' }
+    @{ Pattern = 'src/Controls/src/Core/TabbedPage';          Category = 'TabbedPage' }
+    @{ Pattern = 'src/Controls/src/Core/TableView';           Category = 'TableView' }
+    @{ Pattern = 'src/Controls/src/Core/TimePicker';          Category = 'TimePicker' }
+    @{ Pattern = 'src/Controls/src/Core/ToolbarItem';         Category = 'ToolbarItem' }
+    @{ Pattern = 'src/Controls/src/Core/WebView';             Category = 'WebView' }
+    @{ Pattern = 'src/Controls/src/Core/Window';              Category = 'Window' }
+    @{ Pattern = 'src/Controls/src/Core/VisualStateManager';  Category = 'VisualStateManager' }
+    @{ Pattern = 'src/Controls/src/Core/Shadow';              Category = 'Shadow' }
+    @{ Pattern = 'src/Controls/src/Core/Brush';               Category = 'Brush' }
+    @{ Pattern = 'src/Core/src/Handlers/HybridWebView';       Category = 'WebView' }
+    @{ Pattern = 'src/Core/src/Platform/';                    Category = 'ViewBaseTests' }
+    @{ Pattern = 'src/Core/src/Handlers/';                    Category = 'ViewBaseTests' }
+    @{ Pattern = 'src/Essentials/';                           Category = 'Essentials' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/FlyoutPage'; Category = 'FlyoutPage' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/TabbedPage'; Category = 'TabbedPage' }
+    @{ Pattern = 'src/Controls/src/Core/Handlers/NavigationPage'; Category = 'Navigation' }
+    @{ Pattern = 'src/Controls/src/Core/SafeArea';            Category = 'SafeAreaEdges' }
+    @{ Pattern = 'src/Controls/src/Core/Platform/iOS/Extensions/SafeArea'; Category = 'SafeAreaEdges' }
+)
+
+if ([string]::IsNullOrWhiteSpace($diff)) {
+    Write-Host "No changes detected under '$TestRoot'." -ForegroundColor Cyan
+} else {
+    Write-Host "Test file changes detected under '$TestRoot'." -ForegroundColor Green
+}
+
+$categoryPattern = '^\+\s*\[Category\((?<value>[^\)]*)\)\]'
+$addedCategories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+# ============================================================================
+# TIER 1: Scan test file diffs for [Category] attributes
+# ============================================================================
+
+if (-not [string]::IsNullOrWhiteSpace($diff)) {
+    foreach ($line in $diff -split "`n") {
+        if ($line -match $categoryPattern) {
+            $rawValue = $Matches['value'].Trim()
+            if ([string]::IsNullOrWhiteSpace($rawValue)) {
+                continue
+            }
+
+            if ($rawValue -match '^UITestCategories\.(?<name>[A-Za-z0-9_]+)$') {
+                $category = $Matches['name']
+            } elseif ($rawValue -match '^["''](?<name>[A-Za-z0-9_ -]+)["'']$') {
+                $category = $Matches['name']
+            } else {
+                if ($rawValue -match 'nameof\(UITestCategories\.(?<name>[A-Za-z0-9_]+)\)') {
+                    $category = $Matches['name']
+                } else {
+                    $message = "Unrecognized category expression '$rawValue'. Expected formats: UITestCategories.<Name>, nameof(UITestCategories.<Name>), or a quoted string."
+                    Write-Host "##[error]$message"
+                    throw $message
+                }
+            }
+
+            $category = $category.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($category)) {
+                $addedCategories.Add($category) | Out-Null
+            }
+        }
+    }
+
+    if ($addedCategories.Count -eq 0) {
+        # Scan modified test files for existing [Category] attributes
+        Write-Host "No new Category attributes in diff. Scanning modified files for existing categories..." -ForegroundColor Cyan
+        $modifiedFiles = @(git diff --diff-filter=AMR --name-only $mergeBase HEAD -- "$TestRoot" | Where-Object { $_ -match '\.cs$' })
+        foreach ($file in $modifiedFiles) {
+            if (-not (Test-Path $file)) { continue }
+            $content = Get-Content $file -Raw
+            $fileMatches = [regex]::Matches($content, '\[Category\(([^\)]*)\)\]')
+            foreach ($m in $fileMatches) {
+                $rawValue = $m.Groups[1].Value.Trim()
+                if ([string]::IsNullOrWhiteSpace($rawValue)) { continue }
+                if ($rawValue -match '^UITestCategories\.(?<name>[A-Za-z0-9_]+)$') {
+                    $cat = $Matches['name']
+                } elseif ($rawValue -match '^["''](?<name>[A-Za-z0-9_ -]+)["'']$') {
+                    $cat = $Matches['name']
+                } elseif ($rawValue -match 'nameof\(UITestCategories\.(?<name>[A-Za-z0-9_]+)\)') {
+                    $cat = $Matches['name']
+                } else { continue }
+                $cat = $cat.Trim()
+                if (-not [string]::IsNullOrWhiteSpace($cat)) {
+                    $addedCategories.Add($cat) | Out-Null
+                }
+            }
+        }
+    }
+
+    if ($addedCategories.Count -gt 0) {
+        Write-Host "Tier 1 (test files): $([string]::Join(', ', $addedCategories))" -ForegroundColor Green
+    }
+}
+
+# ============================================================================
+# TIER 2: Source-path heuristic mapping (product code → categories)
+# ============================================================================
+
+$tier2Categories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$touchesControls = $false
+
+foreach ($file in $allChangedFiles) {
+    if ($file -like 'src/Controls/*' -or $file -like 'src/Core/*' -or $file -like 'src/Essentials/*') {
+        $touchesControls = $true
+    }
+    foreach ($mapping in $pathToCategoryMap) {
+        if ($file -like "$($mapping.Pattern)*") {
+            $tier2Categories.Add($mapping.Category) | Out-Null
+        }
+    }
+}
+
+if ($tier2Categories.Count -gt 0) {
+    Write-Host "Tier 2 (source paths): $([string]::Join(', ', $tier2Categories))" -ForegroundColor Green
+    foreach ($c in $tier2Categories) { $addedCategories.Add($c) | Out-Null }
+}
+
+# ============================================================================
+# TIER 3: AI-provided categories (from pre-flight reasoning)
+# ============================================================================
+
+if (-not [string]::IsNullOrWhiteSpace($AiCategories)) {
+    $aiCatList = @($AiCategories -split '[,\n]' | ForEach-Object { ($_ -replace '\s*[-—].*$', '').Trim() } | Where-Object { $_ -and $_ -ne 'NONE' })
+    if ($aiCatList.Count -gt 0) {
+        Write-Host "Tier 3 (AI reasoning): $([string]::Join(', ', $aiCatList))" -ForegroundColor Green
+        foreach ($c in $aiCatList) { $addedCategories.Add($c) | Out-Null }
+    }
+}
+
+# ============================================================================
+# FINAL DECISION
+# ============================================================================
+
+if ($addedCategories.Count -eq 0) {
+    if ($touchesControls) {
+        # Changed files under src/Controls/ but couldn't map to specific categories — run all
+        Write-Host "Changed files touch Controls/Core/Essentials but no specific categories identified. Running all." -ForegroundColor Yellow
+        return
+    } else {
+        # No UI-relevant changes at all
+        Write-Host "No UI-relevant changes detected. No UI test categories to run." -ForegroundColor Cyan
+        Write-Host "##vso[task.setvariable variable=UITestCategoryList;isOutput=true]NONE"
+        return
+    }
+}
+
+Write-Host "Detected categories from PR changes: $([string]::Join(', ', $addedCategories))" -ForegroundColor Green
+
+# Build matrix JSON expected by Azure Pipelines strategy matrix (CATEGORYGROUP values)
+$matrix = [ordered]@{}
+$index = 0
+foreach ($category in ($addedCategories | Sort-Object)) {
+    $key = "Category_$index"
+    $matrix[$key] = @{ CATEGORYGROUP = $category }
+    $index++
+}
+
+$matrixJson = $matrix | ConvertTo-Json -Depth 5
+
+Write-Host "##vso[task.setvariable variable=UITestCategoryMatrix;isOutput=true]$matrixJson"
+Write-Host "##vso[task.setvariable variable=UITestCategoryList;isOutput=true]$([string]::Join(',', ($addedCategories | Sort-Object)))"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## What this does

**Before:** Every PR runs ~24,000 UI tests across all categories (~2+ hours).

**After:** The pipeline detects which UI test categories a PR actually touches and only runs those. A PR that changes `Button` code only runs Button tests (~400 tests, ~30 min).

## How it works

When `maui-pr-uitests` runs for a PR:

1. A new **Discover** stage analyzes the PR diff
2. It detects relevant categories using three methods:
   - **From test files** — finds `[Category(UITestCategories.X)]` in changed test files
   - **From source paths** — maps product code to categories (e.g. `Shell/` → Shell, `Button*` → Button)
   - **From AI** — the PR review agent can suggest categories during pre-flight
3. Each test job checks if its category group matches. If not, it **skips** (completes in seconds instead of ~30 min)
4. If nothing matches (e.g. docs-only PR), all UI tests are skipped

### Escape hatches

- Add `run-all-uitests` label to force the full matrix
- Queue manually with specific categories via the `categories` pipeline parameter

## Files changed

| File | What it does |
|------|-------------|
| `eng/scripts/detect-ui-test-categories.ps1` | The detection script — 3-tier logic with 60+ path-to-category mappings |
| `eng/pipelines/common/ui-tests.yml` | Adds Discover stage before test stages |
| `eng/pipelines/common/ui-tests-steps.yml` | Adds per-job filter gate that skips non-matching categories |
| `eng/pipelines/ci-uitests.yml` | Adds `prNumber` and `categories` parameters for manual queue |
| `eng/pipelines/ci-copilot.yml` | Passes `DNCENG_PUBLIC_PAT` for cross-org build queuing |
| `.github/scripts/post-uitest-categories-comment.ps1` | Posts test results with platform table and failure details |
| `.github/scripts/trigger-uitest-pipeline.ps1` | Orchestrator for detect → queue → monitor flow |
| `.github/scripts/Review-PR.ps1` | Detects categories during review, gate retry on env errors |
| `.github/scripts/post-ai-summary-comment.ps1` | Adds UI Tests section to the unified AI summary |
| `.github/pr-review/pr-preflight.md` | Adds step for AI to identify impacted categories |

## Tested on

Validated on 30+ PRs. Examples of targeted runs vs full matrix:

| PR | Detected | Tests run | vs Full matrix |
|----|----------|-----------|----------------|
| #35009 | ToolbarItem | 467 | 24,000 |
| #34997 | RadioButton | 496 | 24,000 |
| #35079 | SearchBar,Shell | 2,218 | 24,000 |
| #34637 | Shape | 505 | 24,000 |
| #35072 | Navigation,Shell | 2,540 | 24,000 |
