### PR TITLE
Fix CustomSwipeControl sample - add missing event handler

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/CustomSwipeControl.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/CustomSwipeControl.xaml.cs
@@ -1,14 +1,18 @@
-﻿using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
+﻿using System;
+using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 {
-	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class CustomSwipeControl
 	{
 		public CustomSwipeControl()
 		{
 			InitializeComponent();
+		}
+
+		void OnInvoked(object? sender, EventArgs e)
+		{
+			// Handle swipe item invoked
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The XAML file references `Invoked="OnInvoked"` on a SwipeItem, but the handler was missing from the code-behind. This caused XSG (XAML Source Generator) to report an error when trying to compile the sample with SourceGen.

## Changes

- Added the missing `OnInvoked` event handler to `CustomSwipeControl.xaml.cs`
- Removed `[XamlCompilation(XamlCompilationOptions.Skip)]` attribute since the file can now be compiled properly

Fixes #33877