### PR TITLE
Make XAML Source Generator (XSG) the default inflator for .NET 11

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,16 +3,6 @@
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="$(MSBuildThisFileDirectory)eng\Environment.Build.props" />
 
   <PropertyGroup>
-    <!-- 
-      Keep backward compatibility with XamlC, XamlCompilationAttribute, and xaml-comp processing instruction
-      in SourceGen and Build.Tasks projects (which target netstandard2.0 and can't use NET12_0_OR_GREATER).
-      This flag will be removed in NET12 when [XamlCompilation] becomes a no-op.
-      -->
-    <_MauiXamlSourceGenBackCompat>true</_MauiXamlSourceGenBackCompat>
-    <DefineConstants Condition=" '$(_MauiXamlSourceGenBackCompat)' == 'true' ">$(DefineConstants);_MAUIXAML_SOURCEGEN_BACKCOMPAT</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Detailed trimmer warnings, if present -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,8 @@
   <PropertyGroup>
     <!-- 
       Keep backward compatibility with XamlC, XamlCompilationAttribute, and xaml-comp processing instruction
-      This will be removed in NET12
+      in SourceGen and Build.Tasks projects (which target netstandard2.0 and can't use NET12_0_OR_GREATER).
+      This flag will be removed in NET12 when [XamlCompilation] becomes a no-op.
       -->
     <_MauiXamlSourceGenBackCompat>true</_MauiXamlSourceGenBackCompat>
     <DefineConstants Condition=" '$(_MauiXamlSourceGenBackCompat)' == 'true' ">$(DefineConstants);_MAUIXAML_SOURCEGEN_BACKCOMPAT</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,15 @@
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="$(MSBuildThisFileDirectory)eng\Environment.Build.props" />
 
   <PropertyGroup>
+    <!-- 
+      Keep backward compatibility with XamlC, XamlCompilationAttribute, and xaml-comp processing instruction
+      This will be removed in NET12
+      -->
+    <_MauiXamlSourceGenBackCompat>true</_MauiXamlSourceGenBackCompat>
+    <DefineConstants Condition=" '$(_MauiXamlSourceGenBackCompat)' == 'true' ">$(DefineConstants);_MAUIXAML_SOURCEGEN_BACKCOMPAT</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Detailed trimmer warnings, if present -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,16 +3,6 @@
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="$(MSBuildThisFileDirectory)eng\Environment.Build.props" />
 
   <PropertyGroup>
-    <!-- 
-      Keep backward compatibility with XamlC, XamlCompilationAttribute, and xaml-comp processing instruction
-      When we're ready to turn this off, we can remove all code depending on this condition, and drop this property group
-      -->
-
-    <_MauiXamlSourceGenBackCompat>true</_MauiXamlSourceGenBackCompat>
-    <DefineConstants Condition=" '$(_MauiXamlSourceGenBackCompat)' == 'true' ">$(DefineConstants);_MAUIXAML_SOURCEGEN_BACKCOMPAT</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Detailed trimmer warnings, if present -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>

--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -6,6 +6,7 @@ The following switches are toggled for applications running on Mono for `TrimMod
 
 | MSBuild Property Name | AppContext Setting | Description |
 |-|-|-|
+| MauiXamlInflator | N/A | Controls how XAML files are processed. See [XAML Inflator](#mauixamlinflator) section below. |
 | MauiEnableIVisualAssemblyScanning | Microsoft.Maui.RuntimeFeature.IsIVisualAssemblyScanningEnabled | When enabled, MAUI will scan assemblies for types implementing `IVisual` and for `[assembly: Visual(...)]` attributes and register these types. |
 | MauiShellSearchResultsRendererDisplayMemberNameSupported | Microsoft.Maui.RuntimeFeature.IsShellSearchResultsRendererDisplayMemberNameSupported | When disabled, it is necessary to always set `ItemTemplate` of any `SearchHandler`. Displaying search results through `DisplayMemberName` will not work. |
 | MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, the `[QueryProperty(...)]` attributes won't be used to set values to properties when navigating. |
@@ -17,6 +18,38 @@ The following switches are toggled for applications running on Mono for `TrimMod
 | EnableDiagnostics | Microsoft.Maui.RuntimeFeature.EnableDiagnostics | Enables diagnostic for the running app |
 | EnableMauiDiagnostics | Microsoft.Maui.RuntimeFeature.EnableMauiDiagnostics | Enables MAUI specific diagnostics, like VisualDiagnostics and BindingDiagnostics. Defaults to EnableDiagnostics |
 | _EnableMauiAspire | Microsoft.Maui.RuntimeFeature.EnableMauiAspire | When enabled, MAUI Aspire integration features are available. **Warning**: Using Aspire outside of Debug configuration may introduce performance and security risks in production. |
+
+## MauiXamlInflator
+
+Controls how XAML files are processed and compiled. Starting with .NET 11, the default value is `SourceGen`.
+
+**Available Values:**
+- `SourceGen` (default) - XAML is compiled to C# at build time using a source generator. This provides the best performance and debugging experience, including full XAML Hot Reload support.
+- `Runtime` - XAML is inflated at runtime. This has negative performance impact and is deprecated.
+- `XamlC` - XAML is compiled using the XamlC IL weaver after compilation. This prevents some debugging capabilities like XAML Hot Reload and is deprecated.
+
+**Example:**
+```xml
+<PropertyGroup>
+  <!-- Use default (SourceGen) - recommended -->
+  <!-- No need to specify MauiXamlInflator -->
+  
+  <!-- Or explicitly set deprecated inflators (will produce warning MAUI1001) -->
+  <MauiXamlInflator>Runtime</MauiXamlInflator>
+</PropertyGroup>
+```
+
+**Per-file override:**
+You can override the inflator for individual XAML files using item metadata:
+```xml
+<ItemGroup>
+  <MauiXaml Update="MyPage.xaml" Inflator="Runtime" />
+</ItemGroup>
+```
+
+**Breaking Change in .NET 11:**
+- The `[XamlCompilation]` attribute is now obsolete with `error: true`. Use MSBuild properties or item metadata instead.
+- The default inflator changed from configuration-based (Runtime in Debug, XamlC in Release) to `SourceGen` for all configurations.
 
 ## MauiEnableIVisualAssemblyScanning
 

--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -49,10 +49,10 @@ You can override the inflator for individual XAML files using item metadata:
 
 **Changes in .NET 11:**
 - The default inflator changed from configuration-based (Runtime in Debug, XamlC in Release) to `SourceGen` for all configurations.
-- The `[XamlCompilation]` attribute is still supported but will be deprecated in .NET 12.
+- The `[XamlCompilation]` attribute is deprecated (produces warning) but still functional.
 
-**Breaking Change in .NET 12:**
-- The `[XamlCompilation]` attribute will be obsolete with `error: true`. Use MSBuild properties or item metadata instead.
+**Changes in .NET 12:**
+- The `[XamlCompilation]` attribute will be obsolete with `error: true` and becomes a no-op. Use MSBuild properties or item metadata instead.
 
 ## MauiEnableIVisualAssemblyScanning
 

--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -47,9 +47,12 @@ You can override the inflator for individual XAML files using item metadata:
 </ItemGroup>
 ```
 
-**Breaking Change in .NET 11:**
-- The `[XamlCompilation]` attribute is now obsolete with `error: true`. Use MSBuild properties or item metadata instead.
+**Changes in .NET 11:**
 - The default inflator changed from configuration-based (Runtime in Debug, XamlC in Release) to `SourceGen` for all configurations.
+- The `[XamlCompilation]` attribute is still supported but will be deprecated in .NET 12.
+
+**Breaking Change in .NET 12:**
+- The `[XamlCompilation]` attribute will be obsolete with `error: true`. Use MSBuild properties or item metadata instead.
 
 ## MauiEnableIVisualAssemblyScanning
 

--- a/src/Controls/samples/Controls.Sample.Embedding/Maui.Controls.Sample.Embedding.csproj
+++ b/src/Controls/samples/Controls.Sample.Embedding/Maui.Controls.Sample.Embedding.csproj
@@ -10,6 +10,8 @@
     <Nullable>enable</Nullable>
     <MauiEnablePlatformUsings>true</MauiEnablePlatformUsings>
     <NoWarn>$(NoWarn);XC0022</NoWarn>
+    <!-- This sample has nullability mismatches - use Runtime inflation -->
+    <MauiXamlInflator>Runtime</MauiXamlInflator>
 
     <!-- Display name -->
     <ApplicationTitle>.NET MAUI Embedding</ApplicationTitle>

--- a/src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj
+++ b/src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj
@@ -12,6 +12,8 @@
     <IsPackable>false</IsPackable>
     <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
     <NoWarn>$(NoWarn);XC0022</NoWarn>
+    <!-- This sample uses deprecated APIs - use Runtime inflation -->
+    <MauiXamlInflator>Runtime</MauiXamlInflator>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>

--- a/src/Controls/samples/Controls.Sample.Profiling/Startup.cs
+++ b/src/Controls/samples/Controls.Sample.Profiling/Startup.cs
@@ -3,7 +3,9 @@ using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Hosting;
 
+#pragma warning disable CS0618 // XamlCompilationAttribute is deprecated, remove this in .NET 12
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+#pragma warning restore CS0618
 
 namespace Maui.Controls.Sample.Profiling
 {

--- a/src/Controls/samples/Controls.Sample.Profiling/Startup.cs
+++ b/src/Controls/samples/Controls.Sample.Profiling/Startup.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.Maui;
 using Microsoft.Maui.Controls.Hosting;
-using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Hosting;
-
-#pragma warning disable CS0618 // XamlCompilationAttribute is deprecated, remove this in .NET 12
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
-#pragma warning restore CS0618
 
 namespace Maui.Controls.Sample.Profiling
 {

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -95,11 +95,12 @@
   <!-- These XAML files have XSG parsing issues, use Runtime inflator until fixed -->
   <!-- Must be after Maui.InTree.props to properly override the globbed items -->
   <ItemGroup>
-    <MauiXaml Remove="Pages/Controls/SwipeViewGalleries/*.xaml;Pages/Others/StyleSheetsPage.xaml;Pages/Others/TwoPaneViewPage.xaml;Pages/Controls/ButtonPage.xaml" />
+    <MauiXaml Remove="Pages/Controls/SwipeViewGalleries/*.xaml;Pages/Others/StyleSheetsPage.xaml;Pages/Others/TwoPaneViewPage.xaml;Pages/Controls/ButtonPage.xaml;Pages/Controls/RadioButtonGalleries/RadioButtonContentGallery.xaml" />
     <MauiXaml Include="Pages/Controls/SwipeViewGalleries/*.xaml" Inflator="Runtime" />
     <MauiXaml Include="Pages/Others/StyleSheetsPage.xaml" Inflator="Runtime" />
     <MauiXaml Include="Pages/Others/TwoPaneViewPage.xaml" Inflator="Runtime" />
     <MauiXaml Include="Pages/Controls/ButtonPage.xaml" Inflator="Runtime" />
+    <MauiXaml Include="Pages/Controls/RadioButtonGalleries/RadioButtonContentGallery.xaml" Inflator="Runtime" />
   </ItemGroup>
 
   <!-- These XAML files use obsolete APIs (Device, NamedSize) intentionally for demonstration -->

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -12,6 +12,8 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA1416;CS0618;XC0618;XC0022</NoWarn>
     <Nullable>enable</Nullable>
+    <!-- This sample project uses deprecated APIs for demonstration - use Runtime inflation -->
+    <MauiXamlInflator>Runtime</MauiXamlInflator>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
@@ -91,5 +93,6 @@
   <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\..\BlazorWebView\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.targets" />
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
+
 
 </Project>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -12,8 +12,6 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA1416;CS0618;XC0618;XC0022</NoWarn>
     <Nullable>enable</Nullable>
-    <!-- This sample project uses deprecated APIs for demonstration - use Runtime inflation -->
-    <MauiXamlInflator>Runtime</MauiXamlInflator>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>
@@ -94,5 +92,52 @@
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
 
+  <!-- These XAML files have XSG parsing issues, use Runtime inflator until fixed -->
+  <!-- Must be after Maui.InTree.props to properly override the globbed items -->
+  <ItemGroup>
+    <MauiXaml Remove="Pages/Controls/SwipeViewGalleries/*.xaml;Pages/Others/StyleSheetsPage.xaml;Pages/Others/TwoPaneViewPage.xaml;Pages/Controls/ButtonPage.xaml" />
+    <MauiXaml Include="Pages/Controls/SwipeViewGalleries/*.xaml" Inflator="Runtime" />
+    <MauiXaml Include="Pages/Others/StyleSheetsPage.xaml" Inflator="Runtime" />
+    <MauiXaml Include="Pages/Others/TwoPaneViewPage.xaml" Inflator="Runtime" />
+    <MauiXaml Include="Pages/Controls/ButtonPage.xaml" Inflator="Runtime" />
+  </ItemGroup>
+
+  <!-- These XAML files use obsolete APIs (Device, NamedSize) intentionally for demonstration -->
+  <ItemGroup>
+    <MauiXaml Update="AppResources.xaml" NoWarn="0612" />
+    <MauiXaml Update="Controls/CardView/CardView.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/AppShell.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Compatibility/ListViewPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/CompatibilityPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/CollectionViewGalleries/CarouselViewGalleries/CarouselViewPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/EditorPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/IndicatorPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/RadioButtonGalleries/ContentProperties.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/RadioButtonGalleries/RadioButtonGroupGalleryPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/ShapesGalleries/ClipCornerRadiusGallery.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/ShapesGalleries/ClipGallery.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/ShapesGalleries/InvalidateClipGallery.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/SliderPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Controls/StepperPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/ControlsPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Core/BorderGalleries/BorderLayout.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Core/DispatcherPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Core/GesturesPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Core/ShadowGalleries/ShadowPlaygroundPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/CorePage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Layouts/FlexLayoutPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Layouts/ScrollViewPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/Layouts/ScrollViewPages/ScrollToEndPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/LayoutsPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/MainPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/OthersPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/PlatformSpecificsPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/UserInterface/FontsPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/UserInterface/VisualStatesPage.xaml" NoWarn="0612" />
+    <MauiXaml Update="Pages/UserInterfacePage.xaml" NoWarn="0612" />
+  </ItemGroup>
 
 </Project>

--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml.cs
@@ -18,7 +18,7 @@ namespace Maui.Controls.Sample.Pages
 
 		public string ShellTitle { get; set; } = "Welcome to Shell";
 
-		void OnChangeTabBarBackgroundColor(object sender, EventArgs e)
+		void OnChangeTabBarBackgroundColor(object? sender, EventArgs e)
 		{
 			var random = new Random();
 

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/ListViewGalleries/ListViewContextActions.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/ListViewGalleries/ListViewContextActions.xaml.cs
@@ -17,15 +17,15 @@ namespace Maui.Controls.Sample.Pages
 					.ToList();
 		}
 
-		private void OnDetailClicked(object sender, EventArgs e)
+		private void OnDetailClicked(object? sender, EventArgs e)
 		{
-			var mi = ((MenuItem)sender);
+			var mi = ((MenuItem)sender!);
 			DisplayAlertAsync("Detail Action", $"Details for item {mi.CommandParameter}", "OK");
 		}
 
-		private void OnDeleteClicked(object sender, EventArgs e)
+		private void OnDeleteClicked(object? sender, EventArgs e)
 		{
-			var mi = ((MenuItem)sender);
+			var mi = ((MenuItem)sender!);
 			DisplayAlertAsync("Delete Action", $"Deleting item {mi.CommandParameter}!", "OK");
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGalleryMainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGalleryMainPage.xaml.cs
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.Pages
 			Application.Current!.Windows[0].Page = page;
 		}
 
-		void OnTabbedPageAsRoot(object sender, EventArgs e)
+		void OnTabbedPageAsRoot(object? sender, EventArgs e)
 		{
 			var topTabs =
 				new TabbedPage()
@@ -37,7 +37,7 @@ namespace Maui.Controls.Sample.Pages
 			SetNewMainPage(topTabs);
 		}
 
-		void OnSetToBottomTabs(object sender, EventArgs e)
+		void OnSetToBottomTabs(object? sender, EventArgs e)
 		{
 			var bottomTabs = new TabbedPage()
 			{
@@ -53,12 +53,12 @@ namespace Maui.Controls.Sample.Pages
 			this.Window!.Page = bottomTabs;
 		}
 
-		void OnChangeTabIndex(object sender, EventArgs e)
+		void OnChangeTabIndex(object? sender, EventArgs e)
 		{
 			GetTabbedPage().CurrentPage = GetTabbedPage().Children[1];
 		}
 
-		void OnToggleTabBar(object sender, EventArgs e)
+		void OnToggleTabBar(object? sender, EventArgs e)
 		{
 			if ((GetTabbedPage().BarBackground as SolidColorBrush)?.Color == SolidColorBrush.Purple.Color)
 				GetTabbedPage().BarBackground = null;
@@ -66,7 +66,7 @@ namespace Maui.Controls.Sample.Pages
 				GetTabbedPage().BarBackground = SolidColorBrush.Purple;
 		}
 
-		void OnToggleTabBarTextColor(object sender, EventArgs e)
+		void OnToggleTabBarTextColor(object? sender, EventArgs e)
 		{
 			if (GetTabbedPage().BarTextColor == Colors.Green)
 				GetTabbedPage().BarTextColor = null;
@@ -74,7 +74,7 @@ namespace Maui.Controls.Sample.Pages
 				GetTabbedPage().BarTextColor = Colors.Green;
 		}
 
-		void OnToggleTabItemUnSelectedColor(object sender, EventArgs e)
+		void OnToggleTabItemUnSelectedColor(object? sender, EventArgs e)
 		{
 			if (GetTabbedPage().UnselectedTabColor == Colors.Blue)
 				GetTabbedPage().UnselectedTabColor = null;
@@ -82,7 +82,7 @@ namespace Maui.Controls.Sample.Pages
 				GetTabbedPage().UnselectedTabColor = Colors.Blue;
 		}
 
-		void OnToggleTabItemSelectedColor(object sender, EventArgs e)
+		void OnToggleTabItemSelectedColor(object? sender, EventArgs e)
 		{
 			if (GetTabbedPage().SelectedTabColor == Colors.Pink)
 				GetTabbedPage().SelectedTabColor = null;
@@ -90,7 +90,7 @@ namespace Maui.Controls.Sample.Pages
 				GetTabbedPage().SelectedTabColor = Colors.Pink;
 		}
 
-		void OnRemoveTab(object sender, EventArgs e)
+		void OnRemoveTab(object? sender, EventArgs e)
 		{
 			if (GetTabbedPage().Children.LastOrDefault() is TabbedPageGalleryMainPage mainPage)
 			{
@@ -98,7 +98,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnRemoveAllTabs(object sender, EventArgs e)
+		void OnRemoveAllTabs(object? sender, EventArgs e)
 		{
 			while (GetTabbedPage().Children.LastOrDefault() is TabbedPageGalleryMainPage mainPage)
 			{
@@ -106,7 +106,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnAddTab(object sender, EventArgs e)
+		void OnAddTab(object? sender, EventArgs e)
 		{
 			GetTabbedPage()
 				.Children

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml.cs
@@ -19,12 +19,12 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = new ButtonPageViewModel();
 		}
 
-		void OnButtonClicked(object sender, System.EventArgs e)
+		void OnButtonClicked(object? sender, System.EventArgs e)
 		{
 			Debug.WriteLine("Clicked");
 		}
 
-		void Button_Clicked(System.Object sender, System.EventArgs e)
+		void Button_Clicked(System.Object? sender, System.EventArgs e)
 		{
 			if (ImageSourceButton.ImageSource is null)
 			{
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnPositionChange(object sender, System.EventArgs e)
+		void OnPositionChange(object? sender, System.EventArgs e)
 		{
 			var newPosition = ((int)positionChange.ContentLayout.Position) + 1;
 
@@ -48,21 +48,21 @@ namespace Maui.Controls.Sample.Pages
 					positionChange.ContentLayout.Spacing);
 		}
 
-		void OnDecreaseSpacing(object sender, System.EventArgs e)
+		void OnDecreaseSpacing(object? sender, System.EventArgs e)
 		{
 			positionChange.ContentLayout =
 				new Button.ButtonContentLayout(positionChange.ContentLayout.Position,
 					positionChange.ContentLayout.Spacing - 1);
 		}
 
-		void OnIncreasingSpacing(object sender, System.EventArgs e)
+		void OnIncreasingSpacing(object? sender, System.EventArgs e)
 		{
 			positionChange.ContentLayout =
 				new Button.ButtonContentLayout(positionChange.ContentLayout.Position,
 					positionChange.ContentLayout.Spacing + 1);
 		}
 
-		void OnLineBreakModeButtonClicked(object sender, System.EventArgs e)
+		void OnLineBreakModeButtonClicked(object? sender, System.EventArgs e)
 		{
 			LineBreakModeButton.LineBreakMode = ImageLineBreakModeButton.LineBreakMode = SelectLineBreakMode();
 		}
@@ -90,13 +90,13 @@ namespace Maui.Controls.Sample.Pages
 
 		int _backgroundCount;
 
-		void OnBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			BackgroundButton.Text = $"Background tapped {_backgroundCount} times";
 			_backgroundCount++;
 		}
 
-		void OnChangeBrushButtonClicked(System.Object sender, System.EventArgs e)
+		void OnChangeBrushButtonClicked(System.Object? sender, System.EventArgs e)
 		{
 			UpdateButtonBrush();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CheckBoxPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CheckBoxPage.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages
 			UpdateControls();
 		}
 
-		void OnChangeIsCheckedButtonClicked(object sender, EventArgs e)
+		void OnChangeIsCheckedButtonClicked(object? sender, EventArgs e)
 		{
 			_isGreen = !_isGreen;
 			UpdateControls();

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CarouselViewGalleries/CarouselViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CarouselViewGalleries/CarouselViewPage.xaml.cs
@@ -9,7 +9,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		async void TapGestureRecognizer_Tapped(object sender, EventArgs e)
+		async void TapGestureRecognizer_Tapped(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("Item", "Tapped", "Successfully");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
@@ -64,7 +64,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.DataTemplateSelecto
 			set => SetValue(ref _shouldTriggerReset, value);
 		}
 
-		void Insert_OnClicked(object sender, EventArgs e)
+		void Insert_OnClicked(object? sender, EventArgs e)
 		{
 			if (!IsValid(out var index))
 				return;
@@ -72,7 +72,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.DataTemplateSelecto
 			Items.Insert(index, CreateDrink());
 		}
 
-		void Add_OnClicked(object sender, EventArgs e)
+		void Add_OnClicked(object? sender, EventArgs e)
 		{
 			if (!IsValid(out var _))
 				return;
@@ -89,7 +89,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.DataTemplateSelecto
 			OnPropertyChanged(callerName);
 		}
 
-		void Remove_OnClicked(object sender, EventArgs e)
+		void Remove_OnClicked(object? sender, EventArgs e)
 		{
 			if (!IsValid(out var index))
 				return;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewRTLGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewRTLGallery.xaml.cs
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 			SearchBar.SearchCommand = new Command(() => _demoFilteredItemSource.FilterItems(SearchBar.Text));
 		}
 
-		void OnPickerSelectedIndexChanged(object sender, EventArgs e)
+		void OnPickerSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			switch (Picker.SelectedIndex)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ExampleTemplates.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ExampleTemplates.cs
@@ -539,7 +539,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			});
 		}
 
-		static void More_Clicked(object sender, EventArgs e)
+		static void More_Clicked(object? sender, EventArgs e)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml.cs
@@ -20,13 +20,13 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
 		}
 
-		void AddContentClicked(object sender, System.EventArgs e)
+		void AddContentClicked(object? sender, System.EventArgs e)
 		{
 			if (sender is VisualElement ve && ve.Parent is StackLayout sl)
 				sl.Children.Add(new Label() { Text = "Grow" });
 		}
 
-		void ToggleHeader(object sender, System.EventArgs e)
+		void ToggleHeader(object? sender, System.EventArgs e)
 		{
 			header = CollectionView.Header ?? header;
 
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 				CollectionView.Header = null;
 		}
 
-		void ToggleFooter(object sender, System.EventArgs e)
+		void ToggleFooter(object? sender, System.EventArgs e)
 		{
 			footer = CollectionView.Footer ?? footer;
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
@@ -26,13 +26,13 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 
 
 
-		void AddContentClicked(object sender, System.EventArgs e)
+		void AddContentClicked(object? sender, System.EventArgs e)
 		{
 			if (sender is VisualElement ve && ve.Parent is StackLayout sl)
 				sl.Children.Add(new Label() { Text = "Grow" });
 		}
 
-		void ToggleHeader(object sender, System.EventArgs e)
+		void ToggleHeader(object? sender, System.EventArgs e)
 		{
 			header = CollectionView.Header ?? header;
 
@@ -42,7 +42,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 				CollectionView.Header = null;
 		}
 
-		void ToggleFooter(object sender, System.EventArgs e)
+		void ToggleFooter(object? sender, System.EventArgs e)
 		{
 			footer = CollectionView.Footer ?? footer;
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ItemsUpdatingScrollModeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ItemsUpdatingScrollModeGallery.xaml.cs
@@ -48,7 +48,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 			await _viewModel.LoadItemsAsync();
 		}
 
-		void OnItemsUpdatingScrollModeChanged(object sender, EventArgs e)
+		void OnItemsUpdatingScrollModeChanged(object? sender, EventArgs e)
 		{
 			CollectionView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)((EnumPicker)sender!).SelectedItem;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -30,12 +30,12 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 			_collectionView.ItemsSource = _demoFilteredItemSource.Items;
 		}
 
-		void ScrollToMiddle_Clicked(object sender, EventArgs e)
+		void ScrollToMiddle_Clicked(object? sender, EventArgs e)
 		{
 			_collectionView.ScrollTo(_demoFilteredItemSource.Items.Count / 2, position: ScrollToPosition.Start, animate: false);
 		}
 
-		void AddItemAbove_Clicked(object sender, EventArgs e)
+		void AddItemAbove_Clicked(object? sender, EventArgs e)
 		{
 			var index = (_demoFilteredItemSource.Items.Count / 2) - 1;
 
@@ -46,7 +46,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 				index));
 		}
 
-		void AddItemBelow_Clicked(object sender, EventArgs e)
+		void AddItemBelow_Clicked(object? sender, EventArgs e)
 		{
 			var index = (_demoFilteredItemSource.Items.Count / 2) + 2;
 
@@ -57,7 +57,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.ScrollModeGalleries
 				index));
 		}
 
-		void AddItemToEnd_Clicked(object sender, EventArgs e)
+		void AddItemToEnd_Clicked(object? sender, EventArgs e)
 		{
 			_demoFilteredItemSource.Items.Add(
 				new CollectionViewGalleryTestItem(DateTime.Now,

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
@@ -17,14 +17,14 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			InitializeComponent();
 		}
 
-		private void ClearAndAdd(object sender, EventArgs e)
+		private void ClearAndAdd(object? sender, EventArgs e)
 		{
 			_vm.SelectedItems!.Clear();
 			_vm.SelectedItems!.Add(_vm.Items![1]);
 			_vm.SelectedItems!.Add(_vm.Items![2]);
 		}
 
-		private void ResetClicked(object sender, EventArgs e)
+		private void ResetClicked(object? sender, EventArgs e)
 		{
 			_vm.SelectedItems = new ObservableCollection<object>
 			{
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			};
 		}
 
-		private void DirectUpdateClicked(object sender, EventArgs e)
+		private void DirectUpdateClicked(object? sender, EventArgs e)
 		{
 			CollectionView.SelectedItems.Clear();
 			CollectionView.SelectedItems.Add(_vm.Items![0]);

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionSynchronization.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionSynchronization.xaml.cs
@@ -20,7 +20,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			BindingContext = new SelectionSyncModel();
 		}
 
-		void SwitchSourceClicked(object sender, EventArgs e)
+		void SwitchSourceClicked(object? sender, EventArgs e)
 		{
 			var newSource = new List<string> { "Item -1", "Item 0", "Item 1", "Item 3", "Item 4", "Item 5" };
 			CVSwitchSource.ItemsSource = newSource;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
@@ -16,12 +16,12 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			BindingContext = _vm;
 		}
 
-		private void ResetClicked(object sender, EventArgs e)
+		private void ResetClicked(object? sender, EventArgs e)
 		{
 			_vm.SelectedItem = _vm.Items![0];
 		}
 
-		private void ClearClicked(object sender, EventArgs e)
+		private void ClearClicked(object? sender, EventArgs e)
 		{
 			_vm.SelectedItem = null;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/DatePickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/DatePickerPage.xaml.cs
@@ -30,12 +30,12 @@ namespace Maui.Controls.Sample.Pages
 			IsOpenDatePicker.Closed -= IsOpenDatePickerClosed;
 		}
 
-		void OnUpdateBackgroundButtonClicked(object sender, EventArgs e)
+		void OnUpdateBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			UpdateDatePickerBackground();
 		}
 
-		void OnClearBackgroundButtonClicked(object sender, EventArgs e)
+		void OnClearBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			BackgroundDatePicker.Background = null;
 		}
@@ -57,32 +57,32 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void OnFocusDatePickerFocused(object sender, FocusEventArgs e)
+		void OnFocusDatePickerFocused(object? sender, FocusEventArgs e)
 		{
 			Debug.WriteLine("Focused");
 		}
 
-		void OnFocusDatePickerUnfocused(object sender, FocusEventArgs e)
+		void OnFocusDatePickerUnfocused(object? sender, FocusEventArgs e)
 		{
 			Debug.WriteLine("Unfocused");
 		}
 
-		void SetDatePickerToNull(object sender, EventArgs e)
+		void SetDatePickerToNull(object? sender, EventArgs e)
 		{
 			NullDatePicker.Date = null;
 		}
 
-		void SetDatePickerToToday(object sender, EventArgs e)
+		void SetDatePickerToToday(object? sender, EventArgs e)
 		{
 			NullDatePicker.Date = DateTime.Now;
 		}
 
-		void OnOpenClicked(object sender, EventArgs e)
+		void OnOpenClicked(object? sender, EventArgs e)
 		{
 			IsOpenDatePicker.IsOpen = true;
 		}
 
-		void OnCloseClicked(object sender, EventArgs e)
+		void OnCloseClicked(object? sender, EventArgs e)
 		{
 			IsOpenDatePicker.IsOpen = false;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml.cs
@@ -13,30 +13,30 @@ namespace Maui.Controls.Sample.Pages
 			UpdateEditorBackground();
 		}
 
-		void OnEditorCompleted(object sender, EventArgs e)
+		void OnEditorCompleted(object? sender, EventArgs e)
 		{
-			var text = ((Editor)sender).Text;
+			var text = ((Editor)sender!).Text;
 			DisplayAlertAsync("Completed", text, "Ok");
 		}
 
-		void OnEditorFocused(object sender, FocusEventArgs e)
+		void OnEditorFocused(object? sender, FocusEventArgs e)
 		{
-			var text = ((Editor)sender).Text;
+			var text = ((Editor)sender!).Text;
 			DisplayAlertAsync("Focused", text, "Ok");
 		}
 
-		void OnEditorUnfocused(object sender, FocusEventArgs e)
+		void OnEditorUnfocused(object? sender, FocusEventArgs e)
 		{
-			var text = ((Editor)sender).Text;
+			var text = ((Editor)sender!).Text;
 			DisplayAlertAsync("Unfocused", text, "Ok");
 		}
 
-		void OnUpdateBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnUpdateBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			UpdateEditorBackground();
 		}
 
-		void OnClearBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnClearBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			BackgroundEditor.Background = null;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -35,12 +35,12 @@ namespace Maui.Controls.Sample.Pages
 			UpdateEntryBackgroundColor();
 		}
 
-		void OnSlideCursorPositionValueChanged(object sender, ValueChangedEventArgs e)
+		void OnSlideCursorPositionValueChanged(object? sender, ValueChangedEventArgs e)
 		{
 			entryCursor.CursorPosition = (int)e.NewValue;
 		}
 
-		void OnSlideSelectionValueChanged(object sender, ValueChangedEventArgs e)
+		void OnSlideSelectionValueChanged(object? sender, ValueChangedEventArgs e)
 		{
 			entrySelection.SelectionLength = (int)e.NewValue;
 		}
@@ -61,40 +61,40 @@ namespace Maui.Controls.Sample.Pages
 				sldSelection.Maximum = ((Entry)sender!).Text.Length;
 		}
 
-		void OnEntryCompleted(object sender, EventArgs e)
+		void OnEntryCompleted(object? sender, EventArgs e)
 		{
-			var text = ((Microsoft.Maui.Controls.Entry)sender).Text;
+			var text = ((Microsoft.Maui.Controls.Entry)sender!).Text;
 			DisplayAlertAsync("Completed", text, "Ok");
 		}
 
-		void OnEntryFocused(object sender, FocusEventArgs e)
+		void OnEntryFocused(object? sender, FocusEventArgs e)
 		{
-			var text = ((Microsoft.Maui.Controls.Entry)sender).Text;
+			var text = ((Microsoft.Maui.Controls.Entry)sender!).Text;
 			DisplayAlertAsync("Focused", text, "Ok");
 		}
 
-		void OnEntryUnfocused(object sender, FocusEventArgs e)
+		void OnEntryUnfocused(object? sender, FocusEventArgs e)
 		{
-			var text = ((Entry)sender).Text;
+			var text = ((Entry)sender!).Text;
 			DisplayAlertAsync("Unfocused", text, "Ok");
 		}
 
-		void OnUpdateBackgroundColorButtonClicked(object sender, System.EventArgs e)
+		void OnUpdateBackgroundColorButtonClicked(object? sender, System.EventArgs e)
 		{
 			UpdateEntryBackgroundColor();
 		}
 
-		void OnClearBackgroundColorButtonClicked(object sender, System.EventArgs e)
+		void OnClearBackgroundColorButtonClicked(object? sender, System.EventArgs e)
 		{
 			BackgroundColorEntry.BackgroundColor = null;
 		}
 
-		void OnUpdateBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnUpdateBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			UpdateEntryBackground();
 		}
 
-		void OnClearBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnClearBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			BackgroundEntry.Background = null;
 		}
@@ -123,17 +123,17 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void ShowSoftInputAsyncButton_Clicked(object sender, EventArgs e)
+		void ShowSoftInputAsyncButton_Clicked(object? sender, EventArgs e)
 		{
 			PlaceholderEntryItem.ShowSoftInputAsync(System.Threading.CancellationToken.None);
 		}
 
-		void HideSoftInputAsyncButton_Clicked(object sender, EventArgs e)
+		void HideSoftInputAsyncButton_Clicked(object? sender, EventArgs e)
 		{
 			PlaceholderEntryItem.HideSoftInputAsync(System.Threading.CancellationToken.None);
 		}
 
-		void OnReturnTypeEntryTextChanged(object sender, TextChangedEventArgs e)
+		void OnReturnTypeEntryTextChanged(object? sender, TextChangedEventArgs e)
 		{
 			Random rnd = new Random();
 			var returnTypeCount = Enum.GetNames(typeof(ReturnType)).Length;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/HybridWebViewPage.xaml.cs
@@ -18,12 +18,12 @@ namespace Maui.Controls.Sample.Pages
 		}
 
 		int count;
-		private void SendMessageButton_Clicked(object sender, EventArgs e)
+		private void SendMessageButton_Clicked(object? sender, EventArgs e)
 		{
 			hwv.SendRawMessage($"Hello from C#! #{count++}");
 		}
 
-		private async void InvokeJSMethodButton_Clicked(object sender, EventArgs e)
+		private async void InvokeJSMethodButton_Clicked(object? sender, EventArgs e)
 		{
 			var statusResult = "";
 
@@ -47,7 +47,7 @@ namespace Maui.Controls.Sample.Pages
 			Dispatcher.Dispatch(() => statusText.Text += statusResult);
 		}
 
-		private async void InvokeAsyncJSMethodButton_Clicked(object sender, EventArgs e)
+		private async void InvokeAsyncJSMethodButton_Clicked(object? sender, EventArgs e)
 		{
 			var statusResult = "";
 
@@ -69,12 +69,12 @@ namespace Maui.Controls.Sample.Pages
 			Dispatcher.Dispatch(() => statusText.Text += statusResult);
 		}
 
-		private void hwv_RawMessageReceived(object sender, HybridWebViewRawMessageReceivedEventArgs e)
+		private void hwv_RawMessageReceived(object? sender, HybridWebViewRawMessageReceivedEventArgs e)
 		{
 			Dispatcher.Dispatch(() => statusText.Text += Environment.NewLine + e.Message);
 		}
 
-		private async void InvokeJSExceptionButton_Clicked(object sender, EventArgs e)
+		private async void InvokeJSExceptionButton_Clicked(object? sender, EventArgs e)
 		{
 			var statusResult = "";
 
@@ -97,7 +97,7 @@ namespace Maui.Controls.Sample.Pages
 			Dispatcher.Dispatch(() => statusText.Text += statusResult);
 		}
 
-		private async void InvokeJSAsyncExceptionButton_Clicked(object sender, EventArgs e)
+		private async void InvokeJSAsyncExceptionButton_Clicked(object? sender, EventArgs e)
 		{
 			var statusResult = "";
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImageButtonPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImageButtonPage.xaml.cs
@@ -25,30 +25,30 @@ namespace Maui.Controls.Sample.Pages
 			UpdateImageButtonBackground();
 		}
 
-		void OnImageButtonClicked(object sender, EventArgs e)
+		void OnImageButtonClicked(object? sender, EventArgs e)
 		{
 			_clickTotal += 1;
 			InfoLabel.Text = $"{_clickTotal} ImageButton click{(_clickTotal == 1 ? "" : "s")}";
 		}
 
-		void OnResizeImageButtonClicked(object sender, EventArgs e)
+		void OnResizeImageButtonClicked(object? sender, EventArgs e)
 		{
 			ResizeImageButton.HeightRequest = 100;
 			ResizeImageButton.WidthRequest = 100;
 		}
 
-		void UseOnlineSource_Clicked(object sender, EventArgs e)
+		void UseOnlineSource_Clicked(object? sender, EventArgs e)
 		{
 			AnimatedGifImage.Source =
 				ImageSource.FromUri(new Uri("https://raw.githubusercontent.com/dotnet/maui/126f47aaf9d5c01224f54fe1c6bfb1c8299cc2fe/src/Compatibility/ControlGallery/src/iOS/GifTwo.gif"));
 		}
 
-		void OnUpdateBackgroundButtonClicked(object sender, EventArgs e)
+		void OnUpdateBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			UpdateImageButtonBackground();
 		}
 
-		void OnRemoveBackgroundButtonClicked(object sender, EventArgs e)
+		void OnRemoveBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			BackgroundImageButton.Background = null;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml.cs
@@ -20,12 +20,12 @@ namespace Maui.Controls.Sample.Pages
 			StreamSourceImage.Source = ImageSource.FromStream(() => new MemoryStream(imageBytes));
 		}
 
-		void AnimationStartStop_Clicked(object sender, EventArgs e)
+		void AnimationStartStop_Clicked(object? sender, EventArgs e)
 		{
 			AnimatedGifImage.IsAnimationPlaying = !AnimatedGifImage.IsAnimationPlaying;
 		}
 
-		void UseOnlineSource_Clicked(object sender, EventArgs e)
+		void UseOnlineSource_Clicked(object? sender, EventArgs e)
 		{
 			AnimatedGifImage.Source =
 				ImageSource.FromUri(new Uri("https://raw.githubusercontent.com/dotnet/maui/126f47aaf9d5c01224f54fe1c6bfb1c8299cc2fe/src/Compatibility/ControlGallery/src/iOS/GifTwo.gif"));

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml.cs
@@ -17,12 +17,12 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = new LabelViewModel();
 		}
 
-		void TapGestureRecognizer_Tapped(object sender, EventArgs e)
+		void TapGestureRecognizer_Tapped(object? sender, EventArgs e)
 		{
 			SetRandomBackgroundColor(GestureSpan);
 		}
 
-		void ChangeFormattedString_Clicked(object sender, EventArgs e)
+		void ChangeFormattedString_Clicked(object? sender, EventArgs e)
 		{
 			labelFormattedString.FormattedText = new FormattedString
 			{
@@ -41,26 +41,26 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void OnLink1Tapped(object sender, EventArgs e)
+		void OnLink1Tapped(object? sender, EventArgs e)
 		{
 			SetRandomBackgroundColor(Link1);
 		}
 
-		void OnLink2Tapped(object sender, EventArgs e)
+		void OnLink2Tapped(object? sender, EventArgs e)
 		{
 			SetRandomBackgroundColor(Link2);
 		}
 
-		void OnLink3Tapped(object sender, EventArgs e)
+		void OnLink3Tapped(object? sender, EventArgs e)
 		{
 			SetRandomBackgroundColor(Link3);
 		}
-		void OnLink4Tapped(object sender, EventArgs e)
+		void OnLink4Tapped(object? sender, EventArgs e)
 		{
 			SetRandomBackgroundColor(Link4);
 		}
 
-		void OnLink5Tapped(object sender, EventArgs e)
+		void OnLink5Tapped(object? sender, EventArgs e)
 		{
 			SetRandomBackgroundColor(Link5);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml.cs
@@ -76,12 +76,12 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			pinsMap.Pins.Add(microsoftPin);
 		}
 
-		void OnAddPinClicked(object sender, EventArgs e)
+		void OnAddPinClicked(object? sender, EventArgs e)
 		{
 			AddPin();
 		}
 
-		void OnRemovePinClicked(object sender, EventArgs e)
+		void OnRemovePinClicked(object? sender, EventArgs e)
 		{
 			if (pinsMap.Pins.Count > 0)
 			{
@@ -90,7 +90,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			}
 		}
 
-		void OnAdd10PinsClicked(object sender, EventArgs e)
+		void OnAdd10PinsClicked(object? sender, EventArgs e)
 		{
 			for (int i = 0; i <= 10; i++)
 			{
@@ -107,7 +107,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			});
 		}
 
-		void OnMapClicked(object sender, MapClickedEventArgs e)
+		void OnMapClicked(object? sender, MapClickedEventArgs e)
 		{
 			DisplayAlertAsync("Map", $"Map {e.Location.Latitude}, {e.Location.Longitude} clicked.", "Ok");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapTypeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapTypeGallery.xaml.cs
@@ -13,11 +13,11 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			InitializeComponent();
 		}
 
-		void MapTypePicker_SelectedIndexChanged(object sender, System.EventArgs e)
+		void MapTypePicker_SelectedIndexChanged(object? sender, System.EventArgs e)
 		{
-			var picker = (Picker)sender;
+			var picker = (Picker)sender!;
 
-			switch (picker.SelectedItem.ToString())
+			switch (picker.SelectedItem!.ToString())
 			{
 				default:
 				case "Street":
@@ -32,7 +32,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			}
 		}
 
-		void OnSliderValueChanged(object sender, ValueChangedEventArgs e)
+		void OnSliderValueChanged(object? sender, ValueChangedEventArgs e)
 		{
 			double zoomLevel = e.NewValue;
 			double latlongDegrees = 360 / (Math.Pow(2, zoomLevel));

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PinItemsSourceGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PinItemsSourceGallery.xaml.cs
@@ -20,7 +20,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			map.MoveToRegion(MapSpan.FromCenterAndRadius(new Position(39.8283459, -98.5794797), Distance.FromMiles(1500)));
 		}
 
-		void OnMapClicked(object sender, MapClickedEventArgs e)
+		void OnMapClicked(object? sender, MapClickedEventArgs e)
 		{
 			System.Diagnostics.Debug.WriteLine($"MapClick: {e.Location.Latitude}, {e.Location.Longitude}");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PolygonsGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PolygonsGallery.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			InitializeComponent();
 		}
 
-		void OnClearMapElementsClicked(object sender, EventArgs args)
+		void OnClearMapElementsClicked(object? sender, EventArgs args)
 		{
 			MapElementsMap.MapElements.Clear();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/PickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/PickerPage.xaml.cs
@@ -46,9 +46,9 @@ namespace Maui.Controls.Sample.Pages
 			IsOpenPicker.Closed -= IsOpenPickerClosed;
 		}
 
-		void OnSelectedIndexChanged(object sender, EventArgs e)
+		void OnSelectedIndexChanged(object? sender, EventArgs e)
 		{
-			string selectedCountry = (string)((Picker)sender).SelectedItem;
+			string selectedCountry = (string)((Picker)sender!).SelectedItem;
 			DisplayAlertAsync("SelectedIndexChanged", selectedCountry, "Ok");
 		}
 
@@ -61,12 +61,12 @@ namespace Maui.Controls.Sample.Pages
 
 		public string[] MorePickerItems { get; } = Enumerable.Range(1, 20).Select(i => $"Item {i}").ToArray();
 
-		void OnUpdateBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnUpdateBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			UpdatePickerBackground();
 		}
 
-		void OnClearBackgroundButtonClicked(object sender, System.EventArgs e)
+		void OnClearBackgroundButtonClicked(object? sender, System.EventArgs e)
 		{
 			BackgroundPicker.Background = null;
 		}
@@ -88,19 +88,19 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void OnClearItemsButtonClicked(object sender, EventArgs e)
+		void OnClearItemsButtonClicked(object? sender, EventArgs e)
 		{
 			DynamicItemsPicker.Items.Clear();
 		}
 
-		void OnAddItemsButtonClicked(object sender, EventArgs e)
+		void OnAddItemsButtonClicked(object? sender, EventArgs e)
 		{
 			DynamicItemsPicker.Items.Add("New Item 1");
 			DynamicItemsPicker.Items.Add("New Item 2");
 			DynamicItemsPicker.Items.Add("New Item 3");
 		}
 
-		void OnReplaceItemsButtonClicked(object sender, EventArgs e)
+		void OnReplaceItemsButtonClicked(object? sender, EventArgs e)
 		{
 			DynamicItemsPicker.Items.Clear();
 
@@ -109,12 +109,12 @@ namespace Maui.Controls.Sample.Pages
 			DynamicItemsPicker.Items.Add("Item Three");
 		}
 
-		void OnSetBindingContextClicked(object sender, EventArgs e)
+		void OnSetBindingContextClicked(object? sender, EventArgs e)
 		{
 			UpdatePickerBindingContext();
 		}
 
-		void OnRemoveBindingContextClicked(object sender, EventArgs e)
+		void OnRemoveBindingContextClicked(object? sender, EventArgs e)
 		{
 			BindingContextLayout.BindingContext = null;
 		}
@@ -134,13 +134,13 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void OnUpdateHorizontalOptionsClicked(object sender, EventArgs e)
+		void OnUpdateHorizontalOptionsClicked(object? sender, EventArgs e)
 		{
 			AlignmentPicker.HorizontalOptions = GetLayoutOptions(_horizontalOptionsIndex);
 			UpdateIndex(ref _horizontalOptionsIndex);
 		}
 
-		void OnUpdateVerticalOptionsClicked(object sender, EventArgs e)
+		void OnUpdateVerticalOptionsClicked(object? sender, EventArgs e)
 		{
 			AlignmentPicker.VerticalOptions = GetLayoutOptions(_verticalOptionsIndex);
 			UpdateIndex(ref _verticalOptionsIndex);
@@ -169,12 +169,12 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnOpenClicked(object sender, EventArgs e)
+		void OnOpenClicked(object? sender, EventArgs e)
 		{
 			IsOpenPicker.IsOpen = true;
 		}
 
-		void OnCloseClicked(object sender, EventArgs e)
+		void OnCloseClicked(object? sender, EventArgs e)
 		{
 			IsOpenPicker.IsOpen = false;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ProgressBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ProgressBarPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnProgressToClicked(object sender, EventArgs args)
+		void OnProgressToClicked(object? sender, EventArgs args)
 		{
 			ProgressToBar.ProgressTo(1.0, 1000, Easing.Linear);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml.cs
@@ -15,12 +15,12 @@ namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
 			BindingContext = _viewModel;
 		}
 
-		private void Set_Button_Clicked(object sender, System.EventArgs e)
+		private void Set_Button_Clicked(object? sender, System.EventArgs e)
 		{
 			_viewModel.Selection = "B";
 		}
 
-		private void Clear_Button_Clicked(object sender, System.EventArgs e)
+		private void Clear_Button_Clicked(object? sender, System.EventArgs e)
 		{
 			_viewModel.Selection = null;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RefreshViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RefreshViewPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		private void OnToggleRefreshColorClicked(object sender, System.EventArgs e)
+		private void OnToggleRefreshColorClicked(object? sender, System.EventArgs e)
 		{
 			if (refreshView.RefreshColor == Colors.Red)
 			{
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void OnToggleRefreshBackgroundColorClicked(object sender, System.EventArgs e)
+		private void OnToggleRefreshBackgroundColorClicked(object? sender, System.EventArgs e)
 		{
 			if (refreshView.Background == SolidColorBrush.Yellow)
 			{
@@ -34,10 +34,10 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void OnTriggerRefreshClicked(object sender, System.EventArgs e) =>
+		private void OnTriggerRefreshClicked(object? sender, System.EventArgs e) =>
 			refreshView.IsRefreshing = !refreshView.IsRefreshing;
 
-		private void OnToggleEnabledClicked(object sender, System.EventArgs e) =>
+		private void OnToggleEnabledClicked(object? sender, System.EventArgs e) =>
 			refreshView.IsEnabled = !refreshView.IsEnabled;
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml.cs
@@ -10,21 +10,21 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnSearchBarFocused(object sender, FocusEventArgs e)
+		void OnSearchBarFocused(object? sender, FocusEventArgs e)
 		{
-			var text = ((SearchBar)sender).Text;
+			var text = ((SearchBar)sender!).Text;
 			DisplayAlertAsync("Focused", text, "Ok");
 		}
 
-		void OnSearchBarUnfocused(object sender, FocusEventArgs e)
+		void OnSearchBarUnfocused(object? sender, FocusEventArgs e)
 		{
-			var text = ((SearchBar)sender).Text;
+			var text = ((SearchBar)sender!).Text;
 			DisplayAlertAsync("Unfocused", text, "Ok");
 		}
 
-		void OnSearchBarTextChanged(object sender, TextChangedEventArgs args)
+		void OnSearchBarTextChanged(object? sender, TextChangedEventArgs args)
 		{
-			var text = ((SearchBar)sender).Text;
+			var text = ((SearchBar)sender!).Text;
 			Debug.WriteLine($"SearchBar Text changed: {text}");
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/ClipCornerRadiusGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/ClipCornerRadiusGallery.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			InitializeComponent();
 		}
 
-		void OnCornerChanged(object sender, ValueChangedEventArgs e)
+		void OnCornerChanged(object? sender, ValueChangedEventArgs e)
 		{
 			RoundRectangleGeometry.CornerRadius = new CornerRadius(
 				TopLeftCorner.Value,

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/UpdatePathDataGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesGalleries/UpdatePathDataGallery.xaml.cs
@@ -16,7 +16,7 @@ namespace Maui.Controls.Sample.Pages.ShapesGalleries
 			_pathFigureCollectionConverter = new PathFigureCollectionConverter();
 		}
 
-		void OnUpdatePathDataButtonClicked(object sender, EventArgs args)
+		void OnUpdatePathDataButtonClicked(object? sender, EventArgs args)
 		{
 			_counter += 10;
 			string pathData = $"M 10,100 C 10,{300 + _counter} {300 + _counter},-200 {300 + _counter},100";

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesPage.xaml.cs
@@ -9,7 +9,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnMoreSamplesClicked(object sender, EventArgs args)
+		void OnMoreSamplesClicked(object? sender, EventArgs args)
 		{
 			Navigation.PushAsync(new Pages.ShapesGalleries.ShapesGallery());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml.cs
@@ -14,12 +14,12 @@ namespace Maui.Controls.Sample.Pages
 			UpdateInfo();
 		}
 
-		void OnValueChanged(object sender, ValueChangedEventArgs args)
+		void OnValueChanged(object? sender, ValueChangedEventArgs args)
 		{
 			Debug.WriteLine($"Slider Value: {args.NewValue}");
 		}
 
-		private void ToggleImageSource(object sender, System.EventArgs e)
+		private void ToggleImageSource(object? sender, System.EventArgs e)
 		{
 			if (_imageSource is null)
 			{
@@ -33,18 +33,18 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnDynamicValueChanged(object sender, ValueChangedEventArgs args)
+		void OnDynamicValueChanged(object? sender, ValueChangedEventArgs args)
 		{
 			UpdateInfo();
 		}
 
-		void OnUpdateMinimumButtonClicked(object sender, System.EventArgs e)
+		void OnUpdateMinimumButtonClicked(object? sender, System.EventArgs e)
 		{
 			DynamicSlider.Minimum = 4;
 			UpdateInfo();
 		}
 
-		void OnUpdateMaximumButtonClicked(object sender, System.EventArgs e)
+		void OnUpdateMaximumButtonClicked(object? sender, System.EventArgs e)
 		{
 			DynamicSlider.Maximum = 8;
 			UpdateInfo();

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/StepperPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/StepperPage.xaml.cs
@@ -10,12 +10,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnValueChanged(object sender, ValueChangedEventArgs args)
+		void OnValueChanged(object? sender, ValueChangedEventArgs args)
 		{
 			Debug.WriteLine($"Stepper Value: {args.NewValue}");
 		}
 
-		void OnEnableButtonClicked(object sender, System.EventArgs e)
+		void OnEnableButtonClicked(object? sender, System.EventArgs e)
 		{
 			if (EnableStepper.IsEnabled)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/BasicSwipeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/BasicSwipeGallery.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		async void OnInvoked(object sender, EventArgs e)
+		async void OnInvoked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("SwipeView", "Delete Invoked", "OK");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/CustomSizeSwipeViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/CustomSizeSwipeViewGallery.xaml.cs
@@ -11,17 +11,17 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		void OnContentClicked(object sender, EventArgs args)
+		void OnContentClicked(object? sender, EventArgs args)
 		{
 			DisplayAlertAsync("OnClicked", "The Content Button has been clicked.", "Ok");
 		}
 
-		void OnRightItemsClicked(object sender, EventArgs args)
+		void OnRightItemsClicked(object? sender, EventArgs args)
 		{
 			DisplayAlertAsync("OnClicked", "The RightItems Button has been clicked.", "Ok");
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			DisplayAlertAsync("Custom SwipeItem", "Button Clicked!", "Ok");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/HorizontalSwipeThresholdGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/HorizontalSwipeThresholdGallery.xaml.cs
@@ -12,12 +12,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		void OnThresholdRevealSliderChanged(object sender, ValueChangedEventArgs args)
+		void OnThresholdRevealSliderChanged(object? sender, ValueChangedEventArgs args)
 		{
 			RevealThresholdSwipeView.Close();
 		}
 
-		void OnThresholdExecuteSliderChanged(object sender, ValueChangedEventArgs args)
+		void OnThresholdExecuteSliderChanged(object? sender, ValueChangedEventArgs args)
 		{
 			ExecuteThresholdSwipeView.Close();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemPositionGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemPositionGallery.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			ModePicker.SelectedIndex = 0;
 		}
 
-		void OnModePickerSelectedIndexChanged(object sender, EventArgs e)
+		void OnModePickerSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			LeftSwipeItems.Mode = TopSwipeItems.Mode = RightSwipeItems.Mode = BottomSwipeItems.Mode = ModePicker.SelectedIndex == 0 ? SwipeMode.Reveal : SwipeMode.Execute;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemSizeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemSizeGallery.xaml.cs
@@ -9,7 +9,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		void OnSwipeItemInvoked(object sender, EventArgs e)
+		void OnSwipeItemInvoked(object? sender, EventArgs e)
 		{
 			DisplayAlertAsync("SwipeItemSizeGallery", "Delete SwipeItem Invoked", "Ok");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemViewPositionGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeItemViewPositionGallery.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			ModePicker.SelectedIndex = 0;
 		}
 
-		void OnModePickerSelectedIndexChanged(object sender, EventArgs e)
+		void OnModePickerSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			LeftSwipeItems.Mode = TopSwipeItems.Mode = RightSwipeItems.Mode = BottomSwipeItems.Mode = ModePicker.SelectedIndex == 0 ? SwipeMode.Reveal : SwipeMode.Execute;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeListViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeListViewGallery.xaml.cs
@@ -18,7 +18,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			WeakReferenceMessenger.Default.Register<SwipeViewGalleryViewModel, string>(this, "delete", (_, sender) => { DisplayAlertAsync("SwipeView", "Delete", "Ok"); });
 		}
 
-		async void OnSwipeListViewItemTapped(object sender, ItemTappedEventArgs args)
+		async void OnSwipeListViewItemTapped(object? sender, ItemTappedEventArgs args)
 		{
 			await DisplayAlertAsync("OnSwipeListViewItemTapped", "You have tapped a ListView item", "Ok");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewNoLayoutGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewNoLayoutGallery.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		async void OnInvoked(object sender, EventArgs e)
+		async void OnInvoked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("SwipeView", "SwipeItem Invoked", "OK");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/VerticalSwipeThresholdGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/VerticalSwipeThresholdGallery.xaml.cs
@@ -11,12 +11,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		void OnThresholdRevealSliderChanged(object sender, ValueChangedEventArgs args)
+		void OnThresholdRevealSliderChanged(object? sender, ValueChangedEventArgs args)
 		{
 			RevealThresholdSwipeView.Close();
 		}
 
-		void OnThresholdExecuteSliderChanged(object sender, ValueChangedEventArgs args)
+		void OnThresholdExecuteSliderChanged(object? sender, ValueChangedEventArgs args)
 		{
 			ExecuteThresholdSwipeView.Close();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/TimePickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/TimePickerPage.xaml.cs
@@ -29,12 +29,12 @@ namespace Maui.Controls.Sample.Pages
 			IsOpenTimePicker.Closed -= IsOpenTimePickerClosed;
 		}
 
-		void OnUpdateBackgroundButtonClicked(object sender, EventArgs e)
+		void OnUpdateBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			UpdateTimePickerBackground();
 		}
 
-		void OnClearBackgroundButtonClicked(object sender, EventArgs e)
+		void OnClearBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			BackgroundTimePicker.Background = null;
 		}
@@ -56,22 +56,22 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void SetTimePickerToNull(object sender, EventArgs e)
+		void SetTimePickerToNull(object? sender, EventArgs e)
 		{
 			NullTimePicker.Time = null;
 		}
 
-		void SetTimePickerToNow(object sender, EventArgs e)
+		void SetTimePickerToNow(object? sender, EventArgs e)
 		{
 			NullTimePicker.Time = DateTime.Now.TimeOfDay;
 		}
 
-		void OnOpenClicked(object sender, EventArgs e)
+		void OnOpenClicked(object? sender, EventArgs e)
 		{
 			IsOpenTimePicker.IsOpen = true;
 		}
 
-		void OnCloseClicked(object sender, EventArgs e)
+		void OnCloseClicked(object? sender, EventArgs e)
 		{
 			IsOpenTimePicker.IsOpen = false;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/TitleBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/TitleBarPage.xaml.cs
@@ -39,7 +39,7 @@ namespace Maui.Controls.Sample.Pages
 			Application.Current!.Windows[0].TitleBar = _customTitleBar;
 		}
 
-		private void SetIconCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void SetIconCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -51,7 +51,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void ColorButton_Clicked(object sender, EventArgs e)
+		private void ColorButton_Clicked(object? sender, EventArgs e)
 		{
 			if (Microsoft.Maui.Graphics.Color.TryParse(ColorTextBox.Text, out var color))
 			{
@@ -59,7 +59,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void ForegroundColorButton_Clicked(object sender, EventArgs e)
+		private void ForegroundColorButton_Clicked(object? sender, EventArgs e)
 		{
 			if (Microsoft.Maui.Graphics.Color.TryParse(ForegroundColorTextBox.Text, out var color))
 			{
@@ -67,7 +67,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void LeadingCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void LeadingCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -82,7 +82,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void ContentCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void ContentCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -101,12 +101,12 @@ namespace Maui.Controls.Sample.Pages
 		}
 
 
-		async void PushNewTitleBarPage_Clicked(object sender, EventArgs e)
+		async void PushNewTitleBarPage_Clicked(object? sender, EventArgs e)
 		{
 			await Navigation.PushAsync(new TitleBarPage());
 		}
 
-		void ToggleTitleBarOnWindow_Clicked(object sender, EventArgs e)
+		void ToggleTitleBarOnWindow_Clicked(object? sender, EventArgs e)
 		{
 			if (Window.TitleBar is not null)
 				Window.TitleBar = null;
@@ -114,7 +114,7 @@ namespace Maui.Controls.Sample.Pages
 				Window.TitleBar = _customTitleBar;
 		}
 
-		void ToggleHasNavigationBar_Clicked(object sender, EventArgs eventArgs)
+		void ToggleHasNavigationBar_Clicked(object? sender, EventArgs eventArgs)
 		{
 			if (Shell.GetNavBarIsVisible(this))
 			{
@@ -128,7 +128,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void TrailingCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void TrailingCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -155,7 +155,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void TallModeCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void TallModeCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewGalleries/WebViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewGalleries/WebViewGallery.xaml.cs
@@ -30,7 +30,7 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			MauiWebView.ProcessTerminated -= OnMauiWebViewProcessTerminated;
 		}
 
-		void OnUpdateHtmlSourceClicked(object sender, EventArgs args)
+		void OnUpdateHtmlSourceClicked(object? sender, EventArgs args)
 		{
 			Random rnd = new();
 			HtmlWebViewSource htmlWebViewSource = new();
@@ -38,7 +38,7 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			htmlWebViewSource.Html += $"<h1>Updated Content {rnd.Next()}!</h1><br>";
 		}
 
-		void OnGoBackClicked(object sender, EventArgs args)
+		void OnGoBackClicked(object? sender, EventArgs args)
 		{
 			Debug.WriteLine($"CanGoBack {MauiWebView.CanGoBack}");
 
@@ -48,7 +48,7 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			}
 		}
 
-		void OnGoForwardClicked(object sender, EventArgs args)
+		void OnGoForwardClicked(object? sender, EventArgs args)
 		{
 			Debug.WriteLine($"CanGoForward {MauiWebView.CanGoForward}");
 
@@ -58,12 +58,12 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			}
 		}
 
-		void OnReloadClicked(object sender, EventArgs args)
+		void OnReloadClicked(object? sender, EventArgs args)
 		{
 			MauiWebView.Reload();
 		}
 
-		void OnEvalClicked(object sender, EventArgs args)
+		void OnEvalClicked(object? sender, EventArgs args)
 		{
 			MauiWebView.Eval("alert('text')");
 		}
@@ -91,7 +91,7 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 #endif
 		}
 
-		async void OnEvalAsyncClicked(object sender, EventArgs args)
+		async void OnEvalAsyncClicked(object? sender, EventArgs args)
 		{
 			MauiWebView.Eval("alert('text')");
 
@@ -101,12 +101,12 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			EvalResultLabel.Text = result;
 		}
 
-		async void OnLoadHtmlFileClicked(object sender, EventArgs e)
+		async void OnLoadHtmlFileClicked(object? sender, EventArgs e)
 		{
 			await LoadMauiAsset();
 		}
 
-		async void OnSetUserAgentClicked(object sender, EventArgs e)
+		async void OnSetUserAgentClicked(object? sender, EventArgs e)
 		{
 			input.Text = "useragent.html";
 			await LoadMauiAsset();
@@ -121,17 +121,17 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			FileWebView.Source = new HtmlWebViewSource { Html = html };
 		}
 
-		void OnAllowMixedContentClicked(object sender, EventArgs e)
+		void OnAllowMixedContentClicked(object? sender, EventArgs e)
 		{
 			MauiWebView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetMixedContentMode(MixedContentHandling.AlwaysAllow);
 		}
 
-		void OnEnableZoomControlsClicked(object sender, EventArgs e)
+		void OnEnableZoomControlsClicked(object? sender, EventArgs e)
 		{
 			MauiWebView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().EnableZoomControls(true);
 		}
 
-		void OnJavaScriptEnabledClicked(object sender, EventArgs e)
+		void OnJavaScriptEnabledClicked(object? sender, EventArgs e)
 		{
 			bool isJavaScriptEnabled = MauiWebView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().IsJavaScriptEnabled();
 
@@ -147,12 +147,12 @@ namespace Maui.Controls.Sample.Pages.WebViewGalleries
 			}
 		}
 
-		void OnLoadHtml5VideoClicked(object sender, EventArgs e)
+		void OnLoadHtml5VideoClicked(object? sender, EventArgs e)
 		{
 			MauiWebView.Source = new UrlWebViewSource { Url = "video.html" };
 		}
 
-		void OnLoadHttpBinClicked(object sender, EventArgs e)
+		void OnLoadHttpBinClicked(object? sender, EventArgs e)
 		{
 			// on httpbin.org find the section where you can load the cookies for the website.
 			// The cookie that is set below should show up for this to succeed.

--- a/src/Controls/samples/Controls.Sample/Pages/Core/AlertsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/AlertsPage.xaml.cs
@@ -17,30 +17,30 @@ namespace Maui.Controls.Sample.Pages
 			await DisplayAlertAsync("Alert", "Welcome to the Alerts Page", "Hello!");
 		}
 
-		async void OnAlertSimpleClicked(object sender, EventArgs e)
+		async void OnAlertSimpleClicked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("Alert", "You have been alerted", "OK");
 		}
 
-		async void OnAlertYesNoClicked(object sender, EventArgs e)
+		async void OnAlertYesNoClicked(object? sender, EventArgs e)
 		{
 			var answer = await DisplayAlertAsync("Question?", "Would you like to play a game", "Yes", "No");
 			Debug.WriteLine("Answer: " + answer);
 		}
 
-		async void OnActionSheetSimpleClicked(object sender, EventArgs e)
+		async void OnActionSheetSimpleClicked(object? sender, EventArgs e)
 		{
 			var action = await DisplayActionSheetAsync("ActionSheet: Send to?", "Cancel", null, "Email", "Twitter", "Facebook");
 			Debug.WriteLine("Action: " + action);
 		}
 
-		async void OnActionSheetCancelDeleteClicked(object sender, EventArgs e)
+		async void OnActionSheetCancelDeleteClicked(object? sender, EventArgs e)
 		{
 			var action = await DisplayActionSheetAsync("ActionSheet: SavePhoto?", "Cancel", "Delete", "Photo Roll", "Email");
 			Debug.WriteLine("Action: " + action);
 		}
 
-		async void OnQuestion1ButtonClicked(object sender, EventArgs e)
+		async void OnQuestion1ButtonClicked(object? sender, EventArgs e)
 		{
 			string result = await DisplayPromptAsync("Question 1", "What's your name?", initialValue: string.Empty);
 
@@ -50,7 +50,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		async void OnQuestion2ButtonClicked(object sender, EventArgs e)
+		async void OnQuestion2ButtonClicked(object? sender, EventArgs e)
 		{
 			string result = await DisplayPromptAsync("Question 2", "What's 5 + 5?", initialValue: "10", maxLength: 2, keyboard: Keyboard.Numeric);
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ApplicationControlPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ApplicationControlPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnTerminateClicked(object sender, EventArgs e)
+		void OnTerminateClicked(object? sender, EventArgs e)
 		{
 			Application.Current!.Quit();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderClipPlayground.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderClipPlayground.xaml.cs
@@ -18,22 +18,22 @@ namespace Maui.Controls.Sample.Pages
 			UpdateCornerRadius();
 		}
 
-		void OnBorderShapeSelectedIndexChanged(object sender, EventArgs e)
+		void OnBorderShapeSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			UpdateBorderShape();
 		}
 
-		void OnBorderChanged(object sender, TextChangedEventArgs e)
+		void OnBorderChanged(object? sender, TextChangedEventArgs e)
 		{
 			UpdateBorder();
 		}
 
-		void OnBorderWidthChanged(object sender, ValueChangedEventArgs e)
+		void OnBorderWidthChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateBorder();
 		}
 
-		void OnCornerRadiusChanged(object sender, ValueChangedEventArgs e)
+		void OnCornerRadiusChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateCornerRadius();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderPlayground.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderPlayground.xaml.cs
@@ -24,58 +24,58 @@ namespace Maui.Controls.Sample.Pages
 			UpdateCornerRadius();
 		}
 
-		void OnBorderContentSelectedIndexChanged(object sender, EventArgs e)
+		void OnBorderContentSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			UpdateBorderContent();
 			UpdateBorder();
 		}
 
-		void OnBorderShapeSelectedIndexChanged(object sender, EventArgs e)
+		void OnBorderShapeSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			UpdateBorderShape();
 		}
 
-		void OnBorderLineJoinSelectedIndexChanged(object sender, EventArgs e)
+		void OnBorderLineJoinSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			UpdateBorderShape();
 		}
 
-		void OnBorderLineCapSelectedIndexChanged(object sender, EventArgs e)
+		void OnBorderLineCapSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			UpdateBorderShape();
 		}
 
-		void OnBackgroundChanged(object sender, TextChangedEventArgs e)
+		void OnBackgroundChanged(object? sender, TextChangedEventArgs e)
 		{
 			UpdateBackground();
 		}
 
-		void OnBorderChanged(object sender, TextChangedEventArgs e)
+		void OnBorderChanged(object? sender, TextChangedEventArgs e)
 		{
 			UpdateBorder();
 		}
 
-		void OnBorderWidthChanged(object sender, ValueChangedEventArgs e)
+		void OnBorderWidthChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateBorder();
 		}
 
-		void OnBorderDashArrayChanged(object sender, TextChangedEventArgs e)
+		void OnBorderDashArrayChanged(object? sender, TextChangedEventArgs e)
 		{
 			UpdateBorder();
 		}
 
-		void OnBorderDashOffsetChanged(object sender, ValueChangedEventArgs e)
+		void OnBorderDashOffsetChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateBorder();
 		}
 
-		void OnCornerRadiusChanged(object sender, ValueChangedEventArgs e)
+		void OnCornerRadiusChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateCornerRadius();
 		}
 
-		void OnContentBackgroundCheckBoxChanged(object sender, CheckedChangedEventArgs e)
+		void OnContentBackgroundCheckBoxChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			UpdateContentBackground();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderStyles.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BorderGalleries/BorderStyles.xaml.cs
@@ -14,9 +14,9 @@ namespace Maui.Controls.Sample.Pages
 			ChangeCornerRadius(0);
 		}
 
-		void OnIncreaseCornerRadius(object sender, EventArgs e) => ChangeCornerRadius(10);
+		void OnIncreaseCornerRadius(object? sender, EventArgs e) => ChangeCornerRadius(10);
 
-		void OnDecreaseCornerRadius(object sender, EventArgs e) => ChangeCornerRadius(-10);
+		void OnDecreaseCornerRadius(object? sender, EventArgs e) => ChangeCornerRadius(-10);
 
 		void ChangeCornerRadius(double delta)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BrushesPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BrushesPage.xaml.cs
@@ -20,7 +20,7 @@ namespace Maui.Controls.Sample.Pages
 		public Color Start { get; set; } = Colors.Red;
 		public Color Stop { get; set; } = Colors.Orange;
 
-		void OnUpdateSolidColorClicked(object sender, EventArgs e)
+		void OnUpdateSolidColorClicked(object? sender, EventArgs e)
 		{
 			var color = GetRandomColor();
 
@@ -31,12 +31,12 @@ namespace Maui.Controls.Sample.Pages
 				solidBrushPolygon.Color = color;
 		}
 
-		void OnRemovePolygonSolidColorClicked(object sender, EventArgs e)
+		void OnRemovePolygonSolidColorClicked(object? sender, EventArgs e)
 		{
 			BrushChangesLayout.Children.Remove(SolidBrushPolygon);
 		}
 
-		void OnUpdateLinearColorsClicked(object sender, EventArgs e)
+		void OnUpdateLinearColorsClicked(object? sender, EventArgs e)
 		{
 			var gradientStop = GetRandomGradientStop();
 			var color = GetRandomColor();
@@ -54,12 +54,12 @@ namespace Maui.Controls.Sample.Pages
 			randomStop.Color = color;
 		}
 
-		void OnRemovePolygonLinearColorsClicked(object sender, EventArgs e)
+		void OnRemovePolygonLinearColorsClicked(object? sender, EventArgs e)
 		{
 			BrushChangesLayout.Children.Remove(LinearBrushPolygon);
 		}
 
-		void OnUpdateRadialColorsClicked(object sender, EventArgs e)
+		void OnUpdateRadialColorsClicked(object? sender, EventArgs e)
 		{
 			var gradientStop = GetRandomGradientStop();
 			var color = GetRandomColor();
@@ -68,7 +68,7 @@ namespace Maui.Controls.Sample.Pages
 			UpdateGradientStopColor(RadialBrushPolygon.Fill as RadialGradientBrush, gradientStop, color);
 		}
 
-		void OnRemovePolygonRadialColorsClicked(object sender, EventArgs e)
+		void OnRemovePolygonRadialColorsClicked(object? sender, EventArgs e)
 		{
 			BrushChangesLayout.Children.Remove(RadialBrushPolygon);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ContextFlyoutPage.xaml.cs
@@ -92,23 +92,23 @@ namespace Maui.Controls.Sample.Pages
 		int count;
 		private bool _isDynamicCommandEnabled;
 
-		void OnIncrementByOneClicked(object sender, EventArgs e)
+		void OnIncrementByOneClicked(object? sender, EventArgs e)
 		{
 			count++;
 			OnPropertyChanged(nameof(CounterValue));
 		}
 
-		void OnIncrementMenuItemClicked(object sender, EventArgs e)
+		void OnIncrementMenuItemClicked(object? sender, EventArgs e)
 		{
-			var menuItem = (MenuFlyoutItem)sender;
-			var incrementAmount = int.Parse((string)menuItem.CommandParameter);
+			var menuItem = (MenuFlyoutItem)sender!;
+			var incrementAmount = int.Parse((string)menuItem.CommandParameter!);
 			count += incrementAmount;
 			OnPropertyChanged(nameof(CounterValue));
 		}
 
 		public string CounterValue => count.ToString("N0");
 
-		async void OnEntryShowTextClicked(object sender, EventArgs e)
+		async void OnEntryShowTextClicked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync(
 				title: "Entry",
@@ -116,17 +116,17 @@ namespace Maui.Controls.Sample.Pages
 				cancel: "OK");
 		}
 
-		void OnEntryAddTextClicked(object sender, EventArgs e)
+		void OnEntryAddTextClicked(object? sender, EventArgs e)
 		{
 			EntryWithContextFlyout.Text += " more text!";
 		}
 
-		void OnEntryClearTextClicked(object sender, EventArgs e)
+		void OnEntryClearTextClicked(object? sender, EventArgs e)
 		{
 			EntryWithContextFlyout.Text = "";
 		}
 
-		async void OnImageContextClicked(object sender, EventArgs e)
+		async void OnImageContextClicked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync(
 				title: "Image",
@@ -134,33 +134,33 @@ namespace Maui.Controls.Sample.Pages
 				cancel: "OK");
 		}
 
-		void OnWebViewGoToSiteClicked(object sender, EventArgs e)
+		void OnWebViewGoToSiteClicked(object? sender, EventArgs e)
 		{
 			ContextMenuWebView.Source = new UrlWebViewSource() { Url = "https://github.com/dotnet/maui", };
 		}
 
-		async void OnWebViewInvokeJSClicked(object sender, EventArgs e)
+		async void OnWebViewInvokeJSClicked(object? sender, EventArgs e)
 		{
 			await ContextMenuWebView.EvaluateJavaScriptAsync(@"alert('help, i\'m being invoked!');");
 		}
 
 		int newMenuItemCount = 0;
 
-		void OnAddMenuClicked(object sender, EventArgs e)
+		void OnAddMenuClicked(object? sender, EventArgs e)
 		{
-			var contextFlyout = (((MenuFlyoutItem)sender).Parent as MenuFlyout)!;
+			var contextFlyout = (((MenuFlyoutItem)sender!).Parent as MenuFlyout)!;
 			AddNewMenu(contextFlyout, "top-level");
 		}
 
-		void OnAddSubMenuClicked(object sender, EventArgs e)
+		void OnAddSubMenuClicked(object? sender, EventArgs e)
 		{
-			var subMenu = (MenuFlyoutSubItem)((MenuFlyoutItem)sender).Parent;
+			var subMenu = (MenuFlyoutSubItem)((MenuFlyoutItem)sender!).Parent!;
 			AddNewMenu(subMenu, "sub-menu", subMenu.Count - 2, subMenu.Count % 2 == 0);
 			CheckSubMenu();
 		}
-		void OnRemoveSubMenuClicked(object sender, EventArgs e)
+		void OnRemoveSubMenuClicked(object? sender, EventArgs e)
 		{
-			var subMenu = (MenuFlyoutSubItem)((MenuFlyoutItem)sender).Parent;
+			var subMenu = (MenuFlyoutSubItem)((MenuFlyoutItem)sender!).Parent!;
 			subMenu.RemoveAt(subMenu.Count - 3);
 			CheckSubMenu();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		async void OnFailAccessClicked(object sender, EventArgs e)
+		async void OnFailAccessClicked(object? sender, EventArgs e)
 		{
 			try
 			{
@@ -27,7 +27,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		async void OnAccessClicked(object sender, EventArgs e)
+		async void OnAccessClicked(object? sender, EventArgs e)
 		{
 			try
 			{
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnLaterClicked(object sender, EventArgs e)
+		void OnLaterClicked(object? sender, EventArgs e)
 		{
 			var now = DateTime.Now;
 			laterLabel.Dispatcher.DispatchDelayed(TimeSpan.FromSeconds(3), () =>
@@ -58,7 +58,7 @@ namespace Maui.Controls.Sample.Pages
 
 		IDispatcherTimer? _timer;
 
-		void OnTimerClicked(object sender, EventArgs e)
+		void OnTimerClicked(object? sender, EventArgs e)
 		{
 			if (_timer != null)
 			{
@@ -90,7 +90,7 @@ namespace Maui.Controls.Sample.Pages
 		bool keepRunning;
 
 		[Obsolete]
-		void OnObsoleteClicked(object sender, EventArgs e)
+		void OnObsoleteClicked(object? sender, EventArgs e)
 		{
 			if (keepRunning)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DragAndDropBetweenLayouts.xaml.cs
@@ -34,9 +34,9 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = this;
 		}
 
-		private void OnDragStarting(object sender, DragStartingEventArgs e)
+		private void OnDragStarting(object? sender, DragStartingEventArgs e)
 		{
-			var boxView = (View)((Element)sender)!.Parent;
+			var boxView = (View)((Element)sender!).Parent!;
 			DragStartingTitle.IsVisible = true;
 			DragStartingPositionLabel.Text = $"- Self X:{(int)e.GetPosition(boxView)!.Value.X}, Y:{(int)e.GetPosition(boxView)!.Value.Y}";
 			DragStartingScreenPositionLabel.Text = $"- Screen X:{(int)e.GetPosition(null)!.Value.X}, Y:{(int)e.GetPosition(null)!.Value.Y}";
@@ -52,9 +52,9 @@ namespace Maui.Controls.Sample.Pages
 				SLAllColors.Background = SolidColorBrush.LightBlue;
 		}
 
-		private void OnDropCompleted(object sender, DropCompletedEventArgs e)
+		private void OnDropCompleted(object? sender, DropCompletedEventArgs e)
 		{
-			var sl = ((Element)sender).Parent as StackLayout;
+			var sl = ((Element)sender!).Parent as StackLayout;
 
 			if (sl == SLAllColors)
 				SLRainbow.Background = SolidColorBrush.White;
@@ -63,9 +63,9 @@ namespace Maui.Controls.Sample.Pages
 
 		}
 
-		private void OnDragOver(object sender, DragEventArgs e)
+		private void OnDragOver(object? sender, DragEventArgs e)
 		{
-			var sl = (StackLayout)((Element)sender).Parent;
+			var sl = (StackLayout)((Element)sender!).Parent!;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -84,9 +84,9 @@ namespace Maui.Controls.Sample.Pages
 			sl.Background = SolidColorBrush.LightPink;
 		}
 
-		private void OnDragLeave(object sender, DragEventArgs e)
+		private void OnDragLeave(object? sender, DragEventArgs e)
 		{
-			var sl = (StackLayout)((Element)sender).Parent;
+			var sl = (StackLayout)((Element)sender!).Parent!;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;
@@ -105,9 +105,9 @@ namespace Maui.Controls.Sample.Pages
 			sl.Background = SolidColorBrush.LightBlue;
 		}
 
-		private void OnDrop(object sender, DropEventArgs e)
+		private void OnDrop(object? sender, DropEventArgs e)
 		{
-			var sl = ((Element)sender).Parent as StackLayout;
+			var sl = ((Element)sender!).Parent as StackLayout;
 
 			if (!e.Data.Properties.ContainsKey("Source"))
 				return;

--- a/src/Controls/samples/Controls.Sample/Pages/Core/FlyoutPageGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/FlyoutPageGallery.xaml.cs
@@ -15,7 +15,7 @@ namespace Maui.Controls.Sample.Pages
 			flyoutBehaviorPicker.SelectedIndexChanged += OnFlyoutBehaviorPickerSelectedIndexChanged;
 		}
 
-		void OnGestureEnabledCheckChanged(object sender, CheckedChangedEventArgs e)
+		void OnGestureEnabledCheckChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (FlyoutPage == null)
 				return;
@@ -62,14 +62,14 @@ namespace Maui.Controls.Sample.Pages
 			FlyoutPage.FlyoutLayoutBehavior = (FlyoutLayoutBehavior)behavior;
 		}
 
-		void ShowFlyout(object sender, EventArgs e)
+		void ShowFlyout(object? sender, EventArgs e)
 		{
 			if (FlyoutPage == null)
 				return;
 			FlyoutPage.IsPresented = true;
 		}
 
-		void CloseFlyout(object sender, EventArgs e)
+		void CloseFlyout(object? sender, EventArgs e)
 		{
 			if (FlyoutPage == null)
 				return;

--- a/src/Controls/samples/Controls.Sample/Pages/Core/FocusPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/FocusPage.xaml.cs
@@ -9,17 +9,17 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnFocusClicked(object sender, EventArgs e)
+		void OnFocusClicked(object? sender, EventArgs e)
 		{
 			FocusEntry.Focus();
 		}
 
-		void OnUnfocusClicked(object sender, EventArgs e)
+		void OnUnfocusClicked(object? sender, EventArgs e)
 		{
 			FocusEntry.Unfocus();
 		}
 
-		void OnFocusEntryFocusChanged(object sender, Microsoft.Maui.Controls.FocusEventArgs e)
+		void OnFocusEntryFocusChanged(object? sender, Microsoft.Maui.Controls.FocusEventArgs e)
 		{
 			InfoLabel.Text += e.IsFocused ? "Focused" + Environment.NewLine : "Unfocused" + Environment.NewLine;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/InputTransparentPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/InputTransparentPage.xaml.cs
@@ -11,13 +11,13 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void ClickFail(object sender, EventArgs e)
+		void ClickFail(object? sender, EventArgs e)
 		{
 			Debug.WriteLine("Failure; You shouldn't have been able to interact with that.");
 			DisplayAlertAsync("Failure", "You shouldn't have been able to interact with that.", "OK");
 		}
 
-		void ClickSuccess(object sender, EventArgs e)
+		void ClickSuccess(object? sender, EventArgs e)
 		{
 			Debug.WriteLine("Success; That should have worked, and it did!");
 			DisplayAlertAsync("Success", "That should have worked, and it did!", "OK");

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MenuBarPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MenuBarPage.cs
@@ -27,7 +27,7 @@ namespace Maui.Controls.Sample.Pages
 			);
 		}
 
-		void ItemClicked(object sender, EventArgs e)
+		void ItemClicked(object? sender, EventArgs e)
 		{
 			if (sender is MenuFlyoutItem mfi)
 			{
@@ -35,7 +35,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnToggleMenuBarItem(object sender, EventArgs e)
+		void OnToggleMenuBarItem(object? sender, EventArgs e)
 		{
 			var barItem =
 				MenuBarItems.FirstOrDefault(x => x.Text == "Added Menu");

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
@@ -44,7 +44,7 @@ namespace Maui.Controls.Sample.Pages
 			PopModal.IsVisible = Navigation.ModalStack.Count > 0;
 		}
 
-		async void PushNavigationModalClicked(object sender, EventArgs e)
+		async void PushNavigationModalClicked(object? sender, EventArgs e)
 		{
 			var modalPage = new ModalPage();
 			Page pushMe = new NavigationPage(modalPage)
@@ -58,7 +58,7 @@ namespace Maui.Controls.Sample.Pages
 
 		}
 
-		async void PushModalClicked(object sender, EventArgs e)
+		async void PushModalClicked(object? sender, EventArgs e)
 		{
 			Page pushMe = new ModalPage()
 			{
@@ -69,7 +69,7 @@ namespace Maui.Controls.Sample.Pages
 			await Navigation.PushModalAsync(pushMe);
 		}
 
-		async void PushClicked(object sender, EventArgs e)
+		async void PushClicked(object? sender, EventArgs e)
 		{
 			await Navigation.PushAsync(new ModalPage()
 			{
@@ -78,12 +78,12 @@ namespace Maui.Controls.Sample.Pages
 			});
 		}
 
-		async void PopModalClicked(object sender, EventArgs e)
+		async void PopModalClicked(object? sender, EventArgs e)
 		{
 			await Navigation.PopModalAsync();
 		}
 
-		async void PushFlyoutPageClicked(object sender, EventArgs e)
+		async void PushFlyoutPageClicked(object? sender, EventArgs e)
 		{
 			var modalPage = new ModalPage();
 			Page newMainPage = new NavigationPage(modalPage)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -15,17 +15,17 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = this;
 		}
 
-		void OnNewWindowClicked(object sender, EventArgs e)
+		void OnNewWindowClicked(object? sender, EventArgs e)
 		{
 			Application.Current!.OpenWindow(new Window(new MultiWindowPage()));
 		}
 
-		void OnCloseWindowClicked(object sender, EventArgs e)
+		void OnCloseWindowClicked(object? sender, EventArgs e)
 		{
 			Application.Current!.CloseWindow(Window);
 		}
 
-		void ActivateWindowClicked(object sender, EventArgs e)
+		void ActivateWindowClicked(object? sender, EventArgs e)
 		{
 			IReadOnlyList<Window> windows = Application.Current!.Windows;
 
@@ -44,24 +44,24 @@ namespace Maui.Controls.Sample.Pages
 			Application.Current!.ActivateWindow(windowToActivate);
 		}
 
-		async void OnOpenDialogClicked(object sender, EventArgs e)
+		async void OnOpenDialogClicked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("Information", "The dialog should open by Window.", "Ok");
 		}
 
-		void OnSetMaxSize(object sender, EventArgs e)
+		void OnSetMaxSize(object? sender, EventArgs e)
 		{
 			Window.MaximumWidth = 800;
 			Window.MaximumHeight = 600;
 		}
 
-		void OnSetMinSize(object sender, EventArgs e)
+		void OnSetMinSize(object? sender, EventArgs e)
 		{
 			Window.MinimumWidth = 640;
 			Window.MinimumHeight = 480;
 		}
 
-		void OnSetFreeSize(object sender, EventArgs e)
+		void OnSetFreeSize(object? sender, EventArgs e)
 		{
 			Window.MaximumWidth = double.PositiveInfinity;
 			Window.MaximumHeight = double.PositiveInfinity;
@@ -70,13 +70,13 @@ namespace Maui.Controls.Sample.Pages
 			Window.MinimumHeight = -1d;
 		}
 
-		void OnSetCustomSize(object sender, EventArgs e)
+		void OnSetCustomSize(object? sender, EventArgs e)
 		{
 			Window.Width = 700;
 			Window.Height = 500;
 		}
 
-		void OnCenterWindow(object sender, EventArgs e)
+		void OnCenterWindow(object? sender, EventArgs e)
 		{
 			var disp = DeviceDisplay.MainDisplayInfo;
 
@@ -84,12 +84,12 @@ namespace Maui.Controls.Sample.Pages
 			Window.Y = (disp.Height / disp.Density - Window.Height) / 2;
 		}
 
-		void isMinimizableSwitch_Toggled(object sender, ToggledEventArgs e)
+		void isMinimizableSwitch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			Window.IsMinimizable = e.Value;
 		}
 
-		void isMaximizableSwitch_Toggled(object sender, ToggledEventArgs e)
+		void isMaximizableSwitch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			Window.IsMaximizable = e.Value;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
@@ -22,43 +22,43 @@ namespace Maui.Controls.Sample.Pages
 			this.Title = $"PAGE NUMBER {pageCount}";
 		}
 
-		void InsertPage(object sender, EventArgs e)
+		void InsertPage(object? sender, EventArgs e)
 		{
 			Navigation.InsertPageBefore(new NavigationGallery(), Navigation.NavigationStack.Last());
 		}
 
-		async void PopPage(object sender, EventArgs e)
+		async void PopPage(object? sender, EventArgs e)
 		{
 			await Navigation.PopAsync(true);
 		}
 
-		async void PushPage(object sender, EventArgs e)
+		async void PushPage(object? sender, EventArgs e)
 		{
 			await Navigation.PushAsync(new NavigationGallery(), true);
 		}
 
-		async void PopToRoot(object sender, EventArgs e)
+		async void PopToRoot(object? sender, EventArgs e)
 		{
 			await Navigation.PopToRootAsync(true);
 		}
 
-		void RemovePage(object sender, EventArgs e)
+		void RemovePage(object? sender, EventArgs e)
 		{
 			if (Navigation.NavigationStack.Count >= 2)
 				Navigation.RemovePage(Navigation.NavigationStack[Navigation.NavigationStack.Count - 2]);
 		}
 
-		void ToggleNavigationBar(object sender, EventArgs e)
+		void ToggleNavigationBar(object? sender, EventArgs e)
 		{
 			NavigationPage.SetHasNavigationBar(this, !NavigationPage.GetHasNavigationBar(this));
 		}
 
-		void ToggleBackButton(object sender, EventArgs e)
+		void ToggleBackButton(object? sender, EventArgs e)
 		{
 			NavigationPage.SetHasBackButton(this, !NavigationPage.GetHasBackButton(this));
 		}
 
-		void ToggleSecondaryToolbarItem(object sender, EventArgs e)
+		void ToggleSecondaryToolbarItem(object? sender, EventArgs e)
 		{
 			if (!this.ToolbarItems.Where(x => x.Order == ToolbarItemOrder.Secondary).Any())
 			{
@@ -75,7 +75,7 @@ namespace Maui.Controls.Sample.Pages
 		}
 
 
-		void SwapRoot(object sender, EventArgs e)
+		void SwapRoot(object? sender, EventArgs e)
 		{
 			if (_currentNavStack == null)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PanGestureGalleries/PanGestureEventsGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PanGestureGalleries/PanGestureEventsGallery.xaml.cs
@@ -9,7 +9,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnPanGestureRecognizerUpdated(object sender, PanUpdatedEventArgs e)
+		void OnPanGestureRecognizerUpdated(object? sender, PanUpdatedEventArgs e)
 		{
 			InfoLabel.Text = $"StatusType: {e.StatusType}, TotalX: {e.TotalX}, TotalY: {e.TotalY}";
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PointerGestureGalleryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PointerGestureGalleryPage.xaml.cs
@@ -23,52 +23,52 @@ namespace Maui.Controls.Sample.Pages
 			colorfulHoverLabel.GestureRecognizers.Add(colorfulHoverGesture);
 		}
 
-		void PointerHoverStarted(object sender, PointerEventArgs e)
+		void PointerHoverStarted(object? sender, PointerEventArgs e)
 		{
 			pgrLabel.Text = "Thanks for hovering me! Now press me!";
 			pgrLabel.BackgroundColor = Colors.PaleGreen;
 		}
 
-		void PointerHoverEnded(object sender, PointerEventArgs e)
+		void PointerHoverEnded(object? sender, PointerEventArgs e)
 		{
 			pgrLabel.Text = "Hover me again!";
 			pgrPositionLabel.Text = "Hover above label to reveal pointer position again";
 			pgrLabel.BackgroundColor = Colors.Transparent;
 		}
 
-		void PointerMoved(object sender, PointerEventArgs e)
+		void PointerMoved(object? sender, PointerEventArgs e)
 		{
-			pgrPositionLabel.Text = $"Pointer position is at: {e.GetPosition((View)sender)}";
+			pgrPositionLabel.Text = $"Pointer position is at: {e.GetPosition((View)sender!)}";
 			pgrPositionToWindow.Text = $"Pointer position inside window: {e.GetPosition(null)}";
 			pgrPositionToThisLabel.Text = $"Pointer position relative to this label: {e.GetPosition(pgrPositionToThisLabel)}";
 		}
 
-		void PointerPressStarted(object sender, PointerEventArgs e)
+		void PointerPressStarted(object? sender, PointerEventArgs e)
 		{
 			pgrLabel.Text = "Thanks for pressing me! Now release me!";
 			pgrLabel.BackgroundColor = Colors.SkyBlue;
 		}
 
-		void PointerPressEnded(object sender, PointerEventArgs e)
+		void PointerPressEnded(object? sender, PointerEventArgs e)
 		{
 			pgrLabel.Text = "Thanks for releasing me! Press me again or leave me!";
 			pgrLabel.BackgroundColor = Colors.Yellow;
 		}
 
-		void HoverBegan(object sender, PointerEventArgs e)
+		void HoverBegan(object? sender, PointerEventArgs e)
 		{
 			hoverLabel.Text = "Thanks for hovering me!";
 		}
 
-		void HoverEnded(object sender, PointerEventArgs e)
+		void HoverEnded(object? sender, PointerEventArgs e)
 		{
 			hoverLabel.Text = "Hover me again!";
 			positionLabel.Text = "Hover above label to reveal pointer position again";
 		}
 
-		void HoverMoved(object sender, PointerEventArgs e)
+		void HoverMoved(object? sender, PointerEventArgs e)
 		{
-			positionLabel.Text = $"Pointer position is at: {e.GetPosition((View)sender)}";
+			positionLabel.Text = $"Pointer position is at: {e.GetPosition((View)sender!)}";
 			positionToWindow.Text = $"Pointer position inside window: {e.GetPosition(null)}";
 			positionToThisLabel.Text = $"Pointer position relative to this label: {e.GetPosition(positionToThisLabel)}";
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml.cs
@@ -33,7 +33,7 @@ namespace Maui.Controls.Sample.Pages
 			await Navigation.PushAsync(new SemanticsPage());
 		}
 
-		private void SetSemanticFocusButton_Clicked(object sender, System.EventArgs e)
+		private void SetSemanticFocusButton_Clicked(object? sender, System.EventArgs e)
 		{
 			semanticFocusLabel.SetSemanticFocus();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShadowGalleries/InvalidateShadowHostPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShadowGalleries/InvalidateShadowHostPage.xaml.cs
@@ -12,18 +12,18 @@ namespace Maui.Controls.Sample.Pages
 			UpdateShadowOffset();
 		}
 
-		void OnUpdateHostSizeClicked(object sender, EventArgs args)
+		void OnUpdateHostSizeClicked(object? sender, EventArgs args)
 		{
 			var random = new Random();
 			ShadowHost.MinimumHeightRequest = ShadowHost.MinimumWidthRequest = random.Next(100, 300);
 		}
 
-		void OnShadowOffsetXChanged(object sender, ValueChangedEventArgs e)
+		void OnShadowOffsetXChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateShadowOffset();
 		}
 
-		void OnShadowOffsetYChanged(object sender, ValueChangedEventArgs e)
+		void OnShadowOffsetYChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateShadowOffset();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShadowGalleries/ShadowPlaygroundPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShadowGalleries/ShadowPlaygroundPage.xaml.cs
@@ -12,17 +12,17 @@ namespace Maui.Controls.Sample.Pages
 			UpdateShadowOffset();
 		}
 
-		void RemoveShadowClicked(object sender, EventArgs e)
+		void RemoveShadowClicked(object? sender, EventArgs e)
 		{
 			ClippedShadowView.Shadow = ShadowView.Shadow = ShadowViewGradient.Shadow = LabelShadowView.Shadow = null!;
 		}
 
-		void OnShadowOffsetXChanged(object sender, ValueChangedEventArgs e)
+		void OnShadowOffsetXChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateShadowOffset();
 		}
 
-		void OnShadowOffsetYChanged(object sender, ValueChangedEventArgs e)
+		void OnShadowOffsetYChanged(object? sender, ValueChangedEventArgs e)
 		{
 			UpdateShadowOffset();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -42,18 +42,18 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 			popToRoot.IsVisible = Navigation.NavigationStack.Count > 1;
 		}
 
-		async void OnPushPage(object sender, EventArgs e)
+		async void OnPushPage(object? sender, EventArgs e)
 		{
 			await Navigation.PushAsync(new ShellChromeGallery());
 		}
 
-		async void OnPopPage(object sender, EventArgs e)
+		async void OnPopPage(object? sender, EventArgs e)
 		{
 			if (Navigation.NavigationStack.Count > 1)
 				await Navigation.PopAsync();
 		}
 
-		async void OnPopToRoot(object sender, EventArgs e)
+		async void OnPopToRoot(object? sender, EventArgs e)
 		{
 			await Navigation.PopToRootAsync();
 		}
@@ -83,14 +83,14 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 			AppShell.FlyoutHeaderBehavior = (FlyoutHeaderBehavior)flyoutHeaderBehavior.SelectedIndex;
 		}
 
-		void OnToggleFlyoutIsPresented(object sender, EventArgs e)
+		void OnToggleFlyoutIsPresented(object? sender, EventArgs e)
 		{
 			if (AppShell is null)
 				return;
 			AppShell.FlyoutIsPresented = !AppShell.FlyoutIsPresented;
 		}
 
-		void OnToggleFlyoutBackgroundColor(object sender, EventArgs e)
+		void OnToggleFlyoutBackgroundColor(object? sender, EventArgs e)
 		{
 			if (AppShell is null)
 				return;
@@ -112,24 +112,24 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 			flyoutBackgroundColor.Background = AppShell.FlyoutBackground;
 		}
 
-		void OnToggleNavBarHasShadow(object sender, EventArgs e)
+		void OnToggleNavBarHasShadow(object? sender, EventArgs e)
 		{
 			Shell.SetNavBarHasShadow(this, !Shell.GetNavBarHasShadow(this));
 		}
 
-		void OnToggleNavBarIsVisible(object sender, EventArgs e)
+		void OnToggleNavBarIsVisible(object? sender, EventArgs e)
 		{
 			Shell.SetNavBarIsVisible(this, !Shell.GetNavBarIsVisible(this));
 		}
 
-		void OnToggleBackButtonIsVisible(object sender, EventArgs e)
+		void OnToggleBackButtonIsVisible(object? sender, EventArgs e)
 		{
 			var backButtonBehavior = Shell.GetBackButtonBehavior(this) ?? new BackButtonBehavior();
 			backButtonBehavior.IsVisible = !backButtonBehavior.IsVisible;
 			Shell.SetBackButtonBehavior(this, backButtonBehavior);
 		}
 
-		void OnToggleSearchHandler(object sender, EventArgs e)
+		void OnToggleSearchHandler(object? sender, EventArgs e)
 		{
 			var searchHandler = Shell.GetSearchHandler(this);
 			if (searchHandler != null)
@@ -138,24 +138,24 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 				AddSearchHandler("text here");
 		}
 
-		void OnToggleTabBar(object sender, EventArgs e)
+		void OnToggleTabBar(object? sender, EventArgs e)
 		{
 			Shell.SetTabBarIsVisible(this, !Shell.GetTabBarIsVisible(this));
 		}
 
-		void OnToggleTabBarTitleColor(object sender, EventArgs e)
+		void OnToggleTabBarTitleColor(object? sender, EventArgs e)
 		{
 			var random = new Random();
 			Shell.SetTabBarTitleColor(Shell.Current.CurrentItem, Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)));
 		}
 
-		void OnToggleTabBarUnselectedColor(object sender, EventArgs e)
+		void OnToggleTabBarUnselectedColor(object? sender, EventArgs e)
 		{
 			var random = new Random();
 			Shell.SetTabBarUnselectedColor(Shell.Current.CurrentItem, Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)));
 		}
 
-		void OnToggleTabBarForegroundColor(object sender, EventArgs e)
+		void OnToggleTabBarForegroundColor(object? sender, EventArgs e)
 		{
 			var random = new Random();
 			Shell.SetTabBarForegroundColor(Shell.Current.CurrentItem, Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)));

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ToolbarPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ToolbarPage.cs
@@ -22,7 +22,7 @@ public partial class ToolbarPage
 		BindingContext = this;
 	}
 
-	void ItemClicked(object sender, EventArgs e)
+	void ItemClicked(object? sender, EventArgs e)
 	{
 		if (sender is ToolbarItem tbi)
 		{
@@ -30,17 +30,17 @@ public partial class ToolbarPage
 		}
 	}
 
-	void Button_Clicked(object sender, EventArgs e)
+	void Button_Clicked(object? sender, EventArgs e)
 	{
 		secondary4.IsEnabled = !secondary4.IsEnabled;
 	}
 
-	void Button_Clicked1(object sender, EventArgs e)
+	void Button_Clicked1(object? sender, EventArgs e)
 	{
 		primary1.IsEnabled = !primary1.IsEnabled;
 	}
 
-	void Button_Clicked2(object sender, EventArgs e)
+	void Button_Clicked2(object? sender, EventArgs e)
 	{
 		// 5 second delay so you can have the menu open and see the change.
 		// However, the menu will close if change happens. There is no way around this.
@@ -53,12 +53,12 @@ public partial class ToolbarPage
 		});
 	}
 
-	void Button_Clicked3(object sender, EventArgs e)
+	void Button_Clicked3(object? sender, EventArgs e)
 	{
 		secondary1.Text = secondary1.Text == "Test Secondary (1)" ? "Changed Text" : "Test Secondary (1)";
 	}
 
-	void Button_Clicked4(object sender, EventArgs e)
+	void Button_Clicked4(object? sender, EventArgs e)
 	{
 		_cachedSecondary3 ??= secondary3;
 
@@ -72,7 +72,7 @@ public partial class ToolbarPage
 		}
 	}
 
-	void Button_Clicked5(object sender, EventArgs e)
+	void Button_Clicked5(object? sender, EventArgs e)
 	{
 		secondary3.Command = new Command(() =>
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/WindowTitleBar.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/WindowTitleBar.xaml.cs
@@ -10,7 +10,7 @@
 			InitializeComponent();
 		}
 
-		public async void OnPushModalClicked(object sender, EventArgs args)
+		public async void OnPushModalClicked(object? sender, EventArgs args)
 		{
 			await Navigation.PushModalAsync(new ContentPage()
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/HitTestingPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/HitTestingPage.xaml.cs
@@ -32,12 +32,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		private void RectangleSelectionCheckBox_CheckedChanged(object sender, Microsoft.Maui.Controls.CheckedChangedEventArgs e)
+		private void RectangleSelectionCheckBox_CheckedChanged(object? sender, Microsoft.Maui.Controls.CheckedChangedEventArgs e)
 		{
 			_state = RectangleSelectionCheckBox.IsChecked ? State.RectangleSelectionPickFirst : State.SingleSelection;
 		}
 
-		private void ContentPage_Loaded(object sender, EventArgs e)
+		private void ContentPage_Loaded(object? sender, EventArgs e)
 		{
 			_window = this.GetParentWindow();
 			_overlay = new WindowOverlay(_window);
@@ -85,7 +85,7 @@ namespace Maui.Controls.Sample.Pages
 
 
 
-		private void ContentPage_Unloaded(object sender, EventArgs e)
+		private void ContentPage_Unloaded(object? sender, EventArgs e)
 		{
 			_overlay!.RemoveWindowElement(this);
 			_window!.RemoveOverlay(_overlay);

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/LayoutIsEnabledPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/LayoutIsEnabledPage.xaml.cs
@@ -50,14 +50,14 @@ namespace Maui.Controls.Sample.Pages
 
 		public Command TheCommand { get; }
 
-		void OnDisableLayoutBtnClicked(object sender, EventArgs e)
+		void OnDisableLayoutBtnClicked(object? sender, EventArgs e)
 		{
 			MainLayout.IsEnabled = !MainLayout.IsEnabled;
 
-			((Button)sender).Text = MainLayout.IsEnabled ? "Disable Layout" : "Enable Layout";
+			((Button)sender!).Text = MainLayout.IsEnabled ? "Disable Layout" : "Enable Layout";
 		}
 
-		void OnDisableButtonBtnClicked(object sender, EventArgs e)
+		void OnDisableButtonBtnClicked(object? sender, EventArgs e)
 		{
 			DisabledButton.IsEnabled = !DisabledButton.IsEnabled;
 			DisabledCommandButton.IsEnabled = !DisabledCommandButton.IsEnabled;
@@ -65,7 +65,7 @@ namespace Maui.Controls.Sample.Pages
 			DisabledButton.Text = DisabledButton.IsEnabled ? "Enabled" : "Disabled";
 			DisabledCommandButton.Text = DisabledCommandButton.IsEnabled ? "Enabled" : "Disabled";
 
-			((Button)sender).Text = DisabledButton.IsEnabled ? "Disable Button" : "Enable Button";
+			((Button)sender!).Text = DisabledButton.IsEnabled ? "Disable Button" : "Enable Button";
 		}
 
 		void OnThe()

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollToEndPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollToEndPage.xaml.cs
@@ -10,12 +10,12 @@ namespace Maui.Controls.Sample.Pages.ScrollViewPages
 			InitializeComponent();
 		}
 
-		async void OnButtonClicked(object sender, EventArgs e)
+		async void OnButtonClicked(object? sender, EventArgs e)
 		{
 			await scrollView.ScrollToAsync(finalLabel, ScrollToPosition.End, true);
 		}
 
-		void OnScrollViewScrolled(object sender, ScrolledEventArgs e)
+		void OnScrollViewScrolled(object? sender, ScrolledEventArgs e)
 		{
 			Console.WriteLine($"ScrollX: {e.ScrollX}, ScrollY: {e.ScrollY}");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewOrientationPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewOrientationPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages.ScrollViewPages
 			InitializeComponent();
 		}
 
-		public void OrientationSelectedIndexChanged(object sender, EventArgs args)
+		public void OrientationSelectedIndexChanged(object? sender, EventArgs args)
 		{
 			ScrollViewer.Orientation = (ScrollOrientation)Orientation.SelectedIndex;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewTemplatePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPages/ScrollViewTemplatePage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages.ScrollViewPages
 			InitializeComponent();
 		}
 
-		private void OnCounterClicked(object sender, EventArgs e)
+		private void OnCounterClicked(object? sender, EventArgs e)
 		{
 			count++;
 

--- a/src/Controls/samples/Controls.Sample/Pages/Others/GraphicsViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/GraphicsViewPage.xaml.cs
@@ -13,37 +13,37 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 			=> GraphicsView.Invalidate();
 
-		void GraphicsView_DragInteraction(object sender, TouchEventArgs e)
+		void GraphicsView_DragInteraction(object? sender, TouchEventArgs e)
 			=> UpdateInteractions("Drag Touches", e);
 
-		void GraphicsView_CancelInteraction(object sender, EventArgs e)
+		void GraphicsView_CancelInteraction(object? sender, EventArgs e)
 			=> UpdateInteractions("Cancel Touches");
 
-		void GraphicsView_EndInteraction(object sender, TouchEventArgs e)
+		void GraphicsView_EndInteraction(object? sender, TouchEventArgs e)
 			=> UpdateInteractions("End Touches", e);
 
-		void GraphicsView_StartInteraction(object sender, TouchEventArgs e)
+		void GraphicsView_StartInteraction(object? sender, TouchEventArgs e)
 			=> UpdateInteractions("Start Touch", e);
 
-		void GraphicsView_StartHoverInteraction(object sender, TouchEventArgs e)
+		void GraphicsView_StartHoverInteraction(object? sender, TouchEventArgs e)
 			=> UpdateInteractions("Start Hover", e);
 
-		void GraphicsView_MoveHoverInteraction(object sender, TouchEventArgs e)
+		void GraphicsView_MoveHoverInteraction(object? sender, TouchEventArgs e)
 			=> UpdateInteractions("Move Hover", e);
 
-		void GraphicsView_EndHoverInteraction(object sender, EventArgs e)
+		void GraphicsView_EndHoverInteraction(object? sender, EventArgs e)
 			=> UpdateInteractions("End Hover");
 
-		void GraphicsView_Tapped(object sender, EventArgs args)
+		void GraphicsView_Tapped(object? sender, EventArgs args)
 			=> UpdateGestures("TapGestureRecognizer");
 
-		void GraphicsView_PanUpdated(object sender, PanUpdatedEventArgs args)
+		void GraphicsView_PanUpdated(object? sender, PanUpdatedEventArgs args)
 			=> UpdateGestures("PanGestureRecognizer");
 
-		void GraphicsView_PinchUpdated(object sender, PinchGestureUpdatedEventArgs args)
+		void GraphicsView_PinchUpdated(object? sender, PinchGestureUpdatedEventArgs args)
 			=> UpdateGestures("PinchGestureRecognizer ");
 
 		void UpdateInteractions(string name, TouchEventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -26,7 +26,7 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = vm = new RenderBindingModel();
 		}
 
-		async void RenderWindow_Clicked(object sender, EventArgs e)
+		async void RenderWindow_Clicked(object? sender, EventArgs e)
 		{
 			Reset();
 			stopwatch.Start();
@@ -38,7 +38,7 @@ namespace Maui.Controls.Sample.Pages
 			await RenderView(renderImage);
 		}
 
-		async void RenderButton_Clicked(object sender, EventArgs e)
+		async void RenderButton_Clicked(object? sender, EventArgs e)
 		{
 			Reset();
 			stopwatch.Start();
@@ -50,7 +50,7 @@ namespace Maui.Controls.Sample.Pages
 			await RenderView(renderImage);
 		}
 
-		async void RenderViewSaved_Clicked(object sender, EventArgs e)
+		async void RenderViewSaved_Clicked(object? sender, EventArgs e)
 		{
 			if (imageStream is not null)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Others/TemplatePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/TemplatePage.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages
 		}
 
 		int count = 0;
-		private void OnCounterClicked(object sender, EventArgs e)
+		private void OnCounterClicked(object? sender, EventArgs e)
 		{
 			count++;
 			CounterLabel.Text = $"Current count: {count}";

--- a/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml.cs
@@ -11,14 +11,14 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void TestAddOverlayWindow(object sender, EventArgs e)
+		void TestAddOverlayWindow(object? sender, EventArgs e)
 		{
 			var window = GetParentWindow();
 			overlay ??= new TestWindowOverlay(window);
 			window.AddOverlay(overlay);
 		}
 
-		void TestRemoveOverlayWindow(object sender, EventArgs e)
+		void TestRemoveOverlayWindow(object? sender, EventArgs e)
 		{
 			if (overlay is not null)
 			{
@@ -27,14 +27,14 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void TestVisualTreeHelper(object sender, EventArgs e)
+		void TestVisualTreeHelper(object? sender, EventArgs e)
 		{
 			var overlay = GetParentWindow().VisualDiagnosticsOverlay;
 			overlay.RemoveAdorners();
 			overlay.AddAdorner(TestButton, false);
 		}
 
-		void EnableElementPicker(object sender, EventArgs e)
+		void EnableElementPicker(object? sender, EventArgs e)
 		{
 			GetParentWindow().VisualDiagnosticsOverlay.EnableElementSelector = true;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidEntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidEntryPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnSelectedIndexChanged(object sender, EventArgs e)
+		void OnSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			ImeFlags flag = (ImeFlags)Enum.Parse(typeof(ImeFlags), _picker.SelectedItem.ToString()!);
 			_entry.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetImeOptions(flag);

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidListViewFastScrollPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidListViewFastScrollPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = new ListViewViewModel();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			listView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetIsFastScrollEnabled(!listView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().IsFastScrollEnabled());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSoftInputModeAdjustPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSoftInputModeAdjustPage.xaml.cs
@@ -12,12 +12,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnPanButtonClicked(object sender, EventArgs e)
+		void OnPanButtonClicked(object? sender, EventArgs e)
 		{
 			Microsoft.Maui.Controls.Application.Current!.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Pan);
 		}
 
-		void OnResizeButtonClicked(object sender, EventArgs e)
+		void OnResizeButtonClicked(object? sender, EventArgs e)
 		{
 			Microsoft.Maui.Controls.Application.Current!.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().UseWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSwipeViewTransitionModePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidSwipeViewTransitionModePage.xaml.cs
@@ -14,13 +14,13 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnSwipeViewTransitionModeChanged(object sender, EventArgs e)
+		void OnSwipeViewTransitionModeChanged(object? sender, EventArgs e)
 		{
-			SwipeTransitionMode transitionMode = (SwipeTransitionMode)((EnumPicker)sender).SelectedItem;
+			SwipeTransitionMode transitionMode = (SwipeTransitionMode)((EnumPicker)sender!).SelectedItem!;
 			swipeView.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetSwipeTransitionMode(transitionMode);
 		}
 
-		async void OnDeleteSwipeItemInvoked(object sender, EventArgs e)
+		async void OnDeleteSwipeItemInvoked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("SwipeView", "Delete invoked.", "OK");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTabbedPageSwipePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTabbedPageSwipePage.xaml.cs
@@ -13,17 +13,17 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnSwipePagingButtonClicked(object sender, EventArgs e)
+		void OnSwipePagingButtonClicked(object? sender, EventArgs e)
 		{
 			On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetIsSwipePagingEnabled(!On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().IsSwipePagingEnabled());
 		}
 
-		void OnSmoothScrollButtonClicked(object sender, EventArgs e)
+		void OnSmoothScrollButtonClicked(object? sender, EventArgs e)
 		{
 			On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().SetIsSmoothScrollEnabled(!On<Microsoft.Maui.Controls.PlatformConfiguration.Android>().IsSmoothScrollEnabled());
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTitleViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Android/AndroidTitleViewPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/ContentPageTwo.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/ContentPageTwo.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 			_returnToPlatformSpecificsPage = restore;
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			_returnToPlatformSpecificsPage.Execute(null);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsAddRemoveToolbarItemsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsAddRemoveToolbarItemsPage.xaml.cs
@@ -26,19 +26,19 @@ namespace Maui.Controls.Sample.Pages
 #endif
 		}
 
-		void OnAddPrimaryButtonClicked(object sender, EventArgs e)
+		void OnAddPrimaryButtonClicked(object? sender, EventArgs e)
 		{
 			int index = ParentPage.ToolbarItems.Count(item => item.Order == ToolbarItemOrder.Primary) + 1;
 			ParentPage.ToolbarItems.Add(new ToolbarItem(string.Format("Primary {0}", index), "calculator.png", _action, ToolbarItemOrder.Primary));
 		}
 
-		void OnAddSecondaryButtonClicked(object sender, EventArgs e)
+		void OnAddSecondaryButtonClicked(object? sender, EventArgs e)
 		{
 			int index = ParentPage.ToolbarItems.Count(item => item.Order == ToolbarItemOrder.Secondary) + 1;
 			ParentPage.ToolbarItems.Add(new ToolbarItem(string.Format("Secondary {0}", index), "calculator.png", _action, ToolbarItemOrder.Secondary));
 		}
 
-		void OnRemoveButtonClicked(object sender, EventArgs e)
+		void OnRemoveButtonClicked(object? sender, EventArgs e)
 		{
 			if (ParentPage.ToolbarItems.Any())
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseStyleChangerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseStyleChangerPage.xaml.cs
@@ -30,7 +30,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnPickerSelectedIndexChanged(object sender, EventArgs e)
+		void OnPickerSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetCollapseStyle((CollapseStyle)Enum.Parse(typeof(CollapseStyle), picker.Items[picker.SelectedIndex]));
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseWidthAdjusterPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsCollapseWidthAdjusterPage.xaml.cs
@@ -19,7 +19,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnChangeButtonClicked(object sender, EventArgs e)
+		void OnChangeButtonClicked(object? sender, EventArgs e)
 		{
 			double width;
 			if (double.TryParse(entry.Text, out width))

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsDragAndDropCustomization.xaml.cs
@@ -23,7 +23,7 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void DropGestureRecognizer_DragOver(System.Object sender, Microsoft.Maui.Controls.DragEventArgs e)
+		void DropGestureRecognizer_DragOver(System.Object? sender, Microsoft.Maui.Controls.DragEventArgs e)
 		{
 #if WINDOWS
 			var dragUI = e.PlatformArgs!.DragEventArgs.DragUIOverride;

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsListViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsListViewPage.xaml.cs
@@ -14,17 +14,17 @@ namespace Maui.Controls.Sample.Pages
 			UpdateLabel();
 		}
 
-		async void OnListViewItemTapped(object sender, ItemTappedEventArgs e)
+		async void OnListViewItemTapped(object? sender, ItemTappedEventArgs e)
 		{
 			await DisplayAlertAsync("Item Tapped", "ItemTapped event fired.", "OK");
 		}
 
-		async void TapGestureRecognizer_Tapped(object sender, EventArgs e)
+		async void TapGestureRecognizer_Tapped(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("Tap Gesture Recognizer", "Tapped event fired.", "OK");
 		}
 
-		void OnToggleButtonClicked(object sender, EventArgs e)
+		void OnToggleButtonClicked(object? sender, EventArgs e)
 		{
 			switch (_listView.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetSelectionMode())
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsReadingOrderPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsReadingOrderPage.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages
 			UpdateLabel();
 		}
 
-		void OnToggleButtonClicked(object sender, EventArgs e)
+		void OnToggleButtonClicked(object? sender, EventArgs e)
 		{
 			var detectReadingOrder = _editor.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetDetectReadingOrderFromContent();
 

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsRefreshViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsRefreshViewPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 			enumPicker.SelectedIndex = 0;
 		}
 
-		void OnSelectedIndexChanged(object sender, EventArgs e)
+		void OnSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			refreshView.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetRefreshPullDirection((RefreshPullDirection)enumPicker.SelectedItem);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsSearchBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsSearchBarPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnToggleButtonClicked(object sender, EventArgs e)
+		void OnToggleButtonClicked(object? sender, EventArgs e)
 		{
 			_searchBar.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetIsSpellCheckEnabled(!_searchBar.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetIsSpellCheckEnabled());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsTileBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsTileBarPage.xaml.cs
@@ -39,7 +39,7 @@ namespace Maui.Controls.Sample.Pages
 			Window.TitleBar = _customTitleBar;
 		}
 
-		private void SetIconCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void SetIconCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -51,7 +51,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void ColorButton_Clicked(object sender, EventArgs e)
+		private void ColorButton_Clicked(object? sender, EventArgs e)
 		{
 			if (Microsoft.Maui.Graphics.Color.TryParse(ColorTextBox.Text, out var color))
 			{
@@ -59,7 +59,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void ForegroundColorButton_Clicked(object sender, EventArgs e)
+		private void ForegroundColorButton_Clicked(object? sender, EventArgs e)
 		{
 			if (Microsoft.Maui.Graphics.Color.TryParse(ForegroundColorTextBox.Text, out var color))
 			{
@@ -67,7 +67,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void LeadingCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void LeadingCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -82,7 +82,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void ContentCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void ContentCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -100,7 +100,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void TrailingCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void TrailingCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -127,7 +127,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		private void TallModeCheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+		private void TallModeCheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
 		{
 			if (e.Value)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsToolbarPlacementChangerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsToolbarPlacementChangerPage.xaml.cs
@@ -30,7 +30,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnPickerSelectedIndexChanged(object sender, EventArgs e)
+		void OnPickerSelectedIndexChanged(object? sender, EventArgs e)
 		{
 			ParentPage.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetToolbarPlacement((ToolbarPlacement)Enum.Parse(typeof(ToolbarPlacement), picker.Items[picker.SelectedIndex]));
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsVisualElementAccessKeysPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsVisualElementAccessKeysPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		async void OnButtonClicked(object sender, EventArgs e)
+		async void OnButtonClicked(object? sender, EventArgs e)
 		{
 			var button = sender as Button;
 			await DisplayAlertAsync("Button clicked", $"Clicked {button?.Text}", "OK");

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/Windows/WindowsWebViewPage.xaml.cs
@@ -16,12 +16,12 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void OnToggleButtonClicked(object sender, EventArgs e)
+		void OnToggleButtonClicked(object? sender, EventArgs e)
 		{
 			_webView.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetIsJavaScriptAlertEnabled(!_webView.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().IsJavaScriptAlertEnabled());
 		}
 
-		void OnLoadLocalAssetWithHtmlSourceAndBaseUrl(object sender, EventArgs e)
+		void OnLoadLocalAssetWithHtmlSourceAndBaseUrl(object? sender, EventArgs e)
 		{
 			_webView.Source = new HtmlWebViewSource
 			{
@@ -30,7 +30,7 @@ namespace Maui.Controls.Sample.Pages
 			};
 		}
 
-		void OnLoadLocalAssetWithUrlSource(object sender, EventArgs e)
+		void OnLoadLocalAssetWithUrlSource(object? sender, EventArgs e)
 		{
 			_webView.Source = new UrlWebViewSource
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSBlurEffectPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSBlurEffectPage.xaml.cs
@@ -12,22 +12,22 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnNoBlurButtonClicked(object sender, EventArgs e)
+		void OnNoBlurButtonClicked(object? sender, EventArgs e)
 		{
 			image.On<iOS>().UseBlurEffect(BlurEffectStyle.None);
 		}
 
-		void OnExtraLightBlurButtonClicked(object sender, EventArgs e)
+		void OnExtraLightBlurButtonClicked(object? sender, EventArgs e)
 		{
 			image.On<iOS>().UseBlurEffect(BlurEffectStyle.ExtraLight);
 		}
 
-		void OnLightBlurButtonClicked(object sender, EventArgs e)
+		void OnLightBlurButtonClicked(object? sender, EventArgs e)
 		{
 			image.On<iOS>().UseBlurEffect(BlurEffectStyle.Light);
 		}
 
-		void OnDarkBlurButtonClicked(object sender, EventArgs e)
+		void OnDarkBlurButtonClicked(object? sender, EventArgs e)
 		{
 			image.On<iOS>().UseBlurEffect(BlurEffectStyle.Dark);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDatePickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDatePickerPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			switch (datePicker.On<iOS>().UpdateMode())
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSDragAndDropRequestFullSize.xaml.cs
@@ -30,7 +30,7 @@ namespace Maui.Controls.Sample.Pages
 #endif
 		}
 
-		void DragGestureRecognizer_DragStarting(System.Object sender, Microsoft.Maui.Controls.DragStartingEventArgs e)
+		void DragGestureRecognizer_DragStarting(System.Object? sender, Microsoft.Maui.Controls.DragStartingEventArgs e)
 		{
 #if IOS || MACCATALYST
 			if (drawnImageSwitch.IsToggled)
@@ -74,19 +74,19 @@ namespace Maui.Controls.Sample.Pages
 #endif
 		}
 
-		void Drawn_Switch_Toggled(object sender, ToggledEventArgs e)
+		void Drawn_Switch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			if (e.Value)
 				dotnetBotImageSwitch.IsToggled = false;
 		}
 
-		void DotnetBot_Switch_Toggled(object sender, ToggledEventArgs e)
+		void DotnetBot_Switch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			if (e.Value)
 				drawnImageSwitch.IsToggled = false;
 		}
 
-		void DropGestureRecognizer_DragOver(System.Object sender, Microsoft.Maui.Controls.DragEventArgs e)
+		void DropGestureRecognizer_DragOver(System.Object? sender, Microsoft.Maui.Controls.DragEventArgs e)
 		{
 #if IOS || MACCATALYST
 			if (copySwitch.IsToggled)
@@ -98,11 +98,11 @@ namespace Maui.Controls.Sample.Pages
 #endif
 		}
 
-		void FullSized_Switch_Toggled(object sender, ToggledEventArgs e)
+		void FullSized_Switch_Toggled(object? sender, ToggledEventArgs e)
 		{
 		}
 
-		void Copy_Switch_Toggled(object sender, ToggledEventArgs e)
+		void Copy_Switch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -111,7 +111,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void Move_Switch_Toggled(object sender, ToggledEventArgs e)
+		void Move_Switch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			if (e.Value)
 			{
@@ -120,7 +120,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void Forbidden_Switch_Toggled(object sender, ToggledEventArgs e)
+		void Forbidden_Switch_Toggled(object? sender, ToggledEventArgs e)
 		{
 			if (e.Value)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSEntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSEntryPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			entry.On<iOS>().SetAdjustsFontSizeToFitWidth(!entry.On<iOS>().AdjustsFontSizeToFitWidth());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSFlyoutPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSFlyoutPage.xaml.cs
@@ -15,12 +15,12 @@ namespace Maui.Controls.Sample.Pages
 			returnToPlatformSpecificsPage = restore;
 		}
 
-		void OnShadowButtonClicked(object sender, EventArgs e)
+		void OnShadowButtonClicked(object? sender, EventArgs e)
 		{
 			On<iOS>().SetApplyShadow(!On<iOS>().GetApplyShadow());
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			returnToPlatformSpecificsPage.Execute(null);
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSHideHomeIndicatorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSHideHomeIndicatorPage.xaml.cs
@@ -12,22 +12,22 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void NavigationPage_Clicked(object sender, EventArgs e)
+		void NavigationPage_Clicked(object? sender, EventArgs e)
 		{
 			Navigation.PushAsync(new iOSHideHomeIndicatorNavigationPageDemo());
 		}
 
-		void TabbedPage_Clicked(object sender, EventArgs e)
+		void TabbedPage_Clicked(object? sender, EventArgs e)
 		{
 			Navigation.PushAsync(new iOSHideHomeIndicatorPageDemo());
 		}
 
-		void FlyoutPage_Clicked(object sender, EventArgs e)
+		void FlyoutPage_Clicked(object? sender, EventArgs e)
 		{
 			Navigation.PushAsync(new iOSHideHomeIndicatorFlyoutPageDemo());
 		}
 
-		void Shell_Clicked(object sender, EventArgs e)
+		void Shell_Clicked(object? sender, EventArgs e)
 		{
 			Navigation.PushAsync(new iOSHideHomeIndicatorShellDemo());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSLargeTitlePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSLargeTitlePage.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			switch (On<iOS>().LargeTitleDisplay())
 			{
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSModalPagePresentationStyle.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSModalPagePresentationStyle.xaml.cs
@@ -38,26 +38,26 @@ namespace Maui.Controls.Sample.Pages
 			this.isChildPage = isChildPage;
 		}
 
-		async void OnPushFormSheetClicked(object sender, EventArgs e)
+		async void OnPushFormSheetClicked(object? sender, EventArgs e)
 		{
 			Microsoft.Maui.Controls.Page pushMe = new iOSModalPagePresentationStyle(UIModalPresentationStyle.FormSheet, true);
 			await Navigation.PushModalAsync(pushMe);
 		}
 
-		async void OnPushPopoverClicked(object sender, EventArgs e)
+		async void OnPushPopoverClicked(object? sender, EventArgs e)
 		{
 			Microsoft.Maui.Controls.Page pushMe = new iOSModalPagePresentationStyle(UIModalPresentationStyle.Popover, true, originButton);
 			await Navigation.PushModalAsync(pushMe);
 		}
 
-		async void OnPushPopoverOffsetClicked(object sender, EventArgs e)
+		async void OnPushPopoverOffsetClicked(object? sender, EventArgs e)
 		{
 			var offset = new System.Drawing.Rectangle(0, 0, 100, 10);
 			Microsoft.Maui.Controls.Page pushMe = new iOSModalPagePresentationStyle(UIModalPresentationStyle.Popover, true, originButton2, offset);
 			await Navigation.PushModalAsync(pushMe);
 		}
 
-		async void OnReturnButtonClicked(object sender, EventArgs e)
+		async void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			if (isChildPage)
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSPanGestureRecognizerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSPanGestureRecognizerPage.xaml.cs
@@ -14,13 +14,13 @@ namespace Maui.Controls.Sample.Pages
 			BindingContext = new ListViewViewModel();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			Microsoft.Maui.Controls.Application.Current!.On<iOS>().SetPanGestureRecognizerShouldRecognizeSimultaneously(
 				!Microsoft.Maui.Controls.Application.Current!.On<iOS>().GetPanGestureRecognizerShouldRecognizeSimultaneously());
 		}
 
-		void OnPanUpdated(object sender, PanUpdatedEventArgs e)
+		void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
 		{
 			_messageLabel.Text = $"panned x:{e.TotalX} y:{e.TotalY}";
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSPickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSPickerPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			switch (picker.On<iOS>().UpdateMode())
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSafeAreaPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSafeAreaPage.xaml.cs
@@ -10,7 +10,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.None;
 			(sender as Button)!.IsEnabled = false;

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSScrollViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSScrollViewPage.xaml.cs
@@ -12,12 +12,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			scrollView.On<iOS>().SetShouldDelayContentTouches(!scrollView.On<iOS>().ShouldDelayContentTouches());
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSearchBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSearchBarPage.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnSearchBarStyleButtonClicked(object sender, EventArgs e)
+		void OnSearchBarStyleButtonClicked(object? sender, EventArgs e)
 		{
 			switch (searchBar.On<iOS>().GetSearchBarStyle())
 			{
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnToggleBackgroundButtonClicked(object sender, EventArgs e)
+		void OnToggleBackgroundButtonClicked(object? sender, EventArgs e)
 		{
 			searchBar.BackgroundColor = (searchBar.BackgroundColor == Colors.Teal) ? Colors.Black : Colors.Teal;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSliderUpdateOnTapPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSliderUpdateOnTapPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			_slider.On<iOS>().SetUpdateOnTap(!_slider.On<iOS>().GetUpdateOnTap());
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSStatusBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSStatusBarPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnPrefersStatusBarHiddenButtonClicked(object sender, EventArgs e)
+		void OnPrefersStatusBarHiddenButtonClicked(object? sender, EventArgs e)
 		{
 			switch (On<iOS>().PrefersStatusBarHidden())
 			{
@@ -28,7 +28,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnPreferredStatusBarUpdateAnimationButtonClicked(object sender, EventArgs e)
+		void OnPreferredStatusBarUpdateAnimationButtonClicked(object? sender, EventArgs e)
 		{
 			switch (On<iOS>().PreferredStatusBarUpdateAnimation())
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSwipeViewTransitionModePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSSwipeViewTransitionModePage.xaml.cs
@@ -14,13 +14,13 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnSwipeViewTransitionModeChanged(object sender, EventArgs e)
+		void OnSwipeViewTransitionModeChanged(object? sender, EventArgs e)
 		{
 			SwipeTransitionMode transitionMode = (SwipeTransitionMode)(sender as EnumPicker)!.SelectedItem;
 			swipeView.On<iOS>().SetSwipeTransitionMode(transitionMode);
 		}
 
-		async void OnDeleteSwipeItemInvoked(object sender, EventArgs e)
+		async void OnDeleteSwipeItemInvoked(object? sender, EventArgs e)
 		{
 			await DisplayAlertAsync("SwipeView", "Delete invoked.", "OK");
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTimePickerPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTimePickerPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnButtonClicked(object sender, EventArgs e)
+		void OnButtonClicked(object? sender, EventArgs e)
 		{
 			switch (timePicker.On<iOS>().UpdateMode())
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTitleViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTitleViewPage.xaml.cs
@@ -12,7 +12,7 @@ namespace Maui.Controls.Sample.Pages
 			_searchBar.Effects.Add(Effect.Resolve("XamarinDocs.SearchBarEffect"));
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentNavigationBarPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentNavigationBarPage.xaml.cs
@@ -13,12 +13,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnTranslucentNavigationBarButtonClicked(object sender, EventArgs e)
+		void OnTranslucentNavigationBarButtonClicked(object? sender, EventArgs e)
 		{
 			(this.Window!.Page as Microsoft.Maui.Controls.NavigationPage)!.On<iOS>().SetIsNavigationBarTranslucent(!(this.Window!.Page as Microsoft.Maui.Controls.NavigationPage)!.On<iOS>().IsNavigationBarTranslucent());
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentTabbedPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/PlatformSpecifics/iOS/iOSTranslucentTabbedPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnToggleButtonClicked(object sender, EventArgs e)
+		void OnToggleButtonClicked(object? sender, EventArgs e)
 		{
 			switch (On<iOS>().GetTranslucencyMode())
 			{
@@ -27,7 +27,7 @@ namespace Maui.Controls.Sample.Pages
 			}
 		}
 
-		void OnReturnButtonClicked(object sender, EventArgs e)
+		void OnReturnButtonClicked(object? sender, EventArgs e)
 		{
 			Navigation.PopAsync();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/SettingsPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/SettingsPage.xaml.cs
@@ -11,12 +11,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		void OnTapGestureRecognizerTapped(object sender, EventArgs args)
+		void OnTapGestureRecognizerTapped(object? sender, EventArgs args)
 		{
 			Navigation.PopModalAsync();
 		}
 
-		void OnRTLToggled(object sender, ToggledEventArgs e)
+		void OnRTLToggled(object? sender, ToggledEventArgs e)
 		{
 			var mainPage = this.Window!.Page;
 

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/AnimationPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/AnimationPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		async void OnStartAnimationButtonClicked(object sender, EventArgs e)
+		async void OnStartAnimationButtonClicked(object? sender, EventArgs e)
 		{
 			SetIsEnabledButtonState(false, true);
 
@@ -37,7 +37,7 @@ namespace Maui.Controls.Sample.Pages
 			SetIsEnabledButtonState(true, false);
 		}
 
-		void OnStartCustomAnimationButtonClicked(object sender, EventArgs e)
+		void OnStartCustomAnimationButtonClicked(object? sender, EventArgs e)
 		{
 			var parentAnimation = new Animation();
 			var scaleUpAnimation = new Animation(v => DotNetBotImage.Scale = v, 1, 2, Easing.SpringIn);
@@ -51,7 +51,7 @@ namespace Maui.Controls.Sample.Pages
 			parentAnimation.Commit(this, "CustomAnimation", 16, 4000, null, (v, c) => SetIsEnabledButtonState(true, false));
 		}
 
-		void OnCancelAnimationButtonClicked(object sender, EventArgs e)
+		void OnCancelAnimationButtonClicked(object? sender, EventArgs e)
 		{
 			Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(DotNetBotImage);
 			SetIsEnabledButtonState(true, false);

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(IOPath.GetFullPath(Assembly), readerParameters))
 				{
+#if !NET12_0_OR_GREATER
 #pragma warning disable CS0618 // Type or member is obsolete - backcompat for [XamlCompilation]
 					CustomAttribute xamlcAttr = null;
 					if (assemblyDefinition.HasCustomAttributes &&
@@ -217,12 +218,14 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					}
 
 					xamlcAttr = null;
+#endif
 
 					foreach (var module in assemblyDefinition.Modules)
 					{
 						var skipmodule = skipassembly;
 						(bool, XamlInflator)? moduleInflatorOptions = assemblyInflatorOptions;
 
+#if !NET12_0_OR_GREATER
 						if (module.HasCustomAttributes &&
 							(xamlcAttr =
 								module.CustomAttributes.FirstOrDefault(
@@ -236,6 +239,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 						}
 						xamlcAttr = null;
 #pragma warning restore CS0618
+#endif
 
 						LoggingHelper.LogMessage(Low, $"{new string(' ', 2)}Module: {module.Name}");
 						var resourcesToPrune = new List<EmbeddedResource>();
@@ -260,6 +264,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 							var skiptype = skipmodule;
 							(bool, XamlInflator)? typeInflatorOptions = moduleInflatorOptions;
 
+#if !NET12_0_OR_GREATER
 #pragma warning disable CS0618 // Type or member is obsolete - backcompat for [XamlCompilation]
 							if (typeDef.HasCustomAttributes &&
 								(xamlcAttr =
@@ -274,6 +279,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 							}
 							xamlcAttr = null;
 #pragma warning restore CS0618
+#endif
 
 							if (Type != null)
 								skiptype = !(Type == classname);

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(IOPath.GetFullPath(Assembly), readerParameters))
 				{
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+#pragma warning disable CS0618 // Type or member is obsolete - backcompat for [XamlCompilation]
 					CustomAttribute xamlcAttr = null;
 					if (assemblyDefinition.HasCustomAttributes &&
 						(xamlcAttr =
@@ -217,14 +217,12 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					}
 
 					xamlcAttr = null;
-#endif
 
 					foreach (var module in assemblyDefinition.Modules)
 					{
 						var skipmodule = skipassembly;
 						(bool, XamlInflator)? moduleInflatorOptions = assemblyInflatorOptions;
 
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
 						if (module.HasCustomAttributes &&
 							(xamlcAttr =
 								module.CustomAttributes.FirstOrDefault(
@@ -237,7 +235,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 								skipmodule = false;
 						}
 						xamlcAttr = null;
-#endif
+#pragma warning restore CS0618
 
 						LoggingHelper.LogMessage(Low, $"{new string(' ', 2)}Module: {module.Name}");
 						var resourcesToPrune = new List<EmbeddedResource>();
@@ -262,7 +260,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 							var skiptype = skipmodule;
 							(bool, XamlInflator)? typeInflatorOptions = moduleInflatorOptions;
 
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+#pragma warning disable CS0618 // Type or member is obsolete - backcompat for [XamlCompilation]
 							if (typeDef.HasCustomAttributes &&
 								(xamlcAttr =
 									typeDef.CustomAttributes.FirstOrDefault(
@@ -275,7 +273,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 									skiptype = false;
 							}
 							xamlcAttr = null;
-#endif
+#pragma warning restore CS0618
 
 							if (Type != null)
 								skiptype = !(Type == classname);

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -202,42 +202,10 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(IOPath.GetFullPath(Assembly), readerParameters))
 				{
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-					CustomAttribute xamlcAttr = null;
-					if (assemblyDefinition.HasCustomAttributes &&
-						(xamlcAttr =
-							assemblyDefinition.CustomAttributes.FirstOrDefault(
-								ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute")) != null)
-					{
-						var options = (XamlCompilationOptions)xamlcAttr.ConstructorArguments[0].Value;
-						if ((options & XamlCompilationOptions.Skip) == XamlCompilationOptions.Skip)
-							skipassembly = true;
-						if ((options & XamlCompilationOptions.Compile) == XamlCompilationOptions.Compile)
-							skipassembly = false;
-					}
-
-					xamlcAttr = null;
-#endif
-
 					foreach (var module in assemblyDefinition.Modules)
 					{
 						var skipmodule = skipassembly;
 						(bool, XamlInflator)? moduleInflatorOptions = assemblyInflatorOptions;
-
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-						if (module.HasCustomAttributes &&
-							(xamlcAttr =
-								module.CustomAttributes.FirstOrDefault(
-									ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute")) != null)
-						{
-							var options = (XamlCompilationOptions)xamlcAttr.ConstructorArguments[0].Value;
-							if ((options & XamlCompilationOptions.Skip) == XamlCompilationOptions.Skip)
-								skipmodule = true;
-							if ((options & XamlCompilationOptions.Compile) == XamlCompilationOptions.Compile)
-								skipmodule = false;
-						}
-						xamlcAttr = null;
-#endif
 
 						LoggingHelper.LogMessage(Low, $"{new string(' ', 2)}Module: {module.Name}");
 						var resourcesToPrune = new List<EmbeddedResource>();
@@ -261,21 +229,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 							}
 							var skiptype = skipmodule;
 							(bool, XamlInflator)? typeInflatorOptions = moduleInflatorOptions;
-
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-							if (typeDef.HasCustomAttributes &&
-								(xamlcAttr =
-									typeDef.CustomAttributes.FirstOrDefault(
-										ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute")) != null)
-							{
-								var options = (XamlCompilationOptions)xamlcAttr.ConstructorArguments[0].Value;
-								if ((options & XamlCompilationOptions.Skip) == XamlCompilationOptions.Skip)
-									skiptype = true;
-								if ((options & XamlCompilationOptions.Compile) == XamlCompilationOptions.Compile)
-									skiptype = false;
-							}
-							xamlcAttr = null;
-#endif
 
 							if (Type != null)
 								skiptype = !(Type == classname);

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -202,10 +202,42 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(IOPath.GetFullPath(Assembly), readerParameters))
 				{
+#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+					CustomAttribute xamlcAttr = null;
+					if (assemblyDefinition.HasCustomAttributes &&
+						(xamlcAttr =
+							assemblyDefinition.CustomAttributes.FirstOrDefault(
+								ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute")) != null)
+					{
+						var options = (XamlCompilationOptions)xamlcAttr.ConstructorArguments[0].Value;
+						if ((options & XamlCompilationOptions.Skip) == XamlCompilationOptions.Skip)
+							skipassembly = true;
+						if ((options & XamlCompilationOptions.Compile) == XamlCompilationOptions.Compile)
+							skipassembly = false;
+					}
+
+					xamlcAttr = null;
+#endif
+
 					foreach (var module in assemblyDefinition.Modules)
 					{
 						var skipmodule = skipassembly;
 						(bool, XamlInflator)? moduleInflatorOptions = assemblyInflatorOptions;
+
+#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+						if (module.HasCustomAttributes &&
+							(xamlcAttr =
+								module.CustomAttributes.FirstOrDefault(
+									ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute")) != null)
+						{
+							var options = (XamlCompilationOptions)xamlcAttr.ConstructorArguments[0].Value;
+							if ((options & XamlCompilationOptions.Skip) == XamlCompilationOptions.Skip)
+								skipmodule = true;
+							if ((options & XamlCompilationOptions.Compile) == XamlCompilationOptions.Compile)
+								skipmodule = false;
+						}
+						xamlcAttr = null;
+#endif
 
 						LoggingHelper.LogMessage(Low, $"{new string(' ', 2)}Module: {module.Name}");
 						var resourcesToPrune = new List<EmbeddedResource>();
@@ -229,6 +261,21 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 							}
 							var skiptype = skipmodule;
 							(bool, XamlInflator)? typeInflatorOptions = moduleInflatorOptions;
+
+#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+							if (typeDef.HasCustomAttributes &&
+								(xamlcAttr =
+									typeDef.CustomAttributes.FirstOrDefault(
+										ca => ca.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute")) != null)
+							{
+								var options = (XamlCompilationOptions)xamlcAttr.ConstructorArguments[0].Value;
+								if ((options & XamlCompilationOptions.Skip) == XamlCompilationOptions.Skip)
+									skiptype = true;
+								if ((options & XamlCompilationOptions.Compile) == XamlCompilationOptions.Compile)
+									skiptype = false;
+							}
+							xamlcAttr = null;
+#endif
 
 							if (Type != null)
 								skiptype = !(Type == classname);

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -8,8 +8,7 @@
 		<EnableDefaultCssItems Condition="'$(EnableDefaultCssItems)'==''">True</EnableDefaultCssItems>
     <!-- default MauiXaml inflators  -->
     <_MauiXamlInflator Condition="' $(MauiXamlInflator)' != '' ">$(MauiXamlInflator)</_MauiXamlInflator>
-    <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' And '$(Configuration)' == 'Debug' ">Runtime</_MauiXamlInflator>
-    <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' And '$(Configuration)' != 'Debug' ">XamlC</_MauiXamlInflator>
+    <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' ">SourceGen</_MauiXamlInflator>
 
     <EnableMauiXamlDiagnostics Condition=" '$(EnableMauiXamlDiagnostics)' == '' ">$(EnableMauiDiagnostics)</EnableMauiXamlDiagnostics>
     <EnableMauiXamlDiagnostics Condition=" '$(EnableMauiXamlDiagnostics)' == '' And '$(Configuration)' == 'Debug' ">$(EnableDiagnostics)</EnableMauiXamlDiagnostics>
@@ -86,13 +85,12 @@
 
   <Target Name="_MauiXamlComputeInflator">
   	<ItemGroup>
-      <!-- Compute the configuration-based default inflator (independent of MauiXamlInflator property) -->
-      <_MauiXamlDefaultInflator Condition=" '$(Configuration)' == 'Debug' " Include="Runtime" />
-      <_MauiXamlDefaultInflator Condition=" '$(Configuration)' != 'Debug' " Include="XamlC" />
+      <!-- Default inflator is SourceGen -->
+      <_MauiXamlDefaultInflator Include="SourceGen" />
       
       <!-- Assign the default inflator to MauiXaml that don't have any -->
       <!-- there's a roslyn bug that stops parsing value at the first semicolon. replace them all https://github.com/dotnet/roslyn/issues/43970 -->
-      <!-- Special value 'Default' reverts to configuration-based defaults (Runtime in Debug, XamlC in Release) -->
+      <!-- Special value 'Default' uses the default inflator (SourceGen) -->
       <MauiXaml Condition="'%(MauiXaml.Inflator)' == 'Default'" Inflator="@(_MauiXamlDefaultInflator)" />
       <MauiXaml Inflator="$([MSBuild]::ValueOrDefault('%(MauiXaml.Inflator)','$(_MauiXamlInflator)').Replace(';', ','))"/>
       <MauiXaml NoWarn="$([MSBuild]::ValueOrDefault('%(MauiXaml.NoWarn)','').Replace(';', ','))"/>
@@ -107,17 +105,11 @@
       <_MauiXaml_AsEmbeddedResource Include="@(_MauiXaml_XC)" KeepDuplicates="false" />      
 	</ItemGroup>
 	
-	<!-- Inform when XAML source generation is enabled -->
-	<Message 
-		Text="XAML source generation is enabled (MauiXamlInflator=SourceGen). This generates C# code from XAML at compile time for better performance. To disable, remove the MauiXamlInflator line from your .csproj file (reverts to configuration-based defaults: Runtime in Debug, XamlC in Release)." 
-		Importance="high" 
-		Condition="'$(MauiXamlInflator)' != '' And $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('sourcegen'))" />
-	
-	<!-- Warn when Runtime or XamlC inflator is explicitly set -->
+	<!-- Warn when using deprecated Runtime or XamlC inflator -->
 	<Warning 
 		Code="MAUI1001"
-		Text="MauiXamlInflator is explicitly set to '$(MauiXamlInflator)'. The 'Runtime' inflator negatively impacts runtime performance and is only recommended for Debug builds. The 'XamlC' inflator prevents debugging capabilities like XAML Hot Reload. Consider setting it to 'SourceGen' for optimal performance and debugging experience, or remove it to use configuration-based defaults (Runtime in Debug, XamlC in Release)." 
-		Condition="'$(MauiXamlInflator)' != '' And ($([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('runtime')) Or $([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('xamlc')))" />
+		Text="MauiXamlInflator is set to '$(MauiXamlInflator)'. The 'Runtime' and 'XamlC' inflators are deprecated. Consider using 'SourceGen' for optimal performance and debugging experience." 
+		Condition="'$(MauiXamlInflator)' != '' And !$([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('sourcegen'))" />
   </Target>
 
   <!-- Inject MauiXaml and MauiCss as AdditionalFiles for partial type generation-->

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -85,13 +85,8 @@
 
   <Target Name="_MauiXamlComputeInflator">
   	<ItemGroup>
-      <!-- Default inflator is SourceGen -->
-      <_MauiXamlDefaultInflator Include="SourceGen" />
-      
-      <!-- Assign the default inflator to MauiXaml that don't have any -->
+      <!-- Assign the default inflator (SourceGen) to MauiXaml that don't have any -->
       <!-- there's a roslyn bug that stops parsing value at the first semicolon. replace them all https://github.com/dotnet/roslyn/issues/43970 -->
-      <!-- Special value 'Default' uses the default inflator (SourceGen) -->
-      <MauiXaml Condition="'%(MauiXaml.Inflator)' == 'Default'" Inflator="@(_MauiXamlDefaultInflator)" />
       <MauiXaml Inflator="$([MSBuild]::ValueOrDefault('%(MauiXaml.Inflator)','$(_MauiXamlInflator)').Replace(';', ','))"/>
       <MauiXaml NoWarn="$([MSBuild]::ValueOrDefault('%(MauiXaml.NoWarn)','').Replace(';', ','))"/>
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -103,7 +103,7 @@
 	<!-- Warn when using deprecated Runtime or XamlC inflator -->
 	<Warning 
 		Code="MAUI1001"
-		Text="MauiXamlInflator is set to '$(MauiXamlInflator)'. The 'Runtime' and 'XamlC' inflators are deprecated. Consider using 'SourceGen' for optimal performance and debugging experience." 
+		Text="MauiXamlInflator is set to '$(MauiXamlInflator)'. The 'Runtime' and 'XamlC' inflators are deprecated. Consider removing the MauiXamlInflator property to use the default 'SourceGen' inflator for optimal performance and debugging experience." 
 		Condition="'$(MauiXamlInflator)' != '' And !$([System.String]::new('$(MauiXamlInflator)').ToLowerInvariant().Contains('sourcegen'))" />
   </Target>
 

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -321,12 +321,14 @@ static class CodeBehindCodeWriter
 			return false;
 		}
 
+#if !NET12_0_OR_GREATER
 		// if the following xml processing instruction is present
 		//
 		// <?xaml-comp compile="true" ?>
 		//
 		// we will generate a xaml.g.cs file with the default ctor calling InitializeComponent, and a XamlCompilation attribute
 		var hasXamlCompilationProcessingInstruction = GetXamlCompilationProcessingInstruction(root.OwnerDocument);
+#endif
 
 		var rootClass = root.Attributes["Class", XamlParser.X2006Uri]
 					 ?? root.Attributes["Class", XamlParser.X2009Uri];
@@ -335,8 +337,12 @@ static class CodeBehindCodeWriter
 		{
 			XmlnsHelper.ParseXmlns(rootClass.Value, out rootType, out rootClrNamespace, out _, out _);
 		}
+#if !NET12_0_OR_GREATER
 		else if (hasXamlCompilationProcessingInstruction
 				&& (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri))
+#else
+		else if (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri)
+#endif
 		{
 			//make sure the base type can be resolved. if not, don't consider this as xaml, and move away
 			var typeArgs = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
@@ -377,6 +383,7 @@ static class CodeBehindCodeWriter
 		return true;
 	}
 
+#if !NET12_0_OR_GREATER
 	//true, unless explicitely false
 	static bool GetXamlCompilationProcessingInstruction(XmlDocument xmlDoc)
 	{
@@ -390,6 +397,7 @@ static class CodeBehindCodeWriter
 
 		return true;
 	}
+#endif
 
 	internal static string GetWarningDisable(XmlDocument xmlDoc)
 	{

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -107,10 +107,6 @@ static class CodeBehindCodeWriter
 		sb.AppendLine("{");
 		sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlFilePath(\"{projItem.RelativePath?.Replace("\\", "\\\\")}\")]");
 
-#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
-		if (addXamlCompilationAttribute && !alreadyHasXamlCompilationAttribute)
-			sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlCompilation(global::Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Compile)]");
-#endif
 		if (!addXamlCompilationAttribute && (xamlInflators & XamlInflator.XamlC) == 0 && !alreadyHasXamlCompilationAttribute)
 			sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlCompilation(global::Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Skip)]");
 
@@ -325,15 +321,6 @@ static class CodeBehindCodeWriter
 			return false;
 		}
 
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-		// if the following xml processing instruction is present
-		//
-		// <?xaml-comp compile="true" ?>
-		//
-		// we will generate a xaml.g.cs file with the default ctor calling InitializeComponent, and a XamlCompilation attribute
-		var hasXamlCompilationProcessingInstruction = GetXamlCompilationProcessingInstruction(root.OwnerDocument);
-#endif
-
 		var rootClass = root.Attributes["Class", XamlParser.X2006Uri]
 					 ?? root.Attributes["Class", XamlParser.X2009Uri];
 
@@ -341,12 +328,7 @@ static class CodeBehindCodeWriter
 		{
 			XmlnsHelper.ParseXmlns(rootClass.Value, out rootType, out rootClrNamespace, out _, out _);
 		}
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-		else if (hasXamlCompilationProcessingInstruction
-				&& (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri))
-#else
 		else if (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri)
-#endif
 		{
 			//make sure the base type can be resolved. if not, don't consider this as xaml, and move away
 			var typeArgs = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
@@ -386,22 +368,6 @@ static class CodeBehindCodeWriter
 
 		return true;
 	}
-
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-	//true, unless explicitely false
-	static bool GetXamlCompilationProcessingInstruction(XmlDocument xmlDoc)
-	{
-		if (xmlDoc.SelectSingleNode("processing-instruction('xaml-comp')") is not XmlProcessingInstruction instruction)
-			return true;
-
-		var parts = instruction.Data.Split(' ', '=');
-		var indexOfCompile = Array.IndexOf(parts, "compile");
-		if (indexOfCompile != -1)
-			return !parts[indexOfCompile + 1].Trim('"', '\'').Equals("false", StringComparison.OrdinalIgnoreCase);
-
-		return true;
-	}
-#endif
 
 	internal static string GetWarningDisable(XmlDocument xmlDoc)
 	{

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -107,8 +107,10 @@ static class CodeBehindCodeWriter
 		sb.AppendLine("{");
 		sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlFilePath(\"{projItem.RelativePath?.Replace("\\", "\\\\")}\")]");
 
+#pragma warning disable CS0618 // XamlCompilation is deprecated but still generated for backcompat
 		if (!addXamlCompilationAttribute && (xamlInflators & XamlInflator.XamlC) == 0 && !alreadyHasXamlCompilationAttribute)
-			sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlCompilation(global::Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Skip)]");
+			sb.AppendLine($"\t#pragma warning disable CS0618\n\t[global::Microsoft.Maui.Controls.Xaml.XamlCompilation(global::Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Skip)]\n\t#pragma warning restore CS0618");
+#pragma warning restore CS0618
 
 		if (hideFromIntellisense)
 		{

--- a/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
+++ b/src/Controls/src/SourceGen/CodeBehindCodeWriter.cs
@@ -107,10 +107,6 @@ static class CodeBehindCodeWriter
 		sb.AppendLine("{");
 		sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlFilePath(\"{projItem.RelativePath?.Replace("\\", "\\\\")}\")]");
 
-#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
-		if (addXamlCompilationAttribute && !alreadyHasXamlCompilationAttribute)
-			sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlCompilation(global::Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Compile)]");
-#endif
 		if (!addXamlCompilationAttribute && (xamlInflators & XamlInflator.XamlC) == 0 && !alreadyHasXamlCompilationAttribute)
 			sb.AppendLine($"\t[global::Microsoft.Maui.Controls.Xaml.XamlCompilation(global::Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Skip)]");
 
@@ -325,14 +321,12 @@ static class CodeBehindCodeWriter
 			return false;
 		}
 
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
 		// if the following xml processing instruction is present
 		//
 		// <?xaml-comp compile="true" ?>
 		//
 		// we will generate a xaml.g.cs file with the default ctor calling InitializeComponent, and a XamlCompilation attribute
 		var hasXamlCompilationProcessingInstruction = GetXamlCompilationProcessingInstruction(root.OwnerDocument);
-#endif
 
 		var rootClass = root.Attributes["Class", XamlParser.X2006Uri]
 					 ?? root.Attributes["Class", XamlParser.X2009Uri];
@@ -341,12 +335,8 @@ static class CodeBehindCodeWriter
 		{
 			XmlnsHelper.ParseXmlns(rootClass.Value, out rootType, out rootClrNamespace, out _, out _);
 		}
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
 		else if (hasXamlCompilationProcessingInstruction
 				&& (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri))
-#else
-		else if (root.NamespaceURI == XamlParser.MauiUri || root.NamespaceURI == XamlParser.MauiGlobalUri)
-#endif
 		{
 			//make sure the base type can be resolved. if not, don't consider this as xaml, and move away
 			var typeArgs = GetAttributeValue(root, "TypeArguments", XamlParser.X2006Uri, XamlParser.X2009Uri);
@@ -387,7 +377,6 @@ static class CodeBehindCodeWriter
 		return true;
 	}
 
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
 	//true, unless explicitely false
 	static bool GetXamlCompilationProcessingInstruction(XmlDocument xmlDoc)
 	{
@@ -401,7 +390,6 @@ static class CodeBehindCodeWriter
 
 		return true;
 	}
-#endif
 
 	internal static string GetWarningDisable(XmlDocument xmlDoc)
 	{

--- a/src/Controls/src/Xaml/XamlCompilationAttribute.cs
+++ b/src/Controls/src/Xaml/XamlCompilationAttribute.cs
@@ -4,9 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
-#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
 	[Obsolete("Specify xaml inflator and other options using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
-#endif
 	[Flags]
 	public enum XamlCompilationOptions
 	{
@@ -14,9 +12,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		Compile = XamlInflator.XamlC,
 	}
 
-#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
 	[Obsolete("Specify xaml inflator and other options using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
-#endif
 	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class, Inherited = false)]
 	public sealed class XamlCompilationAttribute : Attribute
 	{
@@ -27,24 +23,4 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public XamlCompilationOptions XamlCompilationOptions { get; set; }
 	}
-
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
-	static class XamlCExtensions
-	{
-		public static bool IsCompiled(this Type type)
-		{
-			var attr = type.GetCustomAttribute<XamlCompilationAttribute>();
-			if (attr != null)
-				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
-			attr = type.Module.GetCustomAttribute<XamlCompilationAttribute>();
-			if (attr != null)
-				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
-			attr = type.Assembly.GetCustomAttribute<XamlCompilationAttribute>();
-			if (attr != null)
-				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
-
-			return false;
-		}
-	}
-#endif
 }

--- a/src/Controls/src/Xaml/XamlCompilationAttribute.cs
+++ b/src/Controls/src/Xaml/XamlCompilationAttribute.cs
@@ -4,7 +4,9 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
 	[Obsolete("Specify xaml inflator and other options using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
+#endif
 	[Flags]
 	public enum XamlCompilationOptions
 	{
@@ -12,7 +14,9 @@ namespace Microsoft.Maui.Controls.Xaml
 		Compile = XamlInflator.XamlC,
 	}
 
+#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
 	[Obsolete("Specify xaml inflator and other options using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
+#endif
 	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class, Inherited = false)]
 	public sealed class XamlCompilationAttribute : Attribute
 	{
@@ -23,4 +27,24 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public XamlCompilationOptions XamlCompilationOptions { get; set; }
 	}
+
+#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+	static class XamlCExtensions
+	{
+		public static bool IsCompiled(this Type type)
+		{
+			var attr = type.GetCustomAttribute<XamlCompilationAttribute>();
+			if (attr != null)
+				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
+			attr = type.Module.GetCustomAttribute<XamlCompilationAttribute>();
+			if (attr != null)
+				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
+			attr = type.Assembly.GetCustomAttribute<XamlCompilationAttribute>();
+			if (attr != null)
+				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
+
+			return false;
+		}
+	}
+#endif
 }

--- a/src/Controls/src/Xaml/XamlCompilationAttribute.cs
+++ b/src/Controls/src/Xaml/XamlCompilationAttribute.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls.Xaml
 {
 #if NET12_0_OR_GREATER
 	[Obsolete("XamlCompilationOptions is no longer used. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
-#elif NET11_0_OR_GREATER
+#else
 	[Obsolete("XamlCompilationOptions is deprecated. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />")]
 #endif
 	[Flags]
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 #if NET12_0_OR_GREATER
 	[Obsolete("XamlCompilationAttribute is no longer used. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
-#elif NET11_0_OR_GREATER
+#else
 	[Obsolete("XamlCompilationAttribute is deprecated. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />")]
 #endif
 	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class, Inherited = false)]
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Controls.Xaml
 	}
 
 #if !NET12_0_OR_GREATER
+#pragma warning disable CS0618 // Type or member is obsolete - internal backcompat code
 	static class XamlCExtensions
 	{
 		public static bool IsCompiled(this Type type)
@@ -50,5 +51,6 @@ namespace Microsoft.Maui.Controls.Xaml
 			return false;
 		}
 	}
+#pragma warning restore CS0618
 #endif
 }

--- a/src/Controls/src/Xaml/XamlCompilationAttribute.cs
+++ b/src/Controls/src/Xaml/XamlCompilationAttribute.cs
@@ -4,8 +4,10 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
-#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
-	[Obsolete("Specify xaml inflator and other options using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
+#if NET12_0_OR_GREATER
+	[Obsolete("XamlCompilationOptions is no longer used. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
+#elif NET11_0_OR_GREATER
+	[Obsolete("XamlCompilationOptions is deprecated. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />")]
 #endif
 	[Flags]
 	public enum XamlCompilationOptions
@@ -14,8 +16,10 @@ namespace Microsoft.Maui.Controls.Xaml
 		Compile = XamlInflator.XamlC,
 	}
 
-#if !_MAUIXAML_SOURCEGEN_BACKCOMPAT
-	[Obsolete("Specify xaml inflator and other options using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
+#if NET12_0_OR_GREATER
+	[Obsolete("XamlCompilationAttribute is no longer used. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />", error: true)]
+#elif NET11_0_OR_GREATER
+	[Obsolete("XamlCompilationAttribute is deprecated. Specify xaml inflator using msbuild metadata on MauiXaml items in your .csproj: <MauiXaml Update=\"YourFile.xaml\" Inflator=\"XamlC\" />")]
 #endif
 	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class, Inherited = false)]
 	public sealed class XamlCompilationAttribute : Attribute
@@ -28,7 +32,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		public XamlCompilationOptions XamlCompilationOptions { get; set; }
 	}
 
-#if _MAUIXAML_SOURCEGEN_BACKCOMPAT
+#if !NET12_0_OR_GREATER
 	static class XamlCExtensions
 	{
 		public static bool IsCompiled(this Type type)

--- a/src/Controls/tests/DeviceTests/Xaml/RadioButtonUsing.xaml.cs
+++ b/src/Controls/tests/DeviceTests/Xaml/RadioButtonUsing.xaml.cs
@@ -3,7 +3,9 @@ using Microsoft.Maui.Controls.Xaml;
 
 namespace Microsoft.Maui.DeviceTests
 {
+#pragma warning disable CS0618 // XamlCompilationAttribute is deprecated, remove this in .NET 12
 	[XamlCompilation(XamlCompilationOptions.Compile)]
+#pragma warning restore CS0618
 	public partial class RadioButtonUsing : ContentPage
 	{
 		public RadioButtonUsing()

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(itemGroup);
 
 			//Let's enable XamlC assembly-wide
-			project.Add(AddFile("AssemblyInfo.cs", "Compile", "[assembly: Microsoft.Maui.Controls.Xaml.XamlCompilation (Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Compile)]"));
+			project.Add(AddFile("AssemblyInfo.cs", "Compile", "#pragma warning disable CS0618\n[assembly: Microsoft.Maui.Controls.Xaml.XamlCompilation (Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Compile)]"));
 
 			//Add a single CSS file
 			project.Add(AddFile("Foo.css", "MauiCss", Css.Foo));
@@ -299,7 +299,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 
 		}
 
-		// Tests the MauiXamlCValidateOnly=True MSBuild property
+		// Tests the default build behavior with SourceGen inflator
 		[Theory]
 		[InlineData("Debug")]
 		[InlineData("Release")]
@@ -318,16 +318,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			AssertExists(testDll, nonEmpty: true);
 			using var assembly = AssemblyDefinition.ReadAssembly(testDll);
 			var resources = assembly.MainModule.Resources.OfType<EmbeddedResource>().Select(e => e.Name).ToArray();
-			if (configuration == "Debug")
-			{
-				// XAML files should remain as EmbeddedResource
-				Assert.Contains("test.MainPage.xaml", resources);
-			}
-			else
-			{
-				// XAML files should *not* remain as EmbeddedResource
-				Assert.DoesNotContain("test.MainPage.xaml", resources);
-			}
+			// With SourceGen as default inflator, XAML files are not embedded as resources
+			Assert.DoesNotContain("test.MainPage.xaml", resources);
 		}
 
 		[Fact(Skip = "source gen changes")]

--- a/src/Essentials/samples/Samples/App.xaml.cs
+++ b/src/Essentials/samples/Samples/App.xaml.cs
@@ -7,7 +7,9 @@ using Microsoft.Maui.Controls.Xaml;
 using Samples.View;
 using Device = Microsoft.Maui.Controls.Device;
 
+#pragma warning disable CS0618 // XamlCompilationAttribute is deprecated, remove this in .NET 12
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+#pragma warning restore CS0618
 
 namespace Samples
 {

--- a/src/Essentials/samples/Samples/Essentials.Sample.csproj
+++ b/src/Essentials/samples/Samples/Essentials.Sample.csproj
@@ -10,6 +10,8 @@
     <SampleProject>true</SampleProject>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA1416;XC0022</NoWarn>
+    <!-- This sample uses deprecated APIs for demonstration - use Runtime inflation -->
+    <MauiXamlInflator>Runtime</MauiXamlInflator>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst')) and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">maccatalyst-arm64</RuntimeIdentifier>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MauiApp.1.csproj
@@ -20,14 +20,6 @@
     <EnableDefaultCssItems>false</EnableDefaultCssItems>
     <Nullable>enable</Nullable>
 
-    <!-- Enable XAML source generation for faster build times and improved performance.
-         This generates C# code from XAML at compile time instead of runtime inflation.
-         To disable, remove this line.
-         For individual files, you can override by setting Inflator metadata:
-           <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-           <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-    <MauiXamlInflator>SourceGen</MauiXamlInflator>
-
     <!-- Display name -->
     <ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -20,14 +20,6 @@
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
         <Nullable>enable</Nullable>
 
-        <!-- Enable XAML source generation for faster build times and improved performance.
-             This generates C# code from XAML at compile time instead of runtime inflation.
-             To disable, remove this line.
-             For individual files, you can override by setting Inflator metadata:
-               <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-               <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-        <MauiXamlInflator>SourceGen</MauiXamlInflator>
-
         <!-- Display name -->
         <ApplicationTitle>XmlEncodedAppName</ApplicationTitle>
 

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -11,14 +11,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
-
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">17.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -19,13 +19,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 <!--#if (IncludeSampleContent) -->
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 <!--#endif -->

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Droid/MauiApp.1.Droid.csproj
@@ -9,13 +9,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.Mac/MauiApp.1.Mac.csproj
@@ -9,13 +9,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.WinUI/MauiApp.1.WinUI.csproj
@@ -15,14 +15,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
-
 		<!-- We do not want XAML files to be processed as .NET MAUI XAML, but rather WinUI XAML. -->
 		<EnableDefaultMauiItems>false</EnableDefaultMauiItems>
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1.iOS/MauiApp.1.iOS.csproj
@@ -9,13 +9,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseMaui>true</UseMaui>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/MauiApp.1.csproj
@@ -8,13 +8,6 @@
 		<UseMaui>true</UseMaui>
 		<Nullable>enable</Nullable>
 
-		<!-- Enable XAML source generation for faster build times and improved performance.
-		     This generates C# code from XAML at compile time instead of runtime inflation.
-		     To disable, remove this line.
-		     For individual files, you can override by setting Inflator metadata:
-		       <MauiXaml Update="MyPage.xaml" Inflator="Default" /> (reverts to defaults: Runtime for Debug, XamlC for Release)
-		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
-		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -11,6 +11,8 @@
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
+    <!-- This project uses deprecated Frame controls - use Runtime inflation -->
+    <MauiXamlInflator>Runtime</MauiXamlInflator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/DeviceRunner.cs
@@ -11,7 +11,9 @@ using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Storage;
 using Xunit;
 
+#pragma warning disable CS0618 // XamlCompilation is obsolete
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+#pragma warning restore CS0618
 
 namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 {


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR makes the XAML Source Generator (XSG) the default XAML inflator for .NET 11, replacing the previous configuration-based defaults (Runtime in Debug, XamlC in Release).

## Changes

### 1. Default Inflator Change
- Changed `MauiXamlInflator` default from `Runtime` (Debug) / `XamlC` (Release) to `SourceGen` for all configurations
- Added warning `MAUI1001` when explicitly setting `MauiXamlInflator` to a non-SourceGen value, suggesting to remove the property

### 2. Template Updates
- Removed explicit `<MauiXamlInflator>SourceGen</MauiXamlInflator>` from all 9 template files since SourceGen is now the default

### 3. Deprecate `[XamlCompilation]` Attribute
- `XamlCompilationAttribute` and `XamlCompilationOptions` are now marked `[Obsolete]` with a warning in .NET 11
- In .NET 12+, the attribute will become an error (wrapped with `#if !NET12_0_OR_GREATER`)
- Backward compatibility code still honors the attribute in .NET 11

### 4. Sample Project Fixes
- Several sample projects that use deprecated APIs now explicitly set `<MauiXamlInflator>Runtime</MauiXamlInflator>` to avoid SourceGen surfacing obsolete API usage as errors

### 5. Documentation
- Added `MauiXamlInflator` section to `docs/design/FeatureSwitches.md`

## Breaking Changes

1. **Default inflator changed**: Projects without explicit `MauiXamlInflator` will now use `SourceGen` instead of `Runtime`/`XamlC`
2. **`[XamlCompilation]` is deprecated**: Shows warning in .NET 11, will be error in .NET 12. Users should migrate to MSBuild properties/metadata:
   ```xml
   <PropertyGroup>
     <MauiXamlInflator>SourceGen</MauiXamlInflator>
   </PropertyGroup>
   
   <!-- Or per-file: -->
   <MauiXaml Update="MyPage.xaml" Inflator="Runtime" />
   ```

## Migration Path

For users who want to keep the old behavior:
```xml
<PropertyGroup>
  <!-- Use Runtime inflation (like Debug mode previously) -->
  <MauiXamlInflator>Runtime</MauiXamlInflator>
</PropertyGroup>
```
