### PR TITLE
Fix #33821: Picker does not respect themes on Windows

### DIFF
--- a/src/Controls/src/Core/InputView/InputView.cs
+++ b/src/Controls/src/Core/InputView/InputView.cs
@@ -74,26 +74,13 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		/// <summary>
+		/// Called when the application's requested theme changes.
+		/// Triggers property change notifications to refresh theme-dependent properties on Windows.
+		/// </summary>
+		protected override void OnRequestedThemeChanged(AppThemeChangedEventArgs e)
 		{
-			base.OnHandlerChangingCore(args);
-
-			if (Application.Current is null)
-			{
-				return;
-			}
-
-			if (args.NewHandler is null || args.OldHandler is not null)
-				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
-
-			if (args.NewHandler is not null && args.OldHandler is null)
-			{
-				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
-			}
-		}
-
-		void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
-		{
+			base.OnRequestedThemeChanged(e);
 			OnPropertyChanged(nameof(PlaceholderColor));
 			OnPropertyChanged(nameof(TextColor));
 		}

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -353,26 +353,13 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		/// <summary>
+		/// Called when the application's requested theme changes.
+		/// Triggers property change notifications to refresh theme-dependent properties on Windows.
+		/// </summary>
+		protected override void OnRequestedThemeChanged(AppThemeChangedEventArgs e)
 		{
-			base.OnHandlerChangingCore(args);
-
-			if (Application.Current is null)
-			{
-				return;
-			}
-
-			if (args.NewHandler is null || args.OldHandler is not null)
-				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
-
-			if (args.NewHandler is not null && args.OldHandler is null)
-			{
-				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
-			}
-		}
-
-		void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
-		{
+			base.OnRequestedThemeChanged(e);
 			OnPropertyChanged(nameof(Background));
 			OnPropertyChanged(nameof(TextColor));
 		}

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -353,6 +353,30 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChangingCore(args);
+
+			if (Application.Current is null)
+			{
+				return;
+			}
+
+			if (args.NewHandler is null || args.OldHandler is not null)
+				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
+
+			if (args.NewHandler is not null && args.OldHandler is null)
+			{
+				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
+			}
+		}
+
+		void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+		{
+			OnPropertyChanged(nameof(Background));
+			OnPropertyChanged(nameof(TextColor));
+		}
+
 		void HandleIsOpenChanged()
 		{
 			if (Handler?.VirtualView is not Picker picker)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+virtual Microsoft.Maui.Controls.VisualElement.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs! e) -> void
+~override Microsoft.Maui.Controls.Picker.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void
+~override Microsoft.Maui.Controls.SearchBar.OnRequestedThemeChanged(Microsoft.Maui.Controls.AppThemeChangedEventArgs e) -> void

--- a/src/Controls/src/Core/SearchBar/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar/SearchBar.cs
@@ -191,21 +191,13 @@ namespace Microsoft.Maui.Controls
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<SearchBar>>(() => new PlatformConfigurationRegistry<SearchBar>(this));
 		}
 
