### PR TITLE
[iOS] Fix WebView GoBack/GoForward not working for HtmlWebViewSource

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30381.cs
@@ -15,6 +15,7 @@ public class Issue30381 : ContentPage
     {
         CreateUI();
         SetupWebView();
+        MyWebView.Navigated += OnWebViewNavigated;
     }
 
     void CreateUI()
@@ -156,5 +157,14 @@ public class Issue30381 : ContentPage
     {
         CanGoBackLabel.Text = $"CanGoBack: {MyWebView.CanGoBack}";
         CanGoForwardLabel.Text = $"CanGoForward: {MyWebView.CanGoForward}";
+    }
+
+    void OnWebViewNavigated(object sender, WebNavigatedEventArgs e)
+    {
+        if (e.Url.Contains("github.com", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update navigation status after navigation completes
+            UpdateNavigationStatus();
+        }
     }
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30381.cs
@@ -1,0 +1,160 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 30381, "WebView GoBack/GoForward not working for HtmlWebViewSource on iOS", PlatformAffected.iOS)]
+public class Issue30381 : ContentPage
+{
+    WebView MyWebView;
+    Label CanGoBackLabel;
+    Label CanGoForwardLabel;
+    Button ClickLinkButton;
+    Button GoBackButton;
+    Button GoForwardButton;
+    Button UpdateStatusButton;
+
+    public Issue30381()
+    {
+        CreateUI();
+        SetupWebView();
+    }
+
+    void CreateUI()
+    {
+        // Create all UI elements in code
+        var instructionLabel = new Label
+        {
+            Text = "Click the link in WebView to navigate, then test CanGoForward",
+            AutomationId = "InstructionLabel",
+            FontAttributes = FontAttributes.Bold
+        };
+
+        MyWebView = new WebView
+        {
+            AutomationId = "TestWebView",
+            HeightRequest = 300
+        };
+
+        GoBackButton = new Button
+        {
+            Text = "Go Back",
+            AutomationId = "GoBackButton"
+        };
+        GoBackButton.Clicked += OnGoBackClicked;
+
+        GoForwardButton = new Button
+        {
+            Text = "Go Forward",
+            AutomationId = "GoForwardButton"
+        };
+        GoForwardButton.Clicked += OnGoForwardClicked;
+
+        ClickLinkButton = new Button
+        {
+            Text = "Click Link",
+            AutomationId = "ClickLinkButton"
+        };
+        ClickLinkButton.Clicked += OnClickLinkClicked;
+
+        UpdateStatusButton = new Button
+        {
+            Text = "Get Status",
+            AutomationId = "UpdateStatusButton"
+        };
+        UpdateStatusButton.Clicked += OnUpdateStatusClicked;
+
+        var buttonLayout = new HorizontalStackLayout
+        {
+            Spacing = 10,
+            Children = { GoBackButton, GoForwardButton, ClickLinkButton, UpdateStatusButton }
+        };
+
+        CanGoBackLabel = new Label
+        {
+            AutomationId = "CanGoBackLabel",
+            Text = "CanGoBack: False"
+        };
+
+        CanGoForwardLabel = new Label
+        {
+            AutomationId = "CanGoForwardLabel",
+            Text = "CanGoForward: False"
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 20,
+            Spacing = 10,
+            Children =
+            {
+                instructionLabel,
+                MyWebView,
+                buttonLayout,
+                CanGoBackLabel,
+                CanGoForwardLabel,
+            }
+        };
+    }
+
+    void SetupWebView()
+    {
+        MyWebView.Source = new HtmlWebViewSource
+        {
+            Html = @"
+            <html>
+            <head>
+                <title>Wikipedia</title>
+                <style>
+                    body { font-family: Arial; padding: 16px; line-height: 1.6; }
+                    h1 { color: #3366cc; }
+                    a { color: #0645ad; text-decoration: none; padding: 5px; background: #f0f0f0; border-radius: 3px; }
+                    a:hover { background: #e0e0e0; }
+                </style>
+            </head>
+            <body>
+                <h1>Welcome to Wikipedia</h1>
+                <p>Wikipedia is a free online encyclopedia.</p>
+                <p>Read more <a href='https://github.com/dotnet/maui' id='testLink'>here</a>.</p>
+            </body>
+            </html>"
+        };
+
+        UpdateNavigationStatus();
+    }
+
+    async void OnClickLinkClicked(object sender, EventArgs e)
+    {
+        // Use JavaScript to programmatically click the link
+        await MyWebView.EvaluateJavaScriptAsync("document.getElementById('testLink').click();");
+        // Don't update status here - user needs to click Update Status button
+    }
+
+    void OnUpdateStatusClicked(object sender, EventArgs e)
+    {
+        UpdateNavigationStatus();
+    }
+
+    void OnGoBackClicked(object sender, EventArgs e)
+    {
+        if (MyWebView.CanGoBack)
+        {
+            MyWebView.GoBack();
+        }
+        
+        UpdateNavigationStatus();
+    }
+
+    void OnGoForwardClicked(object sender, EventArgs e)
+    {
+        if (MyWebView.CanGoForward)
+        {
+            MyWebView.GoForward();
+        }
+        
+        UpdateNavigationStatus();
+    }
+
+    void UpdateNavigationStatus()
+    {
+        CanGoBackLabel.Text = $"CanGoBack: {MyWebView.CanGoBack}";
+        CanGoForwardLabel.Text = $"CanGoForward: {MyWebView.CanGoForward}";
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue30381.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 30381, "WebView GoBack/GoForward not working for HtmlWebViewSource on iOS", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 30381, "WebView GoBack/GoForward not working for HtmlWebViewSource on iOS", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue30381 : ContentPage
 {
     WebView MyWebView;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -1,4 +1,4 @@
-# if TEST_FAILS_ON_ANDROID      //Using JavaScript to click the URL is not working on Android.
+# if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_WINDOWS    //Using JavaScript to click the URL is not working on Android and Windows.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue30381 : _IssuesUITest
+{
+    public override string Issue => "WebView GoBack/GoForward not working for HtmlWebViewSource on iOS";
+
+    public Issue30381(TestDevice device) : base(device)
+    {
+    }
+
+    [Test]
+    [Category(UITestCategories.WebView)]
+    public void WebViewCanGoForwardShouldHaveValueAfterNavigation()
+    {
+        // Wait for WebView to load
+        App.WaitForElement("TestWebView");
+        App.WaitForElement("ClickLinkButton");
+
+        // Click the link via JavaScript to navigate to external URL
+        App.Tap("ClickLinkButton");
+
+        // Wait for navigation to complete
+        // Add a delay to allow navigation to process
+        Thread.Sleep(3000);
+        App.Tap("UpdateStatusButton");
+        Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: True"));
+        Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: False"));
+
+        App.Tap("GoBackButton");
+
+        // Wait for back navigation to complete
+        Thread.Sleep(2000);
+
+        Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: False"));
+        Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: True"));
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -17,13 +17,14 @@ public class Issue30381 : _IssuesUITest
     public void WebViewCanGoForwardShouldHaveValueAfterNavigation()
     {
         App.WaitForElement("ClickLinkButton");
+        Thread.Sleep(2000);
 
         // Click the link via JavaScript to navigate to external URL
         App.Tap("ClickLinkButton");
 
         // Wait for navigation to complete
         // Add a delay to allow navigation to process
-        Thread.Sleep(3000);
+        Thread.Sleep(2000);
         App.Tap("UpdateStatusButton");
         Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: True"));
         Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: False"));
@@ -35,5 +36,12 @@ public class Issue30381 : _IssuesUITest
         App.Tap("UpdateStatusButton");
         Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: False"));
         Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: True"));
+
+        App.Tap("GoForwardButton");
+
+        Thread.Sleep(2000);
+        App.Tap("UpdateStatusButton");
+        Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: True"));
+        Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: False"));
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -1,3 +1,4 @@
+# if TEST_FAILS_ON_ANDROID      //Using JavaScript to click the URL is not working on Android.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -42,3 +43,4 @@ public class Issue30381 : _IssuesUITest
         Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: False"));
     }
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -16,8 +16,6 @@ public class Issue30381 : _IssuesUITest
     [Category(UITestCategories.WebView)]
     public void WebViewCanGoForwardShouldHaveValueAfterNavigation()
     {
-        // Wait for WebView to load
-        App.WaitForElement("TestWebView");
         App.WaitForElement("ClickLinkButton");
 
         // Click the link via JavaScript to navigate to external URL
@@ -34,7 +32,7 @@ public class Issue30381 : _IssuesUITest
 
         // Wait for back navigation to complete
         Thread.Sleep(2000);
-
+        App.Tap("UpdateStatusButton");
         Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: False"));
         Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: True"));
     }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -31,15 +31,12 @@ public class Issue30381 : _IssuesUITest
 
         App.Tap("GoBackButton");
 
-        // Wait for back navigation to complete
-        Thread.Sleep(2000);
         App.Tap("UpdateStatusButton");
         Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: False"));
         Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: True"));
 
         App.Tap("GoForwardButton");
 
-        Thread.Sleep(2000);
         App.Tap("UpdateStatusButton");
         Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: True"));
         Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: False"));

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -18,23 +18,22 @@ public class Issue30381 : _IssuesUITest
     public void WebViewCanGoForwardShouldHaveValueAfterNavigation()
     {
         App.WaitForElement("ClickLinkButton");
-        Thread.Sleep(2000);
+        // Wait for the WebView to load the initial content before clicking the link
+        Thread.Sleep(1000);
 
         // Click the link via JavaScript to navigate to external URL
         App.Tap("ClickLinkButton");
-
-        // Wait for navigation to complete
-        // Add a delay to allow navigation to process
-        Thread.Sleep(2000);
+        App.WaitForTextToBePresentInElement("CanGoBackLabel", "CanGoBack: True");
+        
         App.Tap("UpdateStatusButton");
-        Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: True"));
-        Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: False"));
+        App.WaitForTextToBePresentInElement("CanGoBackLabel", "CanGoBack: True");
+        App.WaitForTextToBePresentInElement("CanGoForwardLabel", "CanGoForward: False");
 
         App.Tap("GoBackButton");
 
         App.Tap("UpdateStatusButton");
-        Assert.That(App.FindElement("CanGoBackLabel").GetText(), Is.EqualTo("CanGoBack: False"));
-        Assert.That(App.FindElement("CanGoForwardLabel").GetText(), Is.EqualTo("CanGoForward: True"));
+        App.WaitForTextToBePresentInElement("CanGoBackLabel", "CanGoBack: False");
+        App.WaitForTextToBePresentInElement("CanGoForwardLabel", "CanGoForward: True");
 
         App.Tap("GoForwardButton");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue30381.cs
@@ -1,4 +1,4 @@
-# if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_WINDOWS    //Using JavaScript to click the URL is not working on Android and Windows.
+#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_WINDOWS    //Using JavaScript to click the URL is not working on Android and Windows.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -96,26 +96,26 @@ namespace Microsoft.Maui.Platform
 		}
 
 		public void LoadHtml(string? html, string? baseUrl)
-    {
-        if (html != null)
-        {
-            if (!string.IsNullOrEmpty(baseUrl))
-            {
-                LoadHtmlString(html, new NSUrl(baseUrl, true));
-            }
-            else
-            {
-				// Create a unique data URL to ensure proper navigation history
-				// LoadHtmlString doesn't create entries in the back/forward list
-				// Using LoadRequest with a data URL ensures the HTML content appears in navigation history
-				var base64Html = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(html));
-				var dataUrl = $"data:text/html;charset=utf-8;base64,{base64Html}";
+		{
+			if (html != null)
+			{
+				if (!string.IsNullOrEmpty(baseUrl))
+				{
+					LoadHtmlString(html, new NSUrl(baseUrl, true));
+				}
+				else
+				{
+					// Create a unique data URL to ensure proper navigation history
+					// LoadHtmlString doesn't create entries in the back/forward list
+					// Using LoadRequest with a data URL ensures the HTML content appears in navigation history
+					var base64Html = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(html));
+					var dataUrl = $"data:text/html;charset=utf-8;base64,{base64Html}";
 
-                // Use LoadRequest with data URL for proper navigation history
-                LoadRequest(new NSUrlRequest(new NSUrl(dataUrl)));
-            }
-        }
-    }
+					// Use LoadRequest with data URL for proper navigation history
+					LoadRequest(new NSUrlRequest(new NSUrl(dataUrl)));
+				}
+			}
+		}
 
 
 		async Task LoadUrlAsync(string? url)

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -99,12 +99,6 @@ namespace Microsoft.Maui.Platform
     {
         if (html != null)
         {
-            // Create a unique data URL to ensure proper navigation history
-            // LoadHtmlString doesn't create entries in the back/forward list
-            // Using LoadRequest with a data URL ensures the HTML content appears in navigation history
-            var base64Html = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(html));
-            var dataUrl = $"data:text/html;charset=utf-8;base64,{base64Html}";
-            
             // If baseUrl is provided, we need to use LoadData to respect it for relative resources
             if (!string.IsNullOrEmpty(baseUrl))
             {
@@ -112,6 +106,12 @@ namespace Microsoft.Maui.Platform
             }
             else
             {
+				// Create a unique data URL to ensure proper navigation history
+				// LoadHtmlString doesn't create entries in the back/forward list
+				// Using LoadRequest with a data URL ensures the HTML content appears in navigation history
+				var base64Html = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(html));
+				var dataUrl = $"data:text/html;charset=utf-8;base64,{base64Html}";
+
                 // Use LoadRequest with data URL for proper navigation history
                 LoadRequest(new NSUrlRequest(new NSUrl(dataUrl)));
             }

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -103,14 +103,12 @@ namespace Microsoft.Maui.Platform
             // LoadHtmlString doesn't create entries in the back/forward list
             // Using LoadRequest with a data URL ensures the HTML content appears in navigation history
             var base64Html = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(html));
-            var dataUrl = $"data:text/html;base64,{base64Html}";
+            var dataUrl = $"data:text/html;charset=utf-8;base64,{base64Html}";
             
             // If baseUrl is provided, we need to use LoadData to respect it for relative resources
             if (!string.IsNullOrEmpty(baseUrl))
             {
-                var nsBaseUrl = new NSUrl(baseUrl, true);
-                var htmlData = NSData.FromString(html, NSStringEncoding.UTF8);
-                LoadData(htmlData, "text/html", "UTF-8", nsBaseUrl);
+                LoadHtmlString(html, new NSUrl(baseUrl, true));
             }
             else
             {

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Maui.Platform
     {
         if (html != null)
         {
-            // If baseUrl is provided, we need to use LoadData to respect it for relative resources
             if (!string.IsNullOrEmpty(baseUrl))
             {
                 LoadHtmlString(html, new NSUrl(baseUrl, true));

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-
 		async Task LoadUrlAsync(string? url)
 		{
 			try

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -99,21 +99,22 @@ namespace Microsoft.Maui.Platform
 		{
 			if (html != null)
 			{
-				if (!string.IsNullOrEmpty(baseUrl))
-				{
-					LoadHtmlString(html, new NSUrl(baseUrl, true));
-				}
-				else
-				{
-					// Create a unique data URL to ensure proper navigation history
-					// LoadHtmlString doesn't create entries in the back/forward list
-					// Using LoadRequest with a data URL ensures the HTML content appears in navigation history
-					var base64Html = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(html));
-					var dataUrl = $"data:text/html;charset=utf-8;base64,{base64Html}";
+				// Use the provided baseUrl, or fall back to the app bundle path so that
+				// relative resources (images, CSS, JS) bundled with the app continue to resolve.
+				var resolvedBaseUrl = !string.IsNullOrEmpty(baseUrl)
+					? new NSUrl(baseUrl, true)
+					: new NSUrl(NSBundle.MainBundle.BundlePath, true);
 
-					// Use LoadRequest with data URL for proper navigation history
-					LoadRequest(new NSUrlRequest(new NSUrl(dataUrl)));
-				}
+				// LoadSimulatedRequest (iOS 15+) is used instead of LoadHtmlString or a data: URL because:
+				//   1. History  — creates a back/forward history entry for both the null and non-null
+				//                 BaseUrl cases, so GoBack/GoForward work correctly for HtmlWebViewSource.
+				//   2. Privacy  — the HTML document is passed as a parameter; WKWebView.Url only reflects
+				//                 the base URL, so the page contents are never exposed in URLs, logs, or
+				//                 navigation-event arguments.
+				//   3. Compat   — preserves the resolved base URL as the origin, keeping cookies,
+				//                 JavaScript evaluation, and relative-resource resolution working exactly
+				//                 as they did with the previous LoadHtmlString approach.
+				LoadSimulatedRequest(new NSUrlRequest(resolvedBaseUrl), html);
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Platform
 					? new NSUrl(baseUrl, true)
 					: new NSUrl(NSBundle.MainBundle.BundlePath, true);
 
-				// LoadSimulatedRequest (iOS 15+) is used instead of LoadHtmlString or a data: URL because:
+				// LoadSimulatedRequest (iOS 15+ / macCatalyst 15+) is preferred over LoadHtmlString because:
 				//   1. History  — creates a back/forward history entry for both the null and non-null
 				//                 BaseUrl cases, so GoBack/GoForward work correctly for HtmlWebViewSource.
 				//   2. Privacy  — the HTML document is passed as a parameter; WKWebView.Url only reflects
@@ -114,7 +114,15 @@ namespace Microsoft.Maui.Platform
 				//   3. Compat   — preserves the resolved base URL as the origin, keeping cookies,
 				//                 JavaScript evaluation, and relative-resource resolution working exactly
 				//                 as they did with the previous LoadHtmlString approach.
-				LoadSimulatedRequest(new NSUrlRequest(resolvedBaseUrl), html);
+				// On iOS 13/14 and earlier macCatalyst, fall back to LoadHtmlString.
+				if (OperatingSystem.IsIOSVersionAtLeast(15) || OperatingSystem.IsMacCatalystVersionAtLeast(15))
+				{
+					LoadSimulatedRequest(new NSUrlRequest(resolvedBaseUrl), html);
+				}
+				else
+				{
+					LoadHtmlString(html, resolvedBaseUrl);
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

On iOS, LoadHtml uses LoadHtmlString(), which does not add the HTML page to WebView history.
Because of this, GoBack() cannot navigate back after loading HTML.

### Description of Change

<!-- Enter description of the fix in this section -->
MauiWKWebView.cs — Replaced LoadHtmlString() with LoadSimulatedRequest() (iOS 15+ / MacCatalyst 15+). This method loads the HTML content while creating a proper WKWebView back/forward history entry, enabling GoBack()/GoForward() to work correctly. For iOS 13/14 and earlier MacCatalyst, the implementation falls back to LoadHtmlString() to preserve compatibility.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #30381

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/1b328f84-c5d4-4b6f-a2b3-bbffbf338895" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/4ca2e343-b452-4958-afd3-b8f1ff5eafde" width="300" height="600"> |
