### PR TITLE
[ci] Fix public vs internal aces

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -98,21 +98,16 @@ parameters:
 - name: MacOSPool
   type: object
   default:
-    name: AcesShared
-    demands:
+    internal:
+      name: Azure Pipelines
+      vmImage: $(HostedMacImage)
+      label: macOS
+    public:
+      name: AcesShared
+      demands:
         - ImageOverride -equals ACES_VM_SharedPool_Tahoe
-    os: macOS
-    label: macOS
+      label: macOS
 
-# ARM64 macOS pool (Apple Silicon)
-- name: MacOSPoolArm64
-  type: object
-  default:
-    name: AcesShared
-    demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
-    os: macOS
-    label: macOS-arm64
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
@@ -205,7 +200,10 @@ stages:
       buildscript: $(_buildScript)
     - name: mac_unit_tests
       displayName: macOS Unit Tests
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 90
       testOS: macOS
       buildscript: $(_buildScriptMacOS)
@@ -226,7 +224,10 @@ stages:
       timeout: 120
       testCategory: Samples
     - name: mac_sample_tests
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 240
       testCategory: Samples
 
@@ -255,7 +256,10 @@ stages:
       timeout: 120
       testCategory: Build
     - name: mac_buildtemplate_tests
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 240
       testCategory: Build
 
@@ -269,7 +273,10 @@ stages:
       timeout: 120
       testCategory: Blazor
     - name: mac_blazortemplate_tests
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 240
       testCategory: Blazor
 
@@ -283,40 +290,61 @@ stages:
       timeout: 120
       testCategory: MultiProject
     - name: mac_multitemplate_tests
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 120
       testCategory: MultiProject
 
     # TODO: macOSTemplates and AOT template categories
     - name: mac_runandroid_tests
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 240
       testCategory: RunOnAndroid
 
     # RunOniOS - Individual test methods run in parallel
     # ARM64 (Apple Silicon) lanes - using MacOSPoolArm64
     - name: mac_runios_maui_debug_arm64
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiDebug
 
     - name: mac_runios_maui_release_arm64
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiRelease
 
     - name: mac_runios_maui_trim_arm64
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiReleaseTrimFull
 
     - name: mac_runios_blazor_debug_arm64
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorDebug
 
     - name: mac_runios_blazor_release_arm64
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorRelease
 
@@ -328,44 +356,65 @@ stages:
     #   testName: RunOniOS_BlazorReleaseTrimFull
 
     - name: mac_runios_nativeaot_arm64
-      pool: ${{ parameters.MacOSPoolArm64 }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiNativeAOT
 
     # MacOSPool lanes - comparison with ARM64 pool
     # Only run on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
     - name: mac_runios_maui_debug
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiDebug
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_maui_release
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiRelease
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_maui_trim
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiReleaseTrimFull
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_blazor_debug
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorDebug
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_blazor_release
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorRelease
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_nativeaot
-      pool: ${{ parameters.MacOSPool }}
+      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
+        pool: ${{ parameters.MacOSPool.public }}
+      ${{ else }}:  
+        pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiNativeAOT
       condition: ${{ parameters.macOSPoolLaneCondition }}

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -202,7 +202,7 @@ stages:
       displayName: macOS Unit Tests
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
         pool: ${{ parameters.MacOSPool.public }}
-      ${{ else }}:  
+      ${{ else }}:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 90
       testOS: macOS


### PR DESCRIPTION
### Description of Change

ACES doesn t existing on the internal dnceng so we need to keep what we had. 

This pull request updates the Azure Pipelines configuration for macOS jobs to simplify pool selection and improve flexibility. The main change is the removal of the separate `MacOSPoolArm64` parameter and the introduction of conditional logic to select between internal and public macOS pools based on the build definition. This allows all macOS test and build stages to use a unified pool configuration, streamlining maintenance and making it easier to manage resources for different build scenarios.

Key changes:

**Pipeline Pool Configuration:**

* Removed the `MacOSPoolArm64` parameter and consolidated macOS pool definitions into a single `MacOSPool` parameter with `internal` and `public` options.

**Conditional Pool Selection in Stages:**

* Updated all macOS-related stages (unit tests, sample tests, template tests, and iOS/Android test jobs) to use conditional logic for pool selection: if the build is for `'maui-pr'`, the `public` pool is used; otherwise, the `internal` pool is used. [[1]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L208-R206) [[2]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L229-R230) [[3]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L258-R262) [[4]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L272-R279) [[5]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L286-R347) [[6]](diffhunk://#diff-07a82fab001c5b336d89cb64918f0a88b6b66f03d88d67e0fa13c65202455120L331-R417)