### PR TITLE
Add `UseMaterial3` build property to Sandbox, HostApp and Controls.Sample Projects

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -13,6 +13,9 @@
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
+    <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 
+       and rebuild the entire codebase using: dotnet build ./Microsoft.Maui.BuildTasks.slnf -->
+    <UseMaterial3>false</UseMaterial3>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -15,6 +15,9 @@
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
+    <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 
+       and rebuild the entire codebase using: dotnet build ./Microsoft.Maui.BuildTasks.slnf -->
+    <UseMaterial3>false</UseMaterial3>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -13,6 +13,9 @@
     <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
+  <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 
+       and rebuild the entire codebase using: dotnet build ./Microsoft.Maui.BuildTasks.slnf -->
+    <UseMaterial3>false</UseMaterial3>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
This pull request introduces a new `UseMaterial3` property, set to `false` by default, across several project files. It also adds documentation comments to clarify that if this flag is changed, developers must delete the `artifacts` folder and rebuild the entire codebase to avoid build issues.

Configuration and documentation updates:

* Added the `<UseMaterial3>false</UseMaterial3>` property to `Maui.Controls.Sample.Sandbox.csproj`, `Maui.Controls.Sample.csproj`, and `Controls.TestCases.HostApp.csproj`, along with comments explaining the need to clean artifacts and rebuild if the flag is changed. [[1]](diffhunk://#diff-d99ae49df2f89869b0081632bce2fb57dff57b036662b3f6c8e5feeb6a66ef9dR16-R18) [[2]](diffhunk://#diff-af863121b6168780847c8835ede77fb1b01120fa3f9dd5fb48a846128f9c08fdR18-R20) [[3]](diffhunk://#diff-c73eb67a2a515f32003a6bdc59df7156d492dfcafb1b828723476f67cd439103R16-R18)

Fixes #

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
