### PR TITLE
Implement Lazy ResourceDictionary for SourceGen (~8x faster inflation)

### DIFF
--- a/docs/lazy-resourcedictionary-spec.md
+++ b/docs/lazy-resourcedictionary-spec.md
@@ -1,0 +1,142 @@
+# Lazy ResourceDictionary Specification
+
+## Problem
+
+1. **Slow inflation time**: All resources are instantiated upfront during XAML inflation, even if never used
+2. **No `x:Shared` support**: Resources that need parenting (e.g., `StrokeShape`) cannot be StaticResources because the same instance is shared - causing crashes when multiple elements try to parent the same object
+
+## Proposed Solution
+
+Store `Func<object>` factories instead of object instances in ResourceDictionary. Resources are created on-demand when accessed.
+
+### API Changes
+
+```csharp
+public class ResourceDictionary
+{
+    // NEW: Add a resource factory instead of an instance
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void AddFactory(string key, Func<object> factory, bool shared = true);
+    
+    // NEW: Add an implicit style factory (uses TargetType.FullName as key)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void AddFactory(Type targetType, Func<Style> factory, bool shared = true);
+    
+    // MODIFIED: TryGetValue now invokes factory if stored value is a factory
+    // For shared=true: invoke once, cache result
+    // For shared=false: invoke every time (x:Shared="false")
+}
+```
+
+### Internal Storage
+
+```csharp
+// Wrapper to distinguish factories from regular values
+internal sealed class LazyResource
+{
+    public Func<object> Factory { get; }
+    public bool Shared { get; }
+    private object? _cachedValue;
+    
+    public object GetValue()
+    {
+        if (!Shared) return Factory();
+        return _cachedValue ??= Factory();
+    }
+}
+
+// _innerDictionary stores either:
+// - object (existing behavior)
+// - LazyResource (new lazy behavior)
+```
+
+### Behavior
+
+| Scenario | `shared=true` (default) | `shared=false` |
+|----------|------------------------|----------------|
+| First access | Invoke factory, cache result, return | Invoke factory, return |
+| Subsequent | Return cached | Invoke factory, return |
+
+## Source Generator Integration
+
+**SourceGen-only for now**: XamlC support would add significant complexity. Runtime inflator support is feasible (existing PR) but not in scope for initial implementation.
+
+```csharp
+// Generated code (SourceGen)
+Resources.AddFactory("MyColor", () => new Color(...), shared: true);
+Resources.AddFactory("MyShape", () => new RoundRectangle { ... }, shared: false);
+
+// Implicit style
+Resources.AddFactory(typeof(Label), () => new Style(typeof(Label)) { ... }, shared: true);
+```
+
+### XAML Syntax
+
+```xaml
+<!-- Default: x:Shared="true" (cached, current behavior) -->
+<Style x:Key="MyStyle" TargetType="Button">...</Style>
+
+<!-- New: x:Shared="false" (new instance per access) -->
+<RoundRectangle x:Key="MyShape" x:Shared="false" CornerRadius="10"/>
+```
+
+## Scope
+
+| Inflator | Lazy RD | x:Shared | Notes |
+|----------|---------|----------|-------|
+| **SourceGen** | ✅ | ✅ | Initial implementation |
+| **Runtime** | ❌ | ❌ | Feasible, future work |
+| **XamlC** | ❌ | ❌ | Complex, not planned |
+
+## Exclusions
+
+**Value types** (structs like `Thickness`, `CornerRadius`) are excluded from lazy treatment - no benefit since they're copied on access.
+
+## Feature Flag
+
+LazyRD is **enabled by default** for all XAML files compiled with SourceGen. This provides improved performance out of the box.
+
+To opt-out per file:
+```xml
+<MauiXaml Update="MyPage.xaml" LazyRD="false" />
+```
+
+To opt-out globally:
+```xml
+<MauiXamlLazyRD>false</MauiXamlLazyRD>
+```
+
+## API Surface
+
+`AddFactory` is `[EditorBrowsable(Never)]` - generated code only, not for direct use.
+
+**Public iteration behavior:**
+- `Keys` → returns keys only, does NOT invoke factories
+- `Values` → resolves lazy values (invokes factory, caches if shared)
+- `GetEnumerator()` / `foreach` → returns `KeyValuePair<string, object>` with resolved values
+
+Internal `_innerDictionary` stores `LazyResource`, but public API always resolves — no breaking change.
+
+## Benefits
+
+- ⚡ **Faster startup**: Resources created only when needed
+- 🔧 **x:Shared for free**: `StrokeShape` in StaticResource finally works
+- 📦 **No runtime cost for unused resources**
+
+## Risks
+
+- ⚠️ `x:Shared` only works with SourceGen (acceptable trade-off)
+
+## Future Considerations
+
+- **ApplyToDerivedTypes optimization**: Store `ApplyToDerivedTypes` bool alongside `Type targetType` in implicit style registration, so we don't need to inflate the style just to check this property during style resolution.
+
+- **Default `x:Shared=false` via attribute**: Mark types like `StrokeShape`, `RoundRectangle`, etc. with an attribute (e.g., `[NotSharedByDefault]`) so SourceGen automatically treats them as `x:Shared="false"` without explicit XAML markup.
+
+- **Immutable reference types**: Some reference types are effectively immutable (e.g., `Color` if it were a class, `SolidColorBrush` with frozen state). These could potentially skip lazy creation since sharing is safe. Consider an `[Immutable]` or `[SharedByDefault]` attribute to opt specific types out of lazy creation overhead while still being shareable.
+
+- **Thread safety**: The current `LazyResource.GetValue()` implementation uses a simple check-then-cache pattern without synchronization. This mirrors `ResourceDictionary` itself which uses `Dictionary<string, object>` (not thread-safe). If multi-threaded resource access becomes a requirement, consider using `Lazy<T>` with `LazyThreadSafetyMode.ExecutionAndPublication`. For now, the simpler implementation is preferred since MAUI resource access is UI-thread-only in practice.
+
+- **DynamicResource with runtime-added lazy resources**: `AddFactory` fires `ValuesChanged` with the internal `LazyResource` wrapper instead of the resolved value. This breaks DynamicResource bindings that exist before the resource is added at runtime. Not an issue for SourceGen (resources added during `InitializeComponent` before bindings). Fix: resolve lazy values in `OnValueChanged` or have `Element.OnResourcesChanged` handle `LazyResource` resolution.
+
+- **Nested ResourceDictionaries inside lazy resources**: If a lazy resource has its own `.Resources` property (e.g., a ControlTemplate with embedded resources), those nested resources may not be populated. The lambda uses `stopOnResourceDictionary: true` to prevent infinite recursion. Edge case - needs investigation if real-world usage requires this.

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -39,4 +40,3 @@ static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Mic
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!
-﻿#nullable enable

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -39,4 +40,3 @@ static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Mic
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!
-﻿#nullable enable

--- a/src/Controls/src/Build.Tasks/BuildException.cs
+++ b/src/Controls/src/Build.Tasks/BuildException.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public static BuildExceptionCode ResourceDictMissingKey = new BuildExceptionCode("XC", 0126, nameof(ResourceDictMissingKey), "");
 		public static BuildExceptionCode XKeyNotLiteral = new BuildExceptionCode("XC", 0127, nameof(XKeyNotLiteral), "");
 		public static BuildExceptionCode StaticResourceSyntax = new BuildExceptionCode("XC", 0128, nameof(StaticResourceSyntax), "");
+		public static BuildExceptionCode XSharedNotSupported = new BuildExceptionCode("XC", 0129, nameof(XSharedNotSupported), "");
 
 		//CSC equivalents
 		public static BuildExceptionCode ObsoleteProperty = new BuildExceptionCode("XC", 0618, nameof(ObsoleteProperty), ""); //warning

--- a/src/Controls/src/Build.Tasks/ErrorMessages.resx
+++ b/src/Controls/src/Build.Tasks/ErrorMessages.resx
@@ -271,4 +271,7 @@
   <data name="StaticResourceSyntax" xml:space="preserve">
     <value>A key is required in {StaticResource}.</value>
   </data>  
+  <data name="XSharedNotSupported" xml:space="preserve">
+    <value>x:Shared is only supported with SourceGen inflator. Remove the attribute or switch to SourceGen.</value>
+  </data>
 </root>

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 			if (TrySetRuntimeName(propertyName, Context.Variables[(ElementNode)parentNode], node))
 				return;
+			if (propertyName == XmlName.xShared)
+				throw new BuildException(BuildExceptionCode.XSharedNotSupported, node as IXmlLineInfo, null);
 			if (skips.Contains(propertyName))
 				return;
 			if (parentNode is ElementNode && ((ElementNode)parentNode).SkipProperties.Contains(propertyName))

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
@@ -31,5 +31,7 @@
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="LineInfo" />
     <CompilerVisibleProperty Include="Configuration" />
     <CompilerVisibleProperty Include="EnablePreviewFeatures" />
+    <CompilerVisibleProperty Include="MauiXamlLazyRD" />
+		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="LazyRD" />
 	</ItemGroup>
 </Project>

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -851,7 +851,14 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		internal void OnResourcesChangedKeys(IEnumerable<string> keys)
 		{
-			OnResourcesChangedKeys(keys, key => this.TryGetResource(key, out var v) ? v : null);
+			OnResourcesChangedKeys(keys, key =>
+			{
+				// Style class keys need to be merged across the entire parent chain,
+				// not just return the first match from TryGetResource.
+				if (key.StartsWith(Style.StyleClassPrefix, StringComparison.Ordinal))
+					return this.GetMergedStyleClassResource(key);
+				return this.TryGetResource(key, out var v) ? v : null;
+			});
 		}
 
 		/// <summary>

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Maui.Controls
 			RealParent = value;
 			if (RealParent != null)
 			{
-				OnParentResourcesChanged(RealParent.GetMergedResources());
+				OnParentResourcesChangedKeys(RealParent.GetMergedResourceKeys());
 				((IElementDefinition)RealParent).AddResourcesChangedListener(OnParentResourcesChanged);
 			}
 
@@ -758,12 +758,29 @@ namespace Microsoft.Maui.Controls
 			if (e == ResourcesChangedEventArgs.StyleSheets)
 				ApplyStyleSheets();
 			else
-				OnParentResourcesChanged(e.Values);
+				OnParentResourcesChangedKeys(e.Keys, e.ResolveValue);
 		}
 
 		internal virtual void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)
 		{
 			OnResourcesChanged(values);
+		}
+
+		/// <summary>
+		/// Called when parent resources change, using keys only to avoid resolving lazy resources.
+		/// Values are looked up on-demand only for resources that are actually bound via DynamicResource.
+		/// </summary>
+		internal virtual void OnParentResourcesChangedKeys(IEnumerable<string> keys)
+		{
+			OnResourcesChangedKeys(keys);
+		}
+
+		/// <summary>
+		/// Called when parent resources change, using keys and a resolver to avoid resolving lazy resources.
+		/// </summary>
+		internal virtual void OnParentResourcesChangedKeys(IEnumerable<string> keys, Func<string, object> resolver)
+		{
+			OnResourcesChangedKeys(keys, resolver);
 		}
 
 		internal override void OnRemoveDynamicResource(BindableProperty property)
@@ -780,7 +797,7 @@ namespace Microsoft.Maui.Controls
 			if (e == ResourcesChangedEventArgs.StyleSheets)
 				ApplyStyleSheets();
 			else
-				OnResourcesChanged(e.Values);
+				OnResourcesChangedKeys(e.Keys, e.ResolveValue);
 		}
 
 		internal void OnResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)
