### PR TITLE
Add MacCatalyst platform support to local UI testing scripts

### DIFF
--- a/.github/instructions/sandbox.instructions.md
+++ b/.github/instructions/sandbox.instructions.md
@@ -36,7 +36,7 @@ This guide applies when you:
 - ✅ **ALWAYS** check for errors/exceptions FIRST before claiming success
 - ✅ **ALWAYS** verify "Test completed" marker appears in output
 - ✅ **ALWAYS** verify expected test actions in logs (Tapping, Screenshot, etc.)
-- ✅ **ALWAYS** check device logs for debug logging markers (use both Console.WriteLine and Debug.WriteLine - see Log Capture section)
+- ✅ **ALWAYS** check device logs for Console.WriteLine markers (e.g., "SANDBOX: ...")
 - ✅ **ALWAYS** verify artifacts exist (screenshots, if test captures them)
 
 ### Rule 1: NEVER ASSUME TEST COMPLETION
@@ -54,7 +54,7 @@ After running BuildAndRunSandbox.ps1, you MUST:
 
 ### Rule 3: VALIDATE DEVICE LOGS FOR EXPECTED BEHAVIOR
 - ✅ **DO** check device logs confirm your expected test actions happened
-- ✅ **DO** grep for your debug logging markers (e.g., "SANDBOX.*CLICKED") - use both Console.WriteLine and Debug.WriteLine for cross-platform coverage
+- ✅ **DO** grep for your Console.WriteLine markers (e.g., "SANDBOX.*CLICKED")
 - ❌ **DO NOT** claim the test worked without verifying device logs show the action
 
 ### Rule 4: SYSTEMATIC VALIDATION CHECKLIST
@@ -283,7 +283,7 @@ gh pr checkout <PR_NUMBER>
    - Check AutomationIds: `grep AutomationId MainPage.xaml`
    - Update test to use those IDs (not template defaults)
    - Add test logic: tap buttons, verify labels
-   - Add debug logging markers (both Console.WriteLine and Debug.WriteLine for cross-platform coverage)
+   - Add Console.WriteLine markers for debugging
 
 3. **Example**:
    ```bash
@@ -481,7 +481,7 @@ This proves the test scenario correctly reproduces the bug.
 │ 1. Update MainPage.xaml[.cs] with your test scenario       │
 │    - Add UI elements for reproduction                       │
 │    - Add AutomationIds to all interactive elements          │
-│    - Add debug logging (Console + Debug.WriteLine)          │
+│    - Add Console.WriteLine markers for debugging            │
 ├─────────────────────────────────────────────────────────────┤
 │ 2. Update Appium test to match your MainPage               │
 │    CustomAgentLogsTmp/Sandbox/RunWithAppiumTest.cs         │
@@ -679,41 +679,18 @@ cat CustomAgentLogsTmp/Sandbox/appium.log
 
 ### 📝 Adding Debug Logging to Your Test Scenario
 
-**Use BOTH `Console.WriteLine` AND `Debug.WriteLine` for cross-platform log capture.**
+**Use `Console.WriteLine` for logging** - it works on all platforms.
 
-Different platforms capture different logging mechanisms:
-
-| Platform | Console.WriteLine | Debug.WriteLine | Notes |
-|----------|-------------------|-----------------|-------|
-| **Android** | ✅ Tag: `DOTNET` | ✅ Tag: `<package>` | Both work |
-| **iOS** | ✅ via `libSystem.Native.dylib` | ❌ Not captured | Use Console.WriteLine |
-| **MacCatalyst** | ❌ Not captured | ✅ via os_log | Use Debug.WriteLine |
-
-**Recommended pattern for cross-platform logging:**
 ```csharp
-using System.Diagnostics;
-
 // Use a unique prefix for easy grep
-Console.WriteLine("SANDBOX_CONSOLE: Button clicked");
-Debug.WriteLine("SANDBOX_DEBUG: Button clicked");
-
-// Or create a helper method:
-void Log(string message)
-{
-    Console.WriteLine($"SANDBOX: {message}");
-    Debug.WriteLine($"SANDBOX: {message}");
-}
+Console.WriteLine("SANDBOX: Button clicked");
+Console.WriteLine($"SANDBOX: Value is {myValue}");
 ```
 
 **Searching logs:**
 ```bash
-# Android - will find both Console.WriteLine and Debug.WriteLine
 grep "SANDBOX" CustomAgentLogsTmp/Sandbox/android-device.log
