### PR TITLE
[ci] Add support for running device and uitests on internal

### DIFF
--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -3,9 +3,14 @@
         <HelixType>test/devices/</HelixType>
         <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
         <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios'">osx.15.arm64.maui.open</HelixTargetQueues>
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst'">osx.15.arm64.maui.open</HelixTargetQueues>
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'android'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
+        <!-- Public queues (default) -->
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' != 'True'">osx.15.arm64.maui.open</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' != 'True'">osx.15.arm64.maui.open</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' != 'True'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
+        <!-- Internal queues -->
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.15.arm64</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.15.arm64</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' == 'True'">ubuntu.2204.amd64.android.33</HelixTargetQueues>
         <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>
         <Creator Condition="'$(HelixAccessToken)' == ''">maui</Creator>
         <IncludeDotNetCli>true</IncludeDotNetCli>

--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -8,7 +8,7 @@
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' != 'True'">osx.15.arm64.maui.open</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' != 'True'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
         <!-- Internal queues -->
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.26.arm64;osx.15.iphone.maui</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.26.arm64;osx.15.arm64.iphone.maui</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.26.arm64</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' == 'True'">ubuntu.2204.amd64.android.33</HelixTargetQueues>
         <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>

--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -8,8 +8,8 @@
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' != 'True'">osx.15.arm64.maui.open</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' != 'True'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
         <!-- Internal queues -->
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.26.arm64;osx.15.arm64.iphone.maui</HelixTargetQueues>
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.26.arm64</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.15.arm64.iphone.maui</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.15.arm64.iphone.maui</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' == 'True'">ubuntu.2204.amd64.android.33</HelixTargetQueues>
         <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>
         <Creator Condition="'$(HelixAccessToken)' == ''">maui</Creator>

--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -8,8 +8,8 @@
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' != 'True'">osx.15.arm64.maui.open</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' != 'True'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
         <!-- Internal queues -->
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.15.arm64</HelixTargetQueues>
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.15.arm64</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.26.arm64</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.26.arm64</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' == 'True'">ubuntu.2204.amd64.android.33</HelixTargetQueues>
         <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>
         <Creator Condition="'$(HelixAccessToken)' == ''">maui</Creator>

--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -8,7 +8,7 @@
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' != 'True'">osx.15.arm64.maui.open</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' != 'True'">ubuntu.2204.amd64.android.33.open</HelixTargetQueues>
         <!-- Internal queues -->
-        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.26.arm64</HelixTargetQueues>
+        <HelixTargetQueues Condition="'$(TargetOS)' == 'ios' and '$(HelixInternal)' == 'True'">osx.26.arm64;osx.15.iphone.maui</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'maccatalyst' and '$(HelixInternal)' == 'True'">osx.26.arm64</HelixTargetQueues>
         <HelixTargetQueues Condition="'$(TargetOS)' == 'android' and '$(HelixInternal)' == 'True'">ubuntu.2204.amd64.android.33</HelixTargetQueues>
         <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios'">true</TargetsAppleMobile>

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -46,6 +46,9 @@ parameters:
 - name: checkoutDirectory
   type: string
   default: $(System.DefaultWorkingDirectory)
+- name: HelixAccessToken
+  type: string
+  default: ''
 
 stages:
 - stage: devicetests_build
@@ -149,6 +152,7 @@ stages:
               HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=False
             ${{ else }}:
               HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsIOS
@@ -202,6 +206,7 @@ stages:
               HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=False
             ${{ else }}:
               HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsMacCatalyst
@@ -253,6 +258,7 @@ stages:
               HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=False
             ${{ else }}:
               HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid
@@ -359,6 +365,7 @@ stages:
               HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=False
             ${{ else }}:
               HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid_CoreCLR

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -183,7 +183,7 @@ stages:
       jobs:
       - job: device_tests_maccatalyst
         displayName: Run DeviceTests MacCatalyst (Mono)
-        timeoutInMinutes: 60
+        timeoutInMinutes: 240
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -74,7 +74,7 @@ stages:
       jobs:
       - job: builddevice_tests
         displayName: Build Device Tests (Mono)
-        timeoutInMinutes: 60
+        timeoutInMinutes: 120
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}
@@ -287,7 +287,7 @@ stages:
       jobs:
       - job: builddevice_tests_coreclr
         displayName: Build Device Tests (CoreCLR)
-        timeoutInMinutes: 60
+        timeoutInMinutes: 120
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -145,7 +145,10 @@ stages:
         - template: /eng/common/templates-official/steps/send-to-helix.yml
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=True
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsIOS
@@ -195,7 +198,10 @@ stages:
         - template: /eng/common/templates-official/steps/send-to-helix.yml
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=True
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsMacCatalyst
@@ -243,7 +249,10 @@ stages:
         - template: /eng/common/templates-official/steps/send-to-helix.yml
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=True
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid
@@ -346,7 +355,10 @@ stages:
         - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/steps/send-to-helix.yml', '/eng/common/templates-official/steps/send-to-helix.yml@self') }}
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=True
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid_CoreCLR

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -50,7 +50,30 @@ variables:
 
 parameters:
 