@@ -788,8 +805,13 @@ namespace Microsoft.Maui.Controls
 			if (values == null)
 				return;
 			if (_changeHandlers != null)
+			{
+#pragma warning disable CS0618 // Legacy code path for backward compatibility
+				var e = new ResourcesChangedEventArgs(values);
+#pragma warning restore CS0618
 				foreach (Action<object, ResourcesChangedEventArgs> handler in _changeHandlers.ToList())
-					handler(this, new ResourcesChangedEventArgs(values));
+					handler(this, e);
+			}
 			if (_dynamicResources == null)
 				return;
 			if (_bindableResources == null)
@@ -814,6 +836,70 @@ namespace Microsoft.Maui.Controls
 					OnResourceChanged(changedResource.Item1, value.Value, changedResource.Item2);
 
 				var bindableObject = value.Value as BindableObject;
+				if (bindableObject != null && (bindableObject as Element)?.Parent == null)
+				{
+					if (!_bindableResources.Contains(bindableObject))
+						_bindableResources.Add(bindableObject);
+					SetInheritedBindingContext(bindableObject, BindingContext);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Called when resources change, using keys only to avoid resolving lazy resources.
+		/// Values are looked up on-demand only for resources that are actually bound via DynamicResource.
+		/// </summary>
+		internal void OnResourcesChangedKeys(IEnumerable<string> keys)
+		{
+			OnResourcesChangedKeys(keys, key => this.TryGetResource(key, out var v) ? v : null);
+		}
+
+		/// <summary>
+		/// Called when resources change, using keys and a resolver to avoid resolving lazy resources.
+		/// Values are looked up on-demand only for resources that are actually bound via DynamicResource.
+		/// </summary>
+		internal void OnResourcesChangedKeys(IEnumerable<string> keys, Func<string, object> resolver)
+		{
+			if (keys == null)
+				return;
+			
+			// Notify change handlers with keys + resolver (they can resolve on-demand)
+			if (_changeHandlers != null)
+			{
+				var e = new ResourcesChangedEventArgs(keys, resolver);
+				foreach (Action<object, ResourcesChangedEventArgs> handler in _changeHandlers.ToList())
+					handler(this, e);
+			}
+			
+			if (_dynamicResources == null)
+				return;
+			if (_bindableResources == null)
+				_bindableResources = new List<BindableObject>();
+			foreach (string key in keys)
+			{
+				List<(BindableProperty, SetterSpecificity)> changedResources = null;
+				foreach (KeyValuePair<BindableProperty, (string, SetterSpecificity)> dynR in DynamicResources)
+				{
+					// when the DynamicResource bound to a BindableProperty is
+					// changing then the BindableProperty needs to be refreshed;
+					// The .Value.Item1 is the name of DynamicResource to which the BindableProperty is bound.
+					if (dynR.Value.Item1 != key)
+						continue;
+					changedResources = changedResources ?? new List<(BindableProperty, SetterSpecificity)>();
+					changedResources.Add((dynR.Key, dynR.Value.Item2));
+				}
+				if (changedResources == null)
+					continue;
+				
+				// Only now do we look up the value - on demand
+				object value = resolver(key);
+				if (value == null)
+					continue;
+					
+				foreach ((BindableProperty, SetterSpecificity) changedResource in changedResources)
+					OnResourceChanged(changedResource.Item1, value, changedResource.Item2);
+
+				var bindableObject = value as BindableObject;
 				if (bindableObject != null && (bindableObject as Element)?.Parent == null)
 				{
 					if (!_bindableResources.Contains(bindableObject))

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
+*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
-~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 Microsoft.Maui.Controls.LongPressGestureRecognizer
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.get -> double
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.set -> void
@@ -20,10 +20,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.G
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
 Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -31,11 +29,18 @@ static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProper
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
-*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer
@@ -19,26 +21,29 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.G
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
 Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
-*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer
@@ -19,26 +21,29 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.G
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
 Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
-*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
+*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
-~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 Microsoft.Maui.Controls.LongPressGestureRecognizer
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.get -> double
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.set -> void
@@ -20,10 +20,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.G
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
 Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -31,11 +29,18 @@ static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProper
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
-*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
+*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
-~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 Microsoft.Maui.Controls.LongPressGestureRecognizer
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.get -> double
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.set -> void
@@ -20,10 +20,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.G
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
 Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -31,11 +29,18 @@ static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProper
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
-*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
+*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
-~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 Microsoft.Maui.Controls.LongPressGestureRecognizer
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.get -> double
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.set -> void
@@ -20,10 +20,8 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.G
 Microsoft.Maui.Controls.LongPressedEventArgs
 Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
 Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -31,11 +29,18 @@ static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProper
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.get -> object
 ~Microsoft.Maui.Controls.AppThemeBinding.Light.set -> void
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
-*REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,10 +1,5 @@
 #nullable enable
-~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
-Microsoft.Maui.Controls.LongPressedEventArgs
-Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
-Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
-virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressGestureRecognizer
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.get -> double
 Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovement.set -> void
@@ -12,17 +7,19 @@ Microsoft.Maui.Controls.LongPressGestureRecognizer.Command.get -> System.Windows
 Microsoft.Maui.Controls.LongPressGestureRecognizer.Command.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameter.get -> object?
 Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameter.set -> void
-Microsoft.Maui.Controls.LongPressGestureRecognizer.LongPressed -> System.EventHandler<Microsoft.Maui.Controls.LongPressedEventArgs!>?
 Microsoft.Maui.Controls.LongPressGestureRecognizer.LongPressGestureRecognizer() -> void
+Microsoft.Maui.Controls.LongPressGestureRecognizer.LongPressed -> System.EventHandler<Microsoft.Maui.Controls.LongPressedEventArgs!>?
 Microsoft.Maui.Controls.LongPressGestureRecognizer.LongPressing -> System.EventHandler<Microsoft.Maui.Controls.LongPressingEventArgs!>?
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDuration.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.get -> int
 Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequired.set -> void
 Microsoft.Maui.Controls.LongPressGestureRecognizer.State.get -> Microsoft.Maui.GestureStatus
+Microsoft.Maui.Controls.LongPressedEventArgs
+Microsoft.Maui.Controls.LongPressedEventArgs.LongPressedEventArgs(object? parameter) -> void
+Microsoft.Maui.Controls.LongPressedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.LongPressingEventArgs
 Microsoft.Maui.Controls.LongPressingEventArgs.LongPressingEventArgs(Microsoft.Maui.GestureStatus status) -> void
-virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.LongPressingEventArgs.Status.get -> Microsoft.Maui.GestureStatus
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.AllowableMovementProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -30,3 +27,11 @@ static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.CommandProper
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.MinimumPressDurationProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.NumberOfTouchesRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.LongPressGestureRecognizer.StateProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.LongPressedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.Keys.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResolveValue(string key) -> object
+~Microsoft.Maui.Controls.Internals.ResourcesChangedEventArgs.ResourcesChangedEventArgs(System.Collections.Generic.IEnumerable<string> keys, System.Func<string, object> resolver) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
+~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
+~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -487,8 +487,8 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentException($"A resource with the key '{key}' is already present in the ResourceDictionary.");
 			var lazyResource = new LazyResource(factory, shared);
 			_innerDictionary.Add(key, lazyResource);
-			// Note: We don't fire OnValueChanged here since the value hasn't been resolved yet.
-			// The event will contain the LazyResource wrapper, which is internal behavior.
+			// Fire OnValueChanged so DynamicResource bindings are notified of the new key.
+			// The event value is the LazyResource wrapper; actual resolution happens on first access.
 			OnValueChanged(key, lazyResource);
 		}
 

--- a/src/Controls/src/Core/ResourcesChangedEventArgs.cs
+++ b/src/Controls/src/Core/ResourcesChangedEventArgs.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Microsoft.Maui.Controls.Internals
 {
@@ -10,16 +11,38 @@ namespace Microsoft.Maui.Controls.Internals
 	public class ResourcesChangedEventArgs : EventArgs
 	{
 		/// <summary>Singleton instance used for stylesheet changes.</summary>
-		public static readonly ResourcesChangedEventArgs StyleSheets = new ResourcesChangedEventArgs(null);
+		public static readonly ResourcesChangedEventArgs StyleSheets = new ResourcesChangedEventArgs((IEnumerable<string>)null, null);
+
+		readonly Func<string, object> _resolver;
+
+		/// <summary>Creates a new <see cref="ResourcesChangedEventArgs"/> with the specified keys and resolver.</summary>
+		/// <param name="keys">The changed resource keys.</param>
+		/// <param name="resolver">Function to resolve a value by key (called on-demand).</param>
+		public ResourcesChangedEventArgs(IEnumerable<string> keys, Func<string, object> resolver)
+		{
+			Keys = keys;
+			_resolver = resolver;
+		}
 
 		/// <summary>Creates a new <see cref="ResourcesChangedEventArgs"/> with the specified values.</summary>
 		/// <param name="values">The changed resource values.</param>
+		[Obsolete("Use the constructor with keys and resolver to avoid resolving lazy resources.")]
 		public ResourcesChangedEventArgs(IEnumerable<KeyValuePair<string, object>> values)
 		{
-			Values = values;
+			Keys = values?.Select(kvp => kvp.Key);
+			_resolver = key => values?.FirstOrDefault(kvp => kvp.Key == key).Value;
 		}
 
-		/// <summary>Gets the changed resource values.</summary>
-		public IEnumerable<KeyValuePair<string, object>> Values { get; private set; }
+		/// <summary>Gets the changed resource keys.</summary>
+		public IEnumerable<string> Keys { get; }
+
+		/// <summary>Gets the changed resource values. Enumerating this will resolve lazy resources.</summary>
+		public IEnumerable<KeyValuePair<string, object>> Values => 
+			Keys?.Select(k => new KeyValuePair<string, object>(k, _resolver?.Invoke(k)));
+
+		/// <summary>Resolves a single resource value by key.</summary>
+		/// <param name="key">The resource key.</param>
+		/// <returns>The resolved value, or null if not found.</returns>
+		public object ResolveValue(string key) => _resolver?.Invoke(key);
 	}
 }

--- a/src/Controls/src/Core/ResourcesExtensions.cs
+++ b/src/Controls/src/Core/ResourcesExtensions.cs
@@ -55,6 +55,42 @@ namespace Microsoft.Maui.Controls
 			return resources;
 		}
 
+		/// <summary>
+		/// Gets all merged resource keys without resolving lazy values.
+		/// Used for resource change propagation where values are looked up on-demand.
+		/// </summary>
+		public static IEnumerable<string> GetMergedResourceKeys(this IElementDefinition element)
+		{
+			HashSet<string> keys = null;
+			while (element != null)
+			{
+				var ve = element as IResourcesProvider;
+				if (ve != null && ve.IsResourcesCreated)
+				{
+					keys = keys ?? new(StringComparer.Ordinal);
+					foreach (string key in ve.Resources.MergedResourcesKeys)
+					{
+						keys.Add(key);
+					}
+				}
+				var app = element as Application;
+				if (app != null && app.SystemResources != null)
+				{
+					keys = keys ?? new(StringComparer.Ordinal);
+					foreach (var kvp in app.SystemResources)
+						keys.Add(kvp.Key);
+				}
+				if (app != null)
+				{
+					keys = keys ?? new(StringComparer.Ordinal);
+					keys.Add(AppThemeBinding.AppThemeResource);
+				}
+
+				element = element.Parent;
+			}
+			return keys;
+		}
+
 		public static bool TryGetResource(this IElementDefinition element, string key, out object value)
 		{
 			while (element != null)

--- a/src/Controls/src/Core/ResourcesExtensions.cs
+++ b/src/Controls/src/Core/ResourcesExtensions.cs
@@ -109,5 +109,29 @@ namespace Microsoft.Maui.Controls
 			value = null;
 			return false;
 		}
+
+		/// <summary>
+		/// Merges style class resources across the entire parent chain.
+		/// Style classes with the same key at different levels must be combined into a single list.
+		/// </summary>
+		public static object GetMergedStyleClassResource(this IElementDefinition element, string key)
+		{
+			List<Style> merged = null;
+			while (element != null)
+			{
+				if (element is IResourcesProvider ve && ve.IsResourcesCreated && ve.Resources.TryGetValue(key, out var value) && value is IList<Style> styles)
+				{
+					merged ??= new List<Style>();
+					merged.AddRange(styles);
+				}
+				if (element is Application app && app.SystemResources != null && app.SystemResources.TryGetValue(key, out var sysValue) && sysValue is IList<Style> sysStyles)
+				{
+					merged ??= new List<Style>();
+					merged.AddRange(sysStyles);
+				}
+				element = element.Parent;
+			}
+			return merged;
+		}
 	}
 }

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -863,9 +863,40 @@ internal class KnownMarkups
 			return false;
 		}
 
