### PR TITLE
[Testing] Fix for flaky UITests in CI - 2

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CollectionView/CollectionViewDynamicChanges/CollectionViewDynamicOptionsPage.xaml
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CollectionView/CollectionViewDynamicChanges/CollectionViewDynamicOptionsPage.xaml
@@ -4,16 +4,16 @@
              x:Class="Maui.Controls.Sample.CollectionViewDynamicOptionsPage"
               xmlns:local="clr-namespace:Maui.Controls.Sample"
              Title="CollectionViewDynamicOptionsPage">
- <ContentPage.ToolbarItems>
-        <ToolbarItem Text="Apply"
-                     Clicked="ApplyButton_Clicked"
-                     AutomationId="Apply"/>
-    </ContentPage.ToolbarItems>
     <ScrollView>
         <Grid Padding="1"
               RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto">
             <StackLayout Grid.Row="1"
                          Padding="1">
+                <!-- Apply Button -->
+                <Button Text="Apply"
+                        Clicked="ApplyButton_Clicked"
+                        HorizontalOptions="Center"
+                        AutomationId="Apply"/>
                 <!-- Empty View -->
                 <Label Text="EmptyView:"
                        FontSize="12"


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

This pull request updates the UI for the `CollectionViewDynamicOptionsPage` by moving the "Apply" action from the toolbar to a button within the page content. This change improves discoverability and accessibility of the "Apply" action in CI.

UI changes:

* Removed the ToolbarItem for the "Apply" action from the page's toolbar and replaced it with a Button labelled "Apply", placed inside the main content area to address the ValidateDynamicGroupHeaderTemplateDisplayed test case failure in CI.