### PR TITLE
[XEXPR] Lazy ResourceDictionary with AddFactory API

### DIFF
--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds lazy resource instantiation to `ResourceDictionary` via factory functions. Resources are created on-demand when first accessed, enabling faster startup and `x:Shared` support for SourceGen.

Closes #28985

## Specification

See full spec: https://gist.github.com/StephaneDelcroix/36cc853aa004169609e2176b5c0ebc0a

### Problem

1. **Slow inflation time**: All resources are instantiated upfront during XAML inflation, even if never used
2. **No `x:Shared` support**: Resources that need parenting (e.g., `StrokeShape`) cannot be StaticResources because the same instance is shared - causing crashes when multiple elements try to parent the same object

### Solution

Store `Func<object>` factories instead of object instances. Resources are created on-demand when accessed.

### API

```csharp
// Add a resource factory
[EditorBrowsable(EditorBrowsableState.Never)]
public void AddFactory(string key, Func<object> factory, bool shared = true);

// Add an implicit style factory
[EditorBrowsable(EditorBrowsableState.Never)]  
public void AddFactory(Func<Style> factory, bool shared = true);
```

### Behavior

| `shared` | First Access | Subsequent |
|----------|--------------|------------|
| `true` (default) | Invoke factory, cache | Return cached |
| `false` | Invoke factory | Invoke factory |

### Scope

| Inflator | Lazy RD | x:Shared |
|----------|---------|----------|
| **SourceGen** | ✅ | ✅ |
| **Runtime** | ❌ (could add) | ❌ |
| **XamlC** | ❌ (possible but hard) | ❌ |

## Changes

- Add `LazyResource` wrapper class
- Add `AddFactory` methods to `ResourceDictionary`
- Update all value accessors to resolve lazy resources
- `Keys` enumeration does NOT invoke factories
- Add 7 unit tests

## Benefits

- ⚡ Faster startup (resources created only when needed)
- 🔧 `x:Shared` for free (`StrokeShape` in StaticResource finally works)
- 📦 No runtime cost for unused resources
