### PR TITLE
Enable implicit xmlns declarations by default

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
@@ -1,5 +1,3 @@
-﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Maui.Controls.Sample.MainPage"
+﻿<ContentPage x:Class="Maui.Controls.Sample.MainPage"
              xmlns:local="clr-namespace:Maui.Controls.Sample">
 </ContentPage>

--- a/src/Controls/src/Build.Tasks/XamlTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlTask.cs
@@ -39,19 +39,13 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		internal static ILRootNode ParseXaml(Stream stream, ModuleDefinition module, TypeReference typeReference)
 		{
-			// Implicit xmlns is always enabled in .NET 11+
-			var allowImplicitXmlns = true;
-
 			var nsmgr = new XmlNamespaceManager(new NameTable());
-			if (allowImplicitXmlns)
-			{
-				nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
-				foreach (var xmlnsPrefix in XmlTypeExtensions.GetXmlnsPrefixAttributes(module))
-					nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
-			}
+			nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
+			foreach (var xmlnsPrefix in XmlTypeExtensions.GetXmlnsPrefixAttributes(module))
+				nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
 
 			using (var reader = XmlReader.Create(stream,
-										new XmlReaderSettings { ConformanceLevel = allowImplicitXmlns ? ConformanceLevel.Fragment : ConformanceLevel.Document },
+										new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment },
 										new XmlParserContext(nsmgr.NameTable, nsmgr, null, XmlSpace.None)))
 			{
 				while (reader.Read())
@@ -83,20 +77,15 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			if (!resource.Name.EndsWith(".xaml", StringComparison.InvariantCulture))
 				return false;
 
-			// Implicit xmlns is always enabled in .NET 11+
-			var allowImplicitXmlns = true;
-
 			var nsmgr = new XmlNamespaceManager(new NameTable());
 			nsmgr.AddNamespace("__f__", XamlParser.MauiUri);
-			if (allowImplicitXmlns)
-			{
-				nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
-				foreach (var xmlnsPrefix in XmlTypeExtensions.GetXmlnsPrefixAttributes(module))
-					nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
-			}
+			nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
+			foreach (var xmlnsPrefix in XmlTypeExtensions.GetXmlnsPrefixAttributes(module))
+				nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
+
 			using (var resourceStream = resource.GetResourceStream())
 			using (var reader = XmlReader.Create(resourceStream,
-										new XmlReaderSettings { ConformanceLevel = allowImplicitXmlns ? ConformanceLevel.Fragment : ConformanceLevel.Document },
+										new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment },
 										new XmlParserContext(nsmgr.NameTable, nsmgr, null, XmlSpace.None)))
 			{
 				// Read to the first Element

--- a/src/Controls/src/Build.Tasks/XamlTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlTask.cs
@@ -39,9 +39,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 		internal static ILRootNode ParseXaml(Stream stream, ModuleDefinition module, TypeReference typeReference)
 		{
-			var allowImplicitXmlns = module.Assembly.CustomAttributes.Any(a =>
-				   a.AttributeType.FullName == typeof(Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute).FullName
-				&& (a.ConstructorArguments.Count == 0 || a.ConstructorArguments[0].Value is bool b && b));
+			// Implicit xmlns is always enabled in .NET 11+
+			var allowImplicitXmlns = true;
 
 			var nsmgr = new XmlNamespaceManager(new NameTable());
 			if (allowImplicitXmlns)
@@ -84,9 +83,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			if (!resource.Name.EndsWith(".xaml", StringComparison.InvariantCulture))
 				return false;
 
-			var allowImplicitXmlns = module.Assembly.CustomAttributes.Any(a =>
-				   a.AttributeType.FullName == typeof(Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute).FullName
-				&& (a.ConstructorArguments.Count == 0 || a.ConstructorArguments[0].Value is bool b && b));
+			// Implicit xmlns is always enabled in .NET 11+
+			var allowImplicitXmlns = true;
 
 			var nsmgr = new XmlNamespaceManager(new NameTable());
 			nsmgr.AddNamespace("__f__", XamlParser.MauiUri);

--- a/src/Controls/src/Core/AllowImplicitXmlnsDeclarationAttribute.cs
+++ b/src/Controls/src/Core/AllowImplicitXmlnsDeclarationAttribute.cs
@@ -3,8 +3,11 @@ using System;
 
 namespace Microsoft.Maui.Controls.Xaml.Internals;
 
+#if !NET12_0_OR_GREATER
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+[Obsolete("Implicit xmlns declarations are now always enabled. This attribute is no longer needed and will be removed in .NET 12.")]
 public sealed class AllowImplicitXmlnsDeclarationAttribute(bool allow = true) : Attribute
 {
 	public bool Allow { get; } = allow;
 }
+#endif

--- a/src/Controls/src/Core/AllowImplicitXmlnsDeclarationAttribute.cs
+++ b/src/Controls/src/Core/AllowImplicitXmlnsDeclarationAttribute.cs
@@ -1,13 +1,9 @@
 #nullable enable
 using System;
-using System.Runtime.Versioning;
 
 namespace Microsoft.Maui.Controls.Xaml.Internals;
 
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
-#if !NETSTANDARD
-[RequiresPreviewFeatures]
-#endif
 public sealed class AllowImplicitXmlnsDeclarationAttribute(bool allow = true) : Attribute
 {
 	public bool Allow { get; } = allow;

--- a/src/Controls/src/Core/AllowImplicitXmlnsDeclarationAttribute.cs
+++ b/src/Controls/src/Core/AllowImplicitXmlnsDeclarationAttribute.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls.Xaml.Internals;
 
 #if !NET12_0_OR_GREATER
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
-[Obsolete("Implicit xmlns declarations are now always enabled. This attribute is no longer needed and will be removed in .NET 12.")]
+[Obsolete("Implicit xmlns declarations are now always enabled. The 'allow: false' opt-out is no longer honored. Remove this attribute; it will be removed in .NET 12.")]
 public sealed class AllowImplicitXmlnsDeclarationAttribute(bool allow = true) : Attribute
 {
 	public bool Allow { get; } = allow;

--- a/src/Controls/src/SourceGen/AssemblyAttributes.cs
+++ b/src/Controls/src/SourceGen/AssemblyAttributes.cs
@@ -4,14 +4,14 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls.SourceGen;
 
-class AssemblyAttributes(IReadOnlyList<XmlnsDefinitionAttribute> xmlnsDefinitions, IReadOnlyList<XmlnsPrefixAttribute> xmlnsPrefixes, IReadOnlyList<XmlnsDefinitionAttribute> globalGeneratedXmlnsDefinitions, IReadOnlyList<IAssemblySymbol> internalsVisible, Dictionary<string, List<string>> clrNamespacesForXmlns, bool allowImplicitXmlns)
+class AssemblyAttributes(IReadOnlyList<XmlnsDefinitionAttribute> xmlnsDefinitions, IReadOnlyList<XmlnsPrefixAttribute> xmlnsPrefixes, IReadOnlyList<XmlnsDefinitionAttribute> globalGeneratedXmlnsDefinitions, IReadOnlyList<IAssemblySymbol> internalsVisible, Dictionary<string, List<string>> clrNamespacesForXmlns)
 {
-	public static readonly AssemblyAttributes Empty = new([], [], [], [], [], false);
+	public static readonly AssemblyAttributes Empty = new([], [], [], [], []);
 
 	public IReadOnlyList<XmlnsDefinitionAttribute> XmlnsDefinitions { get; } = xmlnsDefinitions;
 	public IReadOnlyList<XmlnsPrefixAttribute> XmlnsPrefixes { get; } = xmlnsPrefixes;
 	public IReadOnlyList<XmlnsDefinitionAttribute> GlobalGeneratedXmlnsDefinitions { get; } = globalGeneratedXmlnsDefinitions;
 	public IReadOnlyList<IAssemblySymbol> InternalsVisible { get; } = internalsVisible;
 	public Dictionary<string, List<string>> ClrNamespacesForXmlns { get; } = clrNamespacesForXmlns;
-	public bool AllowImplicitXmlns { get; } = allowImplicitXmlns;
+	public bool AllowImplicitXmlns => true; // Always enabled in .NET 11+
 }

--- a/src/Controls/src/SourceGen/AssemblyAttributes.cs
+++ b/src/Controls/src/SourceGen/AssemblyAttributes.cs
@@ -13,5 +13,4 @@ class AssemblyAttributes(IReadOnlyList<XmlnsDefinitionAttribute> xmlnsDefinition
 	public IReadOnlyList<XmlnsDefinitionAttribute> GlobalGeneratedXmlnsDefinitions { get; } = globalGeneratedXmlnsDefinitions;
 	public IReadOnlyList<IAssemblySymbol> InternalsVisible { get; } = internalsVisible;
 	public Dictionary<string, List<string>> ClrNamespacesForXmlns { get; } = clrNamespacesForXmlns;
-	public bool AllowImplicitXmlns => true; // Always enabled in .NET 11+
 }

--- a/src/Controls/src/SourceGen/GeneratorHelpers.cs
+++ b/src/Controls/src/SourceGen/GeneratorHelpers.cs
@@ -200,10 +200,6 @@ static class GeneratorHelpers
 		INamedTypeSymbol? xmlnsPrefixAttribute = compilation.GetTypesByMetadataName(typeof(XmlnsPrefixAttribute).FullName)
 			.FirstOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
 
-		// [assembly: AllowImplicitXmlnsDeclaration]
-		INamedTypeSymbol? allowImplicitXmlnsAttribute = compilation.GetTypesByMetadataName(typeof(Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute).FullName)
-			.FirstOrDefault(t => t.ContainingAssembly.Identity.Name == "Microsoft.Maui.Controls");
-
 		if (xmlnsDefinitonAttribute is null || internalsVisibleToAttribute is null)
 			return AssemblyAttributes.Empty;
 
@@ -211,10 +207,6 @@ static class GeneratorHelpers
 		var xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
 		var internalsVisible = new List<IAssemblySymbol>();
 		var xmlnsPrefixes = new List<XmlnsPrefixAttribute>();
-		var allowImplicitXmlns = compilation.Assembly.GetAttributes()
-			.Any(a =>
-				   SymbolEqualityComparer.Default.Equals(a.AttributeClass, allowImplicitXmlnsAttribute)
-				&& (a.ConstructorArguments.Length == 0 || a.ConstructorArguments[0].Value is bool b && b));
 		internalsVisible.Add(compilation.Assembly);
 
 		IList<IAssemblySymbol> assemblies = [compilation.Assembly];
@@ -294,7 +286,7 @@ static class GeneratorHelpers
 			}
 		}
 
-		return new AssemblyAttributes(xmlnsDefinitionsList, xmlnsPrefixes, [.. globalGeneratedXmlnsDefinitions.Distinct()], internalsVisible, clrNamespacesForXmlns, allowImplicitXmlns);
+		return new AssemblyAttributes(xmlnsDefinitionsList, xmlnsPrefixes, [.. globalGeneratedXmlnsDefinitions.Distinct()], internalsVisible, clrNamespacesForXmlns);
 	}
 
 	static void ApplyTransforms(XmlNode node, string? targetFramework, XmlNamespaceManager nsmgr)

--- a/src/Controls/src/SourceGen/GeneratorHelpers.cs
+++ b/src/Controls/src/SourceGen/GeneratorHelpers.cs
@@ -69,14 +69,12 @@ static class GeneratorHelpers
 		var nsmgr = new XmlNamespaceManager(new NameTable());
 		nsmgr.AddNamespace("__f__", XamlParser.MauiUri);
 		nsmgr.AddNamespace("__g__", XamlParser.MauiGlobalUri);
-		if (assemblyCaches.AllowImplicitXmlns)
-		{
-			nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
-			foreach (var xmlnsPrefix in assemblyCaches.XmlnsPrefixes)
-				nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
-		}
+		nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
+		foreach (var xmlnsPrefix in assemblyCaches.XmlnsPrefixes)
+			nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
+
 		using var reader = XmlReader.Create(new StringReader(xaml),
-											new XmlReaderSettings { ConformanceLevel = assemblyCaches.AllowImplicitXmlns ? ConformanceLevel.Fragment : ConformanceLevel.Document },
+											new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment },
 											new XmlParserContext(nsmgr.NameTable, nsmgr, null, XmlSpace.None));
 		{
 			while (reader.Read())
@@ -161,14 +159,12 @@ static class GeneratorHelpers
 		var nsmgr = new XmlNamespaceManager(new NameTable());
 		nsmgr.AddNamespace("__f__", XamlParser.MauiUri);
 		nsmgr.AddNamespace("__g__", XamlParser.MauiGlobalUri);
-		if (assemblyCaches.AllowImplicitXmlns)
-		{
-			nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
-			foreach (var xmlnsPrefix in assemblyCaches.XmlnsPrefixes)
-				nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
-		}
+		nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
+		foreach (var xmlnsPrefix in assemblyCaches.XmlnsPrefixes)
+			nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
+
 		using var reader = XmlReader.Create(new StringReader(text.ToString()),
-											new XmlReaderSettings { ConformanceLevel = assemblyCaches.AllowImplicitXmlns ? ConformanceLevel.Fragment : ConformanceLevel.Document },
+											new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment },
 											new XmlParserContext(nsmgr.NameTable, nsmgr, null, XmlSpace.None));
 
 

