### PR TITLE
[testing] Add xaml and resizetizer tests to run on helix

### DIFF
--- a/.github/skills/run-helix-tests/SKILL.md
+++ b/.github/skills/run-helix-tests/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: run-helix-tests
+description: "Submit and monitor .NET MAUI unit tests on Helix infrastructure. Supports running XAML, Resizetizer, Core, Essentials, and other unit test projects on distributed Helix queues."
+metadata:
+  author: dotnet-maui
+  version: "1.0"
+compatibility: Requires local .dotnet SDK provisioned (run `dotnet cake` first if missing).
+---
+
+# Run Helix Tests Skill
+
+Submit and monitor .NET MAUI unit tests on Helix infrastructure from your local machine.
+
+## Tools Required
+
+This skill uses `pwsh` (PowerShell 7+) to run the scripts. The scripts call the local `.dotnet/dotnet` SDK.
+
+## When to Use
+
+- User asks to "run tests on Helix"
+- User wants to validate test changes on Helix infrastructure
+- User asks to "test on multiple platforms" (Windows + macOS)
+- User wants to debug Helix-specific test failures locally
+- User asks about "Helix unit tests" (not device tests - those use `helix_xharness.proj`)
+
+## Prerequisites
+
+Before running Helix tests, ensure:
+
+1. **Local SDK provisioned**: The `.dotnet/` folder must exist with the SDK
+   ```powershell
+   # If missing, run:
+   dotnet cake --target=dotnet
+   ```
+
+2. **Build tasks compiled** (for first run):
+   ```powershell
+   # Windows
+   .\build.cmd -restore -build -configuration Release -projects .\Microsoft.Maui.BuildTasks.slnf
+
+   # macOS/Linux  
+   ./build.sh -restore -build -configuration Release -projects ./Microsoft.Maui.BuildTasks.slnf
+   ```
+
+## Scripts
+
+All scripts are in `.github/skills/run-helix-tests/scripts/`
+
+### 1. Submit Unit Tests to Helix
+```powershell
+# Submit all unit tests (XAML, Core, Essentials, Resizetizer, etc.)
+pwsh .github/skills/run-helix-tests/scripts/Submit-HelixTests.ps1
+
+# Submit with specific configuration
+pwsh .github/skills/run-helix-tests/scripts/Submit-HelixTests.ps1 -Configuration Debug
+
+# Submit to specific queue only
+pwsh .github/skills/run-helix-tests/scripts/Submit-HelixTests.ps1 -Queue "Windows.10.Amd64.Open"
+```
+
+### 2. Monitor Helix Job Status
+```powershell
+# Monitor a submitted job (use job ID from submission output)
+pwsh .github/skills/run-helix-tests/scripts/Get-HelixJobStatus.ps1 -JobId <JOB_ID>
+
+# Wait for completion with polling
+pwsh .github/skills/run-helix-tests/scripts/Get-HelixJobStatus.ps1 -JobId <JOB_ID> -Wait
+```
+
+### 3. Get Helix Work Item Console Logs
+```powershell
+# Get console output for a specific work item
+pwsh .github/skills/run-helix-tests/scripts/Get-HelixWorkItemLog.ps1 -JobId <JOB_ID> -WorkItem <WORK_ITEM_NAME>
+
+# Get failed work items only
+pwsh .github/skills/run-helix-tests/scripts/Get-HelixWorkItemLog.ps1 -JobId <JOB_ID> -FailedOnly
+```
+
+## Quick Start (Manual)
+
+If you prefer to run directly without scripts:
+
+```powershell
+# Windows
+.\helix.cmd
+
+# macOS/Linux
+./helix.sh
+```
+
+These wrapper scripts set the required environment variables and submit to Helix.
+
+## Test Projects Submitted
+
+The following test projects are submitted to Helix (defined in `eng/helix.proj`):
+
+| Project | Description |
+|---------|-------------|
+| `Controls.Xaml.UnitTests` | XAML parsing and compilation tests |
+| `Controls.Core.UnitTests` | Core controls unit tests |
+| `Controls.BindingSourceGen.UnitTests` | Binding source generator tests |
+| `SourceGen.UnitTests` | General source generator tests |
+| `Core.UnitTests` | Core framework tests |
+| `Essentials.UnitTests` | Essentials APIs tests |
+| `Resizetizer.UnitTests` | Image resizing tests |
+
+## Helix Queues
+
+Tests run on multiple queues in parallel:
+
+| Queue | Platform |
+|-------|----------|
+| `Windows.10.Amd64.Open` | Windows 10 x64 |
+| `osx.15.arm64.maui.open` | macOS 15 ARM64 |
+
+## Workflow
+
+### Submit and Monitor Tests
+
+1. **Submit tests**:
+   ```powershell
+   $result = pwsh .github/skills/run-helix-tests/scripts/Submit-HelixTests.ps1
+   # Note the job IDs from output
+   ```
+
+2. **Monitor progress**:
+   ```powershell
+   pwsh .github/skills/run-helix-tests/scripts/Get-HelixJobStatus.ps1 -JobId $jobId -Wait
+   ```
+
+3. **Check failures** (if any):
+   ```powershell
+   pwsh .github/skills/run-helix-tests/scripts/Get-HelixWorkItemLog.ps1 -JobId $jobId -FailedOnly
+   ```
+
+### Debug a Specific Test Failure
+
+1. Get the job ID from the Helix submission output
+2. Find the failed work item name
+3. Get the console log:
+   ```powershell
+   pwsh .github/skills/run-helix-tests/scripts/Get-HelixWorkItemLog.ps1 -JobId <JOB_ID> -WorkItem "Microsoft.Maui.Controls.Xaml.UnitTests.dll"
+   ```
+
+## Understanding Results
+
+Helix test results are reported to the console and can be viewed at:
+- **Helix Portal**: https://helix.dot.net/api/2019-06-17/jobs/{jobId}
+- **Work Item Console**: https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/console
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| "dotnet not found" | Run `dotnet cake --target=dotnet` to provision SDK |
+| "Build failed" | Run build.cmd/build.sh first to build required projects |
+| "Queue not available" | Check https://helix.dot.net for queue status |
+| "Test timeout" | Some tests have long execution times; this is normal |
+
+## Difference from Device Tests
+
+This skill runs **unit tests** on Helix (`eng/helix.proj`).
+
+For **device tests** (iOS, Android, MacCatalyst emulators/simulators), use:
+```powershell
+# Device tests use helix_xharness.proj instead
+./eng/common/msbuild.sh ./eng/helix_xharness.proj /t:Test /p:TargetOS=ios
+```
+
+See `.github/instructions/helix-device-tests.instructions.md` for device test guidance.