-
-# iOS - will find Console.WriteLine
 grep "SANDBOX" CustomAgentLogsTmp/Sandbox/ios-device.log
-
-# MacCatalyst - will find Debug.WriteLine
 grep "SANDBOX" CustomAgentLogsTmp/Sandbox/catalyst-device.log
 ```
 
@@ -819,7 +796,7 @@ What should I try next?
 **Testing Tips**:
 - For layout bugs: Use `element.GetRect()` to measure positions
 - For SafeArea PRs: Measure child content position, not parent size
-- Add debug logging with BOTH `Console.WriteLine` AND `Debug.WriteLine` for cross-platform coverage (see Log Capture section)
+- Add `Console.WriteLine("SANDBOX: ...")` markers for debugging
 
 ---
 

--- a/.github/instructions/sandbox.instructions.md
+++ b/.github/instructions/sandbox.instructions.md
@@ -36,7 +36,7 @@ This guide applies when you:
 - ✅ **ALWAYS** check for errors/exceptions FIRST before claiming success
 - ✅ **ALWAYS** verify "Test completed" marker appears in output
 - ✅ **ALWAYS** verify expected test actions in logs (Tapping, Screenshot, etc.)
-- ✅ **ALWAYS** check device logs for Console.WriteLine markers
+- ✅ **ALWAYS** check device logs for debug logging markers (use both Console.WriteLine and Debug.WriteLine - see Log Capture section)
 - ✅ **ALWAYS** verify artifacts exist (screenshots, if test captures them)
 
 ### Rule 1: NEVER ASSUME TEST COMPLETION
@@ -54,7 +54,7 @@ After running BuildAndRunSandbox.ps1, you MUST:
 
 ### Rule 3: VALIDATE DEVICE LOGS FOR EXPECTED BEHAVIOR
 - ✅ **DO** check device logs confirm your expected test actions happened
-- ✅ **DO** grep for your Console.WriteLine markers (e.g., "SANDBOX.*CLICKED")
+- ✅ **DO** grep for your debug logging markers (e.g., "SANDBOX.*CLICKED") - use both Console.WriteLine and Debug.WriteLine for cross-platform coverage
 - ❌ **DO NOT** claim the test worked without verifying device logs show the action
 
 ### Rule 4: SYSTEMATIC VALIDATION CHECKLIST
@@ -283,7 +283,7 @@ gh pr checkout <PR_NUMBER>
    - Check AutomationIds: `grep AutomationId MainPage.xaml`
    - Update test to use those IDs (not template defaults)
    - Add test logic: tap buttons, verify labels
-   - Add `Console.WriteLine("SANDBOX ...")` markers
+   - Add debug logging markers (both Console.WriteLine and Debug.WriteLine for cross-platform coverage)
 
 3. **Example**:
    ```bash
@@ -481,7 +481,7 @@ This proves the test scenario correctly reproduces the bug.
 │ 1. Update MainPage.xaml[.cs] with your test scenario       │
 │    - Add UI elements for reproduction                       │
 │    - Add AutomationIds to all interactive elements          │
-│    - Add Console.WriteLine with "SANDBOX" markers           │
+│    - Add debug logging (Console + Debug.WriteLine)          │
 ├─────────────────────────────────────────────────────────────┤
 │ 2. Update Appium test to match your MainPage               │
 │    CustomAgentLogsTmp/Sandbox/RunWithAppiumTest.cs         │
