### PR TITLE
[ai] Add integration test runner skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -265,9 +265,15 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Trigger phrases**: "check build for PR #XXXXX", "why did PR build fail", "get build status"
    - **Used by**: When investigating CI failures
 
+8. **run-integration-tests** (`.github/skills/run-integration-tests/SKILL.md`)
+   - **Purpose**: Build, pack, and run .NET MAUI integration tests locally
+   - **Trigger phrases**: "run integration tests", "test templates locally", "run macOSTemplates tests", "run RunOniOS tests"
+   - **Categories**: Build, WindowsTemplates, macOSTemplates, Blazor, MultiProject, Samples, AOT, RunOnAndroid, RunOniOS
+   - **Note**: **ALWAYS use this skill** instead of manual `dotnet test` commands for integration tests
+
 #### Internal Skills (Used by Agents)
 
-8. **try-fix** (`.github/skills/try-fix/SKILL.md`)
+9. **try-fix** (`.github/skills/try-fix/SKILL.md`)
    - **Purpose**: Proposes ONE independent fix approach, applies it, tests, records result with failure analysis, then reverts
    - **Used by**: pr agent Phase 3 (Fix phase) - rarely invoked directly by users
    - **Behavior**: Reads prior attempts to learn from failures. Max 5 attempts per session.

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -149,9 +149,29 @@ if (!TestEnvironment.IsWindows)
 
 ### Prerequisites
 
-1. Verify `.dotnet/` folder exists (local SDK). If missing, stop and tell user to run `dotnet cake` to provision locally.
-2. Set `MAUI_PACKAGE_VERSION` environment variable. If missing, tests will fail with "MAUI_PACKAGE_VERSION was not set."
-   - Example: `export MAUI_PACKAGE_VERSION=$(ls .dotnet/packs/Microsoft.Maui.Sdk | head -1)`
+1. **Provision the local SDK and workloads** - The `.dotnet/` folder must contain a fully provisioned .NET SDK with MAUI workloads. Run:
+
+   ```bash
+   # Step 1: Download the .NET SDK (creates .dotnet/dotnet binary)
+   ./build.sh --target=dotnet
+   
+   # Step 2: Install MAUI workloads into the local SDK (takes ~5 minutes)
+   ./build.sh --target=dotnet-local-workloads
+   ```
+
+   **Verification**: After provisioning, verify the setup:
+   ```bash
+   # Check dotnet binary exists
+   ls .dotnet/dotnet
+   
+   # Check MAUI workloads are installed
+   ls .dotnet/packs/Microsoft.Maui.Sdk
+   ```
+
+2. **Set `MAUI_PACKAGE_VERSION` environment variable** - If missing, tests will fail with "MAUI_PACKAGE_VERSION was not set."
+   ```bash
+   export MAUI_PACKAGE_VERSION=$(ls .dotnet/packs/Microsoft.Maui.Sdk | head -1)
+   ```
 
 ### Environment Variables
 

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -147,7 +147,34 @@ if (!TestEnvironment.IsWindows)
 
 ## Running Tests Locally
 
-### Prerequisites
+### 🚨 ALWAYS Use the Skill
+
+**When asked to run integration tests, ALWAYS use the `run-integration-tests` skill:**
+
+```powershell
+# macOS examples
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "macOSTemplates" -SkipBuild -SkipInstall -SkipXcodeVersionCheck
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "RunOniOS" -SkipBuild -SkipInstall -SkipXcodeVersionCheck
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "RunOnAndroid" -SkipBuild -SkipInstall
+
+# Windows examples
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "WindowsTemplates" -SkipBuild -SkipInstall
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "Build" -SkipBuild -SkipInstall
+```
+
+The skill handles:
+- ✅ Environment variable setup (`MAUI_PACKAGE_VERSION`, `SKIP_XCODE_VERSION_CHECK`)
+- ✅ Cross-platform support (Windows and macOS)
+- ✅ Test results in TRX format
+- ✅ Proper error reporting
+
+See `.github/skills/run-integration-tests/SKILL.md` for full documentation.
+
+---
+
+### Prerequisites (Manual Setup)
+
+If the skill reports missing prerequisites, provision the local SDK:
 
 1. **Provision the local SDK and workloads** - The `.dotnet/` folder must contain a fully provisioned .NET SDK with MAUI workloads. Run:
 
