### PR TITLE
[Android] ScrollView doesn't work in the Shell Flyout Header 

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11764.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11764.cs
@@ -1,0 +1,90 @@
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 11764, "ScrollView doesn't work in the Shell Flyout Header", PlatformAffected.Android)]
+	public class Issue11764 : TestShell
+	{
+		Label scrollPositionLabel;
+		VerticalStackLayout _views;
+		protected override void Init()
+		{
+			var sampleButton = new Button();
+			sampleButton.Text = "Click to Scroll to Bottom";
+			sampleButton.FontSize = 16;
+			sampleButton.AutomationId = "SampleButton";
+
+			scrollPositionLabel = new Label
+			{
+				Text = "ScrollView - Y position is 0",
+				FontSize = 18,
+				TextColor = Colors.White,
+				BackgroundColor = Colors.Green,
+				Padding = 10
+			};
+			var scrollView = new ScrollView
+			{
+				HeightRequest = 200,
+				AutomationId= "FlyoutScrollView",
+				Content = new VerticalStackLayout
+				{
+					Spacing = 10,
+					Padding = 20,
+					Children =
+					{
+						sampleButton,
+						new Label { Text = "Item 2", FontSize = 16, TextColor = Colors.White },
+						new BoxView { HeightRequest = 100, Color = Colors.Blue },
+						new Label { Text = "Item 3", FontSize = 16, TextColor = Colors.White },
+						new BoxView { HeightRequest = 100, Color = Colors.Orange },
+						new Label { Text = "Item 4", FontSize = 16, TextColor = Colors.White },
+						new BoxView { HeightRequest = 100, Color = Colors.Purple },
+						new Label { Text = "Item 5", FontSize = 16, TextColor = Colors.White },
+						new BoxView { HeightRequest = 100, Color = Colors.Cyan },
+						new Label
+						{
+							Text = "Bottom of ScrollView - This is the last item",
+							FontSize = 18,
+							TextColor = Colors.White,
+							BackgroundColor = Colors.DarkGreen,
+							Padding = 10
+						}
+					}
+				}
+			};
+			scrollView.Scrolled += scrollView_Scrolled;
+			_views = new VerticalStackLayout
+			{
+				Children =
+				{
+					scrollView,
+					scrollPositionLabel
+				}
+			};
+			FlyoutHeader = _views;
+			AddFlyoutItem(CreatePage("Page 1"), "Page 1");
+		}
+
+		private void scrollView_Scrolled(object sender, ScrolledEventArgs e)
+		{
+			scrollPositionLabel.Text = "The ScrollView is scrolls vertically";
+		}
+		ContentPage CreatePage(string title)
+		{
+            var buttonText = new Button();
+			buttonText.Text = "Open Flyout";
+			buttonText.AutomationId = "OpenFlyoutButton";
+            buttonText.Clicked += (sender, e) => Shell.Current.FlyoutIsPresented = true;
+			return new ContentPage
+			{
+				Title = title,
+				Content = new VerticalStackLayout
+				{
+					Padding = 20,
+					Children =
+					{
+						buttonText,
+                    }
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue11764.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue11764.cs
@@ -15,6 +15,7 @@ namespace Maui.Controls.Sample.Issues
 			scrollPositionLabel = new Label
 			{
 				Text = "ScrollView - Y position is 0",
+				AutomationId = "ScrollResultLabel",
 				FontSize = 18,
 				TextColor = Colors.White,
 				BackgroundColor = Colors.Green,

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11764.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11764.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue11764 : _IssuesUITest
+	{
+		public Issue11764(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "ScrollView doesn't work in the Shell Flyout Header";
+
+		[Test]
+		[Category(UITestCategories.ScrollView)]
+		public async Task ScrollViewInFlyoutHeaderShouldScroll()
+        {
+            App.WaitForElement("OpenFlyoutButton");
+            App.Tap("OpenFlyoutButton");
+            App.WaitForElement("SampleButton");
+			await Task.Delay(400); // Wait for the flyout to settle
+			App.ScrollDown("FlyoutScrollView",ScrollStrategy.Gesture,0.90);
+            App.WaitForElement("The ScrollView is scrolls vertically");
+        }
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11764.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue11764.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -14,14 +15,29 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 		[Test]
 		[Category(UITestCategories.ScrollView)]
-		public async Task ScrollViewInFlyoutHeaderShouldScroll()
-        {
-            App.WaitForElement("OpenFlyoutButton");
-            App.Tap("OpenFlyoutButton");
-            App.WaitForElement("SampleButton");
-			await Task.Delay(400); // Wait for the flyout to settle
-			App.ScrollDown("FlyoutScrollView",ScrollStrategy.Gesture,0.90);
-            App.WaitForElement("The ScrollView is scrolls vertically");
-        }
+		public void ScrollViewInFlyoutHeaderShouldScroll()
+		{
+			const string scrollResultLabel = "ScrollResultLabel";
+			const string expectedText = "The ScrollView is scrolls vertically";
+
+			App.WaitForElement("OpenFlyoutButton");
+			App.Tap("OpenFlyoutButton");
+
+			// Wait for flyout content to be ready before attempting gesture input.
+			App.WaitForElement("FlyoutScrollView", timeout: TimeSpan.FromSeconds(10));
+			App.WaitForElement("SampleButton", timeout: TimeSpan.FromSeconds(10));
+			App.WaitForElement(scrollResultLabel, timeout: TimeSpan.FromSeconds(10));
+
+			for (var attempt = 0; attempt < 4; attempt++)
+			{
+				App.ScrollDown("FlyoutScrollView", ScrollStrategy.Gesture, 0.90);
+
+				var labelText = App.WaitForElement(scrollResultLabel).GetText();
+				if (labelText == expectedText)
+					return;
+			}
+
+			Assert.Fail($"Expected '{expectedText}' after scrolling flyout header ScrollView.");
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -233,14 +233,7 @@ namespace Microsoft.Maui.Platform
 
 			// Request parent to not intercept touch events while we're scrolling
 			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
-			if (ev.Action == MotionEventActions.Down)
-			{
-				Parent?.RequestDisallowInterceptTouchEvent(true);
-			}
-			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
-			{
-				Parent?.RequestDisallowInterceptTouchEvent(false);
-			}
+			ScrollViewExtensions.HandleTouchEvent(ev, Parent);
 
 			// The nested ScrollViews will allow us to scroll EITHER vertically OR horizontally in a single gesture.
 			// This will allow us to also scroll diagonally.
@@ -493,14 +486,7 @@ namespace Microsoft.Maui.Platform
 
 			// Request parent to not intercept touch events while we're scrolling
 			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
-			if (ev.Action == MotionEventActions.Down)
-			{
-				Parent?.RequestDisallowInterceptTouchEvent(true);
-			}
-			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
-			{
-				Parent?.RequestDisallowInterceptTouchEvent(false);
-			}
+			ScrollViewExtensions.HandleTouchEvent(ev, Parent);
 
 			// If the touch is caught by the horizontal scrollview, forward it to the parent 
 			_parentScrollView.ShouldSkipOnTouch = true;

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -231,6 +231,17 @@ namespace Microsoft.Maui.Platform
 				return false;
 			}
 
+			// Request parent to not intercept touch events while we're scrolling
+			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
+			if (ev.Action == MotionEventActions.Down)
+			{
+				Parent?.RequestDisallowInterceptTouchEvent(true);
+			}
+			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
+			{
+				Parent?.RequestDisallowInterceptTouchEvent(false);
+			}
+
 			// The nested ScrollViews will allow us to scroll EITHER vertically OR horizontally in a single gesture.
 			// This will allow us to also scroll diagonally.
 			// We'll fall through to the base event so we still get the fling from the ScrollViews.
@@ -479,6 +490,17 @@ namespace Microsoft.Maui.Platform
 
 			if (!_parentScrollView.Enabled)
 				return false;
+
+			// Request parent to not intercept touch events while we're scrolling
+			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
+			if (ev.Action == MotionEventActions.Down)
+			{
+				Parent?.RequestDisallowInterceptTouchEvent(true);
+			}
+			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
+			{
+				Parent?.RequestDisallowInterceptTouchEvent(false);
+			}
 
 			// If the touch is caught by the horizontal scrollview, forward it to the parent 
 			_parentScrollView.ShouldSkipOnTouch = true;

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -25,11 +25,9 @@ namespace Microsoft.Maui.Platform
 		ScrollBarVisibility _horizontalScrollVisibility;
 		bool _didSafeAreaEdgeConfigurationChange = true;
 		bool _isInsetListenerSet;
-		IViewParent? _drawerLayoutParent;
 
 		internal float LastX { get; set; }
 		internal float LastY { get; set; }
-		internal IViewParent? DrawerLayoutParent => _drawerLayoutParent;
 
 		internal bool ShouldSkipOnTouch;
 		internal int HorizontalScrollOffset => _hScrollView?.ScrollX ?? 0;
@@ -63,7 +61,6 @@ namespace Microsoft.Maui.Platform
 		public override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
-			_drawerLayoutParent = ScrollViewExtensions.FindDrawerLayoutAncestor(Parent);
 			_isInsetListenerSet = MauiWindowInsetListenerExtensions.TrySetMauiWindowInsetListener(this, _context);
 		}
 
@@ -73,7 +70,6 @@ namespace Microsoft.Maui.Platform
 			if (_isInsetListenerSet)
 				MauiWindowInsetListenerExtensions.RemoveMauiWindowInsetListener(this, _context);
 
-			_drawerLayoutParent = null;
 			_isInsetListenerSet = false;
 			_didSafeAreaEdgeConfigurationChange = true;
 		}
@@ -237,8 +233,7 @@ namespace Microsoft.Maui.Platform
 
 			// Request parent to not intercept touch events while we're scrolling
 			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
-			if (_drawerLayoutParent != null)
-				ScrollViewExtensions.HandleTouchEvent(ev, _drawerLayoutParent);
+			ScrollViewExtensions.HandleTouchEvent(ev, Parent);
 
 			// The nested ScrollViews will allow us to scroll EITHER vertically OR horizontally in a single gesture.
 			// This will allow us to also scroll diagonally.
@@ -491,8 +486,7 @@ namespace Microsoft.Maui.Platform
 
 			// Request parent to not intercept touch events while we're scrolling
 			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
-			if (_parentScrollView.DrawerLayoutParent != null)
-				ScrollViewExtensions.HandleTouchEvent(ev, _parentScrollView.DrawerLayoutParent);
+			ScrollViewExtensions.HandleTouchEvent(ev, Parent);
 
 			// If the touch is caught by the horizontal scrollview, forward it to the parent 
 			_parentScrollView.ShouldSkipOnTouch = true;

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -25,9 +25,11 @@ namespace Microsoft.Maui.Platform
 		ScrollBarVisibility _horizontalScrollVisibility;
 		bool _didSafeAreaEdgeConfigurationChange = true;
 		bool _isInsetListenerSet;
+		IViewParent? _drawerLayoutParent;
 
 		internal float LastX { get; set; }
 		internal float LastY { get; set; }
+		internal IViewParent? DrawerLayoutParent => _drawerLayoutParent;
 
 		internal bool ShouldSkipOnTouch;
 		internal int HorizontalScrollOffset => _hScrollView?.ScrollX ?? 0;
@@ -61,6 +63,7 @@ namespace Microsoft.Maui.Platform
 		public override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
+			_drawerLayoutParent = ScrollViewExtensions.FindDrawerLayoutAncestor(Parent);
 			_isInsetListenerSet = MauiWindowInsetListenerExtensions.TrySetMauiWindowInsetListener(this, _context);
 		}
 
@@ -70,6 +73,7 @@ namespace Microsoft.Maui.Platform
 			if (_isInsetListenerSet)
 				MauiWindowInsetListenerExtensions.RemoveMauiWindowInsetListener(this, _context);
 
+			_drawerLayoutParent = null;
 			_isInsetListenerSet = false;
 			_didSafeAreaEdgeConfigurationChange = true;
 		}
@@ -233,7 +237,8 @@ namespace Microsoft.Maui.Platform
 
 			// Request parent to not intercept touch events while we're scrolling
 			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
-			ScrollViewExtensions.HandleTouchEvent(ev, Parent);
+			if (_drawerLayoutParent != null)
+				ScrollViewExtensions.HandleTouchEvent(ev, _drawerLayoutParent);
 
 			// The nested ScrollViews will allow us to scroll EITHER vertically OR horizontally in a single gesture.
 			// This will allow us to also scroll diagonally.
@@ -486,7 +491,8 @@ namespace Microsoft.Maui.Platform
 
 			// Request parent to not intercept touch events while we're scrolling
 			// This allows ScrollView to work properly inside containers like DrawerLayout (Shell Flyout)
-			ScrollViewExtensions.HandleTouchEvent(ev, Parent);
+			if (_parentScrollView.DrawerLayoutParent != null)
+				ScrollViewExtensions.HandleTouchEvent(ev, _parentScrollView.DrawerLayoutParent);
 
 			// If the touch is caught by the horizontal scrollview, forward it to the parent 
 			_parentScrollView.ShouldSkipOnTouch = true;

--- a/src/Core/src/Platform/Android/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ScrollViewExtensions.cs
@@ -42,5 +42,17 @@ namespace Microsoft.Maui.Platform
 				scrollView.SetContent(nativeContent);
 			}
 		}
+
+		internal static void HandleTouchEvent(MotionEvent ev, IViewParent? parent)
+		{
+			if (ev.Action == MotionEventActions.Down)
+			{
+				parent?.RequestDisallowInterceptTouchEvent(true);
+			}
+			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
+			{
+				parent?.RequestDisallowInterceptTouchEvent(false);
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ScrollViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Views;
+using AndroidX.DrawerLayout.Widget;
 
 namespace Microsoft.Maui.Platform
 {
@@ -43,16 +44,27 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static void HandleTouchEvent(MotionEvent ev, IViewParent? parent)
+		internal static void HandleTouchEvent(MotionEvent ev, IViewParent parent)
 		{
 			if (ev.Action == MotionEventActions.Down)
 			{
-				parent?.RequestDisallowInterceptTouchEvent(true);
+				parent.RequestDisallowInterceptTouchEvent(true);
 			}
 			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
 			{
-				parent?.RequestDisallowInterceptTouchEvent(false);
+				parent.RequestDisallowInterceptTouchEvent(false);
 			}
+		}
+
+		internal static DrawerLayout? FindDrawerLayoutAncestor(IViewParent? parent)
+		{
+			for (IViewParent? current = parent; current != null; current = current.Parent)
+			{
+				if (current is DrawerLayout drawerLayout)
+					return drawerLayout;
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ScrollViewExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Android.Views;
-using AndroidX.DrawerLayout.Widget;
 
 namespace Microsoft.Maui.Platform
 {
@@ -44,27 +43,16 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static void HandleTouchEvent(MotionEvent ev, IViewParent parent)
+		internal static void HandleTouchEvent(MotionEvent ev, IViewParent? parent)
 		{
 			if (ev.Action == MotionEventActions.Down)
 			{
-				parent.RequestDisallowInterceptTouchEvent(true);
+				parent?.RequestDisallowInterceptTouchEvent(true);
 			}
 			else if (ev.Action == MotionEventActions.Up || ev.Action == MotionEventActions.Cancel)
 			{
-				parent.RequestDisallowInterceptTouchEvent(false);
+				parent?.RequestDisallowInterceptTouchEvent(false);
 			}
-		}
-
-		internal static DrawerLayout? FindDrawerLayoutAncestor(IViewParent? parent)
-		{
-			for (IViewParent? current = parent; current != null; current = current.Parent)
-			{
-				if (current is DrawerLayout drawerLayout)
-					return drawerLayout;
-			}
-
-			return null;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

Unable to scrolling vertically / horizontally when scrollview placed in Shell.FlyoutHeader in Android platform. The issue doesn't occur in iOS,Mac and windows platforms.
       
### Root Cause:

The issue occurs because Android's DrawerLayout (which powers the Shell Flyout) uses touch event interception to handle the pan gesture that opens and closes the flyout menu. When a ScrollView is placed inside the Shell.FlyoutHeader, the DrawerLayout intercepts touch events before they can reach the ScrollView. This interception happens in the DrawerLayout.OnInterceptTouchEvent() method, which is designed to detect horizontal swipe gestures. However, when a user attempts to scroll vertically within the ScrollView, the DrawerLayout interprets any touch movement as a potential flyout gesture and intercepts the event, preventing the ScrollView from receiving it. As a result, the ScrollView never processes the scroll gesture, and instead, the touch movement is consumed by the DrawerLayout's flyout pan gesture handler. This creates a conflict where vertical scrolling becomes impossible because the parent container's gesture recognition takes priority over the child ScrollView's scroll handling. The user reported that attempting to scroll the content in the flyout header would close the flyout instead of scrolling, which confirms that the DrawerLayout is intercepting and handling the touch events rather than allowing them to reach the ScrollView.

### Description of Change:

The fix implements the standard Android pattern for resolving nested scrolling conflicts by using the RequestDisallowInterceptTouchEvent() API. This method allows a child view to request that its parent not intercept touch events during active touch handling. The fix was applied to both MauiScrollView.OnTouchEvent() and MauiHorizontalScrollView.OnTouchEvent() methods in the src/Core/src/Platform/Android/MauiScrollView.cs file. When a touch begins (MotionEventActions.Down), the ScrollView calls Parent?.RequestDisallowInterceptTouchEvent(true), which tells the parent DrawerLayout to stop intercepting touch events for this gesture sequence. This allows the ScrollView to receive and process all subsequent touch events in the gesture, enabling normal scrolling behavior. When the touch ends (MotionEventActions.Up) or is cancelled (MotionEventActions.Cancel), the ScrollView calls Parent?.RequestDisallowInterceptTouchEvent(false) to restore the parent's ability to intercept touch events for future gestures. This ensures that after scrolling completes, the flyout's horizontal swipe-to-close gesture continues to work normally.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #11764

### Screenshots
| Before  | After  |
|---------|--------|
| <Video width="380" height="1000" alt="image (6)" src="https://github.com/user-attachments/assets/3ea26fee-4aa5-43f8-be95-2ceac2ab231e" /> | <Video width="380" height="1000" alt="image (6)" src="https://github.com/user-attachments/assets/612a25c4-872f-42ca-a181-cd0e5d8358f7" /> |