--- a/.github/skills/run-helix-tests/scripts/Get-HelixJobStatus.ps1
+++ b/.github/skills/run-helix-tests/scripts/Get-HelixJobStatus.ps1
@@ -1,0 +1,159 @@
+<#
+.SYNOPSIS
+    Get status of a Helix job.
+
+.DESCRIPTION
+    Queries the Helix API to get the status of a submitted job and its work items.
+
+.PARAMETER JobId
+    The Helix job ID (GUID format).
+
+.PARAMETER Wait
+    If specified, polls until the job completes.
+
+.PARAMETER PollInterval
+    Seconds between polls when using -Wait. Default: 30
+
+.EXAMPLE
+    ./Get-HelixJobStatus.ps1 -JobId "12345678-1234-1234-1234-123456789abc"
+    
+.EXAMPLE
+    ./Get-HelixJobStatus.ps1 -JobId "12345678-1234-1234-1234-123456789abc" -Wait
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$JobId,
+    
+    [switch]$Wait,
+    
+    [int]$PollInterval = 30
+)
+
+$ErrorActionPreference = "Stop"
+
+$baseUrl = "https://helix.dot.net/api/2019-06-17"
+
+function Get-JobDetails {
+    param([string]$JobId)
+    
+    $url = "$baseUrl/jobs/$JobId/details"
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Get
+        return $response
+    }
+    catch {
+        Write-Host "Error fetching job details: $_" -ForegroundColor Red
+        return $null
+    }
+}
+
+function Get-WorkItems {
+    param([string]$JobId)
+    
+    $url = "$baseUrl/jobs/$JobId/workitems"
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Get
+        return $response
+    }
+    catch {
+        Write-Host "Error fetching work items: $_" -ForegroundColor Red
+        return @()
+    }
+}
+
+function Show-JobStatus {
+    param($Details, $WorkItems)
+    
+    Write-Host ""
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host "  Helix Job: $($Details.JobId)" -ForegroundColor Cyan
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Source:    $($Details.Source)" -ForegroundColor Gray
+    Write-Host "  Type:      $($Details.Type)" -ForegroundColor Gray
+    Write-Host "  Build:     $($Details.Build)" -ForegroundColor Gray
+    Write-Host "  Queue:     $($Details.QueueId)" -ForegroundColor Gray
+    Write-Host ""
+    
+    # Count work item states
+    $pending = ($WorkItems | Where-Object { $_.State -eq "Waiting" -or $_.State -eq "Running" }).Count
+    $passed = ($WorkItems | Where-Object { $_.State -eq "Finished" -and $_.ExitCode -eq 0 }).Count
+    $failed = ($WorkItems | Where-Object { $_.State -eq "Finished" -and $_.ExitCode -ne 0 }).Count
+    $total = $WorkItems.Count
+    
+    Write-Host "  Work Items: $total total" -ForegroundColor White
+    if ($pending -gt 0) { Write-Host "    ⏳ Pending/Running: $pending" -ForegroundColor Yellow }
+    if ($passed -gt 0) { Write-Host "    ✅ Passed: $passed" -ForegroundColor Green }
+    if ($failed -gt 0) { Write-Host "    ❌ Failed: $failed" -ForegroundColor Red }
+    Write-Host ""
+    
+    # Show work item details
+    Write-Host "  Work Item Details:" -ForegroundColor White
+    Write-Host "  ─────────────────────────────────────────────────────────" -ForegroundColor Gray
+    
+    foreach ($item in $WorkItems | Sort-Object Name) {
+        $statusIcon = switch ($item.State) {
+            "Waiting" { "⏳" }
+            "Running" { "🔄" }
+            "Finished" { if ($item.ExitCode -eq 0) { "✅" } else { "❌" } }
+            default { "❓" }
+        }
+        
+        $statusColor = switch ($item.State) {
+            "Waiting" { "Yellow" }
+            "Running" { "Cyan" }
+            "Finished" { if ($item.ExitCode -eq 0) { "Green" } else { "Red" } }
+            default { "Gray" }
+        }
+        
+        Write-Host "  $statusIcon $($item.Name)" -ForegroundColor $statusColor
+        if ($item.State -eq "Finished" -and $item.ExitCode -ne 0) {
+            Write-Host "       Exit Code: $($item.ExitCode)" -ForegroundColor Red
+            Write-Host "       Console: $baseUrl/jobs/$JobId/workitems/$($item.Name)/console" -ForegroundColor Gray
+        }
+    }
+    
+    Write-Host ""
+    Write-Host "  Portal: https://helix.dot.net/api/2019-06-17/jobs/$JobId" -ForegroundColor Gray
+    Write-Host ""
+    
+    return @{
+        Pending = $pending
+        Passed = $passed
+        Failed = $failed
+        Total = $total
+    }
+}
+
+# Main execution
+Write-Host "Fetching Helix job status..." -ForegroundColor Cyan
+
+do {
+    $details = Get-JobDetails -JobId $JobId
+    if (-not $details) {
+        Write-Host "Could not fetch job details. Is the JobId correct?" -ForegroundColor Red
+        exit 1
+    }
+    
+    $workItems = Get-WorkItems -JobId $JobId
+    $status = Show-JobStatus -Details $details -WorkItems $workItems
+    
+    if ($Wait -and $status.Pending -gt 0) {
+        Write-Host "Waiting $PollInterval seconds before next poll..." -ForegroundColor Gray
+        Start-Sleep -Seconds $PollInterval
+        Clear-Host
+    }
+} while ($Wait -and $status.Pending -gt 0)
+
+# Final summary
+if ($status.Failed -gt 0) {
+    Write-Host "❌ Job completed with $($status.Failed) failed work item(s)" -ForegroundColor Red
+    exit 1
+} elseif ($status.Pending -eq 0) {
+    Write-Host "✅ Job completed successfully!" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "⏳ Job still in progress..." -ForegroundColor Yellow
+    exit 0
+}