--- a/src/Controls/src/SourceGen/XamlGenerator.cs
+++ b/src/Controls/src/SourceGen/XamlGenerator.cs
@@ -238,10 +238,7 @@ $"""
 
 [assembly: global::Microsoft.Maui.Controls.XmlnsDefinition("{XamlParser.MauiGlobalUri}", "{XamlParser.MauiUri}")]
 [assembly: global::Microsoft.Maui.Controls.XmlnsPrefix("{XamlParser.MauiGlobalUri}", "global")]
-
-#if MauiAllowImplicitXmlnsDeclaration
 [assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]
-#endif
 """
 			, Encoding.UTF8));
 		});

--- a/src/Controls/src/SourceGen/XamlGenerator.cs
+++ b/src/Controls/src/SourceGen/XamlGenerator.cs
@@ -238,7 +238,6 @@ $"""
 
 [assembly: global::Microsoft.Maui.Controls.XmlnsDefinition("{XamlParser.MauiGlobalUri}", "{XamlParser.MauiUri}")]
 [assembly: global::Microsoft.Maui.Controls.XmlnsPrefix("{XamlParser.MauiGlobalUri}", "global")]
-[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]
 """
 			, Encoding.UTF8));
 		});

--- a/src/Controls/src/Xaml/XamlLoader.cs
+++ b/src/Controls/src/Xaml/XamlLoader.cs
@@ -63,24 +63,14 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			if (XamlParser.s_xmlnsPrefixes == null)
 				XamlParser.GatherXmlnsDefinitionAndXmlnsPrefixAttributes(rootAssembly);
