### PR TITLE
[ci] Disable automatic PR triggers for device and UI tests

### DIFF
--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -22,26 +22,27 @@ trigger:
     - README.md
     - THIRD-PARTY-NOTICES.TXT
 
-pr:
-  branches:
-    include:
-    - main
-    - release/*
-    - net*.0
-    - inflight/*
-  paths:
-    include:
-    - '*'
-    exclude:
-    - .github/**
-    - docs/*
-    - src/Templates/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - README.md
-    - THIRD-PARTY-NOTICES.TXT
+pr: none
+# pr:
+#   branches:
+#     include:
+#     - main
+#     - release/*
+#     - net*.0
+#     - inflight/*
+#   paths:
+#     include:
+#     - '*'
+#     exclude:
+#     - .github/**
+#     - docs/*
+#     - src/Templates/*
+#     - CODE-OF-CONDUCT.md
+#     - CONTRIBUTING.md
+#     - LICENSE.TXT
+#     - PATENTS.TXT
+#     - README.md
+#     - THIRD-PARTY-NOTICES.TXT
 
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -21,25 +21,26 @@ trigger:
     - README.md
     - THIRD-PARTY-NOTICES.TXT
 
-pr:
-  branches:
-    include:
-    - main
-    - release/*
-    - net*.0
-  paths:
-    include:
-    - '*'
-    exclude:
-    - .github/**
-    - docs/*
-    - src/Templates/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - README.md
-    - THIRD-PARTY-NOTICES.TXT
+pr: none
+# pr:
+#   branches:
+#     include:
+#     - main
+#     - release/*
+#     - net*.0
+#   paths:
+#     include:
+#     - '*'
+#     exclude:
+#     - .github/**
+#     - docs/*
+#     - src/Templates/*
+#     - CODE-OF-CONDUCT.md
+#     - CONTRIBUTING.md
+#     - LICENSE.TXT
+#     - PATENTS.TXT
+#     - README.md
+#     - THIRD-PARTY-NOTICES.TXT
 
 variables:
   - template: /eng/pipelines/common/variables.yml@self


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Disables automatic PR triggers for `ci-device-tests` and `ci-uitests` pipelines. PRs will now require `/azp run` to trigger these pipelines.

- Push triggers to main/release branches remain automatic
- Original PR trigger configuration is preserved as comments for easy restoration

## Changes

- `eng/pipelines/ci-device-tests.yml` - Set `pr: none`, commented out original config
- `eng/pipelines/ci-uitests.yml` - Set `pr: none`, commented out original config