### PR TITLE
[Android, iOS] Throw exceptions consistently for invalid StaticResource references to prevent relaunch crashes

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			catch (Exception e)
 			{
 				Context.ExceptionHandler?.Invoke(e);
-				throw e;
+				throw;
 			}
 		}
 

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			catch (Exception e)
 			{
 				Context.ExceptionHandler?.Invoke(e);
-				throw;
+				throw e;
 			}
 		}
 

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -281,10 +281,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 			catch (Exception e)
 			{
-				if (Context.ExceptionHandler != null)
-					Context.ExceptionHandler(e);
-				else
-					throw e;
+				Context.ExceptionHandler?.Invoke(e);
+				throw;
 			}
 		}
 

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -281,8 +281,19 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 			catch (Exception e)
 			{
-				Context.ExceptionHandler?.Invoke(e);
-				throw;
+				// StaticResourceExtension must always rethrow even when a handler is present —
+				// unlike other markup extensions, swallowing this exception would silently apply
+				// an invalid value to the property. Notify the handler first to log the error.
+				if (markupExtension is StaticResourceExtension)
+				{
+					Context.ExceptionHandler?.Invoke(e);
+					throw;
+				}
+
+				if (Context.ExceptionHandler != null)
+					Context.ExceptionHandler(e);
+				else
+					throw;
 			}
 		}
 

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				if (Context.ExceptionHandler != null)
 					Context.ExceptionHandler(e);
 				else
-					throw;
+					throw e;
 			}
 		}
 

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -30,16 +30,15 @@ namespace Microsoft.Maui.Controls.Xaml
 				&& !TryGetApplicationLevelResource(Key, out resource, out resourceDictionary))
 			{
 				var xmlLineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider xmlLineInfoProvider ? xmlLineInfoProvider.XmlLineInfo : null;
+				var ex = new XamlParseException($"StaticResource not found for key {Key}", xmlLineInfo);
 				if (Controls.Internals.ResourceLoader.ExceptionHandler2 is var ehandler && ehandler != null)
 				{
-					var ex = new XamlParseException($"StaticResource not found for key {Key}", xmlLineInfo);
 					var rootObjectProvider = (IRootObjectProvider)serviceProvider.GetService(typeof(IRootObjectProvider));
 					var root = rootObjectProvider.RootObject;
 					ehandler.Invoke((ex, XamlFilePathAttribute.GetFilePathForObject(root)));
-					return null;
 				}
-				else
-					throw new XamlParseException($"StaticResource not found for key {Key}", xmlLineInfo);
+				// Throw an exception when the key is not found
+				throw ex;
 			}
 
 			Diagnostics.ResourceDictionaryDiagnostics.OnStaticResourceResolved(resourceDictionary, Key, valueProvider.TargetObject, valueProvider.TargetProperty);

--- a/src/Controls/tests/DeviceTests/Xaml/StaticResourceTests.cs
+++ b/src/Controls/tests/DeviceTests/Xaml/StaticResourceTests.cs
@@ -7,13 +7,8 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests;
 
 [Category(TestCategory.Xaml)]
-public class StaticResourceTests : IDisposable
+public class StaticResourceTests
 {
-    public void Dispose()
-    {
-        Controls.Internals.ResourceLoader.ExceptionHandler2 = null;
-    }
-
     [Fact("Issue #23903: Missing ControlTemplate with exception handler should throw")]
     [RequiresUnreferencedCode("XAML parsing may require unreferenced code")]
     public void MissingControlTemplate_WithExceptionHandler_ShouldThrow()

--- a/src/Controls/tests/DeviceTests/Xaml/StaticResourceTests.cs
+++ b/src/Controls/tests/DeviceTests/Xaml/StaticResourceTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests;
 
 [Category(TestCategory.Xaml)]
-public class StaticResourceTests
+public class StaticResourceTests : IDisposable
 {
     [Fact("Issue #23903: Missing ControlTemplate with exception handler should throw")]
     [RequiresUnreferencedCode("XAML parsing may require unreferenced code")]
@@ -41,5 +41,10 @@ public class StaticResourceTests
         }
 
         Assert.True(exceptionThrown, "Expected an exception to be thrown for missing ControlTemplate");
+    }
+
+    public void Dispose()
+    {
+        Controls.Internals.ResourceLoader.ExceptionHandler2 = null;
     }
 }

