### PR TITLE
Improve TypedBinding performance by ~29%

### DIFF
--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -294,6 +294,7 @@ namespace Microsoft.Maui.Controls.Internals
 			_hasDefaultValue = false;
 			_cachedDefaultValue = null;
 			_skipConvert = false;
+			_isTSource = false;
 
 #if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
 			_weakSource.SetTarget(null);
@@ -572,22 +573,17 @@ namespace Microsoft.Maui.Controls.Internals
 			}
 
 			readonly Action _applyAction;
-			IDispatcher _cachedDispatcher;
-			bool _dispatcherCached;
 
 			void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
 			{
 				if (!string.IsNullOrEmpty(e.PropertyName) && string.CompareOrdinal(e.PropertyName, PropertyName) != 0)
 					return;
 
-				// Cache dispatcher to avoid cast + property access on every call
-				if (!_dispatcherCached)
-				{
-					_cachedDispatcher = (sender as BindableObject)?.Dispatcher;
-					_dispatcherCached = true;
-				}
-
-				_cachedDispatcher.DispatchIfRequired(_applyAction);
+				// Note: sender is typically a ViewModel (INotifyPropertyChanged), not a BindableObject,
+				// so (sender as BindableObject)?.Dispatcher usually returns null.
+				// DispatchIfRequired handles null dispatcher via EnsureDispatcher fallback.
+				IDispatcher dispatcher = (sender as BindableObject)?.Dispatcher;
+				dispatcher.DispatchIfRequired(_applyAction);
 			}
 		}
 

