### PR TITLE
Fix for unable to open task using keyboard navigation on windows platform

### DIFF
--- a/src/Templates/src/templates/maui-mobile/PageModels/MainPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/MainPageModel.cs
@@ -38,6 +38,9 @@ public partial class MainPageModel : ObservableObject, IProjectTaskPageModel
 	[ObservableProperty]
 	private Project? selectedProject;
 
+	[ObservableProperty]
+	private ProjectTask? selectedTask;
+
 	public bool HasCompletedTasks
 		=> Tasks?.Any(t => t.IsCompleted) ?? false;
 

--- a/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
+++ b/src/Templates/src/templates/maui-mobile/PageModels/ProjectDetailPageModel.cs
@@ -56,6 +56,9 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		new IconData { Icon = FluentUI.bot_24_regular, Description = "Bot Icon" }
 	};
 
+	[ObservableProperty]
+	private ProjectTask? selectedTask;
+
 	private bool _canDelete;
 
 	public bool CanDelete

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
@@ -10,10 +10,7 @@
     StrokeShape="RoundRectangle 20"
     Background="{AppThemeBinding Light={StaticResource LightSecondaryBackground}, Dark={StaticResource DarkSecondaryBackground}}"
     x:DataType="models:ProjectTask">
-    
-     <effectsView:SfEffectsView
-        TouchDownEffects="Highlight"
-        HighlightBackground="{AppThemeBinding Light={StaticResource DarkOnLightBackground}, Dark={StaticResource LightOnDarkBackground}}">
+
         <shimmer:SfShimmer
             BackgroundColor="Transparent"
             VerticalOptions="Fill"
@@ -44,12 +41,6 @@
                             HorizontalOptions="Start"
                             VerticalOptions="Center"
                             LineBreakMode="WordWrap"/>
-
-                        <Grid.GestureRecognizers>
-                            <TapGestureRecognizer
-                                Command="{Binding NavigateToTaskCommand, Source={RelativeSource AncestorType={x:Type pageModels:IProjectTaskPageModel}}, x:DataType=pageModels:IProjectTaskPageModel}"
-                                CommandParameter="{Binding .}"/>
-                        </Grid.GestureRecognizers>
                     </Grid>
 
                     <CheckBox Grid.Column="0"
@@ -63,5 +54,4 @@
                 </Grid>
             </shimmer:SfShimmer.Content>
         </shimmer:SfShimmer>
-    </effectsView:SfEffectsView>
 </Border>

--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -81,14 +81,23 @@
                                 Command="{Binding CleanTasksCommand}"
                                 SemanticProperties.Description="Clean tasks" />
                         </Grid>
-                        <VerticalStackLayout Grid.Row="5" Spacing="15"
-                            BindableLayout.ItemsSource="{Binding Tasks}">
-                            <BindableLayout.ItemTemplate>
+                        <CollectionView ItemsSource="{Binding Tasks}"
+                                        Grid.Row="5"
+                                        x:Name="TasksCollectionView"
+                                        SelectionMode="Single"
+                                        SelectedItem="{Binding SelectedTask}"
+                                        SelectionChangedCommand="{Binding NavigateToTaskCommand}"
+                                        SelectionChangedCommandParameter="{Binding SelectedTask}">
+                            <CollectionView.ItemsLayout>
+                                <LinearItemsLayout Orientation="Vertical"
+                                                   ItemSpacing="15"/>
+                            </CollectionView.ItemsLayout>
+                            <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <controls:TaskView TaskCompletedCommand="{Binding TaskCompletedCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" />
+                                    <controls:TaskView TaskCompletedCommand="{Binding TaskCompletedCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}"/>
                                 </DataTemplate>
-                            </BindableLayout.ItemTemplate>
-                        </VerticalStackLayout>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
                     </Grid>
                 </ScrollView>
             </pullToRefresh:SfPullToRefresh.PullableContent>

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -170,15 +170,22 @@
                         SemanticProperties.Description="Clean up"
                         />
                 </Grid>
-                <VerticalStackLayout 
-                    Spacing="{StaticResource LayoutSpacing}"
-                    BindableLayout.ItemsSource="{Binding Tasks}">
-                    <BindableLayout.ItemTemplate>
+                <CollectionView ItemsSource="{Binding Tasks}"
+                                x:Name="ProjectTasksCollectionView"
+                                SelectionMode="Single"
+                                SelectedItem="{Binding SelectedTask}"
+                                SelectionChangedCommand="{Binding NavigateToTaskCommand}"
+                                SelectionChangedCommandParameter="{Binding SelectedTask}">
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout Orientation="Vertical"
+                                           ItemSpacing="{StaticResource LayoutSpacing}"/>
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <controls:TaskView TaskCompletedCommand="{Binding TaskCompletedCommand, Source={RelativeSource AncestorType={x:Type pageModels:ProjectDetailPageModel}}, x:DataType=pageModels:ProjectDetailPageModel}" />
+                            <controls:TaskView TaskCompletedCommand="{Binding TaskCompletedCommand, Source={RelativeSource AncestorType={x:Type pageModels:ProjectDetailPageModel}}, x:DataType=pageModels:ProjectDetailPageModel}"/>
                         </DataTemplate>
-                    </BindableLayout.ItemTemplate>
-                </VerticalStackLayout>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
             </VerticalStackLayout>
         </ScrollView>
 


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Description
On DeveloperBalance , unable to open task using keyboard navigation on windows platform

### RootCause 
On DeveloperBalance ,TaskList is displayed using VerticalStackLayout with BindableLayout, creates layout elements, which are not focusable. On Windows, keyboard navigation works automatically only for controls, so individual items cannot receive keyboard focus.

### Description of Change
- Replaced VerticalStackLayout with CollectionView, with navigation now handled through the SelectionChanged event
- The previous implementation used SfEffectsView, which was intercepting touch interactions on macOS and preventing item selection. Since the highlight effect on interaction is now managed through CollectionView selection highlight

### Issues Fixed
Fixes #30787 

### Tested the behaviour on the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

 
### Output Screenshot
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="300" height="150" alt="Before Fix" src="https://github.com/user-attachments/assets/a248fc9a-5cbd-4360-9942-8d1824f60d1a">|<video width="300" height="150" alt="After Fix" src="https://github.com/user-attachments/assets/15328185-d877-44f0-8e1c-18840a9103d2">|
