### PR TITLE
Add XML documentation to Controls.Core.Design and enable CS1591

### DIFF
--- a/src/Controls/src/Core.Design/BoundsDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/BoundsDesignTypeConverter.cs
@@ -4,8 +4,12 @@ using System.Globalization;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for bounds values.
+	/// </summary>
 	public class BoundsDesignTypeConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH BoundsTypeConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/ButtonContentDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/ButtonContentDesignTypeConverter.cs
@@ -3,6 +3,9 @@ using System.ComponentModel;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for button content layout values.
+	/// </summary>
 	public class ButtonContentDesignTypeConverter : StringConverter
 	{
 		private static readonly char[] Separators = { ',' };
@@ -15,6 +18,7 @@ namespace Microsoft.Maui.Controls.Design
 		// ButtonContentLayout((ImagePorition)15, DefaultSpacing/*10*/)
 		private enum ImagePosition { Left, Top, Right, Bottom };
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH ButtonContentConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/ColorDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/ColorDesignTypeConverter.cs
@@ -5,8 +5,14 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for Color values.
+	/// </summary>
 	public class ColorDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ColorDesignTypeConverter"/> class.
+		/// </summary>
 		public ColorDesignTypeConverter()
 		{ }
 
@@ -173,6 +179,7 @@ namespace Microsoft.Maui.Controls.Design
 			knowValuesSet.Add("Default");
 		}
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues => knownValues;
 
 		// #rgb, #rrggbb, #aarrggbb are all valid 
@@ -188,6 +195,7 @@ namespace Microsoft.Maui.Controls.Design
 		const string RxFuncPattern = "^(?<func>rgba|argb|rgb|hsla|hsl|hsva|hsv)\\(((?<v>\\d%?),){2}((?<v>\\d%?)|(?<v>\\d%?),(?<v>\\d%?))\\);?$";
 		static readonly Lazy<Regex> RxFuncExpr = new(() => new Regex(RxFuncPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline));
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			var str = value?.ToString();

--- a/src/Controls/src/Core.Design/ConstraintDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/ConstraintDesignTypeConverter.cs
@@ -3,8 +3,12 @@ using System.Globalization;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for constraint values.
+	/// </summary>
 	public class ConstraintDesignTypeConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH ConstraintTypeConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/Controls.Core.Design.csproj
+++ b/src/Controls/src/Core.Design/Controls.Core.Design.csproj
@@ -5,6 +5,8 @@
 		<EnableDefaultCompileItems>False</EnableDefaultCompileItems>
 		<IsPackable>False</IsPackable>
 		<IsTrimmable>false</IsTrimmable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
 		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(_MauiDesignDllBuild)' == 'True' ">
@@ -33,6 +35,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RectTypeDesignConverter.cs" />
     <Compile Include="RegisterMetadata.cs" />
+    <Compile Include="SafeAreaEdgesTypeDesignConverter.cs" />
     <Compile Include="ThicknessTypeDesignConverter.cs" />
     <Compile Include="VisibilityDesignTypeConverter.cs" />
     <Compile Include="VisualDesignTypeConverter.cs" />

--- a/src/Controls/src/Core.Design/CornerRadiusDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/CornerRadiusDesignTypeConverter.cs
@@ -5,8 +5,12 @@ using Controls.Core.Design;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for CornerRadius values.
+	/// </summary>
 	public class CornerRadiusDesignTypeConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH CornerRadiusTypeConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/EasingDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/EasingDesignTypeConverter.cs
@@ -1,13 +1,21 @@
 namespace Microsoft.Maui.Controls.Design
 {
 
+	/// <summary>
+	/// Provides design-time type conversion for Easing values.
+	/// </summary>
 	public class EasingDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EasingDesignTypeConverter"/> class.
+		/// </summary>
 		public EasingDesignTypeConverter()
 		{ }
 
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new string[]
 			{

--- a/src/Controls/src/Core.Design/FlexEnumDesignTypeConverters.cs
+++ b/src/Controls/src/Core.Design/FlexEnumDesignTypeConverters.cs
@@ -8,10 +8,15 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for FlexJustify values.
+	/// </summary>
 	public class FlexJustifyDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"Start",
@@ -23,10 +28,15 @@ namespace Microsoft.Maui.Controls.Design
 			};
 	}
 
