### PR TITLE
Fix memory leak in FlyoutPage when changing the Detail

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/App.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/App.xaml.cs
@@ -9,16 +9,6 @@ public partial class App : Application
 
 	protected override Window CreateWindow(IActivationState? activationState)
 	{
-		// To test shell scenarios, change this to true
-		bool useShell = false;
-
-		if (!useShell)
-		{
-			return new Window(new NavigationPage(new MainPage()));
-		}
-		else
-		{
-			return new Window(new SandboxShell());
-		}
+		return new Window(new AppFlyoutPage());
 	}
 }

--- a/src/Controls/samples/Controls.Sample.Sandbox/AppFlyoutPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/AppFlyoutPage.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<FlyoutPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+            x:Class="Maui.Controls.Sample.AppFlyoutPage"
+            Title="AppFlyoutPage">
+    <FlyoutPage.Flyout>
+        <ContentPage Title="Menu">
+            <CollectionView ItemsSource="{Binding MenuItems}"
+                            SelectionMode="Single"
+                            SelectionChanged="OnMenuItemSelected">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Padding="10">
+                            <Label Text="{Binding Title}" 
+                                   FontSize="16"
+                                   VerticalOptions="Center"/>
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </ContentPage>
+    </FlyoutPage.Flyout>
+</FlyoutPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/AppFlyoutPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/AppFlyoutPage.xaml.cs
@@ -1,0 +1,42 @@
+using Maui.Controls.Sample.Services;
+
+namespace Maui.Controls.Sample;
+
+public partial class AppFlyoutPage : FlyoutPage
+{
+	public class MenuItem
+	{
+		public string Title { get; set; } = string.Empty;
+		public Type PageType { get; set; } = typeof(Page);
+	}
+
+	public List<MenuItem> MenuItems { get; set; }
+
+	public AppFlyoutPage()
+	{
+		InitializeComponent();
+
+		MenuItems = new List<MenuItem>
+		{
+			new MenuItem { Title = "page 1", PageType = typeof(Page1) },
+			new MenuItem { Title = "page 2", PageType = typeof(Page2) }
+		};
+
+		BindingContext = this;
+
+		// Set default detail page
+		Detail = new NavigationPage(new Page1());
+	}
+
+	private void OnMenuItemSelected(object? sender, SelectionChangedEventArgs e)
+	{
+		if (e.CurrentSelection.FirstOrDefault() is MenuItem selectedItem)
+		{
+			var navigationService = new NavigationService();
+			navigationService.Navigate(selectedItem.PageType);
+
+			// Close the flyout after selection
+			IsPresented = false;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Sandbox/Page1.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Page1.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Page1"
+             Title="page 1">
+    <VerticalStackLayout Padding="30"
+                         Spacing="25"
+                         VerticalOptions="Center"
+                         HorizontalOptions="Center">
+        <Button Text="page 1"
+                Clicked="OnNavigateToPage2Clicked"
+                HorizontalOptions="Center"/>
+        <Button Text="Navigate to Page 2"
+                Clicked="OnNavigateToPage2AsyncClicked"
+                HorizontalOptions="Center"/>
+        
+        <Entry Text="Test"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/Page1.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Page1.xaml.cs
@@ -1,0 +1,29 @@
+using Maui.Controls.Sample.Services;
+
+namespace Maui.Controls.Sample;
+
+public partial class Page1 : ContentPage
+{
+	private readonly NavigationService _navigationService;
+
+	public Page1()
+	{
+		InitializeComponent();
+		_navigationService = new NavigationService();
+
+		Loaded += (e, __) =>
+		{
+			_ = MemoryTest.IsAliveAsync();
+		};
+	}
+
+	private void OnNavigateToPage2Clicked(object? sender, EventArgs e)
+	{
+		_navigationService.NavigateAbsolute(typeof(Page2));
+	}
+
+	private void OnNavigateToPage2AsyncClicked(object? sender, EventArgs e)
+	{
+		 _navigationService.Navigate(typeof(Page2));
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Sandbox/Page2.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Page2.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Page2"
+             Title="page 2">
+    <VerticalStackLayout Padding="30"
+                         Spacing="25"
+                         VerticalOptions="Center"
+                         HorizontalOptions="Center">
+        <Label Text="page 2"
+               FontSize="32"
+               HorizontalOptions="Center"/>
+        <Button Text="Navigate to Page 1"
+                Clicked="OnNavigateToPage1Clicked"
+                HorizontalOptions="Center"/>
+        <Entry Text="Test"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/Page2.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Page2.xaml.cs
@@ -1,0 +1,19 @@
+using Maui.Controls.Sample.Services;
+
+namespace Maui.Controls.Sample;
+
+public partial class Page2 : ContentPage
+{
+	private readonly NavigationService _navigationService;
+
+	public Page2()
+	{
+		InitializeComponent();
+		_navigationService = new NavigationService();
+	}
+
+	private void OnNavigateToPage1Clicked(object? sender, EventArgs e)
+	{
+		 _navigationService.Navigate(typeof(Page1));
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Sandbox/Services/NavigationService.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Services/NavigationService.cs
@@ -1,0 +1,102 @@
+namespace Maui.Controls.Sample.Services;
+
+public class NavigationService
+{
+	public void NavigateAbsolute(Type pageType)
+	{
+		var flyoutPage = new AppFlyoutPage();
+		
+		if (pageType == typeof(Page1))
+		{
+			flyoutPage.Detail = new NavigationPage(new Page1());
+		}
+		else if (pageType == typeof(Page2))
+		{
+			flyoutPage.Detail = new NavigationPage(new Page2());
+		}
+
+		var page = (flyoutPage.Detail as NavigationPage)!.CurrentPage;
+		
+		MemoryTest.Add(flyoutPage);
+		MemoryTest.Add(flyoutPage.Detail);
+		MemoryTest.Add(page);
+		Application.Current!.Windows[0].Page = flyoutPage;
+	}
+
+	public void  Navigate(Type pageType)
+	{
+		var currentPage = Application.Current!.Windows[0].Page;
+		
+		if (currentPage is FlyoutPage flyoutPage && flyoutPage.Detail is NavigationPage navigationPage)
+		{
+			Page? targetPage = null;
+			
+			if (pageType == typeof(Page1))
+			{
+				targetPage = new Page1();
+			}
+			else if (pageType == typeof(Page2))
+			{
+				targetPage = new Page2();
+			}
+			
+			if (targetPage != null)
+			{
+				flyoutPage.Detail = new NavigationPage(targetPage);
+				flyoutPage.IsPresented = false;
+			}
+			
+			
+			MemoryTest.Add(flyoutPage);
+			MemoryTest.Add(flyoutPage.Detail);
+			MemoryTest.Add(targetPage!);
+		}
+	}
+}
+static class MemoryTest
+{
+	static readonly List<WeakReference<object>> weakReferences = [];
+
+	public static int Count => weakReferences.Count;
+
+	public static void Add(object obj)
+	{
+		weakReferences.Add(new(obj));
+	}
+
+	public static async Task IsAliveAsync()
+	{
+		RunGC();
+		for (var i = 0; i < weakReferences.Count; i++)
+		{
+			var item = weakReferences[i];
+
+			if (item.TryGetTarget(out var target))
+			{
+				var type = target.GetType();
+				var name = type.FullName;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				await App.Current!.MainPage!.DisplayAlert("Memory leak!", $"The {name} object of {type} Type is still alive", "Ok");
+#pragma warning restore CS0618 // Type or member is obsolete
+			}
+			else
+			{
+				weakReferences.Remove(item);
+			}
+			RunGC();
+		}
+
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				await App.Current!.MainPage!.DisplayAlert("Memory leak!", $"The are {weakReferences.Count} objects still alive", "Ok");
+#pragma warning restore CS0618 // Type or member is obsolete
+	}
+
+	static void RunGC()
+	{
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+	}
+}

--- a/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage/FlyoutPage.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls
 				{
 					previousDetail.SendNavigatedFrom(
 						new NavigatedFromEventArgs(destinationPage: value, NavigationType.Replace));
+					previousDetail.Handler?.DisconnectHandler();
 				}
 
 				_detail.SendNavigatedTo(new NavigatedToEventArgs(previousDetail, NavigationType.Replace));

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -592,7 +592,6 @@ public class MemoryTests : ControlsHandlerTestBase
 		{
 			await OnLoadedAsync(flyoutPage);
 
-			// Create and set first detail page
 			var detailPage1 = new ContentPage { Title = "Detail 1" };
 			var navPage1 = new NavigationPage(detailPage1);
 			flyoutPage.Detail = navPage1;
@@ -606,14 +605,12 @@ public class MemoryTests : ControlsHandlerTestBase
 			references.Add(new(detailPage1.Handler));
 			references.Add(new(detailPage1.Handler.PlatformView));
 
-			// Replace with second detail page
 			var detailPage2 = new ContentPage { Title = "Detail 2" };
 			var navPage2 = new NavigationPage(detailPage2);
 			flyoutPage.Detail = navPage2;
 
 			await OnLoadedAsync(detailPage2);
 
-			// The old detail page and navigation page should be collected
 			navPage1 = null;
 			detailPage1 = null;
 		});
@@ -636,7 +633,6 @@ public class MemoryTests : ControlsHandlerTestBase
 		{
 			await OnLoadedAsync(flyoutPage);
 
-			// Simulate multiple replacements similar to the Sandbox scenario
 			for (int i = 0; i < 5; i++)
 			{
 				var detailPage = new ContentPage { Title = $"Detail {i}" };
@@ -645,7 +641,6 @@ public class MemoryTests : ControlsHandlerTestBase
 				flyoutPage.Detail = navPage;
 				await OnLoadedAsync(detailPage);
 
-				// Track references for first 3 iterations (they should be collected)
 				if (i < 3)
 				{
 					references.Add(new(navPage));
@@ -656,11 +651,9 @@ public class MemoryTests : ControlsHandlerTestBase
 					references.Add(new(detailPage.Handler.PlatformView));
 				}
 
-				// Small delay to simulate real usage
 				await Task.Delay(50);
 			}
 
-			// After loop, the last 2 detail pages are still active, but first 3 should be collected
 		});
 
 		await AssertionExtensions.WaitForGC([.. references]);

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -85,6 +85,7 @@ public class MemoryTests : ControlsHandlerTestBase
 				handlers.AddHandler<TimePicker, TimePickerHandler>();
 				handlers.AddHandler<Toolbar, ToolbarHandler>();
 				handlers.AddHandler<WebView, WebViewHandler>();
+				handlers.AddHandler<FlyoutPage, FlyoutViewHandler>();
 
 #if IOS || MACCATALYST
 				handlers.AddHandler<NavigationPage, NavigationRenderer>();
@@ -585,7 +586,8 @@ public class MemoryTests : ControlsHandlerTestBase
 		var references = new List<WeakReference>();
 		var flyoutPage = new FlyoutPage
 		{
-			Flyout = new ContentPage { Title = "Flyout" }
+			Flyout = new ContentPage { Title = "Flyout" },
+			Detail = new ContentPage { Title = "Detail" }
 		};
 
 		await CreateHandlerAndAddToWindow(new Window(flyoutPage), async () =>
@@ -595,7 +597,7 @@ public class MemoryTests : ControlsHandlerTestBase
 			var detailPage1 = new ContentPage { Title = "Detail 1" };
 			var navPage1 = new NavigationPage(detailPage1);
 			flyoutPage.Detail = navPage1;
-
+			
 			await OnLoadedAsync(detailPage1);
 
 			references.Add(new(navPage1));
@@ -626,7 +628,8 @@ public class MemoryTests : ControlsHandlerTestBase
 		var references = new List<WeakReference>();
 		var flyoutPage = new FlyoutPage
 		{
-			Flyout = new ContentPage { Title = "Flyout" }
+			Flyout = new ContentPage { Title = "Flyout" },
+			Detail = new ContentPage { Title = "Detail" }
 		};
 
 		await CreateHandlerAndAddToWindow(new Window(flyoutPage), async () =>

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -578,7 +578,7 @@ public class MemoryTests : ControlsHandlerTestBase
 		await AssertionExtensions.WaitForGC([.. references]);
 	}
 
-	[Fact("FlyoutPage Detail Does Not Leak When Replaced")]
+	[Fact("FlyoutPage Detail Handler Is Disconnected When Replaced")]
 	public async Task FlyoutPageDetailDoesNotLeak()
 	{
 		SetupBuilder();
@@ -587,40 +587,39 @@ public class MemoryTests : ControlsHandlerTestBase
 		var flyoutPage = new FlyoutPage
 		{
 			Flyout = new ContentPage { Title = "Flyout" },
-			Detail = new ContentPage { Title = "Detail" }
+			Detail = new NavigationPage(new ContentPage { Title = "Initial Detail" })
 		};
 
 		await CreateHandlerAndAddToWindow(new Window(flyoutPage), async () =>
 		{
 			await OnLoadedAsync(flyoutPage);
 
-			var detailPage1 = new ContentPage { Title = "Detail 1" };
-			var navPage1 = new NavigationPage(detailPage1);
-			flyoutPage.Detail = navPage1;
-			
-			await OnLoadedAsync(detailPage1);
+			// Capture old detail and its handler before replacement
+			var oldDetail = flyoutPage.Detail;
+			var oldHandler = oldDetail.Handler;
+			Assert.NotNull(oldHandler);
 
-			references.Add(new(navPage1));
-			references.Add(new(navPage1.Handler));
-			references.Add(new(navPage1.Handler.PlatformView));
-			references.Add(new(detailPage1));
-			references.Add(new(detailPage1.Handler));
-			references.Add(new(detailPage1.Handler.PlatformView));
+			references.Add(new(oldDetail));
+			references.Add(new(oldHandler));
+			references.Add(new(oldHandler.PlatformView));
 
-			var detailPage2 = new ContentPage { Title = "Detail 2" };
-			var navPage2 = new NavigationPage(detailPage2);
-			flyoutPage.Detail = navPage2;
+			// Replace detail
+			var newDetailPage = new ContentPage { Title = "New Detail" };
+			flyoutPage.Detail = new NavigationPage(newDetailPage);
+			await OnLoadedAsync(newDetailPage);
 
-			await OnLoadedAsync(detailPage2);
+			// The fix calls previousDetail.Handler?.DisconnectHandler() in the Detail setter.
+			// Without the fix, the old handler stays connected (non-null).
+			Assert.Null(oldDetail.Handler);
 
-			navPage1 = null;
-			detailPage1 = null;
+			oldDetail = null;
+			oldHandler = null;
 		});
 
 		await AssertionExtensions.WaitForGC([.. references]);
 	}
 
-	[Fact("FlyoutPage Detail Does Not Leak With Multiple Replacements")]
+	[Fact("FlyoutPage Detail Handler Disconnects With Multiple Replacements")]
 	public async Task FlyoutPageDetailDoesNotLeakWithMultipleReplacements()
 	{
 		SetupBuilder();
@@ -629,7 +628,7 @@ public class MemoryTests : ControlsHandlerTestBase
 		var flyoutPage = new FlyoutPage
 		{
 			Flyout = new ContentPage { Title = "Flyout" },
-			Detail = new ContentPage { Title = "Detail" }
+			Detail = new NavigationPage(new ContentPage { Title = "Initial Detail" })
 		};
 
 		await CreateHandlerAndAddToWindow(new Window(flyoutPage), async () =>
@@ -638,25 +637,27 @@ public class MemoryTests : ControlsHandlerTestBase
 
 			for (int i = 0; i < 5; i++)
 			{
-				var detailPage = new ContentPage { Title = $"Detail {i}" };
-				var navPage = new NavigationPage(detailPage);
-				
-				flyoutPage.Detail = navPage;
-				await OnLoadedAsync(detailPage);
+				var oldDetail = flyoutPage.Detail;
+				var oldHandler = oldDetail.Handler;
+				Assert.NotNull(oldHandler);
 
 				if (i < 3)
 				{
-					references.Add(new(navPage));
-					references.Add(new(navPage.Handler));
-					references.Add(new(navPage.Handler.PlatformView));
-					references.Add(new(detailPage));
-					references.Add(new(detailPage.Handler));
-					references.Add(new(detailPage.Handler.PlatformView));
+					references.Add(new(oldDetail));
+					references.Add(new(oldHandler));
+					references.Add(new(oldHandler.PlatformView));
 				}
 
-				await Task.Delay(50);
-			}
+				var newDetailPage = new ContentPage { Title = $"Detail {i}" };
+				flyoutPage.Detail = new NavigationPage(newDetailPage);
+				await OnLoadedAsync(newDetailPage);
 
+				// Each replacement must disconnect the previous detail's handler
+				Assert.Null(oldDetail.Handler);
+
+				oldDetail = null;
+				oldHandler = null;
+			}
 		});
 
 		await AssertionExtensions.WaitForGC([.. references]);

--- a/src/Core/src/Platform/Android/Navigation/MauiNavHostFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/MauiNavHostFragment.cs
@@ -18,5 +18,11 @@ namespace Microsoft.Maui.Platform
 		protected MauiNavHostFragment(nint javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 		{
 		}
+
+		public override void OnDestroy()
+		{
+			base.OnDestroy();
+			this.Dispose();
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Maui.Platform
 		{
 			_currentView = null;
 			_fragmentContainerView = null;
+			_navigationManager = null;
 
 			base.OnDestroy();
 		}

--- a/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationViewFragment.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Maui.Platform
 			_navigationManager = null;
 
 			base.OnDestroy();
+			this.Dispose();
 		}
 
 		public override Animation OnCreateAnimation(int transit, bool enter, int nextAnim)

--- a/src/Core/src/Platform/Android/Navigation/ScopedFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/ScopedFragment.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnDestroy();
 			IsDestroyed = true;
+
+			DetailView = null!;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Maui.Platform
 				_fragmentContainerView.ViewAttachedToWindow -= OnNavigationPlatformViewAttachedToWindow;
 				_fragmentContainerView.ChildViewAdded -= OnNavigationHostViewAdded;
 			}
-
+			
 			if (_fragmentManager is not null)
 			{
 				CleanUpFragments(_fragmentManager);
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.Platform
 		static void CleanUpFragments(FragmentManager fragmentManager)
 		{
 			fragmentManager.ExecutePendingTransactionsEx();
-			;				if (fragmentManager.BackStackEntryCount > 0)
+			if (fragmentManager.BackStackEntryCount > 0)
 			{
 				fragmentManager.PopBackStackImmediate();
 			}
@@ -347,7 +347,7 @@ namespace Microsoft.Maui.Platform
 				transaction.RemoveEx(fragment);
 			}
 
-			transaction.CommitAllowingStateLoss();
+			transaction.CommitNowAllowingStateLoss();
 			fragmentManager.ExecutePendingTransactionsEx();
 		}
 

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+
 using Android.Content;
 using Android.OS;
 using Android.Views;
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.Platform
 		static void CleanUpFragments(FragmentManager fragmentManager)
 		{
 			fragmentManager.ExecutePendingTransactionsEx();
-			if (fragmentManager.BackStackEntryCount > 0)
+			while (fragmentManager.BackStackEntryCount > 0)
 			{
 				fragmentManager.PopBackStackImmediate();
 			}

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -375,14 +375,6 @@ namespace Microsoft.Maui.Platform
 				_fragmentContainerView.ChildViewAdded += OnNavigationHostViewAdded;
 			}
 		}
-
-
-#pragma warning disable RS0016
-		~StackNavigationManager()
-#pragma warning restore RS0016
-		{
-			System.Diagnostics.Debug.WriteLine($"~StackNavigationManager called");
-		}
 		
 		void OnNavigationPlatformViewAttachedToWindow(object? sender, AView.ViewAttachedToWindowEventArgs e)
 		{


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->

This PR fixes several memory leaks related with NavigationPage and Android fragments.

Comparing the first and last gcdump.

<img width="818" height="251" alt="image" src="https://github.com/user-attachments/assets/0fee2b5d-d83e-4a05-a990-f81f86b343c4" />



### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33355

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
