### PR TITLE
[Testing] Fix for flaky test(SafeAreaShouldWorkOnAllShellTabs) in CI

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33034.cs
@@ -18,6 +18,8 @@ public class Issue33034 : _IssuesUITest
 	{
 		App.WaitForElement("EdgeLabel");
 		App.SetOrientationLandscape();
+		//Adding delay to allow for orientation change to complete
+		Thread.Sleep(2000);
 		var initialRect = App.WaitForElement("EdgeLabel").GetRect();
 
 		App.TapTab("Second Tab");


### PR DESCRIPTION
This pull request makes a minor improvement to the `SafeAreaShouldWorkOnAllShellTabs` test by adding a delay to ensure the orientation change completes before continuing with the test.

**Test reliability improvement:**

- Added a `Thread.Sleep(2000)` after setting the orientation to landscape, allowing time for the orientation change to complete and improving test reliability.