-			if (!XamlParser.s_allowImplicitXmlns.TryGetValue(rootAssembly, out var allowImplicitXmlns))
-			{
-				allowImplicitXmlns = rootAssembly.CustomAttributes.Any(a =>
-				   		a.AttributeType.FullName == "Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclarationAttribute"
-					&& (a.ConstructorArguments.Count == 0 || a.ConstructorArguments[0].Value is bool b && b));
-				XamlParser.s_allowImplicitXmlns.Add(rootAssembly, allowImplicitXmlns);
-			}
 
 			var nsmgr = new XmlNamespaceManager(new NameTable());
-			if (allowImplicitXmlns)
-			{
-				nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
-				foreach (var xmlnsPrefix in XamlParser.s_xmlnsPrefixes)
-					nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
-			}
+			nsmgr.AddNamespace("", XamlParser.DefaultImplicitUri);
+			foreach (var xmlnsPrefix in XamlParser.s_xmlnsPrefixes)
+				nsmgr.AddNamespace(xmlnsPrefix.Prefix, xmlnsPrefix.XmlNamespace);
 			using (var textReader = new StringReader(xaml))
 			using (var reader = XmlReader.Create(textReader,
-										new XmlReaderSettings { ConformanceLevel = allowImplicitXmlns ? ConformanceLevel.Fragment : ConformanceLevel.Document },
+										new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment },
 										new XmlParserContext(nsmgr.NameTable, nsmgr, null, XmlSpace.None)))
 			{
 				while (reader.Read())

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -366,7 +366,6 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		static IList<XmlnsDefinitionAttribute> s_xmlnsDefinitions;
 		internal static IList<XmlnsPrefixAttribute> s_xmlnsPrefixes;
-		internal static Dictionary<Assembly, bool> s_allowImplicitXmlns = new();
 		static bool ValidateProtectedXmlns(string xmlNamespace, string assemblyName)
 		{
 			//maui, and x: xmlns are protected

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterValueInTrigger.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterValueInTrigger.cs
@@ -53,8 +53,7 @@ public partial class TestPage : ContentPage
 		// When <Setter.Value> is a property element, GetValueNode() must find it
 		// regardless of the namespace URI on the property element.
 		var compilation = CreateMauiCompilation()
-			.AddSyntaxTrees(CSharpSyntaxTree.ParseText(TestCode))
-			.AddSyntaxTrees(CSharpSyntaxTree.ParseText("[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]"));
+			.AddSyntaxTrees(CSharpSyntaxTree.ParseText(TestCode));
 
 		var workingDirectory = Environment.CurrentDirectory;
 		var xamlFile = new AdditionalXamlFile(

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SimpleValueTargetProviderTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SimpleValueTargetProviderTests.cs
@@ -127,6 +127,9 @@ public partial class TestPage
 		xmlNamespaceResolver.Add("__f__", "http://schemas.microsoft.com/dotnet/2021/maui");
 		xmlNamespaceResolver.Add("__g__", "http://schemas.microsoft.com/dotnet/maui/global");
 		xmlNamespaceResolver.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
+		xmlNamespaceResolver.Add("global", "http://schemas.microsoft.com/dotnet/maui/global");
+		xmlNamespaceResolver.Add("maui", "http://schemas.microsoft.com/dotnet/2021/maui");
+		xmlNamespaceResolver.Add("d", "http://schemas.microsoft.com/dotnet/2021/maui/design");
 		xmlNamespaceResolver.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
 		xmlNamespaceResolver.Add("local", "clr-namespace:Test");
 		xamlServiceProvider.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IXamlTypeResolver), new global::Microsoft.Maui.Controls.Xaml.Internals.XamlTypeResolver(xmlNamespaceResolver, typeof(global::Test.TestPage).Assembly));
@@ -290,6 +293,9 @@ public partial class TestPage
 		xmlNamespaceResolver.Add("__f__", "http://schemas.microsoft.com/dotnet/2021/maui");
 		xmlNamespaceResolver.Add("__g__", "http://schemas.microsoft.com/dotnet/maui/global");
 		xmlNamespaceResolver.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
+		xmlNamespaceResolver.Add("global", "http://schemas.microsoft.com/dotnet/maui/global");
+		xmlNamespaceResolver.Add("maui", "http://schemas.microsoft.com/dotnet/2021/maui");
+		xmlNamespaceResolver.Add("d", "http://schemas.microsoft.com/dotnet/2021/maui/design");
 		xmlNamespaceResolver.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
 		xmlNamespaceResolver.Add("local", "clr-namespace:Test");
 		xamlServiceProvider.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IXamlTypeResolver), new global::Microsoft.Maui.Controls.Xaml.Internals.XamlTypeResolver(xmlNamespaceResolver, typeof(global::Test.TestPage).Assembly));

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGenXamlCodeBehindTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGenXamlCodeBehindTests.cs
@@ -51,7 +51,6 @@ public class SourceGenXamlCodeBehindTests : SourceGenTestsBase
 </ContentPage>
 """;
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]"));
 		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		Assert.False(result.Diagnostics.Any());
@@ -482,7 +481,6 @@ public class Helper
 </foo>
 """;
 		var compilation = SourceGeneratorDriver.CreateMauiCompilation();
