### PR TITLE
[iOS/Mac] SwipeGestureRecognizer: Avoid firing parent swipes during child scroll gestures

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.iOS.cs
@@ -403,7 +403,15 @@ namespace Microsoft.Maui.Controls.Platform
 			var result = new UISwipeGestureRecognizer();
 			result.NumberOfTouchesRequired = (uint)numFingers;
 			result.Direction = (UISwipeGestureRecognizerDirection)direction;
-			result.ShouldRecognizeSimultaneously = (g, o) => true;
+			result.ShouldRecognizeSimultaneously = (g, o) => 
+			{
+				if (o.View is UIScrollView)
+				{
+					return false;
+				}
+				
+				return true;
+			};
 			result.AddTarget(() => action(direction));
 			return result;
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33375.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33375.cs
@@ -1,0 +1,122 @@
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 33375, "SwipeGestureRecognizer triggers while scrolling CollectionView horizontally on iOS", PlatformAffected.iOS | PlatformAffected.macOS)]
+	public class Issue33375 : TestContentPage
+	{
+		private int swipeCount = 0;
+		private Label _statusLabel;
+
+		protected override void Init()
+		{
+			var items = new ObservableCollection<Issue33375_ItemData>
+			{
+				new Issue33375_ItemData { Name = "Item 1", Description = "Scroll right" },
+				new Issue33375_ItemData { Name = "Item 2", Description = "Keep scrolling" },
+				new Issue33375_ItemData { Name = "Item 3", Description = "More items" },
+				new Issue33375_ItemData { Name = "Item 4", Description = "Even more" },
+				new Issue33375_ItemData { Name = "Item 5", Description = "Last item" },
+				new Issue33375_ItemData { Name = "Item 6", Description = "Extra item" },
+				new Issue33375_ItemData { Name = "Item 7", Description = "Another one" },
+				new Issue33375_ItemData { Name = "Item 8", Description = "Keep going" }
+			};
+
+			var collectionView = new CollectionView
+			{
+				AutomationId = "TestCollectionView",
+				HeightRequest = 200,
+				ItemsSource = items,
+				ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+				{
+					ItemSpacing = 10
+				},
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var border = new Border
+					{
+						Background = Colors.DodgerBlue,
+						Padding = 20,
+						WidthRequest = 150,
+						HeightRequest = 180,
+						StrokeThickness = 0
+					};
+
+					var stack = new VerticalStackLayout
+					{
+						VerticalOptions = LayoutOptions.Center
+					};
+
+					var nameLabel = new Label
+					{
+						FontSize = 20,
+						FontAttributes = FontAttributes.Bold,
+						HorizontalOptions = LayoutOptions.Center
+					};
+					nameLabel.SetBinding(Label.TextProperty, nameof(Issue33375_ItemData.Name));
+
+					var descLabel = new Label
+					{
+						FontSize = 14,
+						HorizontalOptions = LayoutOptions.Center,
+						Margin = new Thickness(0, 10, 0, 0)
+					};
+					descLabel.SetBinding(Label.TextProperty, nameof(Issue33375_ItemData.Description));
+
+					stack.Children.Add(nameLabel);
+					stack.Children.Add(descLabel);
+					border.Content = stack;
+
+					return border;
+				})
+			};
+
+			_statusLabel = new Label
+			{
+				AutomationId = "StatusLabel",
+				Text = "No swipe detected",
+				FontSize = 18,
+				FontAttributes = FontAttributes.Bold,
+				HorizontalOptions = LayoutOptions.Center,
+				Margin = new Thickness(0, 20)
+			};
+
+			var border = new Border
+			{
+				AutomationId = "TestBorder",
+				Background = Colors.LightGray,
+				Padding = 20,
+				Content = new VerticalStackLayout
+				{
+					Spacing = 20,
+					Children =
+					{
+						_statusLabel,
+						collectionView,
+					}
+				}
+			};
+
+			var swipeGesture = new SwipeGestureRecognizer
+			{
+				Direction = SwipeDirection.Right,
+				Threshold = 200,
+				Command = new Command(() =>
+				{
+					swipeCount++;
+					_statusLabel.Text = $"Swipe triggered! Count: {swipeCount}";
+					_statusLabel.TextColor = Colors.Red;
+				})
+			};
+			border.GestureRecognizers.Add(swipeGesture);
+			Content = border;
+		}
+
+		class Issue33375_ItemData
+		{
+			public string Name { get; set; } = string.Empty;
+			public string Description { get; set; } = string.Empty;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33375.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33375.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue33375 : _IssuesUITest
+	{
+		public Issue33375(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "SwipeGestureRecognizer triggers while scrolling CollectionView horizontally on iOS";
+
+		[Test]
+		[Category(UITestCategories.Gestures)]
+		public void SwipeGestureRecognizerShouldNotTriggerWhenScrollingCollectionView()
+		{
+			App.WaitForElement("TestCollectionView");
+			var statusLabel = App.WaitForElement("StatusLabel");
+			Assert.That(statusLabel.GetText(), Is.EqualTo("No swipe detected"));
+			var collectionView = App.FindElement("TestCollectionView");
+
+			// Scroll right in the CollectionView
+			App.DragCoordinates(
+				collectionView.GetRect().CenterX(),
+				collectionView.GetRect().CenterY(),
+				collectionView.GetRect().X + 50,
+				collectionView.GetRect().CenterY()
+			);
+
+			App.WaitForElement("StatusLabel");
+			statusLabel = App.FindElement("StatusLabel");
+			Assert.That(statusLabel.GetText(), Is.EqualTo("No swipe detected"),
+				"SwipeGestureRecognizer should not trigger when scrolling CollectionView");
+
+			// Scroll back left to original position
+			App.DragCoordinates(
+				collectionView.GetRect().X + 50,
+				collectionView.GetRect().CenterY(),
+				collectionView.GetRect().CenterX(),
+				collectionView.GetRect().CenterY()
+			);
+
+			App.WaitForElement("StatusLabel");
+			statusLabel = App.FindElement("StatusLabel");
+			Assert.That(statusLabel.GetText(), Is.EqualTo("No swipe detected"),
+				"SwipeGestureRecognizer should not trigger when scrolling back");
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

SwipeGestureRecognizer on a parent Border is triggered while scrolling a child CollectionView horizontally on iOS/MacCatalyst platforms.
       
### Root Cause:

On iOS/MacCatalyst, when a user scrolls a CollectionView horizontally inside a parent Border that has a SwipeGestureRecognizer attached, the swipe gesture incorrectly triggers during the scroll action. This happens because in GesturePlatformManager.iOS.cs, the CreateSwipeRecognizer method configures the UISwipeGestureRecognizer with ShouldRecognizeSimultaneously = (g, o) => true, which allows the swipe gesture to fire simultaneously with any other gesture recognizer, including the UIScrollView's pan gesture used for scrolling. When the user scrolls the CollectionView to the right, iOS detects both a scroll gesture (from UIScrollView) and a swipe gesture (from the Border), and because simultaneous recognition is enabled, both gestures fire, causing the SwipeGestureRecognizer command to execute even though the user only intended to scroll.

### Description of Change:

Modified the ShouldRecognizeSimultaneously delegate in the CreateSwipeRecognizer method (line 406) to check if the other gesture recognizer's view is a UIScrollView. If it is (o.View is UIScrollView), the method now returns false to prevent simultaneous recognition, giving the scroll gesture priority over the swipe gesture. If the other gesture is not from a scrollview it returns true to maintain the existing behavior for non-scroll gestures. This ensures that scrolling child controls like CollectionView won't inadvertently trigger parent SwipeGestureRecognizers on iOS/MacCatalyst, making the behavior consistent with Android.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #33375     

### Screenshots
| Before  | After  |
|---------|--------|
|  <Video width="369" height="606" alt="image" src="https://github.com/user-attachments/assets/8fa4a99a-dc9b-4399-9813-8205bc1d7f7d" /> | <Video width="369" height="606" alt="image" src="https://github.com/user-attachments/assets/419f983b-a379-4243-83e1-38fb16e49a4d" /> |
