### PR TITLE
Fix release net11 to workload set

### DIFF
--- a/eng/pipelines/ci-official-release.yml
+++ b/eng/pipelines/ci-official-release.yml
@@ -147,6 +147,10 @@ extends:
                   $workloadSetsChannel = ".NET 10 Workload Release"
                   $workloadSetsFeed = "dotnet10-workloads"
                 }
+                if ($manifestPack -like "*.Manifest-11.0*") {
+                  $workloadSetsChannel = ".NET 11 Workload Release"
+                  $workloadSetsFeed = "dotnet11-workloads"
+                }
                 if (!$workloadSetsChannel -or !$workloadSetsFeed) {
                   Write-Error "Could not determine the workload sets channel or feed for the manifest pack '$manifestPack'"
                   exit 1


### PR DESCRIPTION
### Description of Change

This pull request introduces a targeted update to the CI release pipeline, specifically improving support for .NET 11 manifest packs.

Enhancements for .NET 11 support:

* Updated the logic in `eng/pipelines/ci-official-release.yml` to correctly set the workload channel and feed for manifest packs matching `.Manifest-11.0*`, ensuring that .NET 11 releases are routed to the appropriate channel and feed.