### PR TITLE
[Android] Fix for CollectionView Scrolled event is triggered on the initial app load.

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		SnapManager _snapManager;
 		ScrollHelper _scrollHelper;
 		protected RecyclerView.OnScrollListener RecyclerViewScrollListener;
-		bool _isInitialLayoutCompleted;
 
 		EmptyViewAdapter _emptyViewAdapter;
 		readonly DataChangeObserver _emptyCollectionObserver;
@@ -532,8 +531,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			AViewCompat.SetClipBounds(this, new ARect(0, 0, Width, Height));
 #pragma warning restore CS0618 // Obsolete
 
-			// Track layout completion to distinguish initial load from ItemsSource changes.
-			_isInitialLayoutCompleted = true;
 
 			// After a direct (non-animated) scroll operation, we may need to make adjustments
 			// to align the target item; if an adjustment is pending, execute it here.
@@ -649,13 +646,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			RemoveScrollListener();
 
 			RecyclerViewScrollListener = CreateScrollListener();
-
-			// If OnLayout has already been called (i.e., ItemsSource changed after view displayed),
-			// mark layout as complete so the scroll event fires.
-			if (_isInitialLayoutCompleted && RecyclerViewScrollListener is RecyclerViewScrollListener<TItemsView, TItemsViewSource> typedListener)
-			{
-				typedListener.MarkLayoutComplete();
-			}
 
 			AddOnScrollListener(RecyclerViewScrollListener);
 		}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		SnapManager _snapManager;
 		ScrollHelper _scrollHelper;
 		protected RecyclerView.OnScrollListener RecyclerViewScrollListener;
+		bool _isInitialLayoutCompleted;
 
 		EmptyViewAdapter _emptyViewAdapter;
 		readonly DataChangeObserver _emptyCollectionObserver;
@@ -531,6 +532,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			AViewCompat.SetClipBounds(this, new ARect(0, 0, Width, Height));
 #pragma warning restore CS0618 // Obsolete
 
+			// Track layout completion to distinguish initial load from ItemsSource changes.
+			_isInitialLayoutCompleted = true;
+
 			// After a direct (non-animated) scroll operation, we may need to make adjustments
 			// to align the target item; if an adjustment is pending, execute it here.
 			// (Deliberately checking the private member here rather than the property accessor; the accessor will
@@ -645,6 +649,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			RemoveScrollListener();
 
 			RecyclerViewScrollListener = CreateScrollListener();
+
+			// If OnLayout has already been called (i.e., ItemsSource changed after view displayed),
+			// mark layout as complete so the scroll event fires.
+			if (_isInitialLayoutCompleted && RecyclerViewScrollListener is RecyclerViewScrollListener<TItemsView, TItemsViewSource> typedListener)
+			{
+				typedListener.MarkLayoutComplete();
+			}
+
 			AddOnScrollListener(RecyclerViewScrollListener);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -531,7 +531,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			AViewCompat.SetClipBounds(this, new ARect(0, 0, Width, Height));
 #pragma warning restore CS0618 // Obsolete
 
-
 			// After a direct (non-animated) scroll operation, we may need to make adjustments
 			// to align the target item; if an adjustment is pending, execute it here.
 			// (Deliberately checking the private member here rather than the property accessor; the accessor will
@@ -646,7 +645,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			RemoveScrollListener();
 
 			RecyclerViewScrollListener = CreateScrollListener();
-
 			AddOnScrollListener(RecyclerViewScrollListener);
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -29,7 +29,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void UpdateAdapter(ItemsViewAdapter<TItemsView, TItemsViewSource> itemsViewAdapter)
 		{
 			ItemsViewAdapter = itemsViewAdapter;
-			_isInitialLayout = true;
+		}
+
+		internal void MarkLayoutComplete()
+		{
+			_isInitialLayout = false;
 		}
 
 		public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
@@ -43,16 +47,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_horizontalOffset += dx;
 			_verticalOffset += dy;
 
-			// Filter the initial layout callback to prevent Scrolled event from firing on page load.
-			// RecyclerView calls OnScrolled(0,0) during initial layout even without user interaction.
+			// Suppress initial OnScrolled(0,0) during page load; MauiRecyclerView calls
+			// MarkLayoutComplete() after first layout to allow subsequent scroll events.
 			if (_isInitialLayout && dx == 0 && dy == 0)
 			{
 				_isInitialLayout = false;
 				return;
 			}
-
-			// Clear the flag after first actual scroll to ensure subsequent events work normally
-			_isInitialLayout = false;
 
 			var (First, Center, Last) = GetVisibleItemsIndex(recyclerView);
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs

