### PR TITLE
Add UserLocationChanged event and LastUserLocation property to Map

### DIFF
--- a/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Controls.Maps
 			var args = new ClusterClickedEventArgs(controlPins, location);
 			ClusterClicked?.Invoke(this, args);
 			return args.Handled;
+		}
 
 		void IMap.UserLocationUpdated(Location location)
 		{

--- a/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls.Maps
 
 		IList<IMapPin> IMap.Pins => _pins.Cast<IMapPin>().ToList();
 
+		Location? IMap.LastUserLocation => _lastUserLocation;
+
 		void IMap.Clicked(Location location) => MapClicked?.Invoke(this, new MapClickedEventArgs(location));
 
 		bool IMap.ClusterClicked(IReadOnlyList<IMapPin> pins, Location location)
@@ -20,6 +22,11 @@ namespace Microsoft.Maui.Controls.Maps
 			var args = new ClusterClickedEventArgs(controlPins, location);
 			ClusterClicked?.Invoke(this, args);
 			return args.Handled;
+
+		void IMap.UserLocationUpdated(Location location)
+		{
+			_lastUserLocation = location;
+			UserLocationChanged?.Invoke(this, new UserLocationChangedEventArgs(location));
 		}
 
 		void IMap.LongClicked(Location location) => MapLongClicked?.Invoke(this, new MapClickedEventArgs(location));

--- a/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Maui.Controls.Maps
 
 		void IMap.UserLocationUpdated(Location location)
 		{
+			if (Equals(_lastUserLocation, location))
+				return;
+
+			OnPropertyChanging(nameof(LastUserLocation));
 			_lastUserLocation = location;
+			OnPropertyChanged(nameof(LastUserLocation));
 			UserLocationChanged?.Invoke(this, new UserLocationChangedEventArgs(location));
 		}
 

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Maps;
 
 namespace Microsoft.Maui.Controls.Maps
@@ -53,6 +54,7 @@ namespace Microsoft.Maui.Controls.Maps
 		readonly ObservableCollection<MapElement> _mapElements = new();
 		MapSpan? _visibleRegion;
 		MapSpan? _lastMoveToRegion;
+		Location? _lastUserLocation;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Map"/> class with a region.
@@ -214,6 +216,25 @@ namespace Microsoft.Maui.Controls.Maps
 		/// Occurs when the user long-presses/holds on the map control.
 		/// </summary>
 		public event EventHandler<MapClickedEventArgs>? MapLongClicked;
+
+		/// <summary>
+		/// Occurs when the user's location is updated on the map.
+		/// </summary>
+		/// <remarks>
+		/// This event only fires when <see cref="IsShowingUser"/> is set to true
+		/// and location permissions have been granted.
+		/// </remarks>
+		public event EventHandler<UserLocationChangedEventArgs>? UserLocationChanged;
+
+		/// <summary>
+		/// Gets the last known user location from the map, or null if not available.
+		/// </summary>
+		/// <remarks>
+		/// This property requires <see cref="IsShowingUser"/> to be set to true
+		/// and location permissions to be granted. The location is updated as the
+		/// user moves and the map receives location updates.
+		/// </remarks>
+		public Location? LastUserLocation => _lastUserLocation;
 
 		/// <summary>
 		/// Gets the currently visible region of the map.

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -221,7 +221,8 @@ namespace Microsoft.Maui.Controls.Maps
 		/// Occurs when the user's location is updated on the map.
 		/// </summary>
 		/// <remarks>
-		/// This event only fires when <see cref="IsShowingUser"/> is set to true
+		/// This event fires when the platform map handler reports a location update.
+		/// The handler only sends updates when <see cref="IsShowingUser"/> is set to true
 		/// and location permissions have been granted.
 		/// </remarks>
 		public event EventHandler<UserLocationChangedEventArgs>? UserLocationChanged;

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -10,9 +10,11 @@ Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collecti
 Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
+Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
+Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
@@ -25,6 +27,9 @@ Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/UserLocationChangedEventArgs.cs
+++ b/src/Controls/Maps/src/UserLocationChangedEventArgs.cs
@@ -1,0 +1,24 @@
+using Microsoft.Maui.Devices.Sensors;
+
+namespace Microsoft.Maui.Controls.Maps
+{
+	/// <summary>
+	/// Event arguments for the <see cref="Map.UserLocationChanged"/> event.
+	/// </summary>
+	public class UserLocationChangedEventArgs : System.EventArgs
+	{
+		/// <summary>
+		/// Gets the updated user location.
+		/// </summary>
+		public Location Location { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="UserLocationChangedEventArgs"/> class.
+		/// </summary>
+		/// <param name="location">The user's updated location.</param>
+		public UserLocationChangedEventArgs(Location location)
+		{
+			Location = location;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -26,6 +26,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("MapElement Click Events", () => new MapElementClickGallery(), Navigation),
 						GalleryBuilder.NavButton("Map Long Click", () => new MapLongClickGallery(), Navigation),
 						GalleryBuilder.NavButton("Info Window", () => new InfoWindowGallery(), Navigation),
+						GalleryBuilder.NavButton("User Location", () => new UserLocationGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.UserLocationGallery"
+    Title="User Location">
+    <Grid RowDefinitions="Auto, Auto, Auto, *">
+        <!-- Controls -->
+        <HorizontalStackLayout Grid.Row="0" Spacing="5" Padding="10">
+            <Label Text="Show User Location:" VerticalOptions="Center"/>
+            <Switch x:Name="ShowUserSwitch" IsToggled="True" VerticalOptions="Center"/>
+        </HorizontalStackLayout>
+        
+        <!-- Last Location Display -->
+        <Frame Grid.Row="1" Margin="10" Padding="10" BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#333333}">
+            <VerticalStackLayout>
+                <Label Text="Last User Location:" FontAttributes="Bold"/>
+                <Label x:Name="LatitudeLabel" Text="Latitude: --"/>
+                <Label x:Name="LongitudeLabel" Text="Longitude: --"/>
+                <Label x:Name="UpdateCountLabel" Text="Updates received: 0"/>
+            </VerticalStackLayout>
+        </Frame>
+        
+        <!-- Event Log -->
+        <Frame Grid.Row="2" Margin="10" Padding="10" MaximumHeightRequest="120" BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#333333}">
+            <VerticalStackLayout>
+                <Label Text="Recent Location Updates:" FontAttributes="Bold"/>
+                <ScrollView>
+                    <Label x:Name="EventLogLabel" FontSize="11" Text="Waiting for location updates..."/>
+                </ScrollView>
+            </VerticalStackLayout>
+        </Frame>
+        
+        <!-- Map -->
+        <maps:Map x:Name="userLocationMap" Grid.Row="3"
+            IsShowingUser="{Binding IsToggled, Source={x:Reference ShowUserSwitch}}"
+            MapClicked="OnMapClicked"
+            UserLocationChanged="OnUserLocationChanged"/>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Maps;
+
+namespace Maui.Controls.Sample.Pages.MapsGalleries
+{
+	public partial class UserLocationGallery : ContentPage
+	{
+		private int _updateCount = 0;
+		private readonly Queue<string> _eventLog = new();
+		private const int MaxLogEntries = 5;
+
+		public UserLocationGallery()
+		{
+			InitializeComponent();
+			
+			// Set initial map region to somewhere visible
+			var initialLocation = new Location(37.7749, -122.4194); // San Francisco
+			userLocationMap.MoveToRegion(MapSpan.FromCenterAndRadius(initialLocation, Distance.FromMiles(10)));
+		}
+
+		private void OnUserLocationChanged(object sender, UserLocationChangedEventArgs e)
+		{
+			_updateCount++;
+			
+			// Update the labels
+			LatitudeLabel.Text = $"Latitude: {e.Location.Latitude:F6}";
+			LongitudeLabel.Text = $"Longitude: {e.Location.Longitude:F6}";
+			UpdateCountLabel.Text = $"Updates received: {_updateCount}";
+			
+			// Add to event log
+			var timestamp = DateTime.Now.ToString("HH:mm:ss.fff");
+			var logEntry = $"[{timestamp}] ({e.Location.Latitude:F4}, {e.Location.Longitude:F4})";
+			
+			_eventLog.Enqueue(logEntry);
+			while (_eventLog.Count > MaxLogEntries)
+			{
+				_eventLog.Dequeue();
+			}
+			
+			EventLogLabel.Text = string.Join("\n", _eventLog);
+			
+			// Also verify the LastUserLocation property matches
+			var lastLocation = userLocationMap.LastUserLocation;
+			if (lastLocation != null)
+			{
+				System.Diagnostics.Debug.WriteLine($"LastUserLocation: ({lastLocation.Latitude:F6}, {lastLocation.Longitude:F6})");
+			}
+		}
+
+		private void OnMapClicked(object sender, MapClickedEventArgs e)
+		{
+			// Just for additional verification - show where user clicked
+			System.Diagnostics.Debug.WriteLine($"Map clicked at: ({e.Location.Latitude:F6}, {e.Location.Longitude:F6})");
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml.cs
@@ -17,11 +17,11 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			InitializeComponent();
 			
 			// Set initial map region to somewhere visible
-			var initialLocation = new Location(37.7749, -122.4194); // San Francisco
+			var initialLocation = new Microsoft.Maui.Devices.Sensors.Location(37.7749, -122.4194); // San Francisco
 			userLocationMap.MoveToRegion(MapSpan.FromCenterAndRadius(initialLocation, Distance.FromMiles(10)));
 		}
 
-		private void OnUserLocationChanged(object sender, UserLocationChangedEventArgs e)
+		private void OnUserLocationChanged(object? sender, UserLocationChangedEventArgs e)
 		{
 			_updateCount++;
 			
@@ -50,7 +50,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			}
 		}
 
-		private void OnMapClicked(object sender, MapClickedEventArgs e)
+		private void OnMapClicked(object? sender, MapClickedEventArgs e)
 		{
 			// Just for additional verification - show where user clicked
 			System.Diagnostics.Debug.WriteLine($"Map clicked at: ({e.Location.Latitude:F6}, {e.Location.Longitude:F6})");

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/UserLocationGallery.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Maps;
 

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -907,5 +907,125 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMap)map).LongClicked(location);
 			Assert.Equal(1, fireCount); // Should still be 1, not 2
 		}
+
+		#region UserLocationChanged Tests
+
+		[Fact]
+		public void UserLocationChanged_EventRaisedOnLocationUpdate()
+		{
+			// Arrange
+			var map = new Map();
+			var eventRaised = false;
+			Location receivedLocation = null;
+			map.UserLocationChanged += (sender, args) =>
+			{
+				eventRaised = true;
+				receivedLocation = args.Location;
+			};
+
+			var testLocation = new Location(37.7749, -122.4194); // San Francisco
+
+			// Act
+			((IMap)map).UserLocationUpdated(testLocation);
+
+			// Assert
+			Assert.True(eventRaised);
+			Assert.NotNull(receivedLocation);
+			Assert.Equal(37.7749, receivedLocation.Latitude);
+			Assert.Equal(-122.4194, receivedLocation.Longitude);
+		}
+
+		[Fact]
+		public void UserLocationChanged_SenderIsMap()
+		{
+			// Arrange
+			var map = new Map();
+			object sender = null;
+			map.UserLocationChanged += (s, args) => sender = s;
+
+			// Act
+			((IMap)map).UserLocationUpdated(new Location(0, 0));
+
+			// Assert
+			Assert.Same(map, sender);
+		}
+
+		[Fact]
+		public void LastUserLocation_IsNullByDefault()
+		{
+			// Arrange & Act
+			var map = new Map();
+
+			// Assert
+			Assert.Null(map.LastUserLocation);
+		}
+
+		[Fact]
+		public void LastUserLocation_UpdatedOnLocationUpdate()
+		{
+			// Arrange
+			var map = new Map();
+			var testLocation = new Location(51.5074, -0.1278); // London
+
+			// Act
+			((IMap)map).UserLocationUpdated(testLocation);
+
+			// Assert
+			Assert.NotNull(map.LastUserLocation);
+			Assert.Equal(51.5074, map.LastUserLocation.Latitude);
+			Assert.Equal(-0.1278, map.LastUserLocation.Longitude);
+		}
+
+		[Fact]
+		public void LastUserLocation_UpdatedWithLatestLocation()
+		{
+			// Arrange
+			var map = new Map();
+			var firstLocation = new Location(40.7128, -74.0060); // NYC
+			var secondLocation = new Location(34.0522, -118.2437); // LA
+
+			// Act
+			((IMap)map).UserLocationUpdated(firstLocation);
+			((IMap)map).UserLocationUpdated(secondLocation);
+
+			// Assert
+			Assert.NotNull(map.LastUserLocation);
+			Assert.Equal(34.0522, map.LastUserLocation.Latitude);
+			Assert.Equal(-118.2437, map.LastUserLocation.Longitude);
+		}
+
+		[Fact]
+		public void UserLocationChanged_MultipleSubscribers()
+		{
+			// Arrange
+			var map = new Map();
+			int eventCount = 0;
+			map.UserLocationChanged += (s, e) => eventCount++;
+			map.UserLocationChanged += (s, e) => eventCount++;
+
+			// Act
+			((IMap)map).UserLocationUpdated(new Location(0, 0));
+
+			// Assert
+			Assert.Equal(2, eventCount);
+		}
+
+		[Fact]
+		public void IMap_LastUserLocation_ReturnsMapLastUserLocation()
+		{
+			// Arrange
+			var map = new Map();
+			var testLocation = new Location(48.8566, 2.3522); // Paris
+
+			// Act
+			((IMap)map).UserLocationUpdated(testLocation);
+			var iMapLocation = ((IMap)map).LastUserLocation;
+
+			// Assert
+			Assert.NotNull(iMapLocation);
+			Assert.Equal(map.LastUserLocation, iMapLocation);
+		}
+
+		#endregion
 	}
 }

--- a/src/Core/maps/src/Core/IMap.cs
+++ b/src/Core/maps/src/Core/IMap.cs
@@ -54,6 +54,15 @@ namespace Microsoft.Maui.Maps
 		IList<IMapElement> Elements { get; }
 
 		/// <summary>
+		/// Gets the last known user location from the map, or null if not available.
+		/// </summary>
+		/// <remarks>
+		/// This property requires <see cref="IsShowingUser"/> to be set to true.
+		/// The location is updated as the user moves and the map receives location updates.
+		/// </remarks>
+		Location? LastUserLocation { get; }
+
+		/// <summary>
 		/// Method called by the handler when user clicks on the Map.
 		/// </summary>
 		void Clicked(Location position);
@@ -70,6 +79,12 @@ namespace Microsoft.Maui.Maps
 		/// Method called by the handler when user long-presses on the Map.
 		/// </summary>
 		void LongClicked(Location position);
+
+		/// <summary>
+		/// Method called by the handler when the user's location is updated.
+		/// </summary>
+		/// <param name="location">The new user location.</param>
+		void UserLocationUpdated(Location location);
 
 		/// <summary>
 		/// Moves the map so that it displays the specified <see cref="MapSpan"/> region.

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Maui.Maps.Handlers
 				Map.InfoWindowClick -= OnInfoWindowClick;
 				Map.MapClick -= OnMapClick;
 				Map.MapLongClick -= OnMapLongClick;
+
+				Map.MyLocationChange -= OnMyLocationChange;
 			}
 
 			_clusters?.Clear();
@@ -421,6 +423,8 @@ namespace Microsoft.Maui.Maps.Handlers
 			map.MapClick += OnMapClick;
 			map.MapLongClick += OnMapLongClick;
 
+			map.MyLocationChange += OnMyLocationChange;
+
 			if (VirtualView != null)
 			{
 				map.UpdateMapType(VirtualView);
@@ -600,6 +604,14 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		void OnMapLongClick(object? sender, GoogleMap.MapLongClickEventArgs e) =>
 			VirtualView.LongClicked(new Devices.Sensors.Location(e.Point.Latitude, e.Point.Longitude));
+
+		void OnMyLocationChange(object? sender, GoogleMap.MyLocationChangeEventArgs e)
+		{
+			if (e.Location != null && VirtualView != null)
+			{
+				VirtualView.UserLocationUpdated(new Devices.Sensors.Location(e.Location.Latitude, e.Location.Longitude));
+			}
+		}
 
 		void AddPins(IList pins)
 		{

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -375,6 +375,7 @@ namespace Microsoft.Maui.Maps.Platform
 		{
 			RegionChanged += MkMapViewOnRegionChanged;
 			DidSelectAnnotationView += MkMapViewOnAnnotationViewSelected;
+			DidUpdateUserLocation += MkMapViewOnUserLocationUpdated;
 
 			AddGestureRecognizer(_mapClickedGestureRecognizer = new UITapGestureRecognizer(OnMapClicked)
 			{
@@ -403,6 +404,7 @@ namespace Microsoft.Maui.Maps.Platform
 			}
 			RegionChanged -= MkMapViewOnRegionChanged;
 			DidSelectAnnotationView -= MkMapViewOnAnnotationViewSelected;
+			DidUpdateUserLocation -= MkMapViewOnUserLocationUpdated;
 		}
 
 		void MkMapViewOnAnnotationViewSelected(object? sender, MKAnnotationViewEventArgs e)
@@ -435,6 +437,20 @@ namespace Microsoft.Maui.Maps.Platform
 		{
 			if (_handlerRef.TryGetTarget(out IMapHandler? handler) && handler?.VirtualView != null)
 				handler.VirtualView.VisibleRegion = new MapSpan(new Devices.Sensors.Location(Region.Center.Latitude, Region.Center.Longitude), Region.Span.LatitudeDelta, Region.Span.LongitudeDelta);
+		}
+
+		void MkMapViewOnUserLocationUpdated(object? sender, MKUserLocationEventArgs e)
+		{
+			if (e.UserLocation?.Location == null)
+				return;
+
+			if (_handlerRef.TryGetTarget(out IMapHandler? handler) && handler?.VirtualView != null)
+			{
+				var location = new Devices.Sensors.Location(
+					e.UserLocation.Location.Coordinate.Latitude,
+					e.UserLocation.Location.Coordinate.Longitude);
+				handler.VirtualView.UserLocationUpdated(location);
+			}
 		}
 
 		IMapPin GetPinForAnnotation(IMKAnnotation annotation)

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -4,9 +4,11 @@ Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
+Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR adds the ability to receive user location updates from the Map control when `IsShowingUser` is enabled.

### New Public API

- **`Map.LastUserLocation`** - Read-only property that returns the most recent user location, or null if not yet available
- **`Map.UserLocationChanged`** - Event fired whenever the user's location is updated on the map
- **`UserLocationChangedEventArgs`** - Event arguments containing the `Location` property

### Platform Implementation

- **iOS**: Subscribes to `MKMapView.DidUpdateUserLocation` delegate method
- **Android**: Subscribes to `GoogleMap.MyLocationChange` event

### Usage

```csharp
var map = new Map { IsShowingUser = true };

map.UserLocationChanged += (sender, e) =>
{
    Console.WriteLine($"User location: {e.Location.Latitude}, {e.Location.Longitude}");
    
    // Or access the last known location directly
    var lastLocation = map.LastUserLocation;
};
```

### Changes

- Added `LastUserLocation` property and `UserLocationUpdated` method to `IMap` interface
- Added `LastUserLocation` property and `UserLocationChanged` event to `Map` class
- Created `UserLocationChangedEventArgs` class
- iOS: Subscribe to `DidUpdateUserLocation` in `MauiMKMapView`
- Android: Subscribe to `MyLocationChange` in `MapHandler.Android`
- Added 7 unit tests
- Added `UserLocationGallery` sample page

### Issues Fixed

Addresses #14700

### Part of Maps Epic

Part of #33787 (Epic: Maps Control Improvements for .NET 11)