### PR TITLE
Clean up SafeAreaEdgesTypeDesignConverter validation logic

### DIFF
--- a/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
 namespace Microsoft.Maui.Controls.Design
 {
 	public class SafeAreaEdgesTypeDesignConverter : StringConverter

--- a/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
@@ -5,34 +5,48 @@ using Microsoft.Maui;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	public static class StringExtensions
+	{
+		public static bool IsEmpty(this string str) => string.IsNullOrEmpty(str);
+		public static bool EqualsIgnoreCase(this string str, string other) =>
+			str?.Equals(other, StringComparison.OrdinalIgnoreCase) ?? false;
+	}
+
 	public class SafeAreaEdgesTypeDesignConverter : StringConverter
 	{
+		private static readonly string[] ValidValues = { "All", "None", "Default", "SoftInput", "Container" };
+
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH SafeAreaEdgesTypeConverter.ConvertFrom
-			string strValue = value?.ToString()?.Trim();
-			if (string.IsNullOrEmpty(strValue))
+			var strValue = value?.ToString()?.Trim();
+			if (strValue.IsEmpty())
 				return false;
 
-			// Split by comma and check each part
-			string[] parts = strValue.Split(',');
-			
+			// Split by comma and validate each part
+			var parts = strValue.Split(',');
+
 			// Must have 1, 2, or 4 parts
 			if (parts.Length != 1 && parts.Length != 2 && parts.Length != 4)
 				return false;
 
 			// Each part must be a valid SafeAreaRegions value
-			foreach (string part in parts)
+			foreach (var part in parts)
 			{
-				string trimmedPart = part.Trim();
-				if (!string.Equals(trimmedPart, "All", StringComparison.OrdinalIgnoreCase) &&
-					!string.Equals(trimmedPart, "None", StringComparison.OrdinalIgnoreCase) &&
-					!string.Equals(trimmedPart, "Default", StringComparison.OrdinalIgnoreCase) &&
-					!string.Equals(trimmedPart, "SoftInput", StringComparison.OrdinalIgnoreCase) &&
-					!string.Equals(trimmedPart, "Container", StringComparison.OrdinalIgnoreCase))
+				var trimmedPart = part.Trim();
+				var isValidPart = false;
+
+				foreach (var valid in ValidValues)
 				{
-					return false;
+					if (trimmedPart.EqualsIgnoreCase(valid))
+					{
+						isValidPart = true;
+						break;
+					}
 				}
+
+				if (!isValidPart)
+					return false;
 			}
 
 			return true;

--- a/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
@@ -1,26 +1,16 @@
-using System;
-using System.ComponentModel;
-using Controls.Core.Design;
-using Microsoft.Maui;
-
 namespace Microsoft.Maui.Controls.Design
 {
-	public static class StringExtensions
-	{
-		public static bool IsEmpty(this string str) => string.IsNullOrEmpty(str);
-		public static bool EqualsIgnoreCase(this string str, string other) =>
-			str?.Equals(other, StringComparison.OrdinalIgnoreCase) ?? false;
-	}
-
 	public class SafeAreaEdgesTypeDesignConverter : StringConverter
 	{
-		private static readonly string[] ValidValues = { "All", "None", "Default", "SoftInput", "Container" };
+		private static readonly HashSet<string> ValidValues =
+			new HashSet<string>(
+				new[] { "All", "None", "Default", "SoftInput", "Container" },
+				StringComparer.OrdinalIgnoreCase);
 
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH SafeAreaEdgesTypeConverter.ConvertFrom
-			var strValue = value?.ToString()?.Trim();
-			if (strValue.IsEmpty())
+			if (value?.ToString()?.Trim() is not string strValue || strValue.Length == 0)
 				return false;
 
 			// Split by comma and validate each part
@@ -33,19 +23,7 @@ namespace Microsoft.Maui.Controls.Design
 			// Each part must be a valid SafeAreaRegions value
 			foreach (var part in parts)
 			{
-				var trimmedPart = part.Trim();
-				var isValidPart = false;
-
-				foreach (var valid in ValidValues)
-				{
-					if (trimmedPart.EqualsIgnoreCase(valid))
-					{
-						isValidPart = true;
-						break;
-					}
-				}
-
-				if (!isValidPart)
+				if (!ValidValues.Contains(part.Trim()))
 					return false;
 			}
 


### PR DESCRIPTION
### Description

This PR improves the `SafeAreaEdgesTypeDesignConverter` by clarifying the validation logic for easier maintenance.

- Simplified loops for checking valid `SafeAreaRegions` values.
- Kept essential comments for better readability.
- No changes to existing behavior; all validation rules remain unchanged.

### Issues Fixed

No functional bugs were fixed; this PR focuses on code cleanup and readability.