### PR TITLE
Improve test report formatting and summary extraction

### DIFF
--- a/.github/skills/ai-summary-comment/scripts/post-ai-summary-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-ai-summary-comment.ps1
@@ -399,9 +399,9 @@ if (-not $SkipValidation) {
             Write-Host "  ✅ $($phase.Name): Valid" -ForegroundColor Green
         } else {
             Write-Host "  ❌ $($phase.Name): INVALID" -ForegroundColor Red
-            foreach ($error in $result.Errors) {
-                Write-Host "     - $error" -ForegroundColor Red
-                $allValidationErrors += "$($phase.Name): $error"
+            foreach ($err in $result.Errors) {
+                Write-Host "     - $err" -ForegroundColor Red
+                $allValidationErrors += "$($phase.Name): $err"
             }
         }
         
@@ -435,8 +435,8 @@ if (-not $SkipValidation) {
         Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Red
         Write-Host ""
         Write-Host "Found $($allValidationErrors.Count) validation error(s):" -ForegroundColor Red
-        foreach ($error in $allValidationErrors) {
-            Write-Host "  - $error" -ForegroundColor Red
+        foreach ($err in $allValidationErrors) {
+            Write-Host "  - $err" -ForegroundColor Red
         }
         Write-Host ""
         Write-Host "💡 Fix these issues in the state file before posting the review comment." -ForegroundColor Cyan

--- a/.github/skills/ai-summary-comment/scripts/post-verify-tests-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-verify-tests-comment.ps1
@@ -152,8 +152,12 @@ if (-not [string]::IsNullOrWhiteSpace($ReportFile)) {
     
     # Use report content as summary if not provided
     if ([string]::IsNullOrWhiteSpace($Summary)) {
-        # Extract key results from report
-        $Summary = $reportContent
+        # Extract key results from report, excluding verbose "Test Results Details" section
+        if ($reportContent -match '(?s)^(.*?)(?=####\s*Test Results Details)') {
+            $Summary = $Matches[1].TrimEnd()
+        } else {
+            $Summary = $reportContent
+        }
     }
 }
 
@@ -181,19 +185,13 @@ _Run `verify-tests-fail.ps1` for full details._
 }
 
 # Status emoji
-$statusEmoji = if ($Status -eq "Passed") { "✅ PASSED" } else { "❌ FAILED" }
+$statusEmoji = if ($Status -eq "Passed") { "✅ passed" } else { "❌ failed" }
 $modeDesc = if ($Mode -eq "FullVerification") { "Full Verification" } else { "Failure Only" }
 
-# Build verification section content
+# Build verification section content - wrapped in collapsible with status in summary
 $verifyContent = @"
-### 🚦 Test Verification
-
-**Result**: $statusEmoji
-**Mode**: $modeDesc
-**Platform**: $Platform
-
 <details>
-<summary>Expand Details</summary>
+<summary><b>🚦 Test Verification: $statusEmoji</b></summary>
 
 $Summary
 

--- a/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
+++ b/.github/skills/verify-tests-fail-without-fix/scripts/verify-tests-fail.ps1
@@ -564,18 +564,18 @@ function Write-MarkdownReport {
     $statusSymbol = if ($VerificationPassed) { "✅" } else { "❌" }
     
     $markdown = @"
-# Test Verification Report
+### Test Verification Report
 
 **Date:** $reportDate | **Platform:** $($Platform.ToUpper()) | **Status:** $status
 
-## Summary
+#### Summary
 
 | Check | Expected | Actual | Result |
 |-------|----------|--------|--------|
 | Tests WITHOUT fix | FAIL | $(if ($FailedWithoutFix) { "FAIL" } else { "PASS" }) | $(if ($FailedWithoutFix) { "✅" } else { "❌" }) |
 | Tests WITH fix | PASS | $(if ($PassedWithFix) { "PASS" } else { "FAIL" }) | $(if ($PassedWithFix) { "✅" } else { "❌" }) |
 
-## $statusSymbol Final Verdict
+#### $statusSymbol Final Verdict
 
 $(if ($VerificationPassed) {
     @"
@@ -607,7 +607,7 @@ $(if (-not $FailedWithoutFix) {
 
 ---
 
-## Configuration
+#### Configuration
 
 **Platform:** $Platform
 **Test Filter:** $TestFilter
@@ -629,7 +629,7 @@ $(($NewFiles | ForEach-Object { "- ``$_``" }) -join "`n")
 
 ---
 
-## Test Results Details
+#### Test Results Details
 
 ### Test Run 1: WITHOUT Fix
 
@@ -683,7 +683,7 @@ $(Get-Content $WithFixLog -Raw)
 
 ---
 
-## Logs
+#### Logs
 
 - Full verification log: ``$ValidationLog``
 - Test output without fix: ``$WithoutFixLog``


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Refine how test summaries are generated and adjust report markdown for embedding. In post-verify-tests-comment.ps1: extract a concise summary by trimming everything from the start up to the "## Test Results Details" section (regex fallback to full content if not found), lowercase the status labels to "passed/failed", and move the verification block into a collapsible <details> with the status shown in the <summary>. In verify-tests-fail.ps1: downgrade top-level headings to smaller heading levels (e.g. H1->H3, H2->H4) for Summary, Final Verdict, Configuration, Test Results Details, and Logs to produce a less-prominent, embeddable report. Changes are primarily formatting and presentation to keep PR comments concise and readable.