### PR TITLE
[iOS 26] Fix DisplayPromptAsync maxLength not enforced due to new multi-range delegate

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -100,10 +100,7 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						uiTextField.ShouldChangeCharactersInRanges = (textField, ranges, replacementString) =>
 						{
-							if (textField.Text is null)
-								return true;
-
-							var currentLength = textField.Text.Length;
+							var currentLength = textField.Text?.Length ?? 0;
 							var totalRangeLength = 0;
 							for (int i = 0; i < ranges.Length; i++)
 							{

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -96,8 +96,6 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					uiTextField.Placeholder = arguments.Placeholder;
 					uiTextField.Text = arguments.InitialValue;
-					uiTextField.ApplyKeyboard(arguments.Keyboard);
-
 					if (arguments.MaxLength > -1 && (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26)))
 					{
 						uiTextField.ShouldChangeCharactersInRanges = (textField, ranges, replacementString) =>
@@ -121,6 +119,7 @@ namespace Microsoft.Maui.Controls.Platform
 					{
 						uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength <= -1 || field.Text.Length + replacementString.Length - range.Length <= arguments.MaxLength;
 					}
+					uiTextField.ApplyKeyboard(arguments.Keyboard);
 				});
 
 				var oldFrame = alert.View.Frame;


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
On iOS 26, DisplayPromptAsync ignores the maxLength parameter, allowing users to enter an unlimited number of characters beyond the specified limit.

### Root Cause
iOS 26 introduced a new delegate method, ShouldChangeCharactersInRanges, which accepts multiple text ranges instead of the older ShouldChangeCharacters method. On iOS 26, the old delegate is no longer invoked, causing MAUI’s maxLength enforcement to break.

### Description of Change
A runtime version check was added to use the ShouldChangeCharactersInRanges delegate on iOS 26 and later, and the ShouldChangeCharacters delegate on earlier iOS versions. The new delegate calculates the total text length by summing all range lengths and validating the result against maxLength.

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #33549   

### Test case
In the test for DisplayPromptAsync, there is no supported way to type text into the display prompt text fields using Appium.

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/e9c48ea5-1dc8-42da-a5a2-b7de13df39cd" >| <video src="https://github.com/user-attachments/assets/5324954b-d4dd-4013-a3c8-3f5c34a845cf">|