### PR TITLE
ai-summary-comment: Simplify PR finalize to two collapsible sections

### DIFF
--- a/.github/skills/ai-summary-comment/SKILL.md
+++ b/.github/skills/ai-summary-comment/SKILL.md
@@ -56,10 +56,11 @@ Most scripts post to the **same single comment** identified by `<!-- AI Summary 
 
 ### Separate PR Finalization Comment
 
-The `post-pr-finalize-comment.ps1` script posts a **separate comment** identified by `<!-- PR-FINALIZE-COMMENT -->`. This is intentional because:
-- Finalization reviews can happen multiple times (after each commit)
-- Each review is numbered (Review 1, Review 2, etc.)
-- Keeps finalization reviews distinct from automated analysis
+The `post-pr-finalize-comment.ps1` script posts a **separate comment** identified by `<!-- PR-FINALIZE-COMMENT -->`. This comment contains two sections:
+- **Title**: Shows the suggested PR title with comparison to current
+- **Description**: Shows the suggested PR description
+
+If an existing finalize comment exists, it will be replaced with the updated Title and Description sections. This keeps finalization reviews distinct from automated analysis.
 
 ## Section Scripts
 


### PR DESCRIPTION

<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Refactors `post-pr-finalize-comment.ps1` to produce a cleaner, more readable PR finalization comment format:

**Before:** Single collapsible section per review with merged Title/Description content  
**After:** Two separate collapsible sections (Title and Description) for better scannability

#### Changes:
- Replace per-review collapsible sections with dedicated Title and Description sections
- Remove legacy `ReviewNumber` and `ReviewDescription` parameters (no longer needed)
- Add `TitleIssues` parameter for direct title issue specification
- Auto-detect `TitleStatus` from "Title Assessment" section in summary files
- Always replace existing finalize comment instead of merging reviews
- Broaden GitHub API comment fetch to `?per_page=100` to handle PRs with many comments
- Simplify status defaulting logic

### Issues Fixed

N/A - Internal tooling improvement