### PR TITLE
Fix unit test failures not failing the build

### DIFF
--- a/eng/pipelines/common/run-dotnet-preview.yml
+++ b/eng/pipelines/common/run-dotnet-preview.yml
@@ -55,7 +55,7 @@ steps:
         if ([System.Convert]::ToBoolean("${{ parameters.useExitCodeForErrors }}") -and $LASTEXITCODE -ne 0) {
             Write-Host "##vso[task.logissue type=error]Test suite had $LASTEXITCODE failure(s)."
             Write-Host "##vso[task.complete result=Failed;]"
-            exit 0
+            exit $LASTEXITCODE
         }
     displayName: ${{ parameters.displayName }}
     condition: ${{ parameters.condition }}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR fixes a critical issue where unit test failures were not properly failing the build pipeline, allowing PRs to pass CI checks even when tests failed.

## Problem

In `/eng/pipelines/common/run-dotnet-preview.yml` at line 58, when `useExitCodeForErrors: true` is set and tests fail, the script was:

1. ✅ Logging an error message
2. ✅ Marking the task as "Failed" using Azure DevOps logging commands
3. ❌ **Exiting with code 0 (success)**

This caused jobs to show as `succeededWithIssues` instead of `failed`, and overall PR checks would pass even though unit tests failed.

### Example

PR #33391 had failing unit tests:
- Controls.Xaml.UnitTests failed with "Test suite had 1 failure(s)"
- Build timeline showed `"result": "succeededWithIssues"`
- But overall check status was SUCCESS ✅

## Solution

Changed line 58 from:
```powershell
exit 0
```

to:
```powershell
exit $LASTEXITCODE
```

This ensures the PowerShell script exits with the actual failure code from the test run, properly failing the build pipeline.

## Impact

After this change:
- ✅ Unit test failures will properly fail the build
- ✅ PR checks will show as failed when tests fail  
- ✅ Build status will accurately reflect test results
- ✅ No more false positives where builds pass with failing tests

## Testing

This fix will be validated by observing the build behavior on this PR itself. The change is minimal and surgical - only affecting the exit code propagation when tests fail.