### PR TITLE
[ci] Fixes the generation of workloads 

### DIFF
--- a/src/Workload/workloads.csproj
+++ b/src/Workload/workloads.csproj
@@ -2,7 +2,7 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IncludeBuildOutput>false</IncludeBuildOutput>
 


### PR DESCRIPTION
### Description of Change

Fixes the generation of workloads by not requesting the net8.0 workloads (that could be internal)

This pull request updates the target framework of the `workloads.csproj` project to use a newer version of .NET.

.NET target framework update:

* Changed the `TargetFramework` in `workloads.csproj` from `net8.0` to `net10.0`, upgrading the project to use .NET 10.0.