### PR TITLE
[Android] Fix picked images end up with unexpected "_processed" suffix

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -93,9 +93,6 @@ namespace Microsoft.Maui.Media
 					using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
 					rotatedStream.Position = 0;
 					
-					// Close input stream before deleting
-					inputStream.Close();
-					
 					// Delete original file
 					try { File.Delete(captureResult); } catch { }
 					
@@ -162,9 +159,6 @@ namespace Microsoft.Maui.Media
 							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
 							rotatedStream.Position = 0;
 							
-							// Close input stream before deleting
-							inputStream.Close();
-							
 							// Delete original file
 							try { File.Delete(path); } catch { }
 							
@@ -215,9 +209,6 @@ namespace Microsoft.Maui.Media
 					var fileName = System.IO.Path.GetFileName(path);
 					using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
 					rotatedStream.Position = 0;
-					
-					// Close input stream before deleting
-					inputStream.Close();
 					
 					// Delete original file
 					try { File.Delete(path); } catch { }
@@ -286,9 +277,6 @@ namespace Microsoft.Maui.Media
 							var fileName = System.IO.Path.GetFileName(path);
 							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
 							rotatedStream.Position = 0;
-							
-							// Close input stream before deleting
-							inputStream.Close();
 							
 							// Delete original file
 							try { File.Delete(path); } catch { }
@@ -478,9 +466,6 @@ namespace Microsoft.Maui.Media
 							var fileName = System.IO.Path.GetFileName(processedPath);
 							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
 							rotatedStream.Position = 0;
-							
-							// Close input stream before deleting
-							inputStream.Close();
 							
 							// Delete original file
 							try { File.Delete(processedPath); } catch { }

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -91,22 +91,17 @@ namespace Microsoft.Maui.Media
 					using var inputStream = File.OpenRead(captureResult);
 					var fileName = System.IO.Path.GetFileName(captureResult);
 					using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-						
-						var rotatedPath = System.IO.Path.Combine(
-							System.IO.Path.GetDirectoryName(captureResult),
-							System.IO.Path.GetFileNameWithoutExtension(captureResult) + "_rotated" + System.IO.Path.GetExtension(captureResult));
-							
-						using var outputStream = File.Create(rotatedPath);
-						rotatedStream.Position = 0;
-						await rotatedStream.CopyToAsync(outputStream);
-						
-						// Use the rotated image and delete the original
-						try 
-						{ 
-							File.Delete(captureResult);
-						}
-						catch { }
-						captureResult = rotatedPath;
+					rotatedStream.Position = 0;
+					
+					// Close input stream before deleting
+					inputStream.Close();
+					
+					// Delete original file
+					try { File.Delete(captureResult); } catch { }
+					
+					// Write rotated image to original path (preserves filename)
+					using var outputStream = File.Create(captureResult);
+					await rotatedStream.CopyToAsync(outputStream);
 					}
 					
 					// Apply compression/resizing if needed for photos
@@ -219,17 +214,17 @@ namespace Microsoft.Maui.Media
 					using var inputStream = File.OpenRead(path);
 					var fileName = System.IO.Path.GetFileName(path);
 					using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-					
-					var rotatedPath = System.IO.Path.Combine(
-						System.IO.Path.GetDirectoryName(path),
-						System.IO.Path.GetFileNameWithoutExtension(path) + "_rotated" + System.IO.Path.GetExtension(path));
-						
-					using var outputStream = File.Create(rotatedPath);
 					rotatedStream.Position = 0;
-					await rotatedStream.CopyToAsync(outputStream);
 					
-					// Use the rotated image
-					path = rotatedPath;
+					// Close input stream before deleting
+					inputStream.Close();
+					
+					// Delete original file
+					try { File.Delete(path); } catch { }
+					
+					// Write rotated image to original path (preserves filename)
+					using var outputStream = File.Create(path);
+					await rotatedStream.CopyToAsync(outputStream);
 				}
 
 				// Apply compression/resizing if needed
