### PR TITLE
Fix WebView JavaScript string escaping for backslashes and quotes

### DIFF
--- a/src/Controls/tests/Core.UnitTests/WebViewHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WebViewHelperTests.cs
@@ -129,4 +129,31 @@ public class WebViewHelperTests
 		var result = WebViewHelper.EscapeJsString(input);
 		Assert.Equal(input, result);
 	}
+
+	[Fact]
+	public void EscapeJsString_Newlines_EscapesCorrectly()
+	{
+		const string input = "line1\nline2\rline3";
+		const string expected = "line1\\nline2\\rline3";
+		var result = WebViewHelper.EscapeJsString(input);
+		Assert.Equal(expected, result);
+	}
+
+	[Fact]
+	public void EscapeJsString_UnicodeLineSeparators_EscapesCorrectly()
+	{
+		const string input = "line1\u2028line2\u2029line3";
+		const string expected = "line1\\u2028line2\\u2029line3";
+		var result = WebViewHelper.EscapeJsString(input);
+		Assert.Equal(expected, result);
+	}
+
+	[Fact]
+	public void EscapeJsString_MultilineWithQuotesAndBackslashes()
+	{
+		const string input = "var x = 'test\\path';\nalert('done');";
+		const string expected = "var x = \\'test\\\\path\\';\\nalert(\\'done\\');";
+		var result = WebViewHelper.EscapeJsString(input);
+		Assert.Equal(expected, result);
+	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHelper.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHelper.cs
@@ -5,7 +5,8 @@ using System;
 internal static partial class WebViewHelper
 {
 	/// <summary>
-	/// Escapes a JavaScript string for safe inclusion in a single-quoted string literal.
+	/// Escapes backslashes, single quotes, and line terminators in a JavaScript string
+	/// for use in a single-quoted string literal passed to eval().
 	/// </summary>
 	internal static string? EscapeJsString(string? js)
 	{
@@ -15,12 +16,20 @@ internal static partial class WebViewHelper
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
 		bool hasBackslash = js.Contains('\\', StringComparison.Ordinal);
 		bool hasSingleQuote = js.Contains('\'', StringComparison.Ordinal);
+		bool hasNewline = js.Contains('\n', StringComparison.Ordinal);
+		bool hasCarriageReturn = js.Contains('\r', StringComparison.Ordinal);
+		bool hasLineSeparator = js.Contains('\u2028', StringComparison.Ordinal);
+		bool hasParagraphSeparator = js.Contains('\u2029', StringComparison.Ordinal);
 #else
 		bool hasBackslash = js.IndexOf('\\') != -1;
 		bool hasSingleQuote = js.IndexOf('\'') != -1;
+		bool hasNewline = js.IndexOf('\n') != -1;
+		bool hasCarriageReturn = js.IndexOf('\r') != -1;
+		bool hasLineSeparator = js.IndexOf('\u2028') != -1;
+		bool hasParagraphSeparator = js.IndexOf('\u2029') != -1;
 #endif
 
-		if (!hasBackslash && !hasSingleQuote)
+		if (!hasBackslash && !hasSingleQuote && !hasNewline && !hasCarriageReturn && !hasLineSeparator && !hasParagraphSeparator)
 			return js;
 
 		var result = js;
@@ -29,11 +38,31 @@ internal static partial class WebViewHelper
 			result = result.Replace("\\", "\\\\", StringComparison.Ordinal);
 		if (hasSingleQuote)
 			result = result.Replace("'", "\\'", StringComparison.Ordinal);
+
+		// Escape line terminators to prevent SyntaxError in eval('...')
+		if (hasNewline)
+			result = result.Replace("\n", "\\n", StringComparison.Ordinal);
+		if (hasCarriageReturn)
+			result = result.Replace("\r", "\\r", StringComparison.Ordinal);
+		if (hasLineSeparator)
+			result = result.Replace("\u2028", "\\u2028", StringComparison.Ordinal);
+		if (hasParagraphSeparator)
+			result = result.Replace("\u2029", "\\u2029", StringComparison.Ordinal);
 #else
 		if (hasBackslash)
 			result = result.Replace("\\", "\\\\");
 		if (hasSingleQuote)
 			result = result.Replace("'", "\\'");
+
+		// Escape line terminators to prevent SyntaxError in eval('...')
+		if (hasNewline)
+			result = result.Replace("\n", "\\n");
+		if (hasCarriageReturn)
+			result = result.Replace("\r", "\\r");
+		if (hasLineSeparator)
+			result = result.Replace("\u2028", "\\u2028");
+		if (hasParagraphSeparator)
+			result = result.Replace("\u2029", "\\u2029");
 #endif
 
 		return result;


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes JavaScript string escaping in `WebViewHelper.EscapeJsString` to properly handle both backslashes and single quotes.

### Changes
- Escape backslashes **before** single quotes (order matters for `eval()`)
- Prevents potential injection issues when passing strings to JavaScript
- Updated unit tests to cover backslash escaping scenarios

## Testing
- Unit tests added/updated in `WebViewHelperTests.cs`