--- a/.github/skills/run-helix-tests/scripts/Get-HelixWorkItemLog.ps1
+++ b/.github/skills/run-helix-tests/scripts/Get-HelixWorkItemLog.ps1
@@ -1,0 +1,169 @@
+<#
+.SYNOPSIS
+    Get console log for a Helix work item.
+
+.DESCRIPTION
+    Retrieves the console output from a Helix work item execution.
+    Useful for debugging test failures.
+
+.PARAMETER JobId
+    The Helix job ID (GUID format).
+
+.PARAMETER WorkItem
+    The work item name (e.g., "Microsoft.Maui.Controls.Xaml.UnitTests.dll").
+    Supports wildcards.
+
+.PARAMETER FailedOnly
+    If specified, only shows logs for failed work items.
+
+.PARAMETER TailLines
+    Number of lines to show from the end of the log. Default: 100
+
+.EXAMPLE
+    ./Get-HelixWorkItemLog.ps1 -JobId "12345678-..." -WorkItem "Microsoft.Maui.Controls.Xaml.UnitTests.dll"
+    
+.EXAMPLE
+    ./Get-HelixWorkItemLog.ps1 -JobId "12345678-..." -FailedOnly
+    
+.EXAMPLE
+    ./Get-HelixWorkItemLog.ps1 -JobId "12345678-..." -WorkItem "*Xaml*" -TailLines 200
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$JobId,
+    
+    [string]$WorkItem,
+    
+    [switch]$FailedOnly,
+    
+    [int]$TailLines = 100
+)
+
+$ErrorActionPreference = "Stop"
+
+$baseUrl = "https://helix.dot.net/api/2019-06-17"
+
+function Get-WorkItems {
+    param([string]$JobId)
+    
+    $url = "$baseUrl/jobs/$JobId/workitems"
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Get
+        return $response
+    }
+    catch {
+        Write-Host "Error fetching work items: $_" -ForegroundColor Red
+        return @()
+    }
+}
+
+function Get-ConsoleLog {
+    param(
+        [string]$JobId,
+        [string]$WorkItemName
+    )
+    
+    $url = "$baseUrl/jobs/$JobId/workitems/$WorkItemName/console"
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Get
+        return $response
+    }
+    catch {
+        Write-Host "Error fetching console log: $_" -ForegroundColor Red
+        return $null
+    }
+}
+
+function Show-WorkItemLog {
+    param(
+        [string]$JobId,
+        $WorkItem,
+        [int]$TailLines
+    )
+    
+    Write-Host ""
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host "  Work Item: $($WorkItem.Name)" -ForegroundColor Cyan
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  State:     $($WorkItem.State)" -ForegroundColor $(if ($WorkItem.State -eq "Finished") { if ($WorkItem.ExitCode -eq 0) { "Green" } else { "Red" } } else { "Yellow" })
+    Write-Host "  Exit Code: $($WorkItem.ExitCode)" -ForegroundColor $(if ($WorkItem.ExitCode -eq 0) { "Green" } else { "Red" })
+    Write-Host "  Machine:   $($WorkItem.MachineName)" -ForegroundColor Gray
+    Write-Host ""
+    
+    Write-Host "  Console Log (last $TailLines lines):" -ForegroundColor White
+    Write-Host "  ─────────────────────────────────────────────────────────" -ForegroundColor Gray
+    
+    $log = Get-ConsoleLog -JobId $JobId -WorkItemName $WorkItem.Name
+    if ($log) {
+        # Split by lines and take last N
+        $lines = $log -split "`n"
+        $startIndex = [Math]::Max(0, $lines.Count - $TailLines)
+        $relevantLines = $lines[$startIndex..($lines.Count - 1)]
+        
+        foreach ($line in $relevantLines) {
+            # Color code based on content
+            $color = "White"
+            if ($line -match "FAIL|ERROR|Exception|❌") { $color = "Red" }
+            elseif ($line -match "PASS|✅|succeeded") { $color = "Green" }
+            elseif ($line -match "SKIP|⚠️|warning") { $color = "Yellow" }
+            elseif ($line -match "^\s*at ") { $color = "DarkGray" }  # Stack trace
+            
+            Write-Host "  $line" -ForegroundColor $color
+        }
+    } else {
+        Write-Host "  (No console log available)" -ForegroundColor Gray
+    }
+    
+    Write-Host ""
+    Write-Host "  Full log: $baseUrl/jobs/$JobId/workitems/$($WorkItem.Name)/console" -ForegroundColor Gray
+    Write-Host ""
+}
+
+# Main execution
+Write-Host "Fetching Helix work items..." -ForegroundColor Cyan
+
+$workItems = Get-WorkItems -JobId $JobId
+if ($workItems.Count -eq 0) {
+    Write-Host "No work items found for job $JobId" -ForegroundColor Yellow
+    exit 0
+}
+
+# Filter work items
+$filtered = $workItems
+
+if ($FailedOnly) {
+    $filtered = $filtered | Where-Object { $_.State -eq "Finished" -and $_.ExitCode -ne 0 }
+    if ($filtered.Count -eq 0) {
+        Write-Host "✅ No failed work items found!" -ForegroundColor Green
+        exit 0
+    }
+}
+
+if ($WorkItem) {
+    $filtered = $filtered | Where-Object { $_.Name -like $WorkItem }
+    if ($filtered.Count -eq 0) {
+        Write-Host "No work items matching '$WorkItem' found" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "Available work items:" -ForegroundColor Cyan
+        foreach ($item in $workItems) {
+            Write-Host "  - $($item.Name)" -ForegroundColor Gray
+        }
+        exit 1
+    }
+}
+
+# Show logs for each filtered work item
+foreach ($item in $filtered) {
+    Show-WorkItemLog -JobId $JobId -WorkItem $item -TailLines $TailLines
+}
+
+# Summary
+$failedCount = ($filtered | Where-Object { $_.ExitCode -ne 0 }).Count
+if ($failedCount -gt 0) {
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Red
+    Write-Host "  Summary: $failedCount failed work item(s)" -ForegroundColor Red
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Red
+    exit 1
+}