--- a/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/RecyclerViewScrollListener.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		int _horizontalOffset, _verticalOffset;
 		TItemsView _itemsView;
 		readonly bool _getCenteredItemOnXAndY = false;
-		bool _isInitialLayout = true;
 
 		public RecyclerViewScrollListener(TItemsView itemsView, ItemsViewAdapter<TItemsView, TItemsViewSource> itemsViewAdapter) : this(itemsView, itemsViewAdapter, false)
 		{
@@ -31,11 +30,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			ItemsViewAdapter = itemsViewAdapter;
 		}
 
-		internal void MarkLayoutComplete()
-		{
-			_isInitialLayout = false;
-		}
-
 		public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
 		{
 			base.OnScrolled(recyclerView, dx, dy);
@@ -47,11 +41,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_horizontalOffset += dx;
 			_verticalOffset += dy;
 
-			// Suppress initial OnScrolled(0,0) during page load; MauiRecyclerView calls
-			// MarkLayoutComplete() after first layout to allow subsequent scroll events.
-			if (_isInitialLayout && dx == 0 && dy == 0)
+			// Prevent the Scrolled event from firing on initial page load while allowing it for ItemsSource changes.
+			if (!recyclerView.IsLaidOut && dx == 0 && dy == 0)
 			{
-				_isInitialLayout = false;
 				return;
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33333.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33333.cs
@@ -1,0 +1,65 @@
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33333, "CollectionView Scrolled event is triggered on the initial app load", PlatformAffected.Android)]
+public class Issue33333 : ContentPage
+{
+	int _scrolledEventCount = 0;
+
+	public Issue33333()
+	{
+		var items = new ObservableCollection<string>();
+		for (int i = 0; i < 50; i++)
+		{
+			items.Add($"Item {i}");
+		}
+
+		var scrollCountLabel = new Label
+		{
+			AutomationId = "ScrollCountLabel",
+			Text = "Scrolled Event Count: 0",
+			FontSize = 18,
+			Padding = new Thickness(10),
+			BackgroundColor = Colors.LightYellow
+		};
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "TestCollectionView",
+			ItemsSource = items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					Padding = new Thickness(10),
+					VerticalOptions = LayoutOptions.Center
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			})
+		};
+
+		collectionView.Scrolled += (sender, e) =>
+		{
+			_scrolledEventCount++;
+			scrollCountLabel.Text = $"Scrolled Event Count: {_scrolledEventCount}";
+		};
+
+		var instructionLabel = new Label
+		{
+			AutomationId = "InstructionLabel",
+			Text = "The Scrolled event count should remain 0 on initial load. On Android, it incorrectly fires immediately.",
+			Padding = new Thickness(10),
+			FontSize = 14,
+			TextColor = Colors.Gray
+		};
+
+		Content = new StackLayout
+		{
+			Children = { scrollCountLabel, instructionLabel, collectionView }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33333.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33333.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33333 : _IssuesUITest
+{
+	public override string Issue => "CollectionView Scrolled event is triggered on the initial app load";
+
+	public Issue33333(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewScrolledEventShouldNotFireOnInitialLoad()
+	{
+		App.WaitForElement("ScrollCountLabel");
+
+		var scrollCountText = App.FindElement("ScrollCountLabel").GetText();
+		Assert.That(scrollCountText, Is.EqualTo("Scrolled Event Count: 0"),
+			"Scrolled event should not fire on initial load without user interaction");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause

The issue occurs because Android’s RecyclerView natively invokes OnScrolled(0, 0) during the initial layout to notify changes in visible item positions, even when no actual scrolling has occurred. The .NET MAUI CollectionView handler was treating this layout callback as a user scroll event, causing the Scrolled event to fire when the page loaded. This resulted in behavior that was inconsistent with iOS and violated the expectation that the Scrolled event should only be raised in response to actual user interaction.

### Description of Issue Fix

The fix introduces a boolean flag (_isInitialLayout) to filter out the first OnScrolled() invocation when both deltas are zero, identifying it as the initial layout callback. This flag is reset when the adapter is updated to correctly handle subsequent layout cycles. As a result, the Scrolled event is now raised only for genuine scroll activity, ensuring consistent behavior across Android and iOS platforms.

Tested the behavior in the following platforms.
 
- [x] Windows
- [x] Mac
- [x] iOS
- [x] Android

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/33333

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output

Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/d48418bd-679e-413a-8d73-8e85fd190c41">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/fa07fb58-895c-49de-b86c-4243c0e73d64">|


