### PR TITLE
Fix iOS integration test simulator boot race condition

### DIFF
--- a/eng/pipelines/arcade/stage-integration-tests.yml
+++ b/eng/pipelines/arcade/stage-integration-tests.yml
@@ -52,7 +52,7 @@ stages:
         inputs:
           testResultsFormat: VSTest
           testResultsFiles: '$(Agent.TempDirectory)/Microsoft.Maui.IntegrationTests/**/*.trx'
-          testRunTitle: Integration Tests - $(testIdentifier) ${{ coalesce(job.pool.label, job.pool.os) }}
+          testRunTitle: Integration Tests - ${{ job.name }}
           failTaskOnMissingResultsFile: true
         condition: always()
 
@@ -60,7 +60,7 @@ stages:
         displayName: Publish Logs
         inputs:
           targetPath: ${{ parameters.repoLogPath }}
-          artifact: Logs - Integration Tests $(testIdentifier) ${{ coalesce(job.pool.label, job.pool.os) }} $(System.JobAttempt)
+          artifact: Logs - Integration Tests ${{ job.name }} $(System.JobAttempt)
         condition: always()
 
       - template: /eng/pipelines/common/fail-on-issue.yml

--- a/eng/pipelines/arcade/stage-integration-tests.yml
+++ b/eng/pipelines/arcade/stage-integration-tests.yml
@@ -52,7 +52,7 @@ stages:
         inputs:
           testResultsFormat: VSTest
           testResultsFiles: '$(Agent.TempDirectory)/Microsoft.Maui.IntegrationTests/**/*.trx'
-          testRunTitle: Integration Tests - $(testIdentifier)${{ if job.arch }} ${{ job.arch }}${{ endif }}
+          testRunTitle: Integration Tests - $(testIdentifier) ${{ coalesce(job.arch, '') }}
           failTaskOnMissingResultsFile: true
         condition: always()
 
@@ -60,7 +60,7 @@ stages:
         displayName: Publish Logs
         inputs:
           targetPath: ${{ parameters.repoLogPath }}
-          artifact: Logs - Integration Tests $(testIdentifier)${{ if job.arch }} ${{ job.arch }}${{ endif }} $(System.JobAttempt)
+          artifact: Logs - Integration Tests $(testIdentifier) ${{ coalesce(job.arch, '') }} $(System.JobAttempt)
         condition: always()
 
       - template: /eng/pipelines/common/fail-on-issue.yml

--- a/eng/pipelines/arcade/stage-integration-tests.yml
+++ b/eng/pipelines/arcade/stage-integration-tests.yml
@@ -52,7 +52,7 @@ stages:
         inputs:
           testResultsFormat: VSTest
           testResultsFiles: '$(Agent.TempDirectory)/Microsoft.Maui.IntegrationTests/**/*.trx'
-          testRunTitle: Integration Tests - $(testIdentifier) ${{ coalesce(job.arch, '') }}
+          testRunTitle: Integration Tests - ${{ job.name }}
           failTaskOnMissingResultsFile: true
         condition: always()
 
@@ -60,7 +60,7 @@ stages:
         displayName: Publish Logs
         inputs:
           targetPath: ${{ parameters.repoLogPath }}
-          artifact: Logs - Integration Tests $(testIdentifier) ${{ coalesce(job.arch, '') }} $(System.JobAttempt)
+          artifact: Logs - Integration Tests ${{ job.name }} $(System.JobAttempt)
         condition: always()
 
       - template: /eng/pipelines/common/fail-on-issue.yml

--- a/eng/pipelines/arcade/stage-integration-tests.yml
+++ b/eng/pipelines/arcade/stage-integration-tests.yml
@@ -13,7 +13,7 @@ stages:
   jobs:
   - ${{ each job in parameters.jobMatrix }}:
     - job: ${{ job.name }}
-      displayName: ${{ coalesce(job.testName, job.testCategory) }} ${{ coalesce(job.pool.label, job.pool.os) }}
+      displayName: ${{ coalesce(job.testName, job.testCategory) }} ${{ coalesce(job.arch, job.pool.label, job.pool.os) }}
       pool: ${{ job.pool }}
       timeoutInMinutes: ${{ job.timeout }}
       ${{ if job.condition }}:

--- a/eng/pipelines/arcade/stage-integration-tests.yml
+++ b/eng/pipelines/arcade/stage-integration-tests.yml
@@ -52,7 +52,7 @@ stages:
         inputs:
           testResultsFormat: VSTest
           testResultsFiles: '$(Agent.TempDirectory)/Microsoft.Maui.IntegrationTests/**/*.trx'
-          testRunTitle: Integration Tests - ${{ job.name }}
+          testRunTitle: Integration Tests - $(testIdentifier)${{ if job.arch }} ${{ job.arch }}${{ endif }}
           failTaskOnMissingResultsFile: true
         condition: always()
 
@@ -60,7 +60,7 @@ stages:
         displayName: Publish Logs
         inputs:
           targetPath: ${{ parameters.repoLogPath }}
-          artifact: Logs - Integration Tests ${{ job.name }} $(System.JobAttempt)
+          artifact: Logs - Integration Tests $(testIdentifier)${{ if job.arch }} ${{ job.arch }}${{ endif }} $(System.JobAttempt)
         condition: always()
 
       - template: /eng/pipelines/common/fail-on-issue.yml

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -111,9 +111,11 @@ parameters:
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
+# TEMPORARY: Enable x64 lanes for PR validation - will revert after validation
+# Original: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 - name: macOSPoolLaneCondition
   type: string
-  default: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
+  default: true
 
 stages:
 