@@ -290,17 +285,17 @@ namespace Microsoft.Maui.Media
 							using var inputStream = File.OpenRead(path);
 							var fileName = System.IO.Path.GetFileName(path);
 							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-							
-							var rotatedPath = System.IO.Path.Combine(
-								System.IO.Path.GetDirectoryName(path),
-								System.IO.Path.GetFileNameWithoutExtension(path) + "_rotated" + System.IO.Path.GetExtension(path));
-								
-							using var outputStream = File.Create(rotatedPath);
 							rotatedStream.Position = 0;
-							await rotatedStream.CopyToAsync(outputStream);
 							
-							// Use the rotated image
-							path = rotatedPath;
+							// Close input stream before deleting
+							inputStream.Close();
+							
+							// Delete original file
+							try { File.Delete(path); } catch { }
+							
+							// Write rotated image to original path (preserves filename)
+							using var outputStream = File.Create(path);
+							await rotatedStream.CopyToAsync(outputStream);
 						}
 
 						// Apply compression/resizing if needed
@@ -368,21 +363,15 @@ namespace Microsoft.Maui.Media
 
 				if (processedStream != null)
 				{
-					// Determine output extension based on processed data and original filename
-					var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, options?.CompressionQuality ?? 100, inputFileName);
-					var processedFileName = System.IO.Path.GetFileNameWithoutExtension(imagePath) + "_processed" + outputExtension;
-					var processedPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(imagePath), processedFileName);
-
-					// Write processed image to file
-					using var outputStream = File.Create(processedPath);
-					processedStream.Position = 0;
-					await processedStream.CopyToAsync(outputStream);
-
-					// Delete original file
-					try
-					{ originalFile.Delete(); }
-					catch { }
-					return processedPath;
+				// Delete original file first
+				try { originalFile.Delete(); } catch { }
+				
+				// Write processed image to original path (preserves filename)
+				using var outputStream = File.Create(imagePath);
+				processedStream.Position = 0;
+				await processedStream.CopyToAsync(outputStream);
+				
+				return imagePath;
 				}
 
 				// If ImageProcessor returns null (e.g., on .NET Standard), ImageProcessor.IsProcessingNeeded would have returned false,
@@ -488,17 +477,17 @@ namespace Microsoft.Maui.Media
 							using var inputStream = File.OpenRead(processedPath);
 							var fileName = System.IO.Path.GetFileName(processedPath);
 							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-							
-							var rotatedPath = System.IO.Path.Combine(
-								System.IO.Path.GetDirectoryName(processedPath),
-								System.IO.Path.GetFileNameWithoutExtension(processedPath) + "_rotated" + System.IO.Path.GetExtension(processedPath));
-								
-							using var outputStream = File.Create(rotatedPath);
 							rotatedStream.Position = 0;
-							await rotatedStream.CopyToAsync(outputStream);
 							
-							// Use the rotated image
-							processedPath = rotatedPath;
+							// Close input stream before deleting
+							inputStream.Close();
+							
+							// Delete original file
+							try { File.Delete(processedPath); } catch { }
+							
+							// Write rotated image to original path (preserves filename)
+							using var outputStream = File.Create(processedPath);
+							await rotatedStream.CopyToAsync(outputStream);
 						}
 
 						// Apply compression/resizing if needed

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -160,17 +160,17 @@ namespace Microsoft.Maui.Media
 							using var inputStream = File.OpenRead(path);
 							var fileName = System.IO.Path.GetFileName(path);
 							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-							
-							var rotatedPath = System.IO.Path.Combine(
-								System.IO.Path.GetDirectoryName(path),
-								System.IO.Path.GetFileNameWithoutExtension(path) + "_rotated" + System.IO.Path.GetExtension(path));
-								
-							using var outputStream = File.Create(rotatedPath);
 							rotatedStream.Position = 0;
-							await rotatedStream.CopyToAsync(outputStream);
 							