-- name: windowsPool
+# Internal pools (dnceng)
+- name: windowsPoolInternal
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    demands:
+        - ImageOverride -equals 1es-windows-2022
+    image: 1es-windows-2022
+    os: Windows
+
+- name: macOSTestPoolInternal
+  type: object
+  default:
+    name: Azure Pipelines
+    vmImage: macOS-15
+
+- name: macOSPoolInternal
+  type: object
+  default:
+    name: MAUI
+    vmImage: MAUI
+
+# Public pools (dnceng-public)
+- name: windowsPoolPublic
   type: object
   default:
     name: NetCore-Public
@@ -59,13 +82,13 @@ parameters:
     image: 1es-windows-2022-open
     os: Windows
 
-- name: macOSTestPool
+- name: macOSTestPoolPublic
   type: object
   default:
     name: Azure Pipelines
     vmImage: macOS-15
 
-- name: macOSPool
+- name: macOSPoolPublic
   type: object
   default:
     name: MAUI
@@ -84,9 +107,15 @@ stages:
   # Use Helix for iOS / Android and MacCatalyst Device Tests
   - template: /eng/pipelines/arcade/stage-device-tests.yml@self
     parameters:
-      buildPool: ${{ parameters.macOSPool }}
-      testPool: ${{ parameters.windowsPool }}
-      runAsPublic: true
+      # Select pools based on pipeline - internal vs public
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        buildPool: ${{ parameters.macOSPoolInternal }}
+        testPool: ${{ parameters.windowsPoolInternal }}
+        runAsPublic: false
+      ${{ else }}:
+        buildPool: ${{ parameters.macOSPoolPublic }}
+        testPool: ${{ parameters.windowsPoolPublic }}
+        runAsPublic: true
       TargetFrameworkVersion: ${{ targetFrameworkVersion.tfm }}
       prepareSteps:
       - template: /eng/pipelines/common/provision.yml@self
@@ -104,7 +133,10 @@ stages:
   # Just use the old way for Windows Device Tests
   - template: common/device-tests.yml
     parameters:
-      windowsPool: ${{ parameters.windowsPool }}
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        windowsPool: ${{ parameters.windowsPoolInternal }}
+      ${{ else }}:
+        windowsPool: ${{ parameters.windowsPoolPublic }}
       targetFrameworkVersion: ${{ targetFrameworkVersion }}
       windowsVersions: [ 'packaged', 'unpackaged' ]
       skipProvisioning: true

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -69,8 +69,8 @@ parameters:
 - name: macOSPoolInternal
   type: object
   default:
-    name: MAUI
-    vmImage: MAUI
+    name: Azure Pipelines
+    vmImage: macOS-15
 
 # Public pools (dnceng-public)
 - name: windowsPoolPublic

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -47,6 +47,9 @@ variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self
 - template: /eng/pipelines/common/variables.yml@self
 - template: /eng/pipelines/arcade/variables.yml@self
+# Include Helix access token for internal builds
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNet-HelixApi-Access
 
 parameters:
 
@@ -112,6 +115,7 @@ stages:
         buildPool: ${{ parameters.macOSPoolInternal }}
         testPool: ${{ parameters.windowsPoolInternal }}
         runAsPublic: false
+        HelixAccessToken: $(HelixApiAccessToken)
       ${{ else }}:
         buildPool: ${{ parameters.macOSPoolPublic }}
         testPool: ${{ parameters.windowsPoolPublic }}

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -62,7 +62,8 @@ parameters:
     type: boolean
     default: false
 
-  - name: androidPool
+  # Internal pools (dnceng)
+  - name: androidPoolInternal
     type: object
     default:
       name: MAUI
@@ -70,14 +71,54 @@ parameters:
       demands:
         - Agent.OSArchitecture -equals ARM64
   
-  - name: androidPoolLinux
+  - name: androidPoolLinuxInternal
+    type: object
+    default:
+      name: NetCore1ESPool-Internal
+      demands:
+        - ImageOverride -equals 1ESPT-Ubuntu22.04
+
+  - name: iosPoolInternal
+    type: object
+    default:
+      name: MAUI
+      vmImage: MAUI
+  
+  - name: windowsBuildPoolInternal
+    type: object
+    default:
+      name: NetCore1ESPool-Internal
+      demands:
+        - ImageOverride -equals 1es-windows-2022
+    
+  - name: windowsPoolInternal
+    type: object
+    default:
+      name: NetCore1ESPool-Internal
+      demands:
+        - ImageOverride -equals 1es-windows-2022
+
+  - name: macosPoolInternal
+    type: object
+    default:
+      name: Azure Pipelines
+      vmImage: macOS-15
+
+  # Public pools (dnceng-public)
+  - name: androidPoolPublic
+    type: object
+    default:
+      name: MAUI
+      vmImage: MAUI
+  
+  - name: androidPoolLinuxPublic
     type: object
     default:
       name: MAUI-DNCENG
       demands:
         - ImageOverride -equals 1ESPT-Ubuntu22.04
 