+	/// <summary>
+	/// Provides design-time type conversion for FlexDirection values.
+	/// </summary>
 	public class FlexDirectionDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"Column",
@@ -36,10 +46,15 @@ namespace Microsoft.Maui.Controls.Design
 		};
 	}
 
+	/// <summary>
+	/// Provides design-time type conversion for FlexAlignContent values.
+	/// </summary>
 	public class FlexAlignContentDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"Stretch",
@@ -53,10 +68,15 @@ namespace Microsoft.Maui.Controls.Design
 	}
 
 
+	/// <summary>
+	/// Provides design-time type conversion for FlexAlignItems values.
+	/// </summary>
 	public class FlexAlignItemsDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"Stretch",
@@ -67,10 +87,15 @@ namespace Microsoft.Maui.Controls.Design
 	}
 
 
+	/// <summary>
+	/// Provides design-time type conversion for FlexAlignSelf values.
+	/// </summary>
 	public class FlexAlignSelfDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"Auto",
@@ -82,10 +107,15 @@ namespace Microsoft.Maui.Controls.Design
 	}
 
 
+	/// <summary>
+	/// Provides design-time type conversion for FlexWrap values.
+	/// </summary>
 	public class FlexWrapDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"NoWrap",
@@ -95,13 +125,18 @@ namespace Microsoft.Maui.Controls.Design
 	}
 
 
+	/// <summary>
+	/// Provides design-time type conversion for FlexBasis values.
+	/// </summary>
 	public class FlexBasisDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] {
 				"Auto",
 		};
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			if (KnownValues.Any(v => value?.ToString()?.Equals(v, StringComparison.Ordinal) ?? false))

--- a/src/Controls/src/Core.Design/FlowDirectionDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/FlowDirectionDesignTypeConverter.cs
@@ -8,10 +8,15 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for FlowDirection values.
+	/// </summary>
 	public class FlowDirectionDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[]
 			{

--- a/src/Controls/src/Core.Design/FontSizeDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/FontSizeDesignTypeConverter.cs
@@ -4,14 +4,22 @@ using System.Linq;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for font size values.
+	/// </summary>
 	public class FontSizeDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FontSizeDesignTypeConverter"/> class.
+		/// </summary>
 		public FontSizeDesignTypeConverter()
 		{ }
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] { "Default", "Micro", "Small", "Medium", "Large", "Body", "Header", "Title", "Subtitle", "Caption" };
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			if (KnownValues.Any(v => value?.ToString()?.Equals(v, StringComparison.Ordinal) ?? false))

