### PR TITLE
[MacCatalyst] Fix TitleView not expanding to full size when maximizing the window

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1662,7 +1662,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					// For iOS 26+, force TitleView to re-layout on window size changes (iPad Stage Manager, multitasking)
 					// Complements TraitCollectionDidChange handling (device rotation) added in #32815
-					if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+					if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26) || OperatingSystem.IsMacOSVersionAtLeast(13)) 
 					{
 						coordinator.AnimateAlongsideTransition(_ =>
 						{

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue33613.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue33613.cs
@@ -1,0 +1,105 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33613, "Mac Catalyst: NavigationPage.TitleView layout shifts and adds extra spacing when window is maximized", PlatformAffected.macOS)]
+public class Issue33613NavPage : NavigationPage
+{
+	public Issue33613NavPage() : base(new Issue33613MainPage())
+	{
+	}
+}
+
+public class Issue33613MainPage : ContentPage
+{
+	public Issue33613MainPage()
+	{
+		Title = "Main Page";
+		
+		var navigateButton = new Button
+		{
+			Text = "Navigate to Page with TitleView",
+			AutomationId = "NavigateButton"
+		};
+		
+		navigateButton.Clicked += async (s, e) =>
+		{
+			await Navigation.PushAsync(new Issue33613());
+		};
+		
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				new Label
+				{
+					Text = "Issue #33613 - TitleView Layout Test",
+					FontSize = 20,
+					FontAttributes = FontAttributes.Bold,
+					HorizontalOptions = LayoutOptions.Center,
+					AutomationId = "MainPageLabel"
+				},
+				new Label
+				{
+					Text = "Tap the button to navigate to a page with a custom TitleView",
+					FontSize = 14,
+					HorizontalTextAlignment = TextAlignment.Center
+				},
+				navigateButton
+			}
+		};
+	}
+}
+
+public class Issue33613 : ContentPage
+{
+	public Issue33613()
+	{
+		Title = "Issue 33613";
+		
+		// Create TitleView
+		var titleViewGrid = new Grid
+		{
+			BackgroundColor = Colors.LightBlue,
+			HorizontalOptions = LayoutOptions.FillAndExpand,
+			AutomationId = "TitleViewGrid"
+		};
+		
+		var titleLabel = new Label
+		{
+			Text = "Custom TitleView",
+			TextColor = Colors.Black,
+			FontSize = 18,
+			FontAttributes = FontAttributes.Bold,
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			AutomationId = "TitleLabel"
+		};
+		
+		titleViewGrid.Children.Add(titleLabel);
+		NavigationPage.SetTitleView(this, titleViewGrid);
+		
+		// Create page content
+		var goBackButton = new Button
+		{
+			Text = "Go Back",
+			AutomationId = "GoBackButton"
+		};
+		
+		goBackButton.Clicked += async (s, e) =>
+		{
+			await Navigation.PopAsync();
+		};
+		
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children =
+			{
+				goBackButton
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue33613.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue33613.cs
@@ -57,8 +57,6 @@ public class Issue33613 : ContentPage
 	public Issue33613()
 	{
 		Title = "Issue 33613";
-		
-		// Create TitleView
 		var titleViewGrid = new Grid
 		{
 			BackgroundColor = Colors.LightBlue,
@@ -79,27 +77,10 @@ public class Issue33613 : ContentPage
 		
 		titleViewGrid.Children.Add(titleLabel);
 		NavigationPage.SetTitleView(this, titleViewGrid);
-		
-		// Create page content
-		var goBackButton = new Button
-		{
-			Text = "Go Back",
-			AutomationId = "GoBackButton"
-		};
-		
-		goBackButton.Clicked += async (s, e) =>
-		{
-			await Navigation.PopAsync();
-		};
-		
 		Content = new VerticalStackLayout
 		{
 			Padding = 20,
 			Spacing = 10,
-			Children =
-			{
-				goBackButton
-			}
 		};
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue33613.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue33613.cs
@@ -60,7 +60,7 @@ public class Issue33613 : ContentPage
 		var titleViewGrid = new Grid
 		{
 			BackgroundColor = Colors.LightBlue,
-			HorizontalOptions = LayoutOptions.FillAndExpand,
+			HorizontalOptions = LayoutOptions.Fill,
 			AutomationId = "TitleViewGrid"
 		};
 		

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33613.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33613.cs
@@ -1,0 +1,39 @@
+#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_IOS && TEST_FAILS_ON_WINDOWS // This test is specific to Mac Catalyst window maximize/restore behavior
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33613 : _IssuesUITest
+{
+	public override string Issue => "Mac Catalyst: NavigationPage.TitleView layout shifts and adds extra spacing when window is maximized";
+	
+	public Issue33613(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.Navigation)]
+	public void TitleViewLayoutIsCorrectWithBackButton()
+	{
+		App.WaitForElement("NavigateButton");
+		App.Tap("NavigateButton");
+		App.WaitForElement("TitleLabel");
+		var titleLabelRect = App.WaitForElement("TitleLabel").GetRect();
+		var previousWidth = titleLabelRect.Width;
+		
+		App.EnterFullScreen();
+		Thread.Sleep(1000); // Wait for the animation to complete
+		
+		var newTitleLabelRect = App.WaitForElement("TitleLabel").GetRect();
+		var newWidth = newTitleLabelRect.Width;
+		
+		// Test passes if the TitleView width increases when entering full screen
+		// This verifies the TitleView properly expands to fill the available navigation bar space
+		Assert.That(newWidth, Is.GreaterThan(previousWidth), 
+			$"TitleView should expand when window is maximized. Previous: {previousWidth}, New: {newWidth}");
+		
+		App.Tap("GoBackButton");
+		App.WaitForElement("NavigateButton");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33613.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33613.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_IOS && TEST_FAILS_ON_WINDOWS // This test is specific to Mac Catalyst window maximize/restore behavior
+#if TEST_FAILS_ON_WINDOWS // TitleView is not rendered at its full width on the Windows platform during the initial render.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -13,27 +13,23 @@ public class Issue33613 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.Navigation)]
-	public void TitleViewLayoutIsCorrectWithBackButton()
+	public void Issue33613Test()
 	{
 		App.WaitForElement("NavigateButton");
 		App.Tap("NavigateButton");
-		App.WaitForElement("TitleLabel");
-		var titleLabelRect = App.WaitForElement("TitleLabel").GetRect();
+		App.WaitForElement("TitleViewGrid");
+		var titleLabelRect = App.WaitForElement("TitleViewGrid").GetRect();
 		var previousWidth = titleLabelRect.Width;
-		
+#if MACCATALYST || WINDOWS
 		App.EnterFullScreen();
+#elif ANDROID || IOS
+		App.SetOrientationLandscape();
+#endif
 		Thread.Sleep(1000); // Wait for the animation to complete
-		
-		var newTitleLabelRect = App.WaitForElement("TitleLabel").GetRect();
+		var newTitleLabelRect = App.WaitForElement("TitleViewGrid").GetRect();
 		var newWidth = newTitleLabelRect.Width;
-		
-		// Test passes if the TitleView width increases when entering full screen
-		// This verifies the TitleView properly expands to fill the available navigation bar space
 		Assert.That(newWidth, Is.GreaterThan(previousWidth), 
 			$"TitleView should expand when window is maximized. Previous: {previousWidth}, New: {newWidth}");
-		
-		App.Tap("GoBackButton");
-		App.WaitForElement("NavigateButton");
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33613.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33613.cs
@@ -20,14 +20,25 @@ public class Issue33613 : _IssuesUITest
 		App.WaitForElement("TitleViewGrid");
 		var titleLabelRect = App.WaitForElement("TitleViewGrid").GetRect();
 		var previousWidth = titleLabelRect.Width;
-#if MACCATALYST || WINDOWS
-		App.EnterFullScreen();
-#elif ANDROID || IOS
-		App.SetOrientationLandscape();
-#endif
-		Thread.Sleep(1000); // Wait for the animation to complete
-		var newTitleLabelRect = App.WaitForElement("TitleViewGrid").GetRect();
-		var newWidth = newTitleLabelRect.Width;
+		App.ResizeOrRotateWindow();
+		
+		// Poll for width change with timeout (wait for animation to complete)
+		var timeout = TimeSpan.FromSeconds(5);
+		var startTime = DateTime.Now;
+		float newWidth;
+		do
+		{
+			Thread.Sleep(100); // Small delay between polls
+			var newTitleLabelRect = App.WaitForElement("TitleViewGrid").GetRect();
+			newWidth = newTitleLabelRect.Width;
+			
+			if (newWidth > previousWidth)
+				break;
+				
+			if (DateTime.Now - startTime > timeout)
+				break;
+		} while (true);
+		
 		Assert.That(newWidth, Is.GreaterThan(previousWidth), 
 			$"TitleView should expand when window is maximized. Previous: {previousWidth}, New: {newWidth}");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/UtilExtensions.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/UtilExtensions.cs
@@ -94,5 +94,14 @@ namespace Microsoft.Maui.TestCases.Tests
 				searchResults.First().Tap();
 			}
 		}
+
+		public static void ResizeOrRotateWindow(this IApp app)
+		{
+#if MACCATALYST || WINDOWS
+			app.EnterFullScreen();
+#elif ANDROID || IOS
+			app.SetOrientationLandscape();
+#endif
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

The TitleView is not expanding to fullsize, when maximize the window in mac platform.
       
### Root Cause:

The TitleView's frame is not recalculated when the navigation bar width changes, causing the layout to appear incorrect with stale positioning values in mac platform. 

### Description of Change:

I call the UpdateTitleViewFrameForOrientation() method from ViewWillTransitionToSize, which is the appropriate callback for MacCatalyst window resize events. This method runs alongside the transition coordinator’s animation, allowing the TitleView’s frame to be updated smoothly to match the new navigation bar dimensions.

**Tested the behavior in the following platforms.**

- [x] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #33613      

### Screenshots
| Before  | After  |
|---------|--------|
|  <Video width="369" height="606" alt="image" src="https://github.com/user-attachments/assets/5e53e49d-a89f-40a6-9d04-724b35a9c4a6" /> | <Video width="369" height="606" alt="image" src="https://github.com/user-attachments/assets/01889888-5486-49ec-9032-a802339aa568" /> |