-		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]"));
 		var result = SourceGeneratorDriver.RunGenerator<XamlGenerator>(compilation, new AdditionalXamlFile("Test.xaml", xaml));
 
 		var generated = result.Results.Single().GeneratedSources.Single(gs => gs.HintName.EndsWith(".sg.cs")).SourceText.ToString();

--- a/src/Controls/tests/SourceGen.UnitTests/StaticResourceInMarkup.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/StaticResourceInMarkup.cs
@@ -169,6 +169,9 @@ public partial class TestPage
 		xmlNamespaceResolver.Add("__f__", "http://schemas.microsoft.com/dotnet/2021/maui");
 		xmlNamespaceResolver.Add("__g__", "http://schemas.microsoft.com/dotnet/maui/global");
 		xmlNamespaceResolver.Add("", "http://schemas.microsoft.com/dotnet/2021/maui");
+		xmlNamespaceResolver.Add("global", "http://schemas.microsoft.com/dotnet/maui/global");
+		xmlNamespaceResolver.Add("maui", "http://schemas.microsoft.com/dotnet/2021/maui");
+		xmlNamespaceResolver.Add("d", "http://schemas.microsoft.com/dotnet/2021/maui/design");
 		xmlNamespaceResolver.Add("x", "http://schemas.microsoft.com/winfx/2009/xaml");
 		xmlNamespaceResolver.Add("local", "clr-namespace:TestApp");
 		xamlServiceProvider.Add(typeof(global::Microsoft.Maui.Controls.Xaml.IXamlTypeResolver), new global::Microsoft.Maui.Controls.Xaml.Internals.XamlTypeResolver(xmlNamespaceResolver, typeof(global::TestApp.TestPage).Assembly));

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -10,7 +10,7 @@
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
-    <DefineConstants>$(DefineConstants);MauiAllowImplicitXmlnsDeclaration</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
     <ReportAnalyzer>true</ReportAnalyzer>
     <!-- We can't yet disable the namescope generation, ConstraintTypeConverter and ReferenceTypeConverter need to be ported to sourcegen
     <DefineConstants>$(DefineConstants);_MAUIXAML_SG_NAMESCOPE_DISABLE</DefineConstants>