@@ -168,12 +195,9 @@ if (!TestEnvironment.IsWindows)
    ls .dotnet/packs/Microsoft.Maui.Sdk
    ```
 
-2. **Set `MAUI_PACKAGE_VERSION` environment variable** - If missing, tests will fail with "MAUI_PACKAGE_VERSION was not set."
-   ```bash
-   export MAUI_PACKAGE_VERSION=$(ls .dotnet/packs/Microsoft.Maui.Sdk | head -1)
-   ```
+### Environment Variables (Reference)
 
-### Environment Variables
+The skill sets these automatically, but for manual runs:
 
 | Variable | Required | Purpose |
 |----------|----------|---------|
@@ -181,9 +205,15 @@ if (!TestEnvironment.IsWindows)
 | `IOS_TEST_DEVICE` | No | iOS simulator target (e.g., `ios-simulator-64_18.5`) |
 | `SKIP_XCODE_VERSION_CHECK` | No | Set to `true` to bypass Xcode version validation |
 
-### Run Commands
+### Manual Run Commands (Fallback Only)
+
+**⚠️ Only use these if the skill is unavailable:**
 
 ```bash
+# Set environment first
+export MAUI_PACKAGE_VERSION=$(ls .dotnet/packs/Microsoft.Maui.Sdk | head -1)
+export SKIP_XCODE_VERSION_CHECK=true
+
 # Run specific category
 dotnet test src/TestUtils/src/Microsoft.Maui.IntegrationTests \
   --filter "Category=Build"
@@ -191,11 +221,6 @@ dotnet test src/TestUtils/src/Microsoft.Maui.IntegrationTests \
 # Run specific test
 dotnet test src/TestUtils/src/Microsoft.Maui.IntegrationTests \
   --filter "FullyQualifiedName~AppleTemplateTests.RunOniOS"
