### PR TITLE
Enhance pr-finalize skill with code review phase and safety rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,6 +242,7 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Trigger phrases**: "finalize PR #XXXXX", "check PR description for #XXXXX", "review commit message"
    - **Used by**: Before merging any PR, when description may be stale
    - **Note**: Does NOT require agent involvement or session markdown - works on any PR
+   - **🚨 CRITICAL**: NEVER use `--approve` or `--request-changes` - only post comments. Approval is a human decision.
 
 4. **learn-from-pr** (`.github/skills/learn-from-pr/SKILL.md`)
    - **Purpose**: Analyzes completed PR to identify repository improvements (analysis only, no changes applied)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -238,7 +238,7 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Categories**: P/0, milestoned, partner, community, recent, docs-maui
 
 3. **pr-finalize** (`.github/skills/pr-finalize/SKILL.md`)
-   - **Purpose**: Verifies PR title and description match actual implementation. Works on any PR. Optionally updates agent session markdown if present.
+   - **Purpose**: Verifies PR title and description match actual implementation, AND performs multi-model code review (5 models) for best practices before merge.
    - **Trigger phrases**: "finalize PR #XXXXX", "check PR description for #XXXXX", "review commit message"
    - **Used by**: Before merging any PR, when description may be stale
    - **Note**: Does NOT require agent involvement or session markdown - works on any PR

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -238,7 +238,7 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Categories**: P/0, milestoned, partner, community, recent, docs-maui
 
 3. **pr-finalize** (`.github/skills/pr-finalize/SKILL.md`)
-   - **Purpose**: Verifies PR title and description match actual implementation, AND performs multi-model code review (5 models) for best practices before merge.
+   - **Purpose**: Verifies PR title and description match actual implementation, AND performs code review for best practices before merge.
    - **Trigger phrases**: "finalize PR #XXXXX", "check PR description for #XXXXX", "review commit message"
    - **Used by**: Before merging any PR, when description may be stale
    - **Note**: Does NOT require agent involvement or session markdown - works on any PR

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -240,11 +240,12 @@ Review PR #$PRNumber using the pr agent workflow.
 
 $platformInstruction
 
-🚨 **CRITICAL - NEVER CHECKOUT BRANCHES:**
+🚨 **CRITICAL - NEVER MODIFY GIT STATE:**
 - NEVER run ``git checkout``, ``git switch``, ``git fetch``, ``git stash``, or ``git reset``
+- NEVER run ``git push`` - you do NOT have permission to push anything
 - You are ALWAYS on the correct branch already - the script handles this
 - If the state file says "wrong branch", that's stale state - delete it and start fresh
