### PR TITLE
[testing] Skip some tests on iOS26

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -307,6 +307,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		[Trait(TestCategory.SkipOnIOS26, "Font comparison may fail on iOS 26")]
 		public async Task ChangingTextTypeWithFormattedTextSwitchesTextSource()
 		{
 			SetupBuilder();
@@ -723,6 +724,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
+		[Trait(TestCategory.SkipOnIOS26, "Font comparison may fail on iOS 26")]
 		public async Task FontStuffAfterTextTypeIsCorrect()
 		{
 			// Note: this is specifically a Controls-level rule that's inherited from Forms


### PR DESCRIPTION
### Description of Change

This pull request adds a trait to two test methods in the `LabelTests.cs` file to skip them on iOS 26 due to potential font comparison failures.

Test reliability improvements:

* Added the `[Trait(TestCategory.SkipOnIOS26, "Font comparison may fail on iOS 26")]` attribute to the `ChangingTextTypeWithFormattedTextSwitchesTextSource` and `FontStuffAfterTextTypeIsCorrect` test methods in `LabelTests.cs` to skip these tests on iOS 26, addressing unreliable font comparison results. [[1]](diffhunk://#diff-bcab141ed5a07faa1a4dbc74db51c45a69da5a92e4e09d89a7d698ba04c315ceR310) [[2]](diffhunk://#diff-bcab141ed5a07faa1a4dbc74db51c45a69da5a92e4e09d89a7d698ba04c315ceR727)