### PR TITLE
[Testing] Fix for flaky UITests in CI - 4

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CarouselView/CarouselViewControlPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CarouselView/CarouselViewControlPage.xaml.cs
@@ -58,7 +58,7 @@ public partial class CarouselViewControlPage : ContentPage
 		if (int.TryParse(scrollToIndexEntry.Text, out int index) &&
 			index >= 0 && index < carouselView.ItemsSource.Cast<object>().Count())
 		{
-			carouselView.ScrollTo(index);
+			carouselView.ScrollTo(index, animate: false);
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CarouselView/CarouselViewOptionsPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CarouselView/CarouselViewOptionsPage.xaml
@@ -4,12 +4,6 @@
              x:Class="Maui.Controls.Sample.CarouselViewOptionsPage"
              Title="CarouselViewOptionsPage">
 
-       <ContentPage.ToolbarItems>
-              <ToolbarItem Text="Apply"
-                           Clicked="ApplyButton_Clicked"
-                           AutomationId="Apply"/>
-       </ContentPage.ToolbarItems>
-
        <ScrollView>
               <!-- <StackLayout Padding="20"> -->
               <Grid Padding="1"
@@ -17,6 +11,13 @@
 
                      <StackLayout Grid.Row="1"
                                   Padding="1">
+
+                            <!-- Apply Button -->
+                            <Button Text="Apply"
+                                    Clicked="ApplyButton_Clicked"
+                                    HorizontalOptions="Center"
+                                    AutomationId="Apply"/>
+
                             <!-- Items Source -->
                             <Label Text="ItemsSource"
                                    FontAttributes="Bold"/>

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.WaitForElement("Green");
 
 			bool dragDropSuccess = false;
-			for(int i = 0; i < 3; i++)
+			for (int i = 0; i < 3; i++)
 			{
 				App.DragAndDrop("Blue", "Green");
 				Thread.Sleep(500);
@@ -374,8 +374,8 @@ namespace Microsoft.Maui.TestCases.Tests
 					break;
 				}
 			}
-			
-			if(!dragDropSuccess)
+
+			if (!dragDropSuccess)
 			{
 				Assert.Fail("Drag-and-drop operation failed after many attempts. Drop event did not fire.");
 			}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.EnterText("TargetView", "DragAndDropEvents");
 			App.Tap("GoButton");
 
-			Thread.Sleep(1000); // CI-safe delay for page navigation
 			App.WaitForElement("LabelDragElement");
 			App.DragAndDrop("LabelDragElement", "DragTarget");
 
@@ -159,7 +158,6 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.EnterText("TargetView", "DragAndDropEventArgs");
 			App.Tap("GoButton");
 
-			Thread.Sleep(1000); // CI-safe delay for page navigation
 			App.WaitForElement("LabelDragElement");
 			App.DragAndDrop("LabelDragElement", "DragTarget");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/DragAndDropUITests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.EnterText("TargetView", "DragAndDropEvents");
 			App.Tap("GoButton");
 
+			Thread.Sleep(1000); // CI-safe delay for page navigation
 			App.WaitForElement("LabelDragElement");
 			App.DragAndDrop("LabelDragElement", "DragTarget");
 
@@ -158,6 +159,7 @@ namespace Microsoft.Maui.TestCases.Tests
 			App.EnterText("TargetView", "DragAndDropEventArgs");
 			App.Tap("GoButton");
 
+			Thread.Sleep(1000); // CI-safe delay for page navigation
 			App.WaitForElement("LabelDragElement");
 			App.DragAndDrop("LabelDragElement", "DragTarget");
 
@@ -361,13 +363,24 @@ namespace Microsoft.Maui.TestCases.Tests
 
 			App.WaitForElement("Blue");
 			App.WaitForElement("Green");
-			App.DragAndDrop("Blue", "Green");
 