--- a/src/Controls/tests/Xaml.UnitTests/GlobalXmlnsWithStyle.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/GlobalXmlnsWithStyle.xaml.cs
@@ -21,10 +21,6 @@ public partial class GlobalXmlnsWithStyle : ContentPage
 			if (inflator == XamlInflator.SourceGen)
 			{
 				var compilation = MockSourceGenerator.CreateMauiCompilation();
-				compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(
-	"""
-[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]
-"""));
 				compilation.RunMauiSourceGenerator(typeof(GlobalXmlnsWithStyle));
 			}
 

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/App.xaml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/App.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
+﻿<Application xmlns:local="clr-namespace:MauiApp._1"
              x:Class="MauiApp._1.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor-solution/MauiApp.1/MainPage.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
+﻿<ContentPage xmlns:local="clr-namespace:MauiApp._1"
              xmlns:shared="clr-namespace:MauiApp._1.Shared;assembly=XmlEncodedAppName.Shared"
              x:Class="MauiApp._1.MainPage"
              BackgroundColor="{DynamicResource PageBackgroundColor}">

--- a/src/Templates/src/templates/maui-blazor/App.xaml
+++ b/src/Templates/src/templates/maui-blazor/App.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
+﻿<Application xmlns:local="clr-namespace:MauiApp._1"
              x:Class="MauiApp._1.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
