### PR TITLE
Fix implicit styles with BasedOn chains breaking in 10.0.20

### DIFF
--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -113,16 +113,21 @@ namespace Microsoft.Maui.Controls
 			if (_applicableImplicitStyles != null && _applicableImplicitStyles.Count > 0)
 			{
 				// Apply in reverse order (most base first, most derived last)
-				// so derived styles override base styles
+				// so derived styles override base styles.
+				// Use graduated specificities so derived styles have higher priority than base styles.
+				// This is important for AppThemeBinding which continues to update after initial application.
+				// _applicableImplicitStyles[0] = most derived, _applicableImplicitStyles[Count-1] = most base
 				for (int i = _applicableImplicitStyles.Count - 1; i >= 0; i--)
 				{
-					//NOTE specificity could be more fine grained (using distance)
-					((IStyle)_applicableImplicitStyles[i]).Apply(bindable, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+					// Calculate specificity: most derived (i=0) gets highest, most base gets lowest
+					// Use StyleImplicit as base and add offset based on position
+					// This ensures derived style's static values override base style's bindings
+					ushort styleSpecificity = (ushort)(SetterSpecificity.StyleImplicit + (_applicableImplicitStyles.Count - 1 - i));
+					((IStyle)_applicableImplicitStyles[i]).Apply(bindable, new SetterSpecificity(styleSpecificity, 0, 0, 0));
 				}
 			}
 			else
 			{
-				//NOTE specificity could be more fine grained (using distance)
 				ImplicitStyle?.Apply(bindable, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
 			}
 			if (ClassStyles != null)
@@ -275,9 +280,11 @@ namespace Microsoft.Maui.Controls
 				if (_applicableImplicitStyles != null && _applicableImplicitStyles.Count > 0)
 				{
 					// Apply in reverse order (most base first, most derived last)
+					// Use graduated specificities so derived styles have higher priority than base styles.
 					for (int i = _applicableImplicitStyles.Count - 1; i >= 0; i--)
 					{
-						((IStyle)_applicableImplicitStyles[i]).Apply(Target, new SetterSpecificity(SetterSpecificity.StyleImplicit, 0, 0, 0));
+						ushort styleSpecificity = (ushort)(SetterSpecificity.StyleImplicit + (_applicableImplicitStyles.Count - 1 - i));
+						((IStyle)_applicableImplicitStyles[i]).Apply(Target, new SetterSpecificity(styleSpecificity, 0, 0, 0));
 					}
 				}
 				else

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203.xaml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33203">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<!-- Base keyed style for CustomLabel -->
+			<Style x:Key="LabelBase" TargetType="local:CustomLabel33203">
+				<Setter Property="BackgroundColor" Value="Blue"/>
+				<Setter Property="FontSize" Value="20"/>
+			</Style>
+			<!-- Implicit style for CustomLabel based on keyed style with ApplyToDerivedTypes -->
+			<Style BasedOn="{StaticResource LabelBase}" ApplyToDerivedTypes="True" TargetType="local:CustomLabel33203"/>
+
+			<!-- Derived keyed style for DerivedLabel that overrides BackgroundColor -->
+			<Style x:Key="DerivedLabelStyle" BasedOn="{StaticResource LabelBase}" TargetType="local:DerivedLabel33203">
+				<Setter Property="BackgroundColor" Value="Red"/>
+			</Style>
+			<!-- Implicit style for DerivedLabel based on its keyed style with ApplyToDerivedTypes -->
+			<Style BasedOn="{StaticResource DerivedLabelStyle}" ApplyToDerivedTypes="True" TargetType="local:DerivedLabel33203"/>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+	
+	<StackLayout>
+		<!-- CustomLabel should have Blue background from LabelBase keyed style -->
+		<local:CustomLabel33203 x:Name="baseLabel" Text="Base Label"/>
+		<!-- DerivedLabel should have Red background from DerivedLabelStyle keyed style (overriding Blue) -->
+		<local:DerivedLabel33203 x:Name="derivedLabel" Text="Derived Label"/>
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203.xaml.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33203 : ContentPage
+{
+	public Maui33203() => InitializeComponent();
+
+	public Maui33203(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests() => Application.Current = new MockApplication();
+		public void Dispose() => Application.Current = null;
+
+		[Theory]
+		[XamlInflatorData]
+		internal void ImplicitStyleWithBasedOnKeyedStyleWorks(XamlInflator inflator)
+		{
+			// This test reproduces issue #33203 where implicit styles using BasedOn
+			// with keyed styles stopped working in 10.0.20
+			var page = new Maui33203(inflator);
+			Application.Current.LoadPage(page);
+
+			// CustomLabel should have Blue background from the LabelBase keyed style
+			Assert.Equal(Colors.Blue, page.baseLabel.BackgroundColor);
+			Assert.Equal(20, page.baseLabel.FontSize);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void DerivedImplicitStyleOverridesBaseStyle(XamlInflator inflator)
+		{
+			// This test verifies that the more specific DerivedLabel style
+			// overrides the base CustomLabel style's BackgroundColor
+			var page = new Maui33203(inflator);
+			Application.Current.LoadPage(page);
+
+			// DerivedLabel should have Red background from DerivedLabelStyle keyed style
+			// NOT Blue from LabelBase - the derived style should override
+			Assert.Equal(Colors.Red, page.derivedLabel.BackgroundColor);
+			// FontSize should still be inherited from base style
+			Assert.Equal(20, page.derivedLabel.FontSize);
+		}
+	}
+}
+
+// Custom Label classes for testing keyed+BasedOn implicit style scenarios
+public class CustomLabel33203 : Label
+{
+}
+
+public class DerivedLabel33203 : CustomLabel33203
+{
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203AppTheme.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203AppTheme.xaml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33203AppTheme">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<!-- Base keyed style for CustomLabel with AppThemeBinding -->
+			<Style x:Key="LabelBaseAppTheme" TargetType="local:CustomLabel33203AppTheme">
+				<Setter Property="BackgroundColor" Value="{AppThemeBinding Light=Blue, Dark=Blue}"/>
+				<Setter Property="FontSize" Value="20"/>
+			</Style>
+			<!-- Implicit style for CustomLabel based on keyed style with ApplyToDerivedTypes -->
+			<Style BasedOn="{StaticResource LabelBaseAppTheme}" ApplyToDerivedTypes="True" TargetType="local:CustomLabel33203AppTheme"/>
+
+			<!-- Derived keyed style for DerivedLabel that overrides BackgroundColor -->
+			<Style x:Key="DerivedLabelStyleAppTheme" BasedOn="{StaticResource LabelBaseAppTheme}" TargetType="local:DerivedLabel33203AppTheme">
+				<Setter Property="BackgroundColor" Value="Red"/>
+			</Style>
+			<!-- Implicit style for DerivedLabel based on its keyed style with ApplyToDerivedTypes -->
+			<Style BasedOn="{StaticResource DerivedLabelStyleAppTheme}" ApplyToDerivedTypes="True" TargetType="local:DerivedLabel33203AppTheme"/>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+	
+	<StackLayout>
+		<!-- CustomLabel should have Blue background from LabelBaseAppTheme keyed style -->
+		<local:CustomLabel33203AppTheme x:Name="baseLabel" Text="Base Label"/>
+		<!-- DerivedLabel should have Red background from DerivedLabelStyleAppTheme keyed style (overriding Blue AppThemeBinding) -->
+		<local:DerivedLabel33203AppTheme x:Name="derivedLabel" Text="Derived Label"/>
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203AppTheme.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33203AppTheme.xaml.cs
@@ -1,0 +1,84 @@
+using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33203AppTheme : ContentPage
+{
+	public Maui33203AppTheme() => InitializeComponent();
+
+	public Maui33203AppTheme(bool useCompiledXaml)
+	{
+		//this stub will be replaced at compile time
+	}
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		public void Dispose()
+		{
+			AppInfo.SetCurrent(null);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void DerivedStyleOverridesBaseAppThemeBinding(XamlInflator inflator)
+		{
+			// This test reproduces the additional issue from #33203 comment where
+			// when a base style uses AppThemeBinding for a property, the derived style's
+			// override of that property is not applied correctly
+			
+			Application.Current.UserAppTheme = AppTheme.Light;
+			var page = new Maui33203AppTheme(inflator);
+			Application.Current.MainPage = page;
+
+			// CustomLabel should have Blue background from the LabelBaseAppTheme keyed style's AppThemeBinding
+			Assert.Equal(Colors.Blue, page.baseLabel.BackgroundColor);
+			Assert.Equal(20d, page.baseLabel.FontSize);
+
+			// DerivedLabel should have Red background from DerivedLabelStyleAppTheme keyed style
+			// NOT Blue from LabelBaseAppTheme's AppThemeBinding - the derived style's static value should override
+			Assert.Equal(Colors.Red, page.derivedLabel.BackgroundColor);
+			// FontSize should still be inherited from base style
+			Assert.Equal(20d, page.derivedLabel.FontSize);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void DerivedStyleOverridesBaseAppThemeBindingInDarkMode(XamlInflator inflator)
+		{
+			// Test the same scenario in dark mode to ensure AppThemeBinding doesn't interfere
+			
+			Application.Current.UserAppTheme = AppTheme.Dark;
+			var page = new Maui33203AppTheme(inflator);
+			Application.Current.MainPage = page;
+
+			// CustomLabel should have Blue background (dark mode value from AppThemeBinding)
+			Assert.Equal(Colors.Blue, page.baseLabel.BackgroundColor);
+
+			// DerivedLabel should STILL have Red background from DerivedLabelStyleAppTheme
+			// regardless of dark/light mode - static value should override AppThemeBinding
+			Assert.Equal(Colors.Red, page.derivedLabel.BackgroundColor);
+		}
+	}
+}
+
+// Custom Label classes for testing AppThemeBinding override scenarios
+public class CustomLabel33203AppTheme : Label
+{
+}
+
+public class DerivedLabel33203AppTheme : CustomLabel33203AppTheme
+{
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

This fixes issue #33203 where implicit styles using `BasedOn` with keyed styles stopped working in 10.0.20.

### Root Cause

The regression was introduced by PR #32711 which fixed #9648 (`ApplyToDerivedTypes` not working for implicit styles). That fix created wrapper styles to merge multiple applicable implicit styles, but in doing so it replaced the original `BasedOn` chain with a new one, losing the connection to keyed styles that defined the actual property values.

### The Fix

Instead of creating wrapper styles that break `BasedOn` chains, we now store the list of applicable implicit styles and apply them sequentially during `Apply()`. This preserves each style's `BasedOn` chain intact while still supporting the `ApplyToDerivedTypes` functionality from #9648.

### Test Results

- ✅ All 6 tests for #9648 (`ApplyToDerivedTypes` fix) still pass
- ✅ All 1776 XAML unit tests pass (8 skipped, 0 failed)
- ✅ All 164 Style-related Controls.Core unit tests pass
- ✅ User's reproduction scenario (keyed style with `BasedOn`) now works correctly

## Issues Fixed

Fixes #33203