### PR TITLE
[iOS] Fix incorrect FirstVisibleItemIndex reported by CollectionView.Scrolled after programmatic scroll

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (visibleItems)
 			{
-				firstVisibleItemIndex = indexPathsForVisibleItems.First();
+				firstVisibleItemIndex = GetFirstVisibleIndexPath(collectionView) ?? indexPathsForVisibleItems.First();
 				centerItemIndex = GetCenteredIndexPath(collectionView);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
@@ -160,6 +160,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			return index;
+		}
+
+		static NSIndexPath GetFirstVisibleIndexPath(UICollectionView collectionView)
+		{
+			var contentOffset = collectionView.ContentOffset;
+			var contentInset = collectionView.ContentInset;
+
+			// Find the item at the top-left corner of the visible area (with small offset to be inside the cell)
+			var firstPoint = new CGPoint(contentOffset.X + contentInset.Left, contentOffset.Y + contentInset.Top);
+			return collectionView.IndexPathForItemAtPoint(firstPoint);
 		}
 
 		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -124,8 +124,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (visibleItems)
 			{
-				firstVisibleItemIndex = GetFirstVisibleIndexPath(collectionView) ?? indexPathsForVisibleItems.First();
-				centerItemIndex = GetCenteredIndexPath(collectionView);
+				firstVisibleItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: false);
+				centerItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: true);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
 
@@ -162,31 +162,29 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return index;
 		}
 
-		static NSIndexPath GetFirstVisibleIndexPath(UICollectionView collectionView)
+		static NSIndexPath GetIndexPathAtPoint(UICollectionView collectionView, bool isCenterItem)
 		{
-			var contentOffset = collectionView.ContentOffset;
-			var contentInset = collectionView.ContentInset;
-
-			// Find the item at the top-left corner of the visible area (with small offset to be inside the cell)
-			var firstPoint = new CGPoint(contentOffset.X + contentInset.Left, contentOffset.Y + contentInset.Top);
-			return collectionView.IndexPathForItemAtPoint(firstPoint);
-		}
-
-		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)
-		{
-			NSIndexPath centerItemIndex = null;
+			NSIndexPath itemIndex = null;
+			CGPoint point;
 
 			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
 
 			if (indexPathsForVisibleItems.Count == 0)
-				return centerItemIndex;
+				return itemIndex;
 
 			var firstVisibleItemIndex = indexPathsForVisibleItems.First();
+			if (isCenterItem)
+			{
+				point = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
+			}
+			else
+			{
+				point = new CGPoint(collectionView.ContentOffset.X + collectionView.ContentInset.Left, collectionView.ContentOffset.Y + collectionView.ContentInset.Top);
+			}
 
-			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
-			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
-			centerItemIndex = centerIndexPath ?? firstVisibleItemIndex;
-			return centerItemIndex;
+			var indexPath = collectionView.IndexPathForItemAtPoint(point);
+			itemIndex = indexPath ?? firstVisibleItemIndex;
+			return itemIndex;
 		}
 
 		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using CoreGraphics;
 using Foundation;
@@ -124,8 +125,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (visibleItems)
 			{
-				firstVisibleItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: false);
-				centerItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: true);
+				firstVisibleItemIndex = GetFirstVisibleIndexPathUsingLayoutAttributes(collectionView, indexPathsForVisibleItems);
+				centerItemIndex = GetCenteredIndexPath(collectionView);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
 
@@ -162,29 +163,63 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return index;
 		}
 
