### PR TITLE
[Testing] Fix for enable uitests ios26

### DIFF
--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSVirtualKeyboardActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSVirtualKeyboardActions.cs
@@ -16,10 +16,10 @@ namespace UITest.Appium
 			{
 				if (_app.Driver.IsKeyboardShown())
 				{
-					var keyboard = _app.Driver.FindElement(By.XPath("//XCUIElementTypeKeyboard"));
+					var keyboard = _app.Driver.FindElements(By.XPath("//XCUIElementTypeKeyboard")).FirstOrDefault(k => k.Displayed && k.Enabled);
 					// Look for button with name='Return' within keyboard
-					var returnElements = keyboard.FindElement(By.XPath(".//XCUIElementTypeButton[@name='Return']"));
-					returnElements.Click();
+					var returnElements = keyboard?.FindElement(By.XPath(".//XCUIElementTypeButton[@name='Return']"));
+					returnElements?.Click();
 					return CommandResponse.SuccessEmptyResponse;
 				}
 			}

--- a/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSVirtualKeyboardActions.cs
+++ b/src/TestUtils/src/UITest.Appium/Actions/AppiumIOSVirtualKeyboardActions.cs
@@ -16,7 +16,11 @@ namespace UITest.Appium
 			{
 				if (_app.Driver.IsKeyboardShown())
 				{
-					_app.Driver.HideKeyboard("return");
+					var keyboard = _app.Driver.FindElement(By.XPath("//XCUIElementTypeKeyboard"));
+					// Look for button with name='Return' within keyboard
+					var returnElements = keyboard.FindElement(By.XPath(".//XCUIElementTypeButton[@name='Return']"));
+					returnElements.Click();
+					return CommandResponse.SuccessEmptyResponse;
 				}
 			}
 			catch (InvalidElementStateException)

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -1568,7 +1568,7 @@ namespace UITest.Appium
 				{ "isResetAfterEachTest", isResetAfterEachTest }
 			});
 		}
-		
+
 		/// <summary>
 		/// Send the currently running app for this session to the background.
 		/// </summary>
@@ -2201,11 +2201,32 @@ namespace UITest.Appium
 			return app switch
 			{
 				AppiumAndroidApp _ => AppiumQuery.ByXPath("//android.widget.ImageButton[@content-desc='Navigate up']"),
-				AppiumIOSApp _ => AppiumQuery.ByAccessibilityId("Back"),
+				AppiumIOSApp iOSApp => IsIOS26OrLower(iOSApp) ? AppiumQuery.ByAccessibilityId("BackButton") : AppiumQuery.ByAccessibilityId("Back"),
 				AppiumCatalystApp _ => AppiumQuery.ByAccessibilityId("Back"),
 				AppiumWindowsApp _ => AppiumQuery.ByAccessibilityId("NavigationViewBackButton"),
 				_ => throw new ArgumentException("Unsupported app type", nameof(app))
 			};
+		}
+
+		/// <summary>
+		/// Checks if the iOS app is running on iOS 26 or lower.
+		/// </summary>
+		/// <param name="iOSApp">The iOS app instance.</param>
+		/// <returns>True if running on iOS 26 or lower, false otherwise.</returns>
+		static bool IsIOS26OrLower(AppiumIOSApp iOSApp)
+		{
+			var platformVersion = (string?)iOSApp.Driver.Capabilities.GetCapability("platformVersion");
+			if (string.IsNullOrEmpty(platformVersion))
+				return false;
+
+			// Parse major version from strings like "26.0", "26", "17.2", etc.
+			var versionParts = platformVersion.Split('.');
+			if (versionParts.Length > 0 && int.TryParse(versionParts[0], out int majorVersion))
+			{
+				return majorVersion >= 26;
+			}
+
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This pull request resolves the test failure that occurred in this PR https://github.com/dotnet/maui/pull/33622 when enabling the UI test for iOS 26. This PR updates the handling of virtual keyboard dismissal and improves back arrow query logic for iOS in the Appium test utilities. The main changes enhance reliability when interacting with the iOS keyboard and add support for identifying the correct back button based on the iOS version.

**iOS Keyboard Interaction Improvements:**
* In iOS 26, HideKeyboard does not tap the return key, so the keyboard does not close, which causes the test to fail. The method for dismissing the keyboard now explicitly locates and clicks the "Return" button within the keyboard UI instead of using the generic HideKeyboard command, which increases reliability.

**iOS Back Arrow Query Logic:**
* In iOS 26, the back arrow ID changed to BackButton, so Appium does not find the back arrow. For iOS, the logic now checks the platform version: for iOS 26 or higher, it uses the accessibility ID "Back"; for lower versions, it uses "BackButton". This ensures compatibility with UI changes across iOS versions.