### PR TITLE
Update PreReleaseVersionLabel and StabilizePackageVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,14 +5,13 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>30</PatchVersion>
     <SdkBandVersion>10.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
-    <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->
     <IsServicingBuild Condition=" '$(PreReleaseVersionLabel)' == 'servicing' ">true</IsServicingBuild>
     <!-- Enable to remove prerelease label and produce stable package versions. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PreReleaseVersionIteration)' == ''">-$(PreReleaseVersionLabel)</WorkloadVersionSuffix>
     <WorkloadVersionSuffix Condition="'$(WorkloadVersionSuffix)' == '' and '$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>


### PR DESCRIPTION
This pull request updates the build configuration to prepare for a servicing release. The main change is to set the versioning and stabilization flags to produce stable, servicing-labeled package versions by default.

Versioning and build configuration:

* Changed the `PreReleaseVersionLabel` from `ci.main` (and conditional `ci.inflight`) to `servicing` to indicate this is a servicing build.
* Set `StabilizePackageVersion` to `true` by default, ensuring stable (non-prerelease) package versions are produced.