### PR TITLE
Fix SourceGen missing diagnostic for keyless ResourceDictionary items

### DIFF
--- a/eng/pipelines/arcade/stage-unit-tests.yml
+++ b/eng/pipelines/arcade/stage-unit-tests.yml
@@ -98,4 +98,4 @@ stages:
           artifact: Logs - Unit Tests ${{ job.testOS }} $(System.JobAttempt)
         condition: always()
 
-      # - template: /eng/pipelines/common/fail-on-issue.yml
+      - template: /eng/pipelines/common/fail-on-issue.yml

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -110,6 +110,10 @@ static class SetPropertyHelpers
 		var nodeType = getNodeValue(node, context.Compilation.ObjectType).Type;
 		if (collectionType.GetAllMethods("Add", context).FirstOrDefault(m => m.Parameters.Length == 1 && m.Parameters[0].Type.Equals(nodeType, SymbolEqualityComparer.Default)) != null)
 			return true;
+
+		// No x:Key and no typed Add() overload - report error
+		var missingKeyLocation = LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)node, "");
+		context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, missingKeyLocation, "Resources in ResourceDictionary require a x:Key attribute"));
 		return false;
 	}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/AB946693.rt.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/AB946693.rt.xaml.cs
@@ -38,6 +38,15 @@ public partial class AB946693 : ContentPage
 	public AB946693() => InitializeComponent();
 }
 """)
+					.WithAdditionalSource(
+"""
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Gh6192Template : ContentView
+{
+	public Gh6192Template() { }
+}
+""", "Gh6192Template.cs")
 					.RunMauiSourceGenerator(typeof(AB946693));
 				Assert.NotEmpty(result.Diagnostics);
 			}


### PR DESCRIPTION
## Description

Fixes the `KeylessResourceThrowsMeaningfulException` test failure for the SourceGen inflator.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=1266477&view=ms.vss-test-web.build-test-results-tab&runId=35340002&resultId=100327&paneView=debug

## Changes

### 1. SourceGen Fix (`SetPropertyHelpers.cs`)

The `CanAddToResourceDictionary` method was silently returning `false` when a resource item in a ResourceDictionary lacked an `x:Key` and there was no typed `Add()` overload. This was inconsistent with:
- **XamlC**: Throws `BuildException` with "Resources in ResourceDictionary require a x:Key attribute"
- **Runtime**: Throws `XamlParseException` with the same message

Now the SourceGen reports a diagnostic with the same error message.

### 2. Test Fix (`AB946693.rt.xaml.cs`)

The test XAML references `local:Gh6192Template`, but this type was not included in the mock compilation. Without it, the SourceGen could not resolve the type and silently skipped the element (no diagnostics).

Added `Gh6192Template` to the mock compilation so the SourceGen properly processes the XAML and triggers the keyless resource validation.

## Testing

All 3 inflator variants now pass:
- ✅ `Runtime` - Throws `XamlParseException`
- ✅ `XamlC` - Throws `BuildException`  
- ✅ `SourceGen` - Reports diagnostic