### PR TITLE
[XSG] Fix NaN value in XAML generating invalid code

### DIFF
--- a/src/Controls/src/SourceGen/GeneratorHelpers.cs
+++ b/src/Controls/src/SourceGen/GeneratorHelpers.cs
@@ -393,14 +393,34 @@ static class GeneratorHelpers
 
 	/// <summary>
 	/// Formats a value as a culture-independent C# literal for source generation.
-	/// Uses SymbolDisplay.FormatPrimitive to ensure proper handling of special values like NaN and Infinity
-	/// but also numeric types and makes sure they are formatted correctly.
+	/// Handles special floating-point values (NaN, Infinity) and uses SymbolDisplay.FormatPrimitive
+	/// for regular numeric types to ensure they are formatted correctly.
 	/// </summary>
 	/// <param name="value">The value to format</param>
 	/// <param name="quoted">Whether to include quotes around the formatted value</param>
 	/// <returns>A culture-independent string representation suitable for source generation</returns>
 	public static string FormatInvariant(object value, bool quoted = false)
 	{
+		// Handle special floating-point values that SymbolDisplay.FormatPrimitive doesn't prefix correctly
+		if (value is double d)
+		{
+			if (double.IsNaN(d))
+				return "double.NaN";
+			if (double.IsPositiveInfinity(d))
+				return "double.PositiveInfinity";
+			if (double.IsNegativeInfinity(d))
+				return "double.NegativeInfinity";
+		}
+		else if (value is float f)
+		{
+			if (float.IsNaN(f))
+				return "float.NaN";
+			if (float.IsPositiveInfinity(f))
+				return "float.PositiveInfinity";
+			if (float.IsNegativeInfinity(f))
+				return "float.NegativeInfinity";
+		}
+
 		return SymbolDisplay.FormatPrimitive(value, quoteStrings: quoted, useHexadecimalNumbers: false);
 	}
 

