### PR TITLE
[iOS] Fix MauiCALayer and StaticCAShapeLayer crash on finalizer thread

### DIFF
--- a/src/Core/src/Platform/iOS/MauiCALayer.cs
+++ b/src/Core/src/Platform/iOS/MauiCALayer.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Maui.Platform
 
 		protected override void Dispose(bool disposing)
 		{
-			_autosizeToSuperLayerBehavior.Detach();
+			if (disposing)
+			{
+				_autosizeToSuperLayerBehavior.Detach();
+			}
 			base.Dispose(disposing);
 		}
 

--- a/src/Core/src/Platform/iOS/StaticCAGradientLayer.cs
+++ b/src/Core/src/Platform/iOS/StaticCAGradientLayer.cs
@@ -10,7 +10,10 @@ class StaticCAGradientLayer : CAGradientLayer, IAutoSizableCALayer
 
 	protected override void Dispose(bool disposing)
 	{
-		_autosizeToSuperLayerBehavior.Detach();
+		if (disposing)
+		{
+			_autosizeToSuperLayerBehavior.Detach();
+		}
 		base.Dispose(disposing);
 	}
 

--- a/src/Core/src/Platform/iOS/StaticCALayer.cs
+++ b/src/Core/src/Platform/iOS/StaticCALayer.cs
@@ -10,7 +10,10 @@ class StaticCALayer : CALayer, IAutoSizableCALayer
 
 	protected override void Dispose(bool disposing)
 	{
-		_autosizeToSuperLayerBehavior.Detach();
+		if (disposing)
+		{
+			_autosizeToSuperLayerBehavior.Detach();
+		}
 		base.Dispose(disposing);
 	}
 

--- a/src/Core/src/Platform/iOS/StaticCAShapeLayer.cs
+++ b/src/Core/src/Platform/iOS/StaticCAShapeLayer.cs
@@ -10,7 +10,10 @@ class StaticCAShapeLayer : CAShapeLayer, IAutoSizableCALayer
 
 	protected override void Dispose(bool disposing)
 	{
-		_autosizeToSuperLayerBehavior.Detach();
+		if (disposing)
+		{
+			_autosizeToSuperLayerBehavior.Detach();
+		}
 		base.Dispose(disposing);
 	}
 


### PR DESCRIPTION
### Description of Change

`MauiCALayer` and `StaticCAShapeLayer` crash with `EXC_BAD_ACCESS` when disposed on the finalizer thread in Release/AOT builds. The crash occurs because `Dispose()` unconditionally calls `_autosizeToSuperLayerBehavior.Detach()`, which invokes Objective-C methods on native `CALayer` objects that may have already been deallocated by UIKit.

The fix wraps the `Detach()` call in `if (disposing)` to follow the standard .NET dispose pattern - only call into external/native objects during explicit disposal, not during finalization.

### Issues Fixed

Fixes #33800

### Changes

- `src/Core/src/Platform/iOS/MauiCALayer.cs` - Wrap `Detach()` call in `if (disposing)`
- `src/Core/src/Platform/iOS/StaticCAShapeLayer.cs` - Wrap `Detach()` call in `if (disposing)`
- `src/Core/src/Platform/iOS/StaticCALayer.cs` - Wrap `Detach()` call in `if (disposing)`
- `src/Core/src/Platform/iOS/StaticCAGradientLayer.cs` - Wrap `Detach()` call in `if (disposing)`
### Testing

- Built MAUI from source with this fix
- - Tested in a production iOS app (Release/AOT via TestFlight)
- - Confirmed crashes no longer occur with the patched `Microsoft.Maui.Core`