### PR TITLE
[Mac] Fix for preventing macOS picker dialog from closing immediately when opened with Tab

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33463.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33463.cs
@@ -1,0 +1,30 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33463, "[macOS]Picker items are not visible", PlatformAffected.macOS)]
+public class Issue33463 : TestContentPage
+{
+    protected override void Init()
+    {
+        var picker = new Picker
+        {
+            AutomationId = "TestPicker",
+            Title = "Select an item"
+        };
+        picker.Items.Add("Item 1");
+        picker.Items.Add("Item 2");
+        picker.Items.Add("Item 3");
+
+        var entry = new Entry
+        {
+            AutomationId = "TestEntry",
+            Placeholder = "Entry for TAB focus"
+        };
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 12,
+            Spacing = 10,
+            Children = { picker, entry }
+        };
+    }
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33463.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33463.cs
@@ -1,0 +1,34 @@
+#if MACCATALYST // The reported scenario is specific to macOS, where the picker dialog closes automatically when opened using the Tab key, so this test is enabled only for macOS.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33463 : _IssuesUITest
+{
+	public Issue33463(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "[macOS]Picker items are not visible";
+
+	[Test]
+	[Category(UITestCategories.Picker)]
+	public void PickerShouldRemainOpenWhenOpenedUsingTabKey()
+	{
+		App.WaitForElement("TestPicker");
+
+		App.Tap("TestPicker");
+		App.WaitForElement("Done");
+		App.Tap("Done");
+
+		App.SendTabKey();
+		Task.Delay(800).Wait();
+
+		var doneButton = App.FindElement("Done");
+		Assert.That(doneButton, Is.Not.Null, 
+			"The picker dialog should remain open when it is opened using the Tab key.");
+	}
+}
+#endif

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static CommandMapper<IPicker, IPickerHandler> CommandMapper = new(ViewCommandMapper)
 		{
-#if ANDROID
+#if ANDROID || MACCATALYST
 			[nameof(IPicker.Focus)] = MapFocus,
 			[nameof(IPicker.Unfocus)] = MapUnfocus
 #endif

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -43,6 +43,13 @@ namespace Microsoft.Maui.Handlers
 
 		void DisplayAlert(MauiPicker uITextField, int selectedIndex)
 		{
+			// Guard against multiple picker controllers being displayed simultaneously
+			if (_currentPickerController != null)
+			{
+				_currentPickerController.DismissViewController(true, null);
+				_currentPickerController = null;
+			}
+
 			var paddingTitle = 0;
 			if (!string.IsNullOrEmpty(VirtualView.Title))
 				paddingTitle += 25;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause

The issue occurs because the TAB key triggers an EditingDidEnd event that persists when the picker reopens. When the picker opens, EditingDidBegin presents the UIAlertController, but immediately after, another EditingDidEnd event fires due to the lingering focus state. The original code dismissed the picker in the EditingDidEnd handler, causing the picker to close instantly after opening and breaking keyboard navigation.

Regression PR: https://github.com/dotnet/maui/pull/27973

### Description of Issue Fix

The fix involves separating how the picker responds to different dismissal triggers. It removes automatic dismissal from the EditingDidEnd handler, which now only updates the IsFocused and IsOpen state. A new MapUnfocus command handler is added for MacCatalyst that stores a reference to the active UIAlertController and dismisses it only when Unfocus() is called programmatically. This distinguishes between TAB-induced events (no dismissal) and explicit unfocus commands (dismissal), fixing the keyboard navigation issue while maintaining compatibility with existing focus behavior.

Tested the behavior in the following platforms.
 
- [x] Mac
- [ ] Windows
- [ ] iOS
- [ ] Android

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/33463

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output

Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/3ee0d39c-5cfb-4de7-af31-6a69bd60dcee">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/5bd73400-4151-4f6b-aff1-a698b5863bbc">|


