### PR TITLE
[tests] Fix for device tests internal runs

### DIFF
--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -550,7 +550,11 @@ stages:
           - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/steps/send-to-helix.yml', '/eng/common/templates-official/steps/send-to-helix.yml@self') }}
             parameters:
               HelixProjectPath: ${{ parameters.helixProject }}
-              HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_
+              ${{ if eq(parameters.runAsPublic, true) }}:
+                HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_ /p:HelixInternal=False
+              ${{ else }}:
+                HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_ /p:HelixInternal=True
+              HelixAccessToken: ${{ parameters.HelixAccessToken }}
               HelixConfiguration: $(_BuildConfig)
               IncludeDotNetCli: true
               DisplayNamePrefix: DeviceTestsWindows


### PR DESCRIPTION
### Description of Change

This pull request updates the `stage-device-tests.yml` pipeline to better handle internal and public test runs for device tests on Windows. The main improvement is the conditional setting of the `HelixProjectArguments` and the addition of the `HelixAccessToken` parameter, ensuring that internal and public runs are configured correctly.

Pipeline configuration improvements:

* Updated the `HelixProjectArguments` in the device test stage to set `/p:HelixInternal=False` for public runs and `/p:HelixInternal=True` for internal runs, ensuring correct test environment configuration.
* Added the `HelixAccessToken` parameter to the Helix step, supporting authenticated test runs as needed.