### PR TITLE
[ci] Enable CoreCLR iOS device tests on Helix

### DIFF
--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -248,9 +248,9 @@ stages:
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid
 
-# CoreCLR Device Tests Stages (Android only)
+# CoreCLR Device Tests Stages
 - stage: devicetests_build_coreclr
-  displayName: ${{ parameters.TargetFrameworkVersion }} Android CoreCLR Helix Tests
+  displayName: ${{ parameters.TargetFrameworkVersion }} ios/catalyst/android CoreCLR Helix Tests
   dependsOn: []
   jobs:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
@@ -290,7 +290,7 @@ stages:
         - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) -projects '$(Build.SourcesDirectory)/Microsoft.Maui.BuildTasks.slnf' /bl:BuildBuildTasks.binlog $(_OfficialBuildIdArgs)
           displayName: Build BuildTasks
 
-        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) /p:BuildDeviceTests=true /p:UseMonoRuntime=false /p:IncludeIosTargetFrameworks=false /p:IncludeMacCatalystTargetFrameworks=false /bl:BuildDeviceTests.binlog
+        - script: $(_buildScriptMacOS) -restore -build -configuration $(_BuildConfig) /p:BuildDeviceTests=true /p:UseMonoRuntime=false /bl:BuildDeviceTests.binlog
           displayName: Build DeviceTests (CoreCLR)
 
         - publish: ${{ parameters.checkoutDirectory }}/artifacts/bin
@@ -350,3 +350,101 @@ stages:
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid_CoreCLR
+
+- stage: devicetests_ios_coreclr
+  displayName: ${{ parameters.TargetFrameworkVersion }} iOS CoreCLR Helix Tests
+  dependsOn: 
+    - devicetests_build_coreclr
+  jobs:
+  - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
+    parameters:
+      helixRepo: dotnet/maui
+      pool: ${{ parameters.testPool }}
+      enableMicrobuild: false
+      enablePublishUsingPipelines: true
+      enablePublishBuildAssets: ${{ parameters.publishAssets }}
+      enableTelemetry: true
+      enableSourceBuild: ${{ parameters.enableSourceBuild }}
+      enableSourceIndex: ${{ parameters.enableSourceIndex }}
+      sourceIndexParams: ${{ parameters.sourceIndexParams }}
+      publishAssetsImmediately: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: false
+      workspace:
+        clean: all
+      jobs:
+      - job: device_tests_ios_coreclr
+        displayName: Run DeviceTests iOS (CoreCLR)
+        timeoutInMinutes: 240
+        variables:
+        - name: _BuildConfig
+          value: ${{ parameters.BuildConfiguration }}
+        preSteps:
+        - checkout: self
+          fetchDepth: 1
+          clean: true
+
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download Build'
+          condition: succeeded()
+          inputs:
+            artifactName: ${{ parameters.appArtifactName }}_coreclr
+            targetPath: ${{ parameters.checkoutDirectory }}/artifacts/bin
+
+        - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/steps/send-to-helix.yml', '/eng/common/templates-official/steps/send-to-helix.yml@self') }}
+          parameters:
+            HelixProjectPath: ${{ parameters.helixProject }}
+            HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix="_$(_BuildConfig)_CoreCLR" /p:TestRunNamePrefix="DeviceTestsIOS_CoreCLR_"
+            HelixConfiguration: $(_BuildConfig)
+            IncludeDotNetCli: true
+            DisplayNamePrefix: DeviceTestsIOS_CoreCLR
+            WorkItemTimeout: 04:00:00
+            XUnitWorkItemTimeout: 04:00:00
+
+- stage: devicetests_catalyst_coreclr
+  displayName: ${{ parameters.TargetFrameworkVersion }} MacCatalyst CoreCLR Helix Tests
+  dependsOn: 
+    - devicetests_build_coreclr
+  jobs:
+  - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
+    parameters:
+      helixRepo: dotnet/maui
+      pool: ${{ parameters.buildPool }}
+      enableMicrobuild: ${{ parameters.enableMicrobuild }}
+      enablePublishUsingPipelines: true
+      enablePublishBuildAssets: ${{ parameters.publishAssets }}
+      enableTelemetry: true
+      enableSourceBuild: ${{ parameters.enableSourceBuild }}
+      enableSourceIndex: ${{ parameters.enableSourceIndex }}
+      sourceIndexParams: ${{ parameters.sourceIndexParams }}
+      publishAssetsImmediately: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: false
+      workspace:
+        clean: all
+      jobs:
+      - job: device_tests_maccatalyst_coreclr
+        displayName: Run DeviceTests MacCatalyst (CoreCLR)
+        timeoutInMinutes: 60
+        variables:
+        - name: _BuildConfig
+          value: ${{ parameters.BuildConfiguration }}
+        preSteps:
+        - checkout: self
+          fetchDepth: 1
+          clean: true
+
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download Build'
+          condition: succeeded()
+          inputs:
+            artifactName: ${{ parameters.appArtifactName }}_coreclr
+            targetPath: ${{ parameters.checkoutDirectory }}/artifacts/bin
+
+        - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/steps/send-to-helix.yml', '/eng/common/templates-official/steps/send-to-helix.yml@self') }}
+          parameters:
+            HelixProjectPath: ${{ parameters.helixProject }}
+            HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix="_$(_BuildConfig)_CoreCLR" /p:TestRunNamePrefix="DeviceTestsMacCatalyst_CoreCLR_"
+            HelixConfiguration: $(_BuildConfig)
+            IncludeDotNetCli: true
+            DisplayNamePrefix: DeviceTestsMacCatalyst_CoreCLR

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -409,8 +409,8 @@ stages:
   - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/jobs/jobs.yml', '/eng/common/templates-official/jobs/jobs.yml@self') }}
     parameters:
       helixRepo: dotnet/maui
