### PR TITLE
[XSG] Handle NaN values in ThicknessConverter

### DIFF
--- a/src/Controls/src/SourceGen/GeneratorHelpers.cs
+++ b/src/Controls/src/SourceGen/GeneratorHelpers.cs
@@ -424,5 +424,32 @@ static class GeneratorHelpers
 		return SymbolDisplay.FormatPrimitive(value, quoteStrings: quoted, useHexadecimalNumbers: false);
 	}
 
+	/// <summary>
+	/// Tries to parse a double value, including special values like NaN, Infinity, -Infinity.
+	/// </summary>
+	public static bool TryParseDouble(string value, out double result)
+	{
+		value = value.Trim();
+
+		// Handle special values that NumberStyles.Number doesn't parse
+		if (value.Equals("NaN", StringComparison.OrdinalIgnoreCase))
+		{
+			result = double.NaN;
+			return true;
+		}
+		if (value.Equals("Infinity", StringComparison.OrdinalIgnoreCase) ||
+			value.Equals("+Infinity", StringComparison.OrdinalIgnoreCase))
+		{
+			result = double.PositiveInfinity;
+			return true;
+		}
+		if (value.Equals("-Infinity", StringComparison.OrdinalIgnoreCase))
+		{
+			result = double.NegativeInfinity;
+			return true;
+		}
+
+		return double.TryParse(value, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out result);
+	}
 
 }

--- a/src/Controls/src/SourceGen/TypeConverters/ThicknessConverter.cs
+++ b/src/Controls/src/SourceGen/TypeConverters/ThicknessConverter.cs
@@ -1,6 +1,5 @@
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Xml;
 using Microsoft.CodeAnalysis;
 using Microsoft.Maui.Controls.Xaml;
@@ -30,7 +29,7 @@ class ThicknessConverter : ISGTypeConverter
 							&& TryParseDouble(thickness[1], out double v))
 						{
 							var thicknessType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Thickness")!;
-							return $"new {thicknessType.ToFQDisplayString()}({FormatDouble(h)}, {FormatDouble(v)})";
+							return $"new {thicknessType.ToFQDisplayString()}({FormatInvariant(h)}, {FormatInvariant(v)})";
 						}
 						break;
 					case 4:
@@ -40,7 +39,7 @@ class ThicknessConverter : ISGTypeConverter
 							&& TryParseDouble(thickness[3], out double b))
 						{
 							var thicknessType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Thickness")!;
-							return $"new {thicknessType.ToFQDisplayString()}({FormatDouble(l)}, {FormatDouble(t)}, {FormatDouble(r)}, {FormatDouble(b)})";
+							return $"new {thicknessType.ToFQDisplayString()}({FormatInvariant(l)}, {FormatInvariant(t)}, {FormatInvariant(r)}, {FormatInvariant(b)})";
 						}
 						break;
 				}
@@ -50,55 +49,12 @@ class ThicknessConverter : ISGTypeConverter
 				if (TryParseDouble(value, out double l))
 				{
 					var thicknessType = context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Thickness")!;
-					return $"new {thicknessType.ToFQDisplayString()}({FormatDouble(l)})";
+					return $"new {thicknessType.ToFQDisplayString()}({FormatInvariant(l)})";
 				}
 			}
 		}
 
 		context.ReportConversionFailed(xmlLineInfo, value, Descriptors.ThicknessConversionFailed);
 		return "default";
-	}
-
-	/// <summary>
-	/// Tries to parse a double value, including special values like NaN, Infinity, -Infinity.
-	/// </summary>
-	static bool TryParseDouble(string value, out double result)
-	{
-		value = value.Trim();
-
-		// Handle special values that NumberStyles.Number doesn't parse
-		if (value.Equals("NaN", System.StringComparison.OrdinalIgnoreCase))
-		{
-			result = double.NaN;
-			return true;
-		}
-		if (value.Equals("Infinity", System.StringComparison.OrdinalIgnoreCase) ||
-			value.Equals("+Infinity", System.StringComparison.OrdinalIgnoreCase))
-		{
-			result = double.PositiveInfinity;
-			return true;
-		}
-		if (value.Equals("-Infinity", System.StringComparison.OrdinalIgnoreCase))
-		{
-			result = double.NegativeInfinity;
-			return true;
-		}
-
-		return double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
-	}
-
-	/// <summary>
-	/// Formats a double value for C# code generation, handling special values.
-	/// </summary>
-	static string FormatDouble(double value)
-	{
-		if (double.IsNaN(value))
-			return "double.NaN";
-		if (double.IsPositiveInfinity(value))
-			return "double.PositiveInfinity";
-		if (double.IsNegativeInfinity(value))
-			return "double.NegativeInfinity";
-
-		return FormatInvariant(value);
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33871.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33871.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33871">
+	<!-- Test: Thickness type converter should handle NaN values -->
+	<Button x:Name="nanButton" Text="NaN Padding" Padding="NaN"/>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33871.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33871.xaml.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33871 : ContentPage
+{
+	public Maui33871() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void ThicknessConverterHandlesNaN(XamlInflator inflator)
+		{
+			// This test reproduces issue #33871:
+			// XSG fails to parse Padding="NaN" which creates a Thickness with all NaN values.
+			// This is used by Button to indicate "use platform default padding".
+			var page = new Maui33871(inflator);
+
+			Assert.NotNull(page);
+			Assert.NotNull(page.nanButton);
+
+			// Verify the padding was parsed correctly as NaN
+			Assert.True(page.nanButton.Padding.IsNaN);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #33871

The XAML Source Generator's `ThicknessConverter` didn't handle special double values like `NaN`, `Infinity`, and `-Infinity`. This is used by `Button.Padding` to indicate "use platform default padding" via `Padding="NaN"`.

## Changes

- Add `TryParseDouble` helper that handles `NaN`, `Infinity`, `-Infinity` in addition to regular numbers
- Add `FormatDouble` helper that generates `double.NaN`, `double.PositiveInfinity`, `double.NegativeInfinity` in generated code
- Add XAML unit test for `Padding="NaN"`

## Testing

- Added `Maui33871.xaml` test that verifies `Padding="NaN"` works with all three inflators (Runtime, XamlC, SourceGen)
- All 3 test cases pass locally