### PR TITLE
[ci] Try on MAUI pool

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -68,9 +68,9 @@ parameters:
 - name: BuildPlatformsPublic
   type: object
   default:
-  - name: NetCore-Public
+  - name: MAUI-DNCENG
     demands:
-        - ImageOverride -equals 1es-windows-2022-open
+        - ImageOverride -equals 1ESPT-Windows2022
     os: Windows
     buildScript: $(_buildScript)
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui.sln'
@@ -90,9 +90,9 @@ parameters:
         - ImageOverride -equals 1es-windows-2022
       os: windows
     public:
-      name: NetCore-Public
+      name: MAUI-DNCENG
       demands:
-        - ImageOverride -equals 1es-windows-2022-open
+        - ImageOverride -equals 1ESPT-Windows2022
       os: windows
 
 - name: MacOSPool


### PR DESCRIPTION
### Description of Change

Test if these machines are faster.

This pull request updates the build configuration for the MAUI project in the CI pipeline. The main changes involve renaming the build platform and updating the image override to use a new Windows build image.

Build platform and image updates:

* Renamed the build platform from `NetCore-Public` to `MAUI-DNCENG` in the `BuildPlatformsPublic` and `public` sections of `eng/pipelines/ci.yml`. [[1]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L71-R73) [[2]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L93-R95)
* Updated the image override demand from `1es-windows-2022-open` to `1ESPT-Windows2022` to use the new build pool for Windows builds. [[1]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L71-R73) [[2]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L93-R95)