@@ -315,6 +317,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiDebug
+      arch: ARM64
 
     - name: mac_runios_maui_release_arm64
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
@@ -323,6 +326,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiRelease
+      arch: ARM64
 
     - name: mac_runios_maui_trim_arm64
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
@@ -331,6 +335,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiReleaseTrimFull
+      arch: ARM64
 
     - name: mac_runios_blazor_debug_arm64
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
@@ -339,6 +344,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorDebug
+      arch: ARM64
 
     - name: mac_runios_blazor_release_arm64
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
@@ -347,6 +353,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorRelease
+      arch: ARM64
 
     # TODO: Re-enable once ASP.NET Core fixes trimmer warning IL2111 with Blazor Router.NotFoundPage
     # Issue: https://github.com/dotnet/aspnetcore/issues/63951
@@ -354,6 +361,7 @@ stages:
     #   pool: ${{ parameters.MacOSPoolArm64 }}
     #   timeout: 45
     #   testName: RunOniOS_BlazorReleaseTrimFull
+    #   arch: ARM64
 
     - name: mac_runios_nativeaot_arm64
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
@@ -362,6 +370,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiNativeAOT
+      arch: ARM64
 
     # MacOSPool lanes - comparison with ARM64 pool
     # Only run on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
@@ -372,6 +381,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiDebug
+      arch: x64
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_maui_release
@@ -381,6 +391,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiRelease
+      arch: x64
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_maui_trim
@@ -390,6 +401,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiReleaseTrimFull
+      arch: x64
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_blazor_debug
@@ -399,6 +411,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorDebug
+      arch: x64
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_blazor_release
@@ -408,6 +421,7 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_BlazorRelease
+      arch: x64
       condition: ${{ parameters.macOSPoolLaneCondition }}
 
     - name: mac_runios_nativeaot
@@ -417,4 +431,5 @@ stages:
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 45
       testName: RunOniOS_MauiNativeAOT
+      arch: x64
       condition: ${{ parameters.macOSPoolLaneCondition }}

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -111,11 +111,9 @@ parameters:
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
-# TEMPORARY: Enable x64 lanes for PR validation - will revert after validation
-# Original: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 - name: macOSPoolLaneCondition
   type: string
-  default: true
+  default: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 
 stages:
 

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -111,11 +111,9 @@ parameters:
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
-# TEMPORARY: Enable MacOSPool lanes for PR #33884 to validate artifact naming fix
-# Original condition: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 - name: macOSPoolLaneCondition
   type: string
-  default: true
+  default: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 
 stages:
 

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -111,9 +111,11 @@ parameters:
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
+# TEMPORARY: Enable MacOSPool lanes for PR #33884 to validate artifact naming fix
+# Original condition: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 - name: macOSPoolLaneCondition
   type: string
-  default: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
+  default: true
 
 stages:
 

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -111,9 +111,11 @@ parameters:
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
+# TEMPORARY: Enable x64 lanes for PR validation - will revert after validation
+# Original: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
 - name: macOSPoolLaneCondition
   type: string
-  default: or(and(ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/net'), endsWith(variables['Build.SourceBranch'], '.0')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/inflight/'))), and(eq(variables['Build.Reason'], 'PullRequest'), or(and(startsWith(variables['System.PullRequest.TargetBranch'], 'net'), endsWith(variables['System.PullRequest.TargetBranch'], '.0')), startsWith(variables['System.PullRequest.TargetBranch'], 'release/'), startsWith(variables['System.PullRequest.TargetBranch'], 'inflight/'))))
+  default: true
 
 stages:
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Maui.IntegrationTests
 			{
 				TestSimulator.Shutdown();
 				TestSimulator.Launch();
+				// Wait for simulator to fully boot to avoid race condition where
+				// simulator reports "booted" but is still in Booting state internally
+				// This prevents "Unable to lookup in current state: Booting" errors
+				TestSimulator.WaitForBootComplete();
 			}
 		}
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AppleTemplateTests.cs
@@ -27,7 +27,12 @@ namespace Microsoft.Maui.IntegrationTests
 				// Wait for simulator to fully boot to avoid race condition where
 				// simulator reports "booted" but is still in Booting state internally
 				// This prevents "Unable to lookup in current state: Booting" errors
-				TestSimulator.WaitForBootComplete();
+				if (!TestSimulator.WaitForBootComplete())
+				{
+					throw new InvalidOperationException(
+						$"Simulator failed to fully boot within timeout. " +
+						$"Target: {TestSimulator.XHarnessID}, UDID: {TestSimulator.GetUDID()}");
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes iOS integration test failures that have been occurring since Jan 23, 2026 on the `main` branch.

### Root Cause

When launching iOS apps via XHarness/mlaunch, a race condition occurs where the simulator reports as "booted" but is still internally in the "Booting" state. This causes app launch to fail with:

```
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=405):
Unable to lookup in current state: Booting

error HE0042: Could not launch the app on the device: simctl returned exit code 149
```

### Fix

This PR adds a `WaitForBootComplete()` method to the `Simulator` class which uses `simctl bootstatus` to block until the simulator is fully booted before attempting to run tests. The `IOSSimulatorFixture` now calls this method after launching the simulator.

### Affected Tests

- `RunOniOS_MauiDebug`
- `RunOniOS_MauiRelease`
- `RunOniOS_MauiReleaseTrimFull`
- `RunOniOS_BlazorDebug`
- `RunOniOS_BlazorRelease`
- `RunOniOS_MauiNativeAOT`

### Changes

- Added `Simulator.WaitForBootComplete()` method in `Apple/Simulator.cs`
- Updated `IOSSimulatorFixture` constructor to call `WaitForBootComplete()` after `Launch()`