--- a/.github/skills/run-helix-tests/scripts/Submit-HelixTests.ps1
+++ b/.github/skills/run-helix-tests/scripts/Submit-HelixTests.ps1
@@ -1,0 +1,132 @@
+<#
+.SYNOPSIS
+    Submit .NET MAUI unit tests to Helix infrastructure.
+
+.DESCRIPTION
+    This script submits unit tests to Helix queues for distributed testing.
+    It sets up required environment variables and invokes the helix.proj MSBuild project.
+
+.PARAMETER Configuration
+    Build configuration (Debug or Release). Default: Release
+
+.PARAMETER Queue
+    Specific Helix queue to target. If not specified, uses default queues from helix.proj.
+
+.PARAMETER DryRun
+    If specified, shows what would be submitted without actually submitting.
+
+.EXAMPLE
+    ./Submit-HelixTests.ps1
+    
+.EXAMPLE
+    ./Submit-HelixTests.ps1 -Configuration Debug
+    
+.EXAMPLE
+    ./Submit-HelixTests.ps1 -Queue "Windows.10.Amd64.Open"
+#>
+
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+    
+    [string]$Queue,
+    
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+# Find repository root
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) {
+    $repoRoot = (Get-Item $PSScriptRoot).Parent.Parent.Parent.Parent.FullName
+}
+$repoRoot = $repoRoot -replace '/', '\'
+
+Write-Host "Repository root: $repoRoot" -ForegroundColor Cyan
+
+# Check for local SDK
+$dotnetPath = Join-Path $repoRoot ".dotnet"
+$dotnetExe = if ($IsWindows -or $env:OS -match "Windows") {
+    Join-Path $dotnetPath "dotnet.exe"
+} else {
+    Join-Path $dotnetPath "dotnet"
+}
+
+if (-not (Test-Path $dotnetExe)) {
+    Write-Host "ERROR: Local SDK not found at $dotnetPath" -ForegroundColor Red
+    Write-Host "Run 'dotnet cake --target=dotnet' to provision the local SDK first." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Using SDK: $dotnetExe" -ForegroundColor Cyan
+
+# Set required environment variables
+$env:BUILD_SOURCEBRANCH = "main"
+$env:BUILD_REPOSITORY_NAME = "maui"
+$env:SYSTEM_TEAMPROJECT = "public"
+$env:BUILD_REASON = "test"
+$env:DOTNET_ROOT = $dotnetPath
+
+Write-Host ""
+Write-Host "Environment Variables:" -ForegroundColor Cyan
+Write-Host "  BUILD_SOURCEBRANCH: $env:BUILD_SOURCEBRANCH"
+Write-Host "  BUILD_REPOSITORY_NAME: $env:BUILD_REPOSITORY_NAME"
+Write-Host "  SYSTEM_TEAMPROJECT: $env:SYSTEM_TEAMPROJECT"
+Write-Host "  BUILD_REASON: $env:BUILD_REASON"
+Write-Host ""
+
+# Build command
+$helixProj = Join-Path $repoRoot "eng\helix.proj"
+$args = @(
+    "build"
+    $helixProj
+    "/restore"
+    "/t:Test"
+    "/p:Configuration=$Configuration"
+)
+
+if ($Queue) {
+    $args += "/p:HelixTargetQueues=$Queue"
+    Write-Host "Target Queue: $Queue" -ForegroundColor Cyan
+}
+
+# Add binlog for diagnostics
+$binlogPath = Join-Path $repoRoot "artifacts\log\helix-submit.binlog"
+$args += "/bl:$binlogPath"
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Host "DRY RUN - Would execute:" -ForegroundColor Yellow
+    Write-Host "$dotnetExe $($args -join ' ')" -ForegroundColor Gray
+    exit 0
+}
+
+Write-Host ""
+Write-Host "Submitting tests to Helix..." -ForegroundColor Green
+Write-Host "Command: $dotnetExe $($args -join ' ')" -ForegroundColor Gray
+Write-Host ""
+
+# Execute
+Push-Location $repoRoot
+try {
+    & $dotnetExe @args
+    $exitCode = $LASTEXITCODE
+    
+    if ($exitCode -eq 0) {
+        Write-Host ""
+        Write-Host "✅ Tests submitted successfully!" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Monitor results at: https://helix.dot.net" -ForegroundColor Cyan
+        Write-Host "Binlog saved to: $binlogPath" -ForegroundColor Gray
+    } else {
+        Write-Host ""
+        Write-Host "❌ Submission failed with exit code: $exitCode" -ForegroundColor Red
+        Write-Host "Check binlog for details: $binlogPath" -ForegroundColor Yellow
+    }
+    
+    exit $exitCode
+}
+finally {
+    Pop-Location
+}

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -9,7 +9,9 @@
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <FailOnTestFailure>true</FailOnTestFailure>
-    <DotNetCliVersion>$(MicrosoftNETSdkPackageVersion)</DotNetCliVersion>
+    <DotNetCliVersion>$(MicrosoftNETSdkPackageVersion)</DotNetCliVersion> 
+    <!-- Staging directory for MSBuild test payloads -->
+    <MauiHelixPayloadDir>$(RepoRoot)artifacts/helix-payload/</MauiHelixPayloadDir>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,14 +28,56 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <XUnitProject Include="$(RepoRoot)src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj" />
+    <XUnitProject Include="$(RepoRoot)src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Core/tests/UnitTests/Core.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Essentials/test/UnitTests/Essentials.UnitTests.csproj" />
+  </ItemGroup>
 
