### PR TITLE
Fix RunOniOS tests to use architecture-appropriate runtime identifier

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -26,19 +26,22 @@ namespace Microsoft.Maui.IntegrationTests
 		}
 
 		[Test]
-		// [TestCase("maui", "Debug", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		// [TestCase("maui", "Release", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		[TestCase("maui", "Debug", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, "full")]
-		// [TestCase("maui-blazor", "Debug", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		// [TestCase("maui-blazor", "Release", DotNetPrevious, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		[TestCase("maui-blazor", "Debug", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, null)]
-		[TestCase("maui-blazor", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.Mono, "full")]
-		[TestCase("maui", "Release", DotNetCurrent, "iossimulator-x64", RuntimeVariant.NativeAOT, null)]
-		public void RunOniOS(string id, string config, string framework, string runtimeIdentifier, RuntimeVariant runtimeVariant, string trimMode)
+		// [TestCase("maui", "Debug", DotNetPrevious, RuntimeVariant.Mono, null)]
+		// [TestCase("maui", "Release", DotNetPrevious, RuntimeVariant.Mono, null)]
+		[TestCase("maui", "Debug", DotNetCurrent, RuntimeVariant.Mono, null)]
+		[TestCase("maui", "Release", DotNetCurrent, RuntimeVariant.Mono, null)]
+		[TestCase("maui", "Release", DotNetCurrent, RuntimeVariant.Mono, "full")]
+		// [TestCase("maui-blazor", "Debug", DotNetPrevious, RuntimeVariant.Mono, null)]
+		// [TestCase("maui-blazor", "Release", DotNetPrevious, RuntimeVariant.Mono, null)]
+		[TestCase("maui-blazor", "Debug", DotNetCurrent, RuntimeVariant.Mono, null)]
+		[TestCase("maui-blazor", "Release", DotNetCurrent, RuntimeVariant.Mono, null)]
+		[TestCase("maui-blazor", "Release", DotNetCurrent, RuntimeVariant.Mono, "full")]
+		[TestCase("maui", "Release", DotNetCurrent, RuntimeVariant.NativeAOT, null)]
+		public void RunOniOS(string id, string config, string framework, RuntimeVariant runtimeVariant, string trimMode)
 		{
+			// Use architecture-appropriate runtime identifier based on host system
+			string runtimeIdentifier = TestEnvironment.IOSSimulatorRuntimeIdentifier;
+
 			var projectDir = TestDirectory;
 			var projectFile = Path.Combine(projectDir, $"{Path.GetFileName(projectDir)}.csproj");
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/TestEnvironment.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/TestEnvironment.cs
@@ -12,6 +12,15 @@ namespace Microsoft.Maui.IntegrationTests
 
 		public static bool IsRunningOnCI => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME"));
 
+		public static bool IsArm64 => RuntimeInformation.OSArchitecture == Architecture.Arm64;
+
+		/// <summary>
+		/// Gets the appropriate iOS simulator runtime identifier based on the host architecture.
+		/// Returns "iossimulator-arm64" on ARM64 Macs and "iossimulator-x64" on Intel Macs.
+		/// </summary>
+		public static string IOSSimulatorRuntimeIdentifier =>
+			IsArm64 ? "iossimulator-arm64" : "iossimulator-x64";
+
 
 		static string _mauiDir = "";
 		public static string GetMauiDirectory()


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The `RunOniOS` integration tests were failing on ARM64 Mac CI agents because they hardcoded `iossimulator-x64` as the runtime identifier. When running on Apple Silicon Macs, apps built for `iossimulator-x64` cannot run natively on the ARM64 simulator.

## Changes

### TestEnvironment.cs
- Added `IsArm64` property to detect if running on ARM64 architecture
- Added `IOSSimulatorRuntimeIdentifier` property that returns the appropriate runtime identifier based on host architecture:
  - `iossimulator-arm64` on Apple Silicon Macs
  - `iossimulator-x64` on Intel Macs

### AppleTemplateTests.cs
- Removed hardcoded `runtimeIdentifier` parameter from test cases
- Now dynamically determines the runtime identifier using `TestEnvironment.IOSSimulatorRuntimeIdentifier`

## Root Cause

The CI failure was caused by running tests on ARM64 Mac agents with apps built for the x64 architecture. The iOS simulator on ARM64 Macs runs ARM64 binaries natively and cannot execute x64 simulator binaries without issues.

## Related

This follows the same pattern already used in:
- `MacTemplateTest.cs` which uses `RuntimeInformation.OSArchitecture` for architecture detection
- `eng/devices/ios.cake` which has `GetDefaultRuntimeIdentifier()` using architecture detection