### PR TITLE
[Android] Fix Circle Stroke color is incorrectly updated as Fill color.

### DIFF
--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -176,14 +176,19 @@ namespace Microsoft.Maui.Maps.Handlers
 			var nativeCircle = GetNativeCircle(mauiCircle);
 
 			if (nativeCircle == null)
+			{
 				return;
-
+			}
 
 			if (mauiCircle.Stroke is SolidPaint solidPaint)
-				nativeCircle.FillColor = solidPaint.Color.AsColor();
+			{
+				nativeCircle.StrokeColor = solidPaint.Color.AsColor();
+			}
 
 			if (mauiCircle.Fill is SolidPaint solidFillPaint)
+			{
 				nativeCircle.FillColor = solidFillPaint.Color.AsColor();
+			}
 
 			nativeCircle.Center = new LatLng(mauiCircle.Center.Latitude, mauiCircle.Center.Longitude);
 			nativeCircle.Radius = mauiCircle.Radius.Meters;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

<!-- Enter description of the fix in this section -->
This pull request fixes a bug in the `CircleOnPropertyChanged` method of the Android map handler where the circle's stroke color was incorrectly applied to FillColor instead of StrokeColor.

Root Cause: A copy-paste error in `CircleOnPropertyChanged` caused the Stroke paint to be assigned to nativeCircle.FillColor instead of nativeCircle.StrokeColor. The sibling methods PolygonOnPropertyChanged and PolylineOnPropertyChanged correctly set StrokeColor, but the circle method had the wrong property name.

Fix: Changed the assignment from nativeCircle.FillColor to nativeCircle.StrokeColor when mapping mauiCircle.Stroke to the native circle, ensuring stroke and fill colors are applied to the correct native properties.

Bug fix and code clarity improvements:

* Fixed assignment to set `nativeCircle.StrokeColor` (instead of `FillColor`) from the `Stroke` property, ensuring the circle's stroke color is updated correctly.
* Added braces and an explicit null check for `nativeCircle` to improve code readability and prevent potential null reference errors.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33642

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output
| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/f3559741-e794-403c-a590-c9c871f25995"> |<video src="https://github.com/user-attachments/assets/6174a836-082c-4ae8-9a93-09649b92f9b6"> |


