### PR TITLE
[Windows] Fix TitleBar.IsVisible = false the caption buttons become unresponsive

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33171.cs
@@ -1,0 +1,81 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33171, "When TitleBar.IsVisible = false the caption buttons become unresponsive on Windows", PlatformAffected.UWP)]
+public class Issue33171 : ContentPage
+{
+    public Issue33171()
+	{
+		Title = "Issue 33171";
+
+		// Create TitleBar
+		var titleBar = new TitleBar
+		{
+			Title = "Maui App",
+			Subtitle = "Hello, World!",
+			ForegroundColor = Colors.Red,
+			HeightRequest = 48
+		};
+
+		titleBar.LeadingContent = new Image {Source = "dotnet_bot.png", HeightRequest = 24};
+
+		// Set the TitleBar on the current Window when this page appears
+		this.Loaded += (sender, e) =>
+		{
+			if (Window != null)
+			{
+				Window.TitleBar = titleBar;
+			}
+		};
+
+		// Create a label to display window size
+		var windowSizeLabel = new Label
+		{
+			Text = "Window Size: Not set",
+			AutomationId = "WindowSizeLabel",
+			FontSize = 16,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		// Create a button to reduce window width
+		var reduceWidthButton = new Button
+		{
+			Text = "Reduce Window Width",
+			AutomationId = "ReduceWidthButton",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		reduceWidthButton.Clicked += (sender, e) =>
+		{
+			if (Window != null)
+			{
+				// Reduce window width by 50 pixels
+				var currentWidth = Window.Width;
+				var newWidth = Math.Max(currentWidth - 50, 300); // Minimum width of 300
+				Window.Width = newWidth;
+				
+				// Update the label with current window size
+				windowSizeLabel.Text = $"Window Size: {Window.Width:F0} x {Window.Height:F0}";
+			}
+		};
+
+		// Create the page content with a Label
+		Content = new VerticalStackLayout
+		{
+			Spacing = 25,
+			Padding = new Thickness(30),
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+				{
+					new Label
+					{
+						Text = "TitleBar Visibility Test",
+						AutomationId = "TitleBarAlignmentLabel",
+						FontSize = 32,
+						HorizontalOptions = LayoutOptions.Center
+					},
+					windowSizeLabel,
+					reduceWidthButton,
+				}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33171.cs
@@ -3,12 +3,14 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 33171, "When TitleBar.IsVisible = false the caption buttons become unresponsive on Windows", PlatformAffected.UWP)]
 public class Issue33171 : ContentPage
 {
-    public Issue33171()
+	TitleBar titleBar;
+
+	public Issue33171()
 	{
 		Title = "Issue 33171";
 
 		// Create TitleBar
-		var titleBar = new TitleBar
+		titleBar = new TitleBar
 		{
 			Title = "Maui App",
 			Subtitle = "Hello, World!",
@@ -30,7 +32,6 @@ public class Issue33171 : ContentPage
 		// Create a label to display window size
 		var windowSizeLabel = new Label
 		{
-			Text = "Window Size: Not set",
 			AutomationId = "WindowSizeLabel",
 			FontSize = 16,
 			HorizontalOptions = LayoutOptions.Center
@@ -41,20 +42,47 @@ public class Issue33171 : ContentPage
 		{
 			Text = "Reduce Window Width",
 			AutomationId = "ReduceWidthButton",
-			HorizontalOptions = LayoutOptions.Center
 		};
+
+		var changeVisibility = new Button
+		{
+			Text = "Toggle",
+			AutomationId = "ToggleTitleBarVisibilityButton",
+		};
+
+		var getStatus = new Button
+		{
+			Text = "Get Status",
+			AutomationId = "GetStatusButton",
+		};
+
+		getStatus.Clicked += (sender, e) =>
+		{
+			if (Window != null)
+			{
+				windowSizeLabel.Text = Window.Width.ToString();
+			}
+		};
+
+		changeVisibility.Clicked += (sender, e) =>
+		{
+			if (Window != null && Window.TitleBar != null)
+			{
+				titleBar.IsVisible = !titleBar.IsVisible;
+			}
+		};	
+
 
 		reduceWidthButton.Clicked += (sender, e) =>
 		{
 			if (Window != null)
 			{
-				// Reduce window width by 50 pixels
 				var currentWidth = Window.Width;
-				var newWidth = Math.Max(currentWidth - 50, 300); // Minimum width of 300
+				var newWidth = Window.Width/2;
 				Window.Width = newWidth;
+				Window.Height = Window.Height / 2;
 				
-				// Update the label with current window size
-				windowSizeLabel.Text = $"Window Size: {Window.Width:F0} x {Window.Height:F0}";
+				windowSizeLabel.Text = Window.Width.ToString();
 			}
 		};
 
@@ -74,6 +102,8 @@ public class Issue33171 : ContentPage
 						HorizontalOptions = LayoutOptions.Center
 					},
 					windowSizeLabel,
+					changeVisibility,
+					getStatus,
 					reduceWidthButton,
 				}
 		};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33171.cs
@@ -20,6 +20,15 @@ public class Issue33171 : ContentPage
 
 		titleBar.LeadingContent = new Image {Source = "dotnet_bot.png", HeightRequest = 24};
 
+		titleBar.Content = new SearchBar
+		{
+			Placeholder = "Search",
+			PlaceholderColor = Colors.White,
+			MaximumWidthRequest = 300,
+			HorizontalOptions = LayoutOptions.Fill,
+			VerticalOptions = LayoutOptions.Center
+		};
+
 		// Set the TitleBar on the current Window when this page appears
 		this.Loaded += (sender, e) =>
 		{

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
@@ -18,7 +18,7 @@ public class Issue33171 : _IssuesUITest
 		App.Tap("ToggleTitleBarVisibilityButton");
 		App.Tap("ReduceWidthButton");
 		var windowSize = App.FindElement("WindowSizeLabel").GetText();
-		App.TapMaximizeButton(clickButton: true);
+		App.TapMaximizeButton();
 		App.Tap("GetStatusButton");	
 		var newWindowSize = App.FindElement("WindowSizeLabel").GetText();
 		Assert.That(newWindowSize, Is.Not.EqualTo(windowSize), "Window size should change after maximizing the window.");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
@@ -1,3 +1,4 @@
+#if WINDOWS			//This issue is Windows specific
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -24,3 +25,4 @@ public class Issue33171 : _IssuesUITest
 		Assert.That(newWindowSize, Is.Not.EqualTo(windowSize), "Window size should change after maximizing the window.");
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
@@ -3,15 +3,24 @@ using UITest.Appium;
 using UITest.Core;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues;
+
 public class Issue33171 : _IssuesUITest
 {
-    public override string Issue => "When TitleBar.IsVisible = false the caption buttons become unresponsive on Windows";
+	public override string Issue => "When TitleBar.IsVisible = false the caption buttons become unresponsive on Windows";
 
-    public Issue33171(TestDevice device) : base(device) { }
+	public Issue33171(TestDevice device) : base(device) { }
 
-    [Test]
-    [Category(UITestCategories.TitleView)]
-    public void TitleBarCaptionButtonsResponsiveWhenIsVisibleFalse()
-    {
-    }
+	[Test]
+	[Category(UITestCategories.Window)]
+	public void TitleBarCaptionButtonsResponsiveWhenIsVisibleFalse()
+	{
+		App.WaitForElement("ToggleTitleBarVisibilityButton");
+		App.Tap("ToggleTitleBarVisibilityButton");
+		App.Tap("ReduceWidthButton");
+		var windowSize = App.FindElement("WindowSizeLabel").GetText();
+		App.TapMaximizeButton(clickButton: true);
+		App.Tap("GetStatusButton");	
+		var newWindowSize = App.FindElement("WindowSizeLabel").GetText();
+		Assert.That(newWindowSize, Is.Not.EqualTo(windowSize), "Window size should change after maximizing the window.");
+	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33171.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue33171 : _IssuesUITest
+{
+    public override string Issue => "When TitleBar.IsVisible = false the caption buttons become unresponsive on Windows";
+
+    public Issue33171(TestDevice device) : base(device) { }
+
+    [Test]
+    [Category(UITestCategories.TitleView)]
+    public void TitleBarCaptionButtonsResponsiveWhenIsVisibleFalse()
+    {
+    }
+}

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -214,33 +214,26 @@ namespace Microsoft.Maui.Platform
 				this.RefreshThemeResources();
 			}
 
-			// Only set passthrough regions when the title bar is actually visible
-			// to avoid blocking caption button input when title bar is hidden
+			var rectArray = new List<Rect32>();
+			foreach (var child in PassthroughTitlebarElements)
+			{
+				var transform = child.TransformToVisual(null);
+				var bounds = transform.TransformBounds(
+					new FRect(0, 0, child.ActualWidth, child.ActualHeight));
+				var rect = GetRect(bounds, XamlRoot.RasterizationScale);
+				rectArray.Add(rect);
+			}
+
 			if (AppWindowId.HasValue)
 			{
 				var nonClientInputSrc =
 					InputNonClientPointerSource.GetForWindowId(AppWindowId.Value);
 
-				if (AppTitleBarContentControl.Visibility == UI.Xaml.Visibility.Visible)
+				// Only set passthrough regions when the title bar is actually visible
+				// to avoid blocking caption button input when title bar is hidden
+				if (rectArray.Count > 0 && AppTitleBarContentControl.Visibility == UI.Xaml.Visibility.Visible)
 				{
-					var rectArray = new List<Rect32>();
-					foreach (var child in PassthroughTitlebarElements)
-					{
-						var transform = child.TransformToVisual(null);
-						var bounds = transform.TransformBounds(
-							new FRect(0, 0, child.ActualWidth, child.ActualHeight));
-						var rect = GetRect(bounds, XamlRoot.RasterizationScale);
-						rectArray.Add(rect);
-					}
-
-					if (rectArray.Count > 0)
-					{
-						nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, [.. rectArray]);
-					}
-					else
-					{
-						nonClientInputSrc.ClearRegionRects(NonClientRegionKind.Passthrough);
-					}
+					nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, [.. rectArray]);
 				}
 				else
 				{

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -214,24 +214,33 @@ namespace Microsoft.Maui.Platform
 				this.RefreshThemeResources();
 			}
 
-			var rectArray = new List<Rect32>();
-			foreach (var child in PassthroughTitlebarElements)
-			{
-				var transform = child.TransformToVisual(null);
-				var bounds = transform.TransformBounds(
-					new FRect(0, 0, child.ActualWidth, child.ActualHeight));
-				var rect = GetRect(bounds, XamlRoot.RasterizationScale);
-				rectArray.Add(rect);
-			}
-
+			// Only set passthrough regions when the title bar is actually visible
+			// to avoid blocking caption button input when title bar is hidden
 			if (AppWindowId.HasValue)
 			{
 				var nonClientInputSrc =
 					InputNonClientPointerSource.GetForWindowId(AppWindowId.Value);
 
-				if (rectArray.Count > 0)
+				if (AppTitleBarContentControl.Visibility == UI.Xaml.Visibility.Visible)
 				{
-					nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, [.. rectArray]);
+					var rectArray = new List<Rect32>();
+					foreach (var child in PassthroughTitlebarElements)
+					{
+						var transform = child.TransformToVisual(null);
+						var bounds = transform.TransformBounds(
+							new FRect(0, 0, child.ActualWidth, child.ActualHeight));
+						var rect = GetRect(bounds, XamlRoot.RasterizationScale);
+						rectArray.Add(rect);
+					}
+
+					if (rectArray.Count > 0)
+					{
+						nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, [.. rectArray]);
+					}
+					else
+					{
+						nonClientInputSrc.ClearRegionRects(NonClientRegionKind.Passthrough);
+					}
 				}
 				else
 				{

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -747,14 +747,14 @@ namespace UITest.Appium
 			return results;
 		}
 
-		public static bool TapMinimizeButton(this IApp app, bool clickButton = false)
+		public static void TapMinimizeButton(this IApp app)
 		{
 			if (app is not AppiumWindowsApp windowsApp)
-				return false;
+				return;
 
 			var windowsDriver = windowsApp.Driver as WindowsDriver;
 			if (windowsDriver == null)
-				return false;
+				return;
 
 			try
 			{
@@ -762,19 +762,13 @@ namespace UITest.Appium
 
 				if (minimizeButton != null && minimizeButton.Displayed && minimizeButton.Enabled)
 				{
-					if (clickButton)
-					{
-						minimizeButton.Click();
-					}
-					return true;
+					minimizeButton.Click();
 				}
 
-				return false;
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine($"UITest: Error testing minimize button: {ex.Message}");
-				return false;
 			}
 		}
 
@@ -784,14 +778,14 @@ namespace UITest.Appium
 		/// <param name="app">The Windows app instance</param>
 		/// <param name="clickButton">Whether to actually click the maximize button (default: false)</param>
 		/// <returns>True if the maximize/restore button is accessible and responsive</returns>
-		public static bool TapMaximizeButton(this IApp app, bool clickButton = false)
+		public static void TapMaximizeButton(this IApp app)
 		{
 			if (app is not AppiumWindowsApp windowsApp)
-				return false;
+				return;
 
 			var windowsDriver = windowsApp.Driver as WindowsDriver;
 			if (windowsDriver == null)
-				return false;
+				return;
 
 			try
 			{
@@ -799,46 +793,13 @@ namespace UITest.Appium
 
 				if (maximizeButton != null && maximizeButton.Displayed && maximizeButton.Enabled)
 				{
-					if (clickButton)
-					{
-						maximizeButton.Click();
-					}
-					return true;
+					maximizeButton.Click();
 				}
 
-				return false;
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine($"UITest: Error testing maximize button: {ex.Message}");
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// Tests if the Windows close button is accessible (does not actually close the app)
-		/// </summary>
-		/// <param name="app">The Windows app instance</param>
-		/// <returns>True if the close button is accessible</returns>
-		public static bool TapCloseButton(this IApp app)
-		{
-			if (app is not AppiumWindowsApp windowsApp)
-				return false;
-
-			var windowsDriver = windowsApp.Driver as WindowsDriver;
-			if (windowsDriver == null)
-				return false;
-
-			try
-			{
-				var closeButton = FindSystemButton(windowsDriver, "Close", "CloseButton", "PART_Close");
-
-				return closeButton != null && closeButton.Displayed && closeButton.Enabled;
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"UITest: Error testing close button accessibility: {ex.Message}");
-				return false;
 			}
 		}
 
@@ -864,7 +825,7 @@ namespace UITest.Appium
 					}
 					catch { }
 
-					// Strategy 5: By XPath with partial name match (for localized systems)
+					//By XPath with partial name match (for localized systems)
 					try
 					{
 						var element = driver.FindElement(By.XPath($"//*[contains(@Name, '{identifier}')]"));


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
On Windows, when TitleBar.IsVisible is set to false, the system caption buttons (minimize, maximize, close) become unresponsive after resizing the window.

### Description of Change

<!-- Enter description of the fix in this section -->
Updated WindowRootView.UpdateTitleBarContentSize() to apply passthrough regions only when the TitleBar is visible and to clear them when it is hidden, preventing stale regions from blocking caption button interactions.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33171 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [ ] Android
- [x] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Windows**<br> <video src="https://github.com/user-attachments/assets/6b30d580-ea49-4b5d-9e4c-f6db75897d5d" width="600" height="300"> | **Windows**<br> <video src="https://github.com/user-attachments/assets/52f04718-3f2e-4d5e-985b-72efac175af7" width="600" height="300"> |
