### PR TITLE
Improve try-fix comment parsing and summary

### DIFF
--- a/.github/skills/ai-summary-comment/scripts/post-try-fix-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-try-fix-comment.ps1
@@ -261,7 +261,6 @@ $statusEmoji = switch ($Status) {
 }
 
 # Build the new attempt section - compact format
-# Note: blank line after </summary> is required for proper markdown rendering
 $attemptSection = @"
 <details>
 <summary>$statusEmoji Fix $AttemptNumber</summary>
@@ -270,7 +269,7 @@ $attemptSection = @"
 
 # Show brief approach description
 if (-not [string]::IsNullOrWhiteSpace($Approach)) {
-    $attemptSection += "$Approach`n`n"
+    $attemptSection += "`n$Approach`n`n"
 }
 
 # Only show diff if available
@@ -326,7 +325,10 @@ try {
 }
 
 # Build the try-fix section content
-$tryFixHeader = "### 🔧 Try-Fix Analysis`n`n"
+# Count existing attempts to show in summary
+$existingAttemptCount = 0
+$passCount = 0
+$failCount = 0
 
 # Extract existing try-fix section to preserve previous attempts
 $existingTryFixContent = ""
@@ -336,21 +338,63 @@ if ($existingBody -match "(?s)$startPattern(.*?)$endPattern") {
     $existingTryFixContent = $Matches[1].Trim()
 }
 
+# Extract just the inner attempt details (strip outer wrapper and headers)
+$innerAttempts = ""
+if ($existingTryFixContent -match '(?s)<details>\s*<summary><b>🔧 Try-Fix Analysis.*?</summary>\s*(.*?)\s*</details>\s*$') {
+    # New format - extract content inside the outer details
+    $innerAttempts = $Matches[1].Trim()
+} elseif ($existingTryFixContent -match '(?s)### 🔧.*?`n`n(.*)') {
+    # Old header format
+    $innerAttempts = $Matches[1].Trim()
+} else {
+    # Just use as-is but strip any stray headers
+    $innerAttempts = $existingTryFixContent -replace "(?s)^### 🔧[^\n]*\n+", ""
+}
+
+# Strip any leading horizontal rules, <br> tags, or whitespace before the first <details>
+$innerAttempts = $innerAttempts -replace "(?s)^\s*---\s*\n+", ""
+$innerAttempts = $innerAttempts -replace "(?s)^(<br>\s*)+", ""
+$innerAttempts = $innerAttempts.TrimStart()
+
+# Count existing attempts (only count inner <details> that are Fix attempts)
+$existingAttemptCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>[✅❌🔨]')).Count
+$passCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>✅')).Count
+$failCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>❌')).Count
+
 # Check if this attempt number already exists and replace it, or add new
