### PR TITLE
Fix Picker reacts to data changes after the page is closed

### DIFF
--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -343,6 +343,15 @@ namespace Microsoft.Maui.Controls
 
 		protected override void OnHandlerChanged()
 		{
+			// If Handler is being detached, unsubscribe from ItemsSource collection changes
+			if (Handler == null)
+			{
+				if (ItemsSource is INotifyCollectionChanged notifyCollection)
+				{
+					notifyCollection.CollectionChanged -= CollectionChanged;
+				}
+			}
+
 			base.OnHandlerChanged();
 
 			// Process any pending actions when handler becomes available

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Maui.Controls
 		protected override void OnHandlerChanged()
 		{
 			// If Handler is being detached, unsubscribe from ItemsSource collection changes
-			if (Handler == null)
+			if (Handler is null)
 			{
 				if (ItemsSource is INotifyCollectionChanged notifyCollection)
 				{

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -304,14 +304,14 @@ namespace Microsoft.Maui.Controls
 
 		void OnItemsSourceChanged(IList oldValue, IList newValue)
 		{
-			var oldObservable = oldValue as INotifyCollectionChanged;
-			if (oldObservable != null)
-				oldObservable.CollectionChanged -= CollectionChanged;
-
-			var newObservable = newValue as INotifyCollectionChanged;
-			if (newObservable != null)
+			if (ReferenceEquals(oldValue, _subscribedItemsSourceCollection))
 			{
-				newObservable.CollectionChanged += CollectionChanged;
+				UnsubscribeFromItemsSourceCollection();
+			}
+
+			if (Handler is not null)
+			{
+				SubscribeToItemsSourceCollection(newValue as INotifyCollectionChanged);
 			}
 
 			if (newValue != null)
@@ -328,6 +328,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		readonly Queue<Action> _pendingIsOpenActions = new Queue<Action>();
+		INotifyCollectionChanged _subscribedItemsSourceCollection;
 
 		void OnIsOpenPropertyChanged(bool oldValue, bool newValue)
 		{
@@ -343,16 +344,23 @@ namespace Microsoft.Maui.Controls
 
 		protected override void OnHandlerChanged()
 		{
-			// If Handler is being detached, unsubscribe from ItemsSource collection changes
 			if (Handler is null)
 			{
-				if (ItemsSource is INotifyCollectionChanged notifyCollection)
-				{
-					notifyCollection.CollectionChanged -= CollectionChanged;
-				}
+				UnsubscribeFromItemsSourceCollection();
 			}
 
 			base.OnHandlerChanged();
+
+			if (Handler is not null)
+			{
+				SubscribeToItemsSourceCollection(ItemsSource as INotifyCollectionChanged);
+
+				// Keep display items in sync if this Picker is detached and later reattached.
+				if (ItemsSource is not null)
+				{
+					ResetItems();
+				}
+			}
 
 			// Process any pending actions when handler becomes available
 			while (_pendingIsOpenActions.Count > 0 && Handler != null)
@@ -371,6 +379,29 @@ namespace Microsoft.Maui.Controls
 				picker.Opened?.Invoke(picker, PickerOpenedEventArgs.Empty);
 			else
 				picker.Closed?.Invoke(picker, PickerClosedEventArgs.Empty);
+		}
+
+		void SubscribeToItemsSourceCollection(INotifyCollectionChanged collection)
+		{
+			if (collection is null || ReferenceEquals(collection, _subscribedItemsSourceCollection))
+			{
+				return;
+			}
+
+			UnsubscribeFromItemsSourceCollection();
+			_subscribedItemsSourceCollection = collection;
+			_subscribedItemsSourceCollection.CollectionChanged += CollectionChanged;
+		}
+
+		void UnsubscribeFromItemsSourceCollection()
+		{
+			if (_subscribedItemsSourceCollection is null)
+			{
+				return;
+			}
+
+			_subscribedItemsSourceCollection.CollectionChanged -= CollectionChanged;
+			_subscribedItemsSourceCollection = null;
 		}
 
 		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
@@ -461,7 +461,7 @@ public class Issue33307Page2 : ContentPage
 
 		selectedItemLabel = new Label
 		{
-			Text = "Last Selected: None",
+			Text = "None",
 			AutomationId = "StatusLabel",
 			VerticalOptions = LayoutOptions.Center,
 			TextColor = Colors.DarkBlue,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace Maui.Controls.Sample.Issues;
 
@@ -56,12 +57,12 @@ public class Issue33307ContentPage : ContentPage
 		};
 	}
 
-	async void ButtonPage1_Clicked(object? sender, EventArgs e)
+	async void ButtonPage1_Clicked(object sender, EventArgs e)
 	{
 		await Navigation.PushAsync(new Issue33307Page1(mainData));
 	}
 
-	async void ButtonPage2_Clicked(object? sender, EventArgs e)
+	async void ButtonPage2_Clicked(object sender, EventArgs e)
 	{
 		await Navigation.PushAsync(new Issue33307Page2(mainData));
 	}
@@ -92,9 +93,9 @@ public class Issue33307ClassC : INotifyPropertyChanged
 	public string name { get; set; } = string.Empty;
 	public ObservableCollection<Issue33307ClassB> itemsB { get; set; } = new();
 
-	public event PropertyChangedEventHandler? PropertyChanged;
+	public event PropertyChangedEventHandler PropertyChanged;
 
-	public Issue33307ClassB? selected_item
+	public Issue33307ClassB selected_item
 	{
 		get
 		{
@@ -264,7 +265,7 @@ public class Issue33307Page1 : ContentPage
 		Content = mainGrid;
 	}
 
-	void ButtonAddRow_Clicked(object? sender, EventArgs e)
+	void ButtonAddRow_Clicked(object sender, EventArgs e)
 	{
 		var itemB1 = new Issue33307ClassB
 		{
@@ -288,7 +289,7 @@ public class Issue33307Page1 : ContentPage
 		mainData.itemsB.Add(itemB3);
 	}
 
-	async void ButtonDeleteRow_Clicked(object? sender, EventArgs e)
+	async void ButtonDeleteRow_Clicked(object sender, EventArgs e)
 	{
 		if (mainData.itemsB.Count > 1)
 		{
@@ -461,6 +462,7 @@ public class Issue33307Page2 : ContentPage
 		selectedItemLabel = new Label
 		{
 			Text = "Last Selected: None",
+			AutomationId = "StatusLabel",
 			VerticalOptions = LayoutOptions.Center,
 			TextColor = Colors.DarkBlue,
 			FontAttributes = FontAttributes.Bold
@@ -501,7 +503,7 @@ public class Issue33307Page2 : ContentPage
 		Content = mainGrid;
 	}
 
-	async void ButtonDeleteRow_Clicked(object? sender, EventArgs e)
+	async void ButtonDeleteRow_Clicked(object sender, EventArgs e)
 	{
 		foreach (var itemC in mainData.itemsC)
 		{
@@ -516,7 +518,7 @@ public class Issue33307Page2 : ContentPage
 		}
 	}
 
-	void ButtonAddRow_Clicked(object? sender, EventArgs e)
+	void ButtonAddRow_Clicked(object sender, EventArgs e)
 	{
 		var itemC = new Issue33307ClassC
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
@@ -410,7 +410,7 @@ public class Issue33307Page2 : ContentPage
 				rowPicker.SetBinding(Picker.SelectedItemProperty, "selected_item");
 				rowPicker.SelectedIndexChanged += (s, e) =>
 				{
-					if (rowPicker.SelectedItem is ClassB selectedItem)
+					if (rowPicker.SelectedItem is Issue33307ClassB selectedItem)
 					{
 						if (selectedItemLabel != null)
 							selectedItemLabel.Text = selectedItem.name.ToString();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
@@ -1,0 +1,533 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33307, "The Picker is still binding to the property and reacts to data changes after the page is closed.", PlatformAffected.UWP)]
+
+public class Issue33307 : TestNavigationPage
+{
+	protected override void Init()
+	{
+		Navigation.PushAsync(new Issue33307ContentPage());
+	}
+}
+
+public class Issue33307ContentPage : ContentPage
+{
+	Issue33307ClassA mainData;
+
+	public Issue33307ContentPage()
+	{
+		mainData = new Issue33307ClassA();
+
+		Title = "MainPage";
+
+		var stackLayout = new HorizontalStackLayout
+		{
+			Spacing = 100,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var buttonPage1 = new Button
+		{
+			Text = "Page1",
+			AutomationId = "Page1",
+			HeightRequest = 180,
+			WidthRequest = 180
+		};
+		buttonPage1.Clicked += ButtonPage1_Clicked;
+
+		var buttonPage2 = new Button
+		{
+			Text = "Page2",
+			AutomationId = "Page2",
+			HeightRequest = 180,
+			WidthRequest = 180
+		};
+		buttonPage2.Clicked += ButtonPage2_Clicked;
+
+		stackLayout.Add(buttonPage1);
+		stackLayout.Add(buttonPage2);
+
+		Content = new Grid
+		{
+			Children = { stackLayout }
+		};
+	}
+
+	async void ButtonPage1_Clicked(object? sender, EventArgs e)
+	{
+		await Navigation.PushAsync(new Issue33307Page1(mainData));
+	}
+
+	async void ButtonPage2_Clicked(object? sender, EventArgs e)
+	{
+		await Navigation.PushAsync(new Issue33307Page2(mainData));
+	}
+}
+
+public class Issue33307ClassA
+{
+	public int id_counter { get; set; }
+	public ObservableCollection<Issue33307ClassB> itemsB { get; set; } = new();
+	public ObservableCollection<Issue33307ClassC> itemsC { get; set; } = new();
+}
+
+public class Issue33307ClassB
+{
+	public int id { get; set; }
+	public string name { get; set; } = string.Empty;
+	public bool isSelected { get; set; }
+
+	public object Clone()
+	{
+		return MemberwiseClone();
+	}
+}
+
+public class Issue33307ClassC : INotifyPropertyChanged
+{
+	public int id { get; set; }
+	public string name { get; set; } = string.Empty;
+	public ObservableCollection<Issue33307ClassB> itemsB { get; set; } = new();
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+
+	public Issue33307ClassB? selected_item
+	{
+		get
+		{
+			for (var i = 0; i < itemsB.Count; i++)
+			{
+				if (itemsB[i].isSelected)
+					return itemsB[i];
+			}
+			return null;
+		}
+		set
+		{
+			if (value == null)
+			{
+				for (var i = 0; i < itemsB.Count; i++)
+					itemsB[i].isSelected = false;
+			}
+			else
+			{
+				for (var i = 0; i < itemsB.Count; i++)
+				{
+					if (itemsB[i].name == value.name)
+					{
+						itemsB[i].isSelected = true;
+					}
+					else
+					{
+						itemsB[i].isSelected = false;
+					}
+				}
+			}
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(selected_item)));
+		}
+	}
+}
+
+public class Issue33307Page1 : ContentPage
+{
+	Issue33307ClassA mainData;
+	CollectionView collectionView1;
+
+	public Issue33307Page1(Issue33307ClassA mainData)
+	{
+		this.mainData = mainData;
+		Title = "Page1";
+
+		var headerGrid = new Grid
+		{
+			ColumnDefinitions =
+			{
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(new GridLength(60))
+			},
+			ColumnSpacing = 5
+		};
+
+		var nameLabel = new Label { Text = "Name", VerticalOptions = LayoutOptions.Center };
+		Grid.SetColumn(nameLabel, 0);
+		headerGrid.Add(nameLabel);
+
+		var deleteLabel = new Label { Text = "Delete", VerticalOptions = LayoutOptions.Center };
+		Grid.SetColumn(deleteLabel, 1);
+		headerGrid.Add(deleteLabel);
+
+		var headerLayout = new VerticalStackLayout
+		{
+			Spacing = 10,
+			VerticalOptions = LayoutOptions.End,
+			Children =
+			{
+				headerGrid,
+				new BoxView { Color = Colors.Black, HeightRequest = 2, CornerRadius = 20 }
+			}
+		};
+
+		collectionView1 = new CollectionView
+		{
+			HorizontalOptions = LayoutOptions.Fill,
+			BackgroundColor = Colors.WhiteSmoke,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var itemGrid = new Grid
+				{
+					ColumnSpacing = 5,
+					Margin = new Thickness(0, 8, 0, 8),
+					ColumnDefinitions =
+					{
+						new ColumnDefinition(GridLength.Star),
+						new ColumnDefinition(new GridLength(60))
+					}
+				};
+
+				var entry = new Entry
+				{
+					Placeholder = "Name",
+					VerticalOptions = LayoutOptions.Center
+				};
+				entry.SetBinding(Entry.TextProperty, "name");
+				Grid.SetColumn(entry, 0);
+				itemGrid.Add(entry);
+
+				return new VerticalStackLayout
+				{
+					Margin = new Thickness(1, 0, 1, 0),
+					Children =
+					{
+						itemGrid,
+						new BoxView { Color = Colors.Black, HeightRequest = 2, CornerRadius = 20 }
+					}
+				};
+			}),
+			EmptyView = new Label
+			{
+				Text = "No items to display",
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			}
+		};
+		collectionView1.ItemsSource = this.mainData.itemsB;
+
+		var addButton = new Button
+		{
+			Text = "Add items",
+			AutomationId = "AddItems",
+			HorizontalOptions = LayoutOptions.Start
+		};
+		addButton.Clicked += ButtonAddRow_Clicked;
+
+		var delButton = new Button
+		{
+			Text = "Delete",
+			AutomationId = "Delete"
+		};
+		delButton.Clicked += ButtonDeleteRow_Clicked;
+
+		var hStack = new HorizontalStackLayout
+		{
+			Spacing = 20,
+			Children =
+			{
+				addButton,
+				delButton
+			}
+		};
+
+		var mainGrid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star),
+				new RowDefinition(new GridLength(50))
+			},
+			RowSpacing = 11,
+			Margin = new Thickness(10, 10, 10, 20)
+		};
+
+		Grid.SetRow(headerLayout, 0);
+		mainGrid.Add(headerLayout);
+
+		Grid.SetRow(collectionView1, 1);
+		mainGrid.Add(collectionView1);
+
+		Grid.SetRow(hStack, 2);
+		mainGrid.Add(hStack);
+
+		Content = mainGrid;
+	}
+
+	void ButtonAddRow_Clicked(object? sender, EventArgs e)
+	{
+		var itemB1 = new Issue33307ClassB
+		{
+			id = mainData.id_counter++,
+			name = "itemB1"
+		};
+		mainData.itemsB.Add(itemB1);
+
+		var itemB2 = new Issue33307ClassB
+		{
+			id = mainData.id_counter++,
+			name = "itemB2"
+		};
+		mainData.itemsB.Add(itemB2);
+
+		var itemB3 = new Issue33307ClassB
+		{
+			id = mainData.id_counter++,
+			name = "itemB3"
+		};
+		mainData.itemsB.Add(itemB3);
+	}
+
+	async void ButtonDeleteRow_Clicked(object? sender, EventArgs e)
+	{
+		if (mainData.itemsB.Count > 1)
+		{
+			var item = mainData.itemsB[1];
+			RemoveInDependencies(item.id);
+			mainData.itemsB.Remove(item);
+		}
+	}
+
+	void RemoveInDependencies(int id)
+	{
+		foreach (var itemC in mainData.itemsC)
+		{
+			for (int i = 0; i < itemC.itemsB.Count; i++)
+			{
+				if (itemC.itemsB[i].id == id)
+				{
+					itemC.itemsB.RemoveAt(i);
+					break;
+				}
+			}
+		}
+	}
+}
+
+public class Issue33307Page2 : ContentPage
+{
+	Issue33307ClassA mainData;
+	CollectionView collectionView1;
+	Label selectedItemLabel;
+
+	public Issue33307Page2(Issue33307ClassA mainData)
+	{
+		this.mainData = mainData;
+		Title = "Page2";
+
+		var headerGrid = new Grid
+		{
+			ColumnDefinitions =
+			{
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(new GridLength(60))
+			},
+			ColumnSpacing = 5
+		};
+
+		var nameLabel = new Label
+		{
+			Text = "Name",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center
+		};
+		Grid.SetColumn(nameLabel, 0);
+		headerGrid.Add(nameLabel);
+
+		var itemBLabel = new Label
+		{
+			Text = "ItemB",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center
+		};
+		Grid.SetColumn(itemBLabel, 1);
+		headerGrid.Add(itemBLabel);
+
+		var deleteLabel = new Label
+		{
+			Text = "Delete",
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center
+		};
+		Grid.SetColumn(deleteLabel, 2);
+		headerGrid.Add(deleteLabel);
+
+		var headerLayout = new VerticalStackLayout
+		{
+			Spacing = 10,
+			VerticalOptions = LayoutOptions.End,
+			Children =
+			{
+				headerGrid,
+				new BoxView { Color = Colors.Black, HeightRequest = 2, CornerRadius = 20 }
+			}
+		};
+
+		collectionView1 = new CollectionView
+		{
+			HorizontalOptions = LayoutOptions.Fill,
+			BackgroundColor = Colors.WhiteSmoke,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var itemGrid = new Grid
+				{
+					ColumnSpacing = 5,
+					ColumnDefinitions =
+					{
+						new ColumnDefinition(GridLength.Star),
+						new ColumnDefinition(GridLength.Star),
+						new ColumnDefinition(new GridLength(60))
+					}
+				};
+
+				var entry = new Entry
+				{
+					Placeholder = "Name",
+					VerticalOptions = LayoutOptions.Center
+				};
+				entry.SetBinding(Entry.TextProperty, "name");
+				Grid.SetColumn(entry, 0);
+				itemGrid.Add(entry);
+
+				var rowPicker = new Picker
+				{
+					TextColor = Colors.Black,
+					TitleColor = Colors.Gray
+				};
+				rowPicker.SetBinding(Picker.ItemsSourceProperty, "itemsB");
+				rowPicker.ItemDisplayBinding = new Binding("name");
+				rowPicker.SetBinding(Picker.SelectedItemProperty, "selected_item");
+				rowPicker.SelectedIndexChanged += (s, e) =>
+				{
+					if (rowPicker.SelectedItem is ClassB selectedItem)
+					{
+						if (selectedItemLabel != null)
+							selectedItemLabel.Text = selectedItem.name.ToString();
+					}
+					else
+					{
+						selectedItemLabel?.Text = "None";
+					}
+				};
+				Grid.SetColumn(rowPicker, 1);
+				itemGrid.Add(rowPicker);
+
+				return new VerticalStackLayout
+				{
+					Margin = new Thickness(1, 0, 1, 0),
+					Children =
+					{
+						itemGrid,
+						new BoxView { Color = Colors.Black, HeightRequest = 2, CornerRadius = 20 }
+					}
+				};
+			}),
+			EmptyView = new Label
+			{
+				Text = "No items to display",
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center
+			}
+		};
+		collectionView1.ItemsSource = this.mainData.itemsC;
+
+		var addButton = new Button
+		{
+			Text = "Add",
+			AutomationId = "Add",
+			HorizontalOptions = LayoutOptions.Start
+		};
+		addButton.Clicked += ButtonAddRow_Clicked;
+
+		var delItem = new Button
+		{
+			Text = "Select Second Item",
+			AutomationId = "SelectSecondItem",
+			HorizontalOptions = LayoutOptions.Start
+		};
+		delItem.Clicked += ButtonDeleteRow_Clicked;
+
+		selectedItemLabel = new Label
+		{
+			Text = "Last Selected: None",
+			VerticalOptions = LayoutOptions.Center,
+			TextColor = Colors.DarkBlue,
+			FontAttributes = FontAttributes.Bold
+		};
+
+		var hStack = new HorizontalStackLayout
+		{
+			Spacing = 20,
+			Children =
+			{
+				addButton,
+				delItem,
+				selectedItemLabel
+			}
+		};
+
+		var mainGrid = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star),
+				new RowDefinition(new GridLength(50))
+			},
+			RowSpacing = 11,
+			Margin = new Thickness(10, 10, 10, 20)
+		};
+
+		Grid.SetRow(headerLayout, 0);
+		mainGrid.Add(headerLayout);
+
+		Grid.SetRow(collectionView1, 1);
+		mainGrid.Add(collectionView1);
+
+		Grid.SetRow(hStack, 2);
+		mainGrid.Add(hStack);
+
+		Content = mainGrid;
+	}
+
+	async void ButtonDeleteRow_Clicked(object? sender, EventArgs e)
+	{
+		foreach (var itemC in mainData.itemsC)
+		{
+			if (itemC.itemsB.Count > 1)
+			{
+				itemC.selected_item = itemC.itemsB[1];
+			}
+			else if (itemC.itemsB.Count > 0)
+			{
+				itemC.selected_item = itemC.itemsB[0];
+			}
+		}
+	}
+
+	void ButtonAddRow_Clicked(object? sender, EventArgs e)
+	{
+		var itemC = new Issue33307ClassC
+		{
+			id = mainData.id_counter++
+		};
+
+		foreach (var itemB in mainData.itemsB)
+		{
+			itemC.itemsB.Add((Issue33307ClassB)itemB.Clone());
+		}
+
+		mainData.itemsC.Add(itemC);
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33307.cs
@@ -21,8 +21,6 @@ public class Issue33307ContentPage : ContentPage
 	{
 		mainData = new Issue33307ClassA();
 
-		Title = "MainPage";
-
 		var stackLayout = new HorizontalStackLayout
 		{
 			Spacing = 100,

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
@@ -10,7 +10,7 @@ public class Issue33307 : _IssuesUITest
 	public override string Issue => "The Picker is still binding to the property and reacts to data changes after the page is closed.";
 	[Test]
 	[Category(UITestCategories.Picker)]
-	public void VerifyBackButtonTitleUpdates()
+	public void VerifyPickerItemsinNavigation()
 	{
 		App.WaitForElement("Page1");
 		App.Tap("Page1");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue33307 : _IssuesUITest
+	{
+		public Issue33307(TestDevice device) : base(device) { }
+
+		public override string Issue => "The Picker is still binding to the property and reacts to data changes after the page is closed.";
+		[Test]
+		[Category(UITestCategories.Picker)]
+		public void VerifyBackButtonTitleUpdates()
+		{
+			App.WaitForElement("Page1");
+			App.Tap("Page1");
+			App.Tap("AddItems");
+			App.TapBackArrow();
+			App.Tap("Page2");
+			App.Tap("Add");
+			App.Tap("SelectSecondItem");
+			App.TapBackArrow();
+			App.Tap("Page1");
+			App.Tap("Delete");
+			App.TapBackArrow();
+			App.Tap("Page2");
+			App.WaitForElement("Label");
+			Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("None"));
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
@@ -2,31 +2,29 @@ using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
-namespace Microsoft.Maui.TestCases.Tests.Issues
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue33307 : _IssuesUITest
 {
-	public class Issue33307 : _IssuesUITest
-	{
-		public Issue33307(TestDevice device) : base(device) { }
+	public Issue33307(TestDevice device) : base(device) { }
 
-		public override string Issue => "The Picker is still binding to the property and reacts to data changes after the page is closed.";
-		[Test]
-		[Category(UITestCategories.Picker)]
-		public void VerifyBackButtonTitleUpdates()
-		{
-			App.WaitForElement("Page1");
-			App.Tap("Page1");
-			App.Tap("AddItems");
-			App.TapBackArrow();
-			App.Tap("Page2");
-			App.Tap("Add");
-			App.Tap("SelectSecondItem");
-			App.TapBackArrow();
-			App.Tap("Page1");
-			App.Tap("Delete");
-			App.TapBackArrow();
-			App.Tap("Page2");
-			App.WaitForElement("Label");
-			Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("None"));
-		}
+	public override string Issue => "The Picker is still binding to the property and reacts to data changes after the page is closed.";
+	[Test]
+	[Category(UITestCategories.Picker)]
+	public void VerifyBackButtonTitleUpdates()
+	{
+		App.WaitForElement("Page1");
+		App.Tap("Page1");
+		App.Tap("AddItems");
+		App.TapBackArrow();
+		App.Tap("Page2");
+		App.Tap("Add");
+		App.Tap("SelectSecondItem");
+		App.TapBackArrow();
+		App.Tap("Page1");
+		App.Tap("Delete");
+		App.TapBackArrow();
+		App.Tap("Page2");
+		App.WaitForElement("Label");
+		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("None"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33307.cs
@@ -24,7 +24,7 @@ public class Issue33307 : _IssuesUITest
 		App.Tap("Delete");
 		App.TapBackArrow();
 		App.Tap("Page2");
-		App.WaitForElement("Label");
-		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("None"));
+		App.WaitForElement("StatusLabel");
+		Assert.That(App.FindElement("StatusLabel").GetText(), Is.EqualTo("None"));
 	}
 }


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
The issue occurs when a Picker and a CollectionView are both bound to the same ObservableCollection. If you remove an item from the collection using the CollectionView, and that item is currently selected in the Picker, the Picker may not clear its selection or may select the wrong item.

### Description of Change

<!-- Enter description of the fix in this section -->
Picker now unsubscribes from collection change events when its handler is detached, which prevents unwanted updates

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33307 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/c14797c7-a2c5-46a4-a20b-6e71a6977819" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/d2eb0891-4b3f-4528-8117-3f291c9e0029" width="300" height="600"> |
