### PR TITLE
[XSG] Skip compiled binding when RelativeSource is used

### DIFF
--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33247.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33247.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33247"
+    x:DataType="local:Maui33247">
+    <!-- Test: RelativeSource AncestorType with Path=. should return the ContentPage itself -->
+    <Grid x:Name="MainGrid" BackgroundColor="Blue">
+        <Grid.GestureRecognizers>
+            <TapGestureRecognizer x:Name="DirectTapGesture" 
+                Command="{Binding Navigate}"
+                CommandParameter="{Binding Path=., Source={RelativeSource AncestorType={x:Type local:Maui33247}}}" />
+        </Grid.GestureRecognizers>
+        <Label Text="Direct binding test" />
+    </Grid>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33247.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33247.xaml.cs
@@ -1,0 +1,51 @@
+using System.Windows.Input;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+/// <summary>
+/// Test for regression: RelativeSource AncestorType with Path=. returns null in v10.0.20
+/// 
+/// Scenario: A TapGestureRecognizer tries to get a reference to the parent ContentPage via
+/// CommandParameter="{Binding Path=., Source={RelativeSource AncestorType={x:Type local:Maui33247}}}"
+/// 
+/// Expected: The CommandParameter should receive the ContentPage reference.
+/// Bug: In v10.0.20, the CommandParameter was null when using SourceGen because the source generator
+/// was incorrectly compiling the binding to use x:DataType as the source type instead of allowing
+/// the RelativeSource to resolve the source at runtime.
+/// 
+/// Fix: When a binding has a Source property with a RelativeSource, skip the compiled binding path
+/// and use the fallback string-based binding instead.
+/// </summary>
+public partial class Maui33247 : ContentPage
+{
+	public object CapturedParameter { get; private set; }
+
+	public Maui33247()
+	{
+		InitializeComponent();
+		BindingContext = this;
+	}
+
+	public ICommand Navigate => new Command((param) =>
+	{
+		CapturedParameter = param;
+	});
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void DirectRelativeSourceAncestorTypeWithSelfPathReturnsAncestor(XamlInflator inflator)
+		{
+			// Test that RelativeSource AncestorType with Path=. returns the ancestor object for direct children
+			var page = new Maui33247(inflator);
+			
+			// The CommandParameter with RelativeSource AncestorType and Path=. should be the ContentPage itself
+			Assert.NotNull(page.DirectTapGesture.CommandParameter);
+			Assert.IsType<Maui33247>(page.DirectTapGesture.CommandParameter);
+			Assert.Same(page, page.DirectTapGesture.CommandParameter);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33247.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33247.xaml.cs
@@ -19,18 +19,13 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 /// </summary>
 public partial class Maui33247 : ContentPage
 {
-	public object CapturedParameter { get; private set; }
-
 	public Maui33247()
 	{
 		InitializeComponent();
 		BindingContext = this;
 	}
 
-	public ICommand Navigate => new Command((param) =>
-	{
-		CapturedParameter = param;
-	});
+	public ICommand Navigate => new Command((param) => { });
 
 	[Collection("Issue")]
 	public class Tests


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description

When a binding has a `Source` property with a `RelativeSourceExtension`, skip the compiled binding path and use the fallback string-based binding instead.

### Root Cause

When PR #32925 added RelativeSource support to SourceGen, it also inadvertently caused bindings with `RelativeSource` to be compiled using `x:DataType` as the source type. This is incorrect because the source type for `RelativeSource` bindings is determined at runtime, not at compile time.

For example, with:
```xml
<ContentView x:DataType="local:ChildViewModel">
    <TapGestureRecognizer CommandParameter="{Binding Path=., Source={RelativeSource AncestorType={x:Type local:MainPage}}}" />
</ContentView>
```

The SourceGen was generating:
```csharp
return new TypedBinding<ChildViewModel, ChildViewModel>(
    getter: source => (source, true),  // Returns ChildViewModel, not MainPage!
    ...
);
```

### Fix

Added a check in `ProvideValueForBindingExtension` to detect when the binding has a `Source` property with a `RelativeSourceExtension`. In this case, we skip the compiled binding path and use the fallback string-based binding instead, which correctly resolves the source at runtime.

### Issues Fixed
Fixes #33247

### Testing

- Added SourceGen unit tests to verify correct code generation
- Added XAML unit tests to verify the binding works correctly at runtime