-    <!-- <XUnitProject Include="$(RepoRoot)/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj" /> -->
+  <!-- Prepare the staging directory for MSBuild test payloads - runs early during Restore -->
+  <Target Name="PrepareMauiHelixPayload" BeforeTargets="Restore;Build;Test">
+    <MakeDir Directories="$(MauiHelixPayloadDir)src/Workload/Microsoft.Maui.Sdk/Sdk" />
+    <MakeDir Directories="$(MauiHelixPayloadDir)src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0" />
+    
+    <!-- Copy Maui.InTree.props and targets -->
+    <Copy SourceFiles="$(RepoRoot)src/Maui.InTree.props" DestinationFolder="$(MauiHelixPayloadDir)src" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(RepoRoot)src/Maui.InTree.targets" DestinationFolder="$(MauiHelixPayloadDir)src" SkipUnchangedFiles="true" />
+    
+    <!-- Copy Workload SDK files -->
+    <ItemGroup>
+      <WorkloadSdkFiles Include="$(RepoRoot)src/Workload/Microsoft.Maui.Sdk/Sdk/*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WorkloadSdkFiles)" DestinationFolder="$(MauiHelixPayloadDir)src/Workload/Microsoft.Maui.Sdk/Sdk" SkipUnchangedFiles="true" />
+    
+    <!-- Copy Build.Tasks nuget files needed by MSBuild tests -->
+    <ItemGroup>
+      <BuildTasksNugetFiles Include="$(RepoRoot)src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BuildTasksNugetFiles)" DestinationFolder="$(MauiHelixPayloadDir)src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0" SkipUnchangedFiles="true" />
+    
+    <Message Text="Prepared MSBuild test payload at $(MauiHelixPayloadDir)" Importance="high" />
+  </Target>
 
+  <!-- Include payloads for XAML tests -->
+  <ItemGroup>
+    <!-- SourceGen DLL for SourceGen tests -->
+    <HelixCorrelationPayload Include="$(RepoRoot)artifacts/bin/Controls.SourceGen/$(Configuration)/netstandard2.0">
+      <Destination>sourcegen</Destination>
+    </HelixCorrelationPayload>
+    
+    <!-- MSBuild tests payloads -->
+    <!-- .buildtasks folder with all MSBuild targets/props and build task DLLs -->
+    <HelixCorrelationPayload Include="$(RepoRoot).buildtasks">
+      <Destination>buildtasks</Destination>
+    </HelixCorrelationPayload>
+    
+    <!-- MSBuild test support files (Maui.InTree.props/targets and Workload SDK) -->
+    <HelixCorrelationPayload Include="$(MauiHelixPayloadDir)src">
+      <Destination>src</Destination>
+    </HelixCorrelationPayload>
   </ItemGroup>
 
 </Project>

--- a/eng/pipelines/arcade/stage-unit-tests.yml
+++ b/eng/pipelines/arcade/stage-unit-tests.yml
@@ -38,44 +38,6 @@ stages:
       - script: ${{ job.buildScript }} -restore -build -configuration ${{ parameters.buildConfig }} -projects "${{ parameters.buildTaskProjects }}" /p:ArchiveTests=false /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors) /bl:$(Build.Arcade.LogsPath)${{ parameters.buildConfig }}/buildtasks.binlog $(_OfficialBuildIdArgs)
         displayName: 🛠️ Build BuildTasks
 
