### PR TITLE
Fix: missing style file in single file bundle

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -121,16 +121,16 @@
     </ItemGroup>
   </Target>
 
-  <!-- Include static web assets in the single-file bundle. Only include items under wwwroot\ to avoid
-       bundling unrelated MauiAsset items (e.g., Resources\Raw\**). -->
-  <Target Name="_IncludeStaticWebAssetsInSingleFileBundle"
+  <!-- Include computed static web assets in the single-file bundle. Other static web assets
+       are already included via the normal ResolvedFileToPublish flow. -->
+  <Target Name="_IncludeComputedStaticWebAssetsInSingleFileBundle"
           AfterTargets="_ComputeFilesToBundle"
           BeforeTargets="PrepareForBundle"
           Condition="'$(PublishSingleFile)' == 'true'">
 
     <ItemGroup>
-      <_FilesToBundle Include="@(MauiAsset)" Condition="$([System.String]::Copy('%(MauiAsset.TargetPath)').StartsWith('wwwroot'))">
-        <RelativePath>%(MauiAsset.TargetPath)</RelativePath>
+      <_FilesToBundle Include="@(_PublishStaticWebAssetsPreserveNewest)" Condition="'%(_PublishStaticWebAssetsPreserveNewest.SourceType)' == 'Computed'">
+        <RelativePath>%(_PublishStaticWebAssetsPreserveNewest.TargetPath)</RelativePath>
       </_FilesToBundle>
     </ItemGroup>
   </Target>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -121,4 +121,17 @@
     </ItemGroup>
   </Target>
 
+  <!-- Make sure we include all static web assets in the single-file bundle.  -->
+  <Target Name="_IncludeStaticWebAssetsInSingleFileBundle"
+          AfterTargets="_ComputeFilesToBundle"
+          BeforeTargets="PrepareForBundle"
+          Condition="'$(PublishSingleFile)' == 'true'">
+
+    <ItemGroup>
+      <_FilesToBundle Include="@(MauiAsset)" Condition="'%(MauiAsset.TargetPath)' != ''">
+        <RelativePath>%(MauiAsset.TargetPath)</RelativePath>
+      </_FilesToBundle>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -121,14 +121,15 @@
     </ItemGroup>
   </Target>
 
-  <!-- Make sure we include all static web assets in the single-file bundle.  -->
+  <!-- Include static web assets in the single-file bundle. Only include items under wwwroot\ to avoid
+       bundling unrelated MauiAsset items (e.g., Resources\Raw\**). -->
   <Target Name="_IncludeStaticWebAssetsInSingleFileBundle"
           AfterTargets="_ComputeFilesToBundle"
           BeforeTargets="PrepareForBundle"
           Condition="'$(PublishSingleFile)' == 'true'">
 
     <ItemGroup>
-      <_FilesToBundle Include="@(MauiAsset)" Condition="'%(MauiAsset.TargetPath)' != ''">
+      <_FilesToBundle Include="@(MauiAsset)" Condition="$([System.String]::Copy('%(MauiAsset.TargetPath)').StartsWith('wwwroot'))">
         <RelativePath>%(MauiAsset.TargetPath)</RelativePath>
       </_FilesToBundle>
     </ItemGroup>


### PR DESCRIPTION
### Description of Change

When publishing a MAUI Blazor Hybrid app as a single-file executable (`PublishSingleFile=true`), static web assets including scoped CSS (*.styles.css) were not being included in the single-file bundle. At runtime, the `EmbeddedFileProvider` looks for these assets in the extraction directory (`%LOCALAPPDATA%\Temp\.net\<AppName>\<hash>\wwwroot\`), but they were never extracted because they weren't bundled.

Root Cause: The Static Web Assets SDK was designed for ASP.NET Core web servers where static assets should be excluded from single-file bundles (to be served by static file middleware). This is the opposite of what MAUI Blazor Hybrid needs - assets must be included in the bundle for the embedded file provider to work.

The Fix: Added a new MSBuild target `_IncludeComputedStaticWebAssetsInSingleFileBundle` that runs after `_ComputeFilesToBundle` and adds `@(_PublishStaticWebAssetsPreserveNewest)` items with `SourceType=Computed` to `@(_FilesToBundle)`. This ensures computed assets (like scoped CSS bundles) are bundled and extracted at runtime.

### Discussion of decisions made:

- `@(_PublishStaticWebAssetsPreserveNewest)` was chosen because it preserves all static web asset metadata including SourceType
- We filter for `SourceType=Computed` to only include generated assets (like scoped CSS bundles) that didn't flow through the normal `@(ResolvedFileToPublish)` path. User-placed files in wwwroot `(SourceType=Discovered)` are already included via the normal publish flow.
- We must add to `@(_FilesToBundle)` directly, not `@(ResolvedFileToPublish)`, because `_ComputeFilesToBundle` has already run by the time our target executes
- The timing (`AfterTargets="_ComputeFilesToBundle" + BeforeTargets="PrepareForBundle"`) ensures items are added before `PrepareForBundle` copies them to `@(FilesToBundle`)

### Issues Fixed

Fixes #https://github.com/dotnet/maui/issues/33587

### Testing

I tested it by changing the corresponding `.targets` file in my nuget cache and run the reproduction on the repo provided with the issue. By checking the runtime location I confirmed that styles are present when the fix is applied.