@@ -677,6 +677,46 @@ grep "TEST OUTPUT" CustomAgentLogsTmp/Sandbox/android-device.log
 cat CustomAgentLogsTmp/Sandbox/appium.log
 ```
 
+### 📝 Adding Debug Logging to Your Test Scenario
+
+**Use BOTH `Console.WriteLine` AND `Debug.WriteLine` for cross-platform log capture.**
+
+Different platforms capture different logging mechanisms:
+
+| Platform | Console.WriteLine | Debug.WriteLine | Notes |
+|----------|-------------------|-----------------|-------|
+| **Android** | ✅ Tag: `DOTNET` | ✅ Tag: `<package>` | Both work |
+| **iOS** | ✅ via `libSystem.Native.dylib` | ❌ Not captured | Use Console.WriteLine |
+| **MacCatalyst** | ❌ Not captured | ✅ via os_log | Use Debug.WriteLine |
+
+**Recommended pattern for cross-platform logging:**
+```csharp
+using System.Diagnostics;
+
+// Use a unique prefix for easy grep
+Console.WriteLine("SANDBOX_CONSOLE: Button clicked");
+Debug.WriteLine("SANDBOX_DEBUG: Button clicked");
+
+// Or create a helper method:
+void Log(string message)
+{
+    Console.WriteLine($"SANDBOX: {message}");
+    Debug.WriteLine($"SANDBOX: {message}");
+}
+```
+
+**Searching logs:**
+```bash
+# Android - will find both Console.WriteLine and Debug.WriteLine
+grep "SANDBOX" CustomAgentLogsTmp/Sandbox/android-device.log
+
+# iOS - will find Console.WriteLine
+grep "SANDBOX" CustomAgentLogsTmp/Sandbox/ios-device.log
+
+# MacCatalyst - will find Debug.WriteLine
+grep "SANDBOX" CustomAgentLogsTmp/Sandbox/catalyst-device.log
+```
+
 ---
 
 ## 🚨 ABSOLUTE RULE: BuildAndRunSandbox.ps1 is THE ONLY Deployment Method
@@ -779,7 +819,7 @@ What should I try next?
 **Testing Tips**:
 - For layout bugs: Use `element.GetRect()` to measure positions
 - For SafeArea PRs: Measure child content position, not parent size
-- Add `Console.WriteLine("SANDBOX ...")` markers for debugging
+- Add debug logging with BOTH `Console.WriteLine` AND `Debug.WriteLine` for cross-platform coverage (see Log Capture section)
 
 ---
 

--- a/.github/scripts/BuildAndRunHostApp.ps1
+++ b/.github/scripts/BuildAndRunHostApp.ps1
@@ -11,7 +11,7 @@
     4. Captures all device logs and test output
 
 .PARAMETER Platform
-    Target platform: "android" or "ios"
+    Target platform: "android", "ios", or "catalyst" (MacCatalyst)
 
 .PARAMETER TestFilter
     Test filter to pass to dotnet test (e.g., "FullyQualifiedName~Issue12345")
@@ -39,12 +39,15 @@
     
 .EXAMPLE
     ./BuildAndRunHostApp.ps1 -Platform ios -Category "Button"
+    
+.EXAMPLE
+    ./BuildAndRunHostApp.ps1 -Platform catalyst -TestFilter "Issue12345"
 #>
 
 [CmdletBinding(DefaultParameterSetName = "TestFilter")]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("android", "ios")]
+    [ValidateSet("android", "ios", "catalyst")]
     [string]$Platform,
 
     [Parameter(Mandatory = $true, ParameterSetName = "TestFilter")]
@@ -124,22 +127,32 @@ if ($Platform -eq "android") {
 } elseif ($Platform -eq "ios") {
     $TargetFramework = "net10.0-ios"
     $AppBundleId = "com.microsoft.maui.uitests"
+} elseif ($Platform -eq "catalyst") {
+    $TargetFramework = "net10.0-maccatalyst"
+    $AppBundleId = "com.microsoft.maui.uitests"
 }
 
-# Use shared Start-Emulator script to detect and start device
-$startEmulatorParams = @{
-    Platform = $Platform
-}
+# Start emulator/simulator (skip for catalyst - runs on desktop)
+if ($Platform -ne "catalyst") {
+    # Use shared Start-Emulator script to detect and start device
+    $startEmulatorParams = @{
+        Platform = $Platform
+    }
 
-if ($DeviceUdid) {
-    $startEmulatorParams.DeviceUdid = $DeviceUdid
-}
+    if ($DeviceUdid) {
+        $startEmulatorParams.DeviceUdid = $DeviceUdid
+    }
 
-$DeviceUdid = & "$PSScriptRoot/shared/Start-Emulator.ps1" @startEmulatorParams
+    $DeviceUdid = & "$PSScriptRoot/shared/Start-Emulator.ps1" @startEmulatorParams
 
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to start or detect device"
-    exit 1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to start or detect device"
+        exit 1
+    }
+} else {
+    # MacCatalyst runs directly on the Mac - use "host" as placeholder
+    $DeviceUdid = "host"
+    Write-Success "MacCatalyst will run on host Mac (no device needed)"
 }
 
 #endregion
@@ -177,6 +190,8 @@ if ($Platform -eq "android") {
     $TestProject = Join-Path $RepoRoot "src/Controls/tests/TestCases.Android.Tests/Controls.TestCases.Android.Tests.csproj"
 } elseif ($Platform -eq "ios") {
     $TestProject = Join-Path $RepoRoot "src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj"
+} elseif ($Platform -eq "catalyst") {
+    $TestProject = Join-Path $RepoRoot "src/Controls/tests/TestCases.Mac.Tests/Controls.TestCases.Mac.Tests.csproj"
 }
 
 if (-not (Test-Path $TestProject)) {
@@ -208,6 +223,51 @@ if ($Platform -eq "android") {
 # Capture test start time for iOS logs
 $testStartTime = Get-Date
 
+# For MacCatalyst, start log stream BEFORE the test to capture real-time logs
+# For MacCatalyst, launch the app BEFORE running tests so Appium finds the correct bundle
+# This is critical because both maui and maui2 repos may share the same bundle ID
+# We also capture stdout/stderr directly for Console.WriteLine logging
+$catalystAppProcess = $null
+$catalystLogStreamJob = $null
+if ($Platform -eq "catalyst") {
+    # Determine runtime identifier
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+    $rid = if ($arch -eq "arm64") { "maccatalyst-arm64" } else { "maccatalyst-x64" }
+    
+    # Build app path - matches Build-AndDeploy.ps1 output location
+    $appPath = Join-Path $PSScriptRoot "../../artifacts/bin/Controls.TestCases.HostApp/Debug/$TargetFramework/$rid/Controls.TestCases.HostApp.app"
+    $appPath = [System.IO.Path]::GetFullPath($appPath)
+    
+    if (Test-Path $appPath) {
+        Write-Info "Launching MacCatalyst app to register with system..."
+        Write-Info "App path: $appPath"
+        
+        # Make executable (like CI does)
+        $executablePath = Join-Path $appPath "Contents/MacOS/Controls.TestCases.HostApp"
+        if (Test-Path $executablePath) {
+            & chmod +x $executablePath
+            
+            # Launch the executable directly to capture stdout/stderr (Console.WriteLine)
+            # This captures Console.WriteLine which doesn't appear in log stream
+            Write-Info "Starting app executable directly to capture Console.WriteLine output..."
+            $catalystAppProcess = Start-Process -FilePath $executablePath -RedirectStandardOutput $deviceLogFile -RedirectStandardError "$deviceLogFile.stderr" -PassThru
+            
+            # Give app time to launch and register
+            Write-Info "Waiting for app to launch (PID: $($catalystAppProcess.Id))..."
+            Start-Sleep -Seconds 3
+            Write-Success "MacCatalyst app launched with stdout capture"
+        } else {
+            Write-Warning "Executable not found at: $executablePath"
+            # Fallback to 'open' command
+            & open $appPath
+            Start-Sleep -Seconds 3
+        }
+    } else {
+        Write-Warning "MacCatalyst app not found at: $appPath"
+        Write-Warning "Test may use wrong app bundle if another version is registered"
+    }
+}
+
 Write-Info "Executing: dotnet test --filter `"$effectiveFilter`""
 Write-Host ""
 