-		var resource = GetResourceNode(eNode, context, (string)keyValueNode.Value);
-		if (resource is null || !context.Variables.TryGetValue(resource, out var variable))
+		var key = (string)keyValueNode.Value;
+		var resource = GetResourceNode(eNode, context, key);
+		
+		// Try to find the variable in current context or parent contexts (for lambda context)
+		ILocalValue? variable = null;
+		if (resource != null)
 		{
+			var ctx = context;
+			while (ctx != null && variable == null)
+			{
+				if (ctx.Variables.TryGetValue(resource, out var v))
+					variable = v;
+				ctx = ctx.ParentContext;
+			}
+		}
+		
+		if (resource is null || variable is null)
+		{
+			// Resource not in Variables - might be a lazy resource
+			var lazyResource = GetResourceNodeIncludingLazy(eNode, context, key);
+			if (lazyResource != null 
+				&& lazyResource.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var lazyType) 
+				&& lazyType != null)
+			{
+				// Find the Resources property accessor by walking up to find the element with Resources
+				var resourcesAccessor = GetResourcesAccessor(eNode, context, lazyResource);
+				if (resourcesAccessor != null)
+				{
+					returnType = lazyType;
+					value = $"({lazyType.ToFQDisplayString()}){resourcesAccessor}[\"{key}\"]";
+					return true;
+				}
+			}
+			
 			returnType = context.Compilation.ObjectType;
 			value = string.Empty;
 			return false;
@@ -935,8 +966,61 @@ internal class KnownMarkups
 		return false;
 	}
 
+	/// <summary>
+	/// Gets the Resources property accessor for an element containing a resource.
+	/// Walks up the tree to find which element owns the ResourceDictionary.
+	/// Also checks parent contexts for lazy resources inside lambdas.
+	/// </summary>
+	static string? GetResourcesAccessor(ElementNode en, SourceGenContext context, ElementNode resourceNode)
+	{
+		var n = en;
+		while (n != null)
+		{
+			if (n.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "Resources"), out var resourcesNode))
+			{
+				// Check if this Resources node contains our resource
+				bool containsResource = false;
+				if (resourcesNode is ElementNode irn && irn == resourceNode)
+					containsResource = true;
+				else if (resourcesNode is ListNode lr && lr.CollectionItems.Contains(resourceNode))
+					containsResource = true;
+				else if (resourcesNode is ElementNode rd && rd.XmlType.Name == "ResourceDictionary" && rd.CollectionItems.Contains(resourceNode))
+					containsResource = true;
+
+				if (containsResource)
+				{
+					// Check current context and parent contexts for the variable
+					var ctx = context;
+					while (ctx != null)
+					{
+						if (ctx.Variables.TryGetValue(n, out var ownerVar))
+						{
+							return $"{ownerVar.ValueAccessor}.Resources";
+						}
+						ctx = ctx.ParentContext;
+					}
+				}
+			}
+
+			var np = n.Parent;
+			if (np is ElementNode pen)
+				n = pen;
+			else if (np is ListNode lnp && lnp.Parent is ElementNode elnp)
+				n = elnp;
+			else
+				n = null;
+		}
+		return null;
+	}
+
 	//FIXME this could be smarter and look into merged RDs
 	static ElementNode? GetResourceNode(ElementNode en, SourceGenContext context, string key)
