### PR TITLE
[iOS] SafeArea: Return Empty for non-ISafeAreaView views (opt-in model)

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33458.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33458.cs
@@ -1,0 +1,42 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33458, "SafeArea incorrectly applied when using ControlTemplate with ContentPresenter", PlatformAffected.iOS)]
+public class Issue33458 : TestContentPage
+{
+	protected override void Init()
+	{
+		AutomationId = "TestPage";
+		SafeAreaEdges = SafeAreaEdges.None;
+		ControlTemplate = new ControlTemplate(() => new ContentPresenter());
+
+		var stackLayout = new VerticalStackLayout
+		{
+			AutomationId = "TestStackLayout",
+			Padding = new Thickness(30, 0),
+			Spacing = 25,
+			BackgroundColor = Colors.Green,
+			SafeAreaEdges = SafeAreaEdges.None,
+			Children =
+			{
+				new Image
+				{
+					AutomationId = "BotImage",
+					Source = "dotnet_bot.png",
+					HeightRequest = 185,
+					Aspect = Aspect.AspectFit
+				},
+				new Label { AutomationId = "HelloLabel", Text = "Hello, World!" },
+				new Label { AutomationId = "WelcomeLabel", Text = "Welcome to\n.NET Multi-platform App UI" },
+				new Button { AutomationId = "CounterBtn", Text = "Click me", HorizontalOptions = LayoutOptions.Fill }
+			}
+		};
+
+		Content = new ScrollView
+		{
+			AutomationId = "TestScrollView",
+			BackgroundColor = Colors.Red,
+			SafeAreaEdges = SafeAreaEdges.None,
+			Content = stackLayout
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33458.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33458.cs
@@ -1,0 +1,29 @@
+#if IOS || ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33458 : _IssuesUITest
+{
+	public override string Issue => "SafeArea incorrectly applied when using ControlTemplate with ContentPresenter";
+
+	public Issue33458(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.SafeAreaEdges)]
+	public void ScrollViewSafeAreaWorksWithControlTemplate()
+	{
+		var pageRect = App.WaitForElement("TestPage").GetRect();
+		var scrollViewRect = App.WaitForElement("TestScrollView").GetRect();
+
+		// ContentPresenter should not apply safe area - ScrollView should match page bounds
+		Assert.That(scrollViewRect.Y, Is.EqualTo(pageRect.Y),
+			"ScrollView Y should match Page Y - no top inset from ContentPresenter");
+
+		Assert.That(scrollViewRect.Height, Is.EqualTo(pageRect.Height),
+			$"ScrollView height should match Page height - no insets from ContentPresenter. Expected: {pageRect.Height}, Actual: {scrollViewRect.Height}");
+	}
+}
+#endif

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -359,7 +359,9 @@ namespace Microsoft.Maui.Platform
 
 			// Fallback to legacy ISafeAreaView behavior
 			if (View is ISafeAreaView sav)
+			{
 				return sav.IgnoreSafeArea ? SafeAreaPadding.Empty : baseSafeArea;
+			}
 
 			// Non-safe-area views pass through to parent
 			return SafeAreaPadding.Empty;

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -357,13 +357,12 @@ namespace Microsoft.Maui.Platform
 				return new SafeAreaPadding(left, right, top, bottom);
 			}
 
-			// Fallback to legacy behavior
-			if (View is ISafeAreaView sav && sav.IgnoreSafeArea)
-			{
-				return SafeAreaPadding.Empty;
-			}
+			// Fallback to legacy ISafeAreaView behavior
+			if (View is ISafeAreaView sav)
+				return sav.IgnoreSafeArea ? SafeAreaPadding.Empty : baseSafeArea;
 
-			return baseSafeArea;
+			// Non-safe-area views pass through to parent
+			return SafeAreaPadding.Empty;
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

In `MauiView.GetAdjustedSafeAreaInsets()` on iOS, views that don't implement `ISafeAreaView` or `ISafeAreaView2` (such as `ContentPresenter`, `Border`) were falling through to return `baseSafeArea`. This applied full device safe area insets to views that never opted into safe area handling, causing double-padding when used inside ControlTemplates.

### Description of Change

Changed the fallback behavior in `GetAdjustedSafeAreaInsets()` to return `SafeAreaPadding.Empty` instead of `baseSafeArea` for views that don't implement `ISafeAreaView` or `ISafeAreaView2`.

**This is a philosophy change:**
- **Before:** Safe area applied by default (opt-out model)
- **After:** Safe area only applies to views that implement the interfaces (opt-in model)

This aligns iOS with Android, where `SafeAreaExtensions.GetSafeAreaView2()` returns `null` for non-safe-area views.

### Key Technical Details

**Safe area interfaces (opt-in contract):**
- `ISafeAreaView` - Legacy interface with `IgnoreSafeArea` property
- `ISafeAreaView2` - Modern interface with per-edge `SafeAreaRegions` control

**Views that implement these interfaces (safe area works):**
- `ContentPage`, `ContentView`, `Layout`, `ScrollView`, `Border`, `Page`

**Views that don't (now return Empty):**
- `ContentPresenter`, custom views without interface, third-party controls

### What NOT to Do (for future agents)

- ❌ **Don't use Element type in Platform layer** - `src/Core/src/Platform/` cannot reference Controls-layer types like `Element`. Use `IView`, `ISafeAreaView`, `ISafeAreaView2` only.
- ❌ **Don't use type name string matching** - Checking `View.GetType().Name.Contains("ContentPresenter")` is brittle
- ❌ **Don't check ancestor hierarchy for safe area** - Performance cost and wrong abstraction (safe area is per-edge, not binary)

### Edge Cases

| Scenario | Risk | Mitigation |
|----------|------|------------|
| Legacy layouts (`LegacyLayouts/`) | Low | Already `[Obsolete]` |
| Custom views without ISafeAreaView | Medium | Implement interface to opt-in |
| GraphicsView/WebView as root | Low | Parent ContentPage handles safe area |

### Issues Fixed

Fixes #33458

### Platforms Tested

- [x] iOS
- [x] Android  
- [ ] Windows (no SafeAreaEdges implementation)
- [ ] Mac (no SafeAreaEdges implementation)

### Screenshots

| Before Fix | After Fix |
|------------|-----------|
| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/3bd10b79-6472-4e86-b717-d433b56f1f82" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/d30e8c0c-3918-4528-bbd2-6fb3bba8d766" /> |