@@ -229,6 +289,22 @@ try {
 } catch {
     Write-Error "Failed to run tests: $_"
     exit 1
+} finally {
+    # Stop MacCatalyst log stream if it was started
+    if ($catalystLogStreamJob) {
+        Write-Info "Stopping MacCatalyst log stream..."
+        Stop-Job -Job $catalystLogStreamJob -ErrorAction SilentlyContinue
+        Remove-Job -Job $catalystLogStreamJob -Force -ErrorAction SilentlyContinue
+        Write-Success "Log stream stopped"
+    }
+    
+    # Stop MacCatalyst app process if we started it
+    if ($catalystAppProcess -and -not $catalystAppProcess.HasExited) {
+        Write-Info "Stopping MacCatalyst app process (PID: $($catalystAppProcess.Id))..."
+        $catalystAppProcess.Kill()
+        $catalystAppProcess.WaitForExit(5000)
+        Write-Success "App process stopped"
+    }
 }
 
 #endregion
@@ -241,7 +317,8 @@ if ($Platform -eq "android") {
     Write-Info "Dumping Android logcat buffer (filtered to HostApp)..."
     
     # Try to filter by package name (HostApp)
-    & adb -s $DeviceUdid logcat -d | Select-String "com.microsoft.maui.uitests" > $deviceLogFile
+    # Include DOTNET tag for Console.WriteLine and package name for Debug.WriteLine
+    & adb -s $DeviceUdid logcat -d | Select-String "com.microsoft.maui.uitests|DOTNET" > $deviceLogFile
     
     if ((Get-Item $deviceLogFile).Length -eq 0) {
         Write-Warning "No logs found for com.microsoft.maui.uitests, dumping entire logcat..."
@@ -261,6 +338,33 @@ if ($Platform -eq "android") {
     Invoke-Expression "$iosLogCommand > `"$deviceLogFile`" 2>&1"
     
     Write-Info "iOS logs saved to: $deviceLogFile"
+} elseif ($Platform -eq "catalyst") {
+    # On macOS, Console.WriteLine goes to stderr, not stdout
+    # Stderr was captured to $deviceLogFile.stderr, stdout to $deviceLogFile
+    Write-Info "MacCatalyst logs captured via stdout/stderr redirect during test execution"
+    
+    # Check stderr first - this is where Console.WriteLine output goes on macOS
+    $stderrFile = "$deviceLogFile.stderr"
+    if ((Test-Path $stderrFile) -and ((Get-Item $stderrFile).Length -gt 0)) {
+        Write-Info "Console.WriteLine output found in stderr..."
+        # Copy stderr content to main log file (overwrite since stderr is the useful one)
+        Get-Content $stderrFile | Set-Content -Path $deviceLogFile -Encoding UTF8
+    }
+    
+    # If log file is still empty or small, try log show as fallback (for Debug.WriteLine via os_log)
+    $logFileSize = 0
+    if (Test-Path $deviceLogFile) {
+        $logFileSize = (Get-Item $deviceLogFile).Length
+    }
+    
+    if ($logFileSize -lt 100) {
+        Write-Info "Console output was minimal, using os_log fallback (captures Debug.WriteLine)..."
+        $logStartTimeStr = $testStartTime.AddMinutes(-1).ToString("yyyy-MM-dd HH:mm:ss")
+        $catalystLogCommand = "log show --level debug --predicate 'process contains `"Controls.TestCases.HostApp`" OR processImagePath contains `"Controls.TestCases.HostApp`"' --start `"$logStartTimeStr`" --style compact"
+        Invoke-Expression "$catalystLogCommand > `"$deviceLogFile`" 2>&1"
+    }
+    
+    Write-Info "MacCatalyst logs saved to: $deviceLogFile"
 }
 
 #endregion
@@ -272,8 +376,10 @@ if (Test-Path $deviceLogFile) {
     Write-Host "═══════════════════════════════════════════════════════" -ForegroundColor Cyan
     if ($Platform -eq "android") {
         Write-Host "  Android Device Logs (Last 100 lines)" -ForegroundColor Cyan
-    } else {
+    } elseif ($Platform -eq "ios") {
         Write-Host "  iOS Simulator Logs (Last 100 lines)" -ForegroundColor Cyan
+    } elseif ($Platform -eq "catalyst") {
+        Write-Host "  MacCatalyst App Logs (Last 100 lines)" -ForegroundColor Cyan
     }
     Write-Host "═══════════════════════════════════════════════════════" -ForegroundColor Cyan
     

--- a/.github/scripts/BuildAndRunSandbox.ps1
+++ b/.github/scripts/BuildAndRunSandbox.ps1
@@ -5,13 +5,13 @@
 
 .DESCRIPTION
     This script automates the complete workflow for testing MAUI issues:
-    1. Builds the Sandbox app for the target platform (Android or iOS)
+    1. Builds the Sandbox app for the target platform (Android, iOS, or MacCatalyst)
     2. Starts Appium server if not already running
     3. Deploys and launches the app using Appium
     4. Runs the Appium test script to validate the issue
 
 .PARAMETER Platform
-    Target platform: "android" or "ios"
+    Target platform: "android", "ios", or "catalyst"
 
 .PARAMETER Configuration
     Build configuration: "Debug" or "Release" (default: Debug)
@@ -23,13 +23,16 @@
     ./BuildAndRunSandbox.ps1 -Platform android
     
 .EXAMPLE
+    ./BuildAndRunSandbox.ps1 -Platform catalyst
+
+.EXAMPLE
     ./BuildAndRunSandbox.ps1 -Platform android -DeviceUdid emulator-5554
 #>
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("android", "ios")]
+    [ValidateSet("android", "ios", "catalyst")]
     [string]$Platform,
 
     [ValidateSet("Debug", "Release")]
@@ -150,22 +153,31 @@ if ($Platform -eq "android") {
 } elseif ($Platform -eq "ios") {
     $TargetFramework = "net10.0-ios"
     $AppBundleId = "com.microsoft.maui.sandbox"
+} elseif ($Platform -eq "catalyst") {
+    $TargetFramework = "net10.0-maccatalyst"
+    $AppBundleId = "com.microsoft.maui.sandbox"
 }
 
-# Use shared Start-Emulator script to detect and start device
-$startEmulatorParams = @{
-    Platform = $Platform
-}
+# For catalyst, skip emulator detection - runs on host
+if ($Platform -eq "catalyst") {
+    $DeviceUdid = "host"
+    Write-Info "MacCatalyst runs on the host Mac - no device/emulator needed"
+} else {
+    # Use shared Start-Emulator script to detect and start device
+    $startEmulatorParams = @{
+        Platform = $Platform
+    }
 
-if ($DeviceUdid) {
-    $startEmulatorParams.DeviceUdid = $DeviceUdid
-}
+    if ($DeviceUdid) {
+        $startEmulatorParams.DeviceUdid = $DeviceUdid
+    }
 
-$DeviceUdid = & "$PSScriptRoot/shared/Start-Emulator.ps1" @startEmulatorParams
+    $DeviceUdid = & "$PSScriptRoot/shared/Start-Emulator.ps1" @startEmulatorParams
 
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to start or detect device"
-    exit 1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to start or detect device"
+        exit 1
+    }
 }
 
 #endregion
