### PR TITLE
Hide obsolete FontSize values from IDE autocomplete

### DIFF
--- a/src/Controls/src/Core.Design/FontSizeDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/FontSizeDesignTypeConverter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Design
 		// Standard values have been marked obsolete since .NET 9, so we don’t return them
 		// to prevent the IDE’s auto-complete from suggesting them. 
 		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-			=> new StandardValuesCollection(Array.Empty<string> ());
+			=> new StandardValuesCollection(Array.Empty<string>());
 
 		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)

--- a/src/Controls/src/Core.Design/FontSizeDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/FontSizeDesignTypeConverter.cs
@@ -20,6 +20,16 @@ namespace Microsoft.Maui.Controls.Design
 			=> new[] { "Default", "Micro", "Small", "Medium", "Large", "Body", "Header", "Title", "Subtitle", "Caption" };
 
 		/// <inheritdoc/>
+		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+			=> false;
+
+		/// <inheritdoc/>
+		// Standard values have been marked obsolete since .NET 9, so we don’t return them
+		// to prevent the IDE’s auto-complete from suggesting them. 
+		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+			=> new StandardValuesCollection(Array.Empty<string> ());
+
+		/// <inheritdoc/>
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			if (KnownValues.Any(v => value?.ToString()?.Equals(v, StringComparison.Ordinal) ?? false))

--- a/src/Controls/tests/Core.Design.UnitTests/Controls.Core.Design.UnitTests.csproj
+++ b/src/Controls/tests/Core.Design.UnitTests/Controls.Core.Design.UnitTests.csproj
@@ -19,6 +19,7 @@
     <Compile Include="ConstraintDesignTypeConverterTests.cs" />
     <Compile Include="CornerRadiusDesignTypeConverterTests.cs" />
     <Compile Include="DesignTypeConverterTests.cs" />
+    <Compile Include="FontSizeDesignTypeConverterTests.cs" />
     <Compile Include="GridLengthCollectionDesignTypeConverterTests.cs" />
     <Compile Include="GridLengthDesignTypeConverterTests.cs" />
     <Compile Include="ImageSourceDesignTypeConverterTests.cs" />

--- a/src/Controls/tests/Core.Design.UnitTests/FontSizeDesignTypeConverterTests.cs
+++ b/src/Controls/tests/Core.Design.UnitTests/FontSizeDesignTypeConverterTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Maui.Controls.Design;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class FontSizeDesignTypeConverterTests
+	{
+		[Fact]
+		public void FontSizeDesignTypeConverter_StandardValuesNotSupported()
+		{
+			FontSizeDesignTypeConverter converter = new FontSizeDesignTypeConverter();
+			Assert.True(converter.CanConvertFrom(typeof(string)));
+
+			// Standard values should not be supported to prevent IDE autocomplete
+			// from suggesting obsolete named font size values
+			bool actual = converter.GetStandardValuesSupported();
+			Assert.False(actual);
+		}
+
+		[Fact]
+		public void FontSizeDesignTypeConverter_StandardValuesEmpty()
+		{
+			FontSizeDesignTypeConverter converter = new FontSizeDesignTypeConverter();
+
+			// GetStandardValues should return an empty collection
+			var values = converter.GetStandardValues();
+			Assert.Empty(values);
+		}
+
+		[Theory]
+		[InlineData("Default")]
+		[InlineData("Micro")]
+		[InlineData("Small")]
+		[InlineData("Medium")]
+		[InlineData("Large")]
+		[InlineData("Body")]
+		[InlineData("Header")]
+		[InlineData("Title")]
+		[InlineData("Subtitle")]
+		[InlineData("Caption")]
+		public void FontSizeDesignTypeConverter_NamedValuesStillValid(string value)
+		{
+			// Named values are obsolete but should still be valid for backward compatibility
+			FontSizeDesignTypeConverter converter = new FontSizeDesignTypeConverter();
+			bool actual = converter.IsValid(value);
+			Assert.True(actual);
+		}
+
+		[Theory]
+		[InlineData("12")]
+		[InlineData("0")]
+		[InlineData("100")]
+		public void FontSizeDesignTypeConverter_NumericValuesValid(string value)
+		{
+			FontSizeDesignTypeConverter converter = new FontSizeDesignTypeConverter();
+			bool actual = converter.IsValid(value);
+			Assert.True(actual);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[InlineData(" ")]
+		[InlineData("foo")]
+		[InlineData("extra large")]
+		[InlineData("12px")]
+		public void FontSizeDesignTypeConverter_InvalidValues(string value)
+		{
+			FontSizeDesignTypeConverter converter = new FontSizeDesignTypeConverter();
+			bool actual = converter.IsValid(value);
+			Assert.False(actual);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change
This PR hides obsolete FontSize named values (like "Large", "Medium", "Small", etc.) from IDE autocomplete suggestions in XAML.

The named font size values have been marked [obsolete](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.namedsize?view=net-maui-9.0) since .NET 9. However, the design-time type converter was still suggesting these values in the IDE's IntelliSense, leading users to use them and then receive "Obsolete" warnings - especially when using XAML source generation (MauiXamlInflator=SourceGen).

The fix overrides `GetStandardValuesSupported()` to return false and `GetStandardValues()` to return an empty collection in `FontSizeDesignTypeConverter`. This prevents the IDE from suggesting the obsolete named font size values while still allowing them to be used (with appropriate obsolete warnings) for backward compatibility.

### Issues Fixed

https://github.com/dotnet/maui/issues/33560

see also: https://github.com/dotnet/maui/issues/33623