+		=> GetResourceNodeCore(en, context, key, requireInVariables: true);
+
+	static ElementNode? GetResourceNodeIncludingLazy(ElementNode en, SourceGenContext context, string key)
+		=> GetResourceNodeCore(en, context, key, requireInVariables: false);
+
+	static ElementNode? GetResourceNodeCore(ElementNode en, SourceGenContext context, string key, bool requireInVariables)
 	{
 		var n = en;
 		while (n != null)
@@ -955,7 +1039,7 @@ internal class KnownMarkups
 			//single resource in <Resources>
 			if (resourcesNode is ElementNode irn
 				&& irn.Properties.TryGetValue(XmlName.xKey, out INode xKeyNode)
-				&& context.Variables.ContainsKey(irn)
+				&& (!requireInVariables || IsInAnyContextVariables(irn, context))
 				&& xKeyNode is ValueNode xKeyValueNode
 				&& xKeyValueNode.Value as string == key)
 			{
@@ -968,7 +1052,7 @@ internal class KnownMarkups
 				{
 					if (rn is ElementNode irn2
 						&& irn2.Properties.TryGetValue(XmlName.xKey, out INode xKeyNode2)
-						&& context.Variables.ContainsKey(irn2)
+						&& (!requireInVariables || IsInAnyContextVariables(irn2, context))
 						&& xKeyNode2 is ValueNode xKeyValueNode2
 						&& xKeyValueNode2.Value as string == key)
 					{
@@ -985,7 +1069,7 @@ internal class KnownMarkups
 					if (rn is ElementNode irn3
 						&& irn3.Properties.TryGetValue(XmlName.xKey, out INode xKeyNode3)
 						&& irn3.XmlType.Name != "OnPlatform"
-						&& context.Variables.ContainsKey(irn3)
+						&& (!requireInVariables || IsInAnyContextVariables(irn3, context))
 						&& xKeyNode3 is ValueNode xKeyValueNode3
 						&& xKeyValueNode3.Value as string == key)
 					{
@@ -997,5 +1081,21 @@ internal class KnownMarkups
 			n = n.Parent as ElementNode;
 		}
 		return null;
+	}
+
+	/// <summary>
+	/// Checks if a node is in the Variables dictionary of any context in the parent chain.
+	/// This handles lambda contexts where variables are in parent context.
+	/// </summary>
+	static bool IsInAnyContextVariables(INode node, SourceGenContext context)
+	{
+		var ctx = context;
+		while (ctx != null)
+		{
+			if (ctx.Variables.ContainsKey(node))
+				return true;
+			ctx = ctx.ParentContext;
+		}
+		return false;
 	}
 }

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -891,8 +891,16 @@ internal class KnownMarkups
 				var resourcesAccessor = GetResourcesAccessor(eNode, context, lazyResource);
 				if (resourcesAccessor != null)
 				{
-					returnType = lazyType;
-					value = $"({lazyType.ToFQDisplayString()}){resourcesAccessor}[\"{key}\"]";
+					// For markup extensions, use the return type of ProvideValue (stored in the dictionary)
+					// not the declaring type of the markup extension itself
+					ITypeSymbol actualType = lazyType;
+					if (lazyType.IsValueProvider(context, out var provideValueReturnType, out _, out _, out _))
+					{
+						actualType = provideValueReturnType;
+					}
+					
+					returnType = actualType;
+					value = $"({actualType.ToFQDisplayString()}){resourcesAccessor}[\"{key}\"]";
 					return true;
 				}
 			}

--- a/src/Controls/src/SourceGen/NodeSGExtensions.cs
+++ b/src/Controls/src/SourceGen/NodeSGExtensions.cs
@@ -137,6 +137,111 @@ static class NodeSGExtensions
 	public static bool IsResourceDictionary(this ElementNode node, SourceGenContext context)
 		=> context.Variables.TryGetValue(node, out var variable) && variable.Type.InheritsFrom(context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ResourceDictionary")!, context);
 
+	/// <summary>
+	/// Determines if a node should be treated as a lazy resource in ResourceDictionary.
+	/// Lazy resources are created via factory functions for on-demand instantiation.
+	/// </summary>
+	/// <param name="node">The element node to check.</param>
+	/// <param name="parentNode">The parent node.</param>
+	/// <param name="context">The source generation context.</param>
+	/// <returns>True if the node should be a lazy resource; false otherwise.</returns>
+	public static bool IsLazyResource(this ElementNode node, INode parentNode, SourceGenContext context)
+	{
+		// Feature flag must be enabled
+		if (!context.ProjectItem.LazyRD)
+			return false;
+
+		// If we're in a nested context (inside a lambda body), don't treat as lazy
+		// Nested resources should be created eagerly within their parent lambda
+		if (context.ParentContext != null)
+			return false;
+
+		// Check if node has x:Key or is an implicit style (Style without x:Key)
+		bool hasKey = node.Properties.ContainsKey(XmlName.xKey);
+		bool isImplicitStyle = !hasKey && node.XmlType.Name == "Style";
+
+		// Styles with Class attribute need special handling - can't be lazy
+		// The Add method processes the Class property to add to class styles list
+		if (node.XmlType.Name == "Style" && node.Properties.ContainsKey(new XmlName("", "Class")))
+			return false;
+
+		// Must have x:Key OR be an implicit style to be considered lazy
+		if (!hasKey && !isImplicitStyle)
+			return false;
+
+		// Items with x:Name need a variable for field assignment - can't be lazy
+		if (node.Properties.ContainsKey(XmlName.xName))
+			return false;
+
+		// ResourceDictionary elements themselves are containers, not resources
+		if (node.XmlType.Name == "ResourceDictionary")
+			return false;
+
+		// Type must be resolvable to determine if it's a value type
+		// If we can't resolve the type, err on the side of caution and don't treat as lazy
+		if (!node.XmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var typeSymbol) || typeSymbol == null)
+			return false;
+		
+		// Value types should not be lazy (no benefit - value types are copied anyway)
+		if (typeSymbol.IsValueType)
+			return false;
+
+		// Strings should not be lazy - they often require TypeConverter processing
+		// when used with properties like RowDefinitions/ColumnDefinitions
+		if (typeSymbol.SpecialType == SpecialType.System_String)
+			return false;
+
+		// Check if in ResourceDictionary context
+		return IsInResourceDictionaryContext(node, parentNode, context);
+	}
+
+	/// <summary>
+	/// Checks if a node is in a ResourceDictionary context.
+	/// A resource is only lazy if it's:
+	/// 1. Direct child of X.Resources property element
+	/// 2. In a ListNode under X.Resources
+	/// 3. Direct child of ResourceDictionary element
+	/// 4. In a ListNode inside ResourceDictionary
+	/// </summary>
+	static bool IsInResourceDictionaryContext(ElementNode node, INode parentNode, SourceGenContext context)
+	{
+		// Case 1 & 3: Direct child of .Resources property or ResourceDictionary
+		if (parentNode is ElementNode parentElement)
+		{
+			// Check if parent is a ResourceDictionary
+			if (parentElement.XmlType.Name == "ResourceDictionary")
+				return true;
+
+			// Check if parent has us in a .Resources property
+			foreach (var prop in parentElement.Properties)
+			{
+				if (prop.Value == node && prop.Key.LocalName == "Resources")
+					return true;
+			}
+		}
+
+		// Case 2 & 4: In a ListNode that is under .Resources or ResourceDictionary
+		if (parentNode is ListNode listNode)
+		{
+			var grandParent = listNode.Parent;
+			if (grandParent is ElementNode grandParentElement)
+			{
+				// ListNode is direct child of ResourceDictionary
+				if (grandParentElement.XmlType.Name == "ResourceDictionary")
+					return true;
+
+				// ListNode is under a .Resources property
+				foreach (var prop in grandParentElement.Properties)
+				{
+					if (prop.Value == listNode && prop.Key.LocalName == "Resources")
+						return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	public static bool CanConvertTo(this ValueNode valueNode, IFieldSymbol bpFieldSymbol, SourceGenContext context, out ITypeSymbol? converter)
 	{
 		var typeandconverter = bpFieldSymbol.GetBPTypeAndConverter(context);

--- a/src/Controls/src/SourceGen/ProjectItem.cs
+++ b/src/Controls/src/SourceGen/ProjectItem.cs
@@ -69,6 +69,29 @@ record ProjectItem(AdditionalText AdditionalText, AnalyzerConfigOptions Options)
 	public string NoWarn
 		=> Options.GetValueOrNull("build_metadata.additionalfiles.NoWarn") ?? Options.GetValueOrNull("build_property.MauiXamlNoWarn") ?? "";
 
+	/// <summary>
+	/// When true, resources in ResourceDictionary are created lazily via factory functions.
+	/// This enables x:Shared support and faster inflation time.
+	/// </summary>
+	public bool LazyRD
+	{
+		get
+		{
+			// Per-file metadata takes precedence
+			if (Options.IsTrue("build_metadata.additionalfiles.LazyRD"))
+				return true;
+			if (Options.IsFalse("build_metadata.additionalfiles.LazyRD"))
+				return false;
+			// Global build property
+			if (Options.IsTrue("build_property.MauiXamlLazyRD"))
+				return true;
+			if (Options.IsFalse("build_property.MauiXamlLazyRD"))
+				return false;
+			// Default to true for lazy resources (perf improvement)
+			return true;
+		}
+	}
+
 	public string? RelativePath
 		=> Options.GetValueOrNull("build_metadata.additionalfiles.RelativePath");
 

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -237,7 +237,13 @@ static class SetPropertyHelpers
 			// This mirrors the normal flow: CreateValuesVisitor walks the entire tree first
 			node.Accept(new CreateValuesVisitor(lambdaContext), null);
 
-			// Second pass: Set properties on all nodes using SetPropertiesVisitor
+			// Second pass: Set namescopes and register names in the namescope
+			node.Accept(new SetNamescopesAndRegisterNamesVisitor(lambdaContext), null);
+
+			// Third pass: Set resources in ResourceDictionary
+			node.Accept(new SetResourcesVisitor(lambdaContext), null);
+
+			// Fourth pass: Set properties on all nodes using SetPropertiesVisitor
 			// stopOnResourceDictionary=true prevents infinite recursion if there are nested RDs
 			node.Accept(new SetPropertiesVisitor(lambdaContext, stopOnResourceDictionary: true), null);
 

--- a/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
@@ -20,7 +20,7 @@ class CreateValuesVisitor : IXamlNodeVisitor
 	public bool StopOnDataTemplate => true;
 	public bool StopOnResourceDictionary => false;
 	public bool VisitNodeOnDataTemplate => false;
-	public bool SkipChildren(INode node, INode parentNode) => false;
+	public bool SkipChildren(INode node, INode parentNode) => node is ElementNode en && en.IsLazyResource(parentNode, Context);
 	public bool IsResourceDictionary(ElementNode node) => node.IsResourceDictionary(Context);
 
 	public void Visit(ValueNode node, INode parentNode)
@@ -351,6 +351,10 @@ class CreateValuesVisitor : IXamlNodeVisitor
 
 	public void Visit(ElementNode node, INode parentNode)
 	{
+		// Skip lazy RD resources - they will be created inside lambda in SetPropertiesVisitor
+		if (node.IsLazyResource(parentNode, Context))
+			return;
+
 		CreateValue(node, Writer, Context.Variables, Context.Compilation, Context.XmlnsCache, Context);
 	}
 

--- a/src/Controls/src/SourceGen/Visitors/SetFieldsForXNamesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetFieldsForXNamesVisitor.cs
@@ -24,7 +24,7 @@ class SetFieldsForXNamesVisitor : IXamlNodeVisitor
 	public bool StopOnDataTemplate => true;
 	public bool StopOnResourceDictionary => false;
 	public bool VisitNodeOnDataTemplate => false;
-	public bool SkipChildren(INode node, INode parentNode) => false;
+	public bool SkipChildren(INode node, INode parentNode) => node is ElementNode en && en.IsLazyResource(parentNode, Context);
 	public bool IsResourceDictionary(ElementNode node) => node.IsResourceDictionary(Context);
 
 	public void Visit(ValueNode node, INode parentNode)

--- a/src/Controls/src/SourceGen/Visitors/SetNamescopesAndRegisterNames.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetNamescopesAndRegisterNames.cs
@@ -18,7 +18,7 @@ class SetNamescopesAndRegisterNamesVisitor(SourceGenContext context) : IXamlNode
 	public bool StopOnDataTemplate => true;
 	public bool StopOnResourceDictionary => false;
 	public bool VisitNodeOnDataTemplate => false;
-	public bool SkipChildren(INode node, INode parentNode) => false;
+	public bool SkipChildren(INode node, INode parentNode) => node is ElementNode en && en.IsLazyResource(parentNode, Context);
 	public bool IsResourceDictionary(ElementNode node) => node.IsResourceDictionary(Context);
 
 	public void Visit(ValueNode node, INode parentNode)
@@ -46,6 +46,10 @@ class SetNamescopesAndRegisterNamesVisitor(SourceGenContext context) : IXamlNode
 
 	public void Visit(ElementNode node, INode parentNode)
 	{
+		// Skip lazy resources - they're not in Variables
+		if (node.IsLazyResource(parentNode, Context))
+			return;
+
 		ILocalValue namescope;
 		IDictionary<string, ILocalValue> namesInNamescope;
 		var setNameScope = false;

--- a/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetPropertiesVisitor.cs
@@ -23,13 +23,16 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 		XmlName.xFieldModifier,
 		XmlName.xKey,
 		XmlName.xName,
+		XmlName.xShared,
 		XmlName.xTypeArguments,
 	];
 	public bool StopOnResourceDictionary => stopOnResourceDictionary;
 	public TreeVisitingMode VisitingMode => TreeVisitingMode.BottomUp;
 	public bool StopOnDataTemplate => true;
 	public bool VisitNodeOnDataTemplate => true;
-	public bool SkipChildren(INode node, INode parentNode) => false;
+	// Skip children of lazy resources (they'll be created inside lambda), but the lazy resource node itself
+	// gets visited (to emit AddFactory). VisitChildrenOfLazyResource handles this distinction.
+	public bool SkipChildren(INode node, INode parentNode) => node is ElementNode en && en.IsLazyResource(parentNode, Context);
 	public bool IsResourceDictionary(ElementNode node) => node.IsResourceDictionary(Context);
 
 	public void Visit(ValueNode node, INode parentNode)
@@ -44,22 +47,39 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 			string? contentProperty;
 			if (!Context.Variables.ContainsKey((ElementNode)parentNode))
 				return;
-			var parentVar = Context.Variables[(ElementNode)parentNode];
-			if ((contentProperty = parentVar.Type.GetContentPropertyName(context)) != null)
+			var parentVariable = Context.Variables[(ElementNode)parentNode];
+			if ((contentProperty = parentVariable.Type.GetContentPropertyName(context)) != null)
 				propertyName = new XmlName(((ElementNode)parentNode).NamespaceURI, contentProperty);
 			else
 				return;
 		}
 
-		if (TrySetRuntimeName(propertyName, Context.Variables[(ElementNode)parentNode], node))
-			return;
-		if (skips.Contains(propertyName))
+		// Skip x: properties EXCEPT x:Name (which may need RuntimeName processing)
+		// and skip SkipProperties and mc:Ignorable
+		if (skips.Contains(propertyName) && propertyName != XmlName.xName)
 			return;
 		if (parentNode is ElementNode node1 && node1.SkipProperties.Contains(propertyName))
 			return;
 		if (propertyName.Equals(XmlName.mcIgnorable))
 			return;
-		SetPropertyHelpers.SetPropertyValue(Writer, Context.Variables[(ElementNode)parentNode], propertyName, node, Context);
+
+		// Check that parent has a variable before accessing
+		var parentElement = (ElementNode)parentNode;
+		if (!Context.Variables.TryGetValue(parentElement, out var parentVar))
+		{
+			var parentKey = parentElement.Properties.TryGetValue(XmlName.xKey, out var keyNode) && keyNode is ValueNode vn ? vn.Value?.ToString() : "(none)";
+			throw new System.InvalidOperationException($"SetPropertiesVisitor.Visit(ValueNode): Parent '{parentElement.XmlType.Name}' x:Key='{parentKey}' not in Variables for propertyName='{propertyName}'");
+		}
+
+		// Try to set runtime name (for x:Name with RuntimeNameProperty attribute)
+		if (TrySetRuntimeName(propertyName, parentVar, node))
+			return;
+
+		// Skip x:Name after TrySetRuntimeName has had a chance to process it
+		if (propertyName == XmlName.xName)
+			return;
+
+		SetPropertyHelpers.SetPropertyValue(Writer, parentVar, propertyName, node, Context);
 	}
 
 	bool TrySetRuntimeName(XmlName propertyName, ILocalValue localVariable, ValueNode node)
@@ -82,8 +102,20 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 
 	public void Visit(ElementNode node, INode parentNode)
 	{
-		NodeSGExtensions.GetNodeValueDelegate getNodeValue = (node, type) => context.Variables[node];
+		NodeSGExtensions.GetNodeValueDelegate getNodeValue = (n, type) => 
+		{
+			if (!context.Variables.TryGetValue(n, out var val))
+			{
+				var nodeName = n is ElementNode en ? en.XmlType.Name : n?.GetType().Name ?? "null";
+				var nodeKey = n is ElementNode en2 && en2.Properties.TryGetValue(XmlName.xKey, out var kn) && kn is ValueNode vn ? vn.Value?.ToString() : "(none)";
+				throw new System.InvalidOperationException($"getNodeValue delegate: Node '{nodeName}' x:Key='{nodeKey}' not in Variables");
+			}
+			return val;
+		};
 		XmlName propertyName = XmlName.Empty;
+
+		// Store original parentNode for lazy resource check
+		var originalParentNode = parentNode;
 
 		//Simplify ListNodes with single elements
 		//TODO: this should be done with a transform
@@ -96,6 +128,48 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 		if ((propertyName != XmlName.Empty || node.TryGetPropertyName(parentNode, out propertyName))
 		&& skips.Contains(propertyName) || parentNode is ElementNode epn && epn.SkipProperties.Contains(propertyName))
 			return;
+
+		// Handle lazy RD resources - they weren't created in CreateValuesVisitor
+		if (node.IsLazyResource(originalParentNode, Context))
+		{
+			// Find the ResourceDictionary parent
+			ILocalValue? rdVar = null;
+			
+			if (parentNode is ElementNode parentElement && Context.Variables.TryGetValue(parentElement, out var pVar))
+			{
+				var rdType = Context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ResourceDictionary")!;
+				if (pVar.Type.InheritsFrom(rdType, Context))
+				{
+					rdVar = pVar;
+				}
+				else
+				{
+					// Check if it's a .Resources property
+					var resourcesProperty = pVar.Type.GetAllProperties("Resources", Context).FirstOrDefault();
+					if (resourcesProperty != null && resourcesProperty.Type.InheritsFrom(rdType, Context))
+					{
+						rdVar = new DirectValue(resourcesProperty.Type, $"{pVar.ValueAccessor}.Resources");
+					}
+				}
+			}
+			else if (parentNode is ListNode listNode && listNode.Parent is ElementNode grandParentElement && Context.Variables.TryGetValue(grandParentElement, out var gpVar))
+			{
+				// parentNode is a ListNode (e.g., implicit Resources collection)
+				// The grandparent should have a Resources property
+				var rdType = Context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.ResourceDictionary")!;
+				var resourcesProperty = gpVar.Type.GetAllProperties("Resources", Context).FirstOrDefault();
+				if (resourcesProperty != null && resourcesProperty.Type.InheritsFrom(rdType, Context))
+				{
+					rdVar = new DirectValue(resourcesProperty.Type, $"{gpVar.ValueAccessor}.Resources");
+				}
+			}
+
+			if (rdVar != null)
+			{
+				SetPropertyHelpers.AddLazyResourceToResourceDictionary(Writer, rdVar, node, Context);
+				return;
+			}
+		}
 
 		if (propertyName == XmlName._CreateContent)
 		{
@@ -128,11 +202,20 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 			//     return;
 			// if (parentNode is IElementNode && ((IElementNode)parentNode).SkipProperties.Contains(propertyName))
 			//     return;
-			SetPropertyHelpers.SetPropertyValue(Writer, Context.Variables[(ElementNode)parentNode], propertyName, node, Context);
+			if (!Context.Variables.TryGetValue((ElementNode)parentNode, out var pVar1))
+			{
+				var key1 = ((ElementNode)parentNode).Properties.TryGetValue(XmlName.xKey, out var kn1) && kn1 is ValueNode vn1 ? vn1.Value?.ToString() : "(none)";
+				throw new System.InvalidOperationException($"SetPropertiesVisitor.Visit(ElementNode) propertyName != Empty: Parent '{((ElementNode)parentNode).XmlType.Name}' x:Key='{key1}' not in Variables");
+			}
+			SetPropertyHelpers.SetPropertyValue(Writer, pVar1, propertyName, node, Context);
 		}
 		else if (parentNode.IsCollectionItem(node) && parentNode is ElementNode)
 		{
-			var parentVar = Context.Variables[(ElementNode)parentNode];
+			if (!Context.Variables.TryGetValue((ElementNode)parentNode, out var parentVar))
+			{
+				var key2 = ((ElementNode)parentNode).Properties.TryGetValue(XmlName.xKey, out var kn2) && kn2 is ValueNode vn2 ? vn2.Value?.ToString() : "(none)";
+				throw new System.InvalidOperationException($"SetPropertiesVisitor.Visit(ElementNode) IsCollectionItem(parentNode ElementNode): Parent '{((ElementNode)parentNode).XmlType.Name}' x:Key='{key2}' not in Variables");
+			}
 			string? contentProperty;
 
 			if (SetPropertyHelpers.CanAddToResourceDictionary(parentVar, parentVar.Type, node, Context, getNodeValue))
@@ -163,7 +246,12 @@ class SetPropertiesVisitor(SourceGenContext context, bool stopOnResourceDictiona
 			if (skips.Contains(parentList.XmlName))
 				return;
 
-			var parentVar = Context.Variables[(ElementNode)parentNode.Parent];
+			if (!Context.Variables.TryGetValue((ElementNode)parentNode.Parent, out var parentVar))
+			{
+				var grandParent = (ElementNode)parentNode.Parent;
+				var key3 = grandParent.Properties.TryGetValue(XmlName.xKey, out var kn3) && kn3 is ValueNode vn3 ? vn3.Value?.ToString() : "(none)";
+				throw new System.InvalidOperationException($"SetPropertiesVisitor.Visit(ElementNode) IsCollectionItem(parentNode ListNode): GrandParent '{grandParent.XmlType.Name}' x:Key='{key3}' not in Variables. parentList.XmlName='{parentList.XmlName}'");
+			}
 			if (parentNode is ElementNode node1 && node1.SkipProperties.Contains(propertyName))
 				return;
 			var elementType = parentVar.Type;

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			{
 				if (TrySetRuntimeName(propertyName, source, value, node))
 					return;
+				if (propertyName == XmlName.xShared)
+					throw new XamlParseException("x:Shared is only supported with SourceGen inflator. Remove the attribute or switch to SourceGen.", node);
 				if (Skips.Contains(propertyName))
 					return;
 				if (parentElement.SkipProperties.Contains(propertyName))

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Maui.Controls.Xaml
 		//used by X.HR.F
 		internal static object CastTo(object value, object targetProperty)
 		{
+			if (value is null)
+				return null;
+				
 			var bp = targetProperty as BindableProperty;
 			var pi = targetProperty as PropertyInfo;
 

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -50,9 +50,6 @@ namespace Microsoft.Maui.Controls.Xaml
 		//used by X.HR.F
 		internal static object CastTo(object value, object targetProperty)
 		{
-			if (value is null)
-				return null;
-				
 			var bp = targetProperty as BindableProperty;
 			var pi = targetProperty as PropertyInfo;
 

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -303,6 +303,8 @@ namespace Microsoft.Maui.Controls.Xaml
 						return XmlName.xArguments;
 					case "ClassModifier":
 						return XmlName.xClassModifier;
+					case "Shared":
+						return XmlName.xShared;
 					default:
 						Debug.WriteLine("Unhandled attribute {0}", name);
 						return XmlName.Empty;

--- a/src/Controls/src/Xaml/XmlName.cs
+++ b/src/Controls/src/Xaml/XmlName.cs
@@ -16,6 +16,7 @@ internal readonly struct XmlName(string namespaceUri, string localName)
 	public static readonly XmlName xFieldModifier = new("x", "FieldModifier");
 	public static readonly XmlName xKey = new("x", "Key");
 	public static readonly XmlName xName = new("x", "Name");
+	public static readonly XmlName xShared = new("x", "Shared");
 	public static readonly XmlName xTypeArguments = new("x", "TypeArguments");
 	public static readonly XmlName mcIgnorable = new(XamlParser.McUri, "Ignorable");
 	public static readonly XmlName Empty = new();

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Graphics;
 using Xunit;
 using Xunit.Sdk;
 
@@ -460,5 +461,232 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			rd0.Add("foo", "Foo");
 			Assert.Equal("Foo", label.Text);
 		}
+
+		#region Lazy ResourceDictionary (AddFactory) Tests
+
+		[Fact]
+		public void AddFactory_SharedTrue_InvokesFactoryOnce()
+		{
+			var rd = new ResourceDictionary();
+			var invokeCount = 0;
+
+			rd.AddFactory("test", () =>
+			{
+				invokeCount++;
+				return "TestValue";
+			}, shared: true);
+
+			// First access
+			var value1 = rd["test"];
+			Assert.Equal("TestValue", value1);
+			Assert.Equal(1, invokeCount);
+
+			// Second access - should use cached value
+			var value2 = rd["test"];
+			Assert.Equal("TestValue", value2);
+			Assert.Equal(1, invokeCount); // Still 1, factory not invoked again
+		}
+
+		[Fact]
+		public void AddFactory_SharedFalse_InvokesFactoryEachTime()
+		{
+			var rd = new ResourceDictionary();
+			var invokeCount = 0;
+
+			rd.AddFactory("test", () =>
+			{
+				invokeCount++;
+				return $"Value{invokeCount}";
+			}, shared: false);
+
+			// First access
+			var value1 = rd["test"];
+			Assert.Equal("Value1", value1);
+			Assert.Equal(1, invokeCount);
+
+			// Second access - should invoke factory again
+			var value2 = rd["test"];
+			Assert.Equal("Value2", value2);
+			Assert.Equal(2, invokeCount);
+
+			// Third access
+			var value3 = rd["test"];
+			Assert.Equal("Value3", value3);
+			Assert.Equal(3, invokeCount);
+		}
+
+		[Fact]
+		public void AddFactory_TryGetValue_ResolvesFactory()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("test", () => "FactoryValue", shared: true);
+
+			Assert.True(rd.TryGetValue("test", out var value));
+			Assert.Equal("FactoryValue", value);
+		}
+
+		[Fact]
+		public void AddFactory_ContainsKey_ReturnsTrue()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("test", () => "Value", shared: true);
+
+			Assert.True(rd.ContainsKey("test"));
+		}
+
+		[Fact]
+		public void AddFactory_DuplicateKey_Throws()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("test", () => "Value1", shared: true);
+
+			var ex = Assert.Throws<ArgumentException>(() =>
+				rd.AddFactory("test", () => "Value2", shared: true));
+			Assert.Contains("test", ex.Message, StringComparison.InvariantCulture);
+		}
+
+		[Fact]
+		public void AddFactory_ImplicitStyle_UsesTargetTypeAsKey()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory(typeof(Label), () => new Style(typeof(Label))
+			{
+				Setters = { new Setter { Property = Label.TextColorProperty, Value = Colors.Red } }
+			}, shared: true);
+
+			// Should be accessible via type's full name
+			Assert.True(rd.TryGetValue(typeof(Label).FullName, out var value));
+			Assert.IsType<Style>(value);
+			var style = (Style)value;
+			Assert.Equal(typeof(Label), style.TargetType);
+		}
+
+		[Fact]
+		public void AddFactory_Values_ResolvesLazyResources()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("lazy", () => "LazyValue", shared: true);
+			rd.Add("regular", "RegularValue");
+
+			var values = rd.Values.ToList();
+			Assert.Contains("LazyValue", values);
+			Assert.Contains("RegularValue", values);
+		}
+
+		[Fact]
+		public void AddFactory_Enumerate_ResolvesLazyResources()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("lazy", () => "LazyValue", shared: true);
+			rd.Add("regular", "RegularValue");
+
+			var dict = rd.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+			Assert.Equal("LazyValue", dict["lazy"]);
+			Assert.Equal("RegularValue", dict["regular"]);
+		}
+
+		[Fact]
+		public void AddFactory_DoesNotInvokeUntilAccessed()
+		{
+			var rd = new ResourceDictionary();
+			var invoked = false;
+
+			rd.AddFactory("test", () =>
+			{
+				invoked = true;
+				return "Value";
+			}, shared: true);
+
+			// Factory should not be invoked yet
+			Assert.False(invoked);
+
+			// Now access it
+			_ = rd["test"];
+			Assert.True(invoked);
+		}
+
+		[Fact]
+		public void AddFactory_SharedFalse_CreatesNewInstances()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("shape", () => new BoxView(), shared: false);
+
+			var shape1 = rd["shape"];
+			var shape2 = rd["shape"];
+
+			Assert.NotSame(shape1, shape2);
+		}
+
+		[Fact]
+		public void AddFactory_SharedTrue_ReturnsSameInstance()
+		{
+			var rd = new ResourceDictionary();
+			rd.AddFactory("shape", () => new BoxView(), shared: true);
+
+			var shape1 = rd["shape"];
+			var shape2 = rd["shape"];
+
+			Assert.Same(shape1, shape2);
+		}
+
+		[Fact]
+		public void AddFactory_ValuesChanged_FiresWithLazyResourceWrapper_KnownIssue()
+		{
+			// This test documents a known issue: AddFactory fires ValuesChanged with the
+			// internal LazyResource wrapper instead of the resolved value.
+			// This can break DynamicResource bindings that are set up before the resource is added.
+			// 
+			// Future fix: Either resolve before firing, or have Element.OnResourcesChanged 
+			// handle LazyResource resolution.
+
+			var rd = new ResourceDictionary();
+			object eventValue = null;
+
+			((IResourceDictionary)rd).ValuesChanged += (sender, e) =>
+			{
+				eventValue = e.Values.First().Value;
+			};
+
+			rd.AddFactory("myColor", () => Colors.Red, shared: true);
+
+			// Current behavior: eventValue is a LazyResource wrapper, not Colors.Red
+			// This is a known issue - the value is NOT resolved before firing the event
+			Assert.NotNull(eventValue);
+			
+			// This assertion documents the bug - eventValue should be Colors.Red but isn't
+			Assert.NotEqual(Colors.Red, eventValue);
+			
+			// The value IS correct when accessed directly
+			Assert.Equal(Colors.Red, rd["myColor"]);
+		}
+
+		[Fact]
+		public void AddFactory_DynamicResource_ReceivesLazyWrapper_KnownIssue()
+		{
+			// This test documents a known issue: When a DynamicResource binding exists
+			// and a lazy resource is added later, the element receives the LazyResource
+			// wrapper instead of the resolved value.
+
+			var rd = new ResourceDictionary();
+			var label = new Label();
+			
+			// Set up the page hierarchy so DynamicResource can find resources
+			var page = new ContentPage { Content = label };
+			page.Resources = rd;
+
+			// Set up DynamicResource binding BEFORE the resource exists
+			label.SetDynamicResource(Label.TextColorProperty, "myColor");
+
+			// Add the resource via factory - this fires ValuesChanged
+			rd.AddFactory("myColor", () => Colors.Blue, shared: true);
+
+			// Known issue: The label's TextColor is NOT set to Colors.Blue
+			// because OnResourcesChanged received the LazyResource wrapper
+			// 
+			// When fixed, this should be: Assert.Equal(Colors.Blue, label.TextColor);
+			Assert.NotEqual(Colors.Blue, label.TextColor);
+		}
+
+		#endregion
 	}
 }

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/ResourceDictionary.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/ResourceDictionary.cs
@@ -63,14 +63,20 @@ public partial class __TypeDBD64C1C77CDA760
 			return;
 		}
 