@@ -181,7 +193,7 @@ $buildDeployParams = @{
     DeviceUdid = $DeviceUdid
 }
 
-if ($Platform -eq "ios") {
+if ($Platform -eq "ios" -or $Platform -eq "catalyst") {
     $buildDeployParams.BundleId = $AppBundleId
 }
 
@@ -190,6 +202,44 @@ if ($Platform -eq "ios") {
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Build or deployment failed"
     exit 1
+}
+
+# For MacCatalyst, launch the app BEFORE Appium test (similar to BuildAndRunHostApp.ps1)
+$catalystAppProcess = $null
+if ($Platform -eq "catalyst") {
+    # Determine runtime identifier
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+    $rid = if ($arch -eq "arm64") { "maccatalyst-arm64" } else { "maccatalyst-x64" }
+    
+    # Build app path
+    $appPath = Join-Path $RepoRoot "artifacts/bin/Maui.Controls.Sample.Sandbox/$Configuration/$TargetFramework/$rid/Sandbox.app"
+    
+    if (Test-Path $appPath) {
+        Write-Info "Launching MacCatalyst Sandbox app..."
+        Write-Info "App path: $appPath"
+        
+        # Make executable
+        $executablePath = Join-Path $appPath "Contents/MacOS/Maui.Controls.Sample.Sandbox"
+        if (Test-Path $executablePath) {
+            & chmod +x $executablePath
+            
+            # Launch the executable directly to capture stdout/stderr (Console.WriteLine)
+            $deviceLogFile = Join-Path $SandboxAppiumDir "catalyst-device.log"
+            Write-Info "Starting app executable directly to capture Console.WriteLine output..."
+            $catalystAppProcess = Start-Process -FilePath $executablePath -RedirectStandardOutput $deviceLogFile -RedirectStandardError "$deviceLogFile.stderr" -PassThru
+            
+            Write-Info "Waiting for app to launch (PID: $($catalystAppProcess.Id))..."
+            Start-Sleep -Seconds 3
+            Write-Success "MacCatalyst Sandbox app launched with stdout capture"
+        } else {
+            Write-Warning "Executable not found at: $executablePath"
+            # Fallback to 'open' command
+            & open $appPath
+            Start-Sleep -Seconds 3
+        }
+    } else {
+        Write-Warning "MacCatalyst Sandbox app not found at: $appPath"
+    }
 }
 
 #endregion
@@ -259,17 +309,22 @@ Write-Step "Running Appium test..."
 # Define device log file path based on platform
 $deviceLogFile = Join-Path $SandboxAppiumDir "$Platform-device.log"
 
-# Clear logs before test
+# Clear logs before test (skip for catalyst - already capturing stdout/stderr)
 if ($Platform -eq "android") {
     Write-Info "Clearing Android logcat buffer before test..."
     & adb -s $DeviceUdid logcat -c
 } elseif ($Platform -eq "ios") {
     Write-Info "iOS logs will be captured from Appium during test execution..."
+} elseif ($Platform -eq "catalyst") {
+    Write-Info "MacCatalyst logs are being captured via stdout/stderr redirect..."
 }
 
 Push-Location $SandboxAppiumDir
 
 try {
+    # Set DEVICE_UDID environment variable for the test script
+    $env:DEVICE_UDID = $DeviceUdid
+    
     Write-Info "Executing: dotnet run RunWithAppiumTest.cs"
     Write-Info "Test will connect to device: $DeviceUdid"
     Write-Host ""
@@ -324,14 +379,45 @@ try {
         Write-Info "iOS logs saved to: $deviceLogFile"
     }
     
+    # Capture MacCatalyst logs after test completes
+    if ($Platform -eq "catalyst") {
+        Write-Host ""
+        Write-Info "Processing MacCatalyst logs..."
+        
+        # On macOS, Console.WriteLine goes to stderr, not stdout
+        $stderrFile = "$deviceLogFile.stderr"
+        if ((Test-Path $stderrFile) -and ((Get-Item $stderrFile).Length -gt 0)) {
+            Write-Info "Console.WriteLine output found in stderr..."
+            # Copy stderr content to main log file (stderr is where Console.WriteLine goes on macOS)
+            Get-Content $stderrFile | Set-Content -Path $deviceLogFile -Encoding UTF8
+        }
+        
+        # If log file is still empty or small, try log show as fallback
+        $logFileSize = 0
+        if (Test-Path $deviceLogFile) {
+            $logFileSize = (Get-Item $deviceLogFile).Length
+        }
+        
+        if ($logFileSize -lt 100) {
+            Write-Info "Console output was minimal, using os_log fallback..."
+            $logStartTime = (Get-Date).AddMinutes(-2).ToString("yyyy-MM-dd HH:mm:ss")
+            $catalystLogCommand = "log show --level debug --predicate 'process contains `"Maui.Controls.Sample.Sandbox`" OR processImagePath contains `"Maui.Controls.Sample.Sandbox`"' --start `"$logStartTime`" --style compact"
+            Invoke-Expression "$catalystLogCommand > `"$deviceLogFile`" 2>&1"
+        }
+        
+        Write-Info "MacCatalyst logs saved to: $deviceLogFile"
+    }
+    
     # Show device logs
     if (Test-Path $deviceLogFile) {
         Write-Host ""
         Write-Host "═══════════════════════════════════════════════════════" -ForegroundColor Cyan
         if ($Platform -eq "android") {
             Write-Host "  Android Logcat Output (Filtered to Sandbox App)" -ForegroundColor Cyan
-        } else {
+        } elseif ($Platform -eq "ios") {
             Write-Host "  iOS Simulator Logs (Filtered to Sandbox App)" -ForegroundColor Cyan
+        } elseif ($Platform -eq "catalyst") {
+            Write-Host "  MacCatalyst App Logs (Console.WriteLine output)" -ForegroundColor Cyan
         }
         Write-Host "═══════════════════════════════════════════════════════" -ForegroundColor Cyan
         
@@ -351,6 +437,8 @@ try {
             Write-Info "Full device log saved to: $deviceLogFile"
             if ($Platform -eq "android") {
                 Write-Info "All logs are from Sandbox app only (com.microsoft.maui.sandbox)"
+            } elseif ($Platform -eq "catalyst") {
+                Write-Info "All logs are from Sandbox app only (Console.WriteLine output)"
             } else {
                 Write-Info "All logs are from Sandbox app only (Maui.Controls.Sample.Sandbox)"
             }
@@ -403,6 +491,12 @@ try {
         Remove-Job $logcatJob
     }
     
+    # Stop MacCatalyst app if we started it
+    if ($catalystAppProcess -and -not $catalystAppProcess.HasExited) {
+        Write-Info "Stopping MacCatalyst Sandbox app (we started it)..."
+        Stop-Process -Id $catalystAppProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+    
     # Stop Appium if we started it
     if ($appiumJob -and -not $appiumWasRunning) {
         Write-Info "Stopping Appium server (we started it)..."
@@ -420,6 +514,14 @@ Pop-Location
 #endregion
 
 #region Cleanup
+
+# Stop MacCatalyst app if we started it
+if ($catalystAppProcess -and -not $catalystAppProcess.HasExited) {
+    Write-Host ""
+    Write-Info "Stopping MacCatalyst Sandbox app (PID: $($catalystAppProcess.Id))..."
+    Stop-Process -Id $catalystAppProcess.Id -Force -ErrorAction SilentlyContinue
+    Write-Success "MacCatalyst Sandbox app stopped"
+}
 
 # Stop Appium if we started it
 if ($appiumJob -and -not $appiumWasRunning) {

--- a/.github/scripts/shared/Build-AndDeploy.ps1
+++ b/.github/scripts/shared/Build-AndDeploy.ps1
@@ -35,7 +35,7 @@
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("android", "ios")]
+    [ValidateSet("android", "ios", "catalyst")]
     [string]$Platform,
     
     [Parameter(Mandatory=$true)]
@@ -191,6 +191,38 @@ if ($Platform -eq "android") {
     }
     
     Write-Success "App installed successfully"
+    
+    #endregion
+} elseif ($Platform -eq "catalyst") {
+    #region MacCatalyst Build (no deploy step - runs on host)
+    
+    Write-Step "Building $projectName for MacCatalyst..."
+    
+    $buildArgs = @($ProjectPath, "-f", $TargetFramework, "-c", $Configuration)
+    if ($Rebuild) {
+        $buildArgs += "--no-incremental"
+    }
+    
+    Write-Info "Build command: dotnet build $($buildArgs -join ' ')"
+    
+    $buildStartTime = Get-Date
+    
+    # Build app
+    & dotnet build @buildArgs
+    
+    $buildExitCode = $LASTEXITCODE
+    $buildDuration = (Get-Date) - $buildStartTime
+    
+    if ($buildExitCode -ne 0) {
+        Write-Error "Build failed with exit code $buildExitCode"
+        exit $buildExitCode
+    }
+    
+    Write-Success "Build completed in $($buildDuration.TotalSeconds) seconds"
+    
+    # MacCatalyst apps run directly on the Mac - no install step needed
+    # The test framework (Appium) will launch the app directly
+    Write-Success "MacCatalyst app ready (runs on host Mac)"
     
     #endregion
 }

--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -20,7 +20,11 @@
 
   <PropertyGroup>
     <ApplicationTitle>Sandbox</ApplicationTitle>
-    <!-- Workaround: dotnet run on MacCatalyst expects .app bundle name to match assembly name -->
+    <!-- Workaround for https://github.com/dotnet/sdk/issues/47727
+         dotnet run on MacCatalyst constructs the .app bundle path using the assembly name,
+         but the build creates the bundle using ApplicationTitle. This mismatch causes
+         "file not found" errors. Override ApplicationTitle to match assembly name as a
+         workaround. This can be removed once the SDK fix is available. -->
     <ApplicationTitle Condition="$(TargetFramework.Contains('-maccatalyst'))">Maui.Controls.Sample.Sandbox</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.sandbox</ApplicationId>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>

--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -20,6 +20,8 @@
 
   <PropertyGroup>
     <ApplicationTitle>Sandbox</ApplicationTitle>
+    <!-- Workaround: dotnet run on MacCatalyst expects .app bundle name to match assembly name -->
+    <ApplicationTitle Condition="$(TargetFramework.Contains('-maccatalyst'))">Maui.Controls.Sample.Sandbox</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.sandbox</ApplicationId>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR adds MacCatalyst (catalyst) platform support to the local UI testing scripts:
- `BuildAndRunHostApp.ps1` 
- `BuildAndRunSandbox.ps1`

### Changes

**MacCatalyst Support:**
- Added `-Platform catalyst` option to both scripts
- Uses `dotnet run` with `-p:StandardOutputPath` and `-p:StandardErrorPath` MSBuild properties for log capture
- Console.WriteLine output on MacCatalyst goes to **stderr** (not stdout), which is correctly captured

**Logging Guidance Updates:**
- Simplified logging guidance to recommend `Console.WriteLine` universally across all platforms
- Updated sandbox instructions to reflect that `Console.WriteLine` works on Android, iOS, and MacCatalyst

### Platform-Specific Log Capture Summary

| Platform | Console.WriteLine Output | Capture Method |
|----------|-------------------------|----------------|
| Android | `adb logcat` (DOTNET tag) | `adb logcat -s DOTNET` |
| iOS | `os_log` (libSystem.Native.dylib) | `xcrun simctl spawn booted log show` |
| MacCatalyst | **stderr** | `dotnet run -p:StandardErrorPath=file` |

### Testing

Tested locally on all three platforms:
- ✅ Android: Console.WriteLine captured via adb logcat
- ✅ iOS: Console.WriteLine captured via log show  
- ✅ MacCatalyst: Console.WriteLine captured via StandardErrorPath

### Usage

```powershell
# Run UI tests on MacCatalyst
pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform catalyst -TestFilter "FullyQualifiedName~Issue12345"

# Run Sandbox on MacCatalyst
pwsh .github/scripts/BuildAndRunSandbox.ps1 -Platform catalyst
```