-		static NSIndexPath GetIndexPathAtPoint(UICollectionView collectionView, bool isCenterItem)
+		static NSIndexPath GetFirstVisibleIndexPathUsingLayoutAttributes(UICollectionView collectionView, IEnumerable<NSIndexPath> indexPathsForVisibleItems)
 		{
-			NSIndexPath itemIndex = null;
-			CGPoint point;
+			if (!indexPathsForVisibleItems.Any())
+				return null;
+
+			var layout = collectionView.CollectionViewLayout;
+			if (layout is null)
+				return indexPathsForVisibleItems.First();
+
+			var visibleRect = new CGRect(collectionView.ContentOffset, collectionView.Bounds.Size);
+			var layoutAttributes = layout.LayoutAttributesForElementsInRect(visibleRect);
+			if (layoutAttributes is null || layoutAttributes.Length == 0)
+				return indexPathsForVisibleItems.First();
+
+			var flowLayout = layout as UICollectionViewFlowLayout;
+			bool isVertical = flowLayout?.ScrollDirection != UICollectionViewScrollDirection.Horizontal;
+			// Find the first visible cell (not headers/footers) based on scroll direction
+			NSIndexPath firstVisibleIndexPath = null;
+			nfloat minPosition = nfloat.MaxValue;
+
+			for (int i = 0; i < layoutAttributes.Length; i++)
+			{
+				var attr = layoutAttributes[i];
+				// Skip non-cell elements (headers, footers, decorations)
+				if (attr.RepresentedElementCategory != UICollectionElementCategory.Cell)
+					continue;
+
+				// Skip items that don't intersect with visible rect
+				if (!attr.Frame.IntersectsWith(visibleRect))
+					continue;
+
+				nfloat position = isVertical ? attr.Frame.Y : attr.Frame.X;
+				if (position < minPosition)
+				{
+					minPosition = position;
+					firstVisibleIndexPath = attr.IndexPath;
+				}
+			}
+
+			return firstVisibleIndexPath ?? indexPathsForVisibleItems.First();
+		}
+
+		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)
+		{
+			NSIndexPath centerItemIndex = null;
 
 			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
 
 			if (indexPathsForVisibleItems.Count == 0)
-				return itemIndex;
+				return centerItemIndex;
 
 			var firstVisibleItemIndex = indexPathsForVisibleItems.First();
-			if (isCenterItem)
-			{
-				point = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
-			}
-			else
-			{
-				point = new CGPoint(collectionView.ContentOffset.X + collectionView.ContentInset.Left, collectionView.ContentOffset.Y + collectionView.ContentInset.Top);
-			}
 
-			var indexPath = collectionView.IndexPathForItemAtPoint(point);
-			itemIndex = indexPath ?? firstVisibleItemIndex;
-			return itemIndex;
+			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
+			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
+			centerItemIndex = centerIndexPath ?? firstVisibleItemIndex;
+			return centerItemIndex;
 		}
 
 		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -125,8 +125,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (visibleItems)
 			{
-				firstVisibleItemIndex = GetFirstVisibleIndexPath(collectionView) ?? indexPathsForVisibleItems.First();
-				centerItemIndex = GetCenteredIndexPath(collectionView);
+				firstVisibleItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: false);
+				centerItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: true);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
 
@@ -163,31 +163,29 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			return index;
 		}
 
-		static NSIndexPath GetFirstVisibleIndexPath(UICollectionView collectionView)
+		static NSIndexPath GetIndexPathAtPoint(UICollectionView collectionView, bool isCenterItem)
 		{
-			var contentOffset = collectionView.ContentOffset;
-			var contentInset = collectionView.ContentInset;
-
-			// Find the item at the top-left corner of the visible area (with small offset to be inside the cell)
-			var firstPoint = new CGPoint(contentOffset.X + contentInset.Left, contentOffset.Y + contentInset.Top);
-			return collectionView.IndexPathForItemAtPoint(firstPoint);
-		}
-
-		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)
-		{
-			NSIndexPath centerItemIndex = null;
+			NSIndexPath itemIndex = null;
+			CGPoint point;
 
 			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
 
 			if (indexPathsForVisibleItems.Count == 0)
-				return centerItemIndex;
+				return itemIndex;
 
 			var firstVisibleItemIndex = indexPathsForVisibleItems.First();
+			if (isCenterItem)
+			{
+				point = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
+			}
+			else
+			{
+				point = new CGPoint(collectionView.ContentOffset.X + collectionView.ContentInset.Left, collectionView.ContentOffset.Y + collectionView.ContentInset.Top);
+			}
 
-			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
-			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
-			centerItemIndex = centerIndexPath ?? firstVisibleItemIndex;
-			return centerItemIndex;
+			var indexPath = collectionView.IndexPathForItemAtPoint(point);
+			itemIndex = indexPath ?? firstVisibleItemIndex;
+			return itemIndex;
 		}
 
 		// public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using CoreGraphics;
 using Foundation;