-							// Use the rotated image
-							path = rotatedPath;
+							// Close input stream before deleting
+							inputStream.Close();
+							
+							// Delete original file
+							try { File.Delete(path); } catch { }
+							
+							// Write rotated image to original path (preserves filename)
+							using var outputStream = File.Create(path);
+							await rotatedStream.CopyToAsync(outputStream);
 						}
 
 						// Apply compression/resizing if needed

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -23,6 +23,20 @@ namespace Microsoft.Maui.Media
 		public bool IsCaptureSupported
 			=> Application.Context?.PackageManager?.HasSystemFeature(PackageManager.FeatureCameraAny) ?? false;
 
+		static async Task RotateImageInPlace(string filePath, MediaPickerOptions options)
+		{
+			using var inputStream = File.OpenRead(filePath);
+			var fileName = System.IO.Path.GetFileName(filePath);
+			using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
+			rotatedStream.Position = 0;
+			inputStream.Dispose(); // explicit close before delete
+			try
+			{ File.Delete(filePath); }
+			catch { }
+			using var outputStream = File.Create(filePath);
+			await rotatedStream.CopyToAsync(outputStream);
+		}
+
 		internal static bool IsPhotoPickerAvailable
 			=> PickVisualMedia.InvokeIsPhotoPickerAvailable(Platform.AppContext);
 
