### PR TITLE
[net10.0] Update sdk net10 versions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,13 +7,14 @@
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
     <add key="darc-pub-dotnet-android-d611c12" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-d611c121/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-android-d611c12-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-d611c121-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-pub-dotnet-dotnet-02dfa78" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-dotnet-02dfa783/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-dotnet-4ef9fba" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-dotnet-4ef9fba1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-macios -->
+    <add key="darc-pub-dotnet-macios-e6a0fb7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-e6a0fb79/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-macios-8d30875" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-8d308759/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-macios-8acf446" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-8acf4462/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="local" value="LOCAL_PLACEHOLDER" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.102-servicing.25604.105">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.103-servicing.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.2">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.1.12">
       <Uri>https://github.com/dotnet/android</Uri>
@@ -35,128 +35,128 @@
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9779" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.2">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9784" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>8acf44629f2cb0abc8e283f46152608c7051afa1</Sha>
+      <Sha>e6a0fb79426493766332ad077290212fb1c9db4e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9779" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.2">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9784" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>8acf44629f2cb0abc8e283f46152608c7051afa1</Sha>
+      <Sha>e6a0fb79426493766332ad077290212fb1c9db4e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9779" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.2">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9784" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>8acf44629f2cb0abc8e283f46152608c7051afa1</Sha>
+      <Sha>e6a0fb79426493766332ad077290212fb1c9db4e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9779" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.2">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9784" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>8acf44629f2cb0abc8e283f46152608c7051afa1</Sha>
+      <Sha>e6a0fb79426493766332ad077290212fb1c9db4e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.2">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="10.0.2">
+    <Dependency Name="Microsoft.JSInterop" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="10.0.0-prerelease.25575.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -172,37 +172,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25604.105">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.26057.111">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>02dfa783c1f4223a5590a1b689ef381c337db1ab</Sha>
+      <Sha>4ef9fba1ed958b047163527960c27baf2883f835</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,28 +30,28 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>9.0.120</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>10.0.102-servicing.25611.101</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.103-servicing.26057.111</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <MonoPackageVersion>10.0.100</MonoPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>10.0.2</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>10.0.3</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>10.0.2</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.2</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>10.0.2</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>10.0.2</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.2</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.2</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.2</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.2</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.2</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>10.0.2</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>10.0.2</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.2</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>10.0.3</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>10.0.3</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>10.0.3</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>10.0.3</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>10.0.3</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.3</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.3</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>10.0.3</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>10.0.3</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>10.0.3</MicrosoftExtensionsHostingAbstractionsVersion>
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>36.1.12</MicrosoftAndroidSdkWindowsPackageVersion>
     <MicrosoftNETSdkAndroidManifest90100PackageVersion>35.0.105</MicrosoftNETSdkAndroidManifest90100PackageVersion>
@@ -62,10 +62,10 @@
     <MicrosoftiOSSdknet100_262PackageVersion>26.2.10192</MicrosoftiOSSdknet100_262PackageVersion>
     <MicrosofttvOSSdknet100_262PackageVersion>26.2.10192</MicrosofttvOSSdknet100_262PackageVersion>
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <MicrosoftMacCatalystSdknet90_260PackageVersion>26.0.9779</MicrosoftMacCatalystSdknet90_260PackageVersion>
-    <MicrosoftmacOSSdknet90_260PackageVersion>26.0.9779</MicrosoftmacOSSdknet90_260PackageVersion>
-    <MicrosoftiOSSdknet90_260PackageVersion>26.0.9779</MicrosoftiOSSdknet90_260PackageVersion>
-    <MicrosofttvOSSdknet90_260PackageVersion>26.0.9779</MicrosofttvOSSdknet90_260PackageVersion>
+    <MicrosoftMacCatalystSdknet90_260PackageVersion>26.0.9784</MicrosoftMacCatalystSdknet90_260PackageVersion>
+    <MicrosoftmacOSSdknet90_260PackageVersion>26.0.9784</MicrosoftmacOSSdknet90_260PackageVersion>
+    <MicrosoftiOSSdknet90_260PackageVersion>26.0.9784</MicrosoftiOSSdknet90_260PackageVersion>
+    <MicrosofttvOSSdknet90_260PackageVersion>26.0.9784</MicrosofttvOSSdknet90_260PackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>8.0.148</SamsungTizenSdkPackageVersion>
     <!-- wasdk -->
