### PR TITLE
[XSG] Fix RelativeSource AncestorType x:Type resolution

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewBindingContextGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewBindingContextGallery.xaml
@@ -2,7 +2,7 @@
 <ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:vm="clr-namespace:Microsoft.Maui.Controls.ControlGallery.GalleryPages.SwipeViewGalleries"
+    xmlns:vm="clr-namespace:Maui.Controls.Sample.Pages.SwipeViewGalleries"
     x:Class="Maui.Controls.Sample.Pages.SwipeViewGalleries.SwipeViewBindingContextGallery"
     Title="SwipeView BindingContext Gallery">
     <ContentPage.BindingContext>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewBindingContextGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewBindingContextGallery.xaml.cs
@@ -2,12 +2,10 @@
 using System.Windows.Input;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Controls.Xaml;
 
 namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 {
 	[Preserve(AllMembers = true)]
-	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class SwipeViewBindingContextGallery : ContentPage
 	{
 		public SwipeViewBindingContextGallery()

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -148,16 +148,45 @@ internal class KnownMarkups
 
 		// Get the AncestorType property (which is an x:Type extension)
 		ITypeSymbol? ancestorTypeSymbol = null;
-		if (markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out INode? ancestorTypeNode)
-			|| markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
+		INode? ancestorTypeNode = null;
+		if (!markupNode.Properties.TryGetValue(new XmlName("", "AncestorType"), out ancestorTypeNode)
+			&& !markupNode.Properties.TryGetValue(new XmlName(null, "AncestorType"), out ancestorTypeNode))
+			markupNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "AncestorType"), out ancestorTypeNode);
+		
+		if (ancestorTypeNode is not null)
 		{
-			if (ancestorTypeNode is ElementNode typeExtNode && context.Types.TryGetValue(typeExtNode, out ancestorTypeSymbol))
+			if (ancestorTypeNode is ElementNode typeExtNode)
 			{
-				// Type was already resolved by ProvideValueForTypeExtension
+				if (context.Types.TryGetValue(typeExtNode, out ancestorTypeSymbol))
+				{
+					// Type was already resolved by ProvideValueForTypeExtension
+				}
+				else
+				{
+					// x:Type extension not yet processed - resolve it now
+					// This can happen when RelativeSource is processed before the x:Type child
+					if (!typeExtNode.Properties.TryGetValue(new XmlName("", "TypeName"), out INode? typeNameNode)
+						&& !typeExtNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "TypeName"), out typeNameNode)
+						&& typeExtNode.CollectionItems.Count == 1)
+						typeNameNode = typeExtNode.CollectionItems[0];
+
+					if (typeNameNode is ValueNode vnTypeName)
+					{
+						var typeName = vnTypeName.Value as string;
+						if (!IsNullOrEmpty(typeName))
+						{
+							XmlType xmlType = TypeArgumentsParser.ParseSingle(typeName!, typeExtNode.NamespaceResolver, typeExtNode as IXmlLineInfo);
+							xmlType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out var resolvedType);
+							ancestorTypeSymbol = resolvedType;
+							if (resolvedType is not null)
+								context.Types[typeExtNode] = resolvedType;
+						}
+					}
+				}
 			}
 			else if (ancestorTypeNode is ValueNode vnType)
 			{
-				// Try to parse as a type name
+				// Try to parse as a type name directly (without x:Type)
 				var typeName = vnType.Value as string;
 				if (!IsNullOrEmpty(typeName))
 				{

--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -166,6 +166,7 @@ internal class KnownMarkups
 					// x:Type extension not yet processed - resolve it now
 					// This can happen when RelativeSource is processed before the x:Type child
 					if (!typeExtNode.Properties.TryGetValue(new XmlName("", "TypeName"), out INode? typeNameNode)
+						&& !typeExtNode.Properties.TryGetValue(new XmlName(null, "TypeName"), out typeNameNode)
 						&& !typeExtNode.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "TypeName"), out typeNameNode)
 						&& typeExtNode.CollectionItems.Count == 1)
 						typeNameNode = typeExtNode.CollectionItems[0];

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33876.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33876.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33876">
+    <ContentPage.Resources>
+        <DataTemplate x:Key="ItemTemplate">
+            <Label Text="{Binding Command, Source={RelativeSource AncestorType={x:Type local:Maui33876ViewModel}}}" />
+        </DataTemplate>
+    </ContentPage.Resources>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33876.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33876.xaml.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class Maui33876ViewModel
+{
+    public string Command { get; set; } = "Test";
+}
+
+public partial class Maui33876 : ContentPage
+{
+    public Maui33876() => InitializeComponent();
+
+    [Collection("Issue")]
+    public class Tests
+    {
+        [Theory]
+        [XamlInflatorData]
+        internal void RelativeSourceInDataTemplate(XamlInflator inflator)
+        {
+            var page = new Maui33876(inflator);
+            Assert.NotNull(page);
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes XSG (XAML Source Generator) handling of `RelativeSource` with `AncestorType={x:Type ...}`.

**Issue:**
When using `{RelativeSource AncestorType={x:Type vm:Foo}}` inside a DataTemplate, XSG would fail with:
```
error MAUIG1001: An error occurred while parsing Xaml: Invalid RelativeSource Mode '(none)'.
```

**Root causes:**
1. The sample file `SwipeViewBindingContextGallery.xaml` had an incorrect `clr-namespace` (`Microsoft.Maui.Controls.ControlGallery...` instead of `Maui.Controls.Sample...`), which caused the x:Type to fail resolution
2. XSG's `ProvideValueForRelativeSourceExtension` wasn't checking all namespace variations for the AncestorType property

## Changes

- **KnownMarkups.cs**: 
  - Improve x:Type resolution in `ProvideValueForRelativeSourceExtension` to resolve inline when not cached
  - Check empty, null, and MauiUri namespace variations for AncestorType property
  
- **SwipeViewBindingContextGallery.xaml**:
  - Fix `xmlns:vm` to use correct namespace (`Maui.Controls.Sample.Pages.SwipeViewGalleries`)

- **SwipeViewBindingContextGallery.xaml.cs**:
  - Remove `[XamlCompilation(XamlCompilationOptions.Skip)]` since file now compiles correctly

- **Tests**:
  - Add `Maui33876.xaml` test for RelativeSource inside DataTemplate

Fixes #33876