--- a/src/Controls/tests/DeviceTests/Xaml/StaticResourceTests.cs
+++ b/src/Controls/tests/DeviceTests/Xaml/StaticResourceTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.Xaml)]
+public class StaticResourceTests : IDisposable
+{
+    public void Dispose()
+    {
+        Controls.Internals.ResourceLoader.ExceptionHandler2 = null;
+    }
+
+    [Fact("Issue #23903: Missing ControlTemplate with exception handler should throw")]
+    [RequiresUnreferencedCode("XAML parsing may require unreferenced code")]
+    public void MissingControlTemplate_WithExceptionHandler_ShouldThrow()
+    {
+        // Issue #23903: When an exception handler is present (like in debug mode or hot reload),
+        // the StaticResourceExtension should still throw when a resource is not found.
+        // The old behavior was to return null, causing the Page to be null and crashing later
+        // when IWindow.Content was accessed.
+
+        bool handlerCalled = false;
+        Controls.Internals.ResourceLoader.ExceptionHandler2 = (ex) =>
+        {
+            var (exception, filepath) = ex;
+            handlerCalled = true;
+        };
+
+        var xaml = """
+			<?xml version="1.0" encoding="UTF-8"?>
+			<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			             ControlTemplate="{StaticResource InvalidTemplate}">
+			</ContentPage>
+			""";
+
+        var page = new ContentPage();
+
+        // The exception should be thrown even though a handler is present
+        var exception = Assert.Throws<XamlParseException>(() => page.LoadFromXaml(xaml));
+
+        // Verify the handler was called (for logging purposes)
+        Assert.True(handlerCalled, "Exception handler should be called before throwing");
+
+        // Verify the exception message
+        Assert.Contains("StaticResource not found for key InvalidTemplate", exception.Message, StringComparison.Ordinal);
+    }
+}
+

--- a/src/Controls/tests/Xaml.UnitTests/HotReloadStaticResourceException.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/HotReloadStaticResourceException.xaml.cs
@@ -56,29 +56,5 @@ public partial class HotReloadStaticResourceException : ContentPage
 		[Fact(Skip = "This test runs only in debug")]
 		public void MissingResourceExceptionAreHandled() { }
 #endif
-
-		[Theory]
-		[InlineData(XamlInflator.Runtime)]
-		[InlineData(XamlInflator.SourceGen)]
-		internal void MissingResourceThrowsEvenWithExceptionHandler(XamlInflator inflator)
-		{
-			// Issue #23903: StaticResourceExtension should always throw when resource is not found,
-			// regardless of whether an exception handler is present. This ensures consistent behavior
-			// across debug/release and prevents crashes when relaunching apps.
-			bool handlerCalled = false;
-			Controls.Internals.ResourceLoader.ExceptionHandler2 = (ex) =>
-			{
-				handlerCalled = true;
-			};
-
-			// Exception should be thrown even though handler is present
-			var exception = Assert.Throws<XamlParseException>(() => new HotReloadStaticResourceException(inflator));
-
-			// Verify handler was called (for logging purposes)
-			Assert.True(handlerCalled, "Exception handler should be called before throwing");
-
-			// Verify the exception contains the expected message
-			Assert.Contains("StaticResource not found for key", exception.Message, System.StringComparison.Ordinal);
-		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/HotReloadStaticResourceException.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/HotReloadStaticResourceException.xaml.cs
@@ -47,10 +47,14 @@ public partial class HotReloadStaticResourceException : ContentPage
 					handled = true;
 					Assert.Equal(13, xpe.XmlInfo.LinePosition);
 				}
-
 			};
-			var page = new HotReloadStaticResourceException(inflator);
-			Assert.True(handled, "Exception was not handled");
+			
+			// Now expect the exception to be thrown (after handler is invoked)
+			var exception = Assert.Throws<XamlParseException>(() => new HotReloadStaticResourceException(inflator));
+			
+			// Verify handler was invoked and exception details are correct
+			Assert.True(handled, "Exception handler was not invoked");
+			Assert.Contains("StaticResource not found for key MissingResource", exception.Message, System.StringComparison.Ordinal);
 		}
 #else
 		[Fact(Skip = "This test runs only in debug")]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
When an invalid template name is provided, the app crashes on Android and iOS when relaunching the app.

### Root Cause
Inconsistent exception handling in StaticResourceExtension - it returned null when an exception handler was present but threw an exception when debugger is not attached.

### Description of Change
Modified StaticResourceExtension.cs and ApplyPropertiesVisitor.cs to always throw exceptions for invalid StaticResource references, regardless of whether an exception handler is present. Previously, the code returned null and allowing the app to continue. The fix ensures consistent behavior by creating the exception once, optionally logging it through the exception handler if available, and then always throwing it.

### Tested the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/23903

### Screenshots

**iOS:**
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/10cf8b29-6040-4be8-9656-fea5b20d2348"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/948b072f-0603-48cb-85ed-918b9905a2ca">) |

**Android:**
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/88656210-dcb2-4a43-a2d5-45cae040390a"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/739a9ce8-baa7-47c5-8293-c10bad74b9ba">) |