### PR TITLE
BindableObject property access micro-optimizations

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -713,7 +713,7 @@ namespace Microsoft.Maui.Controls
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		BindablePropertyContext GetOrCreateContext(BindableProperty property)
 		{
-#if NETSTANDARD2_0
+#if NETSTANDARD
 			var context = GetContext(property);
 			if (context is null)
 			{

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -187,11 +187,6 @@ namespace Microsoft.Maui.Controls
 					result.IsSet = pair.Key != SetterSpecificity.DefaultValue;
 					result.Value = (T)pair.Value;
 				}
-				else
-				{
-					result.IsSet = false;
-					result.Value = default(T);
-				}
 			}
 
 			return resultArray;

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Dispatching;
@@ -38,8 +39,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		internal ushort _triggerCount = 0;
-		internal Dictionary<TriggerBase, SetterSpecificity> _triggerSpecificity = new Dictionary<TriggerBase, SetterSpecificity>();
-		readonly Dictionary<BindableProperty, BindablePropertyContext> _properties = new Dictionary<BindableProperty, BindablePropertyContext>(4);
+		internal Dictionary<TriggerBase, SetterSpecificity> _triggerSpecificity = new();
+		readonly Dictionary<int, BindablePropertyContext> _properties = new(4);
 		bool _applying;
 		WeakReference _inheritedContext;
 
@@ -172,66 +173,24 @@ namespace Microsoft.Maui.Controls
 			return context == null ? property.DefaultValue : context.Values.GetValue();
 		}
 
