### PR TITLE
[Android] Fix app crash when reopening after back button press

### DIFF
--- a/src/Controls/src/Core/Application/Application.cs
+++ b/src/Controls/src/Core/Application/Application.cs
@@ -507,13 +507,16 @@ namespace Microsoft.Maui.Controls
 
 		internal void RemoveWindow(Window window)
 		{
-			// Do not attempt to close the "MainPage" window
-			if (_singleWindowMainPage != null && window.Page == _singleWindowMainPage)
-				return;
-
 			// Window was closed, stop tracking it
 			if (window is null)
 				return;
+
+			// If this is the MainPage window being removed (e.g., back button on Android),
+			// clear _singleWindowMainPage to allow fresh window creation on app restart.
+			if (_singleWindowMainPage != null && window.Page == _singleWindowMainPage)
+			{
+				_singleWindowMainPage = null;
+			}
 
 			if (window is NavigableElement ne)
 				ne.NavigationProxy.Inner = null;


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #33597

When user presses the physical back button on Android, the Activity is destroyed but the Application instance survives. Previously, `RemoveWindow()` had an early return that prevented the MainPage window from being removed, leaving `_singleWindowMainPage` set and the window in `_windows` list.

On app restart, `CreateWindow()` would create a new window with a new page, but the validation check would fail because `_singleWindowMainPage` still referenced the old page, throwing:
```
System.InvalidOperationException: 'Both MainPage was set and CreateWindow was overridden to provide a page.'
```

## Root Cause

The `RemoveWindow` method had an early return:
```csharp
if (_singleWindowMainPage != null && window.Page == _singleWindowMainPage)
    return;
```

This prevented the MainPage window from ever being removed from `_windows`, causing stale state when the app restarted.

## The Fix

Remove the early return and instead clear `_singleWindowMainPage` when its window is removed. This allows:
1. Proper window cleanup when back button closes the app
2. Fresh window creation when app restarts

## Testing

Manually verified on Android:
1. Run app
2. Navigate to any page (e.g., CorePageView gallery)
3. Press physical back button to close app
4. Reopen app from launcher
5. ✅ App starts successfully without crash