### PR TITLE
[Testing] Fixed Test case failure in PR 33185 - [12/22/2025] Candidate

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22719.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22719.cs
@@ -18,8 +18,10 @@ public class Issue22719 : _IssuesUITest
 		App.WaitForElement("Label");
 #if MACCATALYST // The EnterFullScreen script is applicable only for MacCatalyst
 		App.EnterFullScreen();
-#endif
+		VerifyScreenshot(includeTitleBar: true);
+#elif WINDOWS
 		VerifyScreenshot();
+#endif
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22719.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22719.cs
@@ -16,7 +16,7 @@ public class Issue22719 : _IssuesUITest
 	public void ShouldFlyoutBeVisibleAfterMaximizingWindow()
 	{
 		App.WaitForElement("Label");
-#if MACCATALYST // The EnterFullScreen script is applicable only for MacCatalyst
+#if MACCATALYST //The EnterFullScreen script is applicable only for MacCatalyst
 		App.EnterFullScreen();
 		VerifyScreenshot(includeTitleBar: true);
 #else

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22719.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22719.cs
@@ -19,7 +19,7 @@ public class Issue22719 : _IssuesUITest
 #if MACCATALYST // The EnterFullScreen script is applicable only for MacCatalyst
 		App.EnterFullScreen();
 		VerifyScreenshot(includeTitleBar: true);
-#elif WINDOWS
+#else
 		VerifyScreenshot();
 #endif
 	}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui13872.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui13872.xaml.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using NUnit.Framework;
+using Xunit;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
@@ -7,23 +7,24 @@ public partial class Maui13872 : ContentPage
 {
 	public Maui13872() => InitializeComponent();
 
-	[TestFixture]
-	class Tests
+	[Collection("Issue")]
+	public class Tests
 	{
-		[Test]
-		public void CompiledBindingToIReadOnlyListCount([Values] XamlInflator inflator)
+		[Theory]
+		[XamlInflatorData]
+		internal void CompiledBindingToIReadOnlyListCount(XamlInflator inflator)
 		{
 			var page = new Maui13872(inflator);
 			page.BindingContext = new Maui13872ViewModel();
 
 			// Uncompiled bindings (no x:DataType) - should work with all inflators
-			Assert.That(page.label0.Text, Is.EqualTo("3"), "Uncompiled binding to List.Count");
-			Assert.That(page.label1.Text, Is.EqualTo("3"), "Uncompiled binding to ListCount");
+			Assert.Equal("3", page.label0.Text);
+			Assert.Equal("3", page.label1.Text);
 
 			// Compiled bindings (with x:DataType) - IReadOnlyList<T>.Count should resolve correctly.
 			// Count is defined on IReadOnlyCollection<T> which IReadOnlyList<T> inherits.
-			Assert.That(page.label2.Text, Is.EqualTo("3"), "Compiled binding to List.Count");
-			Assert.That(page.label3.Text, Is.EqualTo("3"), "Compiled binding to ListCount");
+			Assert.Equal("3", page.label2.Text);
+			Assert.Equal("3", page.label3.Text);
 		}
 	}
 }


### PR DESCRIPTION
This pull request updates unit tests in the `Issues` test suite to use the `xUnit` testing framework instead of `NUnit`, modernizes test structure, and improves platform-specific screenshot verification. The most important changes are grouped below:

**Migration from NUnit to xUnit:**

* Replaced `NUnit` attributes and assertions with their `xUnit` equivalents in `Maui13872.xaml.cs` and `Maui31939.xaml.cs`, including changing `[TestFixture]` and `[Test]` to `[Collection("Issue")]`, `[Theory]`, and updating assertion methods. [[1]](diffhunk://#diff-4b69f656993fc5d70bff919b3e23b6516fed4319c75d9466dd2087502d0f5904L2-R27) [[2]](diffhunk://#diff-33c75e5cfbad2cc87eb4da8d7cdb72922dd439512e225be4931f5af08a3bb55eL9-R9) [[3]](diffhunk://#diff-33c75e5cfbad2cc87eb4da8d7cdb72922dd439512e225be4931f5af08a3bb55eL20-R54) [[4]](diffhunk://#diff-33c75e5cfbad2cc87eb4da8d7cdb72922dd439512e225be4931f5af08a3bb55eL67-R67) [[5]](diffhunk://#diff-33c75e5cfbad2cc87eb4da8d7cdb72922dd439512e225be4931f5af08a3bb55eL77-R77)

**Platform-specific Screenshot Verification:**

* Updated `ShouldFlyoutBeVisibleAfterMaximizingWindow()` to use platform-specific screenshot verification logic for MacCatalyst and Windows, ensuring correct UI validation across platforms.