### PR TITLE
Remove debug output from VisualStateManager

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -81,10 +81,6 @@ namespace Microsoft.Maui.Controls
 			groups.Specificity = vsgSpecificity;
 
 			var specificity = vsgSpecificity.CopyStyle(1, 0, 0, 0);
-			
-			// Debug output for issue #27202
-			System.Diagnostics.Debug.WriteLine($"[VSM] GoToState({name}) - VSG specificity: {vsgSpecificity.StyleInfo}");
-			System.Diagnostics.Debug.WriteLine($"[VSM] VSM setter specificity will be used");
 
 			foreach (VisualStateGroup group in groups)
 			{


### PR DESCRIPTION
This pull request makes a minor change to the `GoToState` method in `VisualStateManager.cs` by removing some debug output statements that were previously added for troubleshooting. This helps clean up the code and avoids unnecessary logging in production.