### PR TITLE
[XSG] Change MAUIX2006 from Warning to Error for property element attributes

### DIFF
--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -15,7 +15,7 @@ MAUIX2002 | XamlInflation | Error | Descriptors
 MAUIX2003 | XamlInflation | Error | Descriptors
 MAUIX2004 | XamlInflation | Error | Descriptors
 MAUIX2005 | XamlInflation | Warning | Descriptors
-MAUIX2006 | XamlParsing | Warning | PropertyElementWithAttribute
+MAUIX2006 | XamlParsing | Error | PropertyElementWithAttribute
 MAUIG2024 | XamlInflation | Warning | BindingWithXDataTypeFromOuterScope
 MAUIG2041 | XamlInflation | Error | BindingIndexerNotClosed
 MAUIG2042 | XamlInflation | Error | BindingIndexerEmpty

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 			title: "Property element has attributes",
 			messageFormat: "{0}",
 			category: "XamlParsing",
-			defaultSeverity: DiagnosticSeverity.Warning,
+			defaultSeverity: DiagnosticSeverity.Error,
 			isEnabledByDefault: true);
 
 		// public static BuildExceptionCode TypeResolution = new BuildExceptionCode("XC", 0000, nameof(TypeResolution), "");

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33868.rt.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33868.rt.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Note: This file uses .rt.xaml extension because it contains intentionally invalid XAML
+     that should fail with SourceGen (attributes on property elements are not allowed) -->
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33868">
+	<Grid>
+		<!-- Invalid XAML: Attributes on property elements are not allowed -->
+		<Grid.RowDefinitions Foo="Bar">
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+	</Grid>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33868.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33868.xaml.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33868 : ContentPage
+{
+	public Maui33868() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void PropertyElementWithAttributeShouldError(XamlInflator inflator)
+		{
+			// This test reproduces issue #33868:
+			// Attributes on property elements (e.g., <Grid.RowDefinitions Foo="Bar">)
+			// are invalid XAML. XSG should emit an error (not a warning).
+			if (inflator == XamlInflator.SourceGen)
+			{
+				var result = CreateMauiCompilation()
+					.WithAdditionalSource(
+"""
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui33868 : ContentPage
+{
+	public Maui33868() => InitializeComponent();
+}
+""")
+					.RunMauiSourceGenerator(typeof(Maui33868));
+				
+				// Should have exactly one error diagnostic for the invalid attribute
+				var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+				Assert.Single(errors);
+				Assert.Equal("MAUIX2006", errors[0].Id);
+				Assert.Contains("RowDefinitions", errors[0].GetMessage(), StringComparison.Ordinal);
+			}
+			else
+			{
+				// Runtime is more permissive (it just ignores the attribute)
+				// XamlC is not generated for .rt.xaml files
+				if (inflator == XamlInflator.XamlC)
+				{
+					Assert.Throws<NotSupportedException>(() => new Maui33868(inflator));
+				}
+				else
+				{
+					var page = new Maui33868(inflator);
+					Assert.NotNull(page);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #33868

Property elements (e.g., `<Grid.RowDefinitions>`) should not have XML attributes. This is invalid XAML syntax. XSG already detected this with diagnostic MAUIX2006 but only as a warning. This changes it to an error to enforce correct XAML usage.

## Changes

- Changed `MAUIX2006` (PropertyElementWithAttribute) severity from Warning to Error in `Descriptors.cs`
- Updated `AnalyzerReleases.Unshipped.md` to track the severity change

## Test

Added `Maui33868` test that verifies MAUIX2006 is emitted as an error when a property element has an attribute.