### PR TITLE
[Testing] Fix for flaky UITests in CI - 3

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			try
 			{
-				App.WaitForElement("DropResultLabel");
+				App.FindElement("DropResultLabel").GetText();
 			}
-			catch (TimeoutException)
+			catch (NullReferenceException)
 			{
 				App.DragAndDrop("Red", "Green");
 			}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("Red");
 			App.WaitForElement("Green");
 			App.DragAndDrop("Red", "Green");
+			Thread.Sleep(2000); // Wait for the UI to update after drag and drop
 			var dropResultLabel = App.FindElement("DropResultLabel").GetText();
 			Assert.That(dropResultLabel, Is.EqualTo("Success"));
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
@@ -22,7 +22,18 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("Red");
 			App.WaitForElement("Green");
 			App.DragAndDrop("Red", "Green");
-			Thread.Sleep(2000); // Wait for the UI to update after drag and drop
+
+#if MACCATALYST // In CI DragAndDrop does not effective sometimes so retry once before failing to resolve the flakiness.
+
+			try
+			{
+				App.WaitForElement("DropResultLabel");
+			}
+			catch (TimeoutException)
+			{
+				App.DragAndDrop("Red", "Green");
+			}
+#endif
 			var dropResultLabel = App.FindElement("DropResultLabel").GetText();
 			Assert.That(dropResultLabel, Is.EqualTo("Success"));
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue17531.cs
@@ -27,13 +27,14 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			try
 			{
-				App.FindElement("DropResultLabel").GetText();
+				App.WaitForElement("DropResultLabel");
 			}
-			catch (NullReferenceException)
+			catch (TimeoutException)
 			{
 				App.DragAndDrop("Red", "Green");
 			}
 #endif
+			App.WaitForElement("DropResultLabel");
 			var dropResultLabel = App.FindElement("DropResultLabel").GetText();
 			Assert.That(dropResultLabel, Is.EqualTo("Success"));
 		}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18961.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18961.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			// 8. Verify Entry returns to approximately its original position after keyboard dismissal
 			var finalRect = App.FindElement(LastEntry).GetRect();
-			Assert.That(Math.Abs(finalRect.Y - initialRect.Y), Is.LessThan(50),
+			Assert.That(Math.Abs(finalRect.Y - initialRect.Y), Is.LessThan(5),
 				"Entry should return close to its original position after keyboard dismissal");
 		}
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18961.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18961.cs
@@ -29,26 +29,33 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			await Task.Delay(1000); // Wait for the scroll animation to finish.
 			App.ScrollDown("TestScrollView"); // Ensure that we are at the end of the scroll.
 
-			// 3. Focus latest Entry
+			// 3. Get initial position of the Entry before keyboard opens
 			App.WaitForElement(LastEntry);
+			var initialRect = App.FindElement(LastEntry).GetRect();
+
+			// 4. Focus latest Entry and enter text
 			App.EnterText(LastEntry, "test");
 			App.Click(LastEntry);
 			await Task.Delay(1000);
 
-			// 4. The keyboard has opened and the Entry have been translated above the keyboard.
-			App.Screenshot("The keyboard has opened and the Entry have been translated above the keyboard.");
-			VerifyScreenshot();
+			// 5. Verify the Entry is still visible (not covered by keyboard)
+			// The Entry should be repositioned above the keyboard
+			var entryWithKeyboard = App.FindElement(LastEntry).GetRect();
+			Assert.That(entryWithKeyboard.Y, Is.LessThan(initialRect.Y),
+				"Entry should be moved up when keyboard appears to remain visible");
 
-			// 5. Close the keyboard to see if sizes adjust back.
+			// 6. Close the keyboard to see if sizes adjust back.
 			App.DismissKeyboard();
 			await Task.Delay(1000);
 
-			// 6. Verify the latest Entry text.
+			// 7. Verify the latest Entry text was preserved.
 			var text = App.FindElement(LastEntry).GetText();
 			Assert.That(text, Is.EqualTo("test"));
 
-			// 7. Make sure that everything has returned to the initial size once the keyboard has closed.
-			App.Screenshot("Make sure that everything has returned to the initial size once the keyboard has closed.");
+			// 8. Verify Entry returns to approximately its original position after keyboard dismissal
+			var finalRect = App.FindElement(LastEntry).GetRect();
+			Assert.That(Math.Abs(finalRect.Y - initialRect.Y), Is.LessThan(50),
+				"Entry should return close to its original position after keyboard dismissal");
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19500.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19500.cs
@@ -19,7 +19,7 @@ public class Issue19500 : _IssuesUITest
 	public void TextInEditorShouldScroll()
 	{
 		var yPosLabel = App.WaitForElement(yPositionLabel);
-		App.ScrollDown("editor");
+		App.ScrollDown("editor", ScrollStrategy.Gesture, withInertia: false);
 #if MACCATALYST
 		App.ScrollDown("editor"); // To make sure the editor is scrolled down
 		var yPos = yPosLabel.GetText();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24574.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24574.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			App.DoubleTap("TapLabel");
 
-#if ANDROID
-			// In CI Double tap does not effective sometimes so retry once before failing to resolve the flakiness.
+#if ANDROID || IOS // In CI Double tap does not effective sometimes so retry once before failing to resolve the flakiness.
+
 			try
 			{
 				App.WaitForElement("Double");


### PR DESCRIPTION
This pull request improves the reliability and accuracy of UI tests by addressing test flakiness, enhancing assertions, and refining test logic. The main focus is on making tests more robust across different platforms (especially in CI environments) and ensuring UI behavior is correctly validated.

**Test reliability improvements:**

* Added retry logic for drag-and-drop actions in `GesturesSenderIsView()` on Mac Catalyst to reduce test flakiness in CI environments.
* Extended double-tap retry logic in `TapThenDoubleTap()` to both Android and iOS platforms, not just Android, to handle potential flakiness.

**Test accuracy and validation enhancements:**

* Improved `ModalPageMarginCorrectAfterKeyboardOpens()` by capturing and asserting the position of an `Entry` before and after keyboard appearance/dismissal, ensuring the UI remains visible and returns to its original state.
* Updated `TextInEditorShouldScroll()` to use a more precise scroll command (`ScrollStrategy.Gesture` with `withInertia: false`), improving test consistency.