-		var color = new global::Microsoft.Maui.Graphics.Color(1f, 0.29411766f, 0.078431375f, 1f) /* #FF4B14 */;
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(color!, new global::System.Uri(@"Styles.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 6, 4);
 		var __root = this;
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(__root!, new global::System.Uri(@"Styles.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 2, 2);
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		global::Microsoft.Maui.Controls.Internals.INameScope iNameScope = new global::Microsoft.Maui.Controls.Internals.NameScope();
 #endif
-		__root["AccentColor"] = color;
+		__root.AddFactory("AccentColor", () =>
+		{
+			var color = new global::Microsoft.Maui.Graphics.Color(1f, 0.29411766f, 0.078431375f, 1f) /* #FF4B14 */;
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(color!, new global::System.Uri(@"Styles.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 6, 4);
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+			return color;
+		}, shared: true);
 	}
 }
 

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterCompiledConverters.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterCompiledConverters.cs
@@ -91,8 +91,6 @@ public partial class TestPage
 			return;
 		}
 
-		var style1 = new global::Microsoft.Maui.Controls.Style(typeof(global::Microsoft.Maui.Controls.Label));
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(style1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 5);
 		var resourceDictionary = new global::Microsoft.Maui.Controls.ResourceDictionary();
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(resourceDictionary!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 7, 4);
 		var __root = this;
@@ -103,28 +101,36 @@ public partial class TestPage
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		global::Microsoft.Maui.Controls.Internals.NameScope.SetNameScope(__root, iNameScope);
 #endif
-#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
-		global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
-#endif
-#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
-		global::Microsoft.Maui.Controls.Internals.INameScope iNameScope2 = new global::Microsoft.Maui.Controls.Internals.NameScope();
-#endif
 #line 7 "{{testXamlFilePath}}"
 		__root.Resources = (global::Microsoft.Maui.Controls.ResourceDictionary)resourceDictionary;
 #line default
-		var setter = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.Label.FontSizeProperty, Value = 16D};
-		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 9, 6);
+		resourceDictionary.AddFactory("testStyle", () =>
+		{
+			var style1 = new global::Microsoft.Maui.Controls.Style(typeof(global::Microsoft.Maui.Controls.Label));
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(style1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 5);
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope2 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope3 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+			var setter = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.Label.FontSizeProperty, Value = 16D};
+			if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter!) == null)
+				global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 9, 6);
 #line 9 "{{testXamlFilePath}}"