@@ -125,8 +126,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (visibleItems)
 			{
-				firstVisibleItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: false);
-				centerItemIndex = GetIndexPathAtPoint(collectionView, isCenterItem: true);
+				firstVisibleItemIndex = GetFirstVisibleIndexPathUsingLayoutAttributes(collectionView, indexPathsForVisibleItems);
+				centerItemIndex = GetCenteredIndexPath(collectionView);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
 
@@ -163,29 +164,63 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			return index;
 		}
 
-		static NSIndexPath GetIndexPathAtPoint(UICollectionView collectionView, bool isCenterItem)
+		static NSIndexPath GetFirstVisibleIndexPathUsingLayoutAttributes(UICollectionView collectionView, IEnumerable<NSIndexPath> indexPathsForVisibleItems)
 		{
-			NSIndexPath itemIndex = null;
-			CGPoint point;
+			if (!indexPathsForVisibleItems.Any())
+				return null;
+
+			var layout = collectionView.CollectionViewLayout;
+			if (layout is null)
+				return indexPathsForVisibleItems.First();
+
+			var visibleRect = new CGRect(collectionView.ContentOffset, collectionView.Bounds.Size);
+			var layoutAttributes = layout.LayoutAttributesForElementsInRect(visibleRect);
+			if (layoutAttributes is null || layoutAttributes.Length == 0)
+				return indexPathsForVisibleItems.First();
+
+			var flowLayout = layout as UICollectionViewFlowLayout;
+			bool isVertical = flowLayout?.ScrollDirection != UICollectionViewScrollDirection.Horizontal;
+			// Find the first visible cell (not headers/footers) based on scroll direction
+			NSIndexPath firstVisibleIndexPath = null;
+			nfloat minPosition = nfloat.MaxValue;
+
+			for (int i = 0; i < layoutAttributes.Length; i++)
+			{
+				var attr = layoutAttributes[i];
+				// Skip non-cell elements (headers, footers, decorations)
+				if (attr.RepresentedElementCategory != UICollectionElementCategory.Cell)
+					continue;
+
+				// Skip items that don't intersect with visible rect
+				if (!attr.Frame.IntersectsWith(visibleRect))
+					continue;
+
+				nfloat position = isVertical ? attr.Frame.Y : attr.Frame.X;
+				if (position < minPosition)
+				{
+					minPosition = position;
+					firstVisibleIndexPath = attr.IndexPath;
+				}
+			}
+
+			return firstVisibleIndexPath ?? indexPathsForVisibleItems.First();
+		}
+
+		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)
+		{
+			NSIndexPath centerItemIndex = null;
 
 			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
 
 			if (indexPathsForVisibleItems.Count == 0)
-				return itemIndex;
+				return centerItemIndex;
 
 			var firstVisibleItemIndex = indexPathsForVisibleItems.First();
-			if (isCenterItem)
-			{
-				point = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
-			}
-			else
-			{
-				point = new CGPoint(collectionView.ContentOffset.X + collectionView.ContentInset.Left, collectionView.ContentOffset.Y + collectionView.ContentInset.Top);
-			}
 
-			var indexPath = collectionView.IndexPathForItemAtPoint(point);
-			itemIndex = indexPath ?? firstVisibleItemIndex;
-			return itemIndex;
+			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
+			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
+			centerItemIndex = centerIndexPath ?? firstVisibleItemIndex;
+			return centerItemIndex;
 		}
 
 		// public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (visibleItems)
 			{
-				firstVisibleItemIndex = indexPathsForVisibleItems.First();
+				firstVisibleItemIndex = GetFirstVisibleIndexPath(collectionView) ?? indexPathsForVisibleItems.First();
 				centerItemIndex = GetCenteredIndexPath(collectionView);
 				lastVisibleItemIndex = indexPathsForVisibleItems.Last();
 			}
