### PR TITLE
[ci] Don t try push results if they dont exist

### DIFF
--- a/eng/pipelines/arcade/stage-helix-tests.yml
+++ b/eng/pipelines/arcade/stage-helix-tests.yml
@@ -69,7 +69,7 @@ stages:
         sourceIndexParams: ${{ parameters.sourceIndexParams }}
         publishAssetsImmediately: true
         enablePublishBuildArtifacts: true
-        enablePublishTestResults: true
+        enablePublishTestResults: false
         workspace:
           clean: all
         jobs:


### PR DESCRIPTION
### Description of Change

The default template tries always to push trx, but on helix this is done by Helix itself. 

This pull request makes a small configuration change to the Helix test stage in the pipeline. The change disables the publishing of test results for this stage by setting `enablePublishTestResults` to `false`.