### PR TITLE
[testing] Dont fail xcode script

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -144,7 +144,7 @@ steps:
       if [[ -z "$XCODE_PATH" ]]; then
         echo "ERROR: No suitable Xcode version found for requested version ${ORIGINAL_VERSION}"
         echo "Tried: ${VERSIONS_TO_TRY[*]}"
-        exit 1
+        exit 0
       fi
 
       sudo xcode-select -s "$XCODE_PATH"

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -69,7 +69,7 @@ steps:
     skipAndroidEmulatorImages: ${{ ne(parameters.platform, 'android') }}
     skipAndroidCreateAvds: true
     androidEmulatorApiLevel: ${{ parameters.version }}
-    skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
+    skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows'), eq(parameters.platform, 'catalyst')) }}
     skipSimulatorSetup: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows'), eq(parameters.platform, 'catalyst')) }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}
     ${{ if parameters.skipProvisioning }}:


### PR DESCRIPTION
### Description of Change

Our maccatalyst uitests run in a macOS-14 still, the new provisioning script was failing with Exit code 1 when doesn t find Xcode 26. 