### PR TITLE
[iOS & Catalyst ] Fixed IsEnabled property should work on Tabs 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -247,13 +247,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				CustomizableViewControllers = Array.Empty<UIViewController>();
 
 				// Apply initial IsEnabled state for each tab item
-				if (TabBar.Items.Length >= items.Count)
-				{
-					for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
-					{
-						TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
-					}
-				}
+				SetTabItemsEnabledState();
 
 				if (goTo)
 					GoTo(ShellItem.CurrentItem);
@@ -299,6 +293,28 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			renderer.ShellSection.PropertyChanged += OnShellSectionPropertyChanged;
 		}
 
+		void SetTabItemsEnabledState()
+		{
+			if (TabBar?.Items is null)
+			{
+				return;
+			}
+
+			var items = ShellItemController.GetItems();
+			if (items is null)
+			{
+				return;
+			}
+
+			if (TabBar.Items.Length >= items.Count)
+			{
+				for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
+				{
+					TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
+				}
+			}
+		}
+
 		void CreateTabRenderers()
 		{
 			if (ShellItem.CurrentItem == null)
@@ -325,13 +341,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			CustomizableViewControllers = Array.Empty<UIViewController>();
 
 			// Apply initial IsEnabled state for newly added tab items
-			if (TabBar.Items.Length >= items.Count)
-			{
-				for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
-				{
-					TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
-				}
-			}
+			SetTabItemsEnabledState();
 
 			UpdateTabBarHidden();
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -246,6 +246,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				ViewControllers = viewControllers;
 				CustomizableViewControllers = Array.Empty<UIViewController>();
 
+				// Apply initial IsEnabled state for each tab item
+				if (TabBar.Items.Length >= items.Count)
+				{
+					for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
+					{
+						TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
+					}
+				}
+
 				if (goTo)
 					GoTo(ShellItem.CurrentItem);
 			}
@@ -314,6 +323,15 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 			ViewControllers = viewControllers;
 			CustomizableViewControllers = Array.Empty<UIViewController>();
+
+			// Apply initial IsEnabled state for newly added tab items
+			if (TabBar.Items.Length >= items.Count)
+			{
+				for (int tabIndex = 0; tabIndex < items.Count; tabIndex++)
+				{
+					TabBar.Items[tabIndex].Enabled = items[tabIndex].IsEnabled;
+				}
+			}
 
 			UpdateTabBarHidden();
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33158.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33158.cs
@@ -1,0 +1,130 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33158, "IsEnabledProperty should work on Tabs", PlatformAffected.iOS)]
+public class Issue33158 : Shell
+{
+	public Issue33158()
+	{
+		var mainPageTab = new Tab
+		{
+			Title = "FirstPage",
+			IsEnabled = true,
+		};
+		mainPageTab.Items.Add(new ShellContent
+		{
+			ContentTemplate = new DataTemplate(() => new Issue33158MainPage())
+		});
+
+		var secondPageTab = new Tab
+		{
+			Title = "SecondTab",
+			IsEnabled = false,
+			AutomationId = "SecondTab"
+		};
+		secondPageTab.Items.Add(new ShellContent
+		{
+			ContentTemplate = new DataTemplate(() => new Issue33158SecondPage())
+		});
+		var thirdTab = new Tab
+		{
+			Title = "ThirdTab",
+			IsEnabled = true,
+			AutomationId = "ThirdTab"
+		};
+		thirdTab.Items.Add(new ShellContent
+		{
+			ContentTemplate = new DataTemplate(() => new Issue33158ThirdPage())
+		});
+		var tabBar = new TabBar();
+		tabBar.Items.Add(mainPageTab);
+		tabBar.Items.Add(secondPageTab);
+		tabBar.Items.Add(thirdTab);
+		Items.Add(tabBar);
+	}
+
+	public class Issue33158MainPage : ContentPage
+	{
+		public Issue33158MainPage()
+		{
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+			{
+				new Label
+				{
+					Text = "This is First Page",
+				}
+			}
+			};
+		}
+	}
+
+	public class Issue33158SecondPage : ContentPage
+	{
+		public Issue33158SecondPage()
+		{
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+			{
+				new Label
+				{
+					Text = "This is Second Page",
+					AutomationId = "SecondPageLabel"
+				}
+			}
+			};
+		}
+	}
+	public class Issue33158ThirdPage : ContentPage
+	{
+		public Issue33158ThirdPage()
+		{
+			var label = new Label
+			{
+				Text = "This is Third Page",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				AutomationId = "ThirdPageLabel"
+			};
+
+			var button = new Button
+			{
+				Text = "Enable SecondTab",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				AutomationId = "EnableSecondTab"
+			};
+			button.Clicked += OnButtonClicked;
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+			{
+				label,
+				button
+			}
+			};
+		}
+
+		private void OnButtonClicked(object sender, EventArgs e)
+		{
+			if (Application.Current?.Windows.Count > 0 &&
+				Application.Current.Windows[0].Page is Shell shell)
+			{
+				var secondTab = shell.CurrentItem?.Items[1];
+				if (secondTab is not null)
+					secondTab.IsEnabled = true;
+			}
+			else
+			{
+				System.Diagnostics.Debug.WriteLine("Shell not found!");
+			}
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33158.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33158.cs
@@ -1,0 +1,30 @@
+#if TEST_FAILS_ON_WINDOWS // Existing PR for windows - https://github.com/dotnet/maui/pull/26728
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33158 : _IssuesUITest
+{
+	public Issue33158(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "IsEnabledProperty should work on Tabs";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void Issue33158CheckIsEnabled()
+	{
+		App.WaitForElement("ThirdTab");
+		App.Tap("ThirdTab");
+		App.WaitForElement("ThirdPageLabel");
+		App.Tap("SecondTab");
+		App.WaitForNoElement("SecondPageLabel");
+		App.Tap("EnableSecondTab");
+		App.Tap("SecondTab");
+		App.WaitForElement("SecondPageLabel");
+	}
+}
+#endif


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause 
The load-time handling of the `IsEnabled` property for tab items was not implemented on iOS. As a result, disabled tabs could still be selectable and navigateable 
### Description of Change
 Updated `ShellItemRenderer.cs` to set the `IsEnabled` property of each `TabBar` item based on the corresponding `IsEnabled` value during both initial creation and when the items collection changes.
<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33158 

### Follow-up PR :  

- On **iOS 26** and **Catalyst 26**, navigation between tabs via drag and selection gestures is handled separately in this PR https://github.com/dotnet/maui/pull/33337.

### Tested the behavior in the following platforms

- [ ] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/d133ccd3-abb1-44dd-9135-16b1ebeeb8e6"> | <video src="https://github.com/user-attachments/assets/223f454c-fc1a-4167-b265-8ef6c7e0c8c6"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