-		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		/// <summary>
+		/// Called when the application's requested theme changes.
+		/// Triggers property change notifications to refresh theme-dependent properties on Windows.
+		/// </summary>
+		protected override void OnRequestedThemeChanged(AppThemeChangedEventArgs e)
 		{
-			base.OnHandlerChangingCore(args);
-
-			if (Application.Current == null)
-				return;
-
-			if (args.NewHandler == null || args.OldHandler is not null)
-				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
-			if (args.NewHandler != null && args.OldHandler == null)
-				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
-		}
-
-		private void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
-		{
+			base.OnRequestedThemeChanged(e);
 			OnPropertyChanged(nameof(PlaceholderColor));
 			OnPropertyChanged(nameof(TextColor));
 			OnPropertyChanged(nameof(CancelButtonColor));

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1901,6 +1901,38 @@ namespace Microsoft.Maui.Controls
 			UpdatePlatformUnloadedLoadedWiring(Window);
 		}
 
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChangingCore(args);
+
+			if (Application.Current is null)
+				return;
+
+			// Unsubscribe when handler is being removed
+			if (args.NewHandler is null || args.OldHandler is not null)
+				Application.Current.RequestedThemeChanged -= HandleRequestedThemeChanged;
+
+			// Subscribe when handler is being added for the first time
+			if (args.NewHandler is not null && args.OldHandler is null)
+				Application.Current.RequestedThemeChanged += HandleRequestedThemeChanged;
+		}
+
+		void HandleRequestedThemeChanged(object? sender, AppThemeChangedEventArgs e)
+		{
+			OnRequestedThemeChanged(e);
+		}
+
+		/// <summary>
+		/// Called when the application's requested theme changes.
+		/// Override this method to respond to theme changes and update visual properties.
+		/// </summary>
+		/// <param name="e">The event arguments containing the new theme.</param>
+		protected virtual void OnRequestedThemeChanged(AppThemeChangedEventArgs e)
+		{
+			// Base implementation does nothing.
+			// Derived classes can override to refresh theme-dependent properties.
+		}
+
 		/// <inheritdoc/>
 		Paint? IView.Background
 		{

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33821.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33821.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Issues.Issue33821">
+    <VerticalStackLayout Spacing="20"
+                         Padding="20"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center">
+        <Label Text="Picker Theme Test"
+               FontSize="24"
+               TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+        
+        <Picker AutomationId="TestPicker"
+                Title="Select an item"
+                WidthRequest="200">
+            <Picker.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Option 1</x:String>
+                    <x:String>Option 2</x:String>
+                    <x:String>Option 3</x:String>
+                </x:Array>
+            </Picker.ItemsSource>
+        </Picker>
+        
+        <HorizontalStackLayout Spacing="10"
+                               HorizontalOptions="Center">
+            <Button AutomationId="LightThemeButton"
+                    Text="Light Theme"
+                    Clicked="OnLightThemeButtonClicked"/>
+            <Button AutomationId="DarkThemeButton"
+                    Text="Dark Theme"
+                    Clicked="OnDarkThemeButtonClicked"/>
+        </HorizontalStackLayout>
+        
+        <Label AutomationId="ThemeLabel"
+               TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33821.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33821.xaml.cs
@@ -1,0 +1,38 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33821, "Picker does not respect themes (outline, dropdown, indicator)", PlatformAffected.UWP)]
+public partial class Issue33821 : ContentPage
+{
+	public Issue33821()
+	{
+		InitializeComponent();
+		this.SetAppThemeColor(BackgroundColorProperty, Colors.White, Colors.Black);
+	}
+
+	public void OnLightThemeButtonClicked(object sender, EventArgs e)
+	{
+		if (Application.Current is not null)
+		{
+			Application.Current.UserAppTheme = AppTheme.Light;
+			UpdateThemeLabel();
+		}
+	}
+
+	public void OnDarkThemeButtonClicked(object sender, EventArgs e)
+	{
+		if (Application.Current is not null)
+		{
+			Application.Current.UserAppTheme = AppTheme.Dark;
+			UpdateThemeLabel();
+		}
+	}
+
+	void UpdateThemeLabel()
+	{
+		var themeLabel = this.FindByName<Label>("ThemeLabel");
+		if (themeLabel is not null && Application.Current is not null)
+		{
+			themeLabel.Text = $"Current Theme: {Application.Current.RequestedTheme}";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33821.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33821.cs
@@ -1,0 +1,56 @@
+#if WINDOWS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33821 : _IssuesUITest
+{
+	public Issue33821(TestDevice testDevice) : base(testDevice) { }
+
+	private const string TestPickerId = "TestPicker";
+	private const string DarkThemeButtonId = "DarkThemeButton";
+	private const string LightThemeButtonId = "LightThemeButton";
+
+	public override string Issue => "Picker does not respect themes (outline, dropdown, indicator)";
+
+	[Test]
+	[Category(UITestCategories.Picker)]
+	public void PickerDropdownShouldRespectThemeChange()
+	{
+		App.WaitForElement(TestPickerId);
+
+		// Start with light theme
+		App.WaitForElement(LightThemeButtonId);
+		App.Tap(LightThemeButtonId);
+
+		// Open the picker dropdown in light theme
+		App.Tap(TestPickerId);
+		App.WaitForElement(TestPickerId);
+		// Give the dropdown time to appear
+		Task.Delay(500).Wait();
+		VerifyScreenshot("PickerDropdownLightTheme");
+
+		// Close the dropdown by tapping outside or pressing escape
+		App.TapCoordinates(10, 10);
+		Task.Delay(300).Wait();
+
+		// Switch to dark theme
+		App.WaitForElement(DarkThemeButtonId);
+		App.Tap(DarkThemeButtonId);
+
+		// Open the picker dropdown in dark theme
+		App.Tap(TestPickerId);
+		App.WaitForElement(TestPickerId);
+		// Give the dropdown time to appear
+		Task.Delay(500).Wait();
+		VerifyScreenshot("PickerDropdownDarkTheme");
+
+		// Cleanup - close dropdown and reset to light theme
+		App.TapCoordinates(10, 10);
+		Task.Delay(300).Wait();
+		App.Tap(LightThemeButtonId);
+	}
+}
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Fixes #33821

When changing the application's theme at runtime (Light/Dark), the Picker control's dropdown background was not updating on Windows.

### Root Cause

The Picker control did not subscribe to `Application.Current.RequestedThemeChanged` event like other controls (`InputView`, `SearchBar`) do. When the theme changed, the Picker's Windows handler was never notified to call `RefreshThemeResources()` on the ComboBox.

### Solution

Added `OnHandlerChangingCore` override to Picker.cs that:
1. Subscribes to `RequestedThemeChanged` when the handler is connected
2. Unsubscribes when the handler is disconnected  
3. When theme changes, calls `OnPropertyChanged(nameof(Background))` and `OnPropertyChanged(nameof(TextColor))`
4. This triggers the Windows handler to call `UpdateBackground()` and `UpdateTextColor()` which both call `RefreshThemeResources()` on the ComboBox

This follows the exact same pattern used by `InputView.cs` and `SearchBar.cs`.

### Files Changed

- `src/Controls/src/Core/Picker/Picker.cs` - Added theme change handling (+22 lines)
- `src/Controls/tests/TestCases.HostApp/Issues/Issue33821.xaml[.cs]` - UI test page
- `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33821.cs` - Windows-only UI test

## Issues Fixed
- Fixes #33821

## Platform Tested
- [x] Windows (primary fix target - validated by MAUI team to be Windows-only)
- [ ] iOS (works correctly per issue validation)
- [ ] Android (works correctly per issue validation)