-
-# With iOS device and Xcode skip
-export IOS_TEST_DEVICE="ios-simulator-64_18.5"
-export SKIP_XCODE_VERSION_CHECK=true
-dotnet test ... --filter "Category=RunOniOS"
 ```
 
 ## Common Pitfalls

--- a/.github/skills/run-integration-tests/SKILL.md
+++ b/.github/skills/run-integration-tests/SKILL.md
@@ -105,3 +105,4 @@ pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Test
 | "MAUI_PACKAGE_VERSION was not set" | Ensure build step completed successfully |
 | Template not found | Workload installation may have failed |
 | Build failures | Check `artifacts/log/` for detailed build logs |
+| "Cannot proceed with locked .dotnet folder" | Kill processes using `.dotnet`: `Get-Process \| Where-Object { $_.Path -like "*\.dotnet\*" } \| ForEach-Object { Stop-Process -Id $_.Id -Force }` |

--- a/.github/skills/run-integration-tests/SKILL.md
+++ b/.github/skills/run-integration-tests/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: run-integration-tests
+description: "Build, pack, and run .NET MAUI integration tests locally. Validates templates, samples, and end-to-end scenarios using the local workload."
+metadata:
+  author: dotnet-maui
+  version: "1.0"
+compatibility: Requires Windows for WindowsTemplates category. macOS for macOSTemplates, RunOniOS, RunOnAndroid.
+---
+
+# Run Integration Tests Skill
+
+Build the MAUI product, install local workloads, and run integration tests.
+
+## When to Use
+
+- User asks to "run integration tests"
+- User asks to "test templates locally"
+- User asks to "validate MAUI build with templates"
+- User wants to verify changes don't break template scenarios
+- User asks to run specific test categories (WindowsTemplates, Samples, Build, Blazor, etc.)
+
+## Available Test Categories
+
+| Category | Platform | Description |
+|----------|----------|-------------|
+| `Build` | All | Basic template build tests |
+| `WindowsTemplates` | Windows | Windows-specific template scenarios |
+| `macOSTemplates` | macOS | macOS-specific scenarios |
+| `Blazor` | All | Blazor hybrid templates |
+| `MultiProject` | All | Multi-project templates |
+| `Samples` | All | Sample project builds |
+| `AOT` | macOS | Native AOT compilation |
+| `RunOnAndroid` | macOS | Build, install, run on Android emulator |
+| `RunOniOS` | macOS | iOS simulator tests |
+
+## Scripts
+
+All scripts are in `.github/skills/run-integration-tests/scripts/`
+
+### Run Integration Tests (Full Workflow)
+
+```powershell
+# Run with specific category
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "WindowsTemplates"
+
+# Run with Release configuration
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "Samples" -Configuration "Release"
+
+# Run with custom test filter
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -TestFilter "FullyQualifiedName~BuildSample"
+
+# Skip build step (if already built)
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "Build" -SkipBuild
+```
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `-Category` | No | - | Test category to run (WindowsTemplates, Samples, Build, etc.) |
+| `-TestFilter` | No | - | Custom NUnit test filter expression |
+| `-Configuration` | No | Debug | Build configuration (Debug/Release) |
+| `-SkipBuild` | No | false | Skip build/pack step if already done |
+| `-SkipInstall` | No | false | Skip workload installation if already done |
+| `-ResultsDirectory` | No | artifacts/integration-tests | Directory for test results |
+
+## Workflow Steps
+
+The script performs these steps:
+
+1. **Build & Pack**: `.\build.cmd -restore -pack -configuration $Configuration`
+2. **Install Workloads**: `.dotnet\dotnet build .\src\DotNet\DotNet.csproj -t:Install -c $Configuration`
+3. **Extract Version**: Reads MAUI_PACKAGE_VERSION from installed packs
+4. **Run Tests**: `.dotnet\dotnet test ... -filter "Category=$Category"`
+
+## Example Usage
+
+```powershell
+# Run WindowsTemplates tests
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "WindowsTemplates"
+
+# Run Samples tests
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "Samples"
+
+# Run multiple categories
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -TestFilter "Category=Build|Category=Blazor"
+```
+
+## Prerequisites
+
+- Windows for WindowsTemplates
+- .NET SDK (version from global.json)
+- Sufficient disk space for build artifacts
+
+## Output
+
+- Test results in TRX format at `<ResultsDirectory>/`
+- Build logs in `artifacts/` directory
+- Console output with test pass/fail summary
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "MAUI_PACKAGE_VERSION was not set" | Ensure build step completed successfully |
+| Template not found | Workload installation may have failed |
+| Build failures | Check `artifacts/log/` for detailed build logs |

--- a/.github/skills/run-integration-tests/SKILL.md
+++ b/.github/skills/run-integration-tests/SKILL.md
@@ -51,6 +51,9 @@ pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Test
 
 # Skip build step (if already built)
 pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "Build" -SkipBuild
+
+# macOS: Skip Xcode version check (for version mismatches)
+pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Category "macOSTemplates" -SkipBuild -SkipInstall -SkipXcodeVersionCheck
 ```
 
 ## Parameters
@@ -62,6 +65,7 @@ pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Cate
 | `-Configuration` | No | Debug | Build configuration (Debug/Release) |
 | `-SkipBuild` | No | false | Skip build/pack step if already done |
 | `-SkipInstall` | No | false | Skip workload installation if already done |
+| `-SkipXcodeVersionCheck` | No | false | Skip Xcode version validation (macOS) |
 | `-ResultsDirectory` | No | artifacts/integration-tests | Directory for test results |
 
 ## Workflow Steps
@@ -88,9 +92,10 @@ pwsh .github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1 -Test
 
 ## Prerequisites
 
