### PR TITLE
Improve issue-triage skill: Add gh CLI checks and fix workflow

### DIFF
--- a/.github/skills/issue-triage/scripts/init-triage-session.ps1
+++ b/.github/skills/issue-triage/scripts/init-triage-session.ps1
@@ -62,6 +62,17 @@ try {
     exit 1
 }
 
+# Verify GitHub CLI authentication
+$authStatus = gh auth status 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "  ❌ GitHub CLI (gh) is not authenticated" -ForegroundColor Red
+    Write-Host "  Run: gh auth login" -ForegroundColor Cyan
+    Write-Host ""
+    exit 1
+}
+Write-Host "  ✅ GitHub CLI authenticated" -ForegroundColor Green
+
 # Create output directory
 if (-not (Test-Path $OutputDir)) {
     New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null

--- a/.github/skills/issue-triage/scripts/query-issues.ps1
+++ b/.github/skills/issue-triage/scripts/query-issues.ps1
@@ -99,6 +99,25 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Check for GitHub CLI prerequisite
+try {
+    $null = Get-Command gh -ErrorAction Stop
+} catch {
+    Write-Host ""
+    Write-Host "❌ GitHub CLI (gh) is not installed" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "The issue-triage skill requires GitHub CLI for querying issues." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Installation:" -ForegroundColor Cyan
+    Write-Host "  Windows:  winget install --id GitHub.cli" -ForegroundColor White
+    Write-Host "  macOS:    brew install gh" -ForegroundColor White
+    Write-Host "  Linux:    See https://cli.github.com/manual/installation" -ForegroundColor White
+    Write-Host ""
+    Write-Host "After installation, authenticate with: gh auth login" -ForegroundColor Cyan
+    Write-Host ""
+    exit 1
+}
+
 Write-Host "Querying GitHub issues..." -ForegroundColor Cyan
 
 # Labels to exclude from triage results

--- a/.github/skills/issue-triage/scripts/query-issues.ps1
+++ b/.github/skills/issue-triage/scripts/query-issues.ps1
@@ -118,6 +118,17 @@ try {
     exit 1
 }
 
+# Verify GitHub CLI authentication
+$authStatus = gh auth status 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "❌ GitHub CLI (gh) is not authenticated" -ForegroundColor Red
+    Write-Host "Run: gh auth login" -ForegroundColor Cyan
+    Write-Host ""
+    exit 1
+}
+Write-Host "✅ GitHub CLI authenticated" -ForegroundColor Green
+
 Write-Host "Querying GitHub issues..." -ForegroundColor Cyan
 
 # Labels to exclude from triage results


### PR DESCRIPTION
## Description

Improves the issue-triage skill to prevent common workflow mistakes and ensure proper usage of GitHub CLI.

## Changes

### 1. Prerequisites and Validation
- Added GitHub CLI (gh) prerequisite checks to both scripts
- Scripts now exit gracefully with installation instructions if gh is not found
- Updated SKILL.md with Prerequisites section and installation guide for all platforms

### 2. Milestone Logic Fixes
- Fixed init-triage-session.ps1 to use Invoke-RestMethod for fetching milestones (doesn't require gh)
- Added documentation: milestone names must come from session output, not assumptions
- Included examples of correct vs incorrect milestone suggestions

### 3. Workflow Documentation
- Added critical rule: ALWAYS use skill scripts, never ad-hoc GitHub API queries
- Documented Step 6: Automatically reload issue batches when empty (don't prompt user)
- Added Common Mistakes section with anti-patterns table
- Explained what each script does and why to use them

### 4. Testing
- ✅ Verified init-triage-session.ps1 works with gh installed
- ✅ Verified query-issues.ps1 applies proper exclusion filters
- ✅ Confirmed prerequisite check catches missing gh CLI

## Why These Changes

During a triage session, the agent bypassed the skill's scripts and used ad-hoc GitHub queries, which missed important exclusion filters (s/needs-info, s/needs-repro, area-blazor, etc.). This resulted in incorrect issue counts and suggestions.

Additionally, the agent assumed milestone names like "SR2" and "SR3" without checking what milestones actually exist, leading to invalid suggestions.

These changes ensure future agents (and users) follow the proper workflow and use accurate data.

## Version Bump

- Version: 2.2 → 2.3