### PR TITLE
Add Pin Clustering support for Maps

### DIFF
--- a/src/Controls/Maps/src/ClusterClickedEventArgs.cs
+++ b/src/Controls/Maps/src/ClusterClickedEventArgs.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Devices.Sensors;
+
+namespace Microsoft.Maui.Controls.Maps
+{
+	/// <summary>
+	/// Event arguments for the <see cref="Map.ClusterClicked"/> event.
+	/// </summary>
+	public class ClusterClickedEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Gets the collection of pins contained in this cluster.
+		/// </summary>
+		public IReadOnlyList<Pin> Pins { get; }
+
+		/// <summary>
+		/// Gets the location of the cluster on the map.
+		/// </summary>
+		public Location Location { get; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the default behavior of expanding 
+		/// the cluster (zooming in) should be prevented.
+		/// </summary>
+		/// <remarks>
+		/// By default, tapping a cluster will zoom the map to show all the pins in the cluster.
+		/// Set this to <see langword="true"/> to prevent this behavior and handle the click manually.
+		/// </remarks>
+		public bool Handled { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ClusterClickedEventArgs"/> class.
+		/// </summary>
+		/// <param name="pins">The pins contained in the cluster.</param>
+		/// <param name="location">The location of the cluster.</param>
+		public ClusterClickedEventArgs(IReadOnlyList<Pin> pins, Location location)
+		{
+			Pins = pins ?? throw new ArgumentNullException(nameof(pins));
+			Location = location ?? throw new ArgumentNullException(nameof(location));
+		}
+	}
+}

--- a/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
@@ -13,6 +13,15 @@ namespace Microsoft.Maui.Controls.Maps
 
 		void IMap.Clicked(Location location) => MapClicked?.Invoke(this, new MapClickedEventArgs(location));
 
+		bool IMap.ClusterClicked(IReadOnlyList<IMapPin> pins, Location location)
+		{
+			// Convert IMapPin to Pin for the event args
+			var controlPins = pins.OfType<Pin>().ToList();
+			var args = new ClusterClickedEventArgs(controlPins, location);
+			ClusterClicked?.Invoke(this, args);
+			return args.Handled;
+		}
+
 		MapSpan? IMap.VisibleRegion
 		{
 			get

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Maui.Controls.Maps
 		/// <summary>Bindable property for <see cref="IsZoomEnabled"/>.</summary>
 		public static readonly BindableProperty IsZoomEnabledProperty = BindableProperty.Create(nameof(IsZoomEnabled), typeof(bool), typeof(Map), true);
 
+		/// <summary>Bindable property for <see cref="IsClusteringEnabled"/>.</summary>
+		public static readonly BindableProperty IsClusteringEnabledProperty = BindableProperty.Create(nameof(IsClusteringEnabled), typeof(bool), typeof(Map), default(bool));
+
 		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(Map), default(IEnumerable),
 			propertyChanged: (b, o, n) => ((Map)b).OnItemsSourcePropertyChanged((IEnumerable)o, (IEnumerable)n));
@@ -116,6 +119,21 @@ namespace Microsoft.Maui.Controls.Maps
 		}
 
 		/// <summary>
+		/// Gets or sets a value that indicates if pin clustering is enabled. Default value is <see langword="false"/>.
+		/// This is a bindable property.
+		/// </summary>
+		/// <remarks>
+		/// When enabled, pins that are close together will be grouped into clusters.
+		/// As the user zooms in, clusters will expand to show individual pins.
+		/// Use <see cref="Pin.ClusteringIdentifier"/> to control which pins cluster together.
+		/// </remarks>
+		public bool IsClusteringEnabled
+		{
+			get => (bool)GetValue(IsClusteringEnabledProperty);
+			set => SetValue(IsClusteringEnabledProperty, value);
+		}
+
+		/// <summary>
 		/// Gets or sets the style of the map. Default value is <see cref="MapType.Street"/>. 
 		/// This is a bindable property.
 		/// </summary>
@@ -182,6 +200,15 @@ namespace Microsoft.Maui.Controls.Maps
 		/// Occurs when the user clicks/taps on the map control.
 		/// </summary>
 		public event EventHandler<MapClickedEventArgs>? MapClicked;
