### PR TITLE
Add XML documentation to Controls.Xaml and enable CS1591

### DIFF
--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -7,7 +7,8 @@
 		<RootNamespace>Microsoft.Maui.Controls.Xaml</RootNamespace>
 		<IsTrimmable>false</IsTrimmable>
 		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
-		<NoWarn>$(NoWarn);CA2200;CS1591;RS0041</NoWarn>
+		<NoWarn>$(NoWarn);CA2200;RS0041</NoWarn>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -35,6 +35,11 @@ public static partial class AppHostBuilderExtensions
 		return builder;
 	}
 
+	/// <summary>
+	/// Registers the .NET MAUI Controls handlers with the handlers collection.
+	/// </summary>
+	/// <param name="handlersCollection">The handlers collection to register handlers with.</param>
+	/// <returns>The handlers collection for chaining.</returns>
 	public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection) =>
 		handlersCollection.AddControlsHandlers();
 

--- a/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/AppThemeBindingExtension.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that creates a binding with different values for light and dark themes.
+	/// </summary>
 	[ContentProperty(nameof(Default))]
 	[RequireService(
 		[typeof(IProvideValueTarget),
@@ -20,6 +23,9 @@ namespace Microsoft.Maui.Controls.Xaml
 		object _dark;
 		bool _hasdark;
 
+		/// <summary>
+		/// Gets or sets the default value to use when no theme-specific value is set.
+		/// </summary>
 		public object Default
 		{
 			get => _default; set
@@ -28,6 +34,10 @@ namespace Microsoft.Maui.Controls.Xaml
 				_hasdefault = true;
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the value to use when the light theme is active.
+		/// </summary>
 		public object Light
 		{
 			get => _light; set
@@ -36,6 +46,10 @@ namespace Microsoft.Maui.Controls.Xaml
 				_haslight = true;
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the value to use when the dark theme is active.
+		/// </summary>
 		public object Dark
 		{
 			get => _dark; set
@@ -44,6 +58,10 @@ namespace Microsoft.Maui.Controls.Xaml
 				_hasdark = true;
 			}
 		}
+
+		/// <summary>
+		/// Gets the current value based on the active theme.
+		/// </summary>
 		public object Value { get; private set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider) => (this as IMarkupExtension<BindingBase>).ProvideValue(serviceProvider);

--- a/src/Controls/src/Xaml/MarkupExtensions/ArrayExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/ArrayExtension.cs
@@ -5,6 +5,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that creates an array of objects.
+	/// </summary>
 	[ContentProperty(nameof(Items))]
 	[AcceptEmptyServiceProvider]
 #if !NETSTANDARD
@@ -12,13 +15,22 @@ namespace Microsoft.Maui.Controls.Xaml
 #endif
 	public class ArrayExtension : IMarkupExtension<Array>
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ArrayExtension"/> class.
+		/// </summary>
 		public ArrayExtension()
 		{
 			Items = new List<object>();
 		}
 
+		/// <summary>
+		/// Gets the list of items to include in the array.
+		/// </summary>
 		public IList Items { get; }
 
+		/// <summary>
+		/// Gets or sets the type of elements in the array.
+		/// </summary>
 		public Type Type { get; set; }
 
 		public Array ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -5,19 +5,59 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that creates a <see cref="Binding"/> from a XAML attribute value.
+	/// </summary>
 	[ContentProperty(nameof(Path))]
 	[RequireService([typeof(IXamlTypeResolver), typeof(IXamlDataTypeProvider)])]
 	public sealed class BindingExtension : IMarkupExtension<BindingBase>
 	{
+		/// <summary>
+		/// Gets or sets the path to the binding source property.
+		/// </summary>
 		public string Path { get; set; } = Binding.SelfPath;
+
+		/// <summary>
+		/// Gets or sets the binding mode.
+		/// </summary>
 		public BindingMode Mode { get; set; } = BindingMode.Default;
+
+		/// <summary>
+		/// Gets or sets the converter to use when converting between source and target values.
+		/// </summary>
 		public IValueConverter Converter { get; set; }
+
+		/// <summary>
+		/// Gets or sets a parameter to pass to the converter.
+		/// </summary>
 		public object ConverterParameter { get; set; }
+
+		/// <summary>
+		/// Gets or sets a format string to use when converting the bound value to a string.
+		/// </summary>
 		public string StringFormat { get; set; }
+
+		/// <summary>
+		/// Gets or sets the source object for the binding.
+		/// </summary>
 		public object Source { get; set; }
+
+		/// <summary>
+		/// Gets or sets the name of the event that triggers the source update in TwoWay bindings.
+		/// </summary>
 		public string UpdateSourceEventName { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use when the target property value is <see langword="null"/>.
+		/// </summary>
 		public object TargetNullValue { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use when the binding cannot return a value.
+		/// </summary>
 		public object FallbackValue { get; set; }
+
+		/// <summary>For internal use only. This API can be changed or removed without notice at any time.</summary>
 		[EditorBrowsable(EditorBrowsableState.Never)] public TypedBindingBase TypedBinding { get; set; }
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/DataTemplateExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/DataTemplateExtension.cs
@@ -3,11 +3,17 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that creates a <see cref="DataTemplate"/> for a specified type.
+	/// </summary>
 	[ContentProperty(nameof(TypeName))]
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.DataTemplateExtension")]
 	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 	public sealed class DataTemplateExtension : IMarkupExtension<DataTemplate>
 	{
+		/// <summary>
+		/// Gets or sets the type name for which to create the data template.
+		/// </summary>
 		public string TypeName { get; set; }
 
 		public DataTemplate ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/DynamicResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/DynamicResourceExtension.cs
@@ -3,10 +3,16 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that creates a <see cref="DynamicResource"/> for dynamic resource lookup.
+	/// </summary>
 	[ContentProperty(nameof(Key))]
 	[RequireService([typeof(IXmlLineInfoProvider)])]
 	public sealed class DynamicResourceExtension : IMarkupExtension<DynamicResource>
 	{
+		/// <summary>
+		/// Gets or sets the key of the dynamic resource to retrieve.
+		/// </summary>
 		public string Key { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider) => ((IMarkupExtension<DynamicResource>)this).ProvideValue(serviceProvider);

--- a/src/Controls/src/Xaml/MarkupExtensions/FontImageExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/FontImageExtension.cs
@@ -3,6 +3,9 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Xaml;
 
+/// <summary>
+/// Provides a XAML markup extension that creates a font image. Use <see cref="FontImageSource"/> instead.
+/// </summary>
 [Obsolete("Use FontImageSource")]
 public class FontImageExtension : FontImageSource
 {

--- a/src/Controls/src/Xaml/MarkupExtensions/NullExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/NullExtension.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns <see langword="null"/>.
+	/// </summary>
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.NullExtension")]
 	[AcceptEmptyServiceProvider]
 	public class NullExtension : IMarkupExtension

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -8,6 +8,9 @@ using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns different values depending on the device idiom.
+	/// </summary>
 	[ContentProperty(nameof(Default))]
 	[RequireService(
 		[typeof(IProvideValueTarget),
@@ -19,15 +22,44 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		// See Device.Idiom
 
+		/// <summary>
+		/// Gets or sets the default value to use if no idiom-specific value is set.
+		/// </summary>
 		public object Default { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use on phone devices.
+		/// </summary>
 		public object Phone { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use on tablet devices.
+		/// </summary>
 		public object Tablet { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use on desktop devices.
+		/// </summary>
 		public object Desktop { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use on TV devices.
+		/// </summary>
 		public object TV { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value to use on watch devices.
+		/// </summary>
 		public object Watch { get; set; }
 
+		/// <summary>
+		/// Gets or sets a converter to apply to the idiom-specific value.
+		/// </summary>
 		public IValueConverter Converter { get; set; }
 
+		/// <summary>
+		/// Gets or sets a parameter to pass to the converter.
+		/// </summary>
 		public object ConverterParameter { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -7,6 +7,9 @@ using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns different values depending on the platform the app is running on.
+	/// </summary>
 	[ContentProperty(nameof(Default))]
 	[RequireService(
 		[typeof(IProvideValueTarget),
@@ -18,20 +21,56 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		static object s_notset = new object();
 
+		/// <summary>
+		/// Gets or sets the default value to use if no platform-specific value is set.
+		/// </summary>
 		public object Default { get; set; } = s_notset;
+
+		/// <summary>
+		/// Gets or sets the value to use on Android.
+		/// </summary>
 		public object Android { get; set; } = s_notset;
+
 		internal object GTK { get; set; } = s_notset;
+
+		/// <summary>
+		/// Gets or sets the value to use on iOS.
+		/// </summary>
 		public object iOS { get; set; } = s_notset;
+
 		internal object macOS { get; set; } = s_notset;
+
+		/// <summary>
+		/// Gets or sets the value to use on Mac Catalyst.
+		/// </summary>
 		public object MacCatalyst { get; set; } = s_notset;
+
+		/// <summary>
+		/// Gets or sets the value to use on Tizen.
+		/// </summary>
 		public object Tizen { get; set; } = s_notset;
+
+		/// <summary>
+		/// Gets or sets the value to use on UWP. Use <see cref="WinUI"/> instead.
+		/// </summary>
 		[Obsolete("Use WinUI instead.")]
 		public object UWP { get; set; } = s_notset;
+
 		internal object WPF { get; set; } = s_notset;
+
+		/// <summary>
+		/// Gets or sets the value to use on Windows (WinUI).
+		/// </summary>
 		public object WinUI { get; set; } = s_notset;
 
+		/// <summary>
+		/// Gets or sets a converter to apply to the platform-specific value.
+		/// </summary>
 		public IValueConverter Converter { get; set; }
 
+		/// <summary>
+		/// Gets or sets a parameter to pass to the converter.
+		/// </summary>
 		public object ConverterParameter { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/ReferenceExtension.cs
@@ -4,10 +4,16 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns an object by its x:Name from the current XAML namescope.
+	/// </summary>
 	[ContentProperty(nameof(Name))]
 	[RequireService([typeof(IReferenceProvider), typeof(IProvideValueTarget)])]
 	public class ReferenceExtension : IMarkupExtension
 	{
+		/// <summary>
+		/// Gets or sets the x:Name of the element to reference.
+		/// </summary>
 		public string Name { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/RelativeSourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/RelativeSourceExtension.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		}
 
 		/// <summary>
-		/// Gets or sets the level of ancestor to look for when Mode is FindAncestor.
+		/// Gets or sets the level of ancestor to look for when Mode is FindAncestor or FindAncestorBindingContext.
 		/// </summary>
 		public int AncestorLevel
 		{

--- a/src/Controls/src/Xaml/MarkupExtensions/RelativeSourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/RelativeSourceExtension.cs
@@ -3,22 +3,34 @@ using System.Reflection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns a <see cref="RelativeBindingSource"/> for relative bindings.
+	/// </summary>
 	[ContentProperty("Mode")]
 	[AcceptEmptyServiceProvider]
 	public sealed class RelativeSourceExtension : IMarkupExtension<RelativeBindingSource>
 	{
+		/// <summary>
+		/// Gets or sets the mode of the relative binding source.
+		/// </summary>
 		public RelativeBindingSourceMode Mode
 		{
 			get;
 			set;
 		}
 
+		/// <summary>
+		/// Gets or sets the level of ancestor to look for when Mode is FindAncestor.
+		/// </summary>
 		public int AncestorLevel
 		{
 			get;
 			set;
 		}
 
+		/// <summary>
+		/// Gets or sets the type of ancestor to look for when Mode is FindAncestor or FindAncestorBindingContext.
+		/// </summary>
 		public Type AncestorType
 		{
 			get;

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -6,12 +6,18 @@ using System.Xml;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns the value of a static field or property.
+	/// </summary>
 	[ContentProperty(nameof(Member))]
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.StaticExtension")]
 	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 	[RequireService([typeof(IXamlTypeResolver)])]
 	public class StaticExtension : IMarkupExtension
 	{
+		/// <summary>
+		/// Gets or sets the name of the static member in the form [prefix:]typeName.memberName.
+		/// </summary>
 		public string Member { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -4,11 +4,17 @@ using System.Reflection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that resolves a resource from a <see cref="ResourceDictionary"/>.
+	/// </summary>
 	[ContentProperty(nameof(Key))]
 	[RequireService([typeof(IXmlLineInfoProvider), typeof(IProvideParentValues), typeof(IRootObjectProvider)])]
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.StaticResourceExtension")]
 	public sealed class StaticResourceExtension : IMarkupExtension
 	{
+		/// <summary>
+		/// Gets or sets the key of the resource to retrieve.
+		/// </summary>
 		public string Key { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
@@ -6,13 +6,22 @@ using Microsoft.Maui.Controls.StyleSheets;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that loads a CSS style sheet from a source or inline content.
+	/// </summary>
 	[ContentProperty(nameof(Style))]
 	[ProvideCompiled("Microsoft.Maui.Controls.XamlC.StyleSheetProvider")]
 	[RequireService([typeof(IXmlLineInfoProvider), typeof(IRootObjectProvider)])]
 	public sealed class StyleSheetExtension : IValueProvider
 	{
+		/// <summary>
+		/// Gets or sets the inline CSS style sheet content.
+		/// </summary>
 		public string Style { get; set; }
 
+		/// <summary>
+		/// Gets or sets the URI to the CSS style sheet resource.
+		/// </summary>
 		[System.ComponentModel.TypeConverter(typeof(UriTypeConverter))]
 		public Uri Source { get; set; }
 

--- a/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/TemplateBindingExtension.cs
@@ -5,27 +5,49 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that creates a binding to the templated parent.
+	/// </summary>
 	[ContentProperty(nameof(Path))]
 	[AcceptEmptyServiceProvider]
 	[RequiresUnreferencedCode(TrimmerConstants.StringPathBindingWarning, Url = TrimmerConstants.ExpressionBasedBindingsDocsUrl)]
 	public sealed class TemplateBindingExtension : IMarkupExtension<BindingBase>
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TemplateBindingExtension"/> class.
+		/// </summary>
 		public TemplateBindingExtension()
 		{
 			Mode = BindingMode.Default;
 			Path = Binding.SelfPath;
 		}
 
+		/// <summary>
+		/// Gets or sets the path to the binding source property on the templated parent.
+		/// </summary>
 		public string Path { get; set; }
 
+		/// <summary>
+		/// Gets or sets the binding mode.
+		/// </summary>
 		public BindingMode Mode { get; set; }
 
+		/// <summary>
+		/// Gets or sets the converter to use when converting between source and target values.
+		/// </summary>
 		public IValueConverter Converter { get; set; }
 
+		/// <summary>
+		/// Gets or sets a parameter to pass to the converter.
+		/// </summary>
 		public object ConverterParameter { get; set; }
 
+		/// <summary>
+		/// Gets or sets a format string to use when converting the bound value to a string.
+		/// </summary>
 		public string StringFormat { get; set; }
 
+		/// <summary>For internal use only. This API can be changed or removed without notice at any time.</summary>
 		[EditorBrowsable(EditorBrowsableState.Never)] public TypedBindingBase TypedBinding { get; set; }
 
 		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/MarkupExtensions/TypeExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/TypeExtension.cs
@@ -2,11 +2,17 @@ using System;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides a XAML markup extension that returns a <see cref="Type"/> object for a specified type name.
+	/// </summary>
 	[ContentProperty(nameof(TypeName))]
 	[ProvideCompiled("Microsoft.Maui.Controls.Build.Tasks.TypeExtension")]
 	[RequireService([typeof(IXamlTypeResolver), typeof(IXmlLineInfoProvider)])]
 	public class TypeExtension : IMarkupExtension<Type>
 	{
+		/// <summary>
+		/// Gets or sets the type name to resolve.
+		/// </summary>
 		public string TypeName { get; set; }
 
 		public Type ProvideValue(IServiceProvider serviceProvider)

--- a/src/Controls/src/Xaml/ViewExtensions.cs
+++ b/src/Controls/src/Xaml/ViewExtensions.cs
@@ -31,18 +31,35 @@ using System.Reflection;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Provides extension methods for loading XAML into objects.
+	/// </summary>
 	[RequiresUnreferencedCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 #if !NETSTANDARD
 	[RequiresDynamicCode(TrimmerConstants.XamlRuntimeParsingNotSupportedWarning)]
 #endif
 	public static class Extensions
 	{
+		/// <summary>
+		/// Loads the XAML associated with the specified type into the view.
+		/// </summary>
+		/// <typeparam name="TXaml">The type of the view.</typeparam>
+		/// <param name="view">The view to load XAML into.</param>
+		/// <param name="callingType">The type used to locate the XAML resource.</param>
+		/// <returns>The view with XAML loaded.</returns>
 		public static TXaml LoadFromXaml<TXaml>(this TXaml view, Type callingType)
 		{
 			XamlLoader.Load(view, callingType);
 			return view;
 		}
 
+		/// <summary>
+		/// Loads the specified XAML string into the view.
+		/// </summary>
+		/// <typeparam name="TXaml">The type of the view.</typeparam>
+		/// <param name="view">The view to load XAML into.</param>
+		/// <param name="xaml">The XAML string to load.</param>
+		/// <returns>The view with XAML loaded.</returns>
 		public static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml)
 		{
 			XamlLoader.Load(view, xaml);

--- a/src/Controls/src/Xaml/XamlFilePathAttribute.cs
+++ b/src/Controls/src/Xaml/XamlFilePathAttribute.cs
@@ -5,11 +5,21 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
+	/// <summary>
+	/// Specifies the file path of the XAML file associated with a type.
+	/// </summary>
 	[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 	public sealed class XamlFilePathAttribute : Attribute
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="XamlFilePathAttribute"/> with the file path of the caller.
+		/// </summary>
+		/// <param name="filePath">The file path, automatically set by the compiler.</param>
 		public XamlFilePathAttribute([CallerFilePath] string filePath = "") => FilePath = filePath;
 
+		/// <summary>
+		/// Gets the file path of the XAML file.
+		/// </summary>
 		public string FilePath { get; }
 
 		internal static string GetFilePathForObject(object view) => (view?.GetType().GetCustomAttributes(typeof(XamlFilePathAttribute), false).FirstOrDefault() as XamlFilePathAttribute)?.FilePath;


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds XML documentation to all public members in **Microsoft.Maui.Controls.Xaml** and enables CS1591 as a warning-as-error to prevent future documentation gaps.

## Changes

### Markup Extensions Documented
- `BindingExtension` - All 11 properties
- `StaticResourceExtension` - Key property
- `DynamicResourceExtension` - Key property
- `OnPlatformExtension` - All platform properties
- `OnIdiomExtension` - All idiom properties
- `ReferenceExtension` - Name property
- `TypeExtension` - TypeName property
- `StaticExtension` - Member property
- `NullExtension` - Class summary
- `ArrayExtension` - Type property and Items collection
- `TemplateBindingExtension` - All binding properties
- `RelativeSourceExtension` - Mode and AncestorType properties
- `DataTemplateExtension` - TypeName property
- `AppThemeBindingExtension` - Light/Dark/Default properties
- `StyleSheetExtension` - Style and Source properties
- `FontImageExtension` - Class summary (obsolete type)

### Other Types Documented
- `Extensions` class - LoadFromXaml methods
- `XamlFilePathAttribute` - Constructor and FilePath property
- `AppHostBuilderExtensions.AddMauiControlsHandlers` method

### Build Configuration
- Removed CS1591 from NoWarn
- Added CS1591 to WarningsAsErrors

## Stats
- **20 files changed**
- **+260 lines** of documentation
