### PR TITLE
[.NET11] Update android packages 

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,8 +49,8 @@
     <TargetPlatformMinVersion>12.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsAndroid)' == 'True'">
-    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
-    <TargetPlatformMinVersion>21.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion>23.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(_MauiTargetPlatformIsTizen)' == 'True'">
     <SupportedOSPlatformVersion>6.5</SupportedOSPlatformVersion>

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -3,22 +3,22 @@
   <ItemGroup>
     <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
     <!-- must be kept in sync with the binding library version to it here: -->
-    <PackageReference Update="Xamarin.Android.Glide" Version="4.16.0.14" />
-    <PackageReference Update="Xamarin.AndroidX.Activity" Version="1.10.1.3" />
-    <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.8.0.11" />
-    <PackageReference Update="Xamarin.AndroidX.DynamicAnimation" Version="1.1.0.3" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.9.2.1" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.9.2.1" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.9.2.1" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.Runtime" Version="2.9.2.1" />
-    <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.9.2.1" />
+    <PackageReference Update="Xamarin.Android.Glide" Version="5.0.5.2" />
+    <PackageReference Update="Xamarin.AndroidX.Activity" Version="1.12.4.1" />
+    <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.9.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.DynamicAnimation" Version="1.1.0.5" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.10.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Common" Version="2.9.7.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Fragment" Version="2.9.7.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.Runtime" Version="2.9.7.1" />
+    <PackageReference Update="Xamarin.AndroidX.Navigation.UI" Version="2.9.7.1" />
     <PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="1.1.0.4-alpha07" />
-    <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.29" />
-    <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.6.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.4.0.1" />
-    <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.26" />
-    <PackageReference Update="Xamarin.Google.Android.Material" Version="1.12.0.5" />
-    <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.18.0.1" />
-    <PackageReference Update="Xamarin.GooglePlayServices.Maps" Version="119.2.0.3" />
+    <PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.2.0.2" />
+    <PackageReference Update="Xamarin.AndroidX.Transition" Version="1.7.0.1" />
+    <PackageReference Update="Xamarin.AndroidX.Window.WindowJava" Version="1.5.1.2" />
+    <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.28" />
+    <PackageReference Update="Xamarin.Google.Android.Material" Version="1.13.0.2" />
+    <PackageReference Update="Xamarin.Google.Crypto.Tink.Android" Version="1.20.0.2" />
+    <PackageReference Update="Xamarin.GooglePlayServices.Maps" Version="120.0.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Controls/samples/Controls.Sample.Embedding/Maui.Controls.Sample.Embedding.csproj
+++ b/src/Controls/samples/Controls.Sample.Embedding/Maui.Controls.Sample.Embedding.csproj
@@ -25,7 +25,7 @@
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -32,7 +32,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>

--- a/src/Core/src/Animations/PlatformTicker.Android.cs
+++ b/src/Core/src/Animations/PlatformTicker.Android.cs
@@ -91,20 +91,13 @@ namespace Microsoft.Maui.Animations
 				return ValueAnimator.AreAnimatorsEnabled();
 			}
 
-			if (OperatingSystem.IsAndroidVersionAtLeast(21))
+			// For API levels which support power saving but not AreAnimatorsEnabled, we can check the
+			// power save mode; for these API levels, power saving == ON will mean that animations are disabled
+			return Devices.Battery.EnergySaverStatus switch
 			{
-				// For API levels which support power saving but not AreAnimatorsEnabled, we can check the
-				// power save mode; for these API levels, power saving == ON will mean that animations are disabled
-
-				return Devices.Battery.EnergySaverStatus switch
-				{
-					Devices.EnergySaverStatus.On => false,
-					_ => true,
-				};
-			}
-
-			// We don't support anything below 21
-			return false;
+				Devices.EnergySaverStatus.On => false,
+				_ => true,
+			};
 		}
 
 		class DurationScaleListener : Java.Lang.Object, ValueAnimator.IDurationScaleChangeListener