+
+		/// <summary>
+		/// Occurs when a pin cluster is clicked/tapped.
+		/// </summary>
+		/// <remarks>
+		/// This event only fires when <see cref="IsClusteringEnabled"/> is set to true.
+		/// The event provides information about the cluster including the pins it contains.
+		/// </remarks>
+		public event EventHandler<ClusterClickedEventArgs>? ClusterClicked;
 
 		/// <summary>
 		/// Gets the currently visible region of the map.

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Maui.Controls.Maps
 	/// </summary>
 	public partial class Pin : Element
 	{
+		/// <summary>
+		/// The default clustering identifier used when <see cref="ClusteringIdentifier"/> is not set.
+		/// </summary>
+		public const string DefaultClusteringIdentifier = "maui_default_cluster";
+
 		/// <summary>Bindable property for <see cref="Type"/>.</summary>
 		public static readonly BindableProperty TypeProperty = BindableProperty.Create(nameof(Type), typeof(PinType), typeof(Pin), default(PinType));
 
@@ -21,6 +26,10 @@ namespace Microsoft.Maui.Controls.Maps
 
 		/// <summary>Bindable property for <see cref="Label"/>.</summary>
 		public static readonly BindableProperty LabelProperty = BindableProperty.Create(nameof(Label), typeof(string), typeof(Pin), default(string));
+
+		/// <summary>Bindable property for <see cref="ClusteringIdentifier"/>.</summary>
+		public static readonly BindableProperty ClusteringIdentifierProperty = BindableProperty.Create(nameof(ClusteringIdentifier), typeof(string), typeof(Pin), DefaultClusteringIdentifier);
+
 		private object? _markerId;
 
 		/// <inheritdoc />
@@ -42,6 +51,23 @@ namespace Microsoft.Maui.Controls.Maps
 		{
 			get { return (Location)GetValue(LocationProperty); }
 			set { SetValue(LocationProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the clustering identifier for this pin.
+		/// Pins with the same identifier will be grouped together when clustering is enabled.
+		/// Default value is <see cref="DefaultClusteringIdentifier"/>.
+		/// This is a bindable property.
+		/// </summary>
+		/// <remarks>
+		/// Use different clustering identifiers to create separate groups of pins that 
+		/// cluster independently. For example, you might have one identifier for restaurants
+		/// and another for hotels, so they cluster within their own categories.
+		/// </remarks>
+		public string ClusteringIdentifier
+		{
+			get { return (string)GetValue(ClusteringIdentifierProperty); }
+			set { SetValue(ClusteringIdentifierProperty, value); }
 		}
 
 		/// <summary>

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,14 +1,28 @@
 
 #nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.get -> bool
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Handled.set -> void
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Location.get -> Microsoft.Maui.Devices.Sensors.Location!
+Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.Pins.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>!
+Microsoft.Maui.Controls.Maps.Map.ClusterClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.Maps.MapElement.IsVisible.set -> void
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
+const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
+static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
+    mc:Ignorable="d"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.ClusteringGallery"
+    Title="Pin Clustering">
+    <Grid RowDefinitions="Auto, Auto, *">
+        <HorizontalStackLayout Grid.Row="0" Spacing="5" Padding="5">
+            <Button 
+                Text="Add 50 Pins" 
+                Clicked="OnAdd50PinsClicked" />
+            <Button 
+                Text="Add 100 Pins" 
+                Clicked="OnAdd100PinsClicked" />
+            <Button 
+                Text="Clear Pins"
+                Clicked="OnClearPinsClicked" />
+        </HorizontalStackLayout>
+        <HorizontalStackLayout Grid.Row="1" Spacing="5" Padding="5" VerticalOptions="Center">
+            <Label Text="Clustering:" VerticalOptions="Center" />
+            <Switch 
+                x:Name="clusteringSwitch"
+                IsToggled="True" 
+                Toggled="OnClusteringToggled"
+                VerticalOptions="Center" />
+            <Label x:Name="statusLabel" VerticalOptions="Center" />
+        </HorizontalStackLayout>
+        <maps:Map 
+            x:Name="clusterMap" 
+            Grid.Row="2"
+            IsClusteringEnabled="True"
+            ClusterClicked="OnClusterClicked"
+            MapClicked="OnMapClicked" />
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Maps;
+using Position = Microsoft.Maui.Devices.Sensors.Location;
+
+namespace Maui.Controls.Sample.Pages.MapsGalleries
+{
+	public partial class ClusteringGallery : ContentPage
+	{
+		// Center on a location (e.g., San Francisco area) for demo
+		private readonly Position _center = new Position(37.7749, -122.4194);
+		private readonly Random _random = new Random();
+		private int _clusterClickCount;
+
+		public ClusteringGallery()
+		{
+			InitializeComponent();
+			
+			// Set initial map region
+			var mapSpan = MapSpan.FromCenterAndRadius(_center, Distance.FromKilometers(20));
+			clusterMap.MoveToRegion(mapSpan);
+			
+			// Add some initial pins
+			AddPins(30);
+			UpdateStatus();
+		}
+
+		void OnAdd50PinsClicked(object sender, EventArgs e)
+		{
+			AddPins(50);
+			UpdateStatus();
+		}
+
+		void OnAdd100PinsClicked(object sender, EventArgs e)
+		{
+			AddPins(100);
+			UpdateStatus();
+		}
+
+		void OnClearPinsClicked(object sender, EventArgs e)
+		{
+			clusterMap.Pins.Clear();
+			_clusterClickCount = 0;
+			UpdateStatus();
+		}
+
+		void OnClusteringToggled(object sender, ToggledEventArgs e)
+		{
+			clusterMap.IsClusteringEnabled = e.Value;
+			UpdateStatus();
+		}
+
+		void OnClusterClicked(object sender, ClusterClickedEventArgs e)
+		{
+			_clusterClickCount++;
+			
+			// Show info about the cluster
+			var pinLabels = new List<string>();
+			foreach (var pin in e.Pins)
+			{
+				pinLabels.Add(pin.Label);
+			}
+
+			DisplayAlert(
+				$"Cluster Clicked ({e.Pins.Count} pins)",
+				$"Location: {e.Location.Latitude:F4}, {e.Location.Longitude:F4}\n\nPins: {string.Join(", ", pinLabels.GetRange(0, Math.Min(5, pinLabels.Count)))}{(pinLabels.Count > 5 ? "..." : "")}",
+				"OK");
+			
+			// Set Handled to true to prevent default zoom behavior
+			// Uncomment to test: e.Handled = true;
+			
+			UpdateStatus();
+		}
+
+		void OnMapClicked(object sender, MapClickedEventArgs e)
+		{
+			// Add a pin where user clicks
+			var pin = new Pin
+			{
+				Label = $"Clicked Pin",
+				Address = $"Lat: {e.Location.Latitude:F4}, Lon: {e.Location.Longitude:F4}",
+				Location = e.Location,
+				Type = PinType.Generic
+			};
+			clusterMap.Pins.Add(pin);
+			UpdateStatus();
+		}
+
+		void AddPins(int count)
+		{
+			// Add pins in a cluster around the center
+			for (int i = 0; i < count; i++)
+			{
+				// Random offset within ~20km radius
+				double latOffset = (_random.NextDouble() - 0.5) * 0.3;
+				double lonOffset = (_random.NextDouble() - 0.5) * 0.3;
+				
+				// Alternate between two clustering identifiers for variety
+				string clusterId = i % 3 == 0 ? "restaurants" : Pin.DefaultClusteringIdentifier;
+				
+				var pin = new Pin
+				{
+					Label = $"Pin {clusterMap.Pins.Count + 1}",
+					Address = $"Address {clusterMap.Pins.Count + 1}",
+					Location = new Position(_center.Latitude + latOffset, _center.Longitude + lonOffset),
+					Type = i % 2 == 0 ? PinType.Place : PinType.Generic,
+					ClusteringIdentifier = clusterId
+				};
+				clusterMap.Pins.Add(pin);
+			}
+		}
+
+		void UpdateStatus()
+		{
+			statusLabel.Text = $"Pins: {clusterMap.Pins.Count} | Cluster clicks: {_clusterClickCount}";
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
@@ -52,7 +52,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			UpdateStatus();
 		}
 
-		void OnClusterClicked(object sender, ClusterClickedEventArgs e)
+		async void OnClusterClicked(object sender, ClusterClickedEventArgs e)
 		{
 			_clusterClickCount++;
 			
@@ -63,7 +63,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 				pinLabels.Add(pin.Label);
 			}
 
-			DisplayAlert(
+			await DisplayAlert(
 				$"Cluster Clicked ({e.Pins.Count} pins)",
 				$"Location: {e.Location.Latitude:F4}, {e.Location.Longitude:F4}\n\nPins: {string.Join(", ", pinLabels.GetRange(0, Math.Min(5, pinLabels.Count)))}{(pinLabels.Count > 5 ? "..." : "")}",
 				"OK");

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/ClusteringGallery.xaml.cs
@@ -27,32 +27,32 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			UpdateStatus();
 		}
 
-		void OnAdd50PinsClicked(object sender, EventArgs e)
+		void OnAdd50PinsClicked(object? sender, EventArgs e)
 		{
 			AddPins(50);
 			UpdateStatus();
 		}
 
-		void OnAdd100PinsClicked(object sender, EventArgs e)
+		void OnAdd100PinsClicked(object? sender, EventArgs e)
 		{
 			AddPins(100);
 			UpdateStatus();
 		}
 
-		void OnClearPinsClicked(object sender, EventArgs e)
+		void OnClearPinsClicked(object? sender, EventArgs e)
 		{
 			clusterMap.Pins.Clear();
 			_clusterClickCount = 0;
 			UpdateStatus();
 		}
 
-		void OnClusteringToggled(object sender, ToggledEventArgs e)
+		void OnClusteringToggled(object? sender, ToggledEventArgs e)
 		{
 			clusterMap.IsClusteringEnabled = e.Value;
 			UpdateStatus();
 		}
 
-		async void OnClusterClicked(object sender, ClusterClickedEventArgs e)
+		async void OnClusterClicked(object? sender, ClusterClickedEventArgs e)
 		{
 			_clusterClickCount++;
 			
@@ -74,7 +74,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			UpdateStatus();
 		}
 
-		void OnMapClicked(object sender, MapClickedEventArgs e)
+		void OnMapClicked(object? sender, MapClickedEventArgs e)
 		{
 			// Add a pin where user clicks
 			var pin = new Pin

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -17,6 +17,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Map Type", () => new MapTypeGallery(), Navigation),
 						GalleryBuilder.NavButton("Map Pins", () => new MapPinsGallery(), Navigation),
 						GalleryBuilder.NavButton("Pins ItemsSource", () => new PinItemsSourceGallery(), Navigation),
+						GalleryBuilder.NavButton("Pin Clustering", () => new ClusteringGallery(), Navigation),
 						GalleryBuilder.NavButton("Circle", () => new CircleGallery(), Navigation),
 						GalleryBuilder.NavButton("Polygon", () => new PolygonsGallery(), Navigation),
 						GalleryBuilder.NavButton("Element Visibility & ZIndex", () => new MapElementVisibilityGallery(), Navigation),

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data.Common;
 using System.Linq;

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -619,6 +619,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMapElement)polyline).Clicked();
 
 			Assert.Same(polyline, sender);
+		}
+
+		[Fact]
 		public void IsClusteringEnabledDefaultValue()
 		{
 			var map = new Map();

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -618,6 +618,113 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMapElement)polyline).Clicked();
 
 			Assert.Same(polyline, sender);
+		public void IsClusteringEnabledDefaultValue()
+		{
+			var map = new Map();
+			Assert.False(map.IsClusteringEnabled);
+		}
+
+		[Fact]
+		public void IsClusteringEnabledCanBeSet()
+		{
+			var map = new Map();
+			map.IsClusteringEnabled = true;
+			Assert.True(map.IsClusteringEnabled);
+		}
+
+		[Fact]
+		public void ClusteringIdentifierDefaultValue()
+		{
+			var pin = new Pin { Label = "Test" };
+			Assert.Equal(Pin.DefaultClusteringIdentifier, pin.ClusteringIdentifier);
+			Assert.Equal("maui_default_cluster", pin.ClusteringIdentifier);
+		}
+
+		[Fact]
+		public void ClusteringIdentifierCanBeSet()
+		{
+			var pin = new Pin { Label = "Test", ClusteringIdentifier = "restaurants" };
+			Assert.Equal("restaurants", pin.ClusteringIdentifier);
+		}
+
+		[Fact]
+		public void ClusterClickedEventRaises()
+		{
+			var map = new Map();
+			bool eventRaised = false;
+			ClusterClickedEventArgs receivedArgs = null;
+
+			map.ClusterClicked += (sender, args) =>
+			{
+				eventRaised = true;
+				receivedArgs = args;
+			};
+
+			// Simulate cluster click via IMap interface
+			var pins = new List<Pin>
+			{
+				new Pin { Label = "Pin 1", Location = new Location(0, 0) },
+				new Pin { Label = "Pin 2", Location = new Location(0.1, 0.1) }
+			};
+			var location = new Location(0.05, 0.05);
+
+			var handled = ((IMap)map).ClusterClicked(pins.Cast<IMapPin>().ToList(), location);
+
+			Assert.True(eventRaised);
+			Assert.NotNull(receivedArgs);
+			Assert.Equal(2, receivedArgs.Pins.Count);
+			Assert.Equal(location, receivedArgs.Location);
+			Assert.False(handled); // Default is not handled
+		}
+
+		[Fact]
+		public void ClusterClickedEventCanBeHandled()
+		{
+			var map = new Map();
+			map.ClusterClicked += (sender, args) =>
+			{
+				args.Handled = true;
+			};
+
+			var pins = new List<Pin>
+			{
+				new Pin { Label = "Pin 1", Location = new Location(0, 0) }
+			};
+			var location = new Location(0.05, 0.05);
+
+			var handled = ((IMap)map).ClusterClicked(pins.Cast<IMapPin>().ToList(), location);
+
+			Assert.True(handled);
+		}
+
+		[Fact]
+		public void ClusterClickedEventArgsContainsCorrectData()
+		{
+			var pins = new List<Pin>
+			{
+				new Pin { Label = "Pin 1", Location = new Location(1, 2), Address = "Address 1" },
+				new Pin { Label = "Pin 2", Location = new Location(3, 4), Address = "Address 2" },
+				new Pin { Label = "Pin 3", Location = new Location(5, 6), Address = "Address 3" }
+			};
+			var location = new Location(2, 3);
+
+			var args = new ClusterClickedEventArgs(pins, location);
+
+			Assert.Equal(3, args.Pins.Count);
+			Assert.Equal("Pin 1", args.Pins[0].Label);
+			Assert.Equal("Pin 2", args.Pins[1].Label);
+			Assert.Equal("Pin 3", args.Pins[2].Label);
+			Assert.Equal(2, args.Location.Latitude);
+			Assert.Equal(3, args.Location.Longitude);
+			Assert.False(args.Handled);
+		}
+
+		[Fact]
+		public void PinClusteringIdentifierImplementsIMapPin()
+		{
+			var pin = new Pin { Label = "Test", ClusteringIdentifier = "custom_cluster" };
+			IMapPin mapPin = pin;
+			Assert.Equal("custom_cluster", mapPin.ClusteringIdentifier);
 		}
 	}
 }

--- a/src/Core/maps/src/Core/IMap.cs
+++ b/src/Core/maps/src/Core/IMap.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Maui.Maps
 		bool IsTrafficEnabled { get; }
 
 		/// <summary>
+		/// Gets whether pin clustering is enabled for this map.
+		/// </summary>
+		bool IsClusteringEnabled { get; }
+
+		/// <summary>
 		/// The pins that are to be shown on this Map.
 		/// </summary>
 		IList<IMapPin> Pins { get; }
@@ -52,6 +57,14 @@ namespace Microsoft.Maui.Maps
 		/// Method called by the handler when user clicks on the Map.
 		/// </summary>
 		void Clicked(Location position);
+
+		/// <summary>
+		/// Method called by the handler when a cluster is clicked.
+		/// </summary>
+		/// <param name="pins">The pins in the cluster.</param>
+		/// <param name="location">The location of the cluster.</param>
+		/// <returns><see langword="true"/> if the click was handled and default behavior should be suppressed; otherwise <see langword="false"/>.</returns>
+		bool ClusterClicked(IReadOnlyList<IMapPin> pins, Location location);
 
 		/// <summary>
 		/// Moves the map so that it displays the specified <see cref="MapSpan"/> region.

--- a/src/Core/maps/src/Core/IMapPin.cs
+++ b/src/Core/maps/src/Core/IMapPin.cs
@@ -24,9 +24,17 @@ namespace Microsoft.Maui.Maps
 		Location Location { get; }
 
 		/// <summary>
+<<<<<<< HEAD
 		/// Gets or sets the platform-specific marker identifier.
 		/// </summary>
 		/// <remarks>This should typically not be set by the developer. Doing so might result in unpredictable behavior.</remarks>
+=======
+		/// Gets the clustering identifier for this pin.
+		/// Pins with the same identifier will be grouped together when clustering is enabled.
+		/// </summary>
+		string ClusteringIdentifier { get; }
+
+>>>>>>> ae935ed562 (Add Pin Clustering support for iOS)
 		object? MarkerId { get; set; }
 
 		/// <summary>

--- a/src/Core/maps/src/Core/IMapPin.cs
+++ b/src/Core/maps/src/Core/IMapPin.cs
@@ -24,17 +24,15 @@ namespace Microsoft.Maui.Maps
 		Location Location { get; }
 
 		/// <summary>
-<<<<<<< HEAD
-		/// Gets or sets the platform-specific marker identifier.
-		/// </summary>
-		/// <remarks>This should typically not be set by the developer. Doing so might result in unpredictable behavior.</remarks>
-=======
 		/// Gets the clustering identifier for this pin.
 		/// Pins with the same identifier will be grouped together when clustering is enabled.
 		/// </summary>
 		string ClusteringIdentifier { get; }
 
->>>>>>> ae935ed562 (Add Pin Clustering support for iOS)
+		/// <summary>
+		/// Gets or sets the platform-specific marker identifier.
+		/// </summary>
+		/// <remarks>This should typically not be set by the developer. Doing so might result in unpredictable behavior.</remarks>
 		object? MarkerId { get; set; }
 
 		/// <summary>

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -921,7 +921,7 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			// Recalculate clusters when zoom level changes significantly
 			var currentZoom = _googleMap.CameraPosition.Zoom;
-			if (Math.Abs(currentZoom - _lastClusterZoom) > 0.5f)
+			if (Math.Abs(currentZoom - _lastClusterZoom) > 1.0f)
 			{
 				_lastClusterZoom = currentZoom;
 				_handler.ReclusterPins();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (handler is MapHandler mapHandler)
 			{
 				mapHandler._isClusteringEnabled = map.IsClusteringEnabled;
+				if (!map.IsClusteringEnabled)
+				{
+					mapHandler._clusters?.Clear();
+					mapHandler._clusterMarkers?.Clear();
+				}
 				// Re-add pins to apply clustering changes
 				MapPins(handler, map);
 			}
@@ -689,10 +694,10 @@ double clusterRadius = clusterRadiusBasePixels / Math.Pow(2, zoom);
 				if (bitmap == null)
 					return null;
 					
-				var canvas = new ACanvas(bitmap);
+				using var canvas = new ACanvas(bitmap);
+				using var paint = new APaint();
 				
 				// Draw circle background
-				var paint = new APaint();
 				paint.AntiAlias = true;
 				paint.SetARGB(255, 66, 133, 244); // Google blue
 				canvas.DrawCircle(size / 2f, size / 2f, size / 2f - 2, paint);

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -111,6 +111,16 @@ namespace Microsoft.Maui.Maps.Handlers
 			googleMap?.UpdateIsZoomEnabled(map);
 		}
 
+		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map)
+		{
+			// TODO: Android clustering requires the android-maps-utils library (ClusterManager)
+			// For now, log a warning that clustering is not supported on Android
+			if (map.IsClusteringEnabled)
+			{
+				System.Diagnostics.Debug.WriteLine("Pin clustering is not yet supported on Android. Consider using a third-party library like android-maps-utils.");
+			}
+		}
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg)
 		{
 			MapSpan? newRegion = arg as MapSpan;

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -330,11 +330,11 @@ namespace Microsoft.Maui.Maps.Handlers
 			// At zoom 0 (world view), cluster radius is large
 			// At zoom 21 (street level), cluster radius is tiny
 			// The divisor controls how aggressively pins cluster - smaller = less clustering
-			// 50 pixels on screen ≈ cluster if pins would overlap at this zoom
+						// 50 pixels on screen ≈ cluster if pins would overlap at this zoom
 			// Base cluster radius in approximate screen pixels at zoom 0.
-// Pins whose projected positions fall within this radius are clustered.
-const double clusterRadiusBasePixels = 50.0;
-double clusterRadius = clusterRadiusBasePixels / Math.Pow(2, zoom);
+			// Pins whose projected positions fall within this radius are clustered.
+			const double clusterRadiusBasePixels = 50.0;
+			double clusterRadius = clusterRadiusBasePixels / Math.Pow(2, zoom);
 
 			// Group pins by their clustering identifier
 			var pinsByIdentifier = new Dictionary<string, List<IMapPin>>();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -326,13 +326,16 @@ namespace Microsoft.Maui.Maps.Handlers
 			// At zoom 21 (street level), cluster radius is tiny
 			// The divisor controls how aggressively pins cluster - smaller = less clustering
 			// 50 pixels on screen ≈ cluster if pins would overlap at this zoom
-			double clusterRadius = 50.0 / Math.Pow(2, zoom);
+			// Base cluster radius in approximate screen pixels at zoom 0.
+// Pins whose projected positions fall within this radius are clustered.
+const double clusterRadiusBasePixels = 50.0;
+double clusterRadius = clusterRadiusBasePixels / Math.Pow(2, zoom);
 
 			// Group pins by their clustering identifier
 			var pinsByIdentifier = new Dictionary<string, List<IMapPin>>();
 			foreach (var pin in pins)
 			{
-				var identifier = pin.ClusteringIdentifier ?? "default";
+				var identifier = pin.ClusteringIdentifier ?? Pin.DefaultClusteringIdentifier;
 				if (!pinsByIdentifier.ContainsKey(identifier))
 					pinsByIdentifier[identifier] = new List<IMapPin>();
 				pinsByIdentifier[identifier].Add(pin);
@@ -355,9 +358,13 @@ namespace Microsoft.Maui.Maps.Handlers
 					for (int i = remaining.Count - 1; i >= 0; i--)
 					{
 						var pin = remaining[i];
+						var deltaLat = pin.Location.Latitude - cluster.CenterLatitude;
+						var deltaLng = pin.Location.Longitude - cluster.CenterLongitude;
+						var centerLatRad = cluster.CenterLatitude * (Math.PI / 180.0);
+						var adjustedDeltaLng = deltaLng * Math.Cos(centerLatRad);
 						var distance = Math.Sqrt(
-							Math.Pow(pin.Location.Latitude - cluster.CenterLatitude, 2) +
-							Math.Pow(pin.Location.Longitude - cluster.CenterLongitude, 2));
+							deltaLat * deltaLat +
+							adjustedDeltaLng * adjustedDeltaLng);
 						
 						if (distance <= clusterRadius)
 						{
@@ -511,7 +518,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (_clusterMarkers != null && _clusterMarkers.TryGetValue(e.Marker.Id, out var cluster))
 			{
 				var location = new Devices.Sensors.Location(cluster.CenterLatitude, cluster.CenterLongitude);
-				bool handled = VirtualView.ClusterClicked(cluster.Pins, location);
+				bool handled = VirtualView?.ClusterClicked(cluster.Pins, location) ?? false;
 				
 				if (!handled && Map != null)
 				{

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -17,6 +17,10 @@ using Microsoft.Maui.Graphics.Platform;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Maps.Platform;
 using Microsoft.Maui.Platform;
+using ABitmap = Android.Graphics.Bitmap;
+using ACanvas = Android.Graphics.Canvas;
+using APaint = Android.Graphics.Paint;
+using ARect = Android.Graphics.Rect;
 using ACircle = Android.Gms.Maps.Model.Circle;
 using APolygon = Android.Gms.Maps.Model.Polygon;
 using APolyline = Android.Gms.Maps.Model.Polyline;
@@ -36,6 +40,9 @@ namespace Microsoft.Maui.Maps.Handlers
 		List<APolyline>? _polylines;
 		List<APolygon>? _polygons;
 		List<ACircle>? _circles;
+		bool _isClusteringEnabled;
+		List<MapCluster>? _clusters;
+		Dictionary<string, MapCluster>? _clusterMarkers;
 
 		public GoogleMap? Map { get; private set; }
 
@@ -70,6 +77,8 @@ namespace Microsoft.Maui.Maps.Handlers
 				Map.MapClick -= OnMapClick;
 			}
 
+			_clusters?.Clear();
+			_clusterMarkers?.Clear();
 			_mapReady = null;
 		}
 
@@ -113,11 +122,11 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map)
 		{
-			// TODO: Android clustering requires the android-maps-utils library (ClusterManager)
-			// For now, log a warning that clustering is not supported on Android
-			if (map.IsClusteringEnabled)
+			if (handler is MapHandler mapHandler)
 			{
-				System.Diagnostics.Debug.WriteLine("Pin clustering is not yet supported on Android. Consider using a third-party library like android-maps-utils.");
+				mapHandler._isClusteringEnabled = map.IsClusteringEnabled;
+				// Re-add pins to apply clustering changes
+				MapPins(handler, map);
 			}
 		}
 
@@ -303,6 +312,75 @@ namespace Microsoft.Maui.Maps.Handlers
 			(handler as MapHandler)?.AddMapElements((IList)map.Elements);
 		}
 
+		/// <summary>
+		/// Clusters pins based on their proximity using a simple grid-based algorithm.
+		/// </summary>
+		List<MapCluster> CreateClusters(IList<IMapPin> pins, float zoom)
+		{
+			var clusters = new List<MapCluster>();
+			if (pins == null || pins.Count == 0)
+				return clusters;
+
+			// Cluster radius in degrees, adjusted based on zoom level
+			// At zoom 0 (world view), cluster radius is large
+			// At zoom 21 (street level), cluster radius is tiny
+			double clusterRadius = 180.0 / Math.Pow(2, zoom) * 2;
+
+			// Group pins by their clustering identifier
+			var pinsByIdentifier = new Dictionary<string, List<IMapPin>>();
+			foreach (var pin in pins)
+			{
+				var identifier = pin.ClusteringIdentifier ?? "default";
+				if (!pinsByIdentifier.ContainsKey(identifier))
+					pinsByIdentifier[identifier] = new List<IMapPin>();
+				pinsByIdentifier[identifier].Add(pin);
+			}
+
+			// Create clusters for each group
+			foreach (var group in pinsByIdentifier.Values)
+			{
+				var remaining = new List<IMapPin>(group);
+				
+				while (remaining.Count > 0)
+				{
+					var seed = remaining[0];
+					remaining.RemoveAt(0);
+					
+					var cluster = new MapCluster(seed.Location.Latitude, seed.Location.Longitude);
+					cluster.Pins.Add(seed);
+					
+					// Find all pins within radius
+					for (int i = remaining.Count - 1; i >= 0; i--)
+					{
+						var pin = remaining[i];
+						var distance = Math.Sqrt(
+							Math.Pow(pin.Location.Latitude - cluster.CenterLatitude, 2) +
+							Math.Pow(pin.Location.Longitude - cluster.CenterLongitude, 2));
+						
+						if (distance <= clusterRadius)
+						{
+							cluster.Pins.Add(pin);
+							remaining.RemoveAt(i);
+							
+							// Update cluster center to be the centroid
+							double sumLat = 0, sumLng = 0;
+							foreach (var p in cluster.Pins)
+							{
+								sumLat += p.Location.Latitude;
+								sumLng += p.Location.Longitude;
+							}
+							cluster.CenterLatitude = sumLat / cluster.Pins.Count;
+							cluster.CenterLongitude = sumLng / cluster.Pins.Count;
+						}
+					}
+					
+					clusters.Add(cluster);
+				}
+			}
+
+			return clusters;
+		}
+
 		internal void OnMapReady(GoogleMap map)
 		{
 			if (map == null)
@@ -404,6 +482,37 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		void OnMarkerClick(object? sender, GoogleMap.MarkerClickEventArgs e)
 		{
+			// Check if this is a cluster marker
+			if (_clusterMarkers != null && _clusterMarkers.TryGetValue(e.Marker.Id, out var cluster))
+			{
+				var location = new Devices.Sensors.Location(cluster.CenterLatitude, cluster.CenterLongitude);
+				bool handled = VirtualView.ClusterClicked(cluster.Pins, location);
+				
+				if (!handled && Map != null)
+				{
+					// Default behavior: zoom in to show cluster pins
+					var builder = new LatLngBounds.Builder();
+					foreach (var clusterPin in cluster.Pins)
+					{
+						builder.Include(new LatLng(clusterPin.Location.Latitude, clusterPin.Location.Longitude));
+					}
+					
+					try
+					{
+						var bounds = builder.Build();
+						var update = CameraUpdateFactory.NewLatLngBounds(bounds, 100);
+						Map.AnimateCamera(update);
+					}
+					catch (IllegalStateException)
+					{
+						// Bounds couldn't be built
+					}
+				}
+				
+				e.Handled = true;
+				return;
+			}
+
 			var pin = GetPinForMarker(e.Marker);
 
 			if (pin == null)
@@ -413,13 +522,18 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			// Setting e.Handled = true will prevent the info window from being presented
 			// SendMarkerClick() returns the value of PinClickedEventArgs.HideInfoWindow
-			bool handled = pin.SendMarkerClick();
-			e.Handled = handled;
+			bool markerHandled = pin.SendMarkerClick();
+			e.Handled = markerHandled;
 		}
 
 		void OnInfoWindowClick(object? sender, GoogleMap.InfoWindowClickEventArgs e)
 		{
 			var marker = e.Marker;
+			
+			// Cluster markers don't have info windows
+			if (_clusterMarkers != null && _clusterMarkers.ContainsKey(marker.Id))
+				return;
+			
 			var pin = GetPinForMarker(marker);
 
 			if (pin == null)
@@ -450,6 +564,68 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (_markers == null)
 				_markers = new List<Marker>();
 
+			if (_clusterMarkers == null)
+				_clusterMarkers = new Dictionary<string, MapCluster>();
+			else
+				_clusterMarkers.Clear();
+
+			// Convert to IMapPin list
+			var mapPins = new List<IMapPin>();
+			foreach (var p in pins)
+			{
+				mapPins.Add((IMapPin)p);
+			}
+
+			// When clustering is enabled, create clusters
+			if (_isClusteringEnabled && mapPins.Count > 0)
+			{
+				float zoom = Map.CameraPosition?.Zoom ?? 10f;
+				_clusters = CreateClusters(mapPins, zoom);
+
+				foreach (var cluster in _clusters)
+				{
+					if (cluster.Pins.Count == 1)
+					{
+						// Single pin - add as regular marker
+						var pin = cluster.Pins[0];
+						var pinHandler = pin.ToHandler(MauiContext);
+						if (pinHandler is IMapPinHandler iMapPinHandler)
+						{
+							var marker = Map.AddMarker(iMapPinHandler.PlatformView);
+							if (marker != null)
+							{
+								pin.MarkerId = marker.Id;
+								_markers.Add(marker);
+							}
+						}
+					}
+					else
+					{
+						// Multiple pins - create cluster marker
+						var options = new MarkerOptions();
+						options.SetPosition(new LatLng(cluster.CenterLatitude, cluster.CenterLongitude));
+						options.SetTitle($"{cluster.Pins.Count} items");
+						options.Anchor(0.5f, 0.5f);
+						
+						// Create a circular cluster icon with count
+						var icon = CreateClusterIcon(cluster.Pins.Count);
+						if (icon != null)
+							options.SetIcon(icon);
+						
+						var marker = Map.AddMarker(options);
+						if (marker != null)
+						{
+							_markers.Add(marker);
+							_clusterMarkers[marker.Id] = cluster;
+						}
+					}
+				}
+				
+				_pins = null;
+				return;
+			}
+
+			// Normal non-clustered pins
 			foreach (var p in pins)
 			{
 				IMapPin pin = (IMapPin)p;
@@ -470,6 +646,51 @@ namespace Microsoft.Maui.Maps.Handlers
 
 			}
 			_pins = null;
+		}
+
+		BitmapDescriptor? CreateClusterIcon(int count)
+		{
+			try
+			{
+				int size = 100; // pixels
+				var bitmap = ABitmap.CreateBitmap(size, size, ABitmap.Config.Argb8888!);
+				if (bitmap == null)
+					return null;
+					
+				var canvas = new ACanvas(bitmap);
+				
+				// Draw circle background
+				var paint = new APaint();
+				paint.AntiAlias = true;
+				paint.SetARGB(255, 66, 133, 244); // Google blue
+				canvas.DrawCircle(size / 2f, size / 2f, size / 2f - 2, paint);
+				
+				// Draw border
+				paint.SetStyle(APaint.Style.Stroke);
+				paint.StrokeWidth = 4;
+				paint.SetARGB(255, 255, 255, 255); // White border
+				canvas.DrawCircle(size / 2f, size / 2f, size / 2f - 4, paint);
+				
+				// Draw text
+				paint.SetStyle(APaint.Style.Fill);
+				paint.SetARGB(255, 255, 255, 255); // White text
+				paint.TextSize = count > 99 ? 28 : 36;
+				paint.TextAlign = APaint.Align.Center;
+				
+				var text = count > 99 ? "99+" : count.ToString();
+				var textBounds = new ARect();
+				paint.GetTextBounds(text, 0, text.Length, textBounds);
+				
+				float x = size / 2f;
+				float y = size / 2f + textBounds.Height() / 2f;
+				canvas.DrawText(text, x, y, paint);
+				
+				return BitmapDescriptorFactory.FromBitmap(bitmap);
+			}
+			catch
+			{
+				return null;
+			}
 		}
 
 		protected IMapPin? GetPinForMarker(Marker marker)
@@ -677,6 +898,23 @@ namespace Microsoft.Maui.Maps.Handlers
 			var element = _handler?.VirtualView.Elements.FirstOrDefault(x => x.MapElementId?.ToString() == elementId);
 			element?.Clicked();
 		}
+	}
+
+	/// <summary>
+	/// Represents a cluster of map pins.
+	/// </summary>
+	class MapCluster
+	{
+		public MapCluster(double lat, double lng)
+		{
+			CenterLatitude = lat;
+			CenterLongitude = lng;
+			Pins = new List<IMapPin>();
+		}
+
+		public double CenterLatitude { get; set; }
+		public double CenterLongitude { get; set; }
+		public List<IMapPin> Pins { get; }
 	}
 
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -340,7 +340,7 @@ double clusterRadius = clusterRadiusBasePixels / Math.Pow(2, zoom);
 			var pinsByIdentifier = new Dictionary<string, List<IMapPin>>();
 			foreach (var pin in pins)
 			{
-				var identifier = pin.ClusteringIdentifier ?? Pin.DefaultClusteringIdentifier;
+				var identifier = pin.ClusteringIdentifier ?? "maui_default_cluster";
 				if (!pinsByIdentifier.ContainsKey(identifier))
 					pinsByIdentifier[identifier] = new List<IMapPin>();
 				pinsByIdentifier[identifier].Add(pin);

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -324,7 +324,9 @@ namespace Microsoft.Maui.Maps.Handlers
 			// Cluster radius in degrees, adjusted based on zoom level
 			// At zoom 0 (world view), cluster radius is large
 			// At zoom 21 (street level), cluster radius is tiny
-			double clusterRadius = 180.0 / Math.Pow(2, zoom) * 2;
+			// The divisor controls how aggressively pins cluster - smaller = less clustering
+			// 50 pixels on screen ≈ cluster if pins would overlap at this zoom
+			double clusterRadius = 50.0 / Math.Pow(2, zoom);
 
 			// Group pins by their clustering identifier
 			var pinsByIdentifier = new Dictionary<string, List<IMapPin>>();
@@ -394,6 +396,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			map.SetOnPolygonClickListener(_mapReady);
 			map.SetOnCircleClickListener(_mapReady);
 			map.SetOnPolylineClickListener(_mapReady);
+			map.SetOnCameraIdleListener(_mapReady);
 
 			map.MarkerClick += OnMarkerClick;
 			map.InfoWindowClick += OnInfoWindowClick;
@@ -409,6 +412,28 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 
 			InitialUpdate();
+		}
+
+		/// <summary>
+		/// Recalculates clusters based on current zoom level.
+		/// Called when camera becomes idle after zooming.
+		/// </summary>
+		internal void ReclusterPins()
+		{
+			if (!_isClusteringEnabled || Map == null || VirtualView == null)
+				return;
+
+			// Clear existing markers
+			if (_markers != null)
+			{
+				for (int i = 0; i < _markers.Count; i++)
+					_markers[i].Remove();
+				_markers = null;
+			}
+			_clusterMarkers?.Clear();
+
+			// Re-add pins to trigger reclustering at new zoom level
+			AddPins((IList)VirtualView.Pins);
 		}
 
 		internal void UpdateVisibleRegion(LatLng pos)