-		((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter);
+			((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter);
 #line default
-		var setter1 = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.Label.TextColorProperty, Value = global::Microsoft.Maui.Graphics.Colors.Red};
-		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter1!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 10, 6);
+			var setter1 = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.Label.TextColorProperty, Value = global::Microsoft.Maui.Graphics.Colors.Red};
+			if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter1!) == null)
+				global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 10, 6);
 #line 10 "{{testXamlFilePath}}"
-		((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter1);
+			((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter1);
 #line default
-		resourceDictionary["testStyle"] = style1;
+			return style1;
+		}, shared: true);
 #line 7 "{{testXamlFilePath}}"
 		__root.Resources = (global::Microsoft.Maui.Controls.ResourceDictionary)resourceDictionary;
 #line default

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SimplifyOnPlatform.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SimplifyOnPlatform.cs
@@ -89,8 +89,6 @@ public partial class TestPage
 			return;
 		}
 
-		var style1 = new global::Microsoft.Maui.Controls.Style(typeof(global::Microsoft.Maui.Controls.Label));
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(style1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 7, 10);
 		var __root = this;
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(__root!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 2, 2);
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
@@ -99,25 +97,33 @@ public partial class TestPage
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		global::Microsoft.Maui.Controls.Internals.NameScope.SetNameScope(__root, iNameScope);
 #endif
+		__root.Resources.AddFactory("style", () =>
+		{
+			var style1 = new global::Microsoft.Maui.Controls.Style(typeof(global::Microsoft.Maui.Controls.Label));
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(style1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 7, 10);
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
-		global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
 #endif
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
-		global::Microsoft.Maui.Controls.Internals.INameScope iNameScope2 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope2 = new global::Microsoft.Maui.Controls.Internals.NameScope();
 #endif
-		var setter = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.Label.TextColorProperty, Value = global::Microsoft.Maui.Graphics.Colors.Pink};
-		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 14);
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope3 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+			var setter = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.Label.TextColorProperty, Value = global::Microsoft.Maui.Graphics.Colors.Pink};
+			if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter!) == null)
+				global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 14);
 #line 8 "{{testXamlFilePath}}"
-		((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter);
+			((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter);
 #line default
-		var setter1 = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.VisualElement.IsVisibleProperty, Value = (bool)new global::Microsoft.Maui.Controls.VisualElement.VisibilityConverter().ConvertFromInvariantString("True")!};
-		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter1!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 9, 14);
+			var setter1 = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.VisualElement.IsVisibleProperty, Value = (bool)new global::Microsoft.Maui.Controls.VisualElement.VisibilityConverter().ConvertFromInvariantString("True")!};
+			if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter1!) == null)
+				global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 9, 14);
 #line 9 "{{testXamlFilePath}}"
-		((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter1);
+			((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter1);
 #line default
-		__root.Resources["style"] = style1;
+			return style1;
+		}, shared: true);
 	}
 }
 

--- a/src/Controls/tests/SourceGen.UnitTests/Maui32879Tests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/Maui32879Tests.cs
@@ -94,8 +94,6 @@ public partial class TestPage
 			return;
 		}
 
-		var style1 = new global::Microsoft.Maui.Controls.Style(typeof(global::Microsoft.Maui.Controls.Image));
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(style1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 5);
 		var resourceDictionary = new global::Microsoft.Maui.Controls.ResourceDictionary();
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(resourceDictionary!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 7, 4);
 		var __root = this;
@@ -106,19 +104,27 @@ public partial class TestPage
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		global::Microsoft.Maui.Controls.Internals.NameScope.SetNameScope(__root, iNameScope);
 #endif
-#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
-		global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
-#endif
 #line 7 "{{testXamlFilePath}}"
 		__root.Resources = (global::Microsoft.Maui.Controls.ResourceDictionary)resourceDictionary;
 #line default
-		var setter = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.AbsoluteLayout.LayoutBoundsProperty, Value = (global::Microsoft.Maui.Graphics.Rect)new global::Microsoft.Maui.Controls.BoundsTypeConverter().ConvertFromInvariantString("10,10,20,20")!};
-		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter!) == null)
-			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 9, 6);
+		resourceDictionary.AddFactory("NetworkIndicator", () =>
+		{
+			var style1 = new global::Microsoft.Maui.Controls.Style(typeof(global::Microsoft.Maui.Controls.Image));
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(style1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 5);
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope2 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+			var setter = new global::Microsoft.Maui.Controls.Setter {Property = global::Microsoft.Maui.Controls.AbsoluteLayout.LayoutBoundsProperty, Value = (global::Microsoft.Maui.Graphics.Rect)new global::Microsoft.Maui.Controls.BoundsTypeConverter().ConvertFromInvariantString("10,10,20,20")!};
+			if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(setter!) == null)
+				global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(setter!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 9, 6);
 #line 9 "{{testXamlFilePath}}"
-		((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter);
+			((global::System.Collections.Generic.ICollection<global::Microsoft.Maui.Controls.Setter>)style1.Setters).Add((global::Microsoft.Maui.Controls.Setter)setter);
 #line default
-		resourceDictionary["NetworkIndicator"] = style1;
+			return style1;
+		}, shared: true);
 #line 7 "{{testXamlFilePath}}"
 		__root.Resources = (global::Microsoft.Maui.Controls.ResourceDictionary)resourceDictionary;
 #line default

--- a/src/Controls/tests/SourceGen.UnitTests/StaticResourceInMarkup.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/StaticResourceInMarkup.cs
@@ -118,8 +118,6 @@ public partial class TestPage
 			return;
 		}
 
-		var color = new global::Microsoft.Maui.Graphics.Color(0f, 1f, 0f, 1f) /* #00FF00 */;
-		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(color!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 4);
 		var staticResourceExtension = new global::Microsoft.Maui.Controls.Xaml.StaticResourceExtension();
 		global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(staticResourceExtension!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 11, 9);
 		var myExtension = new global::TestApp.MyExtension();
@@ -137,11 +135,19 @@ public partial class TestPage
 #if !_MAUIXAML_SG_NAMESCOPE_DISABLE
 		label.transientNamescope = iNameScope;
 #endif
-		__root.Resources["MyColor"] = color;
+		__root.Resources.AddFactory("MyColor", () =>
+		{
+			var color = new global::Microsoft.Maui.Graphics.Color(0f, 1f, 0f, 1f) /* #00FF00 */;
+			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(color!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 8, 4);
+#if !_MAUIXAML_SG_NAMESCOPE_DISABLE
+			global::Microsoft.Maui.Controls.Internals.INameScope iNameScope1 = new global::Microsoft.Maui.Controls.Internals.NameScope();
+#endif
+			return color;
+		}, shared: true);
 #line 11 "{{testXamlFilePath}}"
 		staticResourceExtension.Key = "MyColor";
 #line default
-		var color1 = color;
+		var color1 = (global::Microsoft.Maui.Graphics.Color)__root.Resources["MyColor"];
 		if (global::Microsoft.Maui.VisualDiagnostics.GetSourceInfo(color1!) == null)
 			global::Microsoft.Maui.VisualDiagnostics.RegisterSourceInfo(color1!, new global::System.Uri(@"Test.xaml;assembly=SourceGeneratorDriver.Generated", global::System.UriKind.Relative), 11, 9);
 #line 11 "{{testXamlFilePath}}"

