### PR TITLE
[ci] Build and run on ARM platforms for iOS UITests and device tests

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -218,6 +218,20 @@ Task("uitests-apphost")
             properties.Add("_UseNativeAot", "true");
             properties.Add("RuntimeIdentifier", "iossimulator-x64");
         }
+        else if (IsCIBuild() && System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
+        {
+            // On CI with ARM64 agents, build universal binaries for iOS/macCatalyst to support both architectures
+            if (HasArgument("ios"))
+            {
+                Information("Building universal binary for iOS (x64 + arm64) on CI");
+                properties.Add("RuntimeIdentifiers", "iossimulator-x64;iossimulator-arm64");
+            }
+            else if (HasArgument("catalyst") || HasArgument("maccatalyst"))
+            {
+                Information("Building universal binary for MacCatalyst (x64 + arm64) on CI");
+                properties.Add("RuntimeIdentifiers", "maccatalyst-x64;maccatalyst-arm64");
+            }
+        }
 
         if (useNuget)
         {

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -218,20 +218,6 @@ Task("uitests-apphost")
             properties.Add("_UseNativeAot", "true");
             properties.Add("RuntimeIdentifier", "iossimulator-x64");
         }
-        else if (IsCIBuild() && System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
-        {
-            // On CI with ARM64 agents, build universal binaries for iOS/macCatalyst to support both architectures
-            if (HasArgument("ios"))
-            {
-                Information("Building universal binary for iOS (x64 + arm64) on CI");
-                properties.Add("RuntimeIdentifiers", "iossimulator-x64;iossimulator-arm64");
-            }
-            else if (HasArgument("catalyst") || HasArgument("maccatalyst"))
-            {
-                Information("Building universal binary for MacCatalyst (x64 + arm64) on CI");
-                properties.Add("RuntimeIdentifiers", "maccatalyst-x64;maccatalyst-arm64");
-            }
-        }
 
         if (useNuget)
         {

--- a/eng/devices/devices-shared.cake
+++ b/eng/devices/devices-shared.cake
@@ -42,7 +42,25 @@ IEnumerable<string> GetTestApplications(string project, string device, string co
     }
     else
     {
-        applications = FindAppsInDirectory(binDir);
+        // For iOS/macCatalyst multi-RID builds, prefer the universal binary in the parent directory
+        // The RID-specific directories may have stale/invalid code signatures
+        if (!string.IsNullOrEmpty(rid) && (tfm.Contains("ios") || tfm.Contains("maccatalyst")))
+        {
+            var parentBinDir = new DirectoryPath(project).Combine($"{config}/{tfm}");
+            Information($"Checking for universal binary in parent directory: {parentBinDir}");
+            applications = FindAppsInDirectory(parentBinDir);
+
+            // Fall back to RID-specific directory if no universal binary found
+            if (!applications.Any())
+            {
+                Information($"No universal binary found, checking RID-specific directory: {binDir}");
+                applications = FindAppsInDirectory(binDir);
+            }
+        }
+        else
+        {
+            applications = FindAppsInDirectory(binDir);
+        }
     }
 
     // If no applications found, check in specific artifact directories
@@ -74,7 +92,25 @@ IEnumerable<string> SearchInArtifacts(DirectoryPath originalBinDir, string proje
             }
             else
             {
-                applications = FindAppsInDirectory(binDir);
+                // For iOS/macCatalyst multi-RID builds, prefer the universal binary in the parent directory
+                // The RID-specific directories may have stale/invalid code signatures
+                if (!string.IsNullOrEmpty(rid) && (tfm.Contains("ios") || tfm.Contains("maccatalyst")))
+                {
+                    var parentBinDir = MakeAbsolute(new DirectoryPath($"{artifactsDir}{entry.Value}/{config}/{tfm}"));
+                    Information($"Checking for universal binary in parent directory: {parentBinDir}");
+                    applications = FindAppsInDirectory(parentBinDir);
+
+                    // Fall back to RID-specific directory if no universal binary found
+                    if (!applications.Any())
+                    {
+                        Information($"No universal binary found, checking RID-specific directory: {binDir}");
+                        applications = FindAppsInDirectory(binDir);
+                    }
+                }
+                else
+                {
+                    applications = FindAppsInDirectory(binDir);
+                }
             }
 
             if (applications.Any())

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -70,6 +70,8 @@ parameters:
   default:
     name: MAUI
     vmImage: MAUI
+    demands:
+      - Agent.OSArchitecture -equals ARM64
 
 - name: targetFrameworkVersions
   type: object

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -67,6 +67,8 @@ parameters:
     default:
       name: MAUI
       vmImage: MAUI
+      demands:
+        - Agent.OSArchitecture -equals X64
   
   - name: androidPoolLinux
     type: object

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -68,7 +68,7 @@ parameters:
       name: MAUI
       vmImage: MAUI
       demands:
-        - Agent.OSArchitecture -equals X64
+        - Agent.OSArchitecture -equals ARM64
   
   - name: androidPoolLinux
     type: object
@@ -81,7 +81,9 @@ parameters:
     type: object
     default:
       name: MAUI
-      vmImage: MAUI
+      vmImage: MAUI      
+      demands:
+        - Agent.OSArchitecture -equals ARM64
   
   - name: windowsBuildPool
     type: object

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -10,8 +10,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-ios'))">iossimulator-x64;iossimulator-arm64</RuntimeIdentifiers>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -8,8 +8,9 @@
     <MauiTestProject>true</MauiTestProject>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- Disable multi-RID builds to workaround a parallel build issue -->
-    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifiers>
+    <!-- On CI, build universal binaries for iOS/MacCatalyst to support both x64 and arm64 test agents -->
+    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst')) and ('$(CI)' == 'true' or '$(TF_BUILD)' == 'true')">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-ios')) and ('$(CI)' == 'true' or '$(TF_BUILD)' == 'true')">iossimulator-x64;iossimulator-arm64</RuntimeIdentifiers>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -10,8 +10,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-ios')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">iossimulator-x64;iossimulator-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-ios'))">iossimulator-x64;iossimulator-arm64</RuntimeIdentifiers>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 

--- a/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
+++ b/src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj
@@ -11,6 +11,7 @@
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$(TargetFramework.Contains('-ios')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">iossimulator-x64;iossimulator-arm64</RuntimeIdentifiers>
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   <!-- NOTE: By default the UseMaterial3 flag value is false. If you change the UseMaterial3 flag, you MUST delete the artifacts folder 


### PR DESCRIPTION
### Description of Change

Try fix issues where it can t find the correct .app to run the uitests 


https://dev.azure.com/dnceng-public/public/_build/results?buildId=1249376&view=results


This pull request improves support for ARM64 architecture in both CI pipelines and test project configurations. The changes ensure that device and UI tests run on ARM64 agents and expand runtime identifiers for better platform coverage.

**CI Pipeline Updates for ARM64:**

* Added an explicit demand for `Agent.OSArchitecture -equals ARM64` to the `MAUI` pool in both `ci-device-tests.yml` and `ci-uitests.yml`, ensuring these pipelines run on ARM64 agents. [[1]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bR73-R74) [[2]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3R70-R71) [[3]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3R85-R86)

**Test Project Runtime Identifier Enhancements:**

* Updated `Controls.TestCases.HostApp.csproj` to always include both `maccatalyst-x64` and `maccatalyst-arm64` runtime identifiers for Mac Catalyst targets, regardless of host architecture. Also added `iossimulator-x64` and `iossimulator-arm64` for iOS targets, improving test coverage across architectures.