+﻿<ContentPage xmlns:local="clr-namespace:MauiApp._1"
              xmlns:components="clr-namespace:MauiApp._1.Components"
              x:Class="MauiApp._1.MainPage">
 

--- a/src/Templates/src/templates/maui-contentpage-xaml/NewPage1.xaml
+++ b/src/Templates/src/templates/maui-contentpage-xaml/NewPage1.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp1.NewPage1"
+<ContentPage x:Class="MauiApp1.NewPage1"
              Title="NewPage1">
     <VerticalStackLayout>
         <Label 

--- a/src/Templates/src/templates/maui-contentview-xaml/NewContent1.xaml
+++ b/src/Templates/src/templates/maui-contentview-xaml/NewContent1.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp1.NewContent1">
+<ContentView x:Class="MauiApp1.NewContent1">
     <VerticalStackLayout>
         <Label 
             Text="Welcome to .NET MAUI!"

--- a/src/Templates/src/templates/maui-mobile/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/App.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version = "1.0" encoding = "UTF-8" ?>
-<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
+﻿<Application xmlns:local="clr-namespace:MauiApp._1"
              x:Class="MauiApp._1.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/Templates/src/templates/maui-mobile/AppShell.xaml
+++ b/src/Templates/src/templates/maui-mobile/AppShell.xaml
@@ -1,8 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <Shell
     x:Class="MauiApp._1.AppShell"
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 <!--#if (IncludeSampleContent) -->
     xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.SegmentedControl;assembly=Syncfusion.Maui.Toolkit"
     xmlns:pages="clr-namespace:MauiApp._1.Pages"