@@ -852,10 +877,11 @@ namespace Microsoft.Maui.Maps.Handlers
 		}
 	}
 
-	class MapCallbackHandler : Java.Lang.Object, GoogleMap.IOnCameraMoveListener, IOnMapReadyCallback, GoogleMap.IOnPolygonClickListener, GoogleMap.IOnCircleClickListener, GoogleMap.IOnPolylineClickListener
+	class MapCallbackHandler : Java.Lang.Object, GoogleMap.IOnCameraMoveListener, GoogleMap.IOnCameraIdleListener, IOnMapReadyCallback, GoogleMap.IOnPolygonClickListener, GoogleMap.IOnCircleClickListener, GoogleMap.IOnPolylineClickListener
 	{
 		MapHandler? _handler;
 		GoogleMap? _googleMap;
+		float _lastClusterZoom = -1;
 
 		public MapCallbackHandler(MapHandler mapHandler)
 		{
@@ -874,6 +900,20 @@ namespace Microsoft.Maui.Maps.Handlers
 				return;
 
 			_handler?.UpdateVisibleRegion(_googleMap.CameraPosition.Target);
+		}
+
+		void GoogleMap.IOnCameraIdleListener.OnCameraIdle()
+		{
+			if (_googleMap == null || _handler == null)
+				return;
+
+			// Recalculate clusters when zoom level changes significantly
+			var currentZoom = _googleMap.CameraPosition.Zoom;
+			if (Math.Abs(currentZoom - _lastClusterZoom) > 0.5f)
+			{
+				_lastClusterZoom = currentZoom;
+				_handler.ReclusterPins();
+			}
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsZoomEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
+		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg) => throw new NotImplementedException();
 
 		public static void MapPins(IMapHandler handler, IMap map) => throw new NotImplementedException();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsZoomEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
+		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg) => throw new NotImplementedException();
 
 		public static void MapPins(IMapHandler handler, IMap map) => throw new NotImplementedException();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsShowingUser(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
+		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg) => throw new NotImplementedException();
 
 		public static void MapPins(IMapHandler handler, IMap map) => throw new NotImplementedException();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			[nameof(IMap.IsScrollEnabled)] = MapIsScrollEnabled,
 			[nameof(IMap.IsTrafficEnabled)] = MapIsTrafficEnabled,
 			[nameof(IMap.IsZoomEnabled)] = MapIsZoomEnabled,
