### PR TITLE
Fixed: Missing diagnostic in SourceGen when Setter references non-BindableProperty - Candidate Failure Feb 2nd

### DIFF
--- a/src/Controls/src/SourceGen/SetterValueProvider.cs
+++ b/src/Controls/src/SourceGen/SetterValueProvider.cs
@@ -54,6 +54,10 @@ internal class SetterValueProvider : IKnownMarkupValueProvider
 		IFieldSymbol? bpRef = bpNode.GetBindableProperty(context);
 		if (!TryGetBindablePropertyNameAndType(bpRef, bpNode, context, out var bpName, out var bpType))
 		{
+			// Report diagnostic when bindable property cannot be resolved
+			var propertyText = bpNode.Value as string ?? string.Empty;
+			var location = LocationHelpers.LocationCreate(context.ProjectItem.RelativePath!, (IXmlLineInfo)bpNode, propertyText);
+			context.ReportDiagnostic(Diagnostic.Create(Descriptors.MemberResolution, location, propertyText));
 			value = string.Empty;
 			return false;
 		}


### PR DESCRIPTION
### Root Cause of the issue



- The SourceGen XAML inflator was silently failing when a Setter referenced a **non-BindableProperty**/ Property doesn't exist, while XamlC and Runtime inflators correctly reported errors.
 
The Problem:
XamlC behavior (compile-time): Throws BuildException when encountering <Setter Property="NonBindable" /> on a property that isn't a BindableProperty
 
Runtime inflator behavior: Throws XamlParseException for the same invalid XAML
 
SourceGen behavior (BEFORE fix):
 
SetterValueProvider.TryProvideValue() would detect the property can't be resolved
Returns `false` without reporting any diagnostic

**Silently fails - no error message to the developer**
Test expected (`ShouldThrow(inflator: SourceGen`) Assert.NotEmpty(result.Diagnostics) but got empty diagnostics ❌
Why It Failed Silently:
When TryGetBindablePropertyNameAndType() returns false (property not found):


### Description of Change



- Detects failure: When TryGetBindablePropertyNameAndType returns false (property doesn't exist or isn't a BindableProperty)
 
Reports diagnostic: Uses Descriptors.MemberResolution (MAUIX2002) - the standard "cannot resolve member" error
 
Provides context:
 
Exact location in XAML file (line/column)
Property name that failed to resolve
Consistent behavior: Now all three inflators report errors for invalid Setter properties:
 
✅ XamlC → BuildException
✅ Runtime → XamlParseException
✅ SourceGen → Diagnostic (MAUIX2002)


### Unit Test case failed

**ShouldThrow(inflator: SourceGen**
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1272666&view=ms.vss-test-web.build-test-results-tab&runId=35509658&resultId=101501&paneView=debug

Test location: https://github.com/dotnet/maui/blob/inflight/candidate/src/Controls/tests/Xaml.UnitTests/Validation/SetterOnNonBP.rt.xaml.cs#L22



### Issues Fixed



Fixes #33562 


### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="400" height="500"  src="https://github.com/user-attachments/assets/8128a742-460a-48fa-82bb-d310b80f688c"/> | <img width="400" height="500"  src="https://github.com/user-attachments/assets/196f856b-9d45-4604-adc9-ae233ac09b1f"> |