### PR TITLE
[XSG] Fix inline StyleSheet CSS content with quotes

### DIFF
--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -276,7 +276,9 @@ internal class KnownMarkups
 
 		if (styleNode != null)
 		{
-			value = $"global::Microsoft.Maui.Controls.StyleSheets.StyleSheet.FromString(@\"{(styleNode as ValueNode)!.Value as string}\")";
+			// Escape quotes for verbatim string literal (@"") by doubling them
+			var styleContent = ((styleNode as ValueNode)!.Value as string)?.Replace("\"", "\"\"") ?? "";
+			value = $"global::Microsoft.Maui.Controls.StyleSheets.StyleSheet.FromString(@\"{styleContent}\")";
 			return true;
 		}
 		else // sourceNode != null

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33867.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33867.xaml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33867">
+	<!-- Test: Inline StyleSheet with CDATA content (from StyleSheetsPage) -->
+	<ContentPage.Resources>
+		<StyleSheet>
+			<![CDATA[
+stacklayout {
+	-maui-spacing: 15;
+}
+entry {
+	background-color: red;
+	-maui-placeholder: "CSS Placeholder";
+	-maui-placeholder-color: blue;
+}
+			]]>
+		</StyleSheet>
+	</ContentPage.Resources>
+	<StackLayout Padding="30,60,30,30">
+		<Label x:Name="testLabel" Text="3 red text boxes spaced apart with a blue placeholder." />
+		<Entry />
+		<Entry />
+		<Entry />
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33867.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33867.xaml.cs
@@ -36,12 +36,10 @@ public partial class Maui33867 : ContentPage
 				// Verify no compilation errors
 				Assert.Empty(result.Diagnostics);
 			}
-			else
-			{
-				var page = new Maui33867(inflator);
-				Assert.NotNull(page);
-				Assert.NotNull(page.testLabel);
-			}
+
+			var page = new Maui33867(inflator);
+			Assert.NotNull(page);
+			Assert.NotNull(page.testLabel);
 		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33867.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33867.xaml.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33867 : ContentPage
+{
+	public Maui33867() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void InlineStyleSheetWithCDATA(XamlInflator inflator)
+		{
+			// This test reproduces issue #33867:
+			// XSG doesn't correctly parse inline StyleSheet elements with CDATA sections.
+			if (inflator == XamlInflator.SourceGen)
+			{
+				var result = CreateMauiCompilation()
+					.WithAdditionalSource(
+"""
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33867 : ContentPage
+{
+	public Maui33867() => InitializeComponent();
+}
+""")
+					.RunMauiSourceGenerator(typeof(Maui33867));
+				
+				// Verify no compilation errors
+				Assert.Empty(result.Diagnostics);
+			}
+			else
+			{
+				var page = new Maui33867(inflator);
+				Assert.NotNull(page);
+				Assert.NotNull(page.testLabel);
+			}
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #33867

When inline StyleSheet content contains double quotes (e.g., in CSS placeholder strings like `-maui-placeholder: "CSS Placeholder";`), XSG was generating malformed C# code. The issue was that quotes weren't escaped for verbatim string literals.

## Changes

In `KnownMarkups.cs`, the CSS content is now escaped by replacing `"` with `""` before embedding in the generated verbatim string literal.

## Test

Added `Maui33867.xaml` test that includes CSS with quoted content, matching the `StyleSheetsPage.xaml` from the sample app.