### PR TITLE
[Templates] Remove redundant SemanticProperties.Description attribute

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -108,8 +108,7 @@
                     Margin="0,0,0,15"
                     SelectedItems="{Binding SelectedTags, Mode=TwoWay}"
                     SelectionChangedCommand="{Binding SelectionChangedCommand}"
-                    SelectionChangedCommandParameter="{Binding SelectedTags}"
-                    SemanticProperties.Description="Tags Collection">
+                    SelectionChangedCommandParameter="{Binding SelectedTags}">
                     <CollectionView.ItemsLayout>
                         <LinearItemsLayout Orientation="Horizontal" ItemSpacing="{StaticResource LayoutSpacing}" />
                     </CollectionView.ItemsLayout>


### PR DESCRIPTION
Syncing with the maui-samples repo: https://github.com/dotnet/maui-samples/pull/724

Accessibility note (iOS / VoiceOver)
While investigating this issue, it’s worth noting that setting IsAccessibilityElement = true on the UIViewControllerWrapperView causes VoiceOver to treat the wrapper as a single accessibility element. As a result, all child elements (including individual cells) are no longer exposed to the accessibility tree.

This is expected UIKit behavior:
An accessibility element replaces its children in the VoiceOver hierarchy.

Therefore, I've removed the SemanticProperties.Description="Tags Collection"

Fixes https://github.com/dotnet/maui/issues/30891
Fixes https://github.com/dotnet/maui/issues/30749