### PR TITLE
[iOS] Enabled RefreshControl for large Titles

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33169.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33169.cs
@@ -1,0 +1,69 @@
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33169, "[iOS] RefreshView with CollectionView shows graphical glitches when Large Page Titles are enabled", PlatformAffected.iOS)]
+public class Issue33169 : TestNavigationPage
+{
+	protected override void Init()
+	{
+		On<iOS>().SetPrefersLargeTitles(true);
+
+		var statusLabel = new Label
+		{
+			Text = "None",
+			AutomationId = "StatusLabel",
+			FontSize = 20,
+		};
+
+		var items = Enumerable.Range(0, 30).Select(i => $"Item {i}").ToList();
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "TestCollectionView",
+			ItemsSource = items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label { Margin = new Thickness(10) };
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			}),
+		};
+
+		var refreshView = new RefreshView
+		{
+			AutomationId = "TestRefreshView",
+			Content = collectionView,
+		};
+
+		refreshView.Command = new Command(async () =>
+		{
+			statusLabel.Text = "Refreshing";
+			await Task.Delay(500);
+			refreshView.IsRefreshing = false;
+			statusLabel.Text = "SUCCESS";
+		});
+
+		var page = new ContentPage
+		{
+			Title = "RefreshView Large Titles",
+			Content = new Grid
+			{
+				RowDefinitions =
+				{
+					new RowDefinition(GridLength.Auto),
+					new RowDefinition(GridLength.Star),
+				},
+			}
+		};
+
+		Grid.SetRow(statusLabel, 0);
+		Grid.SetRow(refreshView, 1);
+		((Grid)page.Content).Children.Add(statusLabel);
+		((Grid)page.Content).Children.Add(refreshView);
+
+		page.On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Always);
+		Navigation.PushAsync(page);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33169.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33169.cs
@@ -1,0 +1,32 @@
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS
+// Pull-to-refresh via Appium gesture is only supported on iOS and Android
+
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33169 : _IssuesUITest
+{
+	public Issue33169(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "[iOS] RefreshView with CollectionView shows graphical glitches when Large Page Titles are enabled";
+
+	[Test]
+	[Category(UITestCategories.RefreshView)]
+	public void RefreshViewWorksWithLargeTitles()
+	{
+		App.WaitForElement("TestRefreshView");
+
+		// Use a real pull gesture to trigger UIRefreshControl.ValueChanged
+		App.ScrollUp("TestRefreshView");
+
+		// The Command should fire and set StatusLabel to "SUCCESS"
+		App.WaitForTextToBePresentInElement("StatusLabel", "SUCCESS");
+	}
+}
+
+#endif

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -110,9 +110,7 @@ namespace Microsoft.Maui.Platform
 
 			if (view is UIScrollView scrollView)
 			{
-				if (CanUseRefreshControlProperty())
-					scrollView.RefreshControl = null;
-
+				scrollView.RefreshControl = null;
 				return true;
 			}
 
@@ -140,10 +138,7 @@ namespace Microsoft.Maui.Platform
  
 			if (view is UIScrollView scrollView)
 			{
-				if (CanUseRefreshControlProperty())
-					scrollView.RefreshControl = _refreshControl;
-				else
-					scrollView.InsertSubview(_refreshControl, index);
+				scrollView.InsertSubview(_refreshControl, index);
 
 				//Setting the bounds so that the refresh control renders above the potential header
 				_refreshControl.Bounds = new CGRect(
@@ -212,8 +207,5 @@ namespace Microsoft.Maui.Platform
 
 		bool ShouldAllowRefreshGesture =>
 			_isEnabled && _isRefreshEnabled;
-
-		bool CanUseRefreshControlProperty() =>
-			this.GetNavigationController()?.NavigationBar?.PrefersLargeTitles ?? true;
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiRefreshView.cs
+++ b/src/Core/src/Platform/iOS/MauiRefreshView.cs
@@ -138,6 +138,9 @@ namespace Microsoft.Maui.Platform
  
 			if (view is UIScrollView scrollView)
 			{
+				// Always use InsertSubview instead of the RefreshControl property.
+				// The RefreshControl property causes graphical glitches when
+				// NavigationBar.PrefersLargeTitles is enabled (see #33169).
 				scrollView.InsertSubview(_refreshControl, index);
 
 				//Setting the bounds so that the refresh control renders above the potential header


### PR DESCRIPTION
### Fixes https://github.com/dotnet/maui/issues/33169

## Changes
- Always detach the `UIRefreshControl` via `scrollView.RefreshControl = null` when removing it, simplifying cleanup.
- Insert the refresh control directly into the `UIScrollView` instead of using the `RefreshControl` property, avoiding large-title navigation bar interference.
- Removed the `CanUseRefreshControlProperty` helper tied to `NavigationBar.PrefersLargeTitles`, eliminating the conditional path that hid the control.

## Rationale
- Large-title navigation bars were preventing the refresh control from appearing correctly when attached via the `RefreshControl` property. Direct insertion ensures the control remains visible and usable.


|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/5d9aecd6-c32f-457c-9478-4f78bd5c9cbc" width="300px"></video>|<video src="https://github.com/user-attachments/assets/d994e2b6-cdd0-4344-be40-8d14ca592339" width="300px"></video>|








