### PR TITLE
[Testing] Fix for flaky UITests in CI - 3

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12134.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12134.cs
@@ -48,7 +48,11 @@ namespace Maui.Controls.Sample.Issues
 
 		private async void WebViewOnNavigated(object sender, WebNavigatedEventArgs e)
 		{
+#if ANDROID
+			var result = Android.Webkit.CookieManager.Instance?.GetCookie("https://dotnet.microsoft.com");
+#else
 			var result = await ((WebView)sender).EvaluateJavaScriptAsync("document.cookie");
+#endif
 			_label.Text = result.Contains(_guid.ToString(), StringComparison.OrdinalIgnoreCase) ? "Success" : "Failed";
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12134.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12134.cs
@@ -49,7 +49,7 @@ namespace Maui.Controls.Sample.Issues
 		private async void WebViewOnNavigated(object sender, WebNavigatedEventArgs e)
 		{
 #if ANDROID
-			var result = Android.Webkit.CookieManager.Instance?.GetCookie("https://dotnet.microsoft.com");
+			var result = await Task.FromResult(Android.Webkit.CookieManager.Instance?.GetCookie("https://dotnet.microsoft.com"));
 #else
 			var result = await ((WebView)sender).EvaluateJavaScriptAsync("document.cookie");
 #endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12134.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12134.cs
@@ -48,11 +48,7 @@ namespace Maui.Controls.Sample.Issues
 
 		private async void WebViewOnNavigated(object sender, WebNavigatedEventArgs e)
 		{
-#if ANDROID
-			var result = await Task.FromResult(Android.Webkit.CookieManager.Instance?.GetCookie("https://dotnet.microsoft.com"));
-#else
 			var result = await ((WebView)sender).EvaluateJavaScriptAsync("document.cookie");
-#endif
 			_label.Text = result.Contains(_guid.ToString(), StringComparison.OrdinalIgnoreCase) ? "Success" : "Failed";
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18452.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18452.cs
@@ -15,7 +15,7 @@ namespace Maui.Controls.Sample.Issues
 			Label label = new Label();
 			label.AutomationId = "Label";
 
-			const string url = "https://learn.microsoft.com";
+			const string url = "https://learn.microsoft.com/en-us/dotnet/";
 
 			CookieContainer cookieContainer = new();
 			Uri uri = new(url, UriKind.RelativeOrAbsolute);
@@ -36,21 +36,8 @@ namespace Maui.Controls.Sample.Issues
 
 			grid.Children.Add(webView);
 
-			webView.Navigated += async (s, e) =>
+			webView.Navigated += (s, e) =>
 			{
-#if ANDROID
-				await Task.Delay(300);
-				var cookieString = Android.Webkit.CookieManager.Instance?.GetCookie("https://learn.microsoft.com");
-			
-				if (!string.IsNullOrEmpty(cookieString) && cookieString.Contains("DotNetMAUICookie", StringComparison.OrdinalIgnoreCase))
-				{
-					if (!grid.Contains(label))
-					{
-						grid.Children.Add(label);
-						label.Text = "Success";
-					}
-				}
-#else
 				var cookies = webView.Cookies.GetCookies(uri);
 				foreach (Cookie c in cookies)
 				{
@@ -64,7 +51,6 @@ namespace Maui.Controls.Sample.Issues
 						}
 					}
 				}
-#endif
 			};
 
 			Content = grid;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue18452.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue18452.cs
@@ -15,7 +15,7 @@ namespace Maui.Controls.Sample.Issues
 			Label label = new Label();
 			label.AutomationId = "Label";
 
-			const string url = "https://learn.microsoft.com/en-us/dotnet/";
+			const string url = "https://learn.microsoft.com";
 
 			CookieContainer cookieContainer = new();
 			Uri uri = new(url, UriKind.RelativeOrAbsolute);
@@ -36,8 +36,21 @@ namespace Maui.Controls.Sample.Issues
 
 			grid.Children.Add(webView);
 
-			webView.Navigated += (s, e) =>
+			webView.Navigated += async (s, e) =>
 			{
+#if ANDROID
+				await Task.Delay(300);
+				var cookieString = Android.Webkit.CookieManager.Instance?.GetCookie("https://learn.microsoft.com");
+			
+				if (!string.IsNullOrEmpty(cookieString) && cookieString.Contains("DotNetMAUICookie", StringComparison.OrdinalIgnoreCase))
+				{
+					if (!grid.Contains(label))
+					{
+						grid.Children.Add(label);
+						label.Text = "Success";
+					}
+				}
+#else
 				var cookies = webView.Cookies.GetCookies(uri);
 				foreach (Cookie c in cookies)
 				{
@@ -51,6 +64,7 @@ namespace Maui.Controls.Sample.Issues
 						}
 					}
 				}
+#endif
 			};
 
 			Content = grid;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12134.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12134.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if TEST_FAILS_ON_ANDROID // Issue Link - https://github.com/dotnet/maui/issues/33766
+using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -25,3 +26,4 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 		}
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
@@ -16,7 +16,9 @@ public class Issue18420 : _IssuesUITest
 	{
 		App.WaitForElement("RotateButton");
 		App.Tap("RotateButton");
+		Thread.Sleep(1000);
 		App.Tap("RotateButton");
+		Thread.Sleep(1000);
 		App.Tap("RotateButton");
 		App.WaitForElement("RotateButton");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18420.cs
@@ -16,9 +16,9 @@ public class Issue18420 : _IssuesUITest
 	{
 		App.WaitForElement("RotateButton");
 		App.Tap("RotateButton");
-		Thread.Sleep(1000);
+		App.WaitForElement("RotateButton");
 		App.Tap("RotateButton");
-		Thread.Sleep(1000);
+		App.WaitForElement("RotateButton");
 		App.Tap("RotateButton");
 		App.WaitForElement("RotateButton");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue28986_SafeAreaBorderOrientation.cs
@@ -129,6 +129,7 @@ public class Issue28986_SafeAreaBorderOrientation : _IssuesUITest
 
     [Test]
     [Category(UITestCategories.SafeAreaEdges)]
+    [Retry(2)]
     public void SafeAreaBorderMultipleOrientationChanges()
     {
         var borderContent = App.WaitForElement("BorderContent");


### PR DESCRIPTION
This pull request includes targeted improvements to test reliability and platform-specific code handling in the test suite. The main changes address platform differences for cookie retrieval and enhance test stability by adding retries and synchronization points.

Platform-specific handling:

* In `CookiesCorrectlyLoadWithMultipleWebViews` test, added a failing condition to restrict it on the Android platform.

Test stability improvements:

* In `SafeAreaBorderMultipleOrientationChanges` test, the [Retry(2)] attribute was added to reduce flakiness by retrying failed tests up to two times.
* In `ApplyingRotationWithZeroDurationShouldNotCrash` test, an additional App.WaitForElement("RotateButton") was inserted to ensure UI stability before proceeding with the next action.