+			[nameof(IMap.IsClusteringEnabled)] = MapIsClusteringEnabled,
 			[nameof(IMap.Pins)] = MapPins,
 			[nameof(IMap.Elements)] = MapElements,
 		};

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -74,6 +74,13 @@ namespace Microsoft.Maui.Maps.Handlers
 			handler.PlatformView.ZoomEnabled = map.IsZoomEnabled;
 		}
 
+		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map)
+		{
+			handler.PlatformView.IsClusteringEnabled = map.IsClusteringEnabled;
+			// Re-add pins to apply clustering changes
+			handler.PlatformView.AddPins((IList)map.Pins);
+		}
+
 		public static void MapPins(IMapHandler handler, IMap map)
 		{
 			handler.PlatformView.AddPins((IList)map.Pins);

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map)
 		{
 			handler.PlatformView.IsClusteringEnabled = map.IsClusteringEnabled;
-			// Re-add pins to apply clustering changes
+			// Remove existing pins before re-adding to avoid duplicates
+			handler.PlatformView.RemovePins((IList)map.Pins);
 			handler.PlatformView.AddPins((IList)map.Pins);
 		}
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -77,8 +77,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map)
 		{
 			handler.PlatformView.IsClusteringEnabled = map.IsClusteringEnabled;
-			// Remove existing pins before re-adding to avoid duplicates
-			handler.PlatformView.RemovePins((IList)map.Pins);
+			// Re-add pins so they pick up the new clustering state
 			handler.PlatformView.AddPins((IList)map.Pins);
 		}
 

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Maps.Platform
 			if (clusterView == null)
 			{
 				clusterView = new MKMarkerAnnotationView(clusterAnnotation, clusterId);
-				clusterView.CanShowCallout = true;
+				clusterView.CanShowCallout = false; // Don't show callout for clusters
 			}
 			
 			clusterView.Annotation = clusterAnnotation;