@@ -74,19 +74,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.2</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.2</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.2</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.2</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.2</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.2</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>10.0.2</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>10.0.3</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>10.0.3</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>10.0.3</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>10.0.3</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>10.0.3</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>10.0.3</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>10.0.3</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>8.0.16</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -136,13 +136,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.25611.101</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.25611.101</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.25611.101</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25611.101</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>10.0.0-beta.26057.111</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>10.0.0-beta.26057.111</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>10.0.0-beta.26057.111</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.26057.111</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.25611.101</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25611.101</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.26057.111</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.26057.111</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -26,7 +26,7 @@ function SetupCredProvider {
   $url = 'https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1'
   
   Write-Host "Writing the contents of 'installcredprovider.ps1' locally..."
-  Invoke-WebRequest $url -OutFile installcredprovider.ps1
+  Invoke-WebRequest $url -UseBasicParsing -OutFile installcredprovider.ps1
   
   Write-Host 'Installing plugin...'
   .\installcredprovider.ps1 -Force

--- a/eng/common/post-build/nuget-verification.ps1
+++ b/eng/common/post-build/nuget-verification.ps1
@@ -65,7 +65,7 @@ if ($NuGetExePath) {
         Write-Host "Downloading nuget.exe from $nugetExeUrl..."
         $ProgressPreference = 'SilentlyContinue'
         try {
-            Invoke-WebRequest $nugetExeUrl -OutFile $downloadedNuGetExe
+            Invoke-WebRequest $nugetExeUrl -UseBasicParsing -OutFile $downloadedNuGetExe
             $ProgressPreference = 'Continue'
         } catch {
             $ProgressPreference = 'Continue'

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -277,7 +277,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
 
     Retry({
       Write-Host "GET $uri"
-      Invoke-WebRequest $uri -OutFile $installScript
+      Invoke-WebRequest $uri -UseBasicParsing -OutFile $installScript
     })
   }
 
@@ -510,7 +510,7 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
     Write-Host "Downloading $packageName $packageVersion"
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
     Retry({
-      Invoke-WebRequest "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/flat2/$packageName/$packageVersion/$packageName.$packageVersion.nupkg" -OutFile $packagePath
+      Invoke-WebRequest "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/flat2/$packageName/$packageVersion/$packageName.$packageVersion.nupkg" -UseBasicParsing -OutFile $packagePath
     })
 
     if (!(Test-Path $packagePath)) {
@@ -556,23 +556,30 @@ function LocateVisualStudio([object]$vsRequirements = $null){
     Write-Host "Downloading vswhere $vswhereVersion"
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
     Retry({
-      Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+      Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -UseBasicParsing -OutFile $vswhereExe
     })
   }
 
-  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
+  if (!$vsRequirements) {
+    if (Get-Member -InputObject $GlobalJson.tools -Name 'vs' -ErrorAction SilentlyContinue) {
+      $vsRequirements = $GlobalJson.tools.vs
+    } else {
+      $vsRequirements = $null
+    }
+  }
+
   $args = @('-latest', '-format', 'json', '-requires', 'Microsoft.Component.MSBuild', '-products', '*')
 
   if (!$excludePrereleaseVS) {
     $args += '-prerelease'
   }
 
-  if (Get-Member -InputObject $vsRequirements -Name 'version') {
+  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'version' -ErrorAction SilentlyContinue)) {
     $args += '-version'
     $args += $vsRequirements.version
   }
 
-  if (Get-Member -InputObject $vsRequirements -Name 'components') {
+  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'components' -ErrorAction SilentlyContinue)) {
     foreach ($component in $vsRequirements.components) {
       $args += '-requires'
       $args += $component

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "tools": {
-    "dotnet": "10.0.102-servicing.25611.101"
+    "dotnet": "10.0.103-servicing.26057.111"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25611.101",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25611.101"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26057.111",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26057.111"
   }
 }


### PR DESCRIPTION
### Description of Change

This pull request updates several dependency versions and package sources to ensure the project uses the latest stable releases of .NET, macOS/iOS/tvOS/MacCatalyst SDKs, and related libraries. The changes primarily focus on bumping version numbers and updating SHA references for consistency and security, as well as modifying NuGet package sources to match the new dependencies.

Dependency and SDK version updates:

* Updated .NET SDK and related package versions from `10.0.102-servicing.25604.105` to `10.0.103-servicing.26057.111` in `eng/Version.Details.xml` and `eng/Versions.props`, including `Microsoft.NET.Sdk`, `Microsoft.NETCore.App.Ref`, and various `Microsoft.Extensions.*` libraries. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L3-R9) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L33-R54)
* Updated previous .NET 9 stable release versions for `Microsoft.MacCatalyst.Sdk`, `Microsoft.macOS.Sdk`, `Microsoft.iOS.Sdk`, and `Microsoft.tvOS.Sdk` from `26.0.9779` to `26.0.9784` in both `eng/Version.Details.xml` and `eng/Versions.props`. [[1]](diffhunk://#diff-fb62e94a1d6f29f863e3d0a22aa38269f6cd1d7f03b109dc06e2cbf2548b86d3L38-R159) [[2]](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L65-R68)

Toolset and build infrastructure updates:

* Bumped toolset dependency versions (such as `Microsoft.DotNet.Build.Tasks.Feed`, `Microsoft.DotNet.Arcade.Sdk`, and others) to `10.0.0-beta.26057.111` in `eng/Version.Details.xml`, with updated SHA references.

NuGet package source changes:

* Updated and added new NuGet package sources in `NuGet.config` to match the new dependency versions and remove obsolete sources.
