### PR TITLE
[Regression][iOS] Fix MediaPicker PickPhotosAsync getting file name in contentType property

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -294,7 +294,11 @@ namespace Microsoft.Maui.Media
 							await rotatedStream.CopyToAsync(fileStream);
 						}
 						
-						rotatedResults.Add(new FileResult(tempFilePath, result.FileName));
+						var rotatedResult = new FileResult(tempFilePath)
+						{
+							FileName = result.FileName
+						};
+						rotatedResults.Add(rotatedResult);
 					}
 					catch
 					{

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -296,7 +296,8 @@ namespace Microsoft.Maui.Media
 						
 						var rotatedResult = new FileResult(tempFilePath)
 						{
-							FileName = result.FileName
+							FileName = result.FileName,
+							ContentType = result.ContentType
 						};
 						rotatedResults.Add(rotatedResult);
 					}


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
The FileResult constructor was being called with (filePath, fileName) but the second parameter expects a MIME type, not a filename. This caused the filename to be stored as ContentType.

### Description of Change

<!-- Enter description of the fix in this section -->
Fixed FileResult initialization to properly preserve the filename and ContentType.

### Regarding Test Case
Picking an image is not possible in a test.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33348 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/47360519-a071-47eb-9a79-66069f8711a8" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/47a43e9d-c90f-4c79-ac81-779e50198cff" width="300" height="600"> |
