### PR TITLE
Restore OfficialBuildId for proper CI versioning

### DIFF
--- a/eng/Versions.targets
+++ b/eng/Versions.targets
@@ -32,7 +32,6 @@
 
     <PropertyGroup>
       <PreReleaseVersionLabel Condition="'$(CI)' == 'true' and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</PreReleaseVersionLabel>
-      <PreReleaseVersionLabel Condition="'$(CI)' == 'true' and '$(BUILD_REASON)' == 'PullRequest'">$(PreReleaseVersionLabel).pr$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)</PreReleaseVersionLabel>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/Versions.targets
+++ b/eng/Versions.targets
@@ -32,6 +32,7 @@
 
     <PropertyGroup>
       <PreReleaseVersionLabel Condition="'$(CI)' == 'true' and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</PreReleaseVersionLabel>
+      <PreReleaseVersionLabel Condition="'$(CI)' == 'true' and '$(BUILD_REASON)' == 'PullRequest'">$(PreReleaseVersionLabel).pr$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)</PreReleaseVersionLabel>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -38,7 +38,7 @@ variables:
   - name: _PublishArgs
     value: ''
   - name: _OfficialBuildIdArgs
-    value: ''
+    value: /p:OfficialBuildId=$(_BuildOfficialId) /p:_SkipUpdateBuildNumber=true
   # needed for signing
   - name: _SignType
     value: test

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -25,7 +25,7 @@ variables:
 - name: TreatWarningsAsErrors
   value: false
 - name: _OfficialBuildIdArgs
-  value: ''
+  value: /p:OfficialBuildId=$(_BuildOfficalId) /p:_SkipUpdateBuildNumber=true
 - name: ApiScanAppId
   value: cbde2fca-1ca1-47f7-8212-fcdf1a556eb2
 - name: ApiScanTenantId

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -20,12 +20,12 @@ variables:
   value: powershell -ExecutionPolicy ByPass -NoProfile $(Build.SourcesDirectory)\eng\common\msbuild.ps1 -ci
 - name: _msbuildMacOsCommand
   value: $(Build.SourcesDirectory)/eng/common/msbuild.sh --ci
-- name: _BuildOfficalId
+- name: _BuildOfficialId
   value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 - name: TreatWarningsAsErrors
   value: false
 - name: _OfficialBuildIdArgs
-  value: /p:OfficialBuildId=$(_BuildOfficalId) /p:_SkipUpdateBuildNumber=true
+  value: /p:OfficialBuildId=$(_BuildOfficialId) /p:_SkipUpdateBuildNumber=true
 - name: ApiScanAppId
   value: cbde2fca-1ca1-47f7-8212-fcdf1a556eb2
 - name: ApiScanTenantId

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -44,6 +44,10 @@ variables:
     value: test
   - name: _SignArgs
     value: '/p:DotNetSignType=$(_SignType) /p:TeamName=$(TeamName)'
+# PR builds get a distinct version label
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - name: _OfficialBuildIdArgs
+    value: /p:OfficialBuildId=$(_BuildOfficialId) /p:_SkipUpdateBuildNumber=true /p:PreReleaseVersionLabel=ci.pr$(System.PullRequest.PullRequestNumber)
 # Set up non-PR build from internal project
 - ${{ if or(eq(variables['Build.DefinitionName'], 'dotnet-maui'), eq(variables['Build.DefinitionName'], 'dotnet-maui-build')) }}:
   # needed for darc (dependency flow) publishing

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -82,7 +82,7 @@ extends:
         enableMicrobuild: true
         publishAssets: true
         sourceIndexParams:
-          sourceIndexBuildCommand: build.cmd -restore -build -ci /bl:$(Build.Arcade.LogsPath)sourceIndexBuild.binlog /p:OfficialBuildId=$(_BuildOfficalId) /p:_SkipUpdateBuildNumber=true
+          sourceIndexBuildCommand: build.cmd -restore -build -ci /bl:$(Build.Arcade.LogsPath)sourceIndexBuild.binlog /p:OfficialBuildId=$(_BuildOfficialId) /p:_SkipUpdateBuildNumber=true
           binlogPath: $(Build.Arcade.LogsPath)sourceIndexBuild.binlog
         prepareSteps:
         - template: /eng/pipelines/common/provision.yml@self

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -73,7 +73,7 @@ jobs:
       inlineScript: >-
         dotnet build $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
         -t:PushManifestToBuildAssetRegistry
-        -p:OfficialBuildId=$(_BuildOfficalId)
+        -p:OfficialBuildId=$(_BuildOfficialId)
         -p:OutputPath=${{ parameters.nugetArtifactPath }}
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,7 +1,7 @@
 variables:
 - name: BuildVersion
   value: $[counter('buildversion-counter', 5000)]
-- name: _BuildOfficalId
+- name: _BuildOfficialId
   value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -204,7 +204,7 @@ stages:
         value: $(Build.SourcesDirectory)/build.cmd -ci
       - name: _BuildConfig
         value: Release
-      - name: _BuildOfficalId
+      - name: _BuildOfficialId
         value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 
       steps:
@@ -221,7 +221,7 @@ stages:
           repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
           repoLogPath: $(Build.Arcade.LogsPath)
           repoTestResultsPath: $(Build.Arcade.TestResultsPath)
-          officialBuildId: $(_BuildOfficalId)
+          officialBuildId: $(_BuildOfficialId)
           prepareSteps:
           - template: common/provision.yml
             parameters:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR fixes CI and PR build versioning issues and includes several improvements to the pipeline configuration.

### Root Cause

In commit 4fcc7b2c95, the default `_OfficialBuildIdArgs` was changed to an empty string. This caused the `OfficialBuildId` to not be passed to builds, resulting in Arcade treating them as PR validation builds instead of official CI builds. Packages were being labeled as `10.0.30-ci` instead of the expected format `10.0.30-ci.main.YYMMDD.r`.

### Changes

1. **Restore default `_OfficialBuildIdArgs`**: The default value now passes `OfficialBuildId` to the build process, which enables proper versioning with the date-based suffix.

2. **Fix typo across multiple files**: `_BuildOfficalId` → `_BuildOfficialId` (fixed in 6 locations)

3. **Include PR number in package version for PR builds**: PR builds now use `PreReleaseVersionLabel=ci.pr{number}` so the PR number appears in the actual NuGet package filename, not just in build metadata.

### Expected Results

**CI builds** from the main branch will produce packages with versions like:
- `10.0.30-ci.main.25618.1` (where `25618` is SHORT_DATE and `1` is the daily revision)

**PR builds** will produce packages with versions like:
- `10.0.30-ci.pr33209.25618.1` (where `33209` is the PR number)

Instead of the previous broken format:
- `10.0.30-ci`

### Files Changed

- `eng/pipelines/arcade/variables.yml` - Main fix + PR version label
- `eng/pipelines/ci-official.yml` - Typo fix
- `eng/pipelines/handlers.yml` - Typo fix (2 occurrences)
- `eng/pipelines/common/sdk-insertion.yml` - Typo fix
- `eng/pipelines/common/variables.yml` - Typo fix