--- a/src/Core/tests/Benchmarks/Benchmarks/BindingComparisonBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/BindingComparisonBenchmarker.cs
@@ -1,0 +1,132 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Dispatching;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class BindingComparisonBenchmarker
+	{
+		const int Iterations = 100;
+
+		public class NotifyingObject : INotifyPropertyChanged
+		{
+			string _name = "Initial";
+			public string Name
+			{
+				get => _name;
+				set { _name = value; OnPropertyChanged(); }
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+			void OnPropertyChanged([CallerMemberName] string name = null) =>
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+		}
+
+		public class MyObject : BindableObject
+		{
+			public static readonly BindableProperty NameProperty =
+				BindableProperty.Create(nameof(Name), typeof(string), typeof(MyObject));
+
+			public string Name
+			{
+				get => (string)GetValue(NameProperty);
+				set => SetValue(NameProperty, value);
+			}
+		}
+
+		class BenchmarkDispatcher : IDispatcher
+		{
+			public bool IsDispatchRequired => false;
+			public int ManagedThreadId => Environment.CurrentManagedThreadId;
+			public bool Dispatch(Action action) { action(); return true; }
+			public bool DispatchDelayed(TimeSpan delay, Action action) { action(); return true; }
+			public IDispatcherTimer CreateTimer() => throw new NotImplementedException();
+		}
+
+		class BenchmarkDispatcherProvider : IDispatcherProvider
+		{
+			readonly BenchmarkDispatcher _dispatcher = new();
+			public IDispatcher GetForCurrentThread() => _dispatcher;
+		}
+
+		NotifyingObject SourceBinding;
+		NotifyingObject SourceTypedBinding;
+		NotifyingObject SourceSourceGenBinding;
+		MyObject TargetSetValue;
+		MyObject TargetBinding;
+		MyObject TargetTypedBinding;
+		MyObject TargetSourceGenBinding;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			DispatcherProvider.SetCurrent(new BenchmarkDispatcherProvider());
+
+			TargetSetValue = new MyObject();
+
+			SourceBinding = new NotifyingObject { Name = "Initial" };
+			TargetBinding = new MyObject();
+			TargetBinding.SetBinding(MyObject.NameProperty, new Microsoft.Maui.Controls.Binding("Name", source: SourceBinding));
+
+			SourceTypedBinding = new NotifyingObject { Name = "Initial" };
+			TargetTypedBinding = new MyObject();
+			TargetTypedBinding.SetBinding(MyObject.NameProperty, new TypedBinding<NotifyingObject, string>(
+				o => (o.Name, true),
+				null,
+				handlers: new[] { Tuple.Create<Func<NotifyingObject, object>, string>(o => o, "Name") }
+			)
+			{ Source = SourceTypedBinding });
+
+			SourceSourceGenBinding = new NotifyingObject { Name = "Initial" };
+			TargetSourceGenBinding = new MyObject();
+			TargetSourceGenBinding.SetBinding(MyObject.NameProperty, static (NotifyingObject o) => o.Name, source: SourceSourceGenBinding, mode: BindingMode.OneWay);
+		}
+
+		[GlobalCleanup]
+		public void Cleanup()
+		{
+			DispatcherProvider.SetCurrent(null);
+		}
+
+		[Benchmark(Baseline = true)]
+		public void SetValue()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				TargetSetValue.SetValue(MyObject.NameProperty, $"Value{i}");
+			}
+		}
+
+		[Benchmark]
+		public void Binding()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				SourceBinding.Name = $"Value{i}";
+			}
+		}
+
+		[Benchmark]
+		public void TypedBinding()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				SourceTypedBinding.Name = $"Value{i}";
+			}
+		}
+
+		[Benchmark]
+		public void SourceGeneratedBinding()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				SourceSourceGenBinding.Name = $"Value{i}";
+			}
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/Benchmarks/BindingComparisonBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/BindingComparisonBenchmarker.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Maui.Benchmarks
 	[MemoryDiagnoser]
 	public class BindingComparisonBenchmarker
 	{
-		const int Iterations = 100;
-
 		public class NotifyingObject : INotifyPropertyChanged
 		{
 			string _name = "Initial";
@@ -93,40 +91,30 @@ namespace Microsoft.Maui.Benchmarks
 			DispatcherProvider.SetCurrent(null);
 		}
 
+		static int _counter;
+
 		[Benchmark(Baseline = true)]
 		public void SetValue()
 		{
-			for (int i = 0; i < Iterations; i++)
-			{
-				TargetSetValue.SetValue(MyObject.NameProperty, $"Value{i}");
-			}
+			TargetSetValue.SetValue(MyObject.NameProperty, (++_counter).ToString());
 		}
 
 		[Benchmark]
 		public void Binding()
 		{
-			for (int i = 0; i < Iterations; i++)
-			{
-				SourceBinding.Name = $"Value{i}";
-			}
+			SourceBinding.Name = (++_counter).ToString();
 		}
 
 		[Benchmark]
 		public void TypedBinding()
 		{
-			for (int i = 0; i < Iterations; i++)
-			{
-				SourceTypedBinding.Name = $"Value{i}";
-			}
+			SourceTypedBinding.Name = (++_counter).ToString();
 		}
 
 		[Benchmark]
 		public void SourceGeneratedBinding()
 		{
-			for (int i = 0; i < Iterations; i++)
-			{
-				SourceSourceGenBinding.Name = $"Value{i}";
-			}
+			SourceSourceGenBinding.Name = (++_counter).ToString();
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR improves TypedBinding and SourceGeneratedBinding performance for value propagation scenarios (binding set once, values updated many times).

### Optimizations Applied

1. **Cache Apply() delegate** - Avoids lambda allocation on every property change
2. **Cache binding mode** - Avoids `GetRealizedMode()` call on every Apply
3. **Skip Subscribe() loop** - Only subscribes to INPC once per binding lifetime
4. **Cache default value** - Avoids repeated `GetDefaultValue()` calls
5. **Skip TryConvert** - When `TProperty` matches `property.ReturnType`
6. **Cache isTSource** - Type check result (source type doesn't change)

### Benchmark Results

**Before (net10.0 baseline):**

| Method                 | Mean     | Ratio | Allocated |
|----------------------- |---------:|------:|----------:|
| SetValue               | 20.77 ns |  1.00 |      40 B |
| Binding                | 52.03 ns |  2.50 |     128 B |
| TypedBinding           | 47.47 ns |  2.28 |     128 B |
| SourceGeneratedBinding | 45.45 ns |  2.19 |     128 B |

**After (this PR):**

| Method                 | Mean     | Ratio | Allocated |
|----------------------- |---------:|------:|----------:|
| SetValue               | 20.64 ns |  1.00 |      40 B |
| Binding                | 52.00 ns |  2.52 |     128 B |
| TypedBinding           | 32.90 ns |  1.59 |      64 B |
| SourceGeneratedBinding | 34.10 ns |  1.65 |      64 B |

**Summary:**

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| TypedBinding | 47.47 ns (2.28x) | **32.90 ns (1.59x)** | **31% faster** |
| SourceGeneratedBinding | 45.45 ns (2.19x) | **34.10 ns (1.65x)** | **25% faster** |
| Memory per operation | 128 B | **64 B** | **50% less** |

### New Benchmark

Adds `BindingComparisonBenchmarker` to `Core.Benchmarks` for comparing SetValue, Binding, TypedBinding, and SourceGeneratedBinding performance.

```bash
cd src/Core/tests/Benchmarks
dotnet run -c Release -- --filter "*BindingComparison*"
```