-      pool: ${{ parameters.buildPool }}
-      enableMicrobuild: ${{ parameters.enableMicrobuild }}
+      pool: ${{ parameters.testPool }}
+      enableMicrobuild: false
       enablePublishUsingPipelines: true
       enablePublishBuildAssets: ${{ parameters.publishAssets }}
       enableTelemetry: true

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -65,8 +65,8 @@ parameters:
 - name: macOSPool
   type: object
   default:
-    name: MAUI
-    vmImage: MAUI
+    name: Azure Pipelines
+    vmImage: macOS-15
 
 - name: targetFrameworkVersions
   type: object

--- a/eng/pipelines/common/device-tests-jobs.yml
+++ b/eng/pipelines/common/device-tests-jobs.yml
@@ -30,8 +30,6 @@ jobs:
       clean: all
     displayName: Build ${{ parameters.platform }} ${{ parameters.project.desc }} ${{ iif(eq(parameters.useCoreClr, 'true'), ' (CoreCLR)', '(Mono)') }}
     pool: ${{ parameters.pool }}
-    variables:
-      REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
     steps:
     - template: device-tests-steps.yml
       parameters:
@@ -60,8 +58,6 @@ jobs:
         clean: all
       displayName: Run ${{ parameters.platform }} ${{ parameters.project.desc }} ${{ version }}  ${{ iif(eq(parameters.useCoreClr, 'true'), ' (CoreCLR)', '(Mono)') }}
       pool: ${{ parameters.pool }}
-      variables:
-        REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
       steps:
       - template: device-tests-steps.yml
         parameters:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -101,38 +101,47 @@ steps:
       xcrun xcode-select --print-path
       echo
       echo selecting latest xcode...
-      # Use REQUIRED_XCODE for devdiv team project or if CollectionUri contains xamarin, XCODE for others (e.g., maui-pr)
-      if [[ "$(System.TeamProject)" == "devdiv" || "$(System.CollectionUri)" == *"xamarin"* ]]; then
-        XCODE_VERSION=$(REQUIRED_XCODE)
-      else
-        XCODE_VERSION=$(XCODE)
-      fi
+      # XCODE variable is in major.minor format (e.g., 26.1)
+      XCODE_MAJOR_MINOR=$(XCODE)
+      echo "XCODE variable (major.minor): ${XCODE_MAJOR_MINOR}"
       