--- a/src/Controls/src/Core.Design/GridLengthCollectionDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/GridLengthCollectionDesignTypeConverter.cs
@@ -4,13 +4,16 @@ using System.Linq;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for GridLength collection values.
+	/// </summary>
 	public class GridLengthCollectionDesignTypeConverter : TypeConverter
 	{
-		// This tells XAML this converter can be used to process strings
-		// Without this the values won't show up as hints
+		/// <inheritdoc/>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 			=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			if (value?.ToString() is string strValue)

--- a/src/Controls/src/Core.Design/GridLengthDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/GridLengthDesignTypeConverter.cs
@@ -4,13 +4,16 @@ using System.Globalization;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for GridLength values.
+	/// </summary>
 	public class GridLengthDesignTypeConverter : TypeConverter
 	{
-		// This tells XAML this converter can be used to process strings
-		// Without this the values won't show up as hints
+		/// <inheritdoc/>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 			=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			return IsValid(value?.ToString());

--- a/src/Controls/src/Core.Design/ImageSourceDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/ImageSourceDesignTypeConverter.cs
@@ -3,8 +3,12 @@ using System.ComponentModel;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for ImageSource values.
+	/// </summary>
 	public class ImageSourceDesignTypeConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH ImageSourceConverter.ConvertFrom. Note that MAUI runtime allows

--- a/src/Controls/src/Core.Design/ItemsLayoutDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/ItemsLayoutDesignTypeConverter.cs
@@ -1,11 +1,18 @@
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for items layout values.
+	/// </summary>
 	public class ItemsLayoutDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ItemsLayoutDesignTypeConverter"/> class.
+		/// </summary>
 		public ItemsLayoutDesignTypeConverter()
 		{
 		}
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[] { "VerticalList", "HorizontalList", "VerticalGrid", "HorizontalGrid" };
 	}

--- a/src/Controls/src/Core.Design/KeyboardDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/KeyboardDesignTypeConverter.cs
@@ -5,14 +5,22 @@ namespace Microsoft.Maui.Controls.Design
 	using System.Linq;
 	using System.Reflection;
 
+	/// <summary>
+	/// Provides design-time type conversion for Keyboard values.
+	/// </summary>
 	public class KeyboardDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="KeyboardDesignTypeConverter"/> class.
+		/// </summary>
 		public KeyboardDesignTypeConverter()
 		{
 		}
 
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new[]
 			{

--- a/src/Controls/src/Core.Design/KnownValuesDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/KnownValuesDesignTypeConverter.cs
@@ -4,26 +4,38 @@
 	using System.ComponentModel;
 	using System.Linq;
 
+	/// <summary>
+	/// Base class for design-time type converters that provide a list of known values.
+	/// </summary>
 	public abstract class KnownValuesDesignTypeConverter : TypeConverter
 	{
+		/// <summary>
+		/// Gets the array of known values for this type converter.
+		/// </summary>
 		protected abstract string[] KnownValues { get; }
 
+		/// <summary>
+		/// Gets a value indicating whether values are exclusive to the known values list.
+		/// </summary>
 		protected virtual bool ExclusiveToKnownValues { get; } = false;
 
-		// This tells XAML this converter can be used to process strings
-		// Without this the values won't show up as hints
+		/// <inheritdoc/>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 			=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
+		/// <inheritdoc/>
 		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
 			=> new(KnownValues);
 
+		/// <inheritdoc/>
 		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
 			=> ExclusiveToKnownValues;
 
+		/// <inheritdoc/>
 		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
 			=> true;
 
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			if (!ExclusiveToKnownValues)

--- a/src/Controls/src/Core.Design/LayoutOptionsDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/LayoutOptionsDesignTypeConverter.cs
@@ -1,13 +1,21 @@
 ﻿namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for LayoutOptions values.
+	/// </summary>
 	public class LayoutOptionsDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LayoutOptionsDesignTypeConverter"/> class.
+		/// </summary>
 		public LayoutOptionsDesignTypeConverter()
 		{
 		}
 
+		/// <inheritdoc/>
 		protected override bool ExclusiveToKnownValues => true;
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new string[] { "Start", "Center", "End", "Fill", "StartAndExpand", "CenterAndExpand", "EndAndExpand", "FillAndExpand" };
 	}

--- a/src/Controls/src/Core.Design/LinearItemsLayoutDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/LinearItemsLayoutDesignTypeConverter.cs
@@ -1,11 +1,18 @@
 ﻿namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for LinearItemsLayout values.
+	/// </summary>
 	public class LinearItemsLayoutDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LinearItemsLayoutDesignTypeConverter"/> class.
+		/// </summary>
 		public LinearItemsLayoutDesignTypeConverter()
 		{
 		}
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new string[] { "Vertical", "Horizontal" };
 	}

--- a/src/Controls/src/Core.Design/PointTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/PointTypeDesignConverter.cs
@@ -3,8 +3,12 @@ using Controls.Core.Design;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for Point values.
+	/// </summary>
 	public class PointTypeDesignConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH Point.TryParse

--- a/src/Controls/src/Core.Design/RectTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/RectTypeDesignConverter.cs
@@ -3,8 +3,12 @@ using Controls.Core.Design;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for Rect values.
+	/// </summary>
 	public class RectTypeDesignConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH Rect.TryParse

--- a/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui;
 namespace Microsoft.Maui.Controls.Design
 {
 	/// <summary>
-	/// Provides design-time type conversion for SafeAreaRegions values.
+	/// Provides design-time type conversion for SafeAreaEdges values.
 	/// </summary>
 	public class SafeAreaEdgesTypeDesignConverter : StringConverter
 	{

--- a/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/SafeAreaEdgesTypeDesignConverter.cs
@@ -5,8 +5,12 @@ using Microsoft.Maui;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for SafeAreaRegions values.
+	/// </summary>
 	public class SafeAreaEdgesTypeDesignConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH SafeAreaEdgesTypeConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/ThicknessTypeDesignConverter.cs
+++ b/src/Controls/src/Core.Design/ThicknessTypeDesignConverter.cs
@@ -4,8 +4,12 @@ using Controls.Core.Design;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for Thickness values.
+	/// </summary>
 	public class ThicknessTypeDesignConverter : StringConverter
 	{
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH ThicknessTypeConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/VisibilityDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/VisibilityDesignTypeConverter.cs
@@ -4,15 +4,25 @@ using System.ComponentModel;
 
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for visibility values.
+	/// </summary>
 	public class VisibilityDesignTypeConverter : StringConverter
 	{
 		private static readonly string[] validValues = ["Collapse", "Hidden", bool.FalseString, bool.TrueString, "Visible"];
 		private static readonly HashSet<string> supportedValues = new HashSet<string>(validValues, StringComparer.OrdinalIgnoreCase);
 		private static readonly StandardValuesCollection standardValues = new StandardValuesCollection(validValues);
 
+		/// <inheritdoc/>
 		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context) => true;
+
+		/// <inheritdoc/>
 		override public bool GetStandardValuesSupported(ITypeDescriptorContext context) => true;
+
+		/// <inheritdoc/>
 		override public StandardValuesCollection GetStandardValues(ITypeDescriptorContext context) => standardValues;
+
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			// MUST MATCH VisibilityConverter.ConvertFrom

--- a/src/Controls/src/Core.Design/VisualDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/VisualDesignTypeConverter.cs
@@ -1,11 +1,18 @@
 namespace Microsoft.Maui.Controls.Design
 {
+	/// <summary>
+	/// Provides design-time type conversion for Visual values.
+	/// </summary>
 	public class VisualDesignTypeConverter : KnownValuesDesignTypeConverter
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="VisualDesignTypeConverter"/> class.
+		/// </summary>
 		public VisualDesignTypeConverter()
 		{
 		}
 
+		/// <inheritdoc/>
 		protected override string[] KnownValues
 			=> new string[] { "Default" /*, "Material" */ };
 	}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds XML documentation to all public members in **Microsoft.Maui.Controls.Core.Design** (design-time tooling) and enables CS1591 as a warning-as-error to prevent future documentation gaps.

This is the **final project** needed for 100% API documentation coverage across the entire MAUI repository.

## Changes

### Type Converters Documented (24 files)
- `BoundsDesignTypeConverter` - Bounds values
- `ButtonContentDesignTypeConverter` - Button content layout
- `ColorDesignTypeConverter` - Color values
- `ConstraintDesignTypeConverter` - Constraint values
- `CornerRadiusDesignTypeConverter` - Corner radius
- `EasingDesignTypeConverter` - Easing functions
- `FlexJustifyDesignTypeConverter` - FlexLayout justify
- `FlexDirectionDesignTypeConverter` - FlexLayout direction
- `FlexAlignContentDesignTypeConverter` - FlexLayout align content
- `FlexAlignItemsDesignTypeConverter` - FlexLayout align items
- `FlexAlignSelfDesignTypeConverter` - FlexLayout align self
- `FlexWrapDesignTypeConverter` - FlexLayout wrap
- `FlexBasisDesignTypeConverter` - FlexLayout basis
- `FlowDirectionDesignTypeConverter` - Flow direction
- `FontSizeDesignTypeConverter` - Font sizes
- `GridLengthDesignTypeConverter` - Grid lengths
- `GridLengthCollectionDesignTypeConverter` - Grid length collections
- `ImageSourceDesignTypeConverter` - Image sources
- `ItemsLayoutDesignTypeConverter` - Items layout
- `KeyboardDesignTypeConverter` - Keyboard types
- `KnownValuesDesignTypeConverter` - Base class
- `LayoutOptionsDesignTypeConverter` - Layout options
- `LinearItemsLayoutDesignTypeConverter` - Linear items layout
- `PointTypeDesignConverter` - Point values
- `RectTypeDesignConverter` - Rect values
- `SafeAreaEdgesTypeDesignConverter` - Safe area regions
- `ThicknessTypeDesignConverter` - Thickness values
- `VisibilityDesignTypeConverter` - Visibility
- `VisualDesignTypeConverter` - Visual values

### Build Configuration
- Added `GenerateDocumentationFile: true`
- Added `WarningsAsErrors: CS1591`
- Added `SafeAreaEdgesTypeDesignConverter.cs` to csproj

## Stats
- **24 files changed**
- **+174 lines** of documentation