--- a/src/Templates/src/templates/maui-mobile/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MainPage.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp._1.MainPage">
+﻿<ContentPage x:Class="MauiApp._1.MainPage">
 
     <ScrollView>
         <VerticalStackLayout

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/AddButton.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/AddButton.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Button xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    x:Class="MauiApp._1.Pages.Controls.AddButton"
+<Button x:Class="MauiApp._1.Pages.Controls.AddButton"
     ImageSource="{StaticResource IconAdd}" 
     BackgroundColor="{StaticResource Primary}" 
     CornerRadius="30" 

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/CategoryChart.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Border xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-        xmlns:chart="clr-namespace:Syncfusion.Maui.Toolkit.Charts;assembly=Syncfusion.Maui.Toolkit"
+<Border xmlns:chart="clr-namespace:Syncfusion.Maui.Toolkit.Charts;assembly=Syncfusion.Maui.Toolkit"
         xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls" 
         xmlns:shimmer="clr-namespace:Syncfusion.Maui.Toolkit.Shimmer;assembly=Syncfusion.Maui.Toolkit"
         xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/ProjectCardView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/ProjectCardView.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Border xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-        xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls"
+<Border xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls"
         xmlns:models="clr-namespace:MauiApp._1.Models"
         xmlns:fonts="clr-namespace:Fonts"
         xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TagView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TagView.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Border xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-        x:Class="MauiApp._1.Pages.Controls.TagView"
+<Border x:Class="MauiApp._1.Pages.Controls.TagView"
         xmlns:models="clr-namespace:MauiApp._1.Models"
         StrokeShape="RoundRectangle 16" 
         HeightRequest="32" 

--- a/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/Controls/TaskView.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <Border
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:effectsView="clr-namespace:Syncfusion.Maui.Toolkit.EffectsView;assembly=Syncfusion.Maui.Toolkit"
     xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
     xmlns:models="clr-namespace:MauiApp._1.Models"

--- a/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/MainPage.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"             
+﻿<ContentPage xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"             
              xmlns:models="clr-namespace:MauiApp._1.Models"
              xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls"
              xmlns:pullToRefresh="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit"

--- a/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ManageMetaPage.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
+<ContentPage xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
              xmlns:models="clr-namespace:MauiApp._1.Models"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:DataType="pageModels:ManageMetaPageModel"

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectDetailPage.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
+<ContentPage xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
              xmlns:models="clr-namespace:MauiApp._1.Models"
              xmlns:pages="clr-namespace:MauiApp._1.Pages"
              xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit"