-      # - template: /eng/pipelines/arcade/setup-test-env.yml
-      #   parameters:
-      #     mauiSourcePath: ${{ parameters.mauiSourcePath }}
-      #     buildConfig: ${{ parameters.buildConfig }}
-      #     repoLogPath: ${{ parameters.repoLogPath }}
-      #     installPackageArtifacts: false
-      #     buildMSBuildTasks: true
-
-      # - template: /eng/pipelines/common/run-dotnet-preview.yml
-      #   parameters:
-      #     displayName: Run Controls.Xaml.UnitTests - ${{ job.testOS }}
-      #     mauiSourcePath: ${{ parameters.mauiSourcePath }}
-      #     command: test
-      #     project: ${{ parameters.mauiSourcePath }}/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
-      #     arguments: '-c ${{ parameters.buildConfig }} --logger trx --results-directory $(Agent.TempDirectory)/Controls.Xaml.UnitTests /bl:$(Build.Arcade.LogsPath)${{ parameters.buildConfig }}/Controls.Xaml.UnitTests.binlog /p:_SkipUpdateBuildNumber=true'
-      #     useExitCodeForErrors: true
-
-      # - task: PublishTestResults@2
-      #   inputs:
-      #     testResultsFormat: VSTest
-      #     testResultsFiles: $(Agent.TempDirectory)/Controls.Xaml.UnitTests/*.trx
-      #     testRunTitle: Controls.Xaml.UnitTests - ${{ job.testOS }}
-
-      # - template: /eng/pipelines/common/run-dotnet-preview.yml
-      #   parameters:
-      #     displayName: Run Resizetizer.UnitTests - ${{ job.testOS }}
-      #     mauiSourcePath: ${{ parameters.mauiSourcePath }}
-      #     command: test
-      #     project: ${{ parameters.mauiSourcePath }}/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
-      #     arguments: '-c ${{ parameters.buildConfig }} --logger trx --results-directory $(Agent.TempDirectory)/Resizetizer.UnitTests /p:_SkipUpdateBuildNumber=true'
-      #     useExitCodeForErrors: true
-
-      # - task: PublishTestResults@2
-      #   inputs:
-      #     testResultsFormat: VSTest
-      #     testResultsFiles: $(Agent.TempDirectory)/Resizetizer.UnitTests/*.trx
-      #     testRunTitle: Resizetizer.UnitTests - ${{ job.testOS }}
-
       - template: /eng/pipelines/common/run-dotnet-preview.yml
         parameters:
           displayName: Run Graphics.Tests - ${{ job.testOS }}

--- a/eng/pipelines/arcade/stage-unit-tests.yml
+++ b/eng/pipelines/arcade/stage-unit-tests.yml
@@ -46,35 +46,35 @@ stages:
       #     installPackageArtifacts: false
       #     buildMSBuildTasks: true
 