--- a/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
+++ b/src/Core/tests/Benchmarks.Droid/Benchmarks.Droid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(_MauiDotNetTfm)-android</TargetFramework>
-    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.Maui.Benchmarks.Droid</AssemblyName>
     <Nullable>enable</Nullable>

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -60,7 +60,7 @@
 
 
   <PropertyGroup>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Essentials/src/Browser/Browser.android.cs
+++ b/src/Essentials/src/Browser/Browser.android.cs
@@ -65,10 +65,10 @@ namespace Microsoft.Maui.ApplicationModel
 #endif
 
 			// Check if there's flags specified to use
-			if (tabsFlags.HasValue)
+			if (tabsFlags.HasValue && tabsIntent?.Intent != null)
 				tabsIntent.Intent.SetFlags(tabsFlags.Value);
 
-			if (nativeUri != null)
+			if (nativeUri != null && context != null && tabsIntent != null)
 				tabsIntent.LaunchUrl(context, nativeUri);
 		}
 

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -13,7 +13,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -38,7 +38,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>DOTNET_TFM-android</TargetFramework>
-		<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiApp._1</RootNamespace>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
This pull request updates the minimum supported Android platform version across the codebase from API level 21 to API level 23 and upgrades several AndroidX and Google dependencies. It also includes minor code fixes to ensure compatibility with these changes and to prevent runtime errors.

Platform version updates:

* Increased `SupportedOSPlatformVersion` and `TargetPlatformMinVersion` for Android from 21.0 to 23.0 in project and target files, affecting build requirements for all Android projects and templates. [[1]](diffhunk://#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcL52-R53) [[2]](diffhunk://#diff-defa1b5ec944712f9b05ccd6a7babd8897ad11e0c9aad7d14d459610498f359fL28-R28) [[3]](diffhunk://#diff-8b9c404f9891037c65ea0768ec01e0d8930e03001ee9f470e3b906b6aaca8606L43-R43) [[4]](diffhunk://#diff-7e83bb9506bf80facc20f8f8e65a9dd83d8182a7a798a0e9f33d991e77885b76L35-R35) [[5]](diffhunk://#diff-390a8abc062ea23cb41f09cba95230d40af3c6a099eac04fa3729480ff12ab01L4-R4) [[6]](diffhunk://#diff-3da64a09d22fe1c649c9cd1e4d489d0a3836294ec9ac739d1bc2741db0a10203L63-R63) [[7]](diffhunk://#diff-5ce941f8cda449994a41056896936305152d7cd634ce40907a2c2463f164ff68L16-R16) [[8]](diffhunk://#diff-89619ac038b59e0a1637d71c540fb17308cae3fbbf85d6f185598f6b4650cd5eL41-R41) [[9]](diffhunk://#diff-0bdc2f8265754b8666aeb32d0e4560eeed50df8830d6e754d9190f492d495926L5-R5)

Dependency upgrades:

* Updated AndroidX and Google dependencies in `eng/AndroidX.targets` to newer versions, including `Xamarin.Android.Glide`, `Xamarin.AndroidX.Activity`, `Xamarin.AndroidX.Browser`, and others; added a workaround for duplicate class errors with `Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm`.

Code compatibility and bug fixes:

* Improved null checks in `LaunchChromeTabs` in `Browser.android.cs` to prevent potential crashes when setting intent flags or launching URLs.
* Simplified and removed outdated Android version checks in `AreAnimationsEnabled()` in `PlatformTicker.Android.cs` to align with the new minimum API level.## Summary

This PR updates `Xamarin.Google.Android.Material` from `1.12.0.5` to `1.13.0.1` to incorporate the fix for Material Slider's missing `addOnChangeListener` method from [dotnet/android-libraries#1335](https://github.com/dotnet/android-libraries/pull/1335). Also, updated the other packages inorder to avoid the dependency isuses. 

Main reason for update packages: 

The Material Slider binding was missing the `addOnChangeListener` method, which is required for properly handling slider value changes in .NET MAUI applications. This has been fixed in the latest android-libraries package release.

**Related Issue**: dotnet/android-libraries#1335