-- If you think you need to checkout a branch, you are WRONG - ask the user instead
+- If you think you need to switch branches or push changes, you are WRONG - ask the user instead
 
 **Instructions:**
 1. Read the plan template at ``$planTemplatePath`` for the 5-phase workflow

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -380,7 +380,7 @@ if ($DryRun) {
             Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Magenta
             Write-Host ""
             
-            $commentPrompt = "Use the ai-summary-comment skill to post a review comment on PR #$PRNumber. Read the state file at CustomAgentLogsTmp/PRState/pr-$PRNumber.md which contains results from both the PR agent review and pr-finalize phases. Post a single combined summary comment to the PR."
+            $commentPrompt = "Use the ai-summary-comment skill to post a comment on PR #$PRNumber based on the results from the PR agent review and pr-finalize phases in CustomAgentLogsTmp/PRState/pr-$PRNumber.md."
             
             $commentArgs = @(
                 "-p", $commentPrompt,

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -240,6 +240,12 @@ Review PR #$PRNumber using the pr agent workflow.
 
 $platformInstruction
 
+🚨 **CRITICAL - NEVER CHECKOUT BRANCHES:**
+- NEVER run ``git checkout``, ``git switch``, ``git fetch``, ``git stash``, or ``git reset``
+- You are ALWAYS on the correct branch already - the script handles this
+- If the state file says "wrong branch", that's stale state - delete it and start fresh
+- If you think you need to checkout a branch, you are WRONG - ask the user instead
+
 **Instructions:**
 1. Read the plan template at ``$planTemplatePath`` for the 5-phase workflow
 2. Read ``.github/agents/pr.md`` for Phases 1-3 instructions

--- a/.github/skills/ai-summary-comment/scripts/post-pr-finalize-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-pr-finalize-comment.ps1
@@ -147,7 +147,7 @@ Write-Host "╚═════════════════════�
 # ============================================================================
 
 # If PRNumber provided but no SummaryFile, try to find it
-if ($PRNumber -gt 0 -and [string]::IsNullOrWhiteSpace($SummaryFile) -and [string]::IsNullOrWhiteSpace($ReviewDescription)) {
+if ($PRNumber -gt 0 -and [string]::IsNullOrWhiteSpace($SummaryFile)) {
     $summaryPath = "CustomAgentLogsTmp/PRState/$PRNumber/pr-finalize/pr-finalize-summary.md"
     if (-not (Test-Path $summaryPath)) {
         $repoRoot = git rev-parse --show-toplevel 2>$null

--- a/.github/skills/ai-summary-comment/scripts/post-pr-finalize-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-pr-finalize-comment.ps1
@@ -554,16 +554,14 @@ if ($CodeReviewStatus -ne "Skipped" -or -not [string]::IsNullOrWhiteSpace($CodeR
 
 <summary><b>Code Review: $codeReviewEmoji $codeReviewStatusDisplay</b></summary>
 
-<br>
-
 "@
 
     if (-not [string]::IsNullOrWhiteSpace($CodeReviewFindings)) {
         # Trim the findings and ensure proper newline spacing
         $trimmedFindings = $CodeReviewFindings.Trim()
-        $codeReviewSection += $trimmedFindings
+        $codeReviewSection += "`n$trimmedFindings"
     } else {
-        $codeReviewSection += "No significant issues found. Code follows best practices."
+        $codeReviewSection += "`nNo significant issues found. Code follows best practices."
     }
 
     $codeReviewSection += @"

--- a/.github/skills/ai-summary-comment/scripts/post-pr-finalize-comment.ps1
+++ b/.github/skills/ai-summary-comment/scripts/post-pr-finalize-comment.ps1
@@ -4,7 +4,7 @@
     Posts or updates a PR finalize comment on a GitHub Pull Request.
 
 .DESCRIPTION
-    Creates ONE comment for PR finalization with two collapsible sections: Title and Description.
+    Creates ONE comment for PR finalization with three collapsible sections: Title, Description, and Code Review.
     Uses HTML marker <!-- PR-FINALIZE-COMMENT --> for identification.
     
     **Auto-loads from CustomAgentLogsTmp/PRState/{PRNumber}/pr-finalize/**
@@ -24,6 +24,11 @@
     <details>
     <summary><b>Description: ⚠️ Needs Update</b></summary>
     ... description details ...
+    </details>
+    
+    <details>
+    <summary><b>Code Review: ✅ Passed</b></summary>
+    ... code review findings ...
     </details>
 
 .PARAMETER PRNumber
@@ -56,6 +61,12 @@
 .PARAMETER RecommendedDescription
     Full recommended description (optional - only if needs rewrite)
 
+.PARAMETER CodeReviewStatus
+    Code review assessment: "Passed", "IssuesFound", "Skipped" (optional - defaults to "Skipped" if not provided)
+
+.PARAMETER CodeReviewFindings
+    Code review findings content (optional - markdown with critical issues, suggestions, and positive observations)
+
 .PARAMETER DryRun
     Print comment instead of posting
 
@@ -73,7 +84,9 @@
         -TitleStatus "Good" `
         -CurrentTitle "[iOS] Fix SafeArea padding calculation" `
         -DescriptionStatus "Good" `
-        -DescriptionAssessment "Clear structure, accurate technical details, matches implementation"
+        -DescriptionAssessment "Clear structure, accurate technical details, matches implementation" `
+        -CodeReviewStatus "Passed" `
+        -CodeReviewFindings "No critical issues found. Code follows best practices."
 #>
 
 param(
@@ -108,6 +121,13 @@ param(
 
     [Parameter(Mandatory=$false)]
     [string]$RecommendedDescription,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("Passed", "IssuesFound", "Skipped", "")]
+    [string]$CodeReviewStatus,
+
+    [Parameter(Mandatory=$false)]
+    [string]$CodeReviewFindings,
 
     [Parameter(Mandatory=$false)]
     [switch]$DryRun,
@@ -157,10 +177,32 @@ if (-not [string]::IsNullOrWhiteSpace($SummaryFile)) {
         Write-Host "ℹ️  Auto-detected PRNumber: $PRNumber from path" -ForegroundColor Cyan
     }
     
-    # Extract Title assessment
+    # Extract Recommended Title FIRST (needed for TitleStatus detection)
+    if ([string]::IsNullOrWhiteSpace($RecommendedTitle)) {
+        # Try different patterns
+        if ($content -match '\*\*Recommended.*?Title.*?\*\*:?\s*[`"]?([^`"\n]+)[`"]?') {
+            $RecommendedTitle = $Matches[1].Trim()
+        } elseif ($content -match 'Recommended:\s*`([^`]+)`') {
+            $RecommendedTitle = $Matches[1].Trim()
+        } elseif ($content -match '(?s)\*\*Recommended:\*\*\s*```\s*([^\n]+)') {
+            # Code fence format
+            $RecommendedTitle = $Matches[1].Trim()
+        } elseif ($content -match '(?s)### 📋 Title Assessment.+?\*\*Recommended:\*\*\s*```\s*([^\n]+)') {
+            $RecommendedTitle = $Matches[1].Trim()
+        }
+        if ($RecommendedTitle) {
+            Write-Host "ℹ️  Extracted RecommendedTitle: $RecommendedTitle" -ForegroundColor Cyan
+        }
+    }
+    
+    # Extract Title assessment - if RecommendedTitle exists, title needs update
     if ([string]::IsNullOrWhiteSpace($TitleStatus)) {
+        # If we have a recommended title, the title needs update
+        if (-not [string]::IsNullOrWhiteSpace($RecommendedTitle)) {
+            $TitleStatus = "NeedsUpdate"
+        }
         # Look for explicit status in Title Assessment section
-        if ($content -match '(?s)### 📋 Title Assessment.+?\*\*Status:\*\*\s*(✅|❌|⚠️)?\s*(Good|NeedsUpdate|Needs Update)') {
+        elseif ($content -match '(?s)### 📋 Title Assessment.+?\*\*Status:\*\*\s*(✅|❌|⚠️)?\s*(Good|NeedsUpdate|Needs Update)') {
             $statusMatch = $Matches[2] -replace '\s+', ''
             if ($statusMatch -eq "Good") {
                 $TitleStatus = "Good"
@@ -186,24 +228,6 @@ if (-not [string]::IsNullOrWhiteSpace($SummaryFile)) {
         }
         if ($CurrentTitle) {
             Write-Host "ℹ️  Extracted CurrentTitle: $CurrentTitle" -ForegroundColor Cyan
-        }
-    }
-    
-    # Extract Recommended Title
-    if ([string]::IsNullOrWhiteSpace($RecommendedTitle)) {
-        # Try different patterns
-        if ($content -match '\*\*Recommended.*?Title.*?\*\*:?\s*[`"]?([^`"\n]+)[`"]?') {
-            $RecommendedTitle = $Matches[1].Trim()
-        } elseif ($content -match 'Recommended:\s*`([^`]+)`') {
-            $RecommendedTitle = $Matches[1].Trim()
-        } elseif ($content -match '(?s)\*\*Recommended:\*\*\s*```\s*([^\n]+)') {
-            # Code fence format
-            $RecommendedTitle = $Matches[1].Trim()
-        } elseif ($content -match '(?s)### 📋 Title Assessment.+?\*\*Recommended:\*\*\s*```\s*([^\n]+)') {
-            $RecommendedTitle = $Matches[1].Trim()
-        }
-        if ($RecommendedTitle) {
-            Write-Host "ℹ️  Extracted RecommendedTitle: $RecommendedTitle" -ForegroundColor Cyan
         }
     }
     
@@ -308,6 +332,57 @@ if (-not [string]::IsNullOrWhiteSpace($SummaryFile)) {
             $RecommendedDescription = $Matches[1].Trim()
         }
     }
+    
+    # Extract Code Review Status and Findings
+    if ([string]::IsNullOrWhiteSpace($CodeReviewStatus)) {
+        # First, try to find a separate code-review.md file in same directory
+        $summaryDir = Split-Path $SummaryFile -Parent
+        $codeReviewFile = Join-Path $summaryDir "code-review.md"
+        
+        if (Test-Path $codeReviewFile) {
+            Write-Host "ℹ️  Found code-review.md file, loading content..." -ForegroundColor Cyan
+            $codeReviewContent = Get-Content $codeReviewFile -Raw -Encoding UTF8
+            $CodeReviewFindings = $codeReviewContent.Trim()
+            
+            # Determine status from content
+            if ($codeReviewContent -match '🔴 Critical Issues') {
+                $CodeReviewStatus = "IssuesFound"
+            } elseif ($codeReviewContent -match '(✅ Looks Good|No.*?issues found|Code review passed)') {
+                $CodeReviewStatus = "Passed"
+            } else {
+                $CodeReviewStatus = "Passed"
+            }
+        }
+        # Try to extract from summary file - look for Code Review section
+        elseif ($content -match '(?s)## Code Review Findings(.+?)(?=## [A-Z]|---|\z)') {
+            Write-Host "ℹ️  Extracted code review from summary file..." -ForegroundColor Cyan
+            $CodeReviewFindings = $Matches[1].Trim()
+            
+            # Determine status from content
+            if ($CodeReviewFindings -match '🔴 Critical Issues') {
+                $CodeReviewStatus = "IssuesFound"
+            } else {
+                $CodeReviewStatus = "Passed"
+            }
+        }
+        # Also check for ### Code Review format
+        elseif ($content -match '(?s)### 🔍 Code Review(.+?)(?=### [A-Z]|---|\z)') {
+            $CodeReviewFindings = $Matches[1].Trim()
+            if ($CodeReviewFindings -match '🔴 Critical Issues') {
+                $CodeReviewStatus = "IssuesFound"
+            } else {
+                $CodeReviewStatus = "Passed"
+            }
+        }
+        else {
+            # Default to Skipped if no code review found
+            $CodeReviewStatus = "Skipped"
+        }
+        
+        if ($CodeReviewStatus -ne "Skipped") {
+            Write-Host "ℹ️  Detected CodeReviewStatus: $CodeReviewStatus" -ForegroundColor Cyan
+        }
+    }
 }
 
 # Validate required parameters
@@ -336,6 +411,18 @@ if ([string]::IsNullOrWhiteSpace($DescriptionStatus)) {
 
 if ([string]::IsNullOrWhiteSpace($DescriptionAssessment)) {
     throw "DescriptionAssessment is required. Provide via -DescriptionAssessment or use -SummaryFile"
+}
+
+# Warn if description needs work but no recommended description is provided
+if (($DescriptionStatus -eq "NeedsUpdate" -or $DescriptionStatus -eq "NeedsRewrite") -and [string]::IsNullOrWhiteSpace($RecommendedDescription)) {
+    Write-Host "⚠️  Warning: DescriptionStatus is '$DescriptionStatus' but no RecommendedDescription provided." -ForegroundColor Yellow
+    Write-Host "   Consider providing -RecommendedDescription with a suggested PR description." -ForegroundColor Yellow
+}
+
+# Warn if title needs update but no recommended title is provided
+if ($TitleStatus -eq "NeedsUpdate" -and [string]::IsNullOrWhiteSpace($RecommendedTitle)) {
+    Write-Host "⚠️  Warning: TitleStatus is 'NeedsUpdate' but no RecommendedTitle provided." -ForegroundColor Yellow
+    Write-Host "   Consider providing -RecommendedTitle with a suggested title." -ForegroundColor Yellow
 }
 
 # Initialize $titleIssues from parameter if provided, otherwise set default based on status
@@ -379,6 +466,7 @@ $descStatusDisplay = switch ($DescriptionStatus) {
 # Build Title section (collapsible)
 $titleSection = @"
 <details>
+
 <summary><b>Title: $titleEmoji $titleStatusDisplay</b></summary>
 
 <br>
@@ -406,6 +494,7 @@ $titleSection += @"
 # Build Description section (collapsible)
 $descSection = @"
 <details>
+
 <summary><b>Description: $descEmoji $descStatusDisplay</b></summary>
 
 <br>
@@ -435,6 +524,53 @@ $RecommendedDescription
 $descSection += @"
 </details>
 "@
+
+# Code Review status emoji and display
+$codeReviewEmoji = switch ($CodeReviewStatus) {
+    "Passed" { "✅" }
+    "IssuesFound" { "⚠️" }
+    "Skipped" { "⏭️" }
+    default { "⏭️" }
+}
+
+$codeReviewStatusDisplay = switch ($CodeReviewStatus) {
+    "IssuesFound" { "Issues Found" }
+    default { $CodeReviewStatus }
+}
+
+# Build Code Review section (collapsible) - only if not skipped or if we have findings
+$codeReviewSection = ""
+if ($CodeReviewStatus -ne "Skipped" -or -not [string]::IsNullOrWhiteSpace($CodeReviewFindings)) {
+    # Default status to "Passed" if we have findings but no explicit status
+    if ([string]::IsNullOrWhiteSpace($CodeReviewStatus)) {
+        $CodeReviewStatus = "Passed"
+        $codeReviewEmoji = "✅"
+        $codeReviewStatusDisplay = "Passed"
+    }
+    
+    $codeReviewSection = @"
+
+<details>
+
+<summary><b>Code Review: $codeReviewEmoji $codeReviewStatusDisplay</b></summary>
+
+<br>
+
+"@
+
+    if (-not [string]::IsNullOrWhiteSpace($CodeReviewFindings)) {
+        # Trim the findings and ensure proper newline spacing
+        $trimmedFindings = $CodeReviewFindings.Trim()
+        $codeReviewSection += $trimmedFindings
+    } else {
+        $codeReviewSection += "No significant issues found. Code follows best practices."
+    }
+
+    $codeReviewSection += @"
+
+</details>
+"@
+}
 
 # ============================================================================
 # STANDALONE COMMENT HANDLING
@@ -473,6 +609,7 @@ $FINALIZE_MARKER
 $titleSection
 
 $descSection
+$codeReviewSection
 "@
 
 if ($DryRun) {

--- a/.github/skills/pr-finalize/SKILL.md
+++ b/.github/skills/pr-finalize/SKILL.md
@@ -16,6 +16,22 @@ Ensures PR title and description accurately reflect the implementation, and perf
 
 ---
 
+## 🚨 CRITICAL: NEVER Approve or Request Changes
+
+**AI agents must NEVER use `--approve` or `--request-changes` flags.**
+
+| Action | Allowed? | Why |
+|--------|----------|-----|
+| `gh pr review --approve` | ❌ **NEVER** | Approval is a human decision |
+| `gh pr review --request-changes` | ❌ **NEVER** | Blocking PRs is a human decision |
+
+**Only humans can approve or block PRs.** The agent's role is to:
+1. Analyze and provide findings
+2. Post comments with recommendations
+3. Let humans make the final decision
+
+---
+
 ## Phase 1: Title & Description
 
 ### Core Principle: Preserve Quality

--- a/.github/skills/pr-finalize/SKILL.md
+++ b/.github/skills/pr-finalize/SKILL.md
@@ -16,7 +16,9 @@ Ensures PR title and description accurately reflect the implementation, and perf
 
 ---
 
-## 🚨 CRITICAL: NEVER Approve or Request Changes
+## 🚨 CRITICAL RULES
+
+### 1. NEVER Approve or Request Changes
 
 **AI agents must NEVER use `--approve` or `--request-changes` flags.**
 
@@ -25,10 +27,21 @@ Ensures PR title and description accurately reflect the implementation, and perf
 | `gh pr review --approve` | ❌ **NEVER** | Approval is a human decision |
 | `gh pr review --request-changes` | ❌ **NEVER** | Blocking PRs is a human decision |
 
-**Only humans can approve or block PRs.** The agent's role is to:
-1. Analyze and provide findings
-2. Post comments with recommendations
-3. Let humans make the final decision
+### 2. NEVER Post Comments Directly
+
+**This skill is ANALYSIS ONLY.** Never post comments using `gh` commands.
+
+| Action | Allowed? | Why |
+|--------|----------|-----|
+| `gh pr review --comment` | ❌ **NEVER** | Use ai-summary-comment skill instead |
+| `gh pr comment` | ❌ **NEVER** | Use ai-summary-comment skill instead |
+| Analyze and report findings | ✅ **YES** | This is the skill's purpose |
+
+**Correct workflow:**
+1. **This skill**: Analyze PR, produce findings in your response to the user
+2. **User explicitly asks to post comment**: Then invoke `ai-summary-comment` skill
+
+**Only humans control when comments are posted.** Your job is to analyze and present findings.
 
 ---
 
@@ -352,19 +365,21 @@ gh pr diff XXXXX -- path/to/file.cs
 - [Positive observation 2]
 ```
 
-### When to Post Review
+### 🚨 CRITICAL: Do NOT Post Comments Directly
 
-Post a **comment** with your findings. Never approve or request changes - that's a human decision.
+**The pr-finalize skill is ANALYSIS ONLY.** Never post comments using `gh pr review` or `gh pr comment`.
 
-- **Issues found**: Post comment with findings for human review
-- **No issues**: Post comment noting code review passed
+| Action | Allowed? | Why |
+|--------|----------|-----|
+| `gh pr review --comment` | ❌ **NEVER** | Use ai-summary-comment skill instead |
+| `gh pr comment` | ❌ **NEVER** | Use ai-summary-comment skill instead |
+| Analyze and report findings | ✅ **YES** | This is the skill's purpose |
 
-### Example gh CLI Command
+**Workflow:**
+1. **This skill**: Analyze PR, produce findings in your response
+2. **User asks to post**: Then invoke `ai-summary-comment` skill to post
 
-```bash
-# Post review comment (NEVER use --approve or --request-changes)
-gh pr review XXXXX --repo dotnet/maui --comment --body "$reviewBody"
-```
+The user controls when comments are posted. Your job is to analyze and present findings.
 
 ---
 

--- a/.github/skills/pr-finalize/SKILL.md
+++ b/.github/skills/pr-finalize/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: pr-finalize
-description: Finalizes any PR for merge by verifying title/description match implementation AND performing multi-model code review for best practices. Use when asked to "finalize PR", "check PR description", "review commit message", before merging any PR, or when PR implementation changed during review. Do NOT use for extracting lessons (use learn-from-pr), writing tests (use write-tests-agent), or investigating build failures (use pr-build-status).
+description: Finalizes any PR for merge by verifying title/description match implementation AND performing code review for best practices. Use when asked to "finalize PR", "check PR description", "review commit message", before merging any PR, or when PR implementation changed during review. Do NOT use for extracting lessons (use learn-from-pr), writing tests (use write-tests-agent), or investigating build failures (use pr-build-status).
 ---
 
 # PR Finalize
 
-Ensures PR title and description accurately reflect the implementation, and performs a **multi-model code review** for best practices before merge.
+Ensures PR title and description accurately reflect the implementation, and performs a **code review** for best practices before merge.
 
 **Standalone skill** - Can be used on any PR, not just PRs created by the pr agent.
 
 ## Two-Phase Workflow
 
 1. **Title & Description Review** - Verify PR metadata matches implementation
-2. **Multi-Model Code Review** - Get consensus from 5 models on best practices
+2. **Code Review** - Review code for best practices and potential issues
 
 ---
 
@@ -305,113 +305,64 @@ Fixed the issue mentioned in #30897
 
 ---
 
-## Phase 2: Multi-Model Code Review
+## Phase 2: Code Review
 
-After verifying title/description, perform a **multi-model code review** to catch best practice violations and edge cases before merge.
+After verifying title/description, perform a **code review** to catch best practice violations and potential issues before merge.
 
-### Why Multi-Model?
+### Review Focus Areas
 
-Different models catch different issues. Consensus from 5 models provides:
-- Higher confidence in findings (multiple models agree)
-- Broader coverage of edge cases
-- Reduced false positives (single-model quirks filtered out)
+When reviewing code changes, focus on:
 
-### Models to Consult
+1. **Code quality and maintainability** - Clean code, good naming, appropriate abstractions
+2. **Error handling and edge cases** - Null checks, exception handling, boundary conditions
+3. **Performance implications** - Unnecessary allocations, N+1 queries, blocking calls
+4. **Platform-specific concerns** - iOS/Android/Windows differences, platform APIs
+5. **Breaking changes** - API changes, behavior changes that affect existing code
 
-Use 5 diverse models for best coverage:
+### How to Review
 
-| Model | Strengths |
-|-------|-----------|
-| `claude-sonnet-4` | Balanced analysis, good code patterns |
-| `claude-opus-4.5` | Deep reasoning, edge cases |
-| `gpt-5.2` | Practical recommendations |
-| `gpt-5.2-codex` | Code-specific expertise |
-| `gemini-3-pro-preview` | Alternative perspective |
+```bash
+# Get the PR diff
+gh pr diff XXXXX
 
-### Review Prompt Template
-
-Send the same prompt to all 5 models via `task` tool with `model` parameter:
-
+# Review specific files
+gh pr diff XXXXX -- path/to/file.cs
 ```
-Review the following code changes from PR #XXXXX for best practices. Focus on:
-1. Code quality and maintainability
-2. Error handling and edge cases  
-3. Performance implications
-4. Any potential improvements
-
-[Include relevant code snippets from PR diff]
-
-Provide specific, actionable recommendations. Be concise.
-```
-
-### Execution
-
-```csharp
-// Invoke 5 models in parallel using task tool
-task(agent_type: "general-purpose", model: "claude-sonnet-4", prompt: "<review prompt>")
-task(agent_type: "general-purpose", model: "claude-opus-4.5", prompt: "<review prompt>")
-task(agent_type: "general-purpose", model: "gpt-5.2", prompt: "<review prompt>")
-task(agent_type: "general-purpose", model: "gpt-5.2-codex", prompt: "<review prompt>")
-task(agent_type: "general-purpose", model: "gemini-3-pro-preview", prompt: "<review prompt>")
-```
-
-### Synthesize Consensus
-
-After receiving all 5 responses, synthesize findings by agreement level:
-
-| Agreement | Classification | Action |
-|-----------|----------------|--------|
-| **4-5 models agree** | 🔴 Critical | Must fix before merge |
-| **3 models agree** | 🟡 High Priority | Should fix |
-| **2 models agree** | 🟢 Minor | Nice to have |
-| **1 model only** | ⚪ Skip | Likely false positive |
 
 ### Output Format
 
 ```markdown
-## Multi-Model Code Review Consensus
+## Code Review Findings
 
-### 🔴 Critical Issues (4+ models agree)
+### 🔴 Critical Issues
 
 **[Issue Title]**
-- **Models:** claude-sonnet-4, claude-opus-4.5, gpt-5.2, gemini-3-pro-preview
+- **File:** [path/to/file.cs]
 - **Problem:** [Description]
-- **Recommendation:** [Code fix]
+- **Recommendation:** [Code fix or approach]
 
-### 🟡 High Priority (3 models agree)
+### 🟡 Suggestions
 
-**[Issue Title]**
-- **Models:** [List]
-- **Problem:** [Description]  
-- **Recommendation:** [Code fix]
+- [Suggestion 1]
+- [Suggestion 2]
 
-### 🟢 Minor Improvements (2 models agree)
+### ✅ Looks Good
 
-- [Improvement 1]
-- [Improvement 2]
-
-### ✅ Positive Feedback (all models agree)
-
-- [Good practice 1]
-- [Good practice 2]
+- [Positive observation 1]
+- [Positive observation 2]
 ```
 
 ### When to Post Review
 
-- **Critical issues found**: Post review requesting changes with consensus findings
-- **Only minor issues**: Approve with suggestions in comment
-- **No issues**: Approve, note that multi-model review passed
+Post a **comment** with your findings. Never approve or request changes - that's a human decision.
 
-### Example gh CLI Commands
+- **Issues found**: Post comment with findings for human review
+- **No issues**: Post comment noting code review passed
+
+### Example gh CLI Command
 
 ```bash
-# Request changes (critical issues found)
-gh pr review XXXXX --repo dotnet/maui --request-changes --body "$reviewBody"
-
-# Approve with comments (minor issues only)
-gh pr review XXXXX --repo dotnet/maui --approve --body "$reviewBody"
-
-# Comment without approval/rejection
+# Post review comment (NEVER use --approve or --request-changes)
 gh pr review XXXXX --repo dotnet/maui --comment --body "$reviewBody"
 ```
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Enhances the `pr-finalize` skill with a **two-phase workflow** that includes code review, and adds critical safety rules preventing agents from approving or blocking PRs.

### What This PR Does

1. **Adds Phase 2: Code Review** - After verifying title/description, the skill now performs a code review for best practices
2. **Adds critical safety rule** - Agents must NEVER use `--approve` or `--request-changes` flags
3. **Keeps skill focused** - Users can invoke with different models themselves if they want multi-model coverage

---

## Commits

### 1. `2ad480c77d` - Add multi-model code review to pr-finalize skill

**Original commit** that added the code review phase to pr-finalize.

### 2. `71eb8c2216` - Add critical rule: agents must NEVER approve/request-changes on PRs

**Why:** AI agents should never make approval decisions on PRs. That's a human responsibility.

**Changes:**
- Added prominent `🚨 CRITICAL` warning section at top of skill
- Added CRITICAL note to `copilot-instructions.md`
- Only `gh pr review --comment` is allowed

### 3. `335be127cb` - Simplify pr-finalize: remove multi-model orchestration, keep code review

**Why:** After review, decided that multi-model orchestration should be user-controlled, not built into the skill. Users can invoke pr-finalize with different models themselves if they want multi-model coverage.

**Changes:**
- Removed 5-model orchestration logic (model table, parallel execution, consensus synthesis)
- Renamed "Multi-Model Code Review" → "Code Review"
- Fixed contradiction: removed `--approve`/`--request-changes` examples that conflicted with the NEVER rule
- Kept the code review focus areas and output format
- Reduced skill from 422 → 373 lines

---

## The Two-Phase Workflow

### Phase 1: Title & Description Review
- Verify PR metadata matches actual implementation
- Check for required NOTE block
- Ensure title is searchable and informative

### Phase 2: Code Review
- Review code for best practices
- Focus on: code quality, error handling, performance, platform concerns, breaking changes
- Post findings as **comment only** (never approve/request-changes)

---

## Key Safety Rule

```markdown
## 🚨 CRITICAL: NEVER Approve or Request Changes

**AI agents must NEVER use `--approve` or `--request-changes` flags.**

| Action | Allowed? | Why |
|--------|----------|-----|
| `gh pr review --approve` | ❌ **NEVER** | Approval is a human decision |
| `gh pr review --request-changes` | ❌ **NEVER** | Blocking PRs is a human decision |
| `gh pr review --comment` | ✅ **OK** | Findings for human review |
```

---

## Files Changed

| File | Changes |
|------|---------|
| `.github/skills/pr-finalize/SKILL.md` | Added Phase 2 code review, safety rules, simplified orchestration |
| `.github/copilot-instructions.md` | Updated skill description, added CRITICAL note |

---

## Why Not Multi-Model Orchestration?

The original approach had the skill orchestrate 5 different AI models in parallel. This was removed because:

1. **User control** - Users can invoke pr-finalize with `model` parameter themselves
2. **Simplicity** - Skill focuses on *what* to review, not *how* to orchestrate
3. **Flexibility** - Users choose when multi-model is worth the cost
4. **Avoids contradictions** - Original had consensus logic that conflicted with "never approve" rule

---

## Issues Fixed

N/A - Enhancement to agent workflow