### PR TITLE
[testing] Test skipping tests on iOS 26

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 #if __IOS__
 using Foundation;
 #endif
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
@@ -11,7 +13,6 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
-using System.Diagnostics;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -307,7 +308,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Trait(TestCategory.SkipOnIOS26, "Font comparison may fail on iOS 26")]
+		[SkipOnIOSVersion(26, "Font comparison may fail on iOS 26")]
 		public async Task ChangingTextTypeWithFormattedTextSwitchesTextSource()
 		{
 			SetupBuilder();
@@ -512,16 +513,9 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-#if __IOS__
-		[Trait(TestCategory.SkipOnIOS26, "Font comparison may fail on iOS 26")]
-#endif
+		[SkipOnIOSVersion(26, "Font comparison may fail on iOS 26")]
 		public async Task FontStuffAppliesEvenInHtmlMode()
 		{
-#if __IOS__
-			// iOS 26 may have font handling changes that affect HTML text rendering
-			if (OperatingSystem.IsIOSVersionAtLeast(26))
-				return;
-#endif
 			// Note: this is specifically a Controls-level rule that's inherited from Forms
 			// There's no reason other SDKs need to force font properties when dealing 
 			// with HTML text (since HTML can do that on its own)
@@ -724,7 +718,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		[Trait(TestCategory.SkipOnIOS26, "Font comparison may fail on iOS 26")]
+		[SkipOnIOSVersion(26, "Font comparison may fail on iOS 26")]
 		public async Task FontStuffAfterTextTypeIsCorrect()
 		{
 			// Note: this is specifically a Controls-level rule that's inherited from Forms

--- a/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/SearchBar/SearchBarTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
@@ -36,12 +37,9 @@ namespace Microsoft.Maui.DeviceTests
 #if MACCATALYST || IOS
 		// Only Mac Catalyst and iOS needs the CancelButtonColor nuanced handling verifying
 		[Fact(DisplayName = "CancelButtonColor is set correctly")]
-		[Trait(TestCategory.SkipOnIOS26, "iOS 26 changed UISearchBar internal structure")]
+		[SkipOnIOSVersion(26, "iOS 26 changed UISearchBar internal structure")]
 		public async Task CancelButtonColorSetCorrectly()
 		{
-			if (OperatingSystem.IsIOSVersionAtLeast(26))
-				return;
-
 			var expected = Graphics.Colors.Red;
 
 			var searchBar = new SearchBar()

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -42,7 +42,6 @@
 		public const string SearchBar = "SearchBar";
 		public const string Shape = "Shape";
 		public const string Shell = "Shell";
-		public const string SkipOnIOS26 = "SkipOnIOS26";
 		public const string Slider = "Slider";
 		public const string SwipeView = "SwipeView";
 		public const string TabbedPage = "TabbedPage";

--- a/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
+++ b/src/TestUtils/src/DeviceTests/xUnitCustomizations.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,54 @@ using Xunit.Sdk;
 
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Attribute to skip a test on iOS when running on a specific version or higher.
+	/// The test will be skipped at runtime when the iOS version is at least the specified major version.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+	public class SkipOnIOSVersionAttribute : Attribute
+	{
+		public int Major { get; }
+		public int Minor { get; }
+		public int Build { get; }
+		public string Reason { get; }
+
+		public SkipOnIOSVersionAttribute(int major, string reason = "")
+			: this(major, 0, 0, reason)
+		{
+		}
+
+		public SkipOnIOSVersionAttribute(int major, int minor, string reason = "")
+			: this(major, minor, 0, reason)
+		{
+		}
+
+		public SkipOnIOSVersionAttribute(int major, int minor, int build, string reason = "")
+		{
+			Major = major;
+			Minor = minor;
+			Build = build;
+			Reason = reason;
+		}
+
+		public bool ShouldSkip()
+		{
+#if IOS || MACCATALYST
+			return OperatingSystem.IsIOSVersionAtLeast(Major, Minor, Build)
+				|| OperatingSystem.IsMacCatalystVersionAtLeast(Major, Minor, Build);
+#else
+			return false;
+#endif
+		}
+
+		public string GetSkipReason()
+		{
+			if (string.IsNullOrEmpty(Reason))
+				return $"Test skipped on iOS/MacCatalyst {Major}.{Minor}.{Build} or higher";
+			return Reason;
+		}
+	}
+
 	/// <summary>
 	/// This type provides the assembly name for the xUnit attributes specified in
 	/// the linked TestShared\xUnitSharedAttributes.cs file.
@@ -194,7 +243,40 @@ namespace Microsoft.Maui
 
 		public Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
 		{
+			// Check for SkipOnIOSVersionAttribute at runtime
+			var skipAttribute = GetSkipOnIOSVersionAttribute();
+			if (skipAttribute != null && skipAttribute.ShouldSkip())
+			{
+				return SkipTestAsync(messageBus, skipAttribute.GetSkipReason());
+			}
+
 			return _inner.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+		}
+
+		private SkipOnIOSVersionAttribute? GetSkipOnIOSVersionAttribute()
+		{
+			var methodInfo = TestMethod.Method.ToRuntimeMethod();
+			var attribute = methodInfo?.GetCustomAttributes(typeof(SkipOnIOSVersionAttribute), inherit: true)
+				.FirstOrDefault() as SkipOnIOSVersionAttribute;
+
+			if (attribute != null)
+				return attribute;
+
+			// Also check the declaring type
+			var typeInfo = TestMethod.TestClass.Class.ToRuntimeType();
+			return typeInfo?.GetCustomAttributes(typeof(SkipOnIOSVersionAttribute), inherit: true)
+				.FirstOrDefault() as SkipOnIOSVersionAttribute;
+		}
+
+		private Task<RunSummary> SkipTestAsync(IMessageBus messageBus, string skipReason)
+		{
+			var test = new XunitTest(this, DisplayName);
+			
+			messageBus.QueueMessage(new TestStarting(test));
+			messageBus.QueueMessage(new TestSkipped(test, skipReason));
+			messageBus.QueueMessage(new TestFinished(test, 0, null));
+
+			return Task.FromResult(new RunSummary { Total = 1, Skipped = 1 });
 		}
 
 		public void Serialize(IXunitSerializationInfo info)


### PR DESCRIPTION
### Description of Change

Make an trait to skip tests by OS versions

This pull request introduces a new attribute, `SkipOnIOSVersionAttribute`, to simplify and standardize skipping tests on specific iOS or Mac Catalyst versions. It replaces the previous use of the `[Trait]` attribute and manual runtime checks with a more robust and maintainable approach. The new attribute is now used in relevant test files, and the old trait constant is removed.

**Test Skipping Improvements:**

* Added a new `SkipOnIOSVersionAttribute` in `xUnitCustomizations.cs` that allows tests to be skipped at runtime on specified iOS/Mac Catalyst versions, with customizable reasons. This attribute checks the OS version and ensures tests are skipped automatically when appropriate.
* Updated the xUnit test runner logic to detect and honor the new `SkipOnIOSVersionAttribute`, ensuring tests are properly marked as skipped and reported as such.

**Test Code Modernization:**

* Replaced `[Trait(TestCategory.SkipOnIOS26, ...)]` and manual OS version checks in `LabelTests.cs` and `SearchBarTests.cs` with `[SkipOnIOSVersion(26, ...)]` for cleaner and more maintainable test code. [[1]](diffhunk://#diff-bcab141ed5a07faa1a4dbc74db51c45a69da5a92e4e09d89a7d698ba04c315ceL310-R311) [[2]](diffhunk://#diff-bcab141ed5a07faa1a4dbc74db51c45a69da5a92e4e09d89a7d698ba04c315ceL515-L524) [[3]](diffhunk://#diff-bcab141ed5a07faa1a4dbc74db51c45a69da5a92e4e09d89a7d698ba04c315ceL727-R721) [[4]](diffhunk://#diff-672914934d2b7268136016873baa5ff019ca2f304f29df29f7e72723ada06346L39-L44)
* Removed the now-unused `SkipOnIOS26` constant from `TestCategory.cs`.

**General Code Cleanup:**

* Minor improvements to `using` directives for consistency and clarity in affected test files. [[1]](diffhunk://#diff-bcab141ed5a07faa1a4dbc74db51c45a69da5a92e4e09d89a7d698ba04c315ceR3-L14) [[2]](diffhunk://#diff-672914934d2b7268136016873baa5ff019ca2f304f29df29f7e72723ada06346R4) [[3]](diffhunk://#diff-a406bc0870dfc91b01768b17d21294057a9752050c64e6de464fdb7a4a3bc404R5)