-      - template: /eng/pipelines/common/run-dotnet-preview.yml
-        parameters:
-          displayName: Run Controls.Xaml.UnitTests - ${{ job.testOS }}
-          mauiSourcePath: ${{ parameters.mauiSourcePath }}
-          command: test
-          project: ${{ parameters.mauiSourcePath }}/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
-          arguments: '-c ${{ parameters.buildConfig }} --logger trx --results-directory $(Agent.TempDirectory)/Controls.Xaml.UnitTests /bl:$(Build.Arcade.LogsPath)${{ parameters.buildConfig }}/Controls.Xaml.UnitTests.binlog /p:_SkipUpdateBuildNumber=true'
-          useExitCodeForErrors: true
+      # - template: /eng/pipelines/common/run-dotnet-preview.yml
+      #   parameters:
+      #     displayName: Run Controls.Xaml.UnitTests - ${{ job.testOS }}
+      #     mauiSourcePath: ${{ parameters.mauiSourcePath }}
+      #     command: test
+      #     project: ${{ parameters.mauiSourcePath }}/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+      #     arguments: '-c ${{ parameters.buildConfig }} --logger trx --results-directory $(Agent.TempDirectory)/Controls.Xaml.UnitTests /bl:$(Build.Arcade.LogsPath)${{ parameters.buildConfig }}/Controls.Xaml.UnitTests.binlog /p:_SkipUpdateBuildNumber=true'
+      #     useExitCodeForErrors: true
 
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: $(Agent.TempDirectory)/Controls.Xaml.UnitTests/*.trx
-          testRunTitle: Controls.Xaml.UnitTests - ${{ job.testOS }}
+      # - task: PublishTestResults@2
+      #   inputs:
+      #     testResultsFormat: VSTest
+      #     testResultsFiles: $(Agent.TempDirectory)/Controls.Xaml.UnitTests/*.trx
+      #     testRunTitle: Controls.Xaml.UnitTests - ${{ job.testOS }}
 
-      - template: /eng/pipelines/common/run-dotnet-preview.yml
-        parameters:
-          displayName: Run Resizetizer.UnitTests - ${{ job.testOS }}
-          mauiSourcePath: ${{ parameters.mauiSourcePath }}
-          command: test
-          project: ${{ parameters.mauiSourcePath }}/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
-          arguments: '-c ${{ parameters.buildConfig }} --logger trx --results-directory $(Agent.TempDirectory)/Resizetizer.UnitTests /p:_SkipUpdateBuildNumber=true'
-          useExitCodeForErrors: true
+      # - template: /eng/pipelines/common/run-dotnet-preview.yml
+      #   parameters:
+      #     displayName: Run Resizetizer.UnitTests - ${{ job.testOS }}
+      #     mauiSourcePath: ${{ parameters.mauiSourcePath }}
+      #     command: test
+      #     project: ${{ parameters.mauiSourcePath }}/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+      #     arguments: '-c ${{ parameters.buildConfig }} --logger trx --results-directory $(Agent.TempDirectory)/Resizetizer.UnitTests /p:_SkipUpdateBuildNumber=true'
+      #     useExitCodeForErrors: true
 
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: $(Agent.TempDirectory)/Resizetizer.UnitTests/*.trx
-          testRunTitle: Resizetizer.UnitTests - ${{ job.testOS }}
+      # - task: PublishTestResults@2
+      #   inputs:
+      #     testResultsFormat: VSTest
+      #     testResultsFiles: $(Agent.TempDirectory)/Resizetizer.UnitTests/*.trx
+      #     testRunTitle: Resizetizer.UnitTests - ${{ job.testOS }}
 
       - template: /eng/pipelines/common/run-dotnet-preview.yml
         parameters:

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (string.IsNullOrEmpty(Member) || Member.IndexOf(".", StringComparison.Ordinal) == -1)
 				throw new XamlParseException("Syntax for x:Static is [Member=][prefix:]typeName.staticMemberName", serviceProvider);
 
-			var dotIdx = Member.LastIndexOf('.');
+#pragma warning disable CA1865 // Use 'string.LastIndexOf(char)' - CA1307 requires StringComparison
+			var dotIdx = Member.LastIndexOf(".", StringComparison.Ordinal);
+#pragma warning restore CA1865
 			var typename = Member.Substring(0, dotIdx);
 			var membername = Member.Substring(dotIdx + 1);
 

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Microsoft.Maui.Controls.Xaml.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618</NoWarn>
+    <NoWarn>$(NoWarn);0672;0219;0414;CS0436;CS0618;CA2252</NoWarn>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);XC0618;XC0022;XC0023;XC0025;XC0045;MAUIG2045;MAUID1000;MAUIX2005</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
@@ -33,11 +33,11 @@
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Build.Framework" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" Publish="true" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" Publish="true" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" Publish="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" Publish="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -89,6 +89,9 @@
 
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <!-- MSBuild test support files - copy to output for Helix -->
+    <Content Include="MSBuild\_Directory.Build.props" CopyToOutputDirectory="PreserveNewest" Link="MSBuild\_Directory.Build.props" />
+    <Content Include="MSBuild\_Directory.Build.targets" CopyToOutputDirectory="PreserveNewest" Link="MSBuild\_Directory.Build.targets" />
   </ItemGroup>
 
 </Project>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17222.xaml.cs
@@ -39,19 +39,20 @@ public partial class Maui17222 : ContentPage
 
 				var page = new Maui17222(inflator);
 				SourceInfo info = VisualDiagnostics.GetSourceInfo(page);
-				Assert.Equal(new Uri($"Issues{System.IO.Path.DirectorySeparatorChar}Maui17222.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+				// Normalize path separators for cross-platform comparison (compiled on Windows, may run on macOS/Linux via Helix)
+				Assert.Equal("Issues/Maui17222.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", info.SourceUri.OriginalString.Replace('\\', '/'));
 				Assert.Equal(2, info.LineNumber);
 				Assert.Equal(2, info.LinePosition);
 
 				var button = page.button;
 				info = VisualDiagnostics.GetSourceInfo(button);
-				Assert.Equal(new Uri($"Issues{System.IO.Path.DirectorySeparatorChar}Maui17222.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+				Assert.Equal("Issues/Maui17222.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", info.SourceUri.OriginalString.Replace('\\', '/'));
 				Assert.Equal(6, info.LineNumber);
 				Assert.Equal(6, info.LinePosition);
 
 				Style style = button.Style;
 				info = VisualDiagnostics.GetSourceInfo(style);
-				Assert.Equal(new Uri($"Issues{System.IO.Path.DirectorySeparatorChar}Maui17222Style.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+				Assert.Equal("Issues/Maui17222Style.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", info.SourceUri.OriginalString.Replace('\\', '/'));
 				Assert.Equal(5, info.LineNumber);
 				Assert.Equal(6, info.LinePosition);
 
@@ -59,13 +60,13 @@ public partial class Maui17222 : ContentPage
 				Assert.Equal(setter.Property, Button.TextColorProperty);
 				Assert.Equal(setter.Value, Colors.Red);
 				info = VisualDiagnostics.GetSourceInfo(setter);
-				Assert.Equal(new Uri($"Issues{System.IO.Path.DirectorySeparatorChar}Maui17222Style.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+				Assert.Equal("Issues/Maui17222Style.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", info.SourceUri.OriginalString.Replace('\\', '/'));
 				Assert.Equal(6, info.LineNumber);
 				Assert.Equal(10, info.LinePosition);
 
 				style = style.BasedOn;
 				info = VisualDiagnostics.GetSourceInfo(style);
-				Assert.Equal(new Uri($"Issues{System.IO.Path.DirectorySeparatorChar}Maui17222BaseStyle.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", UriKind.Relative), info.SourceUri);
+				Assert.Equal("Issues/Maui17222BaseStyle.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", info.SourceUri.OriginalString.Replace('\\', '/'));
 				Assert.Equal(5, info.LineNumber);
 				Assert.Equal(6, info.LinePosition);
 			}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui17461.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui17461.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui21757.xaml.cs
@@ -6,7 +6,6 @@ using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.UnitTests;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui2418.rtsg.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui2418.rtsg.xaml.cs
@@ -34,7 +34,8 @@ public partial class Maui2418 : ContentPage
 			Assert.NotNull(page);
 			var label0 = page.label0;
 			var sourceInfo = VisualDiagnostics.GetSourceInfo(label0);
-			Assert.Equal($"Issues{System.IO.Path.DirectorySeparatorChar}Maui2418.rtsg.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", sourceInfo.SourceUri.OriginalString);
+			// Normalize path separators for cross-platform comparison (compiled on Windows, may run on macOS/Linux via Helix)
+			Assert.Equal("Issues/Maui2418.rtsg.xaml;assembly=Microsoft.Maui.Controls.Xaml.UnitTests", sourceInfo.SourceUri.OriginalString.Replace('\\', '/'));
 		}
 	}
 #endif

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.props
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.props
@@ -1,6 +1,14 @@
 <Project>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(HELIX_CORRELATION_PAYLOAD)' != ''">
+    <!-- On Helix, use the correlation payload paths -->
+    <MauiRootDirectory>$(HELIX_CORRELATION_PAYLOAD)\</MauiRootDirectory>
+    <MauiSrcDirectory>$(MauiRootDirectory)src\</MauiSrcDirectory>
+    <_MauiBuildTasksLocation>$(MauiRootDirectory)buildtasks\</_MauiBuildTasksLocation>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HELIX_CORRELATION_PAYLOAD)' == ''">
+    <!-- Local development - use relative paths from repo root -->
     <MauiRootDirectory>$(MSBuildThisFileDirectory)..\..\..\..\..\..\..\</MauiRootDirectory>
     <MauiSrcDirectory>$(MauiRootDirectory)src\</MauiSrcDirectory>
     <_MauiBuildTasksLocation>$(MauiRootDirectory).buildtasks\</_MauiBuildTasksLocation>
@@ -8,4 +16,4 @@
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" />
 
-</Project> 
+</Project>

--- a/src/Controls/tests/Xaml.UnitTests/XamlInflatorDataAttribute.cs
+++ b/src/Controls/tests/Xaml.UnitTests/XamlInflatorDataAttribute.cs
@@ -12,8 +12,10 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 /// </summary>
 public class XamlInflatorDataAttribute : DataAttribute
 {
-	public override IEnumerable<object[]> GetData(MethodInfo testMethod) =>
-		Enum.GetValues<XamlInflator>().Select(x => new object[] { x });
+	public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+	{
+		return Enum.GetValues<XamlInflator>().Select(x => new object[] { x });
+	}
 }
 
 /// <summary>
@@ -25,6 +27,7 @@ public class XamlInflatorPairDataAttribute : DataAttribute
 	public override IEnumerable<object[]> GetData(MethodInfo testMethod)
 	{
 		var inflators = Enum.GetValues<XamlInflator>();
+		
 		foreach (var from in inflators)
 		{
 			foreach (var rd in inflators)
@@ -43,8 +46,13 @@ public static class XamlInflatorTestData
 	/// <summary>
 	/// Returns all XamlInflator enum values as test data.
 	/// </summary>
-	public static IEnumerable<object[]> Inflators =>
-		Enum.GetValues<XamlInflator>().Select(x => new object[] { x });
+	public static IEnumerable<object[]> Inflators
+	{
+		get
+		{
+			return Enum.GetValues<XamlInflator>().Select(x => new object[] { x });
+		}
+	}
 
 	/// <summary>
 	/// Returns all pairs of XamlInflator enum values as test data.
@@ -55,6 +63,7 @@ public static class XamlInflatorTestData
 		get
 		{
 			var inflators = Enum.GetValues<XamlInflator>();
+			
 			foreach (var from in inflators)
 			{
 				foreach (var rd in inflators)

--- a/src/Core/src/Fonts/FontFile.cs
+++ b/src/Core/src/Fonts/FontFile.cs
@@ -107,7 +107,9 @@ namespace Microsoft.Maui
 
 			string currentString = "";
 			char lastCharacter = ' ';
-			var index = fontFamily.LastIndexOf('-');
+#pragma warning disable CA1865 // Use 'string.LastIndexOf(char)' - CA1307 requires StringComparison
+			var index = fontFamily.LastIndexOf("-", StringComparison.Ordinal);
+#pragma warning restore CA1865
 			bool multipleCaps = false;
 			var cleansedString = index > 0 ? fontFamily.Substring(0, index) : fontFamily;
 			foreach (var c in cleansedString)

--- a/src/Core/src/Handlers/HybridWebView/FileExtensionContentTypeProvider.cs
+++ b/src/Core/src/Handlers/HybridWebView/FileExtensionContentTypeProvider.cs
@@ -458,7 +458,9 @@ internal sealed class FileExtensionContentTypeProvider
 			return null;
 		}
 
-		int index = path.LastIndexOf('.');
+#pragma warning disable CA1865 // Use 'string.LastIndexOf(char)' - CA1307 requires StringComparison
+		int index = path.LastIndexOf(".", StringComparison.Ordinal);
+#pragma warning restore CA1865
 		if (index < 0)
 		{
 			return null;

--- a/src/SingleProject/Resizetizer/test/UnitTests/BaseTest.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/BaseTest.cs
@@ -134,6 +134,10 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var actual = File.ReadAllText(actualFilename);
 				var expected = File.ReadAllText(expectedFilename);
 
+				// Normalize line endings for cross-platform comparison
+				actual = actual.Replace("\r\n", "\n", StringComparison.Ordinal);
+				expected = expected.Replace("\r\n", "\n", StringComparison.Ordinal);
+
 				Assert.Equal(expected, actual);
 			}
 			else


### PR DESCRIPTION
### Description of Change

Work to run more of our unit tests on Helix.

This pull request updates the unit test project configuration and related pipeline steps. The main changes are to ensure that the `Controls.Xaml.UnitTests` and `Resizetizer.UnitTests` projects are included in the build/test process, but their execution in the CI pipeline is currently commented out.

Test project configuration:

* Added `Controls.Xaml.UnitTests.csproj` and re-enabled `Resizetizer.UnitTests.csproj` in the list of XUnit projects in `eng/helix.proj`, ensuring these test projects are recognized and available for test runs.

Pipeline changes:

* Commented out the steps in `eng/pipelines/arcade/stage-unit-tests.yml` that run and publish results for both
 `Controls.Xaml.UnitTests` and `Resizetizer.UnitTests`, effectively disabling their execution in the CI pipeline for now.
 
Works fine from VS
 <img width="478" height="208" alt="Screenshot 2026-01-29 at 18 30 05" src="https://github.com/user-attachments/assets/9e3d2121-365d-419f-8041-ab9521d3e92f" />