### PR TITLE
Add API documentation to Controls.Foldable and enable CS1591

### DIFF
--- a/src/Controls/Foldable/src/Controls.Foldable.csproj
+++ b/src/Controls/Foldable/src/Controls.Foldable.csproj
@@ -7,7 +7,7 @@
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
   </PropertyGroup>
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('netstandard'))">

--- a/src/Controls/Foldable/src/DualScreenInfo.cs
+++ b/src/Controls/Foldable/src/DualScreenInfo.cs
@@ -63,6 +63,10 @@ namespace Microsoft.Maui.Foldable
 		/// </summary>
 		public event PropertyChangedEventHandler PropertyChanged;
 
+		/// <summary>
+		/// Creates a new <see cref="DualScreenInfo"/> that monitors the specified element's position across screens.
+		/// </summary>
+		/// <param name="element">The visual element to monitor for spanning across screens.</param>
 		public DualScreenInfo(VisualElement element) : this(element, null)
 		{
 		}

--- a/src/Controls/Foldable/src/HostBuilderExtensions.cs
+++ b/src/Controls/Foldable/src/HostBuilderExtensions.cs
@@ -2,10 +2,18 @@
 
 namespace Microsoft.Maui.Foldable
 {
+	/// <summary>
+	/// Extension methods for configuring foldable device support in .NET MAUI applications.
+	/// </summary>
 	public static partial class HostBuilderExtensions
 	{
 		// see Android/HostBuilderExtension.cs for the real implementation
 #if !ANDROID
+		/// <summary>
+		/// Configures the app to detect and respond to foldable device hinge positions and screen configurations.
+		/// </summary>
+		/// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+		/// <returns>The configured <see cref="MauiAppBuilder"/>.</returns>
 		public static MauiAppBuilder UseFoldable(this MauiAppBuilder builder) =>
 			builder;
 #endif

--- a/src/Controls/Foldable/src/SpanModeStateTrigger.cs
+++ b/src/Controls/Foldable/src/SpanModeStateTrigger.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Maui.Controls.Foldable
 	{
 		VisualElement _visualElement;
 		DualScreenInfo _info;
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SpanModeStateTrigger"/> class.
+		/// </summary>
 		public SpanModeStateTrigger()
 		{
 			UpdateState();

--- a/src/Controls/Foldable/src/TwoPaneView.cs
+++ b/src/Controls/Foldable/src/TwoPaneView.cs
@@ -221,6 +221,9 @@ namespace Microsoft.Maui.Controls.Foldable
 			set { SetValue(PanePriorityProperty, value); }
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TwoPaneView"/> class.
+		/// </summary>
 		public TwoPaneView() : this(null)
 		{
 		}

--- a/src/Controls/Foldable/src/WindowSpanModeStateTrigger.cs
+++ b/src/Controls/Foldable/src/WindowSpanModeStateTrigger.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Maui.Controls.Foldable
 	/// </summary>
 	public sealed class WindowSpanModeStateTrigger : StateTriggerBase
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="WindowSpanModeStateTrigger"/> class.
+		/// </summary>
 		public WindowSpanModeStateTrigger()
 		{
 			UpdateState();


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR adds API documentation to the Microsoft.Maui.Controls.Foldable project and enables CS1591 warnings-as-errors to prevent future documentation gaps.

### Changes

**Documentation added:**
- `DualScreenInfo` constructor
- `HostBuilderExtensions.UseFoldable` method
- `TwoPaneView` constructor
- `SpanModeStateTrigger` constructor
- `WindowSpanModeStateTrigger` constructor

**CS1591 enforcement:**
- Enabled `WarningsAsErrors: CS1591` in `Controls.Foldable.csproj`

## Testing

- [x] `dotnet build src/Controls/Foldable/src/Controls.Foldable.csproj -c Release` - passes with CS1591 enforced