--- a/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/ProjectListPage.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
+<ContentPage xmlns:pageModels="clr-namespace:MauiApp._1.PageModels"
              xmlns:models="clr-namespace:MauiApp._1.Models"
              xmlns:controls="clr-namespace:MauiApp._1.Pages.Controls"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"

--- a/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/Pages/TaskDetailPage.xaml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit"
+<ContentPage xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit"
              xmlns:pageModel="clr-namespace:MauiApp._1.PageModels"
              xmlns:models="clr-namespace:MauiApp._1.Models"
              x:DataType="pageModel:TaskDetailPageModel"

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/AppStyles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/AppStyles.xaml
@@ -1,11 +1,8 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<?xaml-comp compile="true" ?>
+﻿<?xaml-comp compile="true" ?>
 <ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:f="clr-namespace:Fonts"
     xmlns:pullToRefresh="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit"
-    xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit">
 
     <x:Double x:Key="sizeNone">0</x:Double>
     <x:Double x:Key="size20">2</x:Double>

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Colors.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Colors.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+﻿<ResourceDictionary>
 
     <!-- Note: For Android please see also Platforms\Android\Resources\values\colors.xml -->
 

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -1,12 +1,9 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+﻿<ResourceDictionary 
 <!--#if (IncludeSampleContent) -->
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:shimmer="clr-namespace:Syncfusion.Maui.Toolkit.Shimmer;assembly=Syncfusion.Maui.Toolkit">
 <!--#endif -->
 <!--#if (!IncludeSampleContent) -->
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    >
 <!--#endif -->
 
     <Style TargetType="ActivityIndicator">

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/App.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/App.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version = "1.0" encoding = "UTF-8" ?>
-<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
+﻿<Application xmlns:local="clr-namespace:MauiApp._1"
              x:Class="MauiApp._1.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/AppShell.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/AppShell.xaml
@@ -1,8 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <Shell
     x:Class="MauiApp._1.AppShell"
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:MauiApp._1"
     Shell.FlyoutBehavior="Disabled"
     Title="MauiApp._1">

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/MainPage.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp._1.MainPage">
+﻿<ContentPage x:Class="MauiApp._1.MainPage">
 
     <ScrollView>
         <VerticalStackLayout

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Colors.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Colors.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+﻿<ResourceDictionary>
 
     <!-- Note: For Android please see also Platforms\Android\Resources\values\colors.xml -->
 

--- a/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-multiproject/MauiApp.1/Resources/Styles/Styles.xaml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+﻿<ResourceDictionary>
 
     <Style TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />

--- a/src/Templates/src/templates/maui-resourcedictionary-xaml/Dictionary1.xaml
+++ b/src/Templates/src/templates/maui-resourcedictionary-xaml/Dictionary1.xaml
@@ -1,6 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp1.Dictionary1">
+﻿<ResourceDictionary x:Class="MauiApp1.Dictionary1">
 
 </ResourceDictionary>

--- a/src/Templates/src/templates/maui-window-xaml/NewWindow1.xaml
+++ b/src/Templates/src/templates/maui-window-xaml/NewWindow1.xaml
@@ -1,6 +1,3 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Window xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp1.NewWindow1"
+<Window x:Class="MauiApp1.NewWindow1"
              Title="NewWindow1">
 </Window>


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Starting with .NET 11, implicit xmlns declarations are enabled by default. XAML files no longer need to include the standard namespace declarations.

## Changes

- Removed `[RequiresPreviewFeatures]` from AllowImplicitXmlnsDeclarationAttribute
- Always emit `[assembly: AllowImplicitXmlnsDeclaration]` in source generator
- Updated all MAUI templates to use implicit xmlns
- Updated Sandbox app MainPage.xaml

## What's Implicit

The default implicit namespace is the global MAUI URI:
- Default namespace: `http://schemas.microsoft.com/dotnet/maui/global`
- `xmlns:x` prefix (via XmlnsPrefix attributes)

Custom namespaces might require explicit declaration.
