### PR TITLE
Mark Color as immutable and make Font a readonly struct

### DIFF
--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.Graphics
 		/// <summary>
 		/// Determines whether the specified <see cref="Color"/> is equal to the current color using byte-precision comparison.
 		/// </summary>
-		public bool Equals(Color other)
+		public virtual bool Equals(Color other)
 		{
 			if (other is null)
 				return false;

--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Graphics
 	/// </summary>
 	[DebuggerDisplay("Red={Red}, Green={Green}, Blue={Blue}, Alpha={Alpha}")]
 	[TypeConverter(typeof(Converters.ColorTypeConverter))]
+	[ImmutableObject(true)]
 	public class Color
 	{
 		/// <summary>

--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.Graphics
 		/// <summary>
 		/// Determines whether the specified <see cref="Color"/> is equal to the current color using byte-precision comparison.
 		/// </summary>
-		public virtual bool Equals(Color other)
+		public bool Equals(Color other)
 		{
 			if (other is null)
 				return false;

--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Graphics
 	[DebuggerDisplay("Red={Red}, Green={Green}, Blue={Blue}, Alpha={Alpha}")]
 	[TypeConverter(typeof(Converters.ColorTypeConverter))]
 	[ImmutableObject(true)]
-	public class Color
+	public record class Color
 	{
 		/// <summary>
 		/// The red component of the color, ranging from 0.0 to 1.0.
@@ -125,12 +125,15 @@ namespace Microsoft.Maui.Graphics
 			}
 		}
 
-		public override bool Equals(object obj)
+		/// <summary>
+		/// Determines whether the specified <see cref="Color"/> is equal to the current color using byte-precision comparison.
+		/// </summary>
+		public virtual bool Equals(Color other)
 		{
-			if (obj is Color other)
-				return ToInt() == other.ToInt();
+			if (other is null)
+				return false;
 
-			return base.Equals(obj);
+			return ToInt() == other.ToInt();
 		}
 
 		[Obsolete("Use ToArgbHex instead.")]

--- a/src/Graphics/src/Graphics/Color.cs
+++ b/src/Graphics/src/Graphics/Color.cs
@@ -113,24 +113,17 @@ namespace Microsoft.Maui.Graphics
 			return $"[Color: Red={r}, Green={g}, Blue={b}, Alpha={a}]";
 		}
 
-		public override int GetHashCode()
-		{
-			unchecked
-			{
-				int hashcode = Red.GetHashCode();
-				hashcode = (hashcode * 397) ^ Green.GetHashCode();
-				hashcode = (hashcode * 397) ^ Blue.GetHashCode();
-				hashcode = (hashcode * 397) ^ Alpha.GetHashCode();
-				return hashcode;
-			}
-		}
+		public override int GetHashCode() => ToInt();
 
 		/// <summary>
 		/// Determines whether the specified <see cref="Color"/> is equal to the current color using byte-precision comparison.
 		/// </summary>
-		public virtual bool Equals(Color other)
+		public virtual bool Equals(Color? other)
 		{
 			if (other is null)
+				return false;
+
+			if (EqualityContract != other.EqualityContract)
 				return false;
 
 			return ToInt() == other.ToInt();

--- a/src/Graphics/src/Graphics/Font.cs
+++ b/src/Graphics/src/Graphics/Font.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Graphics
 	/// <summary>
 	/// Represents a font with a name, weight, and style.
 	/// </summary>
-	public struct Font : IFont, IEquatable<IFont>
+	public readonly struct Font : IFont, IEquatable<IFont>
 	{
 		/// <summary>
 		/// Gets the default font.
@@ -131,17 +131,17 @@ namespace Microsoft.Maui.Graphics
 		/// <summary>
 		/// Gets the font name or family.
 		/// </summary>
-		public string Name { get; private set; }
+		public string Name { get; }
 
 		/// <summary>
 		/// Gets the font weight.
 		/// </summary>
-		public int Weight { get; private set; }
+		public int Weight { get; }
 
 		/// <summary>
 		/// Gets the font style type.
 		/// </summary>
-		public FontStyleType StyleType { get; private set; }
+		public FontStyleType StyleType { get; }
 
 		/// <summary>
 		/// Determines whether the specified font is equal to the current font.

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Microsoft.Maui.Graphics.Color.Color(Microsoft.Maui.Graphics.Color! original) -> void
+override Microsoft.Maui.Graphics.Color.Equals(object? obj) -> bool
+static Microsoft.Maui.Graphics.Color.operator !=(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? left, Microsoft.Maui.Graphics.Color? right) -> bool
+virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
+virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
+virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -6,4 +6,4 @@ static Microsoft.Maui.Graphics.Color.operator ==(Microsoft.Maui.Graphics.Color? 
 virtual Microsoft.Maui.Graphics.Color.<Clone>$() -> Microsoft.Maui.Graphics.Color!
 virtual Microsoft.Maui.Graphics.Color.EqualityContract.get -> System.Type!
 virtual Microsoft.Maui.Graphics.Color.PrintMembers(System.Text.StringBuilder! builder) -> bool
-~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color other) -> bool
+~virtual Microsoft.Maui.Graphics.Color.Equals(Microsoft.Maui.Graphics.Color? other) -> bool


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR improves type safety and documents immutability for core Graphics types.

### Intent

These changes enable future XAML Source Generator (XSG) enhancements. By explicitly marking types as immutable, the source generator can make better optimization decisions, such as:
- Caching instances safely
- Avoiding defensive copies
- Generating more efficient code paths for immutable value assignments

### Changes

1. **Color class**: Added `[ImmutableObject(true)]` attribute
   - Color was already effectively immutable (all fields are `readonly`)
   - The attribute documents this intent for tooling and developers

2. **Font struct**: Converted to `readonly struct`
   - Changed from `struct` to `readonly struct`
   - Changed properties from `{ get; private set; }` to `{ get; }`
   - The `private set` was only used in the constructor, so this is not a breaking change

### Why

- Enables XSG optimizations for immutable types
- Better compiler optimizations for `readonly struct`
- Documents immutability intent explicitly
- Enables better static analysis and tooling support
- No breaking changes for consumers

### API Changes

None - these are non-breaking enhancements that formalize existing immutability guarantees.