### PR TITLE
[iOS/MacCatalyst] Fix CollectionView ScrollTo for horizontal layouts

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs
@@ -146,7 +146,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					return;
 				}
 
-				var position = Items.ScrollToPositionExtensions.ToCollectionViewScrollPosition(args.ScrollToPosition, UICollectionViewScrollDirection.Vertical);
+				var scrollDirection = Controller.GetScrollDirection();
+				var position = Items.ScrollToPositionExtensions.ToCollectionViewScrollPosition(args.ScrollToPosition, scrollDirection);
 
 				Controller.CollectionView.ScrollToItem(indexPath,
 					position, args.IsAnimated);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33852.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33852.cs
@@ -1,0 +1,85 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33852, "CollectionView ScrollTo does not work with horizontal layout", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue33852 : ContentPage
+{
+	public ObservableCollection<string> Items { get; set; }
+	private Label _indexLabel;
+	private CollectionView2 _collectionView;
+	public Issue33852()
+	{
+		Items = new ObservableCollection<string>();
+		for (int i = 0; i <= 50; i++)
+		{
+			Items.Add($"Item_{i}");
+		}
+
+		_indexLabel = new Label
+		{
+			AutomationId = "IndexLabel",
+			Text = "ItemIndex: 0"
+		};
+
+		var scrollToButton = new Button
+		{
+			AutomationId = "ScrollToButton",
+			Text = "Scroll to Item 15",
+			WidthRequest = 150
+		};
+		scrollToButton.Clicked += OnScrollToButtonClicked;
+
+		_collectionView = new CollectionView2
+		{
+			AutomationId = "TestCollectionView",
+			ItemsSource = Items,
+			HeightRequest = 600,
+			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+			{
+				ItemSpacing = 10
+			},
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return new Border
+				{
+					Margin = new Thickness(5),
+					Padding = new Thickness(10),
+					Stroke = Colors.Gray,
+					Content = label
+				};
+			})
+		};
+
+		_collectionView.Scrolled += OnCollectionViewScrolled;
+
+		Content = new StackLayout
+		{
+			Children =
+			{
+				_indexLabel,
+				 scrollToButton,
+				_collectionView
+			}
+		};
+	}
+
+	private void OnCollectionViewScrolled(object sender, ItemsViewScrolledEventArgs e)
+	{
+		if (e.FirstVisibleItemIndex > 0)
+		{
+			_indexLabel.Text = $"The CollectionView is scrolled";
+		}
+		else
+		{
+			_indexLabel.Text = "The CollectionView does not scroll";
+		}
+	}
+
+	private void OnScrollToButtonClicked(object sender, EventArgs e)
+	{
+		_collectionView.ScrollTo(15, position: ScrollToPosition.Start, animate: true);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33852.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33852.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33852 : _IssuesUITest
+{
+    public Issue33852(TestDevice testDevice) : base(testDevice)
+    {
+    }
+
+    public override string Issue => "CollectionView ScrollTo does not work with horizontal layout";
+
+    [Test]
+    [Category(UITestCategories.CollectionView)]
+    public void ProgrammaticScrollToWorksWithHorizontalLayout()
+    {
+        App.WaitForElement("ScrollToButton");
+        App.Tap("ScrollToButton");
+        var firstIndexText = App.FindElement("IndexLabel").GetText();
+        Assert.That(firstIndexText, Is.EqualTo("The CollectionView is scrolled"));
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
CollectionView’s programmatic ScrollTo does not work when using a horizontal ItemsLayout on iOS/MacCatalyst. After calling ScrollTo(index, position: ScrollToPosition.Start, animate: true), the scroll position remains unchanged.

### Root Cause
In the CV2 iOS handler, the scroll direction is hardcoded to Vertical instead of using the actual layout direction. As a result, horizontal layouts receive incorrect scroll position calculations.

### Description of Change
Replace the hardcoded vertical direction with a dynamic call that retrieves the actual scroll direction from the controller. This ensures that horizontal layouts receive the correct scroll position values.

### Fix reference

I have fixed the issue in the same way as CV1, by referring to the following code.

https://github.com/dotnet/maui/blob/52f9fc2a308b518890cf6def72abe422ac997d85/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs#L110

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #33852 

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/1d510715-83bf-412c-a8a3-6f8362dd52bd" >| <video src="https://github.com/user-attachments/assets/0283113a-33ed-4d14-9d1d-a18ab9f2e2d0">|