### PR TITLE
[XEXPR] [Experimental] XAML C# Expressions

### DIFF
--- a/docs/specs/XamlCSharpExpressions.md
+++ b/docs/specs/XamlCSharpExpressions.md
@@ -1,0 +1,313 @@
+# XAML C# Expressions
+
+## Overview
+
+XAML C# Expressions allow writing C# expressions directly in XAML attribute values. The source generator parses these expressions and generates appropriate bindings or event handlers.
+
+### Motivation
+
+Currently, XAML property values can be:
+1. **Literal strings** - `Text="Hello World"`
+2. **Markup extensions** - `Text="{Binding Name}"`, `Text="{StaticResource MyString}"`
+3. **Type converters** - `Color="Red"` (converted via `ColorTypeConverter`)
+
+However, there's no way to directly invoke C# code (methods, properties, expressions) from XAML without creating a binding or code-behind event handler. This leads to:
+- Boilerplate for simple computed values
+- Unnecessary runtime overhead for static computations
+- Reduced readability when simple expressions are wrapped in bindings
+
+### Example
+
+```xml
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:DataType="local:MainBindingContext">
+
+  <StackLayout>
+    <Label Text="{$'{FirstName} {LastName}'}" />
+    <Label Text="{Items.Count}" />
+    <Button Clicked="{(s, e) => Count++}" />
+  </StackLayout>
+
+</ContentPage>
+```
+
+## Expression Resolution
+
+When the source generator encounters a `{...}` value, it applies the following rules.
+
+### Simple Expressions
+
+For simple expressions (single identifier or property path), resolution follows this order:
+
+**1. Markup Extension Match**
+
+If the expression matches a markup extension (e.g., `{Binding ...}`, `{StaticResource ...}`, `{x:Static ...}`), use the markup extension.
+
+**Ambiguity (MAUIX2007):** If a bare identifier like `{Foo}` matches both a markup extension (`FooExtension`) and a resolvable C# property, the markup extension takes precedence and a warning is emitted.
+
+**2. Binding Expression**
+
+If the target property is bindable and the expression can be matched as a BindingContext property path, the generator creates a `Binding`:
+
+```xml
+<Label Text="{Username}" />
+<Label Text="{User.DisplayName}" />
+```
+
+This is equivalent to `{Binding Username}` but with compile-time type checking. The path is resolved against the `x:DataType`.
+
+**Conflict (MAUIX2008):** If the identifier exists on both the page and BindingContext, an error is emitted. See [Disambiguation](#disambiguation) for resolution options.
+
+**3. Local Access**
+
+If the expression cannot be converted to a binding, the generator checks for instance properties or methods on the page/view type:
+
+```xml
+<Label Text="{Title}" />
+<Label Text="{GetFormattedDate()}" />
+```
+
+The value is captured once at initialization time.
+
+**4. Static Invocation**
+
+If no instance member matches, the generator checks for static methods and properties. Global usings are respected:
+
+```xml
+<Label Text="{DateTime.Now}" />
+<Label Text="{Math.Max(A, B)}" />
+```
+
+### Lambda for Events
+
+If the target property is an event and the expression is a lambda, the generator creates a delegate:
+
+```xml
+<Button Clicked="{(s, e) => Count++}" />
+<Button Clicked="{(s, e) => SaveData()}" />
+```
+
+The generator creates a method with the appropriate signature and wires it to the event.
+
+**Note:** Async lambdas (`{async (s, e) => ...}`) are not supported. Use a regular method for async event handling.
+
+### Compound Expressions
+
+Expressions can combine multiple sources. Each part is resolved using the simple expression rules 2-4 above (binding, local, static) — markup extensions are not matched.
+
+**String Interpolation:**
+
+```xml
+<Label Text="{$'{FirstName} {LastName}'}" />
+<Label Text="{$'{Quantity}x {ProductName}'}" />
+<Label Text="{$'Total: {Price:C2}'}" />
+```
+
+Each interpolation hole is analyzed and bound appropriately.
+
+**Operators and Mixed Sources:**
+
+```xml
+<!-- Arithmetic: binding + method -->
+<Label Text="{Price * GetTaxRate()}" />
+
+<!-- Boolean: two bindings -->
+<Label IsVisible="{IsAdmin || IsPrivileged}" />
+
+<!-- Comparison: binding + local -->
+<Label IsVisible="{Count > MinimumCount}" />
+
+<!-- Mixed: string interpolation, binding, static -->
+<Label Text="{$'{Name} - {DateTime.Now:d}'}" />
+```
+
+The generator analyzes the expression and creates appropriate bindings or captured values for each part.
+
+## Expression Syntax
+
+Expressions are standard C#. Any valid C# expression can be used, subject to XML escaping rules.
+
+### Operator Aliases
+
+To avoid XML escaping, you can use word-based operator aliases:
+
+| Alias | C# Equivalent | Example |
+|-------|---------------|---------|
+| `AND` | `&&` | `{.IsLoaded AND .HasData}` |
+| `OR` | `\|\|` | `{.IsEmpty OR .HasError}` |
+| `LT` | `<` | `{.Count LT 100}` |
+| `GT` | `>` | `{.Count GT 0}` |
+| `LTE` | `<=` | `{.Count LTE 100}` |
+| `GTE` | `>=` | `{.Count GTE 0}` |
+
+```xml
+<!-- Readable without escaping -->
+<Label IsVisible="{.IsLoaded AND .HasData}" />
+<Label IsVisible="{.Count GT 0 AND .Count LT 100}" />
+```
+
+Aliases are case-insensitive (`AND`, `and`, `And` all work) and require surrounding spaces.
+
+### XML Escaping
+
+If you prefer standard C# syntax, escape these characters in attributes:
+
+| C# | XAML Attribute |
+|----|----------------|
+| `&&` | `&amp;&amp;` |
+| `<` | `&lt;` |
+| `>` | `&gt;` |
+| `\|\|` | `\|\|` (no escaping needed) |
+
+```xml
+<Label IsVisible="{Count &gt; 0 &amp;&amp; Count &lt; 100}" />
+```
+
+### String Quoting
+
+Since XAML attributes use double quotes, C# strings use single quotes:
+
+```xml
+<Label Text="{Name ?? 'Unknown'}" />
+<Label Text="{IsVip ? 'Gold' : 'Standard'}" />
+```
+
+Single quotes are converted to double quotes in the generated C#. Escape single quotes with backslash: `'it\'s'` becomes `"it's"`.
+
+**Char literals:** For methods expecting `char`, the generator inspects the method signature and preserves char literals:
+
+```xml
+<Label Text="{GetChar('x')}" />  <!-- GetChar(char) → keeps 'x' as char -->
+<Label Text="{GetText('x')}" />  <!-- GetText(string) → converts to "x" -->
+```
+
+### CDATA Alternative
+
+For complex expressions, use element syntax with CDATA to avoid escaping entirely:
+
+```xml
+<Label>
+    <Label.IsVisible><![CDATA[{Count > 0 && Count < 100}]]></Label.IsVisible>
+</Label>
+
+<Label>
+    <Label.Text><![CDATA[{Value ?? "Default"}]]></Label.Text>
+</Label>
+```
+
+**Use CDATA when:**
+- Expression has multiple `&&` or comparison operators
+- You need double-quoted strings
+- You need explicit char literals without semantic analysis
+- The escaped version is hard to read
+
+## Disambiguation
+
+When a `{...}` value could be interpreted as either a markup extension or an expression, disambiguation rules apply.
+
+### Explicit Expression: `{= ...}`
+
+Prefix with `=` to force expression parsing:
+
+```xml
+<Label Text="{= Binding}" />  <!-- Uses the 'Binding' property, not BindingExtension -->
+```
+
+### Page Member: `{this.Foo}`
+
+Use `this.` to explicitly reference a member on the page/view type:
+
+```xml
+<Label Text="{this.Title}" />
+```
+
+### BindingContext Member: `{.Foo}`
+
+Use `.` prefix to explicitly reference a member on the BindingContext:
+
+```xml
+<Label Text="{.Title}" />
+```
+
+This is useful when both page and BindingContext have a property with the same name.
+
+### Member Conflict (MAUIX2008)
+
+When `{Foo}` exists on both the page and BindingContext:
+- **Error**: MAUIX2008 is emitted
+- **Resolution**: Use `{this.Foo}` for page or `{.Foo}` for BindingContext
+
+### Explicit Markup Extension: `{prefix:Name}`
+
+Use an xmlns prefix to explicitly invoke a markup extension:
+
+```xml
+<Label Text="{local:MyMarkup}" />
+```
+
+### Ambiguity Warning (MAUIX2007)
+
+When `{Foo}` matches both a markup extension (`FooExtension`) and a property (`Foo`):
+- **Behavior**: Defaults to markup extension (backward compatible)
+- **Warning**: MAUIX2007 is emitted
+- **Resolution**: Use `{= Foo}` for expression or `{local:Foo}` for explicit markup
+
+This is extremely unlikely in practice—it requires a property name that exactly matches a markup extension name without its `Extension` suffix.
+
+## Two-Way Binding
+
+Simple property paths support two-way binding automatically:
+
+| Expression | Two-Way? |
+|------------|----------|
+| `{Name}` | ✅ |
+| `{User.Name}` | ✅ |
+| `{Price * Qty}` | ❌ |
+| `{Name.ToUpper()}` | ❌ |
+
+Complex expressions (operators, method calls) cannot generate a setter and are one-way only.
+
+## Diagnostics
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| MAUIX2007 | Warning | Bare identifier matches both markup extension and property — defaults to markup |
+| MAUIX2008 | Error | Member exists on both page and BindingContext — use `this.` or `.` to disambiguate |
+| MAUIX2009 | Error | Member not found on page or BindingContext |
+| MAUIX2010 | Info | Complex expression on two-way property — binding will be one-way |
+| MAUIX2013 | Error | Async lambda event handlers are not supported |
+
+## Limitations
+
+- **SourceGen only** — not available in XamlC or Runtime inflation
+- **Single expressions** — no multi-statement blocks or control flow
+- **Event lambdas require parameters** — `{(s, e) => ...}` not `{() => ...}`
+- **No async lambdas** — use regular methods for async event handling
+- **Static types need qualification** — use full path or ensure global usings are in place
+
+## Future Considerations
+
+- **Parameterless event handlers** — `{() => ...}` and `{args => ...}`
+- **RelativeSource bindings** — `{RelativeSource Self.Width}`
+- **Attached properties** — `{grid1.(Grid.Row)}`
+- **Explicit two-way** — `{= Name, Mode=TwoWay}` or `{Name, set: value => Name = value}`
+
+## Syntax Cheat Sheet
+
+| Want to... | Write |
+|------------|-------|
+| Bind to property | `{Name}` |
+| Bind to nested property | `{User.Email}` |
+| Call local method | `{GetDisplayText()}` |
+| Call static method | `{Math.Max(A, B)}` |
+| Compute value | `{A * B}` |
+| Negate bool | `{!Flag}` |
+| Combine bools | `{A &amp;&amp; B}` or `{A \|\| B}` |
+| Ternary | `{IsVip ? 'Gold' : 'Standard'}` |
+| Null-coalesce | `{Value ?? 'Default'}` |
+| Format string | `{$'{Value:F2}'}` |
+| Handle event | `{(s, e) => Action()}` |
+| Force expression | `{= Foo}` |
+| Force page member | `{this.Foo}` |
+| Force BindingContext | `{.Foo}` |

--- a/eng/automation/cspell/cSpell.json
+++ b/eng/automation/cspell/cSpell.json
@@ -21,7 +21,9 @@
         "screencap",
         "mlaunch",
         "devicectl",
-        "xcdevice"
+        "xcdevice",
+        "MAUIX",
+        "Parameterless"
     ],
     "ignoreWords": [],
     "patterns": [

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
@@ -30,5 +30,6 @@
     <CompilerVisibleProperty Include="MauiXamlLineInfo" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="LineInfo" />
     <CompilerVisibleProperty Include="Configuration" />
+    <CompilerVisibleProperty Include="EnablePreviewFeatures" />
 	</ItemGroup>
 </Project>

--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -22,3 +22,10 @@ MAUIG2042 | XamlInflation | Error | BindingIndexerEmpty
 MAUIG2043 | XamlInflation | Error | BindingIndexerTypeUnsupported
 MAUIG2045 | XamlInflation | Warning | BindingPropertyNotFound
 MAUIG2064 | XamlInflation | Error | NamescopeDuplicate
+MAUIX2007 | XamlParsing | Warning | AmbiguousExpressionOrMarkup
+MAUIX2008 | XamlParsing | Error | AmbiguousMemberExpression
+MAUIX2009 | XamlParsing | Error | MemberNotFound
+MAUIX2010 | XamlParsing | Info | ExpressionNotSettable
+MAUIX2011 | XamlParsing | Warning | AmbiguousMemberWithStaticType
+MAUIX2012 | XamlParsing | Error | CSharpExpressionsRequirePreviewFeatures
+MAUIX2013 | XamlParsing | Error | AsyncLambdaNotSupported

--- a/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
+++ b/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
@@ -535,15 +535,23 @@ static class CSharpExpressionHelpers
 					{
 						if (contentStr[j] == '"')
 						{
-							// Check if preceded by backslash (already escaped)
-							if (j > 0 && contentStr[j - 1] == '\\')
+							// Count preceding backslashes to determine if quote is escaped
+							// An odd number means the quote is escaped, even means it's not
+							// e.g., \" = escaped quote, \\" = escaped backslash + unescaped quote
+							int backslashCount = 0;
+							for (int k = j - 1; k >= 0 && contentStr[k] == '\\'; k--)
 							{
-								// Already escaped, just append
+								backslashCount++;
+							}
+							
+							if (backslashCount % 2 == 1)
+							{
+								// Odd backslashes: quote is already escaped
 								sb.Append('"');
 							}
 							else
 							{
-								// Raw quote, escape it
+								// Even backslashes (including 0): quote is not escaped
 								sb.Append("\\\"");
 							}
 						}

--- a/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
+++ b/src/Controls/src/SourceGen/CSharpExpressionHelpers.cs
@@ -1,0 +1,843 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Maui.Controls.SourceGen;
+
+/// <summary>
+/// Represents a C# expression to be emitted directly in generated code.
+/// Used as the Value of a ValueNode when the value is a C# expression rather than a literal string.
+/// </summary>
+/// <param name="Code">The C# expression code to emit.</param>
+/// <param name="TransformQuotes">Whether single quotes should be transformed to double quotes. 
+/// True for attribute values (XML requires escaping), false for element content/CDATA (natural C# allowed).</param>
+internal sealed record Expression(string Code, bool TransformQuotes = true);
+
+/// <summary>
+/// Helper methods for detecting and transforming C# expressions embedded in XAML.
+/// </summary>
+static class CSharpExpressionHelpers
+{
+	// Patterns that indicate unambiguous C# syntax
+	static readonly Regex UnambiguousCSharpPattern = new Regex(
+		@"^{(?:" +
+			@"\s*\(" +                      // Method call or lambda: {(...
+			@"|\s*!" +                       // Negation: {!...
+			@"|\s*new\s+" +                  // Instantiation: {new ...
+			@"|\s*\$['""]" +                 // String interpolation: {$'...' or {$"...
+			@"|\s*typeof\s*\(" +             // typeof: {typeof(...
+			@"|\s*nameof\s*\(" +             // nameof: {nameof(...
+			@"|\s*default\s*\(" +            // default: {default(...
+			@"|\s*sizeof\s*\(" +             // sizeof: {sizeof(...
+			@"|\s*\.[A-Za-z_]" +             // Dot prefix for binding: {.Name
+			@"|\s*this\." +                  // this. prefix for local: {this.Foo
+			@"|\s*BindingContext\." +        // BindingContext. prefix for binding: {BindingContext.Foo
+		@")",
+		RegexOptions.Compiled);
+
+	// Operators that indicate C# expressions (checked after first identifier)
+	// Note: Single-char operators like +, -, *, / require surrounding spaces to avoid
+	// false positives with markup extension syntax like {Binding Path=+...}.
+	// Multi-char operators (==, !=, etc.) are unambiguous and don't need spaces.
+	// This is a heuristic - the actual expression parsing handles all valid C# syntax.
+	static readonly string[] CSharpOperators = new[]
+	{
+		"=>",   // Lambda
+		"??",   // Null-coalescing
+		"?.",   // Null-conditional
+		"&&",   // Logical AND
+		"||",   // Logical OR
+		"==",   // Equality
+		"!=",   // Inequality
+		"<=",   // Less than or equal
+		">=",   // Greater than or equal
+		"<<",   // Left shift
+		">>",   // Right shift
+		"++",   // Increment
+		"--",   // Decrement
+		"+",    // Addition
+		"-",    // Subtraction
+		"*",    // Multiplication
+		"/",    // Division
+		"%",    // Modulo
+		"<",    // Less than
+		">",    // Greater than
+		"?",    // Ternary (start)
+		":",    // Ternary (else) / null-forgiving - checked after markup extension detection
+		// Word aliases require spaces as word boundaries
+		" AND ", // Alias for && (case-insensitive)
+		" OR ",  // Alias for || (case-insensitive)
+		" LT ",  // Alias for < (case-insensitive)
+		" GT ",  // Alias for > (case-insensitive)
+		" LTE ", // Alias for <= (case-insensitive)
+		" GTE ", // Alias for >= (case-insensitive)
+	};
+
+	// Pattern to detect method call: identifier followed by ( with optional content
+	static readonly Regex MethodCallPattern = new Regex(
+		@"{\s*\w+\s*\(",
+		RegexOptions.Compiled);
+
+	// Pattern to detect member access: {Identifier.Identifier} (not a namespace-qualified markup extension)
+	// This distinguishes C# property access like {User.Name} from markup extensions like {local:MyExtension}
+	static readonly Regex MemberAccessPattern = new Regex(
+		@"^\{\s*\w+\.\w+",  // Must have letter.letter (not letter:letter which is namespace)
+		RegexOptions.Compiled);
+
+	/// <summary>
+	/// Determines if the value is an explicit C# expression using {= ...} syntax.
+	/// </summary>
+	public static bool IsExplicitExpression(string? value)
+	{
+		if (string.IsNullOrEmpty(value))
+			return false;
+		
+		var trimmed = value!.Trim();
+		return trimmed.Length > 3 
+			&& trimmed[0] == '{' 
+			&& trimmed[1] == '=' 
+			&& trimmed[trimmed.Length - 1] == '}';
+	}
+
+	/// <summary>
+	/// Determines if the value is an implicit C# expression detected by unambiguous syntax.
+	/// </summary>
+	public static bool IsImplicitExpression(string? value)
+		=> IsImplicitExpression(value, null);
+
+	/// <summary>
+	/// Determines if the value is an implicit C# expression detected by unambiguous syntax.
+	/// </summary>
+	/// <param name="value">The markup string to check.</param>
+	/// <param name="canResolveMarkupExtension">Optional callback to check if a name resolves to a markup extension type.</param>
+	public static bool IsImplicitExpression(string? value, Func<string, bool>? canResolveMarkupExtension)
+	{
+		if (string.IsNullOrEmpty(value))
+			return false;
+
+		var trimmed = value!.Trim();
+		if (trimmed.Length < 3 || trimmed[0] != '{' || trimmed[trimmed.Length - 1] != '}')
+			return false;
+
+		// Check for escape sequence
+		if (trimmed.StartsWith("{}", StringComparison.Ordinal))
+			return false;
+
+		// If it looks like a markup extension call (starts with known or resolvable extension name), 
+		// don't treat it as an implicit expression even if it contains operators
+		if (StartsWithMarkupExtension(trimmed, canResolveMarkupExtension))
+			return false;
+
+		// Check for patterns at the start that are unambiguously C#
+		if (UnambiguousCSharpPattern.IsMatch(trimmed))
+			return true;
+
+		// Check for method call pattern: {identifier(
+		if (MethodCallPattern.IsMatch(trimmed))
+			return true;
+
+		// Check for member access pattern: {Identifier.Identifier} (C# property access, not namespace:type)
+		if (MemberAccessPattern.IsMatch(trimmed))
+			return true;
+
+		// Check for C# operators anywhere in the expression
+		foreach (var op in CSharpOperators)
+		{
+			// Use case-insensitive for word-based aliases (AND, OR, LT, GT, LTE, GTE)
+			var comparison = (op == " AND " || op == " OR " || op == " LT " || op == " GT " || op == " LTE " || op == " GTE ") 
+				? StringComparison.OrdinalIgnoreCase 
+				: StringComparison.Ordinal;
+			if (trimmed.IndexOf(op, comparison) >= 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Checks if the markup string starts with a known or resolvable markup extension name.
+	/// </summary>
+	static bool StartsWithMarkupExtension(string trimmed, Func<string, bool>? canResolveMarkupExtension = null)
+	{
+		// Extract the first identifier after the opening brace
+		// Pattern: {Identifier or {Identifier ... or {prefix:Identifier
+		int start = 1; // Skip '{'
+		while (start < trimmed.Length && char.IsWhiteSpace(trimmed[start]))
+			start++;
+
+		int end = start;
+		while (end < trimmed.Length && (char.IsLetterOrDigit(trimmed[end]) || trimmed[end] == ':'))
+			end++;
+
+		if (end <= start)
+			return false;
+
+		var identifier = trimmed.Substring(start, end - start);
+		
+		// Handle prefixed identifiers like x:Type or local:MyExtension
+		var colonIndex = identifier.IndexOf(':');
+		if (colonIndex >= 0)
+		{
+			// Any prefix:Name pattern is a markup extension (custom or known)
+			// C# doesn't use this syntax, so it's safe to treat as markup
+			return true;
+		}
+
+		// Check known extensions first (fast path)
+		if (IsKnownMarkupExtension(identifier))
+			return true;
+
+		// Check if the type can be resolved as a markup extension via semantic lookup
+		if (canResolveMarkupExtension != null && canResolveMarkupExtension(identifier))
+			return true;
+
+		return false;
+	}
+
+	/// <summary>
+	/// Determines if the value is a C# expression (explicit or implicit).
+	/// </summary>
+	public static bool IsExpression(string? value)
+		=> IsExplicitExpression(value) || IsImplicitExpression(value);
+
+	/// <summary>
+	/// Result of bare identifier classification.
+	/// </summary>
+	internal readonly struct BareIdentifierResult
+	{
+		/// <summary>True if should be treated as C# expression, false for markup extension.</summary>
+		public bool IsExpression { get; init; }
+		
+		/// <summary>True if both markup extension and property exist (ambiguous).</summary>
+		public bool IsAmbiguous { get; init; }
+		
+		/// <summary>The bare identifier name (for diagnostic reporting).</summary>
+		public string? Name { get; init; }
+	}
+
+	/// <summary>
+	/// Attempts to classify the markup string as a C# expression.
+	/// Consolidates all expression detection logic including bare identifier resolution.
+	/// </summary>
+	/// <param name="markupString">The raw markup string including braces.</param>
+	/// <param name="canResolveMarkupExtension">
+	/// Callback to check if a bare identifier can be resolved as a markup extension type.
+	/// Only called for non-prefixed bare identifiers that aren't known markup extensions.
+	/// </param>
+	/// <returns>True if the markup should be treated as a C# expression, false for markup extension.</returns>
+	public static bool IsExpression(string? markupString, Func<string, bool> canResolveMarkupExtension)
+	{
+		return ClassifyExpression(markupString, canResolveMarkupExtension, null).IsExpression;
+	}
+
+	/// <summary>
+	/// Attempts to classify the markup string as a C# expression, with additional property checking for ambiguity detection.
+	/// </summary>
+	/// <param name="markupString">The raw markup string including braces.</param>
+	/// <param name="canResolveMarkupExtension">
+	/// Callback to check if a bare identifier can be resolved as a markup extension type.
+	/// </param>
+	/// <param name="canResolveProperty">
+	/// Optional callback to check if a bare identifier can be resolved as a property.
+	/// Used for detecting ambiguity between markup extensions and properties.
+	/// </param>
+	/// <returns>Classification result including ambiguity information.</returns>
+	public static BareIdentifierResult ClassifyExpression(string? markupString, Func<string, bool> canResolveMarkupExtension, Func<string, bool>? canResolveProperty)
+	{
+		if (string.IsNullOrEmpty(markupString))
+			return new BareIdentifierResult { IsExpression = false };
+
+		// Explicit expressions {= ...} are always expressions
+		if (IsExplicitExpression(markupString))
+			return new BareIdentifierResult { IsExpression = true };
+
+		// Unambiguous C# syntax (operators, method calls, etc.)
+		// Pass the resolver to handle custom markup extensions properly
+		if (IsImplicitExpression(markupString, canResolveMarkupExtension))
+			return new BareIdentifierResult { IsExpression = true };
+
+		// Bare identifiers need special handling
+		if (IsBareIdentifier(markupString!))
+		{
+			var (prefix, name) = ParseBareIdentifier(markupString!);
+
+			// Prefixed identifiers (e.g., {local:Foo}) are always markup extensions
+			if (prefix != null)
+				return new BareIdentifierResult { IsExpression = false };
+
+			var isMarkup = canResolveMarkupExtension(name);
+			var isProperty = canResolveProperty?.Invoke(name) ?? false;
+
+			if (isMarkup)
+			{
+				// Markup extension wins (backward compatible), but check for ambiguity
+				return new BareIdentifierResult 
+				{ 
+					IsExpression = false, 
+					IsAmbiguous = isProperty, 
+					Name = name 
+				};
+			}
+
+			// Not a markup extension - treat as C# expression (property access)
+			return new BareIdentifierResult { IsExpression = true, Name = name };
+		}
+
+		// Not an expression
+		return new BareIdentifierResult { IsExpression = false };
+	}
+
+	// Pattern to match a bare identifier: {Identifier} or {prefix:Identifier}
+	// This is ambiguous - could be a property or a markup extension
+	static readonly Regex BareIdentifierPattern = new Regex(
+		@"^\{\s*(?:(\w+):)?(\w+)\s*\}$",
+		RegexOptions.Compiled);
+
+	/// <summary>
+	/// Determines if the value is a bare identifier that could be ambiguous.
+	/// Returns true for {Foo} or {prefix:Foo} with no additional content.
+	/// </summary>
+	public static bool IsBareIdentifier(string? value)
+	{
+		if (string.IsNullOrEmpty(value))
+			return false;
+		return BareIdentifierPattern.IsMatch(value!.Trim());
+	}
+
+	/// <summary>
+	/// Parses a bare identifier into its prefix and local name components.
+	/// </summary>
+	public static (string? prefix, string name) ParseBareIdentifier(string value)
+	{
+		var match = BareIdentifierPattern.Match(value.Trim());
+		if (!match.Success)
+			return (null, value);
+		
+		var prefix = match.Groups[1].Success ? match.Groups[1].Value : null;
+		var name = match.Groups[2].Value;
+		return (prefix, name);
+	}
+
+	/// <summary>
+	/// List of well-known MAUI markup extensions.
+	/// Used by StartsWithMarkupExtension to avoid treating {Binding Path=X} as C# expression.
+	/// </summary>
+	static readonly HashSet<string> KnownMarkupExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+	{
+		"Binding",
+		"StaticResource",
+		"DynamicResource",
+		"Static",
+		"Reference",
+		"x:Reference",
+		"Type",
+		"x:Type",
+		"Null",
+		"x:Null",
+		"Array",
+		"x:Array",
+		"TemplateBinding",
+		"RelativeSource",
+		"OnPlatform",
+		"OnIdiom",
+		"AppThemeBinding",
+		"DataTemplate",
+		"FontImage",
+	};
+
+	static bool IsKnownMarkupExtension(string name)
+	{
+		return KnownMarkupExtensions.Contains(name) 
+			|| KnownMarkupExtensions.Contains(name + "Extension");
+	}
+
+	/// <summary>
+	/// Extracts the C# code from an expression value and optionally transforms quotes.
+	/// </summary>
+	/// <param name="value">The raw XAML value including braces.</param>
+	/// <param name="transformQuotes">Whether to transform single quotes to double quotes. 
+	/// True for attribute values, false for element content/CDATA.</param>
+	/// <returns>The C# code ready to be emitted.</returns>
+	public static string GetExpressionCode(string value, bool transformQuotes = true)
+	{
+		var trimmed = value.Trim();
+		
+		// Remove outer braces
+		string code;
+		if (IsExplicitExpression(value))
+		{
+			// {= expression} -> expression
+			code = trimmed.Substring(2, trimmed.Length - 3).Trim();
+		}
+		else
+		{
+			// {expression} -> expression
+			code = trimmed.Substring(1, trimmed.Length - 2).Trim();
+		}
+
+		// Transform operator aliases (AND -> &&, OR -> ||) to avoid XML escaping
+		code = TransformOperatorAliases(code);
+
+		// Transform single-quoted strings to double-quoted strings (only for attribute values)
+		return transformQuotes ? TransformQuotes(code) : code;
+	}
+
+	/// <summary>
+	/// Transforms word-based operator aliases to C# operators.
+	/// Allows writing readable expressions without XML escaping.
+	/// </summary>
+	static string TransformOperatorAliases(string code)
+	{
+		// Replace word-based aliases with C# operators (case-insensitive, with spaces)
+		var result = code;
+		
+		// Logical operators
+		result = ReplaceWordOperator(result, " AND ", " && ");
+		result = ReplaceWordOperator(result, " OR ", " || ");
+		
+		// Comparison operators (must do multi-char first to avoid partial replacements)
+		result = ReplaceWordOperator(result, " LTE ", " <= ");
+		result = ReplaceWordOperator(result, " GTE ", " >= ");
+		result = ReplaceWordOperator(result, " LT ", " < ");
+		result = ReplaceWordOperator(result, " GT ", " > ");
+		
+		return result;
+	}
+
+	/// <summary>
+	/// Replaces a word operator case-insensitively, but only outside of string literals.
+	/// </summary>
+	static string ReplaceWordOperator(string code, string word, string replacement)
+	{
+		var result = new StringBuilder();
+		int i = 0;
+		
+		while (i < code.Length)
+		{
+			// Skip string literals (single or double quoted)
+			if (code[i] == '\'' || code[i] == '"')
+			{
+				var quote = code[i];
+				result.Append(code[i]);
+				i++;
+				while (i < code.Length && code[i] != quote)
+				{
+					if (code[i] == '\\' && i + 1 < code.Length)
+					{
+						result.Append(code[i]);
+						result.Append(code[i + 1]);
+						i += 2;
+					}
+					else
+					{
+						result.Append(code[i]);
+						i++;
+					}
+				}
+				if (i < code.Length)
+				{
+					result.Append(code[i]);
+					i++;
+				}
+				continue;
+			}
+			
+			// Check for word match (case-insensitive)
+			if (i + word.Length <= code.Length)
+			{
+				var segment = code.Substring(i, word.Length);
+				if (segment.Equals(word, StringComparison.OrdinalIgnoreCase))
+				{
+					result.Append(replacement);
+					i += word.Length;
+					continue;
+				}
+			}
+			
+			result.Append(code[i]);
+			i++;
+		}
+		
+		return result.ToString();
+	}
+
+	/// <summary>
+	/// Transforms ALL single-quoted strings to double-quoted strings in C# code.
+	/// This is the safe default - use TransformQuotesWithSemantics when you have type context
+	/// to preserve char literals where appropriate.
+	/// </summary>
+	static string TransformQuotes(string code)
+	{
+		var result = new StringBuilder(code.Length);
+		int i = 0;
+
+		while (i < code.Length)
+		{
+			if (code[i] == '\'')
+			{
+				// Find the end of the single-quoted string
+				int start = i;
+				i++; // Skip opening quote
+
+				var content = new StringBuilder();
+				while (i < code.Length)
+				{
+					if (code[i] == '\\' && i + 1 < code.Length)
+					{
+						// Escape sequence
+						char escaped = code[i + 1];
+						if (escaped == '\'')
+						{
+							// \' in single-quoted -> just ' in double-quoted
+							content.Append('\'');
+						}
+						else if (escaped == '"')
+						{
+							// \" stays as \" in double-quoted (already escaped)
+							content.Append("\\\"");
+						}
+						else
+						{
+							// Other escapes (\n, \t, \\, etc.) - keep as-is
+							content.Append(code[i]);
+							content.Append(code[i + 1]);
+						}
+						i += 2;
+					}
+					else if (code[i] == '\'')
+					{
+						// End of string
+						break;
+					}
+					else
+					{
+						content.Append(code[i]);
+						i++;
+					}
+				}
+
+				if (i < code.Length && code[i] == '\'')
+				{
+					i++; // Skip closing quote
+					
+					var contentStr = content.ToString();
+
+					// Always convert to string literal (double quotes)
+					// Use TransformQuotesWithSemantics when semantic context is available
+					// to preserve char literals where the target type expects char
+					var sb = new StringBuilder();
+					for (int j = 0; j < contentStr.Length; j++)
+					{
+						if (contentStr[j] == '"')
+						{
+							// Check if preceded by backslash (already escaped)
+							if (j > 0 && contentStr[j - 1] == '\\')
+							{
+								// Already escaped, just append
+								sb.Append('"');
+							}
+							else
+							{
+								// Raw quote, escape it
+								sb.Append("\\\"");
+							}
+						}
+						else
+						{
+							sb.Append(contentStr[j]);
+						}
+					}
+					result.Append('"');
+					result.Append(sb);
+					result.Append('"');
+				}
+				else
+				{
+					// Unterminated string - copy as-is
+					result.Append(code.Substring(start, i - start));
+				}
+			}
+			else
+			{
+				result.Append(code[i]);
+				i++;
+			}
+		}
+
+		return result.ToString();
+	}
+
+	/// <summary>
+	/// Transforms single-quoted literals to double-quoted strings based on semantic context.
+	/// Uses Roslyn to analyze the expression and determine if each char literal should be a string.
+	/// </summary>
+	/// <param name="code">The C# expression code with single quotes</param>
+	/// <param name="compilation">The compilation for type lookups</param>
+	/// <param name="contextTypes">Types to search for method signatures (dataType, thisType, etc.)</param>
+	/// <returns>Code with char literals converted to strings where the target expects string</returns>
+	public static string TransformQuotesWithSemantics(string code, Compilation compilation, params ITypeSymbol?[] contextTypes)
+	{
+		// Parse the expression to find char literals and their contexts
+		var tree = CSharpSyntaxTree.ParseText(code, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+
+		// Find all char literals and determine which should become strings
+		var charLiterals = root.DescendantNodes()
+			.OfType<LiteralExpressionSyntax>()
+			.Where(l => l.IsKind(SyntaxKind.CharacterLiteralExpression))
+			.ToList();
+
+		if (charLiterals.Count == 0)
+			return code; // No char literals to transform
+
+		// Collect positions that need transformation (char -> string)
+		var transformPositions = new List<(int start, int length, string replacement)>();
+
+		foreach (var literal in charLiterals)
+		{
+			var expectedType = DetermineExpectedType(literal, compilation, contextTypes);
+			
+			// If expected type is string (or unknown and length > 1), transform to string
+			bool shouldBeString = expectedType?.SpecialType == SpecialType.System_String;
+			
+			if (shouldBeString)
+			{
+				// Get the char content and create a string literal
+				var charText = literal.Token.ValueText;
+				var stringLiteral = $"\"{EscapeForString(charText)}\"";
+				transformPositions.Add((literal.SpanStart, literal.Span.Length, stringLiteral));
+			}
+		}
+
+		// Apply transformations in reverse order to preserve positions
+		var result = code;
+		foreach (var (start, length, replacement) in transformPositions.OrderByDescending(t => t.start))
+		{
+			result = result.Substring(0, start) + replacement + result.Substring(start + length);
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Determines the expected type for a literal based on its syntactic context.
+	/// </summary>
+	static ITypeSymbol? DetermineExpectedType(LiteralExpressionSyntax literal, Compilation compilation, ITypeSymbol?[] contextTypes)
+	{
+		// Walk up to find the context
+		var parent = literal.Parent;
+		
+		while (parent != null)
+		{
+			switch (parent)
+			{
+				// Method argument: MethodName('x') - check method signature
+				case ArgumentSyntax arg when arg.Parent is ArgumentListSyntax argList && argList.Parent is InvocationExpressionSyntax invocation:
+					var argIndex = argList.Arguments.IndexOf(arg);
+					var methodType = FindMethodParameterType(invocation, argIndex, compilation, contextTypes);
+					if (methodType != null)
+						return methodType;
+					break;
+
+				// Ternary expression: cond ? 'a' : 'b' - check the other branch or parent context
+				case ConditionalExpressionSyntax conditional:
+					// If one branch is already a string, the other should be too
+					var otherBranch = literal.Parent == conditional.WhenTrue ? conditional.WhenFalse : conditional.WhenTrue;
+					if (otherBranch is LiteralExpressionSyntax otherLiteral && otherLiteral.IsKind(SyntaxKind.StringLiteralExpression))
+						return compilation.GetSpecialType(SpecialType.System_String);
+					// Continue walking up
+					break;
+
+				// Null coalescing: value ?? 'default' - check left side type
+				case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.CoalesceExpression):
+					// The right side should match the left side type
+					// For simplicity, assume string if the literal is multi-char or we can't determine
+					break;
+
+				// Assignment or return - we'd need more context
+				case AssignmentExpressionSyntax:
+				case ReturnStatementSyntax:
+					break;
+			}
+
+			parent = parent.Parent;
+		}
+
+		return null; // Unknown context
+	}
+
+	/// <summary>
+	/// Finds the parameter type for a method invocation at a given argument index.
+	/// </summary>
+	static ITypeSymbol? FindMethodParameterType(InvocationExpressionSyntax invocation, int argIndex, Compilation compilation, ITypeSymbol?[] contextTypes)
+	{
+		// Get the method name
+		string? methodName = invocation.Expression switch
+		{
+			IdentifierNameSyntax id => id.Identifier.Text,
+			MemberAccessExpressionSyntax ma => ma.Name.Identifier.Text,
+			_ => null
+		};
+
+		if (methodName == null)
+			return null;
+
+		// Search for the method in context types
+		foreach (var type in contextTypes.Where(t => t != null))
+		{
+			var method = FindMethod(type!, methodName, invocation.ArgumentList.Arguments.Count);
+			if (method != null && argIndex < method.Parameters.Length)
+			{
+				return method.Parameters[argIndex].Type;
+			}
+		}
+
+		// Check well-known types (string methods like Format, etc.)
+		var stringType = compilation.GetSpecialType(SpecialType.System_String);
+		var stringMethod = FindMethod(stringType, methodName, invocation.ArgumentList.Arguments.Count);
+		if (stringMethod != null && argIndex < stringMethod.Parameters.Length)
+		{
+			return stringMethod.Parameters[argIndex].Type;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Finds a method by name and parameter count on a type.
+	/// </summary>
+	static IMethodSymbol? FindMethod(ITypeSymbol type, string methodName, int paramCount)
+	{
+		var currentType = type;
+		while (currentType != null)
+		{
+			foreach (var member in currentType.GetMembers(methodName))
+			{
+				if (member is IMethodSymbol method && method.Parameters.Length == paramCount)
+					return method;
+			}
+			currentType = currentType.BaseType;
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Escapes a string for use in a C# string literal.
+	/// </summary>
+	static string EscapeForString(string value)
+	{
+		var sb = new StringBuilder();
+		foreach (var c in value)
+		{
+			switch (c)
+			{
+				case '"': sb.Append("\\\""); break;
+				case '\\': sb.Append("\\\\"); break;
+				case '\n': sb.Append("\\n"); break;
+				case '\r': sb.Append("\\r"); break;
+				case '\t': sb.Append("\\t"); break;
+				default: sb.Append(c); break;
+			}
+		}
+		return sb.ToString();
+	}
+
+	// Pattern to match lambda expressions: () => ... or (params) => ...
+	// Note: async lambdas are NOT supported
+	static readonly Regex LambdaPattern = new Regex(
+		@"^\s*\([^)]*\)\s*=>",
+		RegexOptions.Compiled);
+
+	// Pattern to detect async lambda (to reject it)
+	static readonly Regex AsyncLambdaPattern = new Regex(
+		@"^\s*async\s+\([^)]*\)\s*=>",
+		RegexOptions.Compiled);
+
+	/// <summary>
+	/// Checks if the expression code is an async lambda expression.
+	/// </summary>
+	public static bool IsAsyncLambdaExpression(string code)
+	{
+		return AsyncLambdaPattern.IsMatch(code);
+	}
+
+	/// <summary>
+	/// Checks if the expression code is a lambda expression.
+	/// </summary>
+	public static bool IsLambdaExpression(string code)
+	{
+		return LambdaPattern.IsMatch(code);
+	}
+
+	/// <summary>
+	/// Checks if a markup string contains a lambda event handler.
+	/// E.g., {() => DoSomething()} or {(s, e) => Log(s)}
+	/// </summary>
+	public static bool IsLambdaEventHandler(string? value)
+	{
+		if (string.IsNullOrEmpty(value))
+			return false;
+
+		var trimmed = value!.Trim();
+		if (trimmed.Length < 5 || trimmed[0] != '{' || trimmed[trimmed.Length - 1] != '}')
+			return false;
+
+		// Extract inner content
+		string inner;
+		if (trimmed.Length > 3 && trimmed[1] == '=')
+		{
+			// Explicit: {= () => ...}
+			inner = trimmed.Substring(2, trimmed.Length - 3).Trim();
+		}
+		else
+		{
+			// Implicit: {() => ...}
+			inner = trimmed.Substring(1, trimmed.Length - 2).Trim();
+		}
+
+		return IsLambdaExpression(inner);
+	}
+
+	/// <summary>
+	/// Checks if a markup string contains an async lambda event handler.
+	/// Async lambdas are not supported.
+	/// </summary>
+	public static bool IsAsyncLambdaEventHandler(string? value)
+	{
+		if (string.IsNullOrEmpty(value))
+			return false;
+
+		var trimmed = value!.Trim();
+		if (trimmed.Length < 5 || trimmed[0] != '{' || trimmed[trimmed.Length - 1] != '}')
+			return false;
+
+		// Extract inner content
+		string inner;
+		if (trimmed.Length > 3 && trimmed[1] == '=')
+		{
+			// Explicit: {= async () => ...}
+			inner = trimmed.Substring(2, trimmed.Length - 3).Trim();
+		}
+		else
+		{
+			// Implicit: {async () => ...}
+			inner = trimmed.Substring(1, trimmed.Length - 2).Trim();
+		}
+
+		return IsAsyncLambdaExpression(inner);
+	}
+
+	/// <summary>
+	/// Extracts the lambda code from a markup value and transforms it for C# emission.
+	/// </summary>
+	public static string GetLambdaCode(string value)
+	{
+		// Use same extraction as expressions
+		return GetExpressionCode(value);
+	}
+}

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -260,6 +260,63 @@ namespace Microsoft.Maui.Controls.SourceGen
 			defaultSeverity: DiagnosticSeverity.Warning,
 			isEnabledByDefault: true);
 
+		// C# Expressions
+		public static DiagnosticDescriptor AmbiguousExpressionOrMarkup = new DiagnosticDescriptor(
+			id: "MAUIX2007",
+			title: "Ambiguous expression or markup extension",
+			messageFormat: "'{0}' is ambiguous - both a property '{0}' and markup extension '{0}Extension' exist. Use '{{= {0}}}' for the property or '{{local:{0}}}' for the markup extension.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor AmbiguousMemberExpression = new DiagnosticDescriptor(
+			id: "MAUIX2008",
+			title: "Ambiguous member reference in expression",
+			messageFormat: "'{0}' exists on both '{1}' and '{2}'. Use 'this.{0}' for the local member or '.{0}' for the binding.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor MemberNotFound = new DiagnosticDescriptor(
+			id: "MAUIX2009",
+			title: "Member not found in expression",
+			messageFormat: "'{0}' not found on '{1}' or '{2}'.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor AmbiguousMemberWithStaticType = new DiagnosticDescriptor(
+			id: "MAUIX2011",
+			title: "Member name conflicts with static type",
+			messageFormat: "'{0}' exists on '{1}' but is also a well-known static type. Use '.{0}' for the binding or fully qualify the static type (e.g., 'System.{0}').",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor ExpressionNotSettable = new DiagnosticDescriptor(
+			id: "MAUIX2010",
+			title: "Expression cannot be used for two-way binding",
+			messageFormat: "Expression '{0}' cannot generate a setter. Two-way binding to '{1}' will be one-way.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor CSharpExpressionsRequirePreviewFeatures = new DiagnosticDescriptor(
+			id: "MAUIX2012",
+			title: "C# Expressions require EnablePreviewFeatures",
+			messageFormat: "XAML C# Expressions are an experimental feature. Add '<EnablePreviewFeatures>true</EnablePreviewFeatures>' to your project file to enable them.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		public static DiagnosticDescriptor AsyncLambdaNotSupported = new DiagnosticDescriptor(
+			id: "MAUIX2013",
+			title: "Async lambda event handlers are not supported",
+			messageFormat: "Async lambda event handlers are not supported. Use a regular method for async event handling.",
+			category: "XamlParsing",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
 		// public static BuildExceptionCode TypeResolution = new BuildExceptionCode("XC", 0000, nameof(TypeResolution), "");
 		// public static BuildExceptionCode PropertyResolution = new BuildExceptionCode("XC", 0001, nameof(PropertyResolution), "");
 		// public static BuildExceptionCode MissingEventHandler = new BuildExceptionCode("XC", 0002, nameof(MissingEventHandler), "");

--- a/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
+++ b/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
@@ -1,0 +1,674 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Maui.Controls.SourceGen;
+
+/// <summary>
+/// Represents a handler for INPC subscription in a TypedBinding.
+/// </summary>
+internal readonly struct BindingHandler
+{
+	/// <summary>The expression to get the parent object (e.g., "vm => vm" or "vm => vm.User").</summary>
+	public string ParentExpression { get; }
+	
+	/// <summary>The property name to subscribe to (e.g., "Name").</summary>
+	public string PropertyName { get; }
+
+	public BindingHandler(string parentExpression, string propertyName)
+	{
+		ParentExpression = parentExpression;
+		PropertyName = propertyName;
+	}
+}
+
+/// <summary>
+/// Represents a local value that needs to be captured before creating a binding.
+/// </summary>
+internal readonly struct LocalCapture
+{
+	/// <summary>The original expression in the XAML (e.g., "this.TaxRate" or "this.GetMultiplier()").</summary>
+	public string OriginalExpression { get; }
+	
+	/// <summary>The capture variable name (e.g., "__capture_TaxRate").</summary>
+	public string CaptureVariable { get; }
+	
+	/// <summary>The member name being captured (e.g., "TaxRate" or "GetMultiplier").</summary>
+	public string MemberName { get; }
+
+	/// <summary>The full invocation expression (e.g., "TaxRate" or "GetMultiplier()").</summary>
+	public string InvocationExpression { get; }
+
+	public LocalCapture(string originalExpression, string captureVariable, string memberName, string? invocationExpression = null)
+	{
+		OriginalExpression = originalExpression;
+		CaptureVariable = captureVariable;
+		MemberName = memberName;
+		InvocationExpression = invocationExpression ?? memberName;
+	}
+}
+
+/// <summary>
+/// Result of expression analysis including handlers and local captures.
+/// </summary>
+internal readonly struct ExpressionAnalysisResult
+{
+	/// <summary>Handlers for INPC subscription.</summary>
+	public List<BindingHandler> Handlers { get; }
+	
+	/// <summary>Local values that need to be captured.</summary>
+	public List<LocalCapture> Captures { get; }
+	
+	/// <summary>The transformed expression with this.X replaced by __capture_X.</summary>
+	public string TransformedExpression { get; }
+	
+	/// <summary>Whether this expression has any binding properties (needs TypedBinding).</summary>
+	public bool HasBindingProperties => Handlers.Count > 0;
+	
+	/// <summary>Whether this expression has local captures.</summary>
+	public bool HasLocalCaptures => Captures.Count > 0;
+
+	/// <summary>
+	/// Whether this expression is a simple property chain that can have a setter generated.
+	/// True for expressions like "Name" or "User.DisplayName" (no operators, method calls, or captures).
+	/// </summary>
+	public bool IsSettable { get; }
+
+	public ExpressionAnalysisResult(List<BindingHandler> handlers, List<LocalCapture> captures, string transformedExpression, bool isSettable = false)
+	{
+		Handlers = handlers;
+		Captures = captures;
+		TransformedExpression = transformedExpression;
+		IsSettable = isSettable;
+	}
+}
+
+/// <summary>
+/// Analyzes C# expressions to extract property access paths for INPC handlers.
+/// </summary>
+internal static class ExpressionAnalyzer
+{
+	// Pattern to match this.PropertyName
+	private static readonly Regex ThisPrefixPattern = new Regex(
+		@"\bthis\.(\w+)",
+		RegexOptions.Compiled);
+
+	/// <summary>
+	/// Checks if the match is followed by a method call (opening parenthesis).
+	/// </summary>
+	private static bool IsMethodCall(Match match, string text)
+	{
+		var afterMatch = match.Index + match.Length;
+		while (afterMatch < text.Length && char.IsWhiteSpace(text[afterMatch]))
+			afterMatch++;
+		return afterMatch < text.Length && text[afterMatch] == '(';
+	}
+
+	/// <summary>
+	/// Extracts the full method invocation including arguments (e.g., "this.GetMultiplier()" or "this.Calculate(x, y)").
+	/// </summary>
+	private static (string fullExpression, string invocationPart) ExtractMethodInvocation(Match match, string text)
+	{
+		var memberName = match.Groups[1].Value;
+		var afterMatch = match.Index + match.Length;
+		
+		// Skip whitespace
+		while (afterMatch < text.Length && char.IsWhiteSpace(text[afterMatch]))
+			afterMatch++;
+		
+		if (afterMatch >= text.Length || text[afterMatch] != '(')
+		{
+			// Not a method call, shouldn't happen but handle gracefully
+			return (match.Value, memberName);
+		}
+		
+		// Find the matching closing parenthesis
+		var parenStart = afterMatch;
+		var depth = 1;
+		var pos = parenStart + 1;
+		
+		while (pos < text.Length && depth > 0)
+		{
+			var c = text[pos];
+			if (c == '(') depth++;
+			else if (c == ')') depth--;
+			else if (c == '\'' || c == '"')
+			{
+				// Skip string literals
+				var quote = c;
+				pos++;
+				while (pos < text.Length && text[pos] != quote)
+				{
+					if (text[pos] == '\\') pos++; // Skip escaped char
+					pos++;
+				}
+			}
+			pos++;
+		}
+		
+		// Cap pos to text.Length to handle unterminated strings gracefully
+		if (pos > text.Length) pos = text.Length;
+		
+		// Extract the full expression and invocation part
+		var fullExpression = text.Substring(match.Index, pos - match.Index);
+		var invocationPart = memberName + text.Substring(parenStart, pos - parenStart);
+		
+		return (fullExpression, invocationPart);
+	}
+
+	/// <summary>
+	/// Finds bare method calls (without 'this.' prefix) that exist on rootType but not on dataType,
+	/// and returns captures for them.
+	/// </summary>
+	private static List<LocalCapture> CaptureLocalMethods(string expression, ITypeSymbol rootType, ITypeSymbol? dataType, HashSet<string> alreadyCaptured)
+	{
+		var captures = new List<LocalCapture>();
+		var capturedInvocations = new HashSet<string>(StringComparer.Ordinal);
+		var methodIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+		
+		// Parse as an expression and walk the syntax tree
+		var tree = CSharpSyntaxTree.ParseText(expression, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+		
+		foreach (var node in root.DescendantNodes())
+		{
+			// Look for standalone method invocations (not member access like obj.Method())
+			if (node is InvocationExpressionSyntax invocation && 
+				invocation.Expression is IdentifierNameSyntax identifier)
+			{
+				var methodName = identifier.Identifier.Text;
+				
+				// Skip if this method name was captured via this.Method() syntax
+				if (alreadyCaptured.Contains(methodName))
+					continue;
+				
+				// Skip if this is a method on the DataType (will be transformed to __source.X)
+				if (dataType != null && HasMethod(dataType, methodName))
+					continue;
+				
+				// Check if method exists on rootType (local page/view method)
+				if (HasMethod(rootType, methodName))
+				{
+					// Extract the full invocation text including arguments
+					var invocationText = invocation.ToString();
+					
+					// Skip if this exact invocation was already captured
+					if (!capturedInvocations.Add(invocationText))
+						continue;
+					
+					// Use per-method indexed capture variable
+					// e.g., GetA() -> __capture_GetA, GetB() -> __capture_GetB, GetA() again -> __capture_GetA_1
+					if (!methodIndexes.TryGetValue(methodName, out var index))
+					{
+						index = 0;
+						methodIndexes[methodName] = 1;
+					}
+					else
+					{
+						methodIndexes[methodName] = index + 1;
+					}
+					
+					var captureVar = index == 0 
+						? $"__capture_{methodName}" 
+						: $"__capture_{methodName}_{index}";
+					
+					// The invocation expression is the full call (e.g., "GetMultiplier()")
+					captures.Add(new LocalCapture(invocationText, captureVar, methodName, invocationText));
+				}
+			}
+		}
+		
+		// Mark method names as captured for downstream processing
+		foreach (var capture in captures)
+		{
+			alreadyCaptured.Add(capture.MemberName);
+		}
+		
+		return captures;
+	}
+
+	/// <summary>
+	/// Checks if a type has a method with the given name.
+	/// </summary>
+	private static bool HasMethod(ITypeSymbol type, string methodName)
+	{
+		var currentType = type;
+		while (currentType != null)
+		{
+			foreach (var member in currentType.GetMembers(methodName))
+			{
+				if (member is IMethodSymbol)
+					return true;
+			}
+			currentType = currentType.BaseType;
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Analyzes an expression for mixed local+binding scenarios.
+	/// </summary>
+	/// <param name="expression">The C# expression (e.g., "Price * this.TaxRate")</param>
+	/// <param name="sourceParameterName">The lambda parameter name (e.g., "__source")</param>
+	/// <param name="dataType">Optional DataType symbol to filter handlers (only include members on this type)</param>
+	/// <param name="rootType">Optional root type (page/view) to identify local members that need capturing</param>
+	/// <returns>Analysis result with handlers, captures, and transformed expression</returns>
+	public static ExpressionAnalysisResult Analyze(string expression, string sourceParameterName = "__source", ITypeSymbol? dataType = null, ITypeSymbol? rootType = null)
+	{
+		var captures = new List<LocalCapture>();
+		var transformedExpression = expression;
+
+		if (string.IsNullOrWhiteSpace(expression))
+			return new ExpressionAnalysisResult(new List<BindingHandler>(), captures, expression);
+
+		// Handle special prefixes first
+		// Strip leading dot prefix (e.g., ".Name" -> "Name")
+		if (transformedExpression.TrimStart().StartsWith(".", StringComparison.Ordinal) 
+			&& !transformedExpression.TrimStart().StartsWith("..", StringComparison.Ordinal))
+		{
+			var trimmed = transformedExpression.TrimStart();
+			transformedExpression = trimmed.Substring(1); // Remove the leading dot
+		}
+		
+		// Strip BindingContext. prefix (e.g., "BindingContext.Name" -> "Name")
+		if (transformedExpression.TrimStart().StartsWith("BindingContext.", StringComparison.Ordinal))
+		{
+			var trimmed = transformedExpression.TrimStart();
+			transformedExpression = trimmed.Substring("BindingContext.".Length);
+		}
+
+		// Find all this.X patterns and replace with __capture_X
+		var matches = ThisPrefixPattern.Matches(transformedExpression);
+		var seenCaptures = new HashSet<string>();
+		
+		foreach (Match match in matches)
+		{
+			var memberName = match.Groups[1].Value;
+			if (!seenCaptures.Add(memberName))
+				continue;
+				
+			var captureVar = $"__capture_{memberName}";
+			
+			// Check if this is a method call - if so, extract the full invocation including arguments
+			if (IsMethodCall(match, transformedExpression))
+			{
+				var invocation = ExtractMethodInvocation(match, transformedExpression);
+				captures.Add(new LocalCapture(invocation.fullExpression, captureVar, memberName, invocation.invocationPart));
+			}
+			else
+			{
+				captures.Add(new LocalCapture(match.Value, captureVar, memberName));
+			}
+		}
+
+		// Replace this.X(...) or this.X with __capture_X in the expression
+		foreach (var capture in captures)
+		{
+			transformedExpression = transformedExpression.Replace(capture.OriginalExpression, capture.CaptureVariable);
+		}
+
+		// Capture bare local method calls (without 'this.' prefix) that exist on rootType but not on dataType
+		if (rootType != null)
+		{
+			var localMethodCaptures = CaptureLocalMethods(transformedExpression, rootType, dataType, seenCaptures);
+			foreach (var capture in localMethodCaptures)
+			{
+				captures.Add(capture);
+				transformedExpression = transformedExpression.Replace(capture.OriginalExpression, capture.CaptureVariable);
+			}
+		}
+
+		// Extract handlers from the transformed expression (which no longer has this.X)
+		var handlers = ExtractHandlers(transformedExpression, sourceParameterName);
+
+		// Filter handlers to only include:
+		// 1. Top-level handlers (parent == __source) where property exists on DataType
+		// 2. Nested handlers (parent != __source) - always keep since they're on intermediate objects
+		// This excludes things like ToString() and __capture_X at the root level
+		// Also exclude handlers whose parent is a capture variable (__capture_*) - those are local, not bindings
+		if (dataType != null)
+		{
+			handlers = handlers.Where(h => 
+				h.PropertyName == "." || 
+				(h.ParentExpression != sourceParameterName &&  // Keep nested handlers...
+				 !h.ParentExpression.Contains("__capture_")) ||  // ...unless parent is a capture variable
+				HasProperty(dataType, h.PropertyName)  // Top-level must exist on DataType
+			).ToList();
+		}
+
+		// Transform the expression to prefix root identifiers that are on DataType with __source.
+		// This handles complex expressions like "(Price * __capture_TaxRate).ToString()" -> "(__source.Price * __capture_TaxRate).ToString()"
+		if (dataType != null)
+		{
+			transformedExpression = TransformRootIdentifiers(transformedExpression, sourceParameterName, dataType, seenCaptures);
+		}
+
+		// Determine if this is a simple settable property chain (no captures, just member access)
+		var isSettable = captures.Count == 0 && IsSimplePropertyChain(expression);
+
+		return new ExpressionAnalysisResult(handlers, captures, transformedExpression, isSettable);
+	}
+
+	/// <summary>
+	/// Checks if the expression is a simple property chain (e.g., "Name" or "User.DisplayName").
+	/// Returns false for expressions with operators, method calls, or other complex constructs.
+	/// </summary>
+	/// <param name="expression">The expression to check</param>
+	private static bool IsSimplePropertyChain(string expression)
+	{
+		var trimmed = expression.Trim();
+		
+		// Strip leading prefixes that we normalize
+		if (trimmed.StartsWith(".", StringComparison.Ordinal) && !trimmed.StartsWith("..", StringComparison.Ordinal))
+			trimmed = trimmed.Substring(1);
+		if (trimmed.StartsWith("BindingContext.", StringComparison.Ordinal))
+			trimmed = trimmed.Substring("BindingContext.".Length);
+
+		// Parse and check the syntax
+		var tree = CSharpSyntaxTree.ParseText(trimmed, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+		
+		// Get the expression (skip compilation unit wrapper)
+		var expr = root.DescendantNodes().OfType<ExpressionSyntax>().FirstOrDefault();
+		if (expr == null)
+			return false;
+
+		return IsSettableExpression(expr);
+	}
+
+	/// <summary>
+	/// Recursively checks if an expression is a simple settable property chain.
+	/// </summary>
+	/// <param name="node">The syntax node to check</param>
+	private static bool IsSettableExpression(SyntaxNode node)
+	{
+		return node switch
+		{
+			// Simple identifier: "Name"
+			IdentifierNameSyntax => true,
+			// Member access: "User.Name" - check both parts
+			MemberAccessExpressionSyntax memberAccess => 
+				IsSettableExpression(memberAccess.Expression) && memberAccess.Name is IdentifierNameSyntax,
+			// Null-conditional access: "User?.Name" - settable in C# 14+ (guaranteed on .NET 10+)
+			ConditionalAccessExpressionSyntax conditionalAccess =>
+				IsSettableExpression(conditionalAccess.Expression) && IsSettableWhenAccessed(conditionalAccess.WhenNotNull),
+			// Anything else (operators, method calls, etc.) is not settable
+			_ => false
+		};
+	}
+
+	/// <summary>
+	/// Checks if the WhenNotNull part of a conditional access is settable.
+	/// </summary>
+	private static bool IsSettableWhenAccessed(ExpressionSyntax whenNotNull)
+	{
+		return whenNotNull switch
+		{
+			// .Name
+			MemberBindingExpressionSyntax memberBinding => memberBinding.Name is IdentifierNameSyntax,
+			// .Nested.Name
+			MemberAccessExpressionSyntax memberAccess => 
+				IsSettableWhenAccessed(memberAccess.Expression) && memberAccess.Name is IdentifierNameSyntax,
+			_ => false
+		};
+	}
+
+	/// <summary>
+	/// Transforms root identifiers that are on the DataType to use the source parameter prefix.
+	/// </summary>
+	private static string TransformRootIdentifiers(string expression, string sourceParameterName, ITypeSymbol dataType, HashSet<string> capturedIdentifiers)
+	{
+		// Parse as an expression and walk the syntax tree
+		var tree = CSharpSyntaxTree.ParseText(expression, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+		
+		// Find all root identifiers that are directly on the DataType
+		var identifiersToTransform = new List<(int start, int length, string replacement)>();
+		
+		foreach (var node in root.DescendantNodes())
+		{
+			if (node is IdentifierNameSyntax identifier)
+			{
+				var identifierName = identifier.Identifier.Text;
+				
+				// Skip if it's a captured variable
+				if (identifierName.StartsWith("__capture_", StringComparison.Ordinal))
+					continue;
+				
+				// Skip if it's part of this.X (already handled as capture)
+				if (capturedIdentifiers.Contains(identifierName))
+					continue;
+				
+				// Skip if it's the right side of a member access (e.g., User.Name - skip "Name")
+				if (identifier.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == identifier)
+					continue;
+				
+				// Check if this is a root-level invocation (not already prefixed)
+				// e.g., GetDisplayName() should become __source.GetDisplayName()
+				if (identifier.Parent is InvocationExpressionSyntax invocation && invocation.Expression == identifier)
+				{
+					// This is a standalone method call - check if method exists on DataType
+					if (HasMember(dataType, identifierName))
+					{
+						identifiersToTransform.Add((identifier.SpanStart, identifier.Span.Length, $"{sourceParameterName}.{identifierName}"));
+					}
+					continue;
+				}
+				
+				// Check if this identifier exists on the DataType
+				if (HasMember(dataType, identifierName))
+				{
+					identifiersToTransform.Add((identifier.SpanStart, identifier.Span.Length, $"{sourceParameterName}.{identifierName}"));
+				}
+			}
+		}
+		
+		// Apply transformations in reverse order to preserve positions
+		var result = expression;
+		foreach (var (start, length, replacement) in identifiersToTransform.OrderByDescending(t => t.start))
+		{
+			result = result.Substring(0, start) + replacement + result.Substring(start + length);
+		}
+		
+		return result;
+	}
+
+	/// <summary>
+	/// Checks if a type has a member (property, field, or method) with the given name.
+	/// </summary>
+	private static bool HasMember(ITypeSymbol type, string memberName)
+	{
+		var currentType = type;
+		while (currentType != null)
+		{
+			foreach (var member in currentType.GetMembers(memberName))
+			{
+				if (member is IPropertySymbol || member is IFieldSymbol || member is IMethodSymbol)
+					return true;
+			}
+			currentType = currentType.BaseType;
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Checks if a type has a property or field (not method) with the given name.
+	/// Used for INPC handlers which only track properties/fields.
+	/// </summary>
+	private static bool HasProperty(ITypeSymbol type, string memberName)
+	{
+		var currentType = type;
+		while (currentType != null)
+		{
+			foreach (var member in currentType.GetMembers(memberName))
+			{
+				if (member is IPropertySymbol || member is IFieldSymbol)
+					return true;
+			}
+			currentType = currentType.BaseType;
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Extracts all property access handlers from an expression.
+	/// </summary>
+	/// <param name="expression">The C# expression (e.g., "User.Address.City")</param>
+	/// <param name="sourceParameterName">The lambda parameter name (e.g., "__source")</param>
+	/// <returns>List of handlers for INPC subscription</returns>
+	public static List<BindingHandler> ExtractHandlers(string expression, string sourceParameterName = "__source")
+	{
+		var handlers = new List<BindingHandler>();
+
+		if (string.IsNullOrWhiteSpace(expression))
+			return handlers;
+
+		// Parse as an expression
+		var tree = CSharpSyntaxTree.ParseText(expression, new CSharpParseOptions(kind: SourceCodeKind.Script));
+		var root = tree.GetRoot();
+
+		// Find all member access expressions
+		var memberAccesses = new List<MemberAccessExpressionSyntax>();
+		var identifiers = new List<IdentifierNameSyntax>();
+		CollectExpressions(root, memberAccesses, identifiers);
+
+		// Build handlers from member access chains
+		// For "User.Address.City", we want:
+		// - (vm => vm, "User")
+		// - (vm => vm.User, "Address")
+		// - (vm => vm.User.Address, "City")
+
+		foreach (var memberAccess in memberAccesses)
+		{
+			var chain = BuildPropertyChain(memberAccess);
+			if (chain.Count > 0)
+			{
+				AddHandlersForChain(handlers, chain, sourceParameterName);
+			}
+		}
+
+		// Handle bare identifiers (e.g., just "Name") that are not part of a member access
+		foreach (var identifier in identifiers)
+		{
+			// Skip if this identifier is part of a member access expression
+			if (identifier.Parent is MemberAccessExpressionSyntax)
+				continue;
+			
+			// Skip if this identifier is the method name in an invocation
+			// e.g., GetDisplayName in "GetDisplayName()" - parent chain: IdentifierName -> InvocationExpression
+			if (identifier.Parent is InvocationExpressionSyntax)
+				continue;
+			
+			// This is a standalone identifier - add handler for it
+			handlers.Add(new BindingHandler(sourceParameterName, identifier.Identifier.Text));
+		}
+
+		// If no handlers were found but expression is non-empty, add a "." handler
+		// This handles cases like method calls: {.GetDisplayName()} should subscribe to BindingContext
+		if (handlers.Count == 0 && !string.IsNullOrWhiteSpace(expression))
+		{
+			handlers.Add(new BindingHandler(sourceParameterName, "."));
+		}
+
+		// Deduplicate handlers (same parent + property)
+		return DeduplicateHandlers(handlers);
+	}
+
+	/// <summary>
+	/// Recursively collects all MemberAccessExpressionSyntax and IdentifierNameSyntax nodes.
+	/// </summary>
+	private static void CollectExpressions(SyntaxNode node, List<MemberAccessExpressionSyntax> memberAccesses, List<IdentifierNameSyntax> identifiers)
+	{
+		if (node is MemberAccessExpressionSyntax memberAccess)
+		{
+			memberAccesses.Add(memberAccess);
+		}
+		else if (node is IdentifierNameSyntax identifier)
+		{
+			identifiers.Add(identifier);
+		}
+
+		foreach (var child in node.ChildNodes())
+		{
+			CollectExpressions(child, memberAccesses, identifiers);
+		}
+	}
+
+	/// <summary>
+	/// Builds a property chain from a member access expression.
+	/// Returns the chain from root to leaf (e.g., ["User", "Address", "City"]).
+	/// </summary>
+	private static List<string> BuildPropertyChain(MemberAccessExpressionSyntax memberAccess)
+	{
+		var chain = new List<string>();
+		ExpressionSyntax current = memberAccess;
+
+		while (current is MemberAccessExpressionSyntax ma)
+		{
+			// Only include if accessing a simple name (property/field)
+			if (ma.Name is SimpleNameSyntax simpleName)
+			{
+				chain.Insert(0, simpleName.Identifier.Text);
+			}
+			current = ma.Expression;
+		}
+
+		// The root should be an identifier (the first property after the source)
+		if (current is IdentifierNameSyntax rootIdentifier)
+		{
+			chain.Insert(0, rootIdentifier.Identifier.Text);
+		}
+
+		return chain;
+	}
+
+	/// <summary>
+	/// Adds handlers for each level of a property chain.
+	/// </summary>
+	private static void AddHandlersForChain(List<BindingHandler> handlers, List<string> chain, string sourceParameterName)
+	{
+		if (chain.Count == 0)
+			return;
+
+		// Build handlers for each level
+		// Chain: ["User", "Address", "City"]
+		// Handlers:
+		//   - parent: __source, property: "User"
+		//   - parent: __source.User, property: "Address"
+		//   - parent: __source.User.Address, property: "City"
+
+		var parentPath = sourceParameterName;
+		for (int i = 0; i < chain.Count; i++)
+		{
+			var propertyName = chain[i];
+			handlers.Add(new BindingHandler(parentPath, propertyName));
+			
+			// Build up the parent path for the next level
+			parentPath = parentPath + "." + propertyName;
+		}
+	}
+
+	/// <summary>
+	/// Removes duplicate handlers (same parent expression and property name).
+	/// </summary>
+	private static List<BindingHandler> DeduplicateHandlers(List<BindingHandler> handlers)
+	{
+		var seen = new HashSet<string>();
+		var result = new List<BindingHandler>();
+
+		foreach (var handler in handlers)
+		{
+			var key = handler.ParentExpression + "|" + handler.PropertyName;
+			if (seen.Add(key))
+			{
+				result.Add(handler);
+			}
+		}
+
+		return result;
+	}
+}

--- a/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
+++ b/src/Controls/src/SourceGen/ExpressionAnalyzer.cs
@@ -393,7 +393,7 @@ internal static class ExpressionAnalyzer
 			// Member access: "User.Name" - check both parts
 			MemberAccessExpressionSyntax memberAccess => 
 				IsSettableExpression(memberAccess.Expression) && memberAccess.Name is IdentifierNameSyntax,
-			// Null-conditional access: "User?.Name" - settable in C# 14+ (guaranteed on .NET 10+)
+			// Null-conditional access: "User?.Name" - settable in C# 13+ (guaranteed on .NET 10+)
 			ConditionalAccessExpressionSyntax conditionalAccess =>
 				IsSettableExpression(conditionalAccess.Expression) && IsSettableWhenAccessed(conditionalAccess.WhenNotNull),
 			// Anything else (operators, method calls, etc.) is not settable

--- a/src/Controls/src/SourceGen/MemberResolver.cs
+++ b/src/Controls/src/SourceGen/MemberResolver.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Maui.Controls.SourceGen;
+
+/// <summary>
+/// Indicates where a member was found during resolution.
+/// </summary>
+internal enum MemberLocation
+{
+	/// <summary>Member exists only on the page/view type (this).</summary>
+	This,
+	
+	/// <summary>Member exists only on the x:DataType type (BindingContext).</summary>
+	DataType,
+	
+	/// <summary>Member exists on both types - ambiguous, requires explicit prefix.</summary>
+	Both,
+	
+	/// <summary>Member not found on either type.</summary>
+	Neither,
+	
+	/// <summary>Explicitly prefixed with 'this.' - forced to local.</summary>
+	ForcedThis,
+	
+	/// <summary>Explicitly prefixed with '.' or 'BindingContext.' - forced to binding.</summary>
+	ForcedDataType,
+}
+
+/// <summary>
+/// Result of member resolution including location and the resolved expression.
+/// </summary>
+internal readonly struct MemberResolutionResult
+{
+	public MemberLocation Location { get; }
+	
+	/// <summary>The expression with prefix stripped (if any).</summary>
+	public string Expression { get; }
+	
+	/// <summary>The first identifier in the expression (for member lookup).</summary>
+	public string RootIdentifier { get; }
+	
+	/// <summary>True if the root identifier matches a well-known static type name.</summary>
+	public bool ConflictsWithStaticType { get; }
+	
+	public MemberResolutionResult(MemberLocation location, string expression, string rootIdentifier, bool conflictsWithStaticType = false)
+	{
+		Location = location;
+		Expression = expression;
+		RootIdentifier = rootIdentifier;
+		ConflictsWithStaticType = conflictsWithStaticType;
+	}
+	
+	public bool IsBinding => Location == MemberLocation.DataType || Location == MemberLocation.ForcedDataType;
+	public bool IsLocal => Location == MemberLocation.This || Location == MemberLocation.ForcedThis;
+	public bool IsAmbiguous => Location == MemberLocation.Both;
+	public bool IsNotFound => Location == MemberLocation.Neither;
+}
+
+/// <summary>
+/// Resolves member expressions to determine if they reference 'this' members or x:DataType members.
+/// </summary>
+internal static class MemberResolver
+{
+	private const string ThisPrefix = "this.";
+	private const string BindingContextPrefix = "BindingContext.";
+	private const string DotPrefix = ".";
+
+	/// <summary>
+	/// Resolves a member expression to determine its location.
+	/// </summary>
+	/// <param name="expression">The expression (e.g., "User.Name", "this.Title", ".Count")</param>
+	/// <param name="thisType">The type of the page/view (this)</param>
+	/// <param name="dataType">The x:DataType type (may be null if not specified)</param>
+	/// <param name="compilation">The compilation to check for type resolution (optional)</param>
+	/// <returns>Resolution result with location and cleaned expression</returns>
+	public static MemberResolutionResult Resolve(string expression, ITypeSymbol? thisType, ITypeSymbol? dataType, Compilation? compilation = null)
+	{
+		if (string.IsNullOrWhiteSpace(expression))
+			return new MemberResolutionResult(MemberLocation.Neither, expression, string.Empty);
+
+		var trimmed = expression.Trim();
+		
+		// Check for explicit prefixes first
+		if (trimmed.StartsWith(ThisPrefix, StringComparison.Ordinal))
+		{
+			var stripped = trimmed.Substring(ThisPrefix.Length);
+			var root = GetRootIdentifier(stripped);
+			return new MemberResolutionResult(MemberLocation.ForcedThis, stripped, root);
+		}
+		
+		if (trimmed.StartsWith(BindingContextPrefix, StringComparison.Ordinal))
+		{
+			var stripped = trimmed.Substring(BindingContextPrefix.Length);
+			var root = GetRootIdentifier(stripped);
+			return new MemberResolutionResult(MemberLocation.ForcedDataType, stripped, root);
+		}
+		
+		// "." prefix means BindingContext (shorthand)
+		if (trimmed.StartsWith(DotPrefix, StringComparison.Ordinal) && trimmed.Length > 1 && char.IsLetter(trimmed[1]))
+		{
+			var stripped = trimmed.Substring(1);
+			var root = GetRootIdentifier(stripped);
+			return new MemberResolutionResult(MemberLocation.ForcedDataType, stripped, root);
+		}
+
+		// No explicit prefix - need to resolve
+		var rootIdentifier = GetRootIdentifier(trimmed);
+		if (string.IsNullOrEmpty(rootIdentifier))
+			return new MemberResolutionResult(MemberLocation.Neither, trimmed, string.Empty);
+
+		var onThis = thisType != null && HasMember(thisType, rootIdentifier);
+		var onDataType = dataType != null && HasMember(dataType, rootIdentifier);
+		
+		// Check if root identifier also resolves to a type in the compilation
+		var conflictsWithStatic = (onThis || onDataType) && 
+			compilation != null && 
+			ResolvesToType(compilation, rootIdentifier);
+
+		MemberLocation location;
+		if (onThis && onDataType)
+			location = MemberLocation.Both;
+		else if (onThis)
+			location = MemberLocation.This;
+		else if (onDataType)
+			location = MemberLocation.DataType;
+		else
+			location = MemberLocation.Neither;
+
+		return new MemberResolutionResult(location, trimmed, rootIdentifier, conflictsWithStatic);
+	}
+	
+	/// <summary>
+	/// Checks if an identifier resolves to a type in the compilation (including via global usings).
+	/// </summary>
+	private static bool ResolvesToType(Compilation compilation, string identifier)
+	{
+		// Collect all global using namespaces from the compilation's syntax trees
+		var globalNamespaces = new HashSet<string>();
+		
+		foreach (var tree in compilation.SyntaxTrees)
+		{
+			var root = tree.GetRoot();
+			foreach (var usingDirective in root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax>())
+			{
+				// Check for global usings (global using System;)
+				if (usingDirective.GlobalKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GlobalKeyword))
+				{
+					var namespaceName = usingDirective.Name?.ToString();
+					if (!string.IsNullOrEmpty(namespaceName))
+						globalNamespaces.Add(namespaceName!);
+				}
+			}
+		}
+		
+		// Check if the identifier resolves to a type in any of the global namespaces
+		foreach (var ns in globalNamespaces)
+		{
+			var fullName = $"{ns}.{identifier}";
+			var type = compilation.GetTypeByMetadataName(fullName);
+			if (type != null)
+				return true;
+		}
+		
+		// Also check in the global namespace itself
+		var globalType = compilation.GetTypeByMetadataName(identifier);
+		if (globalType != null)
+			return true;
+		
+		return false;
+	}
+
+	/// <summary>
+	/// Extracts the first identifier from an expression.
+	/// </summary>
+	/// <remarks>
+	/// Examples:
+	/// - "User" → "User"
+	/// - "User.Name" → "User"
+	/// - "GetText()" → "GetText"
+	/// - "Items.Count > 0" → "Items"
+	/// </remarks>
+	private static string GetRootIdentifier(string expression)
+	{
+		if (string.IsNullOrEmpty(expression))
+			return string.Empty;
+
+		int i = 0;
+		// Skip leading whitespace
+		while (i < expression.Length && char.IsWhiteSpace(expression[i]))
+			i++;
+
+		if (i >= expression.Length)
+			return string.Empty;
+
+		// First char must be letter or underscore
+		if (!char.IsLetter(expression[i]) && expression[i] != '_')
+			return string.Empty;
+
+		int start = i;
+		// Continue while valid identifier char
+		while (i < expression.Length && (char.IsLetterOrDigit(expression[i]) || expression[i] == '_'))
+			i++;
+
+		return expression.Substring(start, i - start);
+	}
+
+	/// <summary>
+	/// Checks if an expression is a simple identifier (no operators, method calls, etc.).
+	/// Used to determine if a "not found" error should be reported.
+	/// </summary>
+	public static bool IsSimpleIdentifier(string expression)
+	{
+		if (string.IsNullOrWhiteSpace(expression))
+			return false;
+
+		var trimmed = expression.Trim();
+		
+		// Simple identifier: letters, digits, underscores only (and dots for member access)
+		foreach (char c in trimmed)
+		{
+			if (!char.IsLetterOrDigit(c) && c != '_' && c != '.')
+				return false;
+		}
+		
+		// Must start with letter or underscore
+		return char.IsLetter(trimmed[0]) || trimmed[0] == '_';
+	}
+
+	/// <summary>
+	/// Checks if a type has a member (property or field) with the given name.
+	/// </summary>
+	private static bool HasMember(ITypeSymbol type, string memberName)
+	{
+		// Check this type and all base types
+		var currentType = type;
+		while (currentType != null)
+		{
+			foreach (var member in currentType.GetMembers(memberName))
+			{
+				if (member is IPropertySymbol || member is IFieldSymbol)
+					return true;
+			}
+			currentType = currentType.BaseType;
+		}
+		return false;
+	}
+}

--- a/src/Controls/src/SourceGen/ProjectItem.cs
+++ b/src/Controls/src/SourceGen/ProjectItem.cs
@@ -77,4 +77,7 @@ record ProjectItem(AdditionalText AdditionalText, AnalyzerConfigOptions Options)
 
 	public string? TargetPath
 		=> Options.GetValueOrDefault("build_metadata.additionalfiles.TargetPath", AdditionalText.Path);
+
+	public bool EnablePreviewFeatures
+		=> Options.IsTrue("build_property.EnablePreviewFeatures");
 }

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -51,6 +51,12 @@ static class SetPropertyHelpers
 			return;
 		}
 
+		// C# expression that resolves to x:DataType (binding expression)
+		if (!asCollectionItem && TryHandleExpressionBinding(writer, parentVar, bpFieldSymbol, localName, valueNode, context))
+		{
+			return;
+		}
+
 		//If it's a BP, SetValue
 		if (!asCollectionItem && CanSetValue(bpFieldSymbol, valueNode, parentVar.Type, localName, context, getNodeValue, out var explicitPropertyNameForValue))
 		{
@@ -198,14 +204,49 @@ static class SetPropertyHelpers
 		=> writer.WriteLine($"((global::Microsoft.Maui.Controls.Internals.IDynamicResourceHandler){parentVar.ValueAccessor}).SetDynamicResource({fieldSymbol.ToFQDisplayString()}, {(getNodeValue(valueNode, context.Compilation.ObjectType)).ValueAccessor}.Key);");
 
 	static bool CanConnectEvent(ILocalValue parentVar, string localName, INode valueNode, bool attached, SourceGenContext context)
-		//FIXME check event signature
-		=> !attached && valueNode is ValueNode && parentVar.Type.GetAllEvents(localName, context).Any();
+	{
+		if (attached)
+			return false;
+		if (!parentVar.Type.GetAllEvents(localName, context).Any())
+			return false;
+
+		// Accept ValueNode with string (method name) or Expression (lambda)
+		if (valueNode is ValueNode vn)
+		{
+			if (vn.Value is string)
+				return true;
+			if (vn.Value is Expression)
+				return true;
+		}
+		return false;
+	}
 
 	static void ConnectEvent(IndentedTextWriter writer, ILocalValue parentVar, string localName, INode valueNode, SourceGenContext context, bool treeOrder, IndentedTextWriter? icWriter, ILocalValue? inflatorVar)
 	{
 		var eventSymbol = parentVar.Type.GetAllEvents(localName, context).First();
 		var eventType = eventSymbol.Type;
-		var handler = (string)((ValueNode)valueNode).Value;
+		var vn = (ValueNode)valueNode;
+
+		// Handle lambda expressions
+		if (vn.Value is Expression expression)
+		{
+			if (treeOrder && icWriter != null && inflatorVar != null)
+			{
+				writer = icWriter;
+				parentVar = inflatorVar;
+			}
+			// Transform quotes with semantic context
+			var transformedCode = CSharpExpressionHelpers.TransformQuotesWithSemantics(
+				expression.Code, context.Compilation, context.RootType);
+			using (context.ProjectItem.EnableLineInfo ? PrePost.NewLineInfo(writer, (IXmlLineInfo)valueNode, context.ProjectItem) : PrePost.NoBlock())
+			{
+				writer.WriteLine($"{parentVar.ValueAccessor}.{localName} += {transformedCode};");
+			}
+			return;
+		}
+
+		// Original method name handler logic
+		var handler = (string)vn.Value;
 		var handlerSymbol = context.RootType.GetAllMethods(handler, context).FirstOrDefault(m =>
 		{
 			if (m.Name != handler)
@@ -603,6 +644,226 @@ static class SetPropertyHelpers
 			return true;
 
 		return false;
+	}
+
+	/// <summary>
+	/// Handles C# expressions that should generate TypedBindings (when referencing x:DataType members).
+	/// Returns true if the expression was handled, false if it should fall through to other handlers.
+	/// </summary>
+	static bool TryHandleExpressionBinding(IndentedTextWriter writer, ILocalValue parentVar, IFieldSymbol? bpFieldSymbol, string localName, INode valueNode, SourceGenContext context)
+	{
+		// Only handle ValueNode with Expression value
+		if (valueNode is not ValueNode vn || vn.Value is not Expression expression)
+			return false;
+
+		// Need a BindableProperty to set a binding
+		if (bpFieldSymbol == null)
+			return false;
+
+		// Get the parent ElementNode to find x:DataType
+		var parentElement = valueNode.Parent as ElementNode;
+		if (parentElement == null)
+			return false;
+
+		// Try to get x:DataType from the element tree
+		if (!XDataTypeResolver.TryGetXDataType(parentElement, context, out var dataTypeSymbol) || dataTypeSymbol == null)
+		{
+			// No x:DataType - expression is a local 'this' reference, let SetValue handle it
+			return false;
+		}
+
+		// Analyze the expression for mixed local+binding scenarios
+		var analysis = ExpressionAnalyzer.Analyze(expression.Code, "__source", dataTypeSymbol, context.RootType);
+
+		// Check for ambiguity first - resolve the expression
+		var resolution = MemberResolver.Resolve(expression.Code, context.RootType, dataTypeSymbol, context.Compilation);
+
+		// Handle ambiguous case - always an error
+		if (resolution.Location == MemberLocation.Both)
+		{
+			var bothLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.AmbiguousMemberExpression, bothLocation, resolution.RootIdentifier, context.RootType?.Name ?? "this", dataTypeSymbol.Name));
+			return true; // Handled (with error)
+		}
+		
+		// Warn if member name conflicts with a well-known static type
+		if (resolution.ConflictsWithStaticType)
+		{
+			var staticLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
+			var typeName = resolution.Location == MemberLocation.This ? (context.RootType?.Name ?? "this") : dataTypeSymbol.Name;
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.AmbiguousMemberWithStaticType, staticLocation, resolution.RootIdentifier, typeName));
+			// Continue processing - this is just a warning
+		}
+
+		// Handle not-found case for simple identifiers
+		if (resolution.Location == MemberLocation.Neither && 
+			!string.IsNullOrEmpty(resolution.RootIdentifier) && 
+			MemberResolver.IsSimpleIdentifier(expression.Code))
+		{
+			var neitherLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression.Code);
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.MemberNotFound, neitherLocation, resolution.RootIdentifier, context.RootType?.Name ?? "this", dataTypeSymbol.Name));
+			return true; // Handled (with error)
+		}
+
+		// If we have binding handlers, this needs a TypedBinding
+		// This covers complex expressions like (Price * TaxRate) where MemberResolver returns Neither
+		if (analysis.HasBindingProperties)
+		{
+			SetExpressionBinding(writer, parentVar, bpFieldSymbol, expression.Code, dataTypeSymbol, context, vn);
+			return true;
+		}
+
+		// Handle based on member location
+		switch (resolution.Location)
+		{
+			case MemberLocation.This:
+			case MemberLocation.ForcedThis:
+				// Local expression - let SetValue handle it
+				return false;
+
+			case MemberLocation.DataType:
+			case MemberLocation.ForcedDataType:
+				// Binding expression - generate TypedBinding
+				SetExpressionBinding(writer, parentVar, bpFieldSymbol, resolution.Expression, dataTypeSymbol, context, vn);
+				return true;
+
+			case MemberLocation.Neither:
+				// Complex expression with no binding properties - let SetValue handle it
+				return false;
+
+			default:
+				return false;
+		}
+	}
+
+	/// <summary>
+	/// Generates a TypedBinding for a C# expression that references x:DataType members.
+	/// </summary>
+	static void SetExpressionBinding(IndentedTextWriter writer, ILocalValue parentVar, IFieldSymbol bpFieldSymbol, string expression, ITypeSymbol dataTypeSymbol, SourceGenContext context, ValueNode valueNode)
+	{
+		var bpName = bpFieldSymbol.ToFQDisplayString();
+		var bpTypeAndConverter = bpFieldSymbol.GetBPTypeAndConverter(context);
+		var targetType = bpTypeAndConverter?.type ?? context.Compilation.ObjectType;
+		
+		var sourceTypeName = dataTypeSymbol.ToFQDisplayString();
+		var targetTypeName = targetType.ToFQDisplayString();
+
+		// Transform quotes with semantic context - char literals stay as char only if target expects char
+		var transformedExpression = CSharpExpressionHelpers.TransformQuotesWithSemantics(
+			expression, context.Compilation, dataTypeSymbol, context.RootType);
+
+		// Analyze expression for mixed local+binding scenarios
+		var analysis = ExpressionAnalyzer.Analyze(transformedExpression, "__source", dataTypeSymbol, context.RootType);
+		var handlers = analysis.Handlers;
+
+		// Wrap in scoped block if we have captures to avoid duplicate variable names
+		// when multiple expressions capture the same local member
+		bool hasCaptures = analysis.Captures.Count > 0;
+		if (hasCaptures)
+		{
+			writer.WriteLine("{");
+			writer.Indent++;
+			// Generate capture statements for local values (this.X or this.Method())
+			foreach (var capture in analysis.Captures)
+			{
+				writer.WriteLine($"var {capture.CaptureVariable} = this.{capture.InvocationExpression};");
+			}
+		}
+
+		// The getter must return (TProperty value, bool success) tuple
+		using (context.ProjectItem.EnableLineInfo ? PrePost.NewLineInfo(writer, (IXmlLineInfo)valueNode, context.ProjectItem) : PrePost.NoBlock())
+		{
+			writer.WriteLine($"{parentVar.ValueAccessor}.SetBinding({bpName},");
+			writer.Indent++;
+			writer.WriteLine($"new global::Microsoft.Maui.Controls.Internals.TypedBinding<{sourceTypeName}, {targetTypeName}>(");
+			writer.Indent++;
+			// TransformedExpression already has identifiers prefixed with __source. where needed
+			// Add null-forgiving operator if expression contains ?. to suppress nullability warnings
+			var getterExpression = analysis.TransformedExpression;
+			if (getterExpression.Contains("?."))
+				getterExpression += "!";
+			writer.WriteLine($"__source => ({getterExpression}, true),");
+			
+			// Generate setter if expression is a simple property chain
+			if (analysis.IsSettable)
+			{
+				writer.WriteLine($"(__source, __value) => {analysis.TransformedExpression} = __value,");
+			}
+			else
+			{
+				writer.WriteLine($"null,");
+				// Emit info diagnostic when binding a complex expression to a TwoWay property
+				if (IsTwoWayByDefault(bpFieldSymbol))
+				{
+					var location = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)valueNode, expression);
+					context.ReportDiagnostic(Diagnostic.Create(
+						Descriptors.ExpressionNotSettable,
+						location,
+						expression,
+						bpFieldSymbol.Name));
+				}
+			}
+			
+			// Generate handlers array
+			if (handlers.Count == 0)
+			{
+				writer.WriteLine($"null));");
+			}
+			else
+			{
+				writer.WriteLine($"new global::System.Tuple<global::System.Func<{sourceTypeName}, object>, string>[] {{");
+				writer.Indent++;
+				for (int i = 0; i < handlers.Count; i++)
+				{
+					var handler = handlers[i];
+					var comma = i < handlers.Count - 1 ? "," : "";
+					// Lambda parameter is always __source, body is the parent expression
+					writer.WriteLine($"new(static __source => {handler.ParentExpression}, \"{handler.PropertyName}\"){comma}");
+				}
+				writer.Indent--;
+				writer.WriteLine($"}}));");
+			}
+			writer.Indent -= 2;
+		}
+
+		if (hasCaptures)
+		{
+			writer.Indent--;
+			writer.WriteLine("}");
+		}
+	}
+
+	/// <summary>
+	/// Known BindableProperties that default to TwoWay binding mode.
+	/// </summary>
+	static readonly HashSet<string> TwoWayBindableProperties = new HashSet<string>
+	{
+		"global::Microsoft.Maui.Controls.Entry.TextProperty",
+		"global::Microsoft.Maui.Controls.Editor.TextProperty",
+		"global::Microsoft.Maui.Controls.SearchBar.TextProperty",
+		"global::Microsoft.Maui.Controls.InputView.TextProperty",
+		"global::Microsoft.Maui.Controls.DatePicker.DateProperty",
+		"global::Microsoft.Maui.Controls.TimePicker.TimeProperty",
+		"global::Microsoft.Maui.Controls.Picker.SelectedIndexProperty",
+		"global::Microsoft.Maui.Controls.Picker.SelectedItemProperty",
+		"global::Microsoft.Maui.Controls.Slider.ValueProperty",
+		"global::Microsoft.Maui.Controls.Stepper.ValueProperty",
+		"global::Microsoft.Maui.Controls.Switch.IsToggledProperty",
+		"global::Microsoft.Maui.Controls.CheckBox.IsCheckedProperty",
+		"global::Microsoft.Maui.Controls.RadioButton.IsCheckedProperty",
+		"global::Microsoft.Maui.Controls.ListView.SelectedItemProperty",
+		"global::Microsoft.Maui.Controls.CollectionView.SelectedItemProperty",
+		"global::Microsoft.Maui.Controls.CollectionView.SelectedItemsProperty",
+		"global::Microsoft.Maui.Controls.MultiPage<TPage>.CurrentPageProperty",
+	};
+
+	/// <summary>
+	/// Checks if the BindableProperty defaults to TwoWay binding mode.
+	/// </summary>
+	static bool IsTwoWayByDefault(IFieldSymbol bpFieldSymbol)
+	{
+		var fullName = $"{bpFieldSymbol.ContainingType.ToFQDisplayString()}.{bpFieldSymbol.Name}";
+		return TwoWayBindableProperties.Contains(fullName);
 	}
 
 }

--- a/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/ExpandMarkupsVisitor.cs
@@ -72,9 +72,9 @@ class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 				return;
 			}
 
-			// Element content doesn't need quote transformation - natural C# syntax allowed
-			var expressionCode = CSharpExpressionHelpers.GetExpressionCode(trimmed, transformQuotes: false);
-			node.Value = new Expression(expressionCode, TransformQuotes: false);
+			// Extract expression code - single quotes are always transformed to double quotes
+			var expressionCode = CSharpExpressionHelpers.GetExpressionCode(trimmed);
+			node.Value = new Expression(expressionCode);
 		}
 	}
 
@@ -138,10 +138,9 @@ class ExpandMarkupsVisitor(SourceGenContext context) : IXamlNodeVisitor
 			}
 			else
 			{
-				// Extract expression code but DON'T transform quotes yet
-				// Quote transformation happens in SetPropertyHelpers where we have semantic context
-				var expressionCode = CSharpExpressionHelpers.GetExpressionCode(markupString, transformQuotes: false);
-				node = new ValueNode(new Expression(expressionCode, TransformQuotes: true), markupnode.NamespaceResolver, markupnode.LineNumber, markupnode.LinePosition);
+				// Extract expression code - single quotes are always transformed to double quotes
+				var expressionCode = CSharpExpressionHelpers.GetExpressionCode(markupString);
+				node = new ValueNode(new Expression(expressionCode), markupnode.NamespaceResolver, markupnode.LineNumber, markupnode.LinePosition);
 			}
 		}
 

--- a/src/Controls/src/SourceGen/XDataTypeResolver.cs
+++ b/src/Controls/src/SourceGen/XDataTypeResolver.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Microsoft.Maui.Controls.SourceGen;
+
+/// <summary>
+/// Helper to resolve x:DataType from XAML element tree.
+/// Extracted from KnownMarkups.BindingMarkup for reuse in expression resolution.
+/// </summary>
+internal static class XDataTypeResolver
+{
+	/// <summary>
+	/// Tries to get the x:DataType type symbol for an element by walking up the element tree.
+	/// </summary>
+	/// <param name="node">The element node to start from</param>
+	/// <param name="context">The source generation context</param>
+	/// <param name="dataTypeSymbol">The resolved type symbol if found</param>
+	/// <returns>True if x:DataType was found and resolved</returns>
+	public static bool TryGetXDataType(ElementNode node, SourceGenContext context, out ITypeSymbol? dataTypeSymbol)
+	{
+		dataTypeSymbol = null;
+
+		if (!TryFindXDataTypeNode(node, context, out INode? dataTypeNode, out _) || dataTypeNode is null)
+			return false;
+
+		if (dataTypeNode.RepresentsType(XamlParser.X2009Uri, "NullExtension"))
+			return false;
+
+		// TypeExtension: lookup from context's type cache
+		if (dataTypeNode.RepresentsType(XamlParser.X2009Uri, "TypeExtension"))
+		{
+			SourceGenContext? ctx = context;
+			while (ctx is not null)
+			{
+				if (ctx.Types.TryGetValue(dataTypeNode, out dataTypeSymbol))
+					return true;
+				ctx = ctx.ParentContext;
+			}
+			return false;
+		}
+
+		// Value node with type name string
+		string? dataTypeName = (dataTypeNode as ValueNode)?.Value as string;
+		if (dataTypeName is null)
+			return false;
+
+		XmlType? dataType = null;
+		try
+		{
+			dataType = TypeArgumentsParser.ParseSingle(dataTypeName, node.NamespaceResolver, dataTypeNode as System.Xml.IXmlLineInfo);
+		}
+		catch (XamlParseException)
+		{
+			return false;
+		}
+
+		if (dataType is null)
+			return false;
+
+		if (!dataType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out INamedTypeSymbol? symbol))
+			return false;
+
+		dataTypeSymbol = symbol;
+		return true;
+	}
+
+	/// <summary>
+	/// Walks up the element tree to find the nearest x:DataType declaration.
+	/// </summary>
+	private static bool TryFindXDataTypeNode(ElementNode elementNode, SourceGenContext context, out INode? dataTypeNode, out bool isInOuterScope)
+	{
+		isInOuterScope = false;
+		dataTypeNode = null;
+
+		// Special handling for BindingContext={Binding ...}
+		ElementNode? skipNode = null;
+		if (IsBindingContextBinding(elementNode))
+		{
+			skipNode = GetParent(elementNode);
+		}
+
+		ElementNode? node = elementNode;
+		while (node is not null)
+		{
+			if (node != skipNode && node.Properties.TryGetValue(XmlName.xDataType, out dataTypeNode))
+				return true;
+
+			if (DoesNotInheritDataType(node, context))
+				return false;
+
+			if (node.RepresentsType(XamlParser.MauiUri, "DataTemplate"))
+				isInOuterScope = true;
+
+			node = GetParent(node);
+		}
+
+		return false;
+	}
+
+	private static bool IsBindingContextBinding(ElementNode elementNode)
+	{
+		return GetParent(elementNode) is ElementNode parentNode
+			&& elementNode.TryGetPropertyName(parentNode, out var propertyName)
+			&& propertyName.NamespaceURI == ""
+			&& propertyName.LocalName == "BindingContext";
+	}
+
+	private static bool DoesNotInheritDataType(ElementNode node, SourceGenContext context)
+	{
+		return GetParent(node) is ElementNode parentNode
+			&& parentNode.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out INamedTypeSymbol? parentTypeSymbol)
+			&& parentTypeSymbol is not null
+			&& node.TryGetPropertyName(parentNode, out XmlName propertyName)
+			&& parentTypeSymbol.GetAllProperties(propertyName.LocalName, context).FirstOrDefault() is IPropertySymbol propertySymbol
+			&& propertySymbol.GetAttributes().Any(a => a.AttributeClass?.ToFQDisplayString() == "global::Microsoft.Maui.Controls.Xaml.DoesNotInheritDataTypeAttribute");
+	}
+
+	private static ElementNode? GetParent(ElementNode node)
+	{
+		var parent = node.Parent;
+		if (parent is ListNode listNode)
+			return listNode.Parent as ElementNode;
+		if (parent is ElementNode elementNode)
+			return elementNode;
+		return null;
+	}
+}

--- a/src/Controls/src/Xaml/XamlNode.cs
+++ b/src/Controls/src/Xaml/XamlNode.cs
@@ -51,13 +51,20 @@ class ValueNode(object value, IXmlNamespaceResolver namespaceResolver, int linen
 {
 	public object Value { get; set; } = value;
 
+	/// <summary>
+	/// Indicates that this ValueNode was created from an escaped markup string (e.g., "{}{Foo}").
+	/// When true, the Value should be treated as a literal and not processed as a C# expression.
+	/// </summary>
+	public bool IsEscaped { get; init; }
+
 	public override void Accept(IXamlNodeVisitor visitor, INode parentNode)
 		=> visitor.Visit(this, parentNode);
 
 	public override INode Clone()
 		=> new ValueNode(Value, NamespaceResolver, LineNumber, LinePosition)
 		{
-			IgnorablePrefixes = IgnorablePrefixes
+			IgnorablePrefixes = IgnorablePrefixes,
+			IsEscaped = IsEscaped
 		};
 }
 

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (valueString != null && valueString.Trim().StartsWith("{}", StringComparison.Ordinal))
 			{
 				return new ValueNode(valueString.Substring(2), (IXmlNamespaceResolver)reader, ((IXmlLineInfo)reader).LineNumber,
-					((IXmlLineInfo)reader).LinePosition);
+					((IXmlLineInfo)reader).LinePosition) { IsEscaped = true };
 			}
 			if (valueString != null && valueString.Trim().StartsWith("{", StringComparison.Ordinal))
 			{

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -1,0 +1,812 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.Maui.Controls.Xaml.UnitTests.SourceGen;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.SourceGen.SourceGeneratorDriver;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+public class CSharpExpressionDiagnosticsTests : SourceGenXamlInitializeComponentTestBase
+{
+	[Fact]
+	public void AmbiguousMember_ReportsMAUIX2008()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.AmbiguousPage"
+             x:DataType="local:AmbiguousViewModel">
+    <Label Text="{SharedName}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class AmbiguousViewModel : INotifyPropertyChanged
+{
+	public string SharedName { get; set; } = "VM SharedName";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class AmbiguousPage : ContentPage
+{
+	public string SharedName => "Page SharedName";
+	public AmbiguousPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2008");
+	}
+
+	[Fact]
+	public void MemberNotFound_ReportsMAUIX2009()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.NotFoundPage"
+             x:DataType="local:NotFoundViewModel">
+    <Label Text="{NonExistentProperty}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class NotFoundViewModel : INotifyPropertyChanged
+{
+	public string Name { get; set; } = "Name";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class NotFoundPage : ContentPage
+{
+	public NotFoundPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2009");
+	}
+
+	[Fact]
+	public void ExplicitThisPrefix_NoAmbiguousError()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.ExplicitThisPage"
+             x:DataType="local:ExplicitThisViewModel">
+    <Label Text="{this.Title}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class ExplicitThisViewModel : INotifyPropertyChanged
+{
+	public string Title { get; set; } = "VM Title";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class ExplicitThisPage : ContentPage
+{
+	public string Title => "Page Title";
+	public ExplicitThisPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2008 errors because we used explicit this. prefix
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2008");
+	}
+
+	[Fact]
+	public void ExplicitDotPrefix_NoAmbiguousError()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.ExplicitDotPage"
+             x:DataType="local:ExplicitDotViewModel">
+    <Label Text="{.Title}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class ExplicitDotViewModel : INotifyPropertyChanged
+{
+	public string Title { get; set; } = "VM Title";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class ExplicitDotPage : ContentPage
+{
+	public string Title => "Page Title";
+	public ExplicitDotPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2008 errors because we used explicit . prefix
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2008");
+	}
+
+	[Fact]
+	public void MemberConflictsWithStaticType_ReportsMAUIX2011()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.StaticConflictPage"
+             x:DataType="local:StaticConflictViewModel">
+    <Label Text="{Math.Max(A, B).ToString()}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+global using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class MathHelper
+{
+	public int Max(int a, int b) => a > b ? a : b;
+}
+
+public class StaticConflictViewModel : INotifyPropertyChanged
+{
+	public MathHelper Math { get; set; } = new();
+	public int A => 5;
+	public int B => 10;
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class StaticConflictPage : ContentPage
+{
+	public StaticConflictPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2011");
+	}
+
+	[Fact]
+	public void ExplicitDotPrefix_NoStaticTypeConflictWarning()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.NoConflictPage"
+             x:DataType="local:NoConflictViewModel">
+    <Label Text="{.Math.Max(A, B).ToString()}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+global using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class MathHelper
+{
+	public int Max(int a, int b) => a > b ? a : b;
+}
+
+public class NoConflictViewModel : INotifyPropertyChanged
+{
+	public MathHelper Math { get; set; } = new();
+	public int A => 5;
+	public int B => 10;
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class NoConflictPage : ContentPage
+{
+	public NoConflictPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2011 warning because we used explicit . prefix
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2011");
+	}
+
+	[Fact]
+	public void BareIdentifier_AmbiguousBetweenMarkupAndProperty_ReportsMAUIX2007()
+	{
+		// This test verifies that when a bare identifier like {Binding} could be EITHER
+		// a markup extension (BindingExtension) OR a C# expression property (Binding),
+		// we emit MAUIX2007 warning and default to markup extension.
+		// 
+		// We use "Binding" here because it's a known MAUI markup extension that exists
+		// in the default namespace. Having a property named "Binding" on the ViewModel
+		// creates a genuine ambiguity.
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.AmbiguousMarkupPage"
+             x:DataType="local:AmbiguousMarkupViewModel">
+    <Label Text="{Binding}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class AmbiguousMarkupViewModel : INotifyPropertyChanged
+{
+	// Property with same name as the Binding markup extension
+	public string Binding { get; set; } = "From Property";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class AmbiguousMarkupPage : ContentPage
+{
+	public AmbiguousMarkupPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// Should report MAUIX2007 warning about ambiguity
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2007");
+	}
+
+	[Fact]
+	public void BareIdentifier_ExplicitExpressionSyntax_NoAmbiguityWarning()
+	{
+		// Using {= Binding} explicitly indicates C# expression, no ambiguity
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.ExplicitExpressionPage"
+             x:DataType="local:ExplicitExpressionViewModel">
+    <Label Text="{= Binding}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class ExplicitExpressionViewModel : INotifyPropertyChanged
+{
+	public string Binding { get; set; } = "From Property";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class ExplicitExpressionPage : ContentPage
+{
+	public ExplicitExpressionPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2007 warning because we used explicit {= } syntax
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2007");
+	}
+
+	[Fact]
+	public void BareIdentifier_ExplicitMarkupPrefix_NoAmbiguityWarning()
+	{
+		// Using {x:Null} explicitly indicates markup extension, no ambiguity check needed
+		// (This tests that prefixed markup extensions don't trigger ambiguity warnings)
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.ExplicitMarkupPage"
+             x:DataType="local:ExplicitMarkupViewModel">
+    <Label Text="{x:Null}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System;
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class ExplicitMarkupViewModel : INotifyPropertyChanged
+{
+	// Even if there's a property named "Null", the x: prefix makes it unambiguous
+	public string Null { get; set; } = "From Property";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class ExplicitMarkupPage : ContentPage
+{
+	public ExplicitMarkupPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2007 warning because we used explicit x: prefix
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2007");
+	}
+
+	[Fact]
+	public void ComplexExpression_OnTwoWayProperty_EmitsInfoDiagnostic()
+	{
+		// Complex expressions on two-way properties emit MAUIX2010 as Info (not Warning)
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.TwoWayWarningPage"
+             x:DataType="local:TwoWayViewModel">
+    <Entry Text="{.FirstName + ' ' + .LastName}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class TwoWayViewModel : INotifyPropertyChanged
+{
+	public string FirstName { get; set; } = "John";
+	public string LastName { get; set; } = "Doe";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TwoWayWarningPage : ContentPage
+{
+	public TwoWayWarningPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		// MAUIX2010 should be emitted as Info level
+		var diagnostic = result.Diagnostics.FirstOrDefault(d => d.Id == "MAUIX2010");
+		Assert.NotNull(diagnostic);
+		Assert.Equal(DiagnosticSeverity.Info, diagnostic.Severity);
+	}
+
+	[Fact]
+	public void SimplePropertyBinding_OnTwoWayProperty_NoWarning()
+	{
+		// Simple property bindings CAN generate a setter, so no warning
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.TwoWayNoWarningPage"
+             x:DataType="local:TwoWayViewModel">
+    <Entry Text="{FirstName}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class TwoWayViewModel : INotifyPropertyChanged
+{
+	public string FirstName { get; set; } = "John";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TwoWayNoWarningPage : ContentPage
+{
+	public TwoWayNoWarningPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2010 warning because simple property can be two-way
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2010");
+	}
+
+	[Fact]
+	public void NullConditionalAccess_OnTwoWayProperty_IsSettable()
+	{
+		// Null-conditional access (?.) IS settable in C# 14+ (guaranteed on .NET 10+)
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.NullConditionalPage"
+             x:DataType="local:NullConditionalViewModel">
+    <Entry Text="{.User?.Name}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class User
+{
+	public string Name { get; set; } = "Test";
+}
+
+public class NullConditionalViewModel : INotifyPropertyChanged
+{
+	public User? User { get; set; }
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class NullConditionalPage : ContentPage
+{
+	public NullConditionalPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		// No MAUIX2010 because ?. is settable in C# 14+ (.NET 10+)
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2010");
+	}
+
+	[Fact]
+	public void AsyncLambdaEventHandler_ReportsMAUIX2013()
+	{
+		// Async lambdas are not supported for event handlers
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TestApp.AsyncLambdaPage">
+    <Button Clicked="{async (s, e) => await Task.Delay(100)}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class AsyncLambdaPage : ContentPage
+{
+	public AsyncLambdaPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// Should report MAUIX2013 error about async lambda not supported
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2013");
+	}
+
+	[Fact]
+	public void SyncLambdaEventHandler_NoError()
+	{
+		// Sync lambdas are supported
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TestApp.SyncLambdaPage">
+    <Button Clicked="{(s, e) => Count++}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class SyncLambdaPage : ContentPage
+{
+	public int Count { get; set; }
+	public SyncLambdaPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind);
+
+		// No MAUIX2013 error
+		Assert.DoesNotContain(result.Diagnostics, d => d.Id == "MAUIX2013");
+	}
+
+	[Fact]
+	public void CSharpExpression_WithoutPreviewFeatures_ReportsMAUIX2012()
+	{
+		// C# expressions require EnablePreviewFeatures=true
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TestApp.NoPreviewPage">
+    <Label Text="{GetText()}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class NoPreviewPage : ContentPage
+{
+	public string GetText() => "Hello";
+	public NoPreviewPage() => InitializeComponent();
+}
+""";
+
+		var (result, _) = RunGenerator(xaml, codeBehind, enablePreviewFeatures: false);
+
+		// Should report MAUIX2012 error about preview features required
+		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2012");
+	}
+
+	[Fact]
+	public void SingleQuotedLiteral_MethodExpectsString_GeneratesStringLiteral()
+	{
+		// When a method expects string, 'x' should become "x"
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.StringMethodPage"
+             x:DataType="local:StringMethodViewModel">
+    <Label Text="{GetText('x')}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class StringMethodViewModel : INotifyPropertyChanged
+{
+	public string GetText(string input) => $"Got: {input}";
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class StringMethodPage : ContentPage
+{
+	public StringMethodPage() => InitializeComponent();
+}
+""";
+
+		var (result, output) = RunGenerator(xaml, codeBehind);
+
+		// Should compile without errors
+		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+		
+		// Generated code should have "x" (string literal), not 'x' (char literal)
+		Assert.Contains("\"x\"", output, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void SingleQuotedLiteral_MethodExpectsChar_GeneratesCharLiteral()
+	{
+		// When a method expects char, 'x' should stay as 'x'
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.CharMethodPage"
+             x:DataType="local:CharMethodViewModel">
+    <Label Text="{.GetChar('x').ToString()}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class CharMethodViewModel : INotifyPropertyChanged
+{
+	public char GetChar(char input) => input;
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class CharMethodPage : ContentPage
+{
+	public CharMethodPage() => InitializeComponent();
+}
+""";
+
+		var (result, output) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+
+		// Should have no source generator diagnostics (errors)
+		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+		
+		// Generated code should have 'x' (char literal)
+		Assert.Contains("'x'", output, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void OperatorAliases_ANDandOR_TransformedToLogicalOperators()
+	{
+		var xaml =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TestApp"
+             x:Class="TestApp.OperatorAliasPage"
+             x:DataType="local:OperatorAliasViewModel">
+    <Label IsVisible="{.IsLoaded AND .HasData}" />
+    <Label IsVisible="{.IsEmpty OR .HasError}" />
+    <Label IsVisible="{.Count GT 0 AND .Count LT 100}" />
+    <Label IsVisible="{.Count GTE 0 AND .Count LTE 100}" />
+</ContentPage>
+""";
+
+		var codeBehind =
+"""
+using System.ComponentModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace TestApp;
+
+public class OperatorAliasViewModel : INotifyPropertyChanged
+{
+	public bool IsLoaded { get; set; }
+	public bool HasData { get; set; }
+	public bool IsEmpty { get; set; }
+	public bool HasError { get; set; }
+	public int Count { get; set; }
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class OperatorAliasPage : ContentPage
+{
+	public OperatorAliasPage() => InitializeComponent();
+}
+""";
+
+		var (result, output) = RunGenerator(xaml, codeBehind, assertNoCompilationErrors: false);
+		
+		// Should have no source generator diagnostics (errors)
+		Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+		
+		// Generated code should have C# operators instead of aliases
+		Assert.Contains("&&", output, StringComparison.Ordinal);
+		Assert.Contains("||", output, StringComparison.Ordinal);
+		Assert.Contains(" < ", output, StringComparison.Ordinal);
+		Assert.Contains(" > ", output, StringComparison.Ordinal);
+		Assert.Contains(" <= ", output, StringComparison.Ordinal);
+		Assert.Contains(" >= ", output, StringComparison.Ordinal);
+	}
+}

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SourceGenXamlInitializeComponentTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SourceGenXamlInitializeComponentTests.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
 
 public class SourceGenXamlInitializeComponentTestBase : SourceGenTestsBase
 {
-	protected record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, string? NoWarn = null, string Lineinfo = "enable")
-		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, NoWarn: NoWarn, LineInfo: Lineinfo);
+	protected record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, string? NoWarn = null, string Lineinfo = "enable", bool EnablePreviewFeatures = true)
+		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, NoWarn: NoWarn, LineInfo: Lineinfo, EnablePreviewFeatures: EnablePreviewFeatures);
 
-	protected (GeneratorDriverRunResult result, string? text) RunGenerator(string xaml, string code, string noWarn = "", string targetFramework = "", string? path = null, string lineinfo = "enable", bool assertNoCompilationErrors = true)
+	protected (GeneratorDriverRunResult result, string? text) RunGenerator(string xaml, string code, string noWarn = "", string targetFramework = "", string? path = null, string lineinfo = "enable", bool assertNoCompilationErrors = true, bool enablePreviewFeatures = true)
 	{
 		var compilation = CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
 		var workingDirectory = Environment.CurrentDirectory;
-		var xamlFile = new AdditionalXamlFile(Path.Combine(workingDirectory, path ?? "Test.xaml"), xaml, RelativePath: path ?? "Test.xaml", TargetFramework: targetFramework, NoWarn: noWarn, ManifestResourceName: $"{compilation.AssemblyName}.Test.xaml", Lineinfo: lineinfo);
+		var xamlFile = new AdditionalXamlFile(Path.Combine(workingDirectory, path ?? "Test.xaml"), xaml, RelativePath: path ?? "Test.xaml", TargetFramework: targetFramework, NoWarn: noWarn, ManifestResourceName: $"{compilation.AssemblyName}.Test.xaml", Lineinfo: lineinfo, EnablePreviewFeatures: enablePreviewFeatures);
 		var result = RunGenerator<XamlGenerator>(compilation, xamlFile, assertNoCompilationErrors);
 		var generated = result.Results.SingleOrDefault().GeneratedSources.SingleOrDefault(gs => gs.HintName.EndsWith(".xsg.cs")).SourceText?.ToString();
 

--- a/src/Controls/tests/SourceGen.UnitTests/MemberResolverTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/MemberResolverTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+public class MemberResolverTests
+{
+	// Helper to create a type symbol from C# code
+	private static ITypeSymbol? GetTypeSymbol(string typeName, string code)
+	{
+		var compilation = CSharpCompilation.Create("TestAssembly",
+			new[] { CSharpSyntaxTree.ParseText(code) },
+			new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		var type = compilation.GetTypeByMetadataName(typeName);
+		return type;
+	}
+
+	private static ITypeSymbol GetPageType() => GetTypeSymbol("TestApp.MainPage", 
+@"namespace TestApp {
+	public class MainPage {
+		public string Title { get; set; }
+		public string LocalOnly { get; set; }
+		public string SharedName { get; set; }
+	}
+}")!;
+
+	private static ITypeSymbol GetViewModelType() => GetTypeSymbol("TestApp.ViewModel",
+@"namespace TestApp {
+	public class ViewModel {
+		public string Name { get; set; }
+		public string DataTypeOnly { get; set; }
+		public string SharedName { get; set; }
+		public User User { get; set; }
+	}
+	public class User {
+		public string DisplayName { get; set; }
+	}
+}")!;
+
+	[Fact]
+	public void Resolve_ThisPrefix_ReturnsForcedThis()
+	{
+		var result = MemberResolver.Resolve("this.Title", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.ForcedThis, result.Location);
+		Assert.Equal("Title", result.Expression);
+		Assert.Equal("Title", result.RootIdentifier);
+		Assert.True(result.IsLocal);
+		Assert.False(result.IsBinding);
+	}
+
+	[Fact]
+	public void Resolve_DotPrefix_ReturnsForcedDataType()
+	{
+		var result = MemberResolver.Resolve(".Name", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.ForcedDataType, result.Location);
+		Assert.Equal("Name", result.Expression);
+		Assert.Equal("Name", result.RootIdentifier);
+		Assert.True(result.IsBinding);
+		Assert.False(result.IsLocal);
+	}
+
+	[Fact]
+	public void Resolve_BindingContextPrefix_ReturnsForcedDataType()
+	{
+		var result = MemberResolver.Resolve("BindingContext.Name", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.ForcedDataType, result.Location);
+		Assert.Equal("Name", result.Expression);
+		Assert.Equal("Name", result.RootIdentifier);
+		Assert.True(result.IsBinding);
+	}
+
+	[Fact]
+	public void Resolve_OnlyOnThis_ReturnsThis()
+	{
+		var result = MemberResolver.Resolve("LocalOnly", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.This, result.Location);
+		Assert.Equal("LocalOnly", result.Expression);
+		Assert.True(result.IsLocal);
+	}
+
+	[Fact]
+	public void Resolve_OnlyOnDataType_ReturnsDataType()
+	{
+		var result = MemberResolver.Resolve("DataTypeOnly", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.DataType, result.Location);
+		Assert.Equal("DataTypeOnly", result.Expression);
+		Assert.True(result.IsBinding);
+	}
+
+	[Fact]
+	public void Resolve_OnBoth_ReturnsBoth()
+	{
+		var result = MemberResolver.Resolve("SharedName", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.Both, result.Location);
+		Assert.True(result.IsAmbiguous);
+	}
+
+	[Fact]
+	public void Resolve_OnNeither_ReturnsNeither()
+	{
+		var result = MemberResolver.Resolve("NonExistent", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.Neither, result.Location);
+		Assert.True(result.IsNotFound);
+	}
+
+	[Fact]
+	public void Resolve_NestedProperty_ResolvesRoot()
+	{
+		var result = MemberResolver.Resolve("User.DisplayName", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.DataType, result.Location);
+		Assert.Equal("User.DisplayName", result.Expression);
+		Assert.Equal("User", result.RootIdentifier);
+	}
+
+	[Fact]
+	public void Resolve_WithMethodCall_ResolvesRoot()
+	{
+		var result = MemberResolver.Resolve("User.ToString()", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.DataType, result.Location);
+		Assert.Equal("User", result.RootIdentifier);
+	}
+
+	[Fact]
+	public void Resolve_NullDataType_OnlyChecksThis()
+	{
+		var result = MemberResolver.Resolve("Title", GetPageType(), null);
+		
+		Assert.Equal(MemberLocation.This, result.Location);
+	}
+
+	[Fact]
+	public void Resolve_NullThisType_OnlyChecksDataType()
+	{
+		var result = MemberResolver.Resolve("Name", null, GetViewModelType());
+		
+		Assert.Equal(MemberLocation.DataType, result.Location);
+	}
+
+	[Fact]
+	public void Resolve_BothNull_ReturnsNeither()
+	{
+		var result = MemberResolver.Resolve("Anything", null, null);
+		
+		Assert.Equal(MemberLocation.Neither, result.Location);
+	}
+
+	[Fact]
+	public void Resolve_ExpressionWithOperators_ResolvesFirstIdentifier()
+	{
+		var result = MemberResolver.Resolve("User.Age > 18", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.DataType, result.Location);
+		Assert.Equal("User", result.RootIdentifier);
+	}
+
+	[Fact]
+	public void Resolve_DotPrefixWithNestedPath_Works()
+	{
+		var result = MemberResolver.Resolve(".User.DisplayName", GetPageType(), GetViewModelType());
+		
+		Assert.Equal(MemberLocation.ForcedDataType, result.Location);
+		Assert.Equal("User.DisplayName", result.Expression);
+		Assert.Equal("User", result.RootIdentifier);
+	}
+}

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGeneratorDriver.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGeneratorDriver.cs
@@ -18,7 +18,7 @@ public static class SourceGeneratorDriver
 {
 	private static MetadataReference[]? MauiReferences;
 
-	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework, string? NoWarn, string LineInfo="enable");
+	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework, string? NoWarn, string LineInfo="enable", bool EnablePreviewFeatures = true);
 	public static GeneratorDriverRunResult RunGenerator<T>(Compilation compilation, AdditionalFile additionalFile, bool assertNoCompilationErrors = true)
 		where T : IIncrementalGenerator, new()
 		=> RunGenerator<T>(compilation, additionalFiles: [additionalFile], assertNoCompilationErrors);
@@ -185,6 +185,7 @@ public static class SourceGeneratorDriver
 					"build_property.EnableMauiXamlDiagnostics" => "true",
 					"build_property.MauiXamlLineInfo" => _additionalFile.LineInfo != "default" ?  _additionalFile.LineInfo : null,
 					"build_property.MauiXamlNoWarn" => _additionalFile.NoWarn,
+					"build_property.EnablePreviewFeatures" => _additionalFile.EnablePreviewFeatures ? "true" : null,
 
 					_ => null
 				};

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CSharpExpressions"
+             Title="{PageTitle}">
+    <ContentPage.Resources>
+        <x:String x:Key="StaticText">Static Resource Value</x:String>
+        <Color x:Key="TestColor">#FF0000</Color>
+    </ContentPage.Resources>
+    <VerticalStackLayout>
+        <!-- Explicit "=" prefix syntax (test this once) -->
+        <Label x:Name="explicitPropertyLabel" Text="{= ExplicitProperty}" />
+        
+        <!-- Implicit expression - method call -->
+        <Label x:Name="methodCallLabel" Text="{GetText()}" />
+        
+        <!-- Implicit expression - operators -->
+        <Label x:Name="additionLabel" Text="{FirstName + ' ' + LastName}" />
+        
+        <!-- Implicit expression - negation -->
+        <Label x:Name="negationLabel" IsVisible="{!IsHidden}" />
+        
+        <!-- Implicit expression - ternary -->
+        <Label x:Name="ternaryLabel" Text="{IsActive ? 'Active' : 'Inactive'}" />
+        
+        <!-- Implicit expression - null-coalescing -->
+        <Label x:Name="nullCoalescingLabel" Text="{NullableValue ?? 'Default'}" />
+        
+        <!-- Implicit expression - comparison -->
+        <Label x:Name="comparisonLabel" IsVisible="{Count == 0}" />
+        
+        <!-- Implicit expression - boolean AND -->
+        <Label x:Name="booleanAndLabel" IsVisible="{IsDataLoaded &amp;&amp; HasProducts}" />
+        
+        <!-- Implicit expression - boolean OR -->
+        <Label x:Name="booleanOrLabel" IsVisible="{IsEmpty || HasError}" />
+        
+        <!-- Char literal (single char) -->
+        <Label x:Name="charLabel" Text="{GetChar('x').ToString()}" />
+        
+        <!-- Escaped single quotes inside string -->
+        <Label x:Name="escapedSingleQuotesLabel" Text="{value ?? 'it\'s working'}" />
+        
+        <!-- Static method call -->
+        <Label x:Name="staticMethodLabel" Text="{string.Format('Count: {0}', Count)}" />
+        
+        <!-- Bare identifier - no markup extension exists, treated as property -->
+        <Label x:Name="bareIdentifierLabel" Text="{BareProperty}" />
+        
+        <!-- DISAMBIGUATION TESTS: Known markup extensions should work normally -->
+        
+        <!-- Binding markup extension -->
+        <Label x:Name="bindingLabel" Text="{Binding BindableText}" />
+        
+        <!-- StaticResource markup extension -->
+        <Label x:Name="staticResourceLabel" Text="{StaticResource StaticText}" />
+        
+        <!-- OnPlatform markup extension (even with operators inside) -->
+        <Label x:Name="onPlatformLabel" Text="{OnPlatform Default=PlatformDefault, iOS=iOS Value}" />
+        
+        <!-- OnIdiom markup extension -->
+        <Label x:Name="onIdiomLabel" Text="{OnIdiom Default=IdiomDefault, Phone=Phone Value}" />
+        
+        <!-- x:Static markup extension -->
+        <Label x:Name="xStaticLabel" Text="{x:Static Member=x:String.Empty}" />
+        
+        <!-- Nested: Expression inside property that also has Binding -->
+        <Label x:Name="mixedMarkupLabel" 
+               Text="{Binding MixedText}"
+               IsVisible="{IsVisibleProp}" />
+        
+        <!-- LAMBDA EVENT TESTS -->
+        
+        <!-- Lambda event - inline statement -->
+        <Button x:Name="inlineLambdaButton" Text="Inline" Clicked="{(s, e) => ClickCount++}" />
+        
+        <!-- Lambda event - method call -->
+        <Button x:Name="methodLambdaButton" Text="Method" Clicked="{(s, e) => OnButtonClicked()}" />
+        
+        <!-- Lambda event - with sender -->
+        <Button x:Name="senderLambdaButton" Text="Sender" Clicked="{(sender, e) => OnButtonClickedWithSender(sender)}" />
+        
+        <!-- Lambda event - explicit "=" syntax (test this once) -->
+        <Button x:Name="explicitLambdaButton" Text="Explicit" Clicked="{= (s, e) => ClickCount++}" />
+        
+        <!-- Lambda event - TextChanged (different signature) -->
+        <Entry x:Name="lambdaEntry" Text="Test" TextChanged="{(s, e) => OnTextChanged(e.NewTextValue)}" />
+        
+        <!-- STRING INTERPOLATION TESTS -->
+        
+        <!-- Basic string interpolation -->
+        <Label x:Name="interpolationLabel" Text="{$'Hello {FirstName}'}" />
+        
+        <!-- String interpolation with expression -->
+        <Label x:Name="interpolationExprLabel" Text="{$'{FirstName} {LastName}'}" />
+        
+        <!-- String interpolation with method call -->
+        <Label x:Name="interpolationMethodLabel" Text="{$'Result: {GetText()}'}" />
+        
+        <!-- TYPED BINDING TESTS (using separate x:DataType) -->
+        <VerticalStackLayout x:DataType="local:SimpleViewModel">
+            <!-- Simple binding expression: property only on x:DataType -->
+            <Label x:Name="vmLabel" Text="{Name}" />
+            
+            <!-- Explicit binding with dot prefix -->
+            <Label x:Name="dotPrefixLabel" Text="{.Name}" />
+            
+            <!-- Explicit binding with BindingContext prefix -->
+            <Label x:Name="bcPrefixLabel" Text="{BindingContext.Name}" />
+            
+            <!-- Explicit local with this prefix (test this once) -->
+            <Label x:Name="thisPrefixLabel" Text="{this.LocalProperty}" />
+            
+            <!-- Nested property binding -->
+            <Label x:Name="nestedLabel" Text="{User.DisplayName}" />
+            
+            <!-- Method call on BindingContext with explicit dot prefix -->
+            <Label x:Name="vmMethodLabel" Text="{.GetDisplayName()}" />
+            
+            <!-- Method call on BindingContext without prefix (should auto-resolve) -->
+            <Label x:Name="vmMethodBareLabel" Text="{GetDisplayName()}" />
+            
+            <!-- Mixed local+binding: Price from VM, TaxRate from this (auto-detected) -->
+            <Label x:Name="mixedExprLabel" Text="{(Price * TaxRate).ToString('F2')}" />
+            
+            <!-- Mixed for capture test: binding + local method -->
+            <Label x:Name="captureTestLabel" Text="{$'{Price} x {GetMultiplier()}'}" />
+            
+            <!-- Same method with different args in mixed expression: each invocation captured separately -->
+            <Label x:Name="multiMethodArgsLabel" Text="{$'{Price}: {GetFormattedValue(1)} and {GetFormattedValue(2)}'}" />
+            
+            <!-- Duplicate capture: two bindings using same local member with explicit this. prefix -->
+            <Label x:Name="mixedExprLabel2" Text="{(Quantity * this.TaxRate).ToString('F2')}" />
+            <Label x:Name="mixedExprLabel3" Text="{(Price * this.TaxRate).ToString('F2')}" />
+            
+            <!-- Multi-root: two properties from VM -->
+            <Label x:Name="multiRootLabel" Text="{(Price * Quantity).ToString()}" />
+            
+            <!-- String interpolation with binding -->
+            <Label x:Name="vmInterpolationLabel" Text="{$'Hello {Name}!'}" />
+            
+            <!-- String interpolation with multiple bindings and format -->
+            <Label x:Name="vmInterpolationMultiLabel" Text="{$'{Quantity}x at {Price:C2}'}" />
+        </VerticalStackLayout>
+        
+        <!-- CDATA EXPRESSION TESTS -->
+        <!-- CDATA allows natural C# syntax without XML escaping -->
+        
+        <!-- CDATA - boolean AND with natural && syntax -->
+        <Label x:Name="cdataBooleanAndLabel">
+            <Label.IsVisible><![CDATA[{IsDataLoaded && HasProducts}]]></Label.IsVisible>
+        </Label>
+        
+        <!-- CDATA - comparison with natural < > syntax -->
+        <Label x:Name="cdataComparisonLabel">
+            <Label.IsVisible><![CDATA[{Count > 0 && Count < 100}]]></Label.IsVisible>
+        </Label>
+        
+        <!-- CDATA - string with double quotes (no single-quote transformation) -->
+        <Label x:Name="cdataDoubleQuotesLabel">
+            <Label.Text><![CDATA[{value ?? "Default Text"}]]></Label.Text>
+        </Label>
+        
+        <!-- CDATA - string interpolation with double quotes -->
+        <Label x:Name="cdataInterpolationLabel">
+            <Label.Text><![CDATA[{$"Hello {FirstName}!"}]]></Label.Text>
+        </Label>
+        
+        <!-- Test nested this. - method that takes another this. value -->
+        <Label x:Name="nestedThisLabel" Text="{this.CalculateWithRate(this.TaxRate).ToString()}" />
+        
+        <!-- CODE REVIEW EDGE CASE TESTS -->
+        
+        <!-- Test: Escaped double quotes inside single-quoted string -->
+        <Label x:Name="escapedDoubleQuotesLabel" Text="{value ?? 'he said \&quot;hi\&quot;'}" />
+        
+        <!-- Test: Escaped newline char literal -->
+        <Label x:Name="escapedNewlineLabel" Text="{GetChar('\n').ToString()}" />
+        
+        <!-- Test: Escaped tab char literal -->
+        <Label x:Name="escapedTabLabel" Text="{GetChar('\t').ToString()}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
@@ -1,0 +1,767 @@
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+// ViewModel classes for TypedBinding tests
+public class UserInfo : INotifyPropertyChanged
+{
+	private string _displayName = "John Doe";
+	public string DisplayName
+	{
+		get => _displayName;
+		set { _displayName = value; OnPropertyChanged(); }
+	}
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+	protected void OnPropertyChanged([CallerMemberName] string? name = null)
+		=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+public class SimpleViewModel : INotifyPropertyChanged
+{
+	private string _name = "From ViewModel";
+	public string Name
+	{
+		get => _name;
+		set { _name = value; OnPropertyChanged(); }
+	}
+
+	private UserInfo _user = new UserInfo();
+	public UserInfo User
+	{
+		get => _user;
+		set { _user = value; OnPropertyChanged(); }
+	}
+
+	private decimal _price = 100m;
+	public decimal Price
+	{
+		get => _price;
+		set { _price = value; OnPropertyChanged(); }
+	}
+
+	private int _quantity = 2;
+	public int Quantity
+	{
+		get => _quantity;
+		set { _quantity = value; OnPropertyChanged(); }
+	}
+
+	public string GetDisplayName() => $"Display: {Name}";
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+	protected void OnPropertyChanged([CallerMemberName] string? name = null)
+		=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+public partial class CSharpExpressions : ContentPage
+{
+	// Properties for expression testing
+	public string PageTitle => "Test Page";
+	public string ExplicitProperty => "Explicit Value";
+	public string FirstName => "John";
+	public string LastName => "Doe";
+	public bool IsHidden => false;
+	public bool IsActive => true;
+	public string? NullableValue => null;
+	public int Count => 0;
+	public string? value => null;
+	public string BareProperty => "Bare Value";
+	public new bool IsVisible => true;
+	public bool IsVisibleProp => true;
+	public bool IsDataLoaded => true;
+	public bool HasProducts => true;
+	public bool IsEmpty => false;
+	public bool HasError => false;
+
+	// Properties for TypedBinding tests
+	public string LocalProperty => "From Local";
+	public decimal TaxRate => 0.1m;  // 10% tax rate
+
+	// Nested this. test - method that takes a local value
+	public decimal CalculateWithRate(decimal rate) => 100m * rate;
+
+	// Bindable properties for Binding tests
+	public string BindableText { get; set; } = "Bindable Value";
+	public string MixedText { get; set; } = "Mixed Value";
+
+	// Lambda event properties
+	public int ClickCount { get; set; }
+	public bool ButtonClicked { get; private set; }
+	public object? LastSender { get; private set; }
+	public string? LastNewText { get; private set; }
+
+	// Local method call tracking
+	public int GetTextCallCount { get; private set; }
+	public string GetText()
+	{
+		GetTextCallCount++;
+		return "Method Result";
+	}
+	public char GetChar(char c) => c;
+
+	// Capture test method - only used by captureTestLabel
+	public int GetMultiplierCallCount { get; private set; }
+	public decimal GetMultiplier()
+	{
+		GetMultiplierCallCount++;
+		return 1.5m;
+	}
+
+	// Multi-arg capture test - same method called with different args
+	public string GetFormattedValue(int value) => $"Value{value}";
+
+	// Lambda event handlers
+	public void OnButtonClicked() => ButtonClicked = true;
+	public void OnButtonClickedWithSender(object? sender) => LastSender = sender;
+	public void OnTextChanged(string? newValue) => LastNewText = newValue;
+
+	public CSharpExpressions() => InitializeComponent();
+
+	[Collection("Xaml Inflation")]
+	public class Tests
+	{
+		[Fact]
+		public void ExplicitPropertyExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Explicit Value", page.explicitPropertyLabel.Text);
+		}
+
+		[Fact]
+		public void MethodCallExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Method Result", page.methodCallLabel.Text);
+		}
+
+		[Fact]
+		public void LocalMethodCalledOnceAtInit()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 100m };
+				page.BindingContext = vm;
+				
+				// Method should have been called exactly once during initialization
+				Assert.Equal(1, page.GetMultiplierCallCount);
+				
+				// Verify initial value contains "100" and "1" and "5"
+				Assert.StartsWith("100 x 1", page.captureTestLabel.Text, StringComparison.Ordinal);
+				
+				// Change the binding source - binding updates but local method NOT called again
+				vm.Price = 200m;
+				Assert.StartsWith("200 x 1", page.captureTestLabel.Text, StringComparison.Ordinal);
+				Assert.Equal(1, page.GetMultiplierCallCount); // Still 1!
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void SameMethodDifferentArgs_EachCapturedSeparately()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 99m };
+				page.BindingContext = vm;
+				
+				// GetFormattedValue(1) and GetFormattedValue(2) should both be captured
+				Assert.Equal("99: Value1 and Value2", page.multiMethodArgsLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void StringConcatenationExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("John Doe", page.additionLabel.Text);
+		}
+
+		[Fact]
+		public void NegationExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.True(page.negationLabel.IsVisible);
+		}
+
+		[Fact]
+		public void TernaryExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Active", page.ternaryLabel.Text);
+		}
+
+		[Fact]
+		public void NullCoalescingExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Default", page.nullCoalescingLabel.Text);
+		}
+
+		[Fact]
+		public void ComparisonExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.True(page.comparisonLabel.IsVisible);
+		}
+
+		[Fact]
+		public void BooleanAndExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// IsDataLoaded (true) && HasProducts (true) = true
+			Assert.True(page.booleanAndLabel.IsVisible);
+		}
+
+		[Fact]
+		public void BooleanOrExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// IsEmpty (false) || HasError (false) = false
+			Assert.False(page.booleanOrLabel.IsVisible);
+		}
+
+		[Fact]
+		public void CharLiteralExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("x", page.charLabel.Text);
+		}
+
+		[Fact]
+		public void EscapedSingleQuotesExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("it's working", page.escapedSingleQuotesLabel.Text);
+		}
+
+		[Fact]
+		public void StaticMethodCallExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Count: 0", page.staticMethodLabel.Text);
+		}
+
+		[Fact]
+		public void TitlePropertyExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Test Page", page.Title);
+		}
+
+		[Fact]
+		public void BareIdentifierExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Bare Value", page.bareIdentifierLabel.Text);
+		}
+
+		// DISAMBIGUATION TESTS
+
+		[Fact]
+		public void BindingMarkupExtension_NotTreatedAsExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// Binding should work - the text shouldn't be the literal markup string
+			// If it was treated as expression, it would fail to compile or have wrong value
+			Assert.NotEqual("{Binding BindableText}", page.bindingLabel.Text);
+		}
+
+		[Fact]
+		public void StaticResourceMarkupExtension_NotTreatedAsExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Static Resource Value", page.staticResourceLabel.Text);
+		}
+
+		[Fact]
+		public void OnPlatformMarkupExtension_NotTreatedAsExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// OnPlatform should resolve to a value, not be treated as expression
+			Assert.NotNull(page.onPlatformLabel.Text);
+			Assert.NotEqual("{OnPlatform Default=PlatformDefault, iOS=iOS Value}", page.onPlatformLabel.Text);
+		}
+
+		[Fact]
+		public void OnIdiomMarkupExtension_NotTreatedAsExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// OnIdiom should resolve to a value
+			Assert.NotNull(page.onIdiomLabel.Text);
+			Assert.NotEqual("{OnIdiom Default=IdiomDefault, Phone=Phone Value}", page.onIdiomLabel.Text);
+		}
+
+		[Fact]
+		public void XStaticMarkupExtension_NotTreatedAsExpression()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// x:Static should resolve to String.Empty
+			Assert.Equal(string.Empty, page.xStaticLabel.Text);
+		}
+
+		[Fact]
+		public void MixedBindingAndExpression_BothWork()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// Expression should work for IsVisible
+			Assert.True(page.mixedMarkupLabel.IsVisible);
+			// Binding should set text - not the literal markup
+			Assert.NotEqual("{Binding MixedText}", page.mixedMarkupLabel.Text);
+		}
+
+		// LAMBDA EVENT TESTS
+
+		[Fact]
+		public void InlineLambdaEvent()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal(0, page.ClickCount);
+			page.inlineLambdaButton.SendClicked();
+			Assert.Equal(1, page.ClickCount);
+		}
+
+		[Fact]
+		public void MethodLambdaEvent()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.False(page.ButtonClicked);
+			page.methodLambdaButton.SendClicked();
+			Assert.True(page.ButtonClicked);
+		}
+
+		[Fact]
+		public void SenderLambdaEvent()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Null(page.LastSender);
+			page.senderLambdaButton.SendClicked();
+			Assert.Same(page.senderLambdaButton, page.LastSender);
+		}
+
+		[Fact]
+		public void ExplicitLambdaEvent()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal(0, page.ClickCount);
+			page.explicitLambdaButton.SendClicked();
+			Assert.Equal(1, page.ClickCount);
+		}
+
+		[Fact]
+		public void TextChangedLambdaEvent()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Null(page.LastNewText);
+			page.lambdaEntry.Text = "New Value";
+			Assert.Equal("New Value", page.LastNewText);
+		}
+
+		// STRING INTERPOLATION TESTS
+
+		[Fact]
+		public void BasicStringInterpolation()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Hello John", page.interpolationLabel.Text);
+		}
+
+		[Fact]
+		public void StringInterpolationWithMultipleExpressions()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("John Doe", page.interpolationExprLabel.Text);
+		}
+
+		[Fact]
+		public void StringInterpolationWithMethodCall()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Result: Method Result", page.interpolationMethodLabel.Text);
+		}
+
+		// TYPED BINDING TESTS
+
+		[Fact]
+		public void TypedBinding_SimpleProperty()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			page.BindingContext = new SimpleViewModel();
+			Assert.Equal("From ViewModel", page.vmLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_DotPrefix()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			page.BindingContext = new SimpleViewModel();
+			Assert.Equal("From ViewModel", page.dotPrefixLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_BindingContextPrefix()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			page.BindingContext = new SimpleViewModel();
+			Assert.Equal("From ViewModel", page.bcPrefixLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_ThisPrefix()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// this.LocalProperty should NOT be a binding, just a SetValue at init time
+			Assert.Equal("From Local", page.thisPrefixLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_NestedProperty()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			page.BindingContext = new SimpleViewModel();
+			Assert.Equal("John Doe", page.nestedLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_INPC_Updates()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel();
+				page.BindingContext = vm;
+				
+				Assert.Equal("From ViewModel", page.vmLabel.Text);
+				
+				// Change the property - binding should update
+				vm.Name = "Updated Name";
+				Assert.Equal("Updated Name", page.vmLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_NestedProperty_INPC()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel();
+				page.BindingContext = vm;
+				
+				Assert.Equal("John Doe", page.nestedLabel.Text);
+				
+				// Change the nested property - binding should update
+				vm.User.DisplayName = "Jane Smith";
+				Assert.Equal("Jane Smith", page.nestedLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_NestedProperty_ParentChange()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel();
+				page.BindingContext = vm;
+				
+				Assert.Equal("John Doe", page.nestedLabel.Text);
+				
+				// Change the parent property - binding should update
+				vm.User = new UserInfo { DisplayName = "New User" };
+				Assert.Equal("New User", page.nestedLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_MethodCall()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel();
+			page.BindingContext = vm;
+			
+			Assert.Equal("Display: From ViewModel", page.vmMethodLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_BareMethodCall()
+		{
+			// Test that {GetDisplayName()} without prefix resolves to DataType method
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel();
+			page.BindingContext = vm;
+			
+			Assert.Equal("Display: From ViewModel", page.vmMethodBareLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_MixedLocalAndBinding()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel { Price = 100m };
+			page.BindingContext = vm;
+			
+			// Price (100) * TaxRate (0.1) = 10.00 (culture-dependent decimal separator)
+			Assert.StartsWith("10", page.mixedExprLabel.Text, StringComparison.Ordinal);
+			Assert.Equal(5, page.mixedExprLabel.Text!.Length); // "10.00" or "10,00"
+		}
+
+		[Fact]
+		public void TypedBinding_DuplicateCapture()
+		{
+			// Tests that two bindings using same local member (this.TaxRate) don't cause CS0128
+			// The scoped block wrapping ensures each capture is in its own scope
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel { Price = 100m, Quantity = 5 };
+			page.BindingContext = vm;
+			
+			// First binding with explicit this.TaxRate: Quantity (5) * TaxRate (0.1) = 0.50
+			Assert.StartsWith("0", page.mixedExprLabel2.Text, StringComparison.Ordinal);
+			
+			// Second binding with explicit this.TaxRate: Price (100) * TaxRate (0.1) = 10.00
+			Assert.StartsWith("10", page.mixedExprLabel3.Text, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public void TypedBinding_MixedLocalAndBinding_INPC()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 100m };
+				page.BindingContext = vm;
+				
+				Assert.StartsWith("10", page.mixedExprLabel.Text, StringComparison.Ordinal);
+				
+				// Change Price - binding should update (TaxRate was captured at init)
+				vm.Price = 200m;
+				Assert.StartsWith("20", page.mixedExprLabel.Text, StringComparison.Ordinal);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_MultiRoot()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel { Price = 50m, Quantity = 3 };
+			page.BindingContext = vm;
+			
+			// Price (50) * Quantity (3) = 150
+			Assert.Equal("150", page.multiRootLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_MultiRoot_INPC_FirstProperty()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 50m, Quantity = 3 };
+				page.BindingContext = vm;
+				
+				Assert.Equal("150", page.multiRootLabel.Text);
+				
+				// Change Price - binding should update
+				vm.Price = 100m;
+				Assert.Equal("300", page.multiRootLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_MultiRoot_INPC_SecondProperty()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 50m, Quantity = 3 };
+				page.BindingContext = vm;
+				
+				Assert.Equal("150", page.multiRootLabel.Text);
+				
+				// Change Quantity - binding should update
+				vm.Quantity = 4;
+				Assert.Equal("200", page.multiRootLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_StringInterpolation()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel { Name = "World" };
+			page.BindingContext = vm;
+			
+			Assert.Equal("Hello World!", page.vmInterpolationLabel.Text);
+		}
+
+		[Fact]
+		public void TypedBinding_StringInterpolation_INPC()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Name = "World" };
+				page.BindingContext = vm;
+				
+				Assert.Equal("Hello World!", page.vmInterpolationLabel.Text);
+				
+				// Change Name - binding should update
+				vm.Name = "MAUI";
+				Assert.Equal("Hello MAUI!", page.vmInterpolationLabel.Text);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TypedBinding_StringInterpolation_Multiple()
+		{
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			var vm = new SimpleViewModel { Price = 9.99m, Quantity = 5 };
+			page.BindingContext = vm;
+			
+			// Format is culture-dependent, just check structure
+			Assert.StartsWith("5x at", page.vmInterpolationMultiLabel.Text, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public void TypedBinding_StringInterpolation_Multiple_INPC()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 9.99m, Quantity = 5 };
+				page.BindingContext = vm;
+				
+				Assert.StartsWith("5x at", page.vmInterpolationMultiLabel.Text, StringComparison.Ordinal);
+				
+				// Change Quantity - should update
+				vm.Quantity = 10;
+				Assert.StartsWith("10x at", page.vmInterpolationMultiLabel.Text, StringComparison.Ordinal);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		// CDATA EXPRESSION TESTS
+
+		[Fact]
+		public void CdataBooleanAndExpression()
+		{
+			// Tests CDATA with natural && syntax (no XML escaping required)
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.True(page.cdataBooleanAndLabel.IsVisible); // IsDataLoaded && HasProducts = true && true
+		}
+
+		[Fact]
+		public void CdataComparisonExpression()
+		{
+			// Tests CDATA with natural < > syntax (no XML escaping required)
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.False(page.cdataComparisonLabel.IsVisible); // Count (0) > 0 && Count < 100 = false
+		}
+
+		[Fact]
+		public void CdataDoubleQuotesExpression()
+		{
+			// Tests CDATA with natural double quotes (no single-quote transformation)
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Default Text", page.cdataDoubleQuotesLabel.Text); // value ?? "Default Text"
+		}
+
+		[Fact]
+		public void CdataStringInterpolationExpression()
+		{
+			// Tests CDATA with string interpolation using double quotes
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("Hello John!", page.cdataInterpolationLabel.Text); // $"Hello {FirstName}!"
+		}
+
+		[Fact]
+		public void NestedThisExpressions()
+		{
+			// Tests that nested this. expressions work: this.Method(this.Property)
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			// CalculateWithRate(TaxRate) = 100 * 0.1 = 10
+			Assert.StartsWith("10", page.nestedThisLabel.Text, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public void EscapedDoubleQuotesInSingleQuotedString()
+		{
+			// Tests that \" inside single quotes becomes " in the output (not \\")
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("he said \"hi\"", page.escapedDoubleQuotesLabel.Text);
+		}
+
+		[Fact]
+		public void EscapedCharLiterals_Newline()
+		{
+			// Tests that '\n' stays as char literal, not converted to string
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("\n", page.escapedNewlineLabel.Text);
+		}
+
+		[Fact]
+		public void EscapedCharLiterals_Tab()
+		{
+			// Tests that '\t' stays as char literal, not converted to string
+			var page = new CSharpExpressions(XamlInflator.SourceGen);
+			Assert.Equal("\t", page.escapedTabLabel.Text);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/NullConditionalSettable.sgen.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/NullConditionalSettable.sgen.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.NullConditionalSettable"
+			 x:DataType="local:NullConditionalViewModel">
+	<!-- Test: Null-conditional access (?.) in a two-way binding expression -->
+	<Entry x:Name="testEntry" Text="{.User?.Name}" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/NullConditionalSettable.sgen.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/NullConditionalSettable.sgen.xaml.cs
@@ -39,18 +39,18 @@ public partial class NullConditionalSettable : ContentPage
 	[Collection("Issue")]
 	public class Tests
 	{
-		[Theory]
-		[XamlInflatorData]
-		internal void NullConditionalAccessIsSettable(XamlInflator inflator)
+		[Fact]
+		internal void NullConditionalAccessIsSettable()
 		{
 			// This test verifies that null-conditional access (?.) works in two-way bindings.
 			// In C# 14+ (default for .NET 10+), expressions like "user?.Name = value" are valid.
+			// C# Expressions only work with SourceGen, not Runtime or XamlC.
 			var viewModel = new NullConditionalViewModel
 			{
 				User = new NullConditionalUser { Name = "Initial" }
 			};
 
-			var page = new NullConditionalSettable(inflator);
+			var page = new NullConditionalSettable(XamlInflator.SourceGen);
 			page.BindingContext = viewModel;
 
 			Assert.NotNull(page);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/NullConditionalSettable.sgen.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/NullConditionalSettable.sgen.xaml.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+using System.ComponentModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class NullConditionalUser
+{
+	public string Name { get; set; } = "Test";
+}
+
+public class NullConditionalViewModel : INotifyPropertyChanged
+{
+	// Use non-null User for simpler test - the null-conditional still applies
+	// but the actual object will be non-null in our test
+	private NullConditionalUser _user = new();
+
+	public NullConditionalUser User
+	{
+		get => _user;
+		set
+		{
+			_user = value;
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(User)));
+		}
+	}
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+public partial class NullConditionalSettable : ContentPage
+{
+	public NullConditionalSettable() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void NullConditionalAccessIsSettable(XamlInflator inflator)
+		{
+			// This test verifies that null-conditional access (?.) works in two-way bindings.
+			// In C# 14+ (default for .NET 10+), expressions like "user?.Name = value" are valid.
+			var viewModel = new NullConditionalViewModel
+			{
+				User = new NullConditionalUser { Name = "Initial" }
+			};
+
+			var page = new NullConditionalSettable(inflator);
+			page.BindingContext = viewModel;
+
+			Assert.NotNull(page);
+			Assert.NotNull(page.testEntry);
+
+			// Verify the getter works (reads from User?.Name)
+			Assert.Equal("Initial", page.testEntry.Text);
+
+			// Verify the setter works (writes to User?.Name)
+			page.testEntry.Text = "Updated";
+			Assert.Equal("Updated", viewModel.User.Name);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/MockSourceGenerator.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MockSourceGenerator.cs
@@ -33,9 +33,9 @@ public static class MockSourceGenerator
 	public static Compilation WithAdditionalSource(this Compilation compilation, string sourceCode, string hintName = "File.Xaml.cs") =>
 		compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(sourceCode, path: hintName));
 
-	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework);
-	public record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null)
-		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework);
+	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework, bool EnablePreviewFeatures = true);
+	public record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, bool EnablePreviewFeatures = true)
+		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, EnablePreviewFeatures: EnablePreviewFeatures);
 
 	public static AdditionalText ToAdditionalText(string path, string text) => CustomAdditionalText.From(path, text);
 
@@ -218,6 +218,7 @@ public static class MockSourceGenerator
 					"build_metadata.additionalfiles.RelativePath" => _additionalFile.RelativePath,
 					"build_metadata.additionalfiles.Inflator" => "SourceGen",
 					"build_property.targetFramework" => _additionalFile.TargetFramework,
+					"build_property.EnablePreviewFeatures" => _additionalFile.EnablePreviewFeatures ? "true" : null,
 					_ => null
 				};
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

# XAML C# Expressions

Write C# expressions directly in XAML — no more converters, no more boilerplate.

## ⚠️ Experimental Feature

This is an **experimental preview feature** for .NET 11. The API and syntax may change before release.

### How to Enable

Add to your project file:

```xml
<PropertyGroup>
    <EnablePreviewFeatures>true</EnablePreviewFeatures>
</PropertyGroup>
```

Without this flag, using C# expression syntax results in error **MAUIX2012**.

### Requirements

- SourceGen mode (default in .NET 11)
- `x:DataType` attribute on your page/view

## Example

```xml
<ContentPage x:DataType="local:ProductViewModel">
    
    <!-- Simple binding -->
    <Label Text="{ProductName}" />
    
    <!-- String interpolation -->
    <Label Text="{$'{Quantity}x {ProductName}'}" />
    
    <!-- Calculations -->
    <Label Text="{$'Total: ${Price * Quantity:F2}'}" />
    
    <!-- Boolean negation (no converter needed!) -->
    <Label IsVisible="{!IsLoading}" />
    
    <!-- Boolean expressions (no MultiBinding needed!) -->
    <Button Text="Submit" 
            IsEnabled="{HasAccount &amp;&amp; AgreedToTerms}" />
    
    <!-- Inline event handlers (no code-behind needed!) -->
    <Button Text="{$'Clicked {ClickCount} times'}" 
            Clicked="{(s, e) => ClickCount++}" />
    
    <!-- Ternary expressions -->
    <Label Text="{IsVip ? 'Gold Member' : 'Standard'}" />
    
</ContentPage>
```

## Syntax Highlights

Some of the supported expressions (see [full spec](https://github.com/dotnet/maui/blob/dev/stdelc/xaml%2Bcode-clean/docs/specs/XamlCSharpExpressions.md) for complete reference):

| Feature | Syntax | Example |
|---------|--------|---------|
| Property binding | `{Property}` | `{Username}` |
| Nested property | `{A.B}` | `{User.DisplayName}` |
| String interpolation | `{$'..{x}..'}` | `{$'Hello {Name}!'}` |
| Boolean negation | `{!Bool}` | `{!IsHidden}` |
| Boolean AND/OR | `{A && B}` | `{IsLoaded &amp;&amp; HasData}` |
| Arithmetic | `{A * B}` | `{Price * Quantity}` |
| Ternary | `{c ? a : b}` | `{IsVip ? 'Gold' : 'Standard'}` |
| Null-coalesce | `{a ?? b}` | `{Title ?? 'Untitled'}` |
| Lambda events | `{(s, e) => ...}` | `{(s, e) => Count++}` |
| Local method | `{Method()}` | `{GetDisplayText()}` |
| Static member | `{Type.Member}` | `{DateTime.Now}` |

## What's NOT Supported

- Async lambdas (`{async (s, e) => ...}`) — use regular methods
- Parameterless lambdas (`{() => ...}`) — must include `(s, e)`
- XamlC or Runtime inflation — SourceGen only

## Resources

- **Sample App**: [MauiXamlCsharpSample](https://github.com/jfversluis/MauiXamlCsharpSample) by Gerald Versluis
- **Full Spec**: [docs/specs/XamlCSharpExpressions.md](https://github.com/dotnet/maui/blob/dev/stdelc/xaml%2Bcode-clean/docs/specs/XamlCSharpExpressions.md)