-			// Wait for all UI elements to confirm drag and drop operation completion
-			App.WaitForElement("DropRelativeLayout");
-			App.WaitForElement("DropRelativeScreen");
-			App.WaitForElement("DropRelativeLabel");
-			App.WaitForElement("DragStartRelativeScreen");
+			bool dragDropSuccess = false;
+			for(int i = 0; i < 3; i++)
+			{
+				App.DragAndDrop("Blue", "Green");
+				Thread.Sleep(500);
+				App.WaitForElement("DropRelativeLayout");
+				if (GetCoordinatesFromLabel(App.FindElement("DropRelativeLayout").GetText()) != null)
+				{
+					dragDropSuccess = true;
+					break;
+				}
+			}
+			
+			if(!dragDropSuccess)
+			{
+				Assert.Fail("Drag-and-drop operation failed after many attempts. Drop event did not fire.");
+			}
 
 			var dropRelativeToLayout = GetCoordinatesFromLabel(App.FindElement("DropRelativeLayout").GetText());
 			var dropRelativeToScreen = GetCoordinatesFromLabel(App.FindElement("DropRelativeScreen").GetText());

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/CarouselViewFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/CarouselViewFeatureTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
+using System;
 
 namespace Microsoft.Maui.TestCases.Tests;
 
@@ -835,6 +836,17 @@ public class CarouselViewFeatureTests : UITest
 		App.EnterText(ScrollToIndexEntry, "3");
 		App.WaitForElement(ScrollToButton);
 		App.Tap(ScrollToButton);
+#if IOS //In CI CarouselView ScrollTo sometimes scrolls to wrong item
+		try
+		{
+			App.WaitForElement("Item 4");
+		}
+		catch (TimeoutException)
+		{
+			App.WaitForElement(ScrollToButton);
+			App.Tap(ScrollToButton);
+		}
+#endif
 		App.WaitForElement("Item 4");
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/CarouselViewFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/CarouselViewFeatureTests.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
-using System;
 
 namespace Microsoft.Maui.TestCases.Tests;
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
@@ -192,21 +192,19 @@ public class Issue28986_SafeAreaBorderOrientation : _IssuesUITest
         Assert.That(borderContent.GetRect().Width, Is.GreaterThan(0), "Border should remain visible after multiple orientation changes");
         Assert.That(borderContent.GetRect().Height, Is.GreaterThan(0), "Border should remain visible after multiple orientation changes");
 
-        // 7. Verify dimension consistency within same orientation (more reliable than position)
-        // Note: X/Y positions can shift during orientation cycles due to safe area recalculations,
-        // so we verify dimensions instead which should remain consistent
-        const double dimensionTolerance = 10.0;
+        // 7. Verify positioning consistency within same orientation (with tolerance for real orientation changes)
+        const double positionTolerance = 10.0; // Increased tolerance for real device orientation changes
 
-        Assert.That(Math.Abs(initialPortraitBounds.Width - finalPortraitBounds.Width), Is.LessThanOrEqualTo(dimensionTolerance),
-            "Portrait width should be consistent between multiple orientation cycles");
-        Assert.That(Math.Abs(initialPortraitBounds.Height - finalPortraitBounds.Height), Is.LessThanOrEqualTo(dimensionTolerance),
-            "Portrait height should be consistent between multiple orientation cycles");
+        Assert.That(Math.Abs(initialPortraitBounds.X - finalPortraitBounds.X), Is.LessThanOrEqualTo(positionTolerance),
+            "Portrait X position should be consistent between multiple orientation cycles");
+        Assert.That(Math.Abs(initialPortraitBounds.Y - finalPortraitBounds.Y), Is.LessThanOrEqualTo(positionTolerance),
+            "Portrait Y position should be consistent between multiple orientation cycles");
 