-  - name: iosPool
+  - name: iosPoolPublic
     type: object
     default:
       name: MAUI
@@ -85,21 +126,21 @@ parameters:
       demands:
         - Agent.OSArchitecture -equals ARM64
   
-  - name: windowsBuildPool
+  - name: windowsBuildPoolPublic
     type: object
     default:
       name: NetCore-Public
       demands:
         - ImageOverride -equals 1es-windows-2022-open
     
-  - name: windowsPool
+  - name: windowsPoolPublic
     type: object
     default:
       name: NetCore-Public
       demands:
         - ImageOverride -equals 1es-windows-2022-open
 
-  - name: macosPool
+  - name: macosPoolPublic
     type: object
     default:
       name: Azure Pipelines
@@ -109,12 +150,21 @@ stages:
 
   - template: common/ui-tests.yml
     parameters:
-      androidPool: ${{ parameters.androidPool }}
-      androidLinuxPool: ${{ parameters.androidPoolLinux }}
-      iosPool: ${{ parameters.iosPool }}
-      windowsPool: ${{ parameters.windowsPool }}
-      windowsBuildPool: ${{ parameters.windowsBuildPool }}
-      macosPool: ${{ parameters.macosPool }}
+      # Select pools based on pipeline - internal vs public
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        androidPool: ${{ parameters.androidPoolInternal }}
+        androidLinuxPool: ${{ parameters.androidPoolLinuxInternal }}
+        iosPool: ${{ parameters.iosPoolInternal }}
+        windowsPool: ${{ parameters.windowsPoolInternal }}
+        windowsBuildPool: ${{ parameters.windowsBuildPoolInternal }}
+        macosPool: ${{ parameters.macosPoolInternal }}
+      ${{ else }}:
+        androidPool: ${{ parameters.androidPoolPublic }}
+        androidLinuxPool: ${{ parameters.androidPoolLinuxPublic }}
+        iosPool: ${{ parameters.iosPoolPublic }}
+        windowsPool: ${{ parameters.windowsPoolPublic }}
+        windowsBuildPool: ${{ parameters.windowsBuildPoolPublic }}
+        macosPool: ${{ parameters.macosPoolPublic }}
       # BuildNativeAOT is false by default, but true in devdiv environment
       BuildNativeAOT: ${{ or(parameters.BuildNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}
       RunNativeAOT: ${{ parameters.RunNativeAOT }}


### PR DESCRIPTION
### Description of Change

Add support to build internal device tests and uitests pipelines 


This pull request updates the device test pipelines and Helix configuration to better distinguish between internal and public builds. The changes introduce separate build and test pools for internal and public environments, add support for passing Helix access tokens for internal runs, and update queue and argument selection logic to ensure tests are sent to the appropriate Helix queues. Additionally, pipeline timeouts are increased to accommodate longer-running jobs.

Key changes include:

**Pipeline Pool and Token Configuration:**

* Added separate build and test pool parameters for internal and public environments in both `ci-device-tests.yml` and `ci-uitests.yml`, enabling the pipelines to select the correct pools based on whether the build is internal or public. [[1]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bR50-R79) [[2]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bL62-R94) [[3]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3L63-R137)
* Introduced logic to include the Helix access token variable group for internal builds, and added a `HelixAccessToken` parameter to device test stages. [[1]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bR50-R79) [[2]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bR49-R51)

**Helix Queue and Argument Selection:**

* Updated `helix_xharness.proj` to select different Helix target queues for internal and public builds, using the new `HelixInternal` property.
* Modified `stage-device-tests.yml` to pass the `HelixInternal` property and `HelixAccessToken` to Helix jobs based on whether the build is internal or public, ensuring tests are routed to the correct queues. [[1]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL148-R155) [[2]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL198-R209) [[3]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL246-R261) [[4]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL349-R368)

**Pipeline Timeout Adjustments:**

* Increased job timeouts for device test build and run stages to allow for longer test execution, reducing the risk of premature timeouts. [[1]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL74-R77) [[2]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL179-R186) [[3]](diffhunk://#diff-1701856ca68fbbb9e8a01b54e77e4f16271e630dee939e507f9133e4b9e7f46bL275-R290)

**Pipeline Template Usage:**

* Updated stage and job templates to use the new pool parameters and conditional logic, ensuring the correct pools and tokens are applied throughout the pipelines. [[1]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bL85-R119) [[2]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bL105-R141) [[3]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3L106-R161)

These changes collectively improve the reliability and security of the device test pipelines by ensuring internal and public builds use the appropriate resources and credentials.