--- a/src/Controls/tests/SourceGen.UnitTests/Maui33532Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/Maui33532Tests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+/// <summary>
+/// Tests for issue #33532: NaN value in XAML generates invalid code
+/// When Padding="NaN" is used, the source generator was generating bare "NaN" instead of "double.NaN"
+/// </summary>
+public class Maui33532Tests : SourceGenXamlInitializeComponentTestBase
+{
+	[Fact]
+	public void ThicknessWithSingleNaNValue()
+	{
+		// Issue #33532: Padding="NaN" generates invalid code with bare "NaN" instead of "double.NaN"
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Button x:Name="testButton" Padding="NaN" Text="Test"/>
+</ContentPage>
+""";
+
+		var code =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify that NaN is correctly generated as double.NaN
+		Assert.Contains("double.NaN", generated, StringComparison.Ordinal);
+		
+		// Ensure incorrect bare NaN is not generated (would fail with CS0103)
+		// The pattern "new global::Microsoft.Maui.Thickness(NaN)" would be incorrect
+		Assert.DoesNotContain("Thickness(NaN)", generated, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ThicknessWithTwoNaNValues()
+	{
+		// Test Padding="NaN,NaN" (horizontal, vertical)
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Button x:Name="testButton" Padding="NaN,NaN" Text="Test"/>
+</ContentPage>
+""";
+
+		var code =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify that NaN is correctly generated as double.NaN
+		Assert.Contains("double.NaN", generated, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ThicknessWithFourNaNValues()
+	{
+		// Test Padding="NaN,NaN,NaN,NaN" (left, top, right, bottom)
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Button x:Name="testButton" Padding="NaN,NaN,NaN,NaN" Text="Test"/>
+</ContentPage>
+""";
+
+		var code =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify that NaN is correctly generated as double.NaN (should appear 4 times)
+		Assert.Contains("double.NaN", generated, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ThicknessWithMixedNaNAndRegularValues()
+	{
+		// Test mixing NaN with regular values: Padding="NaN,10,NaN,20"
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Button x:Name="testButton" Padding="NaN,10,NaN,20" Text="Test"/>
+</ContentPage>
+""";
+
+		var code =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify that both NaN and regular values are generated correctly
+		Assert.Contains("double.NaN", generated, StringComparison.Ordinal);
+		Assert.Contains("Thickness", generated, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void MarginWithNaNValue()
+	{
+		// Test Margin (also uses ThicknessConverter) with NaN
+		var xaml =
+"""
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Test.TestPage">
+	<Label x:Name="testLabel" Margin="NaN" Text="Test"/>
+</ContentPage>
+""";
+
+		var code =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+		var (result, generated) = RunGenerator(xaml, code, targetFramework: "net10.0");
+		Assert.False(result.Diagnostics.Any());
+
+		// Verify that NaN is correctly generated as double.NaN for Margin
+		Assert.Contains("double.NaN", generated, StringComparison.Ordinal);
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33532.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33532.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33532">
+	<!-- Test: NaN value in XAML should generate valid code with double.NaN -->
+	<StackLayout>
+		<Button x:Name="buttonNaN" Padding="NaN" Text="Padding = NaN"/>
+		<Button x:Name="buttonNaNComma" Padding="NaN,NaN" Text="Padding = NaN,NaN"/>
+		<Button x:Name="buttonNaNFull" Padding="NaN,NaN,NaN,NaN" Text="Padding = NaN,NaN,NaN,NaN"/>
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33532.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33532.xaml.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33532 : ContentPage
+{
+	public Maui33532() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void NaNValueInXamlGeneratesValidCode(XamlInflator inflator)
+		{
+			// This test reproduces issue #33532:
+			// When a XAML file contains NaN as a value (e.g., Padding="NaN"),
+			// the XAML Source Generator was generating invalid C# code using bare "NaN"
+			// instead of "double.NaN", causing CS0103 compiler error.
+			var page = new Maui33532(inflator);
+
+			Assert.NotNull(page);
+			Assert.NotNull(page.buttonNaN);
+			Assert.NotNull(page.buttonNaNComma);
+			Assert.NotNull(page.buttonNaNFull);
+
+			// Verify NaN values were applied correctly (all sides should be NaN)
+			Assert.True(double.IsNaN(page.buttonNaN.Padding.Left));
+			Assert.True(double.IsNaN(page.buttonNaN.Padding.Top));
+			Assert.True(double.IsNaN(page.buttonNaN.Padding.Right));
+			Assert.True(double.IsNaN(page.buttonNaN.Padding.Bottom));
+
+			// Verify 2-value NaN syntax (horizontal, vertical)
+			Assert.True(double.IsNaN(page.buttonNaNComma.Padding.Left));
+			Assert.True(double.IsNaN(page.buttonNaNComma.Padding.Top));
+
+			// Verify 4-value NaN syntax
+			Assert.True(double.IsNaN(page.buttonNaNFull.Padding.Left));
+			Assert.True(double.IsNaN(page.buttonNaNFull.Padding.Top));
+			Assert.True(double.IsNaN(page.buttonNaNFull.Padding.Right));
+			Assert.True(double.IsNaN(page.buttonNaNFull.Padding.Bottom));
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #33532

When a XAML file contains `NaN` as a value (e.g., `Padding="NaN"`), the XAML Source Generator was generating invalid C# code using bare `NaN` instead of `double.NaN`, resulting in:

```
error CS0103: The name 'NaN' does not exist in the current context
```

### Root Cause

The `FormatInvariant()` helper method in `GeneratorHelpers.cs` uses `SymbolDisplay.FormatPrimitive()` which outputs just `"NaN"` for `double.NaN` values, without the required type prefix.

### Fix

Updated `FormatInvariant()` to explicitly check for special floating-point values (`NaN`, `PositiveInfinity`, `NegativeInfinity`) for both `double` and `float` types, and return the properly qualified C# literals (e.g., `double.NaN`, `float.PositiveInfinity`).

## Changes

### Modified
- `src/Controls/src/SourceGen/GeneratorHelpers.cs` - Added special handling for NaN and Infinity values

### Added Tests
- `src/Controls/tests/SourceGen.UnitTests/Maui33532Tests.cs` - 5 SourceGen unit tests for ThicknessConverter with NaN
- `src/Controls/tests/Xaml.UnitTests/Issues/Maui33532.xaml[.cs]` - XAML unit test for all inflators

## Testing

All new tests pass:
- `ThicknessWithSingleNaNValue` - Tests `Padding="NaN"`
- `ThicknessWithTwoNaNValues` - Tests `Padding="NaN,NaN"`
- `ThicknessWithFourNaNValues` - Tests `Padding="NaN,NaN,NaN,NaN"`
- `ThicknessWithMixedNaNAndRegularValues` - Tests `Padding="NaN,10,NaN,20"`
- `MarginWithNaNValue` - Tests `Margin="NaN"`