-        // 8. Verify landscape dimension consistency
-        Assert.That(Math.Abs(firstLandscapeBounds.Width - secondLandscapeBounds.Width), Is.LessThanOrEqualTo(dimensionTolerance),
-            "Landscape width should be consistent between orientation cycles");
-        Assert.That(Math.Abs(firstLandscapeBounds.Height - secondLandscapeBounds.Height), Is.LessThanOrEqualTo(dimensionTolerance),
-            "Landscape height should be consistent between orientation cycles");
+        // 8. Verify landscape positioning consistency
+        Assert.That(Math.Abs(firstLandscapeBounds.X - secondLandscapeBounds.X), Is.LessThanOrEqualTo(positionTolerance),
+            "Landscape X position should be consistent between orientation cycles");
+        Assert.That(Math.Abs(firstLandscapeBounds.Y - secondLandscapeBounds.Y), Is.LessThanOrEqualTo(positionTolerance),
+            "Landscape Y position should be consistent between orientation cycles");
 
         // 9. Verify safe area consistency within same orientation
         Assert.That(initialPortraitSafeArea, Is.EqualTo(finalPortraitSafeArea),

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
@@ -192,19 +192,21 @@ public class Issue28986_SafeAreaBorderOrientation : _IssuesUITest
         Assert.That(borderContent.GetRect().Width, Is.GreaterThan(0), "Border should remain visible after multiple orientation changes");
         Assert.That(borderContent.GetRect().Height, Is.GreaterThan(0), "Border should remain visible after multiple orientation changes");
 
-        // 7. Verify positioning consistency within same orientation (with tolerance for real orientation changes)
-        const double positionTolerance = 10.0; // Increased tolerance for real device orientation changes
+        // 7. Verify dimension consistency within same orientation (more reliable than position)
+        // Note: X/Y positions can shift during orientation cycles due to safe area recalculations,
+        // so we verify dimensions instead which should remain consistent
+        const double dimensionTolerance = 10.0;
 
-        Assert.That(Math.Abs(initialPortraitBounds.X - finalPortraitBounds.X), Is.LessThanOrEqualTo(positionTolerance),
-            "Portrait X position should be consistent between multiple orientation cycles");
-        Assert.That(Math.Abs(initialPortraitBounds.Y - finalPortraitBounds.Y), Is.LessThanOrEqualTo(positionTolerance),
-            "Portrait Y position should be consistent between multiple orientation cycles");
+        Assert.That(Math.Abs(initialPortraitBounds.Width - finalPortraitBounds.Width), Is.LessThanOrEqualTo(dimensionTolerance),
+            "Portrait width should be consistent between multiple orientation cycles");
+        Assert.That(Math.Abs(initialPortraitBounds.Height - finalPortraitBounds.Height), Is.LessThanOrEqualTo(dimensionTolerance),
+            "Portrait height should be consistent between multiple orientation cycles");
 
-        // 8. Verify landscape positioning consistency
-        Assert.That(Math.Abs(firstLandscapeBounds.X - secondLandscapeBounds.X), Is.LessThanOrEqualTo(positionTolerance),
-            "Landscape X position should be consistent between orientation cycles");
-        Assert.That(Math.Abs(firstLandscapeBounds.Y - secondLandscapeBounds.Y), Is.LessThanOrEqualTo(positionTolerance),
-            "Landscape Y position should be consistent between orientation cycles");
+        // 8. Verify landscape dimension consistency
+        Assert.That(Math.Abs(firstLandscapeBounds.Width - secondLandscapeBounds.Width), Is.LessThanOrEqualTo(dimensionTolerance),
+            "Landscape width should be consistent between orientation cycles");
+        Assert.That(Math.Abs(firstLandscapeBounds.Height - secondLandscapeBounds.Height), Is.LessThanOrEqualTo(dimensionTolerance),
+            "Landscape height should be consistent between orientation cycles");
 
         // 9. Verify safe area consistency within same orientation
         Assert.That(initialPortraitSafeArea, Is.EqualTo(finalPortraitSafeArea),


### PR DESCRIPTION
This pull request introduces improvements to the CarouselView feature and enhances the reliability of drag-and-drop UI tests. The most significant changes include updating the way the "Apply" action is triggered in the CarouselView options page, making CarouselView scroll operations non-animated, and improving the robustness of UI tests for both CarouselView and drag-and-drop scenarios.

**CarouselView improvements:**
* Moved the "Apply" action from a toolbar item to a button within the main content area in `CarouselViewOptionsPage.xaml` for better accessibility and user experience.
* Changed the `ScrollTo` method in `CarouselViewControlPage.xaml.cs` to disable animation, ensuring immediate navigation to the selected item.

**UI test reliability enhancements:**
* Improved the drag-and-drop UI test in `DragAndDropUITests.cs` by retrying the drag-and-drop operation up to three times and asserting failure if the drop event does not fire, increasing test robustness against flakiness.
* Added a retry mechanism for the `VerifyCarouselViewWithScrollTo` test on iOS, re-attempting the scroll action if the expected item does not appear, to handle platform-specific flakiness.