### PR TITLE
Add API documentation to Maps and fix TimeChangedEventArgs placeholders

### DIFF
--- a/src/Controls/src/Core/TimeChangedEventArgs.cs
+++ b/src/Controls/src/Core/TimeChangedEventArgs.cs
@@ -3,28 +3,22 @@ using System;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <summary>Event arguments for <see cref="E:Microsoft.Maui.Controls.TimePicker.TimeSelected" /> event.</summary>
-	/// <remarks>To be added.</remarks>
+	/// <summary>Event arguments for the <see cref="TimePicker.TimeSelected"/> event.</summary>
 	public class TimeChangedEventArgs : EventArgs
 	{
-		/// <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.TimeChangedEventArgs" /> object that represents a change from <paramref name="oldTime" /> to <paramref name="newTime" />.</summary>
-		/// <param name="oldTime"></param>
-		/// <param name="newTime"></param>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Creates a new <see cref="TimeChangedEventArgs"/> with the specified old and new times.</summary>
+		/// <param name="oldTime">The previously selected time.</param>
+		/// <param name="newTime">The newly selected time.</param>
 		public TimeChangedEventArgs(TimeSpan? oldTime, TimeSpan? newTime)
 		{
 			OldTime = oldTime;
 			NewTime = newTime;
 		}
 
-		/// <summary>The time that the user entered.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Gets the newly selected time.</summary>
 		public TimeSpan? NewTime { get; private set; }
 
-		/// <summary>The time that was on the element at the time that the user selected it.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Gets the previously selected time.</summary>
 		public TimeSpan? OldTime { get; private set; }
 	}
 }

--- a/src/Core/maps/src/Core/IGeoPathMapElement.cs
+++ b/src/Core/maps/src/Core/IGeoPathMapElement.cs
@@ -3,6 +3,9 @@ using Microsoft.Maui.Devices.Sensors;
 
 namespace Microsoft.Maui.Maps
 {
+	/// <summary>
+	/// Represents a map element that has a path defined by a collection of geographic locations.
+	/// </summary>
 	public interface IGeoPathMapElement : IMapElement, IList<Location>
 	{
 	}

--- a/src/Core/maps/src/Core/IMapPin.cs
+++ b/src/Core/maps/src/Core/IMapPin.cs
@@ -23,10 +23,22 @@ namespace Microsoft.Maui.Maps
 		/// </summary>
 		Location Location { get; }
 
+		/// <summary>
+		/// Gets or sets the platform-specific marker identifier.
+		/// </summary>
+		/// <remarks>This should typically not be set by the developer. Doing so might result in unpredictable behavior.</remarks>
 		object? MarkerId { get; set; }
 
+		/// <summary>
+		/// Sends a marker click event.
+		/// </summary>
+		/// <returns><see langword="true"/> if the info window should be hidden; otherwise, <see langword="false"/>.</returns>
 		bool SendMarkerClick();
 
+		/// <summary>
+		/// Sends an info window click event.
+		/// </summary>
+		/// <returns><see langword="true"/> if the info window should be hidden; otherwise, <see langword="false"/>.</returns>
 		bool SendInfoWindowClick();
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/IMapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/IMapHandler.cs
@@ -13,13 +13,26 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Provides handler functionality for the <see cref="IMap"/> control.
+	/// </summary>
 	public interface IMapHandler : IViewHandler
 	{
+		/// <inheritdoc/>
 		new IMap VirtualView { get; }
+
+		/// <inheritdoc/>
 		new PlatformView PlatformView { get; }
 #if MONOANDROID
+		/// <summary>
+		/// Gets the Google Maps instance for Android.
+		/// </summary>
 		GoogleMap? Map { get; }
 #endif
+		/// <summary>
+		/// Updates the specified map element on the platform.
+		/// </summary>
+		/// <param name="element">The map element to update.</param>
 		void UpdateMapElement(IMapElement element);
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.cs
@@ -13,8 +13,14 @@ using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Handler for the <see cref="IMap"/> control that manages the platform-specific map implementation.
+	/// </summary>
 	public partial class MapHandler : IMapHandler
 	{
+		/// <summary>
+		/// The property mapper that maps cross-platform properties to platform-specific methods.
+		/// </summary>
 		public static IPropertyMapper<IMap, IMapHandler> Mapper = new PropertyMapper<IMap, IMapHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IMap.MapType)] = MapMapType,
@@ -26,18 +32,28 @@ namespace Microsoft.Maui.Maps.Handlers
 			[nameof(IMap.Elements)] = MapElements,
 		};
 
