### PR TITLE
Add FileLoggingProvider for MacCatalyst UI test logging

### DIFF
--- a/.github/agents/pr.md
+++ b/.github/agents/pr.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: "Sequential 5-phase workflow for GitHub issues: Pre-Flight, Tests, Gate, Fix, Report. Phases MUST complete in order. State tracked in .github/agent-pr-session/."
+description: Sequential 5-phase workflow for GitHub issues - Pre-Flight, Tests, Gate, Fix, Report. Phases MUST complete in order. State tracked in .github/agent-pr-session/
 ---
 
 # .NET MAUI Pull Request Agent

--- a/.github/scripts/BuildAndRunHostApp.ps1
+++ b/.github/scripts/BuildAndRunHostApp.ps1
@@ -93,18 +93,15 @@ if (-not (Test-Path $HostAppLogsDir)) {
     Write-Info "Created CustomAgentLogsTmp/UITests directory"
 }
 
-# Clean up old log files from previous runs
+# Clean up ALL old log files from previous runs to avoid confusion
 $deviceLogFile = Join-Path $HostAppLogsDir "$Platform-device.log"
 $testOutputFile = Join-Path $HostAppLogsDir "test-output.log"
 
-if (Test-Path $deviceLogFile) {
-    Remove-Item $deviceLogFile -Force
-    Write-Info "Cleaned up old $Platform-device.log"
-}
-
-if (Test-Path $testOutputFile) {
-    Remove-Item $testOutputFile -Force
-    Write-Info "Cleaned up old test-output.log"
+# Remove all files in the logs directory
+$existingFiles = Get-ChildItem -Path $HostAppLogsDir -File -ErrorAction SilentlyContinue
+if ($existingFiles) {
+    $existingFiles | Remove-Item -Force
+    Write-Info "Cleaned up $($existingFiles.Count) old log file(s) from previous runs"
 }
 
 # Check if dotnet is available
@@ -225,8 +222,8 @@ $testStartTime = Get-Date
 
 # For MacCatalyst, launch the app BEFORE running tests so Appium finds the correct bundle
 # This is critical because both maui and maui2 repos may share the same bundle ID
-# We use dotnet run with StandardOutputPath/StandardErrorPath to capture Console.WriteLine
-# See: https://github.com/dotnet/macios/blob/main/docs/building-apps/build-properties.md#runwithopen
+# MacCatalyst: Just ensure the app is ready - Appium will launch it with the test name
+# The app has built-in file logging that writes directly to MAUI_LOG_FILE path
 $catalystAppProcess = $null
 if ($Platform -eq "catalyst") {
     # Determine runtime identifier
@@ -238,8 +235,7 @@ if ($Platform -eq "catalyst") {
     $appPath = [System.IO.Path]::GetFullPath($appPath)
     
     if (Test-Path $appPath) {
-        Write-Info "Launching MacCatalyst app with dotnet run..."
-        Write-Info "App path: $appPath"
+        Write-Info "MacCatalyst app ready at: $appPath"
         
         # Make executable (like CI does)
         $executablePath = Join-Path $appPath "Contents/MacOS/Controls.TestCases.HostApp"
@@ -247,32 +243,14 @@ if ($Platform -eq "catalyst") {
             & chmod +x $executablePath
         }
         
-        # Use dotnet run with StandardOutputPath/StandardErrorPath
-        # This launches the app via 'open' but captures stdout/stderr to files
-        # Console.WriteLine on MacCatalyst goes to stderr
-        $stderrFile = "$deviceLogFile.stderr"
-        $hostAppProject = Join-Path $PSScriptRoot "../../src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj"
-        $hostAppProject = [System.IO.Path]::GetFullPath($hostAppProject)
-        
-        Write-Info "Starting app with dotnet run (logs to $stderrFile)..."
-        & dotnet run --project $hostAppProject -f $TargetFramework --no-build `
-            -p:StandardOutputPath=$deviceLogFile `
-            -p:StandardErrorPath=$stderrFile 2>&1 | Out-Null
-        
-        # dotnet run exits immediately when using 'open', give app time to launch
-        Start-Sleep -Seconds 3
-        
-        # Get app process ID for later cleanup
-        $catalystAppProcess = Get-Process -Name "Controls.TestCases.HostApp" -ErrorAction SilentlyContinue | Select-Object -First 1
-        if ($catalystAppProcess) {
-            Write-Success "MacCatalyst app launched (PID: $($catalystAppProcess.Id))"
-        } else {
-            Write-Success "MacCatalyst app launched with log capture"
-        }
+        Write-Success "MacCatalyst app prepared (Appium will launch with test name)"
     } else {
         Write-Warning "MacCatalyst app not found at: $appPath"
         Write-Warning "Test may use wrong app bundle if another version is registered"
     }
+    
+    # Set log file path directly - app will write ILogger output here
+    $env:MAUI_LOG_FILE = $deviceLogFile
 }
 
 Write-Info "Executing: dotnet test --filter `"$effectiveFilter`""
@@ -342,26 +320,13 @@ if ($Platform -eq "android") {
     
     Write-Info "iOS logs saved to: $deviceLogFile"
 } elseif ($Platform -eq "catalyst") {
-    # On macOS, Console.WriteLine goes to stderr, not stdout
-    # Stderr was captured to $deviceLogFile.stderr, stdout to $deviceLogFile
-    Write-Info "MacCatalyst logs captured via stdout/stderr redirect during test execution"
-    
-    # Check stderr first - this is where Console.WriteLine output goes on macOS
-    $stderrFile = "$deviceLogFile.stderr"
-    if ((Test-Path $stderrFile) -and ((Get-Item $stderrFile).Length -gt 0)) {
-        Write-Info "Console.WriteLine output found in stderr..."
-        # Copy stderr content to main log file (overwrite since stderr is the useful one)
-        Get-Content $stderrFile | Set-Content -Path $deviceLogFile -Encoding UTF8
-    }
-    
-    # If log file is still empty or small, try log show as fallback (for Debug.WriteLine via os_log)
-    $logFileSize = 0
-    if (Test-Path $deviceLogFile) {
-        $logFileSize = (Get-Item $deviceLogFile).Length
-    }
-    
-    if ($logFileSize -lt 100) {
-        Write-Info "Console output was minimal, using os_log fallback (captures Debug.WriteLine)..."
+    # App writes directly to $deviceLogFile via MAUI_LOG_FILE env var
+    # Just verify the file exists and has content
+    if ((Test-Path $deviceLogFile) -and ((Get-Item $deviceLogFile).Length -gt 0)) {
+        Write-Success "MacCatalyst logs written directly to: $deviceLogFile"
+    } else {
+        # Fall back to os_log if file logging didn't work
+        Write-Info "File logging output was minimal, using os_log fallback..."
         $logStartTimeStr = $testStartTime.AddMinutes(-1).ToString("yyyy-MM-dd HH:mm:ss")
         $catalystLogCommand = "log show --level debug --predicate 'process contains `"Controls.TestCases.HostApp`" OR processImagePath contains `"Controls.TestCases.HostApp`"' --start `"$logStartTimeStr`" --style compact"
         Invoke-Expression "$catalystLogCommand > `"$deviceLogFile`" 2>&1"

--- a/.github/scripts/BuildAndRunHostApp.ps1
+++ b/.github/scripts/BuildAndRunHostApp.ps1
@@ -47,7 +47,7 @@
 [CmdletBinding(DefaultParameterSetName = "TestFilter")]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("android", "ios", "catalyst")]
+    [ValidateSet("android", "ios", "catalyst", "maccatalyst")]
     [string]$Platform,
 
     [Parameter(Mandatory = $true, ParameterSetName = "TestFilter")]
@@ -69,6 +69,11 @@ $ErrorActionPreference = "Stop"
 $RepoRoot = Resolve-Path "$PSScriptRoot/../.."
 $HostAppProject = Join-Path $RepoRoot "src/Controls/tests/TestCases.HostApp/Controls.TestCases.HostApp.csproj"
 $HostAppLogsDir = Join-Path $RepoRoot "CustomAgentLogsTmp/UITests"
+
+# Normalize platform name (accept both "catalyst" and "maccatalyst")
+if ($Platform -eq "maccatalyst") {
+    $Platform = "catalyst"
+}
 
 # Import shared utilities
 . "$PSScriptRoot/shared/shared-utils.ps1"

--- a/src/Controls/tests/TestCases.HostApp/FileLoggingProvider.cs
+++ b/src/Controls/tests/TestCases.HostApp/FileLoggingProvider.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+
+namespace Maui.Controls.Sample;
+
+/// <summary>
+/// A simple file-based logging provider for capturing ILogger output during UI tests.
+/// Enabled when MAUI_ENABLE_FILE_LOGGING environment variable is set to "true".
+/// </summary>
+public class FileLoggingProvider : ILoggerProvider
+{
+	private readonly StreamWriter _writer;
+	private readonly LogLevel _minLevel;
+
+	public FileLoggingProvider(string filePath, LogLevel minLevel = LogLevel.Debug)
+	{
+		_minLevel = minLevel;
+		_writer = new StreamWriter(filePath, append: false) { AutoFlush = true };
+		_writer.WriteLine($"=== MAUI HostApp File Logger Started at {DateTime.Now} ===");
+		_writer.WriteLine($"Log file: {filePath}");
+		_writer.WriteLine($"Minimum log level: {minLevel}");
+		_writer.WriteLine();
+	}
+
+	public ILogger CreateLogger(string categoryName)
+	{
+		return new FileLogger(categoryName, _writer, _minLevel);
+	}
+
+	public void Dispose()
+	{
+		_writer?.Dispose();
+	}
+}
+
+public class FileLogger : ILogger
+{
+	private readonly string _categoryName;
+	private readonly StreamWriter _writer;
+	private readonly LogLevel _minLevel;
+	private static readonly object _lock = new object();
+
+	public FileLogger(string categoryName, StreamWriter writer, LogLevel minLevel)
+	{
+		_categoryName = categoryName;
+		_writer = writer;
+		_minLevel = minLevel;
+	}
+
+	public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+	public bool IsEnabled(LogLevel logLevel) => logLevel >= _minLevel;
+
+	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+	{
+		if (!IsEnabled(logLevel))
+			return;
+
+		var message = formatter(state, exception);
+		var levelString = logLevel switch
+		{
+			LogLevel.Trace => "TRACE",
+			LogLevel.Debug => "DEBUG",
+			LogLevel.Information => "INFO",
+			LogLevel.Warning => "WARN",
+			LogLevel.Error => "ERROR",
+			LogLevel.Critical => "CRIT",
+			_ => "NONE"
+		};
+
+		var timestamp = DateTime.Now.ToString("HH:mm:ss.fff");
+		var logLine = $"[{timestamp}] [{levelString}] {_categoryName}: {message}";
+
+		lock (_lock)
+		{
+			_writer.WriteLine(logLine);
+			if (exception != null)
+			{
+				_writer.WriteLine($"  Exception: {exception}");
+			}
+		}
+
+		// Also write to Console.WriteLine for backward compatibility
+		Console.WriteLine(logLine);
+		if (exception != null)
+		{
+			Console.WriteLine($"  Exception: {exception}");
+		}
+	}
+
+	private class NullScope : IDisposable
+	{
+		public static NullScope Instance { get; } = new NullScope();
+		public void Dispose() { }
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/FileLoggingProvider.cs
+++ b/src/Controls/tests/TestCases.HostApp/FileLoggingProvider.cs
@@ -4,9 +4,9 @@ namespace Maui.Controls.Sample;
 
 /// <summary>
 /// A simple file-based logging provider for capturing ILogger output during UI tests.
-/// Enabled when MAUI_ENABLE_FILE_LOGGING environment variable is set to "true".
+/// Enabled when the MAUI_LOG_FILE environment variable is set to the desired log file path.
 /// </summary>
-public class FileLoggingProvider : ILoggerProvider
+internal class FileLoggingProvider : ILoggerProvider
 {
 	private readonly StreamWriter _writer;
 	private readonly LogLevel _minLevel;
@@ -14,6 +14,11 @@ public class FileLoggingProvider : ILoggerProvider
 	public FileLoggingProvider(string filePath, LogLevel minLevel = LogLevel.Debug)
 	{
 		_minLevel = minLevel;
+		var directory = Path.GetDirectoryName(filePath);
+		if (!string.IsNullOrEmpty(directory))
+		{
+			Directory.CreateDirectory(directory);
+		}
 		_writer = new StreamWriter(filePath, append: false) { AutoFlush = true };
 		_writer.WriteLine($"=== MAUI HostApp File Logger Started at {DateTime.Now} ===");
 		_writer.WriteLine($"Log file: {filePath}");
@@ -32,7 +37,7 @@ public class FileLoggingProvider : ILoggerProvider
 	}
 }
 
-public class FileLogger : ILogger
+internal class FileLogger : ILogger
 {
 	private readonly string _categoryName;
 	private readonly StreamWriter _writer;
@@ -79,7 +84,7 @@ public class FileLogger : ILogger
 			}
 		}
 
-		// Also write to Console.WriteLine for backward compatibility
+		// Also write to console for local debugging visibility
 		Console.WriteLine(logLine);
 		if (exception != null)
 		{

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Maui.Controls.Sample.Issues;
+using Microsoft.Extensions.Logging;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
@@ -7,6 +8,15 @@ namespace Maui.Controls.Sample
 {
 	public static partial class MauiProgram
 	{
+		/// <summary>
+		/// Gets the file logging path from MAUI_LOG_FILE environment variable.
+		/// Returns null if not set (file logging disabled).
+		/// </summary>
+		static string GetFileLogPath()
+		{
+			return Environment.GetEnvironmentVariable("MAUI_LOG_FILE");
+		}
+
 		public static MauiApp CreateMauiApp()
 		{
 			var appBuilder = MauiApp.CreateBuilder();
@@ -14,6 +24,7 @@ namespace Maui.Controls.Sample
 #if IOS || ANDROID || MACCATALYST
 			appBuilder.UseMauiMaps();
 #endif
+
 			appBuilder.UseMauiApp<App>()
 				.ConfigureFonts(fonts =>
 				{
@@ -33,10 +44,9 @@ namespace Maui.Controls.Sample
 				.Issue25436RegisterNavigationService();
 
 #if IOS || MACCATALYST
-
 			appBuilder.ConfigureCollectionViewHandlers();
-
 #endif
+			
 			// Register the custom handler
 			appBuilder.ConfigureMauiHandlers(handlers =>
 			{
@@ -59,6 +69,14 @@ namespace Maui.Controls.Sample
 
 			appBuilder.Services.AddTransient<TransientPage>();
 			appBuilder.Services.AddScoped<ScopedPage>();
+
+			// Add file logging if MAUI_LOG_FILE environment variable is set
+			var logFilePath = GetFileLogPath();
+			if (!string.IsNullOrEmpty(logFilePath))
+			{
+				appBuilder.Logging.AddProvider(new FileLoggingProvider(logFilePath, LogLevel.Debug));
+			}
+
 			return appBuilder.Build();
 		}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UITest.cs
@@ -102,6 +102,13 @@ namespace Microsoft.Maui.TestCases.Tests
 				config.SetTestConfigurationArg("TEST_CONFIGURATION_ARGS", commandLineArgs);
 			}
 
+			// Pass log file path to app if set - app will write ILogger output to this file
+			var logFilePath = Environment.GetEnvironmentVariable("MAUI_LOG_FILE") ?? "";
+			if (!String.IsNullOrEmpty(logFilePath))
+			{
+				config.SetTestConfigurationArg("MAUI_LOG_FILE", logFilePath);
+			}
+
 			return config;
 		}
 


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds a `FileLoggingProvider` to capture ILogger output during MacCatalyst UI tests. This solves the problem where Console.WriteLine and ILogger messages were not being captured when running UI tests via Appium.

### Problem

When running MacCatalyst UI tests with `BuildAndRunHostApp.ps1`, log output was not being captured because:
1. Appium's Mac2 driver relaunches the app with `macos: launchApp`
2. This kills any existing app instance that had stderr capture configured
3. The new app instance launched by Appium has no logging connection to the test script

### Solution

Instead of trying to capture stderr from outside the app, the app now writes its own logs to a file:
1. Test script sets `MAUI_LOG_FILE` environment variable to the desired log path
2. `UITest.cs` passes this env var to the app via Appium's environment args
3. `MauiProgram.cs` checks for the env var and adds `FileLoggingProvider` if set
4. App writes all ILogger output directly to the specified file
5. This works regardless of how the app is launched (directly or via Appium relaunch)

### Changes

- **`FileLoggingProvider.cs`** (new): Simple `ILoggerProvider` implementation that writes formatted log messages to a file with timestamps and log levels
- **`MauiProgram.cs`**: Adds `FileLoggingProvider` to logging pipeline when `MAUI_LOG_FILE` env var is set
- **`UITest.cs`**: Reads `MAUI_LOG_FILE` from environment and passes it to app via `SetTestConfigurationArg`
- **`BuildAndRunHostApp.ps1`**: Simplified - now just sets `MAUI_LOG_FILE` directly to output path instead of copying from temp file

### Usage

```powershell
# Run MacCatalyst UI test with logging
pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform catalyst -TestFilter "FullyQualifiedName~MyTest"

# Logs are written directly to:
# CustomAgentLogsTmp/UITests/catalyst-device.log
```

### Example Log Output

```
=== MAUI HostApp File Logger Started at 1/13/2026 2:29:21 PM ===
Log file: /path/to/catalyst-device.log
Minimum log level: Debug

[14:29:36.015] [ERROR] Microsoft.Maui.IApplication: Error Domain=UISceneErrorDomain Code=0 "The application does not support multiple scenes."
  Exception: Foundation.NSErrorException: Error Domain=UISceneErrorDomain Code=0 ...
```