-      # Check if the specified Xcode version exists, if not try fallback
-      XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app"
-      if [[ ! -d "$XCODE_PATH" ]]; then
-        echo "Xcode version ${XCODE_VERSION} not found at ${XCODE_PATH}"
-        # Extract fallback version by removing the last part after the final dot (e.g., 26.0.1 -> 26.0.0)
-        if [[ "$XCODE_VERSION" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
-          FALLBACK_VERSION="${BASH_REMATCH[1]}.0"
-          FALLBACK_PATH="/Applications/Xcode_${FALLBACK_VERSION}.app"
-          echo "Trying fallback Xcode version: ${FALLBACK_VERSION}"
-          if [[ -d "$FALLBACK_PATH" ]]; then
-            echo "Found fallback Xcode version at ${FALLBACK_PATH}"
-            XCODE_VERSION="$FALLBACK_VERSION"
-            XCODE_PATH="$FALLBACK_PATH"
-          else
-            echo "Warning: Fallback Xcode version ${FALLBACK_VERSION} also not found at ${FALLBACK_PATH}"
-            echo "Proceeding with original version ${XCODE_VERSION} - this may fail"
-          fi
+      # Parse major and minor versions
+      MAJOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f1)
+      MINOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f2)
+      PREV_MINOR=$((MINOR - 1))
+      
+      # Build list of versions to try: major.minor.1, major.minor.0, major.(minor-1).1, major.(minor-1).0
+      VERSIONS_TO_TRY=(
+        "${MAJOR}.${MINOR}.1"
+        "${MAJOR}.${MINOR}.0"
+        "${MAJOR}.${PREV_MINOR}.1"
+        "${MAJOR}.${PREV_MINOR}.0"
+      )
+      
+      echo "Will try Xcode versions in order: ${VERSIONS_TO_TRY[*]}"
+      
+      XCODE_VERSION=""
+      XCODE_PATH=""
+      
+      for VERSION in "${VERSIONS_TO_TRY[@]}"; do
+        CANDIDATE_PATH="/Applications/Xcode_${VERSION}.app"
+        echo "Checking for Xcode ${VERSION} at ${CANDIDATE_PATH}..."
+        if [[ -d "$CANDIDATE_PATH" ]]; then
+          echo "Found Xcode version ${VERSION} at ${CANDIDATE_PATH}"
+          XCODE_VERSION="$VERSION"
+          XCODE_PATH="$CANDIDATE_PATH"
+          break
         else
-          echo "Warning: Cannot determine fallback version for ${XCODE_VERSION}"
-          echo "Proceeding with original version - this may fail"
+          echo "Xcode version ${VERSION} not found"
         fi
-      else
-        echo "Found Xcode version ${XCODE_VERSION} at ${XCODE_PATH}"
+      done
+      
+      if [[ -z "$XCODE_PATH" ]]; then
+        echo "ERROR: None of the Xcode versions were found: ${VERSIONS_TO_TRY[*]}"
+        exit 1
       fi
       
+      echo "Selected Xcode version: ${XCODE_VERSION} at ${XCODE_PATH}"
       sudo xcode-select -s "$XCODE_PATH"
       xcrun xcode-select --print-path
       xcodebuild -version
@@ -146,15 +155,14 @@ steps:
   - ${{ if ne(parameters.skipSimulatorSetup, 'true') }}:
     - script: |
         echo installing simulator runtimes...
-        # Use REQUIRED_XCODE for devdiv team project or if CollectionUri contains xamarin, XCODE for others (e.g., maui-pr)
-        if [[ "$(System.TeamProject)" == "devdiv" || "$(System.CollectionUri)" == *"xamarin"* ]]; then
-          XCODE_VERSION=$(REQUIRED_XCODE)
-        else
-          XCODE_VERSION=$(XCODE)
-        fi
+        # XCODE variable is in major.minor format (e.g., 26.1)
+        XCODE_MAJOR_MINOR=$(XCODE)
+        MAJOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f1)
+        MINOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f2)
+        
         # if we're using Xcode 26.0[.?], then explicitly install the iOS 26.0 simulator (the iOS 26.0.1 simulator doesn't work for us)
         # also install the universal simulator version, so that this bot can run x64 apps in the simulator.
-        if [[ "${XCODE_VERSION}" =~ ^26[.]0.*$ ]]; then
+        if [[ "${MAJOR}" == "26" && "${MINOR}" == "0" ]]; then
           RC=0
           sudo xcodebuild -downloadPlatform iOS -architectureVariant universal -buildVersion 26.0 || RC=$?
           if [[ "$RC" == "70" ]]; then

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -189,6 +189,7 @@ steps:
         fi
       displayName: Install Simulator Runtimes
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+      continueOnError: true
       timeoutInMinutes: 30
 
 # Provision Additional Software

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -57,7 +57,6 @@ stages:
         displayName: Build Sample App
         pool: ${{ parameters.androidPool }}
         variables:
-          REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
           APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
         steps:
           - template: ui-tests-build-sample.yml
@@ -73,7 +72,6 @@ stages:
         displayName: Build Sample App
         pool: ${{ parameters.androidPool }}
         variables:
-          REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
           APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
         steps:
           - template: ui-tests-build-sample.yml
@@ -91,7 +89,6 @@ stages:
           displayName: Build Sample App
           pool: ${{ parameters.androidPool }}
           variables:
-            REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
             APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
           steps:
             - template: ui-tests-build-sample.yml
@@ -135,7 +132,6 @@ stages:
                 displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
                 pool: ${{ parameters.androidLinuxPool }}
                 variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                 steps:
                   - template: ui-tests-steps.yml
@@ -179,7 +175,6 @@ stages:
                 displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
                 pool: ${{ parameters.androidLinuxPool }}
                 variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                 steps:
                   - template: ui-tests-steps.yml
@@ -225,7 +220,6 @@ stages:
                 displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
                 pool: ${{ parameters.iosPool }}
                 variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                 steps:
                   - template: ui-tests-steps.yml
@@ -268,7 +262,6 @@ stages:
                 displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
                 pool: ${{ parameters.iosPool }}
                 variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                 steps:
                   - template: ui-tests-steps.yml
@@ -312,7 +305,6 @@ stages:
                 displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
                 pool: ${{ parameters.iosPool }}
                 variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                 steps:
                   - template: ui-tests-steps.yml
@@ -362,7 +354,6 @@ stages:
                   displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
                   pool: ${{ parameters.iosPool }}
                   variables:
-                    REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                     APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                   steps:
                     - template: ui-tests-steps.yml
@@ -439,7 +430,6 @@ stages:
                 displayName: ${{ coalesce(project.desc, project.name) }}
                 pool: ${{ parameters.macosPool }}
                 variables:
-                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                   APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
                 steps:
                   - template: ui-tests-steps.yml

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -7,12 +7,8 @@ variables:
   value: true
 - name: DOTNET_VERSION
   value: 10.0.100
-- name: REQUIRED_XCODE
-  value: 26.1.0
-- name: DEVICETESTS_REQUIRED_XCODE
-  value: 26.1.0
 - name: XCODE
-  value: 26.1.0
+  value: 26.1
 - name: POWERSHELL_VERSION
   value: 7.4.0
 # Localization variables

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -94,12 +94,6 @@ parameters:
     name: Azure Pipelines
     vmImage: macOS-15
 
-- name: macOSHelixPool
-  type: object
-  default:
-    name: MAUI
-    vmImage: MAUI
-
 - name: targetFrameworkVersions
   type: object
   default:

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -113,7 +113,7 @@ stages:
         iosVersions: [ 'simulator-18.4' ]
         catalystVersions: [ 'latest' ]
         windowsVersions: [ 'packaged', 'unpackaged' ]
-        skipProvisioning: true
+        skipProvisioning: ${{ not(parameters.UseProvisionator) }}
       ${{ else }}:
         androidApiLevels: [ 33, 23 ]
         iosVersions: [ 'simulator-18.4' ]

--- a/eng/provisioning/xcode.csx
+++ b/eng/provisioning/xcode.csx
@@ -5,9 +5,9 @@ using static Xamarin.Provisioning.ProvisioningScript;
 using System;
 using System.Linq;
 
-var desiredXcode = Environment.GetEnvironmentVariable("REQUIRED_XCODE");
+var desiredXcode = Environment.GetEnvironmentVariable("XCODE");
 if (string.IsNullOrEmpty(desiredXcode)) {
-    Console.WriteLine("The environment variable 'REQUIRED_XCODE' must be exported and the value must be a valid value from the 'XreItem' enumeration.");
+    Console.WriteLine("The environment variable 'XCODE' must be exported and the value must be a valid value from the 'XreItem' enumeration.");
     return;
 }
 


### PR DESCRIPTION
### Description of Change
This pull request expands the device test pipeline to add support for running CoreCLR Helix tests on iOS and MacCatalyst, in addition to Android. The changes update the build and test stages to include these new platforms and adjust build parameters accordingly.

**Pipeline expansion for CoreCLR device tests:**

* Updated the `devicetests_build_coreclr` stage to reflect that it now builds for iOS and MacCatalyst in addition to Android, as shown in its `displayName`.
* Modified the build script invocation to always include iOS and MacCatalyst target frameworks for device tests, removing `/p:IncludeIosTargetFrameworks=false` and `/p:IncludeMacCatalystTargetFrameworks=false` so these platforms are now built.

**New test stages for additional platforms:**

* Added a new `devicetests_ios_coreclr` stage to run CoreCLR Helix device tests on iOS, including downloading build artifacts and sending tests to Helix with appropriate parameters.
* Added a new `devicetests_catalyst_coreclr` stage to run CoreCLR Helix device tests on MacCatalyst, with similar steps as the iOS stage.