-
+		/// <summary>
+		/// The command mapper that maps cross-platform commands to platform-specific methods.
+		/// </summary>
 		public static CommandMapper<IMap, IMapHandler> CommandMapper = new(ViewCommandMapper)
 		{
 			[nameof(IMap.MoveToRegion)] = MapMoveToRegion,
 			[nameof(IMapHandler.UpdateMapElement)] = MapUpdateMapElement,
 		};
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapHandler"/> class with default mappers.
+		/// </summary>
 		public MapHandler() : base(Mapper, CommandMapper)
 		{
 
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapHandler"/> class with optional custom mappers.
+		/// </summary>
+		/// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+		/// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
 		public MapHandler(IPropertyMapper? mapper = null, CommandMapper? commandMapper = null)
 		: base(mapper ?? Mapper, commandMapper ?? CommandMapper)
 		{
@@ -47,6 +63,12 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		PlatformView IMapHandler.PlatformView => PlatformView;
 
+		/// <summary>
+		/// Maps the <see cref="IMapHandler.UpdateMapElement"/> command to the platform-specific implementation.
+		/// </summary>
+		/// <param name="handler">The map handler.</param>
+		/// <param name="map">The map control.</param>
+		/// <param name="arg">The <see cref="MapElementHandlerUpdate"/> argument.</param>
 		public static void MapUpdateMapElement(IMapHandler handler, IMap map, object? arg)
 		{
 			if (arg is not MapElementHandlerUpdate args)

--- a/src/Core/maps/src/Handlers/MapElement/IMapElementHandler.cs
+++ b/src/Core/maps/src/Handlers/MapElement/IMapElementHandler.cs
@@ -15,9 +15,15 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Provides handler functionality for <see cref="IMapElement"/> objects.
+	/// </summary>
 	public interface IMapElementHandler : IElementHandler
 	{
+		/// <inheritdoc/>
 		new IMapElement VirtualView { get; }
+
+		/// <inheritdoc/>
 		new PlatformView PlatformView { get; }
 	}
 }

--- a/src/Core/maps/src/Handlers/MapElement/MapElementHandler.cs
+++ b/src/Core/maps/src/Handlers/MapElement/MapElementHandler.cs
@@ -13,8 +13,14 @@ using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Handler for <see cref="IMapElement"/> objects that manages the platform-specific implementation.
+	/// </summary>
 	public partial class MapElementHandler : IMapElementHandler
 	{
+		/// <summary>
+		/// The property mapper that maps cross-platform properties to platform-specific methods.
+		/// </summary>
 		public static IPropertyMapper<IMapElement, IMapElementHandler> Mapper = new PropertyMapper<IMapElement, IMapElementHandler>(ElementMapper)
 		{
 			[nameof(IMapElement.Stroke)] = MapStroke,
@@ -27,12 +33,18 @@ namespace Microsoft.Maui.Maps.Handlers
 #endif
 		};
 
-
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapElementHandler"/> class with the default mapper.
+		/// </summary>
 		public MapElementHandler() : base(Mapper)
 		{
 
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapElementHandler"/> class with an optional custom mapper.
+		/// </summary>
+		/// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
 		public MapElementHandler(IPropertyMapper? mapper = null)
 		: base(mapper ?? Mapper)
 		{

--- a/src/Core/maps/src/Handlers/MapElement/MapElementHandlerUpdate.cs
+++ b/src/Core/maps/src/Handlers/MapElement/MapElementHandlerUpdate.cs
@@ -4,5 +4,10 @@ using System.Text;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Represents an update to a map element, including its index in the collection.
+	/// </summary>
+	/// <param name="Index">The index of the map element in the collection.</param>
+	/// <param name="MapElement">The map element that was updated.</param>
 	public record MapElementHandlerUpdate(int Index, IMapElement MapElement);
 }

--- a/src/Core/maps/src/Handlers/MapPin/IMapPinHandler.cs
+++ b/src/Core/maps/src/Handlers/MapPin/IMapPinHandler.cs
@@ -13,9 +13,15 @@ using PlatformView = System.Object;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Provides handler functionality for <see cref="IMapPin"/> objects.
+	/// </summary>
 	public interface IMapPinHandler : IElementHandler
 	{
+		/// <inheritdoc/>
 		new IMapPin VirtualView { get; }
+
+		/// <inheritdoc/>
 		new PlatformView PlatformView { get; }
 	}
 }

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.cs
@@ -13,8 +13,14 @@ using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
+	/// <summary>
+	/// Handler for <see cref="IMapPin"/> objects that manages the platform-specific implementation.
+	/// </summary>
 	public partial class MapPinHandler : IMapPinHandler
 	{
+		/// <summary>
+		/// The property mapper that maps cross-platform properties to platform-specific methods.
+		/// </summary>
 		public static IPropertyMapper<IMapPin, IMapPinHandler> Mapper = new PropertyMapper<IMapPin, IMapPinHandler>(ElementMapper)
 		{
 			[nameof(IMapPin.Location)] = MapLocation,
@@ -22,11 +28,18 @@ namespace Microsoft.Maui.Maps.Handlers
 			[nameof(IMapPin.Address)] = MapAddress,
 		};
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapPinHandler"/> class with the default mapper.
+		/// </summary>
 		public MapPinHandler() : base(Mapper)
 		{
 
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapPinHandler"/> class with an optional custom mapper.
+		/// </summary>
+		/// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
 		public MapPinHandler(IPropertyMapper? mapper = null)
 		: base(mapper ?? Mapper)
 		{

--- a/src/Core/maps/src/Maps.csproj
+++ b/src/Core/maps/src/Maps.csproj
@@ -8,7 +8,8 @@
     <Nullable>enable</Nullable>
     <IsTrimmable>false</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027</NoWarn>
+    <NoWarn>$(NoWarn);RS0041;RS0026;RS0027</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">

--- a/src/Core/maps/src/Primitives/Distance.cs
+++ b/src/Core/maps/src/Primitives/Distance.cs
@@ -6,22 +6,43 @@ using Microsoft.Maui.Devices.Sensors;
 
 namespace Microsoft.Maui.Maps
 {
+	/// <summary>
+	/// Represents a distance in meters, miles, or kilometers.
+	/// </summary>
 	public struct Distance
 	{
 		const double MetersPerMile = 1609.344;
 		const double MetersPerKilometer = 1000.0;
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Distance"/> struct with a value in meters.
+		/// </summary>
+		/// <param name="meters">The distance in meters.</param>
 		public Distance(double meters)
 		{
 			Meters = meters;
 		}
 
+		/// <summary>
+		/// Gets the distance in meters.
+		/// </summary>
 		public double Meters { get; }
 
+		/// <summary>
+		/// Gets the distance in miles.
+		/// </summary>
 		public double Miles => Meters / MetersPerMile;
 
+		/// <summary>
+		/// Gets the distance in kilometers.
+		/// </summary>
 		public double Kilometers => Meters / MetersPerKilometer;
 
+		/// <summary>
+		/// Creates a new <see cref="Distance"/> from a value in miles.
+		/// </summary>
+		/// <param name="miles">The distance in miles.</param>
+		/// <returns>A new <see cref="Distance"/> instance.</returns>
 		public static Distance FromMiles(double miles)
 		{
 			if (miles < 0)
@@ -32,6 +53,11 @@ namespace Microsoft.Maui.Maps
 			return new Distance(miles * MetersPerMile);
 		}
 
+		/// <summary>
+		/// Creates a new <see cref="Distance"/> from a value in meters.
+		/// </summary>
+		/// <param name="meters">The distance in meters.</param>
+		/// <returns>A new <see cref="Distance"/> instance.</returns>
 		public static Distance FromMeters(double meters)
 		{
 			if (meters < 0)
@@ -42,6 +68,11 @@ namespace Microsoft.Maui.Maps
 			return new Distance(meters);
 		}
 
+		/// <summary>
+		/// Creates a new <see cref="Distance"/> from a value in kilometers.
+		/// </summary>
+		/// <param name="kilometers">The distance in kilometers.</param>
+		/// <returns>A new <see cref="Distance"/> instance.</returns>
 		public static Distance FromKilometers(double kilometers)
 		{
 			if (kilometers < 0)
@@ -52,6 +83,12 @@ namespace Microsoft.Maui.Maps
 			return new Distance(kilometers * MetersPerKilometer);
 		}
 
+		/// <summary>
+		/// Calculates the distance between two geographical positions using the Haversine formula.
+		/// </summary>
+		/// <param name="position1">The first position.</param>
+		/// <param name="position2">The second position.</param>
+		/// <returns>The distance between the two positions.</returns>
 		public static Distance BetweenPositions(Location position1, Location position2)
 		{
 			var latitude1 = position1.Latitude.ToRadians();
@@ -72,11 +109,17 @@ namespace Microsoft.Maui.Maps
 			return FromKilometers(distance);
 		}
 
+		/// <summary>
+		/// Determines whether this instance is equal to another <see cref="Distance"/>.
+		/// </summary>
+		/// <param name="other">The other distance to compare.</param>
+		/// <returns><see langword="true"/> if the distances are equal; otherwise, <see langword="false"/>.</returns>
 		public bool Equals(Distance other)
 		{
 			return Meters.Equals(other.Meters);
 		}
 
+		/// <inheritdoc/>
 		public override bool Equals(object? obj)
 		{
 			if (obj is null)
@@ -84,16 +127,29 @@ namespace Microsoft.Maui.Maps
 			return obj is Distance && Equals((Distance)obj);
 		}
 
+		/// <inheritdoc/>
 		public override int GetHashCode()
 		{
 			return Meters.GetHashCode();
 		}
 
+		/// <summary>
+		/// Determines whether two <see cref="Distance"/> instances are equal.
+		/// </summary>
+		/// <param name="left">The first distance.</param>
+		/// <param name="right">The second distance.</param>
+		/// <returns><see langword="true"/> if the distances are equal; otherwise, <see langword="false"/>.</returns>
 		public static bool operator ==(Distance left, Distance right)
 		{
 			return left.Equals(right);
 		}
 
+		/// <summary>
+		/// Determines whether two <see cref="Distance"/> instances are not equal.
+		/// </summary>
+		/// <param name="left">The first distance.</param>
+		/// <param name="right">The second distance.</param>
+		/// <returns><see langword="true"/> if the distances are not equal; otherwise, <see langword="false"/>.</returns>
 		public static bool operator !=(Distance left, Distance right)
 		{
 			return !left.Equals(right);

--- a/src/Core/maps/src/Primitives/GeographyUtils.cs
+++ b/src/Core/maps/src/Primitives/GeographyUtils.cs
@@ -5,14 +5,32 @@ using Microsoft.Maui.Devices.Sensors;
 
 namespace Microsoft.Maui.Maps
 {
+	/// <summary>
+	/// Provides geography-related utility methods.
+	/// </summary>
 	public static class GeographyUtils
 	{
 		internal const double EarthRadiusKm = 6371;
 
+		/// <summary>
+		/// Converts degrees to radians.
+		/// </summary>
+		/// <param name="degrees">The value in degrees.</param>
+		/// <returns>The value in radians.</returns>
 		public static double ToRadians(this double degrees) => degrees * Math.PI / 180.0;
 
+		/// <summary>
+		/// Converts radians to degrees.
+		/// </summary>
+		/// <param name="radians">The value in radians.</param>
+		/// <returns>The value in degrees.</returns>
 		public static double ToDegrees(this double radians) => radians / Math.PI * 180.0;
 
+		/// <summary>
+		/// Calculates the circumference positions that form the boundary of a circle on the map.
+		/// </summary>
+		/// <param name="circle">The circle element to calculate positions for.</param>
+		/// <returns>A list of positions that approximate the circle's circumference.</returns>
 		public static List<Location> ToCircumferencePositions(this ICircleMapElement circle)
 		{
 			var positions = new List<Location>();

--- a/src/Core/maps/src/Primitives/MapSpan.cs
+++ b/src/Core/maps/src/Primitives/MapSpan.cs
@@ -3,11 +3,20 @@ using Microsoft.Maui.Devices.Sensors;
 
 namespace Microsoft.Maui.Maps
 {
+	/// <summary>
+	/// Represents a rectangular region on the map, defined by a center point and span.
+	/// </summary>
 	public sealed class MapSpan
 	{
 		const double EarthCircumferenceKm = GeographyUtils.EarthRadiusKm * 2 * Math.PI;
 		const double MinimumRangeDegrees = 0.001 / EarthCircumferenceKm * 360; // 1 meter
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MapSpan"/> class with the specified center and span in degrees.
+		/// </summary>
+		/// <param name="center">The center location of the span.</param>
+		/// <param name="latitudeDegrees">The latitude span in degrees.</param>
+		/// <param name="longitudeDegrees">The longitude span in degrees.</param>
 		public MapSpan(Location center, double latitudeDegrees, double longitudeDegrees)
 		{
 			Center = center;
@@ -15,12 +24,24 @@ namespace Microsoft.Maui.Maps
 			LongitudeDegrees = Math.Min(Math.Max(longitudeDegrees, MinimumRangeDegrees), 180.0);
 		}
 
+		/// <summary>
+		/// Gets the center location of this span.
+		/// </summary>
 		public Location Center { get; }
 
+		/// <summary>
+		/// Gets the latitude span in degrees.
+		/// </summary>
 		public double LatitudeDegrees { get; }
 
+		/// <summary>
+		/// Gets the longitude span in degrees.
+		/// </summary>
 		public double LongitudeDegrees { get; }
 
+		/// <summary>
+		/// Gets the approximate radius of the span.
+		/// </summary>
 		public Distance Radius
 		{
 			get
@@ -31,6 +52,12 @@ namespace Microsoft.Maui.Maps
 			}
 		}
 
+		/// <summary>
+		/// Creates a new <see cref="MapSpan"/> with latitude clamped to the specified bounds.
+		/// </summary>
+		/// <param name="north">The northern boundary (0 to 90).</param>
+		/// <param name="south">The southern boundary (-90 to 0).</param>
+		/// <returns>A new <see cref="MapSpan"/> with the clamped latitude.</returns>
 		public MapSpan ClampLatitude(double north, double south)
 		{
 			north = Math.Min(Math.Max(north, 0), 90);
@@ -40,6 +67,7 @@ namespace Microsoft.Maui.Maps
 			return new MapSpan(new Location(lat, Center.Longitude), Math.Min(LatitudeDegrees, maxDLat), LongitudeDegrees);
 		}
 
+		/// <inheritdoc/>
 		public override bool Equals(object? obj)
 		{
 			if (obj is null)
@@ -49,11 +77,18 @@ namespace Microsoft.Maui.Maps
 			return obj is MapSpan && Equals((MapSpan)obj);
 		}
 
+		/// <summary>
+		/// Creates a new <see cref="MapSpan"/> from a center location and radius.
+		/// </summary>
+		/// <param name="center">The center location of the span.</param>
+		/// <param name="radius">The radius of the span.</param>
+		/// <returns>A new <see cref="MapSpan"/> instance.</returns>
 		public static MapSpan FromCenterAndRadius(Location center, Distance radius)
 		{
 			return new MapSpan(center, 2 * DistanceToLatitudeDegrees(radius), 2 * DistanceToLongitudeDegrees(center, radius));
 		}
 
+		/// <inheritdoc/>
 		public override int GetHashCode()
 		{
 			unchecked
@@ -65,16 +100,33 @@ namespace Microsoft.Maui.Maps
 			}
 		}
 
+		/// <summary>
+		/// Determines whether two <see cref="MapSpan"/> instances are equal.
+		/// </summary>
+		/// <param name="left">The first span.</param>
+		/// <param name="right">The second span.</param>
+		/// <returns><see langword="true"/> if the spans are equal; otherwise, <see langword="false"/>.</returns>
 		public static bool operator ==(MapSpan? left, MapSpan? right)
 		{
 			return Equals(left, right);
 		}
 
+		/// <summary>
+		/// Determines whether two <see cref="MapSpan"/> instances are not equal.
+		/// </summary>
+		/// <param name="left">The first span.</param>
+		/// <param name="right">The second span.</param>
+		/// <returns><see langword="true"/> if the spans are not equal; otherwise, <see langword="false"/>.</returns>
 		public static bool operator !=(MapSpan? left, MapSpan? right)
 		{
 			return !Equals(left, right);
 		}
 
+		/// <summary>
+		/// Creates a new <see cref="MapSpan"/> with the specified zoom factor applied.
+		/// </summary>
+		/// <param name="zoomFactor">The zoom factor. Values greater than 1 zoom in, values less than 1 zoom out.</param>
+		/// <returns>A new <see cref="MapSpan"/> with the zoom applied.</returns>
 		public MapSpan WithZoom(double zoomFactor)
 		{
 			double maxDLat = Math.Min(90 - Center.Latitude, 90 + Center.Latitude) * 2;
@@ -113,6 +165,7 @@ namespace Microsoft.Maui.Maps
 			return latCircumference * longitudeDegrees / 360;
 		}
 
+		/// <inheritdoc/>
 		public override string ToString()
 		{
 			return $"{Center}, {LatitudeDegrees}, {LongitudeDegrees}";

--- a/src/Core/maps/src/Primitives/MapSpan.cs
+++ b/src/Core/maps/src/Primitives/MapSpan.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Maui.Maps
 		/// <summary>
 		/// Creates a new <see cref="MapSpan"/> with latitude clamped to the specified bounds.
 		/// </summary>
-		/// <param name="north">The northern boundary (0 to 90).</param>
-		/// <param name="south">The southern boundary (-90 to 0).</param>
+		/// <param name="north">The northern boundary (will be clamped to 0 to 90).</param>
+		/// <param name="south">The southern boundary (will be clamped to -90 to 0).</param>
 		/// <returns>A new <see cref="MapSpan"/> with the clamped latitude.</returns>
 		public MapSpan ClampLatitude(double north, double south)
 		{


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR adds complete XML documentation to the Microsoft.Maui.Maps project and fixes documentation placeholders in Controls.Core.

### Changes

**Core/maps documentation added:**
- `Distance` struct - constructor, properties, factory methods, operators
- `MapSpan` class - constructor, properties, methods  
- `GeographyUtils` class - extension methods
- `IGeoPathMapElement`, `IMapPin` interfaces - previously undocumented members
- `IMapHandler`, `IMapElementHandler`, `IMapPinHandler` interfaces
- `MapHandler`, `MapElementHandler`, `MapPinHandler` handler classes
- `MapElementHandlerUpdate` record

**CS1591 enforcement:**
- Enabled `WarningsAsErrors: CS1591` in `Maps.csproj` to prevent future documentation gaps

**Controls.Core fix:**
- Fixed `TimeChangedEventArgs` - removed "To be added." placeholder documentation

## Testing

- [x] `dotnet build src/Core/maps/src/Maps.csproj -c Release` - passes with CS1591 enforced
- [x] `dotnet build src/Controls/Maps/src/Controls.Maps.csproj -c Release` - passes
- [x] `dotnet build src/Controls/src/Core/Controls.Core.csproj -c Release` - passes