-- Windows for WindowsTemplates
+- Windows for WindowsTemplates, macOS for macOSTemplates/RunOniOS/RunOnAndroid
 - .NET SDK (version from global.json)
 - Sufficient disk space for build artifacts
+- For macOS: Local workloads provisioned via `./build.sh --target=dotnet && dotnet cake --target=dotnet-local-workloads`
 
 ## Output
 

--- a/.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1
+++ b/.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1
@@ -1,0 +1,269 @@
+<#
+.SYNOPSIS
+    Build, pack, and run .NET MAUI integration tests locally.
+
+.DESCRIPTION
+    This script automates the full workflow for running integration tests:
+    1. Build and pack the MAUI product
+    2. Install the generated MAUI workloads locally
+    3. Extract and set MAUI_PACKAGE_VERSION
+    4. Run integration tests with specified filter
+
+.PARAMETER Category
+    Test category to run (WindowsTemplates, Samples, Build, Blazor, MultiProject, etc.)
+
+.PARAMETER TestFilter
+    Custom NUnit test filter expression. Overrides -Category if specified.
+
+.PARAMETER Configuration
+    Build configuration (Debug or Release). Default: Debug
+
+.PARAMETER SkipBuild
+    Skip the build and pack step (useful if already built)
+
+.PARAMETER ResultsDirectory
+    Directory for test results. Default: artifacts/integration-tests
+
+.EXAMPLE
+    .\Run-IntegrationTests.ps1 -Category "WindowsTemplates"
+    
+.EXAMPLE
+    .\Run-IntegrationTests.ps1 -Category "Samples" -Configuration "Release"
+
+.EXAMPLE
+    .\Run-IntegrationTests.ps1 -TestFilter "FullyQualifiedName~BuildSample" -SkipBuild
+#>
+
+param(
+    [Parameter()]
+    [ValidateSet("Build", "WindowsTemplates", "macOSTemplates", "Blazor", "MultiProject", "Samples", "AOT", "RunOnAndroid", "RunOniOS")]
+    [string]$Category,
+
+    [Parameter()]
+    [string]$TestFilter,
+
+    [Parameter()]
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+
+    [Parameter()]
+    [switch]$SkipBuild,
+
+    [Parameter()]
+    [switch]$SkipInstall,
+
+    [Parameter()]
+    [string]$ResultsDirectory = "artifacts/integration-tests"
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (Get-Item $PSScriptRoot).Parent.Parent.Parent.Parent.FullName
+
+Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+Write-Host "║       .NET MAUI Integration Tests Runner                  ║" -ForegroundColor Cyan
+Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Repository Root: $RepoRoot"
+Write-Host "Configuration:   $Configuration"
+Write-Host "Category:        $(if ($Category) { $Category } else { 'Custom filter' })"
+Write-Host "Skip Build:      $SkipBuild"
+Write-Host ""
+
+Push-Location $RepoRoot
+
+try {
+    # ═══════════════════════════════════════════════════════════════════
+    # Step 1: Build and Pack
+    # ═══════════════════════════════════════════════════════════════════
+    if (-not $SkipBuild) {
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        Write-Host "Step 1: Building and Packing MAUI..." -ForegroundColor Yellow
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        
+        $buildCmd = ".\build.cmd"
+        $buildArgs = @("-restore", "-pack", "-configuration", $Configuration)
+        
+        Write-Host "Running: $buildCmd $($buildArgs -join ' ')" -ForegroundColor Gray
+        
+        & $buildCmd @buildArgs
+        
+        if ($LASTEXITCODE -ne 0) {
+            throw "Build and pack failed with exit code $LASTEXITCODE"
+        }
+        
+        Write-Host "✅ Build and pack completed successfully" -ForegroundColor Green
+        Write-Host ""
+    }
+    else {
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        Write-Host "Step 1: Skipping build (SkipBuild specified)" -ForegroundColor Yellow
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        Write-Host ""
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Step 2: Install Workloads
+    # ═══════════════════════════════════════════════════════════════════
+    $dotnetPath = Join-Path $RepoRoot ".dotnet\dotnet.exe"
+    
+    if (-not (Test-Path $dotnetPath)) {
+        throw "Local .dotnet SDK not found at: $dotnetPath. Run build first."
+    }
+
+    if (-not $SkipInstall) {
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        Write-Host "Step 2: Installing MAUI Workloads..." -ForegroundColor Yellow
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        
+        $installArgs = @(
+            "build",
+            ".\src\DotNet\DotNet.csproj",
+            "-t:Install",
+            "-c", $Configuration
+        )
+        
+        Write-Host "Running: $dotnetPath $($installArgs -join ' ')" -ForegroundColor Gray
+        
+        & $dotnetPath @installArgs
+        
+        if ($LASTEXITCODE -ne 0) {
+            throw "Workload installation failed with exit code $LASTEXITCODE"
+        }
+        
+        Write-Host "✅ Workload installation completed successfully" -ForegroundColor Green
+        Write-Host ""
+    }
+    else {
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        Write-Host "Step 2: Skipping workload install (SkipInstall specified)" -ForegroundColor Yellow
+        Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+        Write-Host ""
+    }
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Step 3: Extract MAUI Package Version
+    # ═══════════════════════════════════════════════════════════════════
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+    Write-Host "Step 3: Extracting MAUI Package Version..." -ForegroundColor Yellow
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+    
+    $packsPath = Join-Path $RepoRoot ".dotnet\packs\Microsoft.Maui.Sdk"
+    
+    if (-not (Test-Path $packsPath)) {
+        throw "Microsoft.Maui.Sdk packs not found at: $packsPath"
+    }
+    
+    # Get SDK version from global.json to match the correct MAUI version
+    $globalJsonPath = Join-Path $RepoRoot "global.json"
+    $globalJson = Get-Content $globalJsonPath | ConvertFrom-Json
+    $sdkVersion = $globalJson.tools.dotnet
+    $sdkMajorVersion = $sdkVersion.Split('.')[0]
+    
+    Write-Host "SDK Version: $sdkVersion (major: $sdkMajorVersion)" -ForegroundColor Gray
+    
+    # Find MAUI SDK version matching the current SDK major version
+    $versionFolder = Get-ChildItem -Path $packsPath -Directory | 
+        Where-Object { $_.Name -match "^$sdkMajorVersion\." } |
+        Sort-Object { [Version]($_.Name -replace '-.*$', '') } -Descending |
+        Select-Object -First 1
+    
+    if (-not $versionFolder) {
+        # Fallback to any version if no match found
+        Write-Host "No version matching SDK $sdkMajorVersion.x found, falling back to latest..." -ForegroundColor Yellow
+        $versionFolder = Get-ChildItem -Path $packsPath -Directory | Sort-Object Name -Descending | Select-Object -First 1
+    }
+    
+    if (-not $versionFolder) {
+        throw "No version folders found in: $packsPath"
+    }
+    
+    $mauiPackageVersion = $versionFolder.Name
+    $env:MAUI_PACKAGE_VERSION = $mauiPackageVersion
+    
+    Write-Host "MAUI_PACKAGE_VERSION: $mauiPackageVersion" -ForegroundColor Green
+    Write-Host "✅ Environment variable set" -ForegroundColor Green
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════════
+    # Step 4: Run Integration Tests
+    # ═══════════════════════════════════════════════════════════════════
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+    Write-Host "Step 4: Running Integration Tests..." -ForegroundColor Yellow
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
+    
+    # Create results directory
+    $resultsPath = Join-Path $RepoRoot $ResultsDirectory
+    if (-not (Test-Path $resultsPath)) {
+        New-Item -ItemType Directory -Path $resultsPath -Force | Out-Null
+    }
+    
+    # Build test filter
+    $effectiveFilter = if ($TestFilter) {
+        $TestFilter
+    }
+    elseif ($Category) {
+        "Category=$Category"
+    }
+    else {
+        throw "Either -Category or -TestFilter must be specified"
+    }
+    
+    $testProjectPath = "src\TestUtils\src\Microsoft.Maui.IntegrationTests\Microsoft.Maui.IntegrationTests.csproj"
+    
+    $testArgs = @(
+        "test",
+        $testProjectPath,
+        "--configuration", $Configuration,
+        "--filter", $effectiveFilter,
+        "--logger", "trx",
+        "--results-directory", $resultsPath
+    )
+    
+    Write-Host "Test Filter: $effectiveFilter" -ForegroundColor Cyan
+    Write-Host "Results Directory: $resultsPath" -ForegroundColor Cyan
+    Write-Host "Running: $dotnetPath $($testArgs -join ' ')" -ForegroundColor Gray
+    Write-Host ""
+    
+    & $dotnetPath @testArgs
+    
+    $testExitCode = $LASTEXITCODE
+    
+    Write-Host ""
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host "                    Test Summary                           " -ForegroundColor Cyan
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host "Configuration:        $Configuration"
+    Write-Host "Category/Filter:      $effectiveFilter"
+    Write-Host "MAUI_PACKAGE_VERSION: $mauiPackageVersion"
+    Write-Host "Results Directory:    $resultsPath"
+    
+    if ($testExitCode -eq 0) {
+        Write-Host "Result:               ✅ PASSED" -ForegroundColor Green
+    }
+    else {
+        Write-Host "Result:               ❌ FAILED (Exit Code: $testExitCode)" -ForegroundColor Red
+    }
+    
+    Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Cyan
+    
+    # List TRX files generated
+    $trxFiles = Get-ChildItem -Path $resultsPath -Filter "*.trx" -ErrorAction SilentlyContinue
+    if ($trxFiles) {
+        Write-Host ""
+        Write-Host "Generated TRX Files:" -ForegroundColor Yellow
+        foreach ($trx in $trxFiles) {
+            Write-Host "  - $($trx.FullName)" -ForegroundColor Gray
+        }
+    }
+    
+    exit $testExitCode
+}
+catch {
+    Write-Host ""
+    Write-Host "❌ ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host $_.ScriptStackTrace -ForegroundColor Red
+    exit 1
+}
+finally {
+    Pop-Location
+}

--- a/.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1
+++ b/.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1
@@ -119,13 +119,15 @@ try {
         
         if ($RunningOnWindows) {
             $buildCmd = Join-Path $RepoRoot 'build.cmd'
-            $buildArgs = @("-restore", "-pack", "-configuration", $Configuration)
+            # Use -warnAsError false to match dotnet cake behavior (warnings don't fail the build)
+            $buildArgs = @("-restore", "-pack", "-configuration", $Configuration, "-warnAsError", "false")
             Write-Host "Running: $buildCmd $($buildArgs -join ' ')" -ForegroundColor Gray
             & $buildCmd @buildArgs
         }
         else {
             $buildCmd = Join-Path $RepoRoot 'build.sh'
-            $buildArgs = @("-restore", "-pack", "-configuration", $Configuration)
+            # Use -warnAsError false to match dotnet cake behavior (warnings don't fail the build)
+            $buildArgs = @("-restore", "-pack", "-configuration", $Configuration, "-warnAsError", "false")
             Write-Host "Running: $buildCmd $($buildArgs -join ' ')" -ForegroundColor Gray
             & bash $buildCmd @buildArgs
         }

--- a/.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1
+++ b/.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1
@@ -105,7 +105,7 @@ try {
         Write-Host "Step 1: Building and Packing MAUI..." -ForegroundColor Yellow
         Write-Host "═══════════════════════════════════════════════════════════" -ForegroundColor Yellow
         
-        $buildCmd = ".\build.cmd"
+        $buildCmd = Join-Path $RepoRoot 'build.cmd'
         $buildArgs = @("-restore", "-pack", "-configuration", $Configuration)
         
         Write-Host "Running: $buildCmd $($buildArgs -join ' ')" -ForegroundColor Gray
@@ -233,7 +233,7 @@ try {
         throw "Either -Category or -TestFilter must be specified"
     }
     
-    $testProjectPath = "src\TestUtils\src\Microsoft.Maui.IntegrationTests\Microsoft.Maui.IntegrationTests.csproj"
+    $testProjectPath = Join-Path $RepoRoot "src/TestUtils/src/Microsoft.Maui.IntegrationTests/Microsoft.Maui.IntegrationTests.csproj"
     
     $testArgs = @(
         "test",

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseBuildTest.cs
@@ -102,6 +102,33 @@ namespace Microsoft.Maui.IntegrationTests
 				FileUtilities.ReplaceInFile(TestNuGetConfig, "<add key=\"nuget-only\" value=\"true\" />", "");
 				FileUtilities.ReplaceInFile(TestNuGetConfig, "NUGET_ONLY_PLACEHOLDER", extraPacksDir);
 
+				// Create a Directory.Build.props in the test directory root to prevent MSBuild from
+				// walking up and inheriting the MAUI repo's Arcade SDK settings. This ensures test
+				// projects use their own local obj/bin folders instead of the repo's artifacts folder.
+				var testDirBuildProps = Path.Combine(TestEnvironment.GetTestDirectoryRoot(), "Directory.Build.props");
+				if (!File.Exists(testDirBuildProps))
+				{
+					File.WriteAllText(testDirBuildProps, """
+						<Project>
+						  <!-- This file stops MSBuild from walking up the directory tree and inheriting
+						       the MAUI repo's Directory.Build.props and Arcade SDK settings.
+						       This ensures test projects use their own local obj/bin folders. -->
+						</Project>
+						""");
+				}
+
+				// Also create Directory.Build.targets to prevent target inheritance
+				var testDirBuildTargets = Path.Combine(TestEnvironment.GetTestDirectoryRoot(), "Directory.Build.targets");
+				if (!File.Exists(testDirBuildTargets))
+				{
+					File.WriteAllText(testDirBuildTargets, """
+						<Project>
+						  <!-- This file stops MSBuild from walking up the directory tree and inheriting
+						       the MAUI repo's Directory.Build.targets. -->
+						</Project>
+						""");
+				}
+
 				_isSetupComplete = true;
 			}
 		}


### PR DESCRIPTION
### Description of Change

This pull request introduces a new skill for running integration tests in the .NET MAUI repository, along with major improvements to the documentation and automation for local test execution. The changes ensure that contributors use a standardized, cross-platform workflow for integration tests, reducing manual setup errors and improving reliability. Additionally, test isolation is enhanced by preventing MSBuild from inheriting repo-wide settings in test projects.

**Integration Test Skill Addition & Documentation**

* Added the `run-integration-tests` skill, with full documentation in `.github/skills/run-integration-tests/SKILL.md`, providing automated build, workload installation, environment variable setup, and test execution for various categories and platforms.
* Updated `.github/copilot-instructions.md` to include the new skill, its purpose, trigger phrases, and categories, instructing users to always use the skill for integration tests.
* Overhauled `.github/instructions/integration-tests.instructions.md` to emphasize using the skill, provide example commands, and clarify manual fallback steps and prerequisites.

**Automation & Reliability Improvements**

* Added the PowerShell script `.github/skills/run-integration-tests/scripts/Run-IntegrationTests.ps1` that automates the full workflow: building, packing, installing workloads, setting environment variables, and running tests with results output in TRX format. Includes platform checks and error handling.

**Test Isolation Enhancement**

* Updated `BaseBuildTest.cs` to create `Directory.Build.props` and `Directory.Build.targets` in the test directory root, preventing MSBuild from inheriting repo-wide Arcade SDK settings and ensuring test projects use local obj/bin folders for improved isolation.