### PR TITLE
Add inflight/* branch trigger to UI tests pipeline

### DIFF
--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -4,6 +4,7 @@ trigger:
     - main
     - release/*
     - net*.0
+    - inflight/*
   tags:
     include:
     - '*'
@@ -27,6 +28,7 @@ pr:
     - main
     - release/*
     - net*.0
+    - inflight/*
   paths:
     include:
     - '*'


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The `maui-pr-uitests` pipeline was not running for PRs targeting `inflight/*` branches because they were not included in the trigger configuration.

This was discovered in PR #33380 where `/azp run maui-pr-uitests` returned:
> Azure Pipelines could not run because the pipeline triggers exclude this branch/path.

## Changes

Added `inflight/*` to both `trigger:` and `pr:` branch includes in `eng/pipelines/ci-uitests.yml`, matching what `ci-device-tests.yml` already has.

## Related

- Unblocks: #33380