--- a/src/Controls/tests/Xaml.Benchmarks/Program.cs
+++ b/src/Controls/tests/Xaml.Benchmarks/Program.cs
@@ -18,6 +18,12 @@ public class LayoutBenchmark
 		var page = new UnitTests.Benchmark(XamlInflator.SourceGen);
 	}
 	[Benchmark]
+	public void SourceGen_NoLazyRD()
+	{
+		var page = new UnitTests.BenchmarkNoLazy(XamlInflator.SourceGen);
+	}
+
+	[Benchmark]
 	public void Runtime()
 	{
 		var page = new UnitTests.Benchmark(XamlInflator.Runtime);

--- a/src/Controls/tests/Xaml.UnitTests/Benchmark.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Benchmark.xaml.cs
@@ -28,6 +28,7 @@ public partial class Benchmark : ContentPage
 	[Collection("Xaml Inflation")]
 	public class Tests
 	{
+#if DEBUG
 		private readonly ITestOutputHelper _output;
 
 		public Tests(ITestOutputHelper output)
@@ -123,5 +124,6 @@ public partial class Benchmark : ContentPage
 			Assert.Equal(0, diag.LazyCount);
 			Assert.Equal(diag.TotalCount, diag.EagerCount);
 		}
+#endif
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Benchmark.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Benchmark.xaml.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
 public partial class Benchmark : ContentPage
@@ -18,6 +22,106 @@ public partial class Benchmark : ContentPage
 				break;
 			default:
 				throw new NotSupportedException($"no code for {inflator} generated. check the [XamlProcessing] attribute.");
+		}
+	}
+
+	[Collection("Xaml Inflation")]
+	public class Tests
+	{
+		private readonly ITestOutputHelper _output;
+
+		public Tests(ITestOutputHelper output)
+		{
+			_output = output;
+		}
+
+		[Fact]
+		public void ResourceDictionaryDiagnostics_SourceGen()
+		{
+			var page = new Benchmark("SourceGen");
+			var diag = page.Resources.GetDiagnostics();
+
+			_output.WriteLine($"=== ResourceDictionary Diagnostics (SourceGen with LazyRD) ===");
+			_output.WriteLine($"Total resources: {diag.TotalCount}");
+			_output.WriteLine($"  Eager (value types): {diag.EagerCount}");
+			_output.WriteLine($"  Lazy (ref types): {diag.LazyCount}");
+			_output.WriteLine($"    - Resolved: {diag.ResolvedLazyCount}");
+			_output.WriteLine($"    - Unresolved: {diag.LazyCount - diag.ResolvedLazyCount}");
+			_output.WriteLine("");
+			
+			_output.WriteLine($"Eager keys ({diag.EagerKeys.Count}):");
+			foreach (var key in diag.EagerKeys)
+				_output.WriteLine($"  - {key}");
+			_output.WriteLine("");
+
+			_output.WriteLine($"Resolved lazy keys ({diag.ResolvedKeys.Count}):");
+			foreach (var key in diag.ResolvedKeys)
+			{
+				diag.InvocationCounts.TryGetValue(key, out var count);
+				_output.WriteLine($"  - {key} (invoked {count}x)");
+			}
+			_output.WriteLine("");
+
+			_output.WriteLine($"Unresolved lazy keys ({diag.UnresolvedKeys.Count}):");
+			foreach (var key in diag.UnresolvedKeys)
+				_output.WriteLine($"  - {key}");
+
+			// Assertions
+			Assert.True(diag.TotalCount > 0, "Should have resources");
+			Assert.True(diag.LazyCount > 0, "Should have lazy resources with LazyRD enabled");
+			
+			// With Label uncommented, we expect the Label style to be resolved
+			// but other styles should remain unresolved
+			_output.WriteLine("");
+			_output.WriteLine($"=== Summary ===");
+			_output.WriteLine($"Lazy resources saved from initialization: {diag.LazyCount - diag.ResolvedLazyCount} / {diag.LazyCount}");
+		}
+
+		[Fact]
+		public void ResourceDictionaryDiagnostics_SourceGen_WithExplicitAccess()
+		{
+			var page = new Benchmark("SourceGen");
+			
+			// Before accessing any resource
+			var diagBefore = page.Resources.GetDiagnostics();
+			_output.WriteLine($"=== Before accessing any resource ===");
+			_output.WriteLine($"Resolved: {diagBefore.ResolvedLazyCount} / {diagBefore.LazyCount}");
+			
+			// Access just one resource - the Label style
+			var labelStyle = page.Resources["Microsoft.Maui.Controls.Label"];
+			Assert.NotNull(labelStyle);
+			
+			// After accessing Label style
+			var diagAfter = page.Resources.GetDiagnostics();
+			_output.WriteLine($"");
+			_output.WriteLine($"=== After accessing Label style ===");
+			_output.WriteLine($"Resolved: {diagAfter.ResolvedLazyCount} / {diagAfter.LazyCount}");
+			_output.WriteLine($"");
+			_output.WriteLine($"Resolved keys:");
+			foreach (var key in diagAfter.ResolvedKeys)
+				_output.WriteLine($"  - {key}");
+			_output.WriteLine($"");
+			_output.WriteLine($"Unresolved keys ({diagAfter.UnresolvedKeys.Count}):");
+			// Just show count to keep output short
+			
+			// The Label style should be resolved, along with the colors it uses
+			Assert.True(diagAfter.ResolvedKeys.Contains("Microsoft.Maui.Controls.Label"), "Label style should be resolved");
+		}
+
+		[Fact]
+		public void ResourceDictionaryDiagnostics_XamlC()
+		{
+			var page = new Benchmark("XamlC");
+			var diag = page.Resources.GetDiagnostics();
+
+			_output.WriteLine($"=== ResourceDictionary Diagnostics (XamlC - no lazy) ===");
+			_output.WriteLine($"Total resources: {diag.TotalCount}");
+			_output.WriteLine($"  Eager: {diag.EagerCount}");
+			_output.WriteLine($"  Lazy: {diag.LazyCount}");
+
+			// XamlC doesn't use lazy resources
+			Assert.Equal(0, diag.LazyCount);
+			Assert.Equal(diag.TotalCount, diag.EagerCount);
 		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/BenchmarkNoLazy.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/BenchmarkNoLazy.xaml
@@ -1,0 +1,450 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BenchmarkNoLazy"
+             Title="Benchmark">
+    <ContentPage.Resources>
+        <!-- Colors.xaml -->
+        <Color x:Key="Primary">#512BD4</Color>
+        <Color x:Key="Secondary">#DFD8F7</Color>
+        <Color x:Key="Tertiary">#2B0B98</Color>
+        <Color x:Key="White">White</Color>
+        <Color x:Key="Black">Black</Color>
+        <Color x:Key="Gray100">#E1E1E1</Color>
+        <Color x:Key="Gray200">#C8C8C8</Color>
+        <Color x:Key="Gray300">#ACACAC</Color>
+        <Color x:Key="Gray400">#919191</Color>
+        <Color x:Key="Gray500">#6E6E6E</Color>
+        <Color x:Key="Gray600">#404040</Color>
+        <Color x:Key="Gray900">#212121</Color>
+        <Color x:Key="Gray950">#141414</Color>
+        <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
+        <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}"/>
+        <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource Tertiary}"/>
+        <SolidColorBrush x:Key="WhiteBrush" Color="{StaticResource White}"/>
+        <SolidColorBrush x:Key="BlackBrush" Color="{StaticResource Black}"/>
+        <SolidColorBrush x:Key="Gray100Brush" Color="{StaticResource Gray100}"/>
+        <SolidColorBrush x:Key="Gray200Brush" Color="{StaticResource Gray200}"/>
+        <SolidColorBrush x:Key="Gray300Brush" Color="{StaticResource Gray300}"/>
+        <SolidColorBrush x:Key="Gray400Brush" Color="{StaticResource Gray400}"/>
+        <SolidColorBrush x:Key="Gray500Brush" Color="{StaticResource Gray500}"/>
+        <SolidColorBrush x:Key="Gray600Brush" Color="{StaticResource Gray600}"/>
+        <SolidColorBrush x:Key="Gray900Brush" Color="{StaticResource Gray900}"/>
+        <SolidColorBrush x:Key="Gray950Brush" Color="{StaticResource Gray950}"/>
+
+        <Color x:Key="Yellow100Accent">#F7B548</Color>
+        <Color x:Key="Yellow200Accent">#FFD590</Color>
+        <Color x:Key="Yellow300Accent">#FFE5B9</Color>
+        <Color x:Key="Cyan100Accent">#28C2D1</Color>
+        <Color x:Key="Cyan200Accent">#7BDDEF</Color>
+        <Color x:Key="Cyan300Accent">#C3F2F4</Color>
+        <Color x:Key="Blue100Accent">#3E8EED</Color>
+        <Color x:Key="Blue200Accent">#72ACF1</Color>
+        <Color x:Key="Blue300Accent">#A7CBF6</Color>
+
+        <!-- Styles.xaml -->
+        <Style TargetType="ActivityIndicator">
+            <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+        </Style>
+
+        <Style TargetType="IndicatorView">
+            <Setter Property="IndicatorColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}"/>
+            <Setter Property="SelectedIndicatorColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray100}}"/>
+        </Style>
+
+        <Style TargetType="Border">
+            <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+            <Setter Property="StrokeShape" Value="Rectangle"/>
+            <Setter Property="StrokeThickness" Value="1"/>
+        </Style>
+
+        <Style TargetType="BoxView">
+            <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
+        </Style>
+
+        <Style TargetType="Button">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Primary}}" />
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="Padding" Value="14,10"/>
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
+                                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="CheckBox">
+            <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="DatePicker">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="Editor">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="Entry">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="Frame">
+            <Setter Property="HasShadow" Value="False" />
+            <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
+            <Setter Property="CornerRadius" Value="8" />
+        </Style>
+
+        <Style TargetType="ImageButton">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="BorderColor" Value="Transparent"/>
+            <Setter Property="BorderWidth" Value="0"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="Opacity" Value="0.5" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="Label">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="ListView">
+            <Setter Property="SeparatorColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+            <Setter Property="RefreshControlColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
+        </Style>
+
+        <Style TargetType="Picker">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+            <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                                <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="ProgressBar">
+            <Setter Property="ProgressColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="ProgressColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="RadioButton">
+            <Setter Property="BackgroundColor" Value="Transparent"/>
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="RefreshView">
+            <Setter Property="RefreshColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
+        </Style>
+
+        <Style TargetType="SearchBar">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+            <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
+            <Setter Property="CancelButtonColor" Value="{StaticResource Gray500}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                                <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="SearchHandler">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+            <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
+            <Setter Property="BackgroundColor" Value="Transparent" />
+            <Setter Property="FontFamily" Value="OpenSansRegular" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                                <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="Shadow">
+            <Setter Property="Radius" Value="15" />
+            <Setter Property="Opacity" Value="0.5" />
+            <Setter Property="Brush" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
+            <Setter Property="Offset" Value="10,10" />
+        </Style>
+
+        <Style TargetType="Slider">
+            <Setter Property="MinimumTrackColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="MaximumTrackColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
+            <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="MinimumTrackColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}"/>
+                                <Setter Property="MaximumTrackColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}"/>
+                                <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="SwipeItem">
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        </Style>
+
+        <Style TargetType="Switch">
+            <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="ThumbColor" Value="{StaticResource White}" />
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                                <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="On">
+                            <VisualState.Setters>
+                                <Setter Property="OnColor" Value="{AppThemeBinding Light={StaticResource Secondary}, Dark={StaticResource Gray200}}" />
+                                <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Off">
+                            <VisualState.Setters>
+                                <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="TimePicker">
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+            <Setter Property="BackgroundColor" Value="Transparent"/>
+            <Setter Property="FontFamily" Value="OpenSansRegular"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="MinimumHeightRequest" Value="44"/>
+            <Setter Property="MinimumWidthRequest" Value="44"/>
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal" />
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+
+        <Style TargetType="Page" ApplyToDerivedTypes="True">
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+        </Style>
+
+        <Style TargetType="Shell" ApplyToDerivedTypes="True">
+            <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource Gray950}}" />
+            <Setter Property="Shell.ForegroundColor" Value="{OnPlatform WinUI={StaticResource Primary}, Default={StaticResource White}}" />
+            <Setter Property="Shell.TitleColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
+            <Setter Property="Shell.DisabledColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
+            <Setter Property="Shell.UnselectedColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray200}}" />
+            <Setter Property="Shell.NavBarHasShadow" Value="False" />
+            <Setter Property="Shell.TabBarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Black}}" />
+            <Setter Property="Shell.TabBarForegroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="Shell.TabBarTitleColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="Shell.TabBarUnselectedColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
+        </Style>
+
+        <Style TargetType="NavigationPage">
+            <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource Gray950}}" />
+            <Setter Property="BarTextColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
+            <Setter Property="IconColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
+        </Style>
+
+        <Style TargetType="TabbedPage">
+            <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}" />
+            <Setter Property="BarTextColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+            <Setter Property="UnselectedTabColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
+            <Setter Property="SelectedTabColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
+        </Style>
+    </ContentPage.Resources>
+    <VerticalStackLayout>
+        <Label 
+            Text="Welcome to .NET MAUI!"
+            VerticalOptions="Center" 
+            HorizontalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/BenchmarkNoLazy.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/BenchmarkNoLazy.xaml.cs
@@ -1,0 +1,23 @@
+using System;
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class BenchmarkNoLazy : ContentPage
+{
+	public BenchmarkNoLazy(string inflator)
+	{
+		switch (inflator)
+		{
+			case "Runtime":
+				InitializeComponentRuntime();
+				break;
+			case "XamlC":
+				InitializeComponentXamlC();
+				break;
+			case "SourceGen":
+				InitializeComponentSourceGen();
+				break;
+			default:
+				throw new NotSupportedException($"no code for {inflator} generated. check the [XamlProcessing] attribute.");
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -77,7 +77,12 @@
     <MauiXaml Update="Issues\Issue2578.xaml" NoWarn="0612" />
     <MauiXaml Update="Issues\Issue2659.xaml" NoWarn="0612" />
 
-    <MauiXaml Update="Benchmark.xaml" TreeOrder="true" />
+    <!-- LazyRD feature test -->
+    <MauiXaml Update="Issues\LazyResourceDictionary.sgen.xaml" LazyRD="true" />
+
+    <!-- Benchmark comparison: with and without LazyRD -->
+    <MauiXaml Update="Benchmark.xaml" LazyRD="true" />
+    <MauiXaml Update="BenchmarkNoLazy.xaml" LazyRD="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/LazyResourceDictionary.sgen.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/LazyResourceDictionary.sgen.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.LazyResourceDictionary">
+    <ContentPage.Resources>
+        <Color x:Key="PrimaryColor">Blue</Color>
+        <Thickness x:Key="StandardPadding">10</Thickness>
+        <Style x:Key="MyLabelStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="{StaticResource PrimaryColor}"/>
+        </Style>
+        <!-- x:Shared="false" means each access returns a new instance -->
+        <x:Object x:Key="Handle" x:Shared="false"/>
+        <!-- Implicit style - applies to all Buttons automatically -->
+        <Style TargetType="Button">
+            <Setter Property="BackgroundColor" Value="Green"/>
+            <Setter Property="Padding" Value="{StaticResource StandardPadding}"/>
+        </Style>
+    </ContentPage.Resources>
+    
+    <StackLayout>
+        <Label x:Name="label1" Text="Test Label" Style="{StaticResource MyLabelStyle}"/>
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/LazyResourceDictionary.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/LazyResourceDictionary.xaml.cs
@@ -1,0 +1,90 @@
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class LazyResourceDictionary : ContentPage
+{
+	public LazyResourceDictionary() => InitializeComponent();
+
+	[Collection("Xaml Inflation")]
+	public class Tests
+	{
+		[Fact]
+		public void SharedResourceReturnsSameInstance()
+		{
+			// This test only works with SourceGen (the only inflator that supports LazyRD)
+			var page = new LazyResourceDictionary();
+
+			// Verify keyed style resource is accessible
+			Assert.True(page.Resources.TryGetValue("MyLabelStyle", out var style));
+			Assert.IsType<Style>(style);
+			Assert.Equal(typeof(Label), ((Style)style).TargetType);
+
+			// Accessing the same key returns the same instance (shared=true is default)
+			Assert.True(page.Resources.TryGetValue("MyLabelStyle", out var style2));
+			Assert.Same(style, style2);
+		}
+
+		[Fact]
+		public void NamedElementsStillWork()
+		{
+			var page = new LazyResourceDictionary();
+
+			// Verify named elements work
+			Assert.NotNull(page.label1);
+			Assert.Equal("Test Label", page.label1.Text);
+		}
+
+		[Fact]
+		public void StaticResourceBindingWorks()
+		{
+			var page = new LazyResourceDictionary();
+
+			// Verify the label has the style applied via StaticResource
+			Assert.NotNull(page.label1.Style);
+			Assert.Equal(typeof(Label), page.label1.Style.TargetType);
+		}
+
+		[Fact]
+		public void ColorResourceWorks()
+		{
+			var page = new LazyResourceDictionary();
+
+			// Verify color resource is accessible (lazy)
+			Assert.True(page.Resources.TryGetValue("PrimaryColor", out var color));
+			Assert.IsType<Color>(color);
+			Assert.Equal(Colors.Blue, color);
+		}
+
+		[Fact]
+		public void ImplicitStyleIsInResourceDictionary()
+		{
+			var page = new LazyResourceDictionary();
+
+			// Verify implicit style is in the resource dictionary
+			// Implicit styles use the TargetType.FullName as the key
+			Assert.True(page.Resources.TryGetValue(typeof(Button).FullName, out var implicitStyle));
+			Assert.IsType<Style>(implicitStyle);
+			Assert.Equal(typeof(Button), ((Style)implicitStyle).TargetType);
+		}
+
+		[Fact]
+		public void NonSharedResourceReturnsNewInstanceEachTime()
+		{
+			var page = new LazyResourceDictionary();
+
+			// Access the x:Shared="false" resource multiple times
+			Assert.True(page.Resources.TryGetValue("Handle", out var obj1));
+			Assert.True(page.Resources.TryGetValue("Handle", out var obj2));
+			Assert.True(page.Resources.TryGetValue("Handle", out var obj3));
+
+			// Each access should return a NEW instance
+			Assert.NotSame(obj1, obj2);
+			Assert.NotSame(obj2, obj3);
+			Assert.NotSame(obj1, obj3);
+		}
+	}
+}
+

--- a/src/Controls/tests/Xaml.UnitTests/Issues/XSharedNotSupported.rt.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/XSharedNotSupported.rt.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.XSharedNotSupported">
+    <ContentPage.Resources>
+        <Style x:Key="MyStyle" x:Shared="false" TargetType="Label">
+            <Setter Property="TextColor" Value="Red"/>
+        </Style>
+    </ContentPage.Resources>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/XSharedNotSupported.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/XSharedNotSupported.xaml.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.Maui.Controls.Build.Tasks;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class XSharedNotSupported : ContentPage
+{
+	public XSharedNotSupported() => InitializeComponent();
+
+	[Collection("Xaml Inflation")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void XSharedThrowsOnRuntimeAndXamlC(XamlInflator inflator)
+		{
+			if (inflator == XamlInflator.Runtime)
+			{
+				// x:Shared is only supported with SourceGen - Runtime should throw
+				var ex = Assert.Throws<XamlParseException>(() => new XSharedNotSupported(inflator));
+				Assert.Contains("x:Shared", ex.Message, StringComparison.Ordinal);
+			}
+			else if (inflator == XamlInflator.XamlC)
+			{
+				// XamlC should also throw for x:Shared
+				Assert.Throws<BuildException>(() => MockCompiler.Compile(typeof(XSharedNotSupported)));
+			}
+			else if (inflator == XamlInflator.SourceGen)
+			{
+				// SourceGen supports x:Shared - tested in LazyResourceDictionary.xaml.cs
+				var result = CreateMauiCompilation()
+					.WithAdditionalSource(
+"""
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+[XamlProcessing(XamlInflator.Runtime, true)]
+public partial class XSharedNotSupported : ContentPage
+{
+	public XSharedNotSupported() => InitializeComponent();
+}
+""")
+					.RunMauiSourceGenerator(typeof(XSharedNotSupported));
+				// SourceGen should compile without errors
+				Assert.Empty(result.Diagnostics);
+			}
+		}
+	}
+}

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -33,4 +34,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
 static Microsoft.Maui.Maps.Platform.MapExtensions.UpdateMapStyle(this Android.Gms.Maps.GoogleMap! googleMap, Microsoft.Maui.Maps.IMap! map) -> void
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -34,4 +35,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.H
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -32,4 +33,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.H
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -32,4 +33,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.H
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
-﻿#nullable enable


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Add lazy resource instantiation to XAML SourceGen. Instead of inflating all Styles, Brushes, and other ResourceDictionary entries upfront, resources are now registered as factory functions and inflated on-demand only when accessed.

Fixes #28985 

## How It Works

Before: All resources created during page initialization, even if never used.
After: Resources stored as `Func<object>` factories, inflated only when accessed via `StaticResource`, `DynamicResource`, or code.

## Performance Results

Benchmark with 63 resources (colors, brushes, styles):

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|--------|------|-------|-----------|-------------|
| XamlC (baseline) | 336.88 µs | 1.00 | 352.97 KB | 1.00 |
| **SourceGen LazyRD** | **43.17 µs** | **0.14** | **60.14 KB** | **0.17** |
| SourceGen (no lazy) | 217.30 µs | 0.67 | 258.12 KB | 0.73 |

### Key Metrics
- ⚡ **~8x faster page inflation** - defers Style/Brush creation until needed
- 📉 **~6x less memory** at startup - resources created only when accessed
- 🎯 **88% of resources remain unresolved** in typical usage

## Features

- **`AddFactory` API** on ResourceDictionary for lazy resource registration
- **`x:Shared="false"` support** - each access creates a new instance (fixes crashes with shared `StrokeShape`)
- **Keys-only resource propagation** - prevents premature resolution when adding elements to parent
- **Lazy-friendly `ValuesChanged` event** - uses keys + resolver for on-demand value lookup

## Exclusions from Lazy (inflated normally)

| Type | Reason |
|------|--------|
| Value types | No benefit - copied on access |
| Strings | Need TypeConverter processing |
| Styles with `Class` attribute | Need `Add()` for class style list |
| Items with `x:Name` | Need variable for field assignment |

## Configuration

LazyRD is **enabled by default**. To opt-out:

```xml
<!-- Per-file -->
<MauiXaml Update="file.xaml" LazyRD="false" />

<!-- Global -->
<MauiXamlLazyRD>false</MauiXamlLazyRD>
```

## Testing

- All 1816 XAML unit tests pass
- Benchmark included for validation
