### PR TITLE
[Testing] Fixed Test case failure in PR 33363 - [01/05/2026] Candidate - 1

### DIFF
--- a/src/Core/src/Platform/Android/SearchViewExtensions.cs
+++ b/src/Core/src/Platform/Android/SearchViewExtensions.cs
@@ -150,9 +150,13 @@ namespace Microsoft.Maui.Platform
 				if (image?.Drawable is not null)
 				{
 					if (searchBar.SearchIconColor is not null)
+					{
 						SafeSetTint(image, searchBar.SearchIconColor.ToPlatform());
-					else
-						SafeSetTint(image, Color.Transparent);
+					}
+					else if (TryGetDefaultStateColor(searchView, AAttribute.TextColorPrimary, out var color))
+					{
+						SafeSetTint(image, color);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This pull request refines the logic for setting the search icon color in the Android `SearchView`. This PR https://github.com/dotnet/maui/pull/33071 set the search icon color to transparent if no color was specified, which caused the search icon to become invisible and led to search bar-related test failures. Now, if no custom search icon color is provided, the icon will use the platform's default primary text color instead of becoming transparent.

**Android SearchView icon color handling:**

* Updated `UpdateSearchIconColor` in `SearchViewExtensions.cs` to apply the default primary text color (`TextColorPrimary`) to the search icon when no custom color is set, instead of making it transparent.

<table>
<tr>
<td>
Before fix
</td>
<td>
After fix
</td>
</tr>
<tr>
<td>



https://github.com/user-attachments/assets/22c5dc6f-2e8a-417d-89da-afaa422c9e15
</td>
<td>


https://github.com/user-attachments/assets/b4289eb2-7266-48a2-be12-eb0eabecb40f
</td>
</tr>
</table>