### PR TITLE
[ci] Move to use arm64 pool

### DIFF
--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -67,13 +67,13 @@ parameters:
   type: object
   default:
     name: Azure Pipelines
-    vmImage: macOS-15
+    vmImage: macOS-15-arm64
 
 - name: macOSPoolInternal
   type: object
   default:
     name: Azure Pipelines
-    vmImage: macOS-15
+    vmImage: macOS-15-arm64
 
 # Public pools (dnceng-public)
 - name: windowsPoolPublic
@@ -89,7 +89,7 @@ parameters:
   type: object
   default:
     name: Azure Pipelines
-    vmImage: macOS-15
+    vmImage: macOS-15-arm64
 
 - name: macOSPoolPublic
   type: object

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -74,7 +74,7 @@ parameters:
     default:
       name: NetCore1ESPool-Internal
       demands:
-        - ImageOverride -equals 1es-ubuntu2204
+        - ImageOverride -equals 1es-ubuntu-2204
 
   - name: iosPoolInternal
     type: object

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -72,9 +72,9 @@ parameters:
   - name: androidPoolLinuxInternal
     type: object
     default:
-      name: NetCore1ESPool-Internal
+      name: MAUI-DNCENG
       demands:
-        - ImageOverride -equals 1es-ubuntu-2204
+        - ImageOverride -equals 1ESPT-Ubuntu22.04
 
   - name: iosPoolInternal
     type: object

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -100,7 +100,7 @@ parameters:
     type: object
     default:
       name: Azure Pipelines
-      vmImage: macOS-15-arm64
+      vmImage: macOS-14
 
   # Public pools (dnceng-public)
   - name: androidPoolPublic

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -66,10 +66,8 @@ parameters:
   - name: androidPoolInternal
     type: object
     default:
-      name: MAUI
-      vmImage: MAUI
-      demands:
-        - Agent.OSArchitecture -equals ARM64
+      name: Azure Pipelines
+      vmImage: macOS-15-arm64
   
   - name: androidPoolLinuxInternal
     type: object
@@ -81,8 +79,8 @@ parameters:
   - name: iosPoolInternal
     type: object
     default:
-      name: MAUI
-      vmImage: MAUI
+      name: Azure Pipelines
+      vmImage: macOS-15-arm64
   
   - name: windowsBuildPoolInternal
     type: object
@@ -102,7 +100,7 @@ parameters:
     type: object
     default:
       name: Azure Pipelines
-      vmImage: macOS-15
+      vmImage: macOS-15-arm64
 
   # Public pools (dnceng-public)
   - name: androidPoolPublic

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -74,7 +74,7 @@ parameters:
     default:
       name: NetCore1ESPool-Internal
       demands:
-        - ImageOverride -equals 1ESPT-Ubuntu22.04
+        - ImageOverride -equals 1es-ubuntu2204
 
   - name: iosPoolInternal
     type: object

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -202,7 +202,7 @@ stages:
       buildscript: $(_buildScript)
     - name: mac_unit_tests
       displayName: macOS Unit Tests
-      pool: ${{ parameters.MacOSPool }}
+      pool: ${{ parameters.MacOSPoolArm64 }}
       timeout: 90
       testOS: macOS
       buildscript: $(_buildScriptMacOS)
@@ -223,7 +223,7 @@ stages:
       timeout: 120
       testCategory: Samples
     - name: mac_sample_tests
-      pool: ${{ parameters.MacOSPool }}
+      pool: ${{ parameters.MacOSPoolArm64 }}
       timeout: 240
       testCategory: Samples
 
@@ -252,7 +252,7 @@ stages:
       timeout: 120
       testCategory: Build
     - name: mac_buildtemplate_tests
-      pool: ${{ parameters.MacOSPool }}
+      pool: ${{ parameters.MacOSPoolArm64 }}
       timeout: 240
       testCategory: Build
 
@@ -266,7 +266,7 @@ stages:
       timeout: 120
       testCategory: Blazor
     - name: mac_blazortemplate_tests
-      pool: ${{ parameters.MacOSPool }}
+      pool: ${{ parameters.MacOSPoolArm64 }}
       timeout: 240
       testCategory: Blazor
 
@@ -280,13 +280,13 @@ stages:
       timeout: 120
       testCategory: MultiProject
     - name: mac_multitemplate_tests
-      pool: ${{ parameters.MacOSPool }}
+      pool: ${{ parameters.MacOSPoolArm64 }}
       timeout: 120
       testCategory: MultiProject
 
     # TODO: macOSTemplates and AOT template categories
     - name: mac_runandroid_tests
-      pool: ${{ parameters.MacOSPool }}
+      pool: ${{ parameters.MacOSPoolArm64 }}
       timeout: 240
       testCategory: RunOnAndroid
 


### PR DESCRIPTION
### Description of Change

Try use the macOS-15-arm64 as this has Xcode 26.2 already for net10 and net11 branches. 

This pull request updates the CI pipeline configuration to standardize the use of ARM64-based macOS build agents across device tests, UI tests, and core CI stages. The changes ensure that all macOS jobs run on the newer `macOS-15-arm64` image, improving consistency and compatibility with ARM64 hardware.

**Pipeline configuration updates:**

* Updated all macOS pool definitions in `eng/pipelines/ci-device-tests.yml` to use the `macOS-15-arm64` VM image for internal and public pools, replacing the previous `macOS-15` image. [[1]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bL70-R76) [[2]](diffhunk://#diff-3c01e959fbddcc83fed139e6855a1fb2211a82deff79904912c021d96e433d2bL92-R92)
* Changed macOS pool references in `eng/pipelines/ci-uitests.yml` for both Android and iOS internal pools to use `macOS-15-arm64` and standardized the pool name to `Azure Pipelines`. [[1]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3L69-R70) [[2]](diffhunk://#diff-f0d1c4172dd9c907f376bbf9165bb7866553b059e26c8519320d65b9d4e673e3L84-R83)
* Updated the default macOS pool for internal UI tests in `eng/pipelines/ci-uitests.yml` to use `macOS-15-arm64`.

**Stage pool usage updates:**

* Modified all macOS test stages in `eng/pipelines/ci.yml` to use the new `MacOSPoolArm64` parameter instead of the previous `MacOSPool`, ensuring all macOS jobs run on ARM64 agents. This applies to unit, sample, build template, Blazor template, multi-project template, and Android run tests. [[1]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L205-R205) [[2]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L226-R226) [[3]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L255-R255) [[4]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L269-R269) [[5]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L283-R289)