-		internal LocalValueEnumerator GetLocalValueEnumerator() => new LocalValueEnumerator(this);
-
-		internal sealed class LocalValueEnumerator : IEnumerator<LocalValueEntry>
-		{
-			Dictionary<BindableProperty, BindablePropertyContext>.Enumerator _propertiesEnumerator;
-			internal LocalValueEnumerator(BindableObject bindableObject) => _propertiesEnumerator = bindableObject._properties.GetEnumerator();
-
-			object IEnumerator.Current => Current;
-			public LocalValueEntry Current { get; private set; }
-
-			public bool MoveNext()
-			{
-				if (_propertiesEnumerator.MoveNext())
-				{
-					Current = new LocalValueEntry(_propertiesEnumerator.Current.Key, _propertiesEnumerator.Current.Value.Values.GetValue(), _propertiesEnumerator.Current.Value.Attributes);
-					return true;
-				}
-				return false;
-			}
-
-			public void Dispose() => _propertiesEnumerator.Dispose();
-
-			void IEnumerator.Reset()
-			{
-				((IEnumerator)_propertiesEnumerator).Reset();
-				Current = null;
-			}
-		}
-
-		internal sealed class LocalValueEntry
-		{
-			internal LocalValueEntry(BindableProperty property, object value, BindableContextAttributes attributes)
-			{
-				Property = property;
-				Value = value;
-				Attributes = attributes;
-			}
-
-			public BindableProperty Property { get; }
-			public object Value { get; }
-			public BindableContextAttributes Attributes { get; }
-		}
-
 		internal (bool IsSet, T Value)[] GetValues<T>(BindableProperty[] propArray)
 		{
-			Dictionary<BindableProperty, BindablePropertyContext> properties = _properties;
+			var properties = _properties;
 			var resultArray = new (bool IsSet, T Value)[propArray.Length];
 
 			for (int i = 0; i < propArray.Length; i++)
 			{
-				if (properties.TryGetValue(propArray[i], out var context))
+				ref var result = ref resultArray[i];
+				if (properties.TryGetValue(propArray[i].InternalId, out var context))
 				{
 					var pair = context.Values.GetSpecificityAndValue();
-					resultArray[i].IsSet = pair.Key != SetterSpecificity.DefaultValue;
-					resultArray[i].Value = (T)pair.Value;
+					result.IsSet = pair.Key != SetterSpecificity.DefaultValue;
+					result.Value = (T)pair.Value;
 				}
 				else
 				{
-					resultArray[i].IsSet = false;
-					resultArray[i].Value = default(T);
+					result.IsSet = false;
+					result.Value = default(T);
 				}
 			}
 
@@ -736,7 +695,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		BindablePropertyContext CreateAndAddContext(BindableProperty property)
+		BindablePropertyContext CreateContext(BindableProperty property)
 		{
 			var defaultValueCreator = property.DefaultValueCreator;
 			var context = new BindablePropertyContext { Property = property };
@@ -745,15 +704,31 @@ namespace Microsoft.Maui.Controls
 			if (defaultValueCreator != null)
 				context.Attributes = BindableContextAttributes.IsDefaultValueCreated;
 
-			_properties.Add(property, context);
 			return context;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal BindablePropertyContext GetContext(BindableProperty property) => _properties.TryGetValue(property, out var result) ? result : null;
+		internal BindablePropertyContext GetContext(BindableProperty property) => _properties.TryGetValue(property.InternalId, out var result) ? result : null;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		BindablePropertyContext GetOrCreateContext(BindableProperty property) => GetContext(property) ?? CreateAndAddContext(property);
+		BindablePropertyContext GetOrCreateContext(BindableProperty property)
+		{
+#if NETSTANDARD2_0
+			var context = GetContext(property);
+			if (context is null)
+			{
+				context = CreateContext(property);
+				_properties.Add(property.InternalId, context);
+			}
+#else
+			ref var context = ref CollectionsMarshal.GetValueRefOrAddDefault(_properties, property.InternalId, out var exists);
+			if (!exists)
+			{
+				context = CreateContext(property);
+			}
+#endif
+			return context;
+		}
 
 		void RemoveBinding(BindableProperty property, BindablePropertyContext context, SetterSpecificity specificity)
 		{

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Threading;
 using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Converters;
@@ -181,6 +182,9 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindableProperty.xml" path="//Member[@MemberName='UnsetValue']/Docs/*" />
 		public static readonly object UnsetValue = new object();
 
+		private static int _nextInternalId = int.MinValue;
+		internal readonly int InternalId;
+
 		BindableProperty(string propertyName, [DynamicallyAccessedMembers(ReturnTypeMembers)] Type returnType, [DynamicallyAccessedMembers(DeclaringTypeMembers)] Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
 								 ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,
 								 CoerceValueDelegate coerceValue = null, BindablePropertyBindingChanging bindingChanging = null, bool isReadOnly = false, CreateDefaultValueDelegate defaultValueCreator = null)
@@ -191,6 +195,8 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException(nameof(returnType));
 			if (declaringType is null)
 				throw new ArgumentNullException(nameof(declaringType));
+			
+			InternalId = Interlocked.Increment(ref _nextInternalId);
 
 			// don't use Enum.IsDefined as its redonkulously expensive for what it does
 			if (defaultBindingMode != BindingMode.Default && defaultBindingMode != BindingMode.OneWay && defaultBindingMode != BindingMode.OneWayToSource && defaultBindingMode != BindingMode.TwoWay && defaultBindingMode != BindingMode.OneTime)

--- a/src/Core/tests/Benchmarks/Benchmarks/BindableObjectBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/BindableObjectBenchmarker.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class BindableObjectBenchmarker
+	{
+		BindableProperty[] _properties;
+
+		[Params(1, 3, 8, 15, 30, 50)]
+		public int PropertiesToSet { get; set; }
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			_properties = Enumerable.Range(0, PropertiesToSet)
+				.Select(i => BindableProperty.Create($"Property{i}", typeof(int), typeof(BindableObject), -1))
+				.ToArray();
+		}
+		
+		private class Bindable : BindableObject {}
+
+		[Benchmark]
+		public void SetsAndReadsProperties()
+		{
+			var bindable = new Bindable();
+
+			var count = _properties.Length;
+			for (int i = 0; i < count; i++)
+			{
+				bindable.SetValue(_properties[i], i);
+				_ = bindable.GetValue(_properties[i]);
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

I tried to improve the access time on BindableProperty given they're being accessed a lot during the application usage.
As we can see using Array + SIMD is actually performing better when the number of BindableProperty set on a BindableObject is less than ~10, though it becomes worse after that.
Array + SIMD also (obviously) allocates less memory.

Considering that SIMD may perform differently on different platforms I felt it would be better to simply improve the current Dictionary based implementation by leveraging:
- integer keys
- CollectionMarshal on GetOrAdd

### Benchmarks

| Strategy                 | PropertiesToSet | Mean        | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|----------------------- |---------------- |------------:|---------:|---------:|-------:|-------:|----------:|
| Dictionary<BindableProperty> | 1               |    65.22 ns | 0.246 ns | 0.218 ns | 0.0889 | 0.0001 |     744 B |
| Array + SIMD | 1               |    **52.93 ns** | 0.750 ns | 0.665 ns | 0.0678 |      - |     568 B |
| Dictionary<int,> | 1               |    59.29 ns | 0.563 ns | 0.440 ns | 0.0889 | 0.0001 |     744 B |
| |
| Dictionary<BindableProperty> | 3               |   150.70 ns | 0.344 ns | 0.322 ns | 0.1500 | 0.0005 |    1256 B |
| Array + SIMD | 3               |   **122.09 ns** | 0.163 ns | 0.127 ns | 0.1290 | 0.0002 |    1080 B |
| Dictionary<int,> | 3               |   133.50 ns | 0.231 ns | 0.180 ns | 0.1500 | 0.0005 |    1256 B |
| |
| Dictionary<BindableProperty> | 8               |   426.76 ns | 0.686 ns | 0.641 ns | 0.3662 | 0.0033 |    3064 B |
| Array + SIMD | 8               |   **318.26 ns** | 0.438 ns | 0.409 ns | 0.3028 | 0.0024 |    2536 B |
| Dictionary<int,> | 8               |   338.98 ns | 2.381 ns | 1.988 ns | 0.3662 | 0.0038 |    3064 B |
| |
| Dictionary<BindableProperty> | 15              |   773.49 ns | 2.593 ns | 2.298 ns | 0.5798 | 0.0095 |    4856 B |
| Array + SIMD | 15              |   665.18 ns | 0.846 ns | 0.791 ns | 0.5531 | 0.0076 |    4632 B |
| Dictionary<int,> | 15              |   **581.04 ns** | 0.431 ns | 0.360 ns | 0.5798 | 0.0095 |    4856 B |
| |
| Dictionary<BindableProperty> | 30              | 1,542.20 ns | 3.342 ns | 3.126 ns | 1.1692 | 0.0381 |    9784 B |
| Array + SIMD | 30              | 1,419.83 ns | 1.301 ns | 1.154 ns | 1.0796 | 0.0324 |    9032 B |
| Dictionary<int,> | 30              | **1,165.86 ns** | 1.599 ns | 1.496 ns | 1.1692 | 0.0381 |    9784 B |
| |
| Dictionary<BindableProperty> | 50              | 2,648.69 ns | 3.759 ns | 2.935 ns | 2.0828 | 0.1183 |   17448 B |
| Array + SIMD | 50              | 2,587.54 ns | 3.111 ns | 2.429 ns | 1.8196 | 0.0916 |   15224 B |
| Dictionary<int,> | 50              | **1,997.17 ns** | 2.174 ns | 2.033 ns | 2.0828 | 0.1183 |   17448 B |