@@ -164,25 +164,7 @@ namespace Microsoft.Maui.Maps.Platform
 			var count = clusterAnnotation.MemberAnnotations?.Length ?? 0;
 			clusterView.GlyphText = count.ToString();
 			
-			// Attach click handler for cluster
-			AttachGestureToCluster(clusterView, clusterAnnotation);
-			
 			return clusterView;
-		}
-
-		void AttachGestureToCluster(MKAnnotationView clusterView, MKClusterAnnotation clusterAnnotation)
-		{
-			var recognizers = clusterView.GestureRecognizers;
-			if (recognizers != null)
-			{
-				foreach (var recognizer in recognizers.OfType<UITapGestureRecognizer>().ToArray())
-				{
-					clusterView.RemoveGestureRecognizer(recognizer);
-				}
-			}
-
-			var tapRecognizer = new UITapGestureRecognizer(() => OnClusterClicked(clusterAnnotation));
-			clusterView.AddGestureRecognizer(tapRecognizer);
 		}
 
 		void OnClusterClicked(MKClusterAnnotation clusterAnnotation)
@@ -339,6 +321,16 @@ namespace Microsoft.Maui.Maps.Platform
 		void MkMapViewOnAnnotationViewSelected(object? sender, MKAnnotationViewEventArgs e)
 		{
 			var annotation = e.View.Annotation;
+			
+			// Handle cluster annotation selection
+			if (annotation is MKClusterAnnotation clusterAnnotation)
+			{
+				OnClusterClicked(clusterAnnotation);
+				// Deselect the cluster annotation to allow re-selection
+				DeselectAnnotation(annotation, false);
+				return;
+			}
+			
 			var pin = GetPinForAnnotation(annotation!);
 
 			if (pin == null)

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -138,7 +138,9 @@ namespace Microsoft.Maui.Maps.Platform
 			}
 			else if (OperatingSystem.IsIOSVersionAtLeast(11))
 			{
-				// Clear clustering identifier when disabled
+				// Clear clustering identifier on the view when disabled.
+				// The original value is preserved in the IMapPin data and will be
+				// re-applied from GetPinForAnnotation when clustering is re-enabled.
 				mapPin.ClusteringIdentifier = null;
 			}
 			

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,8 +1,11 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -11,3 +14,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,13 +1,19 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.set -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,13 +1,19 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.get -> bool
+Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.set -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,8 +1,11 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -11,3 +14,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,8 +1,11 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -11,3 +14,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,8 +1,11 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -11,3 +14,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,8 +1,11 @@
 
 #nullable enable
+Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
+Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -11,3 +14,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds Pin Clustering support for the Maps control on iOS/MacCatalyst and Android.

Fixes #11811

## Changes

### New API
- `Map.IsClusteringEnabled` - Enable/disable pin clustering
- `Pin.ClusteringIdentifier` - Group pins into named clusters  
- `Map.ClusterClicked` event - Fired when a cluster marker is tapped
- `ClusterClickedEventArgs` - Contains the list of pins in the clicked cluster

### iOS/MacCatalyst Implementation
- Uses native `MKClusterAnnotation` support
- Cluster clicks handled via `DidSelectAnnotationView` delegate
- Automatic cluster management by MapKit

### Android Implementation
- Custom grid-based clustering algorithm (no external dependencies)
- Clusters recalculate automatically when zoom level changes
- Programmatic cluster icons showing pin count
- Both cluster taps and individual pin taps work correctly

## Testing
- 5 unit tests added for clustering functionality
- Gallery sample page added (`ClusteringGallery`)
- Manually verified on MacCatalyst and Android emulator