### PR TITLE
[All Platforms] Fix RadioButton warning when ControlTemplate is set with View content

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		/// <value>The string "Checked".</value>
 		public const string CheckedVisualState = "Checked";
-		
+
 		/// <summary>
 		/// The visual state name for when the radio button is unchecked.
 		/// </summary>
@@ -38,13 +38,13 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		/// <value>The string "Root".</value>
 		public const string TemplateRootName = "Root";
-		
+
 		/// <summary>
 		/// The name of the checked indicator element in the control template.
 		/// </summary>
 		/// <value>The string "CheckedIndicator".</value>
 		public const string CheckedIndicator = "CheckedIndicator";
-		
+
 		/// <summary>
 		/// The name of the unchecked button element in the control template.
 		/// </summary>
@@ -686,12 +686,15 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		/// <returns>The string representation of the content, or the result of <c>ToString()</c> if content is not a string.</returns>
 		/// <remarks>
-		/// If <see cref="Content"/> is a <see cref="View"/>, a warning is logged and the <c>ToString()</c> representation is used instead.
+		/// If <see cref="Content"/> is a <see cref="View"/> and no <see cref="ControlTemplate"/> is set, a warning is logged 
+		/// and the <c>ToString()</c> representation is used instead. When a ControlTemplate is applied, View content is supported.
 		/// </remarks>
 		public string ContentAsString()
 		{
 			var content = Content;
-			if (content is View)
+			// Only log warning if Content is a View AND no ControlTemplate is set
+			// When ControlTemplate is set, View content IS supported (per documentation)
+			if (content is View && ResolveControlTemplate() == null)
 			{
 				Application.Current?.FindMauiContext()?.CreateLogger<RadioButton>()?.LogWarning("Warning - {RuntimePlatform} does not support View as the {PropertyName} property of RadioButton; the return value of the ToString() method will be displayed instead.", DeviceInfo.Platform, ContentProperty.PropertyName);
 			}

--- a/src/Controls/tests/Core.UnitTests/RadioButtonContentAsStringTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RadioButtonContentAsStringTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	/// <summary>
+	/// Tests for RadioButton ContentAsString() warning behavior.
+	/// Issue #33829: Warning should not be logged when ControlTemplate is set because
+	/// View content IS supported in that scenario.
+	/// </summary>
+	[Category("RadioButton")]
+	public class RadioButtonContentAsStringTests : BaseTestFixture
+	{
+		public RadioButtonContentAsStringTests()
+		{
+			ApplicationExtensions.CreateAndSetMockApplication();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Application.ClearCurrent();
+			}
+			base.Dispose(disposing);
+		}
+
+		[Fact]
+		public void ContentAsStringDoesNotLogWarningWhenControlTemplateIsSet()
+		{
+			// Arrange: RadioButton with ControlTemplate AND View Content
+			// This scenario IS supported per documentation, so no warning should be logged
+			var radioButton = new RadioButton
+			{
+				ControlTemplate = RadioButton.DefaultTemplate,
+				Content = new Label { Text = "Test Label" }
+			};
+
+			// Act
+			var result = radioButton.ContentAsString();
+
+			// Assert: No warning should be logged when ControlTemplate is set
+			Assert.True(MockApplication.MockLogger.Messages.Count == 0,
+				"No warning should be logged when ControlTemplate is set. " +
+				$"Found: {MockApplication.MockLogger.Messages.FirstOrDefault()}");
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public void ContentAsStringLogsWarningWhenNoControlTemplate()
+		{
+			// Arrange: RadioButton without ControlTemplate but with View Content
+			// This scenario is NOT supported, so warning should be logged
+			var radioButton = new RadioButton
+			{
+				Content = new Label { Text = "Test Label" }
+			};
+
+			// Act
+			var result = radioButton.ContentAsString();
+
+			// Assert: Warning SHOULD be logged when ControlTemplate is null
+			Assert.Single(MockApplication.MockLogger.Messages);
+			Assert.Contains("does not support View as the Content property", MockApplication.MockLogger.Messages.First(), StringComparison.Ordinal);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Fixes #33829

When a `RadioButton` has both a `ControlTemplate` applied AND `Content` set to a `View`, the following warning was incorrectly logged:

> Warning - {Platform} does not support View as the Content property of RadioButton; the return value of the ToString() method will be displayed instead.

According to the [documentation](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/radiobutton?view=net-maui-10.0#associate-values-with-radiobuttons), View content IS supported when a ControlTemplate is applied:

> "When a ControlTemplate is applied to a RadioButton, a View can be assigned to the RadioButton.Content property on all platforms."

### Root Cause

The `ContentAsString()` method unconditionally logged a warning when `Content is View`, regardless of whether a `ControlTemplate` was set. This warning was triggered from `UpdateSemantics()` which specifically calls `ContentAsString()` when `ControlTemplate != null`.

### Fix

Modified `ContentAsString()` to only log the warning when `Content is View` AND `ResolveControlTemplate() == null`. This mirrors the pattern already used in Android's `IContentView.Content` getter (line 709).

### Key Technical Details

**Warning condition change:**
- **Before:** `if (content is View)` → Always warn for View content
- **After:** `if (content is View && ResolveControlTemplate() == null)` → Only warn when no ControlTemplate

This aligns with the existing Android pattern and matches documented behavior.

## Issues Fixed

Fixes #33829

## Testing

Added 2 unit tests in `RadioButtonContentAsStringTests.cs`:
- `ContentAsStringDoesNotLogWarningWhenControlTemplateIsSet` - Verifies no warning when ControlTemplate is set
- `ContentAsStringLogsWarningWhenNoControlTemplate` - Verifies warning IS logged without ControlTemplate (existing behavior preserved)

All 35 existing RadioButton tests continue to pass.