-# Match both old format (Attempt N:) and new format (Fix N)
-$attemptPattern = "(?s)<details>\s*<summary>.*?(Attempt $AttemptNumber`:|Fix $AttemptNumber).*?</details>"
-if ($existingTryFixContent -match $attemptPattern) {
+$attemptPattern = "(?s)<details>\s*<summary>[✅❌🔨⚪]\s*Fix $AttemptNumber</summary>.*?</details>"
+if ($innerAttempts -match $attemptPattern) {
     Write-Host "Replacing existing Fix $AttemptNumber..." -ForegroundColor Yellow
-    $tryFixContent = $existingTryFixContent -replace $attemptPattern, $attemptSection
-} elseif (-not [string]::IsNullOrWhiteSpace($existingTryFixContent)) {
+    $tryFixInnerContent = $innerAttempts -replace $attemptPattern, $attemptSection
+} elseif (-not [string]::IsNullOrWhiteSpace($innerAttempts)) {
     Write-Host "Adding new Fix $AttemptNumber..." -ForegroundColor Yellow
-    # Remove header if present to avoid duplication
-    $existingTryFixContent = $existingTryFixContent -replace "^### 🔧 (Try-Fix Analysis|Fix Attempts)\s*`n*", ""
-    $tryFixContent = $tryFixHeader + $existingTryFixContent.TrimEnd() + "`n`n" + $attemptSection
+    $tryFixInnerContent =  $innerAttempts.TrimEnd() + "`n`n" + $attemptSection
+    # Update counts for new attempt
+    $existingAttemptCount++
+    if ($Status -eq "Pass") { $passCount++ } else { $failCount++ }
 } else {
     Write-Host "Creating first fix..." -ForegroundColor Yellow
-    $tryFixContent = $tryFixHeader + $attemptSection
+    $tryFixInnerContent = $attemptSection
+    $existingAttemptCount = 1
+    if ($Status -eq "Pass") { $passCount = 1 } else { $failCount = 1 }
 }
+
+# Build summary line with counts
+$summaryStatus = if ($passCount -gt 0) { "✅ $passCount passed" } else { "" }
+if ($failCount -gt 0) {
+    if ($summaryStatus -ne "") { $summaryStatus += ", " }
+    $summaryStatus += "❌ $failCount failed"
+}
+if ($summaryStatus -eq "") { $summaryStatus = "$existingAttemptCount attempt(s)" }
+
+# Wrap everything in a single collapsible section
+$tryFixContent = @"
+<details>
+<summary><b>🔧 Try-Fix Analysis: $summaryStatus</b></summary><br>
+$tryFixInnerContent
+
+</details>
+"@
 
 # Build the section with markers
 $tryFixSection = @"

--- a/.github/skills/ai-summary-comment/scripts/post-try-fix-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-try-fix-comment.ps1
@@ -357,7 +357,7 @@ $innerAttempts = $innerAttempts -replace "(?s)^(<br>\s*)+", ""
 $innerAttempts = $innerAttempts.TrimStart()
 
 # Count existing attempts (only count inner <details> that are Fix attempts)
-$existingAttemptCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>[✅❌🔨]')).Count
+$existingAttemptCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>[✅❌🔨⚪]')).Count
 $passCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>✅')).Count
 $failCount = ([regex]::Matches($innerAttempts, '<details>\s*<summary>❌')).Count
 
@@ -368,16 +368,16 @@ if ($innerAttempts -match $attemptPattern) {
     $tryFixInnerContent = $innerAttempts -replace $attemptPattern, $attemptSection
 } elseif (-not [string]::IsNullOrWhiteSpace($innerAttempts)) {
     Write-Host "Adding new Fix $AttemptNumber..." -ForegroundColor Yellow
-    $tryFixInnerContent =  $innerAttempts.TrimEnd() + "`n`n" + $attemptSection
-    # Update counts for new attempt
-    $existingAttemptCount++
-    if ($Status -eq "Pass") { $passCount++ } else { $failCount++ }
+    $tryFixInnerContent = $innerAttempts.TrimEnd() + "`n`n" + $attemptSection
 } else {
     Write-Host "Creating first fix..." -ForegroundColor Yellow
     $tryFixInnerContent = $attemptSection
-    $existingAttemptCount = 1
-    if ($Status -eq "Pass") { $passCount = 1 } else { $failCount = 1 }
 }
+
+# Recalculate attempt statistics from the final content to ensure consistency
+$totalAttemptCount = ([regex]::Matches($tryFixInnerContent, '<details>\s*<summary>[✅❌🔨⚪]')).Count
+$passCount = ([regex]::Matches($tryFixInnerContent, '<details>\s*<summary>✅')).Count
+$failCount = ([regex]::Matches($tryFixInnerContent, '<details>\s*<summary>❌')).Count
 
 # Build summary line with counts
 $summaryStatus = if ($passCount -gt 0) { "✅ $passCount passed" } else { "" }
@@ -385,7 +385,7 @@ if ($failCount -gt 0) {
     if ($summaryStatus -ne "") { $summaryStatus += ", " }
     $summaryStatus += "❌ $failCount failed"
 }
-if ($summaryStatus -eq "") { $summaryStatus = "$existingAttemptCount attempt(s)" }
+if ($summaryStatus -eq "") { $summaryStatus = "$totalAttemptCount attempt(s)" }
 
 # Wrap everything in a single collapsible section
 $tryFixContent = @"


### PR DESCRIPTION

> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

The post-try-fix-comment script had several formatting issues:
1. **Duplicated headers** - Old "### 🔧 Try-Fix Analysis" headers accumulated when updating comments
2. **Stray formatting** - Horizontal rules and `<br>` tags accumulated between attempts
3. **No summary** - Users had to expand each attempt to see overall status
4. **Fragile parsing** - Didn't handle both old (header-based) and new (collapsible) formats

### Description of Change

Refactored comment parsing to:

**1. Robust Content Extraction**
- Extract inner attempts area, supporting both:
  - **New format:** `<details><summary><b>🔧 Try-Fix Analysis...</summary>...[attempts]...</details>`
  - **Old format:** `### 🔧 Try-Fix Analysis\n\n...[attempts]...`
- Strip stray headers (`### 🔧...`), horizontal rules (`---`), and `<br>` tags

**2. Accurate Attempt Counting**
- Count existing attempts by status emoji: `✅` (passed), `❌` (failed)
- Recalculate after insertion/replacement to ensure consistency
- Use counts to build summary line: `"✅ 2 passed, ❌ 1 failed"`

**3. Clean Attempt Insertion**
- Operate on inner content only (avoids wrapper duplication)
- Replace existing attempt by number, or append new
- Add newline before Approach text for proper spacing

**4. Single Collapsible Section**
- Wrap all attempts in one `<details>` with summary showing status counts
- Example: `🔧 Try-Fix Analysis: ✅ 2 passed, ❌ 1 failed`
- Eliminates duplicated wrappers and headers

### Key Changes

**File:** `.github/skills/ai-summary-comment/scripts/post-try-fix-comment.ps1`

| Change | Before | After |
|--------|--------|-------|
| **Header handling** | Added `### 🔧` header each time | Single collapsible with summary |
| **Content extraction** | Used entire section as-is | Extract inner attempts, strip wrappers |
| **Counting** | Not implemented | Count ✅/❌ and show in summary |
| **Attempt matching** | Matched old "Attempt N:" format | Match new "Fix N" with emoji |
| **Approach spacing** | `"$Approach\n\n"` | `"\n$Approach\n\n"` (blank line before) |

### Issues Fixed

None (internal improvement to pr agent infrastructure)

### Testing

- Tested with existing try-fix comments (both old and new formats)
- Verified attempt counting and summary generation
- Confirmed no header/wrapper duplication