@@ -161,6 +161,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			}
 
 			return index;
+		}
+
+		static NSIndexPath GetFirstVisibleIndexPath(UICollectionView collectionView)
+		{
+			var contentOffset = collectionView.ContentOffset;
+			var contentInset = collectionView.ContentInset;
+
+			// Find the item at the top-left corner of the visible area (with small offset to be inside the cell)
+			var firstPoint = new CGPoint(contentOffset.X + contentInset.Left, contentOffset.Y + contentInset.Top);
+			return collectionView.IndexPathForItemAtPoint(firstPoint);
 		}
 
 		static NSIndexPath GetCenteredIndexPath(UICollectionView collectionView)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
@@ -1,0 +1,74 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33614, "CollectionView Scrolled event reports incorrect FirstVisibleItemIndex after programmatic ScrollTo", PlatformAffected.iOS)]
+public class Issue33614 : ContentPage
+{
+    public ObservableCollection<string> Items { get; set; }
+    private Label _firstIndexLabel;
+    private CollectionView _collectionView;
+    public Issue33614()
+    {
+        Items = new ObservableCollection<string>();
+        for (int i = 0; i <= 50; i++)
+        {
+            Items.Add($"Item_{i}");
+        }
+
+        _firstIndexLabel = new Label
+        {
+            AutomationId = "FirstIndexLabel",
+            Text = "FirstVisibleItemIndex: 0"
+        };
+
+        var scrollToButton = new Button
+        {
+            AutomationId = "ScrollToButton",
+            Text = "ScrollTo Index 15",
+            WidthRequest = 150
+        };
+        scrollToButton.Clicked += OnScrollToButtonClicked;
+
+        _collectionView = new CollectionView
+        {
+            AutomationId = "TestCollectionView",
+            ItemsSource = Items,
+            HeightRequest = 600,
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var label = new Label();
+                label.SetBinding(Label.TextProperty, ".");
+                return new Border
+                {
+                    Margin = new Thickness(5),
+                    Padding = new Thickness(10),
+                    Stroke = Colors.Gray,
+                    Content = label
+                };
+            })
+        };
+
+        _collectionView.Scrolled += OnCollectionViewScrolled;
+
+        Content = new StackLayout
+        {
+            Children =
+            {
+                _firstIndexLabel,
+                 scrollToButton,
+                _collectionView
+            }
+        };
+    }
+
+    private void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
+    {
+        _firstIndexLabel.Text = $"FirstVisibleItemIndex: {e.FirstVisibleItemIndex}";
+    }
+
+    private void OnScrollToButtonClicked(object sender, EventArgs e)
+    {
+        _collectionView.ScrollTo(15, position: ScrollToPosition.Start, animate: true);
+    }
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
@@ -7,7 +7,7 @@ public class Issue33614 : ContentPage
 {
     public ObservableCollection<string> Items { get; set; }
     private Label _firstIndexLabel;
-    private CollectionView _collectionView;
+    private CollectionView2 _collectionView;
     public Issue33614()
     {
         Items = new ObservableCollection<string>();
@@ -30,7 +30,7 @@ public class Issue33614 : ContentPage
         };
         scrollToButton.Clicked += OnScrollToButtonClicked;
 
-        _collectionView = new CollectionView
+        _collectionView = new CollectionView2
         {
             AutomationId = "TestCollectionView",
             ItemsSource = Items,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 33614, "CollectionView Scrolled event reports incorrect FirstVisibleItemIndex after programmatic ScrollTo", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 33614, "CollectionView Scrolled event reports incorrect FirstVisibleItemIndex after programmatic ScrollTo", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue33614 : ContentPage
 {
     public ObservableCollection<string> Items { get; set; }
@@ -19,7 +19,8 @@ public class Issue33614 : ContentPage
         _firstIndexLabel = new Label
         {
             AutomationId = "FirstIndexLabel",
-            Text = "FirstVisibleItemIndex: 0"
+            Text = "FirstVisibleItemIndex: 0",
+            IsVisible = false,
         };
 
         var scrollToButton = new Button
@@ -65,6 +66,7 @@ public class Issue33614 : ContentPage
     private void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
     {
         _firstIndexLabel.Text = $"FirstVisibleItemIndex: {e.FirstVisibleItemIndex}";
+        _firstIndexLabel.IsVisible = true;
     }
 
     private void OnScrollToButtonClicked(object sender, EventArgs e)

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33614.cs
@@ -2,22 +2,21 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33614 : _IssuesUITest
 {
-    public class Issue33614 : _IssuesUITest
+    public override string Issue => "CollectionView Scrolled event reports incorrect FirstVisibleItemIndex after programmatic ScrollTo";
+
+    public Issue33614(TestDevice device) : base(device) { }
+
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void FirstVisibleItemIndexShouldBeCorrectAfterScrollTo()
     {
-        public override string Issue => "CollectionView Scrolled event reports incorrect FirstVisibleItemIndex after programmatic ScrollTo";
-
-        public Issue33614(TestDevice device) : base(device) { }
-
-        [Test]
-        [Category(UITestCategories.CollectionView)]
-        public void FirstVisibleItemIndexShouldBeCorrectAfterScrollTo()
-        {
-            App.WaitForElement("ScrollToButton");
-            App.Tap("ScrollToButton");
-            var firstIndexText = App.FindElement("FirstIndexLabel").GetText();
-            Assert.That(firstIndexText, Is.EqualTo("FirstVisibleItemIndex: 15"));
-        }
+        App.WaitForElement("ScrollToButton");
+        App.Tap("ScrollToButton");
+        var firstIndexText = App.FindElement("FirstIndexLabel").GetText();
+        Assert.That(firstIndexText, Is.EqualTo("FirstVisibleItemIndex: 15"));
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33614.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+    public class Issue33614 : _IssuesUITest
+    {
+        public override string Issue => "CollectionView Scrolled event reports incorrect FirstVisibleItemIndex after programmatic ScrollTo";
+
+        public Issue33614(TestDevice device) : base(device) { }
+
+        [Test]
+        [Category(UITestCategories.CollectionView)]
+        public void FirstVisibleItemIndexShouldBeCorrectAfterScrollTo()
+        {
+            App.WaitForElement("ScrollToButton");
+            App.Tap("ScrollToButton");
+            var firstIndexText = App.FindElement("FirstIndexLabel").GetText();
+            Assert.That(firstIndexText, Is.EqualTo("FirstVisibleItemIndex: 15"));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
On iOS and MacCatalyst, the CollectionView.Scrolled event reports an incorrect FirstVisibleItemIndex after a programmatic ScrollTo() call. The reported index does not match the actual first visible item displayed on the screen.

### Root Cause
The previous implementation used `IndexPathsForVisibleItems.First()` to determine the first visible item. On iOS/MacCatalyst, that collection can include prefetched cells outside the actual viewport, so the reported first visible index could be earlier than the item shown at the leading edge.

### Description of Change
Updated the iOS CollectionView delegators to compute the first visible item from `LayoutAttributesForElementsInRect(...)` and select the first visible cell that intersects the current viewport. This avoids relying on prefetched cells when raising `Scrolled`.

Applied the fix to both:

[ItemsViewDelegator.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[ItemsViewDelegator2.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #33614

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/484a1141-3cfc-470b-9637-39269679832b" >| <video src="https://github.com/user-attachments/assets/efe17504-4a79-4581-aabb-4443ef779580">|