@@ -85,22 +99,10 @@ namespace Microsoft.Maui.Media
 				if (photo)
 				{
 					captureResult = await CapturePhotoAsync(captureIntent);
-							// Apply rotation if needed for photos
-				if (captureResult is not null && ImageProcessor.IsRotationNeeded(options))
-				{
-					using var inputStream = File.OpenRead(captureResult);
-					var fileName = System.IO.Path.GetFileName(captureResult);
-					using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-					rotatedStream.Position = 0;
-					
-					// Delete original file
-					try { File.Delete(captureResult); } catch { }
-					
-					// Write rotated image to original path (preserves filename)
-					using var outputStream = File.Create(captureResult);
-					await rotatedStream.CopyToAsync(outputStream);
-					}
-					
+					// Apply rotation if needed for photos
+					if (captureResult is not null && ImageProcessor.IsRotationNeeded(options))
+						await RotateImageInPlace(captureResult, options);
+
 					// Apply compression/resizing if needed for photos
 					if (captureResult is not null && ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 					{
@@ -153,19 +155,7 @@ namespace Microsoft.Maui.Media
 					{
 						// Apply rotation if needed
 						if (ImageProcessor.IsRotationNeeded(options))
-						{
-							using var inputStream = File.OpenRead(path);
-							var fileName = System.IO.Path.GetFileName(path);
-							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-							rotatedStream.Position = 0;
-							
-							// Delete original file
-							try { File.Delete(path); } catch { }
-							
-							// Write rotated image to original path (preserves filename)
-							using var outputStream = File.Create(path);
-							await rotatedStream.CopyToAsync(outputStream);
-						}
+							await RotateImageInPlace(path, options);
 
 						// Apply compression/resizing if needed
 						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
@@ -173,7 +163,7 @@ namespace Microsoft.Maui.Media
 							path = await CompressImageIfNeeded(path, options);
 						}
 					}
-					
+
 					return new FileResult(path);
 				}
 
@@ -204,19 +194,7 @@ namespace Microsoft.Maui.Media
 			{
 				// Apply rotation if needed
 				if (ImageProcessor.IsRotationNeeded(options))
-				{
-					using var inputStream = File.OpenRead(path);
-					var fileName = System.IO.Path.GetFileName(path);
-					using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-					rotatedStream.Position = 0;
-					
-					// Delete original file
-					try { File.Delete(path); } catch { }
-					
-					// Write rotated image to original path (preserves filename)
-					using var outputStream = File.Create(path);
-					await rotatedStream.CopyToAsync(outputStream);
-				}
+					await RotateImageInPlace(path, options);
 
 				// Apply compression/resizing if needed
 				if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
@@ -267,24 +245,12 @@ namespace Microsoft.Maui.Media
 				if (!uri?.Equals(AndroidUri.Empty) ?? false)
 				{
 					var path = FileSystemUtils.EnsurePhysicalPath(uri);
-					
+
 					if (photo)
 					{
 						// Apply rotation if needed
 						if (ImageProcessor.IsRotationNeeded(options))
-						{
-							using var inputStream = File.OpenRead(path);
-							var fileName = System.IO.Path.GetFileName(path);
-							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-							rotatedStream.Position = 0;
-							
-							// Delete original file
-							try { File.Delete(path); } catch { }
-							
-							// Write rotated image to original path (preserves filename)
-							using var outputStream = File.Create(path);
-							await rotatedStream.CopyToAsync(outputStream);
-						}
+							await RotateImageInPlace(path, options);
 
 						// Apply compression/resizing if needed
 						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
@@ -351,15 +317,29 @@ namespace Microsoft.Maui.Media
 
 				if (processedStream != null)
 				{
-				// Delete original file first
-				try { originalFile.Delete(); } catch { }
-				
-				// Write processed image to original path (preserves filename)
-				using var outputStream = File.Create(imagePath);
-				processedStream.Position = 0;
-				await processedStream.CopyToAsync(outputStream);
-				
-				return imagePath;
+					// Determine the correct output extension based on the processed format
+					processedStream.Position = 0;
+					var outputExtension = ImageProcessor.DetermineOutputExtension(processedStream, options?.CompressionQuality ?? 100, inputFileName);
+					var originalExtension = System.IO.Path.GetExtension(imagePath);
+
+					// If format changed (e.g., PNG -> JPEG), use new extension
+					string outputPath = imagePath;
+					if (!string.Equals(outputExtension, originalExtension, StringComparison.OrdinalIgnoreCase))
+					{
+						outputPath = System.IO.Path.ChangeExtension(imagePath, outputExtension);
+					}
+
+					// Delete original file first
+					try
+					{ originalFile.Delete(); }
+					catch { }
+
+					// Write processed image to output path with correct extension
+					using var outputStream = File.Create(outputPath);
+					processedStream.Position = 0;
+					await processedStream.CopyToAsync(outputStream);
+
+					return outputPath;
 				}
 
 				// If ImageProcessor returns null (e.g., on .NET Standard), ImageProcessor.IsProcessingNeeded would have returned false,
@@ -458,29 +438,17 @@ namespace Microsoft.Maui.Media
 					foreach (var path in tempResultList)
 					{
 						string processedPath = path;
-						
+
 						// Apply rotation if needed
 						if (ImageProcessor.IsRotationNeeded(options))
-						{
-							using var inputStream = File.OpenRead(processedPath);
-							var fileName = System.IO.Path.GetFileName(processedPath);
-							using var rotatedStream = await ImageProcessor.RotateImageAsync(inputStream, fileName);
-							rotatedStream.Position = 0;
-							
-							// Delete original file
-							try { File.Delete(processedPath); } catch { }
-							
-							// Write rotated image to original path (preserves filename)
-							using var outputStream = File.Create(processedPath);
-							await rotatedStream.CopyToAsync(outputStream);
-						}
+							await RotateImageInPlace(processedPath, options);
 
 						// Apply compression/resizing if needed
 						if (ImageProcessor.IsProcessingNeeded(options?.MaximumWidth, options?.MaximumHeight, options?.CompressionQuality ?? 100))
 						{
 							processedPath = await CompressImageIfNeeded(processedPath, options);
 						}
-						
+
 						resultList.Add(new FileResult(processedPath));
 					}
 				}


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
MediaPicker on Android was appending _rotated and _processed suffixes to filenames when rotating or compressing images, causing the original filename to be lost.

### Description of Change

<!-- Enter description of the fix in this section -->
The updated implementation closes the input stream before performing any file operations, deletes the original file, and writes the processed (rotated) image back to the same file path. This ensures that the original filename is preserved, avoiding the addition of any _rotated or _processed suffixes.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33258 

### Regarding test case
Picking an image is not possible in a test.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/35cb8242-9d10-4926-81b8-d28e291a56fe" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/92249ba3-76af-4d05-a789-8f63d02de86b" width="300" height="600"> |
