### PR TITLE
[iOS] Fixed Shell navigation on search handler suggestion selection

### DIFF
--- a/.github/agent-pr-session/pr-33406.md
+++ b/.github/agent-pr-session/pr-33406.md
@@ -1,0 +1,247 @@
+# PR Review: #33406 - [iOS] Fixed Shell navigation on search handler suggestion selection
+
+**Date:** 2026-01-08 | **Issue:** [#33356](https://github.com/dotnet/maui/issues/33356) | **PR:** [#33406](https://github.com/dotnet/maui/pull/33406)
+
+**Related Prior Attempt:** [PR #33396](https://github.com/dotnet/maui/pull/33396) (closed - Copilot CLI attempt)
+
+## ⏳ Status: IN PROGRESS
+
+| Phase | Status |
+|-------|--------|
+| Pre-Flight | ✅ COMPLETE |
+| 🧪 Tests | ⏳ PENDING |
+| 🚦 Gate | ⏳ PENDING |
+| 🔧 Fix | ⏳ PENDING |
+| 📋 Report | ⏳ PENDING |
+
+---
+
+<details>
+<summary><strong>📋 Issue Summary</strong></summary>
+
+**Issue #33356**: [iOS] Clicking on search suggestions fails to navigate to detail page correctly
+
+**Bug Description**: Clicking on a search suggestion using NavigationBar/SearchBar/custom SearchHandler does not navigate to the detail page correctly on iOS 26.1 & 26.2 with MAUI 10.
+
+**Root Cause (from PR #33406)**: Navigation fails because `UISearchController` was dismissed (`Active = false`) BEFORE `ItemSelected` was called. This triggers a UIKit transition that deactivates the Shell navigation context and prevents the navigation from completing.
+
+**Reproduction App**: https://github.com/dotnet/maui-samples/tree/main/10.0/Fundamentals/Shell/Xaminals
+
+**Steps to Reproduce:**
+1. Open the Xaminals sample app
+2. Deploy to iPhone 17 Pro 26.2 simulator (Xcode 26.2)
+3. Put focus on the search box
+4. Type 'b' (note: search dropdown position is wrong - see Issue #32930)
+5. Click on 'Bengal' in search suggestions
+6. **Issue 1:** No navigation happens (expected: navigate to Bengal cat detail page)
+7. Click on 'Bengal' from the main list - this works correctly
+8. Click back button
+9. **Issue 2:** Navigates to an empty page (expected: navigate back to list)
+10. Click back button again - actually navigates back
+
+**Platforms Affected:**
+- [ ] Android
+- [x] iOS (26.1 & 26.2)
+- [ ] Windows
+- [ ] MacCatalyst
+
+**Regression Info:**
+- **Confirmed regression** starting in version 9.0.90
+- Labels: `t/bug`, `platform/ios`, `s/verified`, `s/triaged`, `i/regression`, `shell-search-handler`, `regressed-in-9.0.90`
+- Issue 2 (empty page on back navigation) specifically reproducible from 9.0.90
+
+**Validated by:** TamilarasanSF4853 (Syncfusion partner) - Confirmed reproducible in VS Code 1.107.1 with MAUI versions 9.0.0, 9.0.82, 9.0.90, 9.0.120, 10.0.0, and 10.0.20 on iOS.
+
+</details>
+
+<details>
+<summary><strong>📁 Files Changed - PR #33406 (Community PR)</strong></summary>
+
+| File | Type | Changes |
+|------|------|---------|
+| `src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs` | Fix | 2 lines (swap order) |
+| `src/Controls/tests/TestCases.HostApp/Issues/Issue33356.cs` | Test (HostApp) | +261 lines |
+| `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs` | Test (NUnit) | +46 lines |
+
+**PR #33406 Fix** (simpler approach - just swap order):
+```diff
+ void OnSearchItemSelected(object? sender, object e)
+ {
+     if (_searchController is null)
+         return;
+
+-    _searchController.Active = false;
+     (SearchHandler as ISearchHandlerController)?.ItemSelected(e);
++    _searchController.Active = false;
+ }
+```
+
+</details>
+
+<details>
+<summary><strong>📁 Files Changed - PR #33396 (Prior Copilot Attempt - CLOSED)</strong></summary>
+
+| File | Type | Changes |
+|------|------|---------|
+| `.github/agent-pr-session/pr-33396.md` | Session | +210 lines |
+| `src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs` | Fix | +17 lines |
+| `src/Controls/tests/TestCases.HostApp/Issues/Issue33356.xaml` | Test (XAML) | +41 lines |
+| `src/Controls/tests/TestCases.HostApp/Issues/Issue33356.xaml.cs` | Test (C#) | +138 lines |
+| `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs` | Test (NUnit) | +70 lines |
+
+**PR #33396 Fix** (more defensive approach with BeginInvokeOnMainThread):
+```diff
+ void OnSearchItemSelected(object? sender, object e)
+ {
+     if (_searchController is null)
+         return;
+
++    // Store the search controller reference before any state changes
++    var searchController = _searchController;
++    
++    // Call ItemSelected first to trigger navigation before dismissing the search UI.
++    // On iOS 26+, setting Active = false before navigation can cause the navigation
++    // to be lost due to the search controller dismissal animation.
+     (SearchHandler as ISearchHandlerController)?.ItemSelected(e);
+-    _searchController.Active = false;
++    
++    // Deactivate the search controller after navigation has been initiated.
++    // Using BeginInvokeOnMainThread ensures this happens after the current run loop,
++    // allowing the navigation to proceed without interference from the dismissal animation.
++    ViewController?.BeginInvokeOnMainThread(() =>
++    {
++        if (searchController is not null)
++        {
++            searchController.Active = false;
++        }
++    });
+ }
+```
+
+</details>
+
+<details>
+<summary><strong>💬 Discussion Summary</strong></summary>
+
+**Key Comments from Issue #33356:**
+- TamilarasanSF4853 (Syncfusion): Validated issue across multiple MAUI versions (9.0.0 through 10.0.20)
+- Issue 2 (empty page on back) specifically regressed in 9.0.90
+- Issue 1 (no navigation on search suggestion tap) affects all tested versions on iOS
+
+**PR #33406 Review Comments:**
+- Copilot PR reviewer caught typo: "searchHander" should be "searchHandler" (5 duplicate comments, all resolved/outdated now)
+- Prior agent review by kubaflo marked it as ✅ APPROVE with comprehensive analysis
+- PureWeen requested `/rebase` (latest comment)
+
+**PR #33396 Review Comments:**
+- PureWeen asked to update state file to match PR number
+- Copilot had firewall issues accessing GitHub API
+
+**Disagreements to Investigate:**
+| File:Line | Reviewer Says | Author Says | Status |
+|-----------|---------------|-------------|--------|
+| N/A | N/A | N/A | No active disagreements |
+
+**Author Uncertainty:**
+- None noted in either PR
+
+</details>
+
+<details>
+<summary><strong>⚖️ Comparison: PR #33406 vs PR #33396</strong></summary>
+
+### Fix Approach Comparison
+
+| Aspect | PR #33406 (Community) | PR #33396 (Copilot) |
+|--------|----------------------|---------------------|
+| **Author** | SubhikshaSf4851 (Syncfusion) | Copilot |
+| **Status** | Open | Closed (draft) |
+| **Lines Changed** | 2 (swap order) | 17 (more defensive) |
+| **Fix Strategy** | Simply swap order of operations | Swap order + dispatch to next run loop |
+| **Test Style** | Code-only (no XAML) | XAML + code-behind |
+| **Test Count** | 1 test method | 2 test methods |
+
+### Which Fix is Better?
+
+**PR #33406 (simpler approach):**
+- ✅ Minimal change - just swaps two lines
+- ✅ Addresses root cause: ItemSelected called while navigation context is valid
+- ⚠️ Dismissal happens synchronously after ItemSelected
+- ⚠️ Could theoretically still interfere if dismissal animation is fast
+
+**PR #33396 (defensive approach):**
+- ✅ Uses BeginInvokeOnMainThread for explicit async deactivation
+- ✅ Stores reference to search controller before state changes
+- ✅ More detailed comments explaining the fix
+- ⚠️ More code complexity
+- ⚠️ Was closed/abandoned
+
+### Recommendation
+
+Both approaches should work. PR #33406 is simpler and has been reviewed/approved. The extra defensive measures in PR #33396 (BeginInvokeOnMainThread) may provide additional safety margin but add complexity.
+
+**Prior agent review on PR #33406** already verified:
+- Tests FAIL without fix (bug reproduced - timeout)
+- Tests PASS with fix (navigation successful)
+
+</details>
+
+<details>
+<summary><strong>🧪 Tests</strong></summary>
+
+**Status**: ⏳ PENDING (need to verify tests compile and reproduce issue)
+
+**PR #33406 Tests:**
+- HostApp: `src/Controls/tests/TestCases.HostApp/Issues/Issue33356.cs` (code-only, no XAML)
+- NUnit: `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs`
+- 1 test: `Issue33356NavigateShouldOccur` - Tests search handler navigation AND back navigation + collection view navigation
+
+**PR #33396 Tests (for reference):**
+- HostApp XAML: `src/Controls/tests/TestCases.HostApp/Issues/Issue33356.xaml`
+- HostApp Code: `src/Controls/tests/TestCases.HostApp/Issues/Issue33356.xaml.cs`
+- NUnit: `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs`
+- 2 tests: `SearchSuggestionTapNavigatesToDetailPage`, `BackNavigationFromDetailPageWorks`
+
+**Test Checklist:**
+- [ ] PR includes UI tests
+- [ ] Tests reproduce the issue
+- [ ] Tests follow naming convention (`Issue33356`)
+
+</details>
+
+<details>
+<summary><strong>🚦 Gate - Test Verification</strong></summary>
+
+**Status**: ⏳ PENDING
+
+- [ ] Tests FAIL without fix (bug reproduced)
+- [ ] Tests PASS with fix (fix validated)
+
+**Prior Agent Review Result (kubaflo on PR #33406):**
+```
+WITHOUT FIX: FAILED - System.TimeoutException: Timed out waiting for element "Issue33356CatNameLabel"
+WITH FIX: PASSED - All 1 tests passed in 21.73 seconds
+```
+
+**Result:** [PENDING - needs re-verification]
+
+</details>
+
+<details>
+<summary><strong>🔧 Fix Candidates</strong></summary>
+
+**Status**: ⏳ PENDING
+
+| # | Source | Approach | Test Result | Files Changed | Notes |
+|---|--------|----------|-------------|---------------|-------|
+| PR | PR #33406 | Swap order: ItemSelected before Active=false | ⏳ PENDING (Gate) | `ShellPageRendererTracker.cs` (2 lines) | Current PR - simpler fix |
+| Alt | PR #33396 | Swap order + BeginInvokeOnMainThread | ✅ VERIFIED (prior test) | `ShellPageRendererTracker.cs` (17 lines) | Prior attempt - more defensive |
+
+**Exhausted:** No
+**Selected Fix:** [PENDING]
+
+</details>
+
+---
+
+**Next Step:** Verify PR #33406 tests compile and Gate passes. Read `.github/agents/pr/post-gate.md` after Gate passes.

--- a/.github/agents/pr/post-gate.md
+++ b/.github/agents/pr/post-gate.md
@@ -133,6 +133,7 @@ Update the state file:
 3. Verify Selected Fix is documented with reasoning
 4. Change 🔧 Fix status to `✅ COMPLETE`
 5. Change 📋 Report status to `▶️ IN PROGRESS`
+6. **Commit and push the state file**
 
 ---
 
@@ -229,7 +230,8 @@ Update all phase statuses to complete.
 **Update state file**:
 1. Change header status to final recommendation
 2. Update all phases to `✅ COMPLETE` or `✅ PASSED`
-3. Present final result to user
+3. **Commit and push the state file**
+4. Present final result to user
 
 ---
 

--- a/.github/agents/pr/post-gate.md
+++ b/.github/agents/pr/post-gate.md
@@ -133,7 +133,6 @@ Update the state file:
 3. Verify Selected Fix is documented with reasoning
 4. Change 🔧 Fix status to `✅ COMPLETE`
 5. Change 📋 Report status to `▶️ IN PROGRESS`
-6. **Commit and push the state file**
 
 ---
 
@@ -230,8 +229,7 @@ Update all phase statuses to complete.
 **Update state file**:
 1. Change header status to final recommendation
 2. Update all phases to `✅ COMPLETE` or `✅ PASSED`
-3. **Commit and push the state file**
-4. Present final result to user
+3. Present final result to user
 
 ---
 

--- a/.github/instructions/uitests.instructions.md
+++ b/.github/instructions/uitests.instructions.md
@@ -171,9 +171,9 @@ Tests should run on all applicable platforms by default. The test infrastructure
 
 ### No Inline #if Directives in Test Methods
 
-**Do NOT use `#if ANDROID`, `#if IOS`, etc. inside test method bodies.** Platform-specific behavior must be hidden behind extension methods for readability.
+**Do NOT use `#if ANDROID`, `#if IOS`, etc. directly in test methods.** Platform-specific behavior must be hidden behind extension methods for readability.
 
-**Note:** File-level `#if` (to exclude entire files) or wrapping entire test methods is acceptable. This rule targets inline conditionals within test logic that make code hard to read and maintain.
+**Note:** This rule is about **code cleanliness**, not platform scope. Using `#if ANDROID ... #else ...` still compiles for all platforms - the issue is that inline directives make test logic hard to read and maintain.
 
 ```csharp
 // ❌ BAD - inline #if in test method (hard to read)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -1045,8 +1045,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			_searchController.Active = false;
 			(SearchHandler as ISearchHandlerController)?.ItemSelected(e);
+			_searchController.Active = false;
 		}
 
 		void SearchButtonClicked(object? sender, EventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33356.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33356.cs
@@ -1,0 +1,261 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33356, "Navigate should occur when an item got selected", PlatformAffected.iOS)]
+public class Issue33356 : Shell
+{
+	public Issue33356()
+	{
+		Routing.RegisterRoute("Issue33356CatDetails", typeof(_33356CatDetailsPage));
+
+		var flyoutItem = new FlyoutItem
+		{
+			Route = "animals",
+			FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems
+		};
+
+		var domesticTab = new Tab
+		{
+			Title = "Domestic",
+			Route = "domestic"
+		};
+
+		domesticTab.Items.Add(new ShellContent
+		{
+			Title = "Cats",
+			Route = "cats",
+			ContentTemplate = new DataTemplate(typeof(_33356CatsPage))
+		});
+
+		flyoutItem.Items.Add(domesticTab);
+
+		Items.Add(flyoutItem);
+	}
+
+	public class _33356Animal
+	{
+		public string Name { get; set; }
+		public string Location { get; set; }
+		public string Details { get; set; }
+	}
+
+	public class _33356CatsPage : ContentPage
+	{
+		public _33356CatsPage()
+		{
+			Title = "Cats";
+
+			var searchHandler = new _33356AnimalSearchHandler
+			{
+				Placeholder = "Enter search term (try 'A')",
+				ShowsResults = true,
+				Animals = _33356CatData.Cats,
+				ItemsSource = _33356CatData.Cats,
+				AutomationId = "Issue33356SearchHandler",
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var nameLabel = new Label
+					{
+						AutomationId = "SearchResultName",
+						FontAttributes = FontAttributes.Bold,
+						VerticalOptions = LayoutOptions.Center
+					};
+					nameLabel.SetBinding(Label.TextProperty, "Name");
+
+					return nameLabel;
+				})
+			};
+
+			Shell.SetSearchHandler(this, searchHandler);
+
+
+
+			var collectionView = new CollectionView
+			{
+				AutomationId = "Issue33356CatsCollectionView",
+				Margin = new Thickness(20),
+				ItemsSource = _33356CatData.Cats,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var grid = new Grid
+					{
+						Padding = 10,
+						RowDefinitions = new RowDefinitionCollection
+						{
+							new RowDefinition { Height = GridLength.Auto },
+							new RowDefinition { Height = GridLength.Auto }
+						}
+					};
+
+					var nameLabel = new Label { FontAttributes = FontAttributes.Bold };
+					nameLabel.SetBinding(Label.TextProperty, "Name");
+
+					var locationLabel = new Label
+					{
+						FontAttributes = FontAttributes.Italic,
+						VerticalOptions = LayoutOptions.End
+					};
+					locationLabel.SetBinding(Label.TextProperty, "Location");
+
+					grid.Children.Add(nameLabel);
+					Grid.SetRow(nameLabel, 0);
+
+					grid.Children.Add(locationLabel);
+					Grid.SetRow(locationLabel, 1);
+
+					return grid;
+				}),
+				SelectionMode = SelectionMode.Single
+			};
+
+			collectionView.SelectionChanged += (s, e) =>
+			{
+				if (e.CurrentSelection.Count == 0)
+					return;
+
+				var animal = e.CurrentSelection.FirstOrDefault() as _33356Animal;
+				if (animal?.Name == null)
+					return;
+
+				string catName = animal.Name;
+				// The following route works because route names are unique in this application.
+				Shell.Current.GoToAsync($"Issue33356CatDetails?name={catName}");
+			};
+
+			var layout = new StackLayout
+			{
+				Children = { collectionView }
+			};
+
+			Content = layout;
+		}
+	}
+
+	public static class _33356CatData
+	{
+		public static IList<_33356Animal> Cats { get; set; }
+
+		static _33356CatData()
+		{
+			Cats = new List<_33356Animal>();
+
+			Cats.Add(new _33356Animal
+			{
+				Name = "Abyssinian",
+				Location = "Ethiopia",
+				Details = "The Abyssinian is a breed of domestic short-haired cat."
+			});
+
+			Cats.Add(new _33356Animal
+			{
+				Name = "Arabian Mau",
+				Location = "Arabian Peninsula",
+				Details = "The Arabian Mau is a formal breed of domestic cat."
+			});
+		}
+	}
+
+	public class _33356AnimalSearchHandler : SearchHandler
+	{
+		public IList<_33356Animal> Animals { get; set; }
+
+		public _33356AnimalSearchHandler()
+		{
+			Animals = new List<_33356Animal>();
+		}
+		protected override async void OnItemSelected(object item)
+		{
+			base.OnItemSelected(item);
+
+			try
+			{
+				if (item is not _33356Animal animal)
+				{
+					return;
+				}
+				// Navigate, passing a string
+				var route = $"Issue33356CatDetails?name={animal.Name}";
+				await Shell.Current.GoToAsync(route);
+
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"Error in OnItemSelected: {ex.Message}");
+				Console.WriteLine($"Stack trace: {ex.StackTrace}");
+			}
+		}
+	}
+
+	[QueryProperty(nameof(Name), "name")]
+	public class _33356CatDetailsPage : ContentPage
+	{
+		public string Name
+		{
+			set
+			{
+				LoadAnimal(value);
+			}
+		}
+
+		public _33356CatDetailsPage()
+		{
+			Title = "Cat Details";
+
+			var scrollView = new ScrollView();
+			var stackLayout = new StackLayout { Margin = new Thickness(20) };
+
+			var nameLabel = new Label
+			{
+				AutomationId = "Issue33356CatNameLabel",
+				HorizontalOptions = LayoutOptions.Center,
+				FontSize = 24,
+				FontAttributes = FontAttributes.Bold
+			};
+			nameLabel.SetBinding(Label.TextProperty, "Name");
+
+			var locationLabel = new Label
+			{
+				AutomationId = "CatLocationLabel",
+				FontAttributes = FontAttributes.Italic,
+				HorizontalOptions = LayoutOptions.Center
+			};
+			locationLabel.SetBinding(Label.TextProperty, "Location");
+
+			var detailsLabel = new Label
+			{
+				AutomationId = "CatDetailsLabel",
+				HorizontalOptions = LayoutOptions.Center,
+				LineBreakMode = LineBreakMode.WordWrap,
+				VerticalOptions = LayoutOptions.Start
+			};
+			detailsLabel.SetBinding(Label.TextProperty, "Details");
+
+			stackLayout.Children.Add(nameLabel);
+			stackLayout.Children.Add(locationLabel);
+			stackLayout.Children.Add(detailsLabel);
+
+			scrollView.Content = stackLayout;
+			Content = scrollView;
+		}
+
+		void LoadAnimal(string name)
+		{
+			foreach (var animal in _33356CatData.Cats)
+			{
+				if (animal.Name == name)
+				{
+					BindingContext = animal;
+					return;
+				}
+			}
+
+			// If animal not found, show a default message
+			BindingContext = new _33356Animal
+			{
+				Name = "Unknown Cat",
+				Location = "Unknown",
+				Details = "Cat details not found."
+			};
+		}
+	}
+}
+

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33356 : _IssuesUITest
+{
+	public Issue33356(TestDevice device)
+		: base(device)
+	{
+	}
+
+	public override string Issue => "Navigate should occur when an item got selected";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void Issue33356NavigateShouldOccur()
+	{
+		App.WaitForElement("Issue33356CatsCollectionView");
+		var searchHander = App.GetShellSearchHandler();
+		searchHander.Tap();
+		searchHander.SendKeys("A");
+#if ANDROID
+		var y = searchHander.GetRect().Y + searchHander.GetRect().Height;
+		App.TapCoordinates(searchHander.GetRect().X + 10, y + 10);
+#else
+		var searchResults = App.FindElements("SearchResultName");
+		searchResults.First().Tap();
+#endif
+		App.WaitForElement("Issue33356CatNameLabel");
+#if ANDROID
+		App.TapBackArrow();
+#else
+		App.Back();
+#endif
+		App.WaitForElement("Issue33356CatsCollectionView");
+		App.WaitForElement("Abyssinian");
+		App.Tap("Abyssinian");
+		App.WaitForElement("Issue33356CatNameLabel");
+#if ANDROID
+		App.TapBackArrow();
+#else
+		App.Back();
+#endif
+		App.WaitForElement("Issue33356CatsCollectionView");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
@@ -29,7 +29,7 @@ public class Issue33356 : _IssuesUITest
 		searchResults.First().Tap();
 #endif
 		App.WaitForElement("Issue33356CatNameLabel");
-#if ANDROID
+#if ANDROID || WINDOWS
 		App.TapBackArrow();
 #else
 		App.Back();
@@ -38,7 +38,7 @@ public class Issue33356 : _IssuesUITest
 		App.WaitForElement("Abyssinian");
 		App.Tap("Abyssinian");
 		App.WaitForElement("Issue33356CatNameLabel");
-#if ANDROID
+#if ANDROID || WINDOWS
 		App.TapBackArrow();
 #else
 		App.Back();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
@@ -6,6 +6,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue33356 : _IssuesUITest
 {
+#if ANDROID
+	const string BackButtonIdentifier = "";
+#else
+	const string BackButtonIdentifier = "Cats";
+#endif
+
 	public Issue33356(TestDevice device)
 		: base(device)
 	{
@@ -21,7 +27,7 @@ public class Issue33356 : _IssuesUITest
 		var searchHander = App.GetShellSearchHandler();
 		searchHander.Tap();
 		searchHander.SendKeys("A");
-#if ANDROID
+#if ANDROID // Android does not support selecting elements in SearchHandler's results so used tap coordinates
 		var y = searchHander.GetRect().Y + searchHander.GetRect().Height;
 		App.TapCoordinates(searchHander.GetRect().X + 10, y + 10);
 #else
@@ -29,20 +35,12 @@ public class Issue33356 : _IssuesUITest
 		searchResults.First().Tap();
 #endif
 		App.WaitForElement("Issue33356CatNameLabel");
-#if ANDROID || WINDOWS
-		App.TapBackArrow();
-#else
-		App.Back();
-#endif
+		App.TapBackArrow(BackButtonIdentifier);
 		App.WaitForElement("Issue33356CatsCollectionView");
 		App.WaitForElement("Abyssinian");
 		App.Tap("Abyssinian");
 		App.WaitForElement("Issue33356CatNameLabel");
-#if ANDROID || WINDOWS
-		App.TapBackArrow();
-#else
-		App.Back();
-#endif
+		App.TapBackArrow(BackButtonIdentifier);
 		App.WaitForElement("Issue33356CatsCollectionView");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
@@ -6,12 +6,6 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue33356 : _IssuesUITest
 {
-#if ANDROID
-	const string BackButtonIdentifier = "";
-#else
-	const string BackButtonIdentifier = "Cats";
-#endif
-
 	public Issue33356(TestDevice device)
 		: base(device)
 	{
@@ -27,20 +21,14 @@ public class Issue33356 : _IssuesUITest
 		var searchHandler = App.GetShellSearchHandler();
 		searchHandler.Tap();
 		searchHandler.SendKeys("A");
-#if ANDROID // Android does not support selecting elements in SearchHandler's results so used tap coordinates
-		var y = searchHandler.GetRect().Y + searchHandler.GetRect().Height;
-		App.TapCoordinates(searchHandler.GetRect().X + 10, y + 10);
-#else
-		var searchResults = App.FindElements("SearchResultName");
-		searchResults.First().Tap();
-#endif
+		App.TapFirstSearchResult(this, searchHandler, "SearchResultName");
 		App.WaitForElement("Issue33356CatNameLabel");
-		App.TapBackArrow(BackButtonIdentifier);
+		App.TapBackArrow(Device == TestDevice.Android ? "" : "Cats");
 		App.WaitForElement("Issue33356CatsCollectionView");
 		App.WaitForElement("Abyssinian");
 		App.Tap("Abyssinian");
 		App.WaitForElement("Issue33356CatNameLabel");
-		App.TapBackArrow(BackButtonIdentifier);
+		App.TapBackArrow(Device == TestDevice.Android ? "" : "Cats");
 		App.WaitForElement("Issue33356CatsCollectionView");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33356.cs
@@ -24,12 +24,12 @@ public class Issue33356 : _IssuesUITest
 	public void Issue33356NavigateShouldOccur()
 	{
 		App.WaitForElement("Issue33356CatsCollectionView");
-		var searchHander = App.GetShellSearchHandler();
-		searchHander.Tap();
-		searchHander.SendKeys("A");
+		var searchHandler = App.GetShellSearchHandler();
+		searchHandler.Tap();
+		searchHandler.SendKeys("A");
 #if ANDROID // Android does not support selecting elements in SearchHandler's results so used tap coordinates
-		var y = searchHander.GetRect().Y + searchHander.GetRect().Height;
-		App.TapCoordinates(searchHander.GetRect().X + 10, y + 10);
+		var y = searchHandler.GetRect().Y + searchHandler.GetRect().Height;
+		App.TapCoordinates(searchHandler.GetRect().X + 10, y + 10);
 #else
 		var searchResults = App.FindElements("SearchResultName");
 		searchResults.First().Tap();

--- a/src/Controls/tests/TestCases.Shared.Tests/UtilExtensions.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UtilExtensions.cs
@@ -79,5 +79,20 @@ namespace Microsoft.Maui.TestCases.Tests
 				throw;
 			}
 		}
+
+		public static void TapFirstSearchResult(this IApp app, UITestContextBase context, IUIElement searchHandler, string searchResultIdentifier = "SearchResultName")
+		{
+			if (context.Device == TestDevice.Android)
+			{
+				// Android does not support selecting elements in SearchHandler results
+				var y = searchHandler.GetRect().Y + searchHandler.GetRect().Height;
+				app.TapCoordinates(searchHandler.GetRect().X + 10, y + 10);
+			}
+			else
+			{
+				var searchResults = app.FindElements(searchResultIdentifier);
+				searchResults.First().Tap();
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause : 
Navigation fails because `UISearchController` was dismissed before `ItemSelected` was called, triggering a UIKit transition that deactivates the Shell navigation context and prevents the navigation from completing
### Description of Change :
Changed the order in `OnSearchItemSelected` in `ShellPageRendererTracker.cs` to call `ItemSelected` before deactivating the search controller for correct event handling.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33356 

### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/0e63dd86-1965-404a-8d07-6d3afd952498"> | <video src="https://github.com/user-attachments/assets/af867272-434f-411e-9a6f-a68a87cfc3a7"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
