### PR TITLE
Add critical rule: agents must NEVER approve/request-changes on PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,6 +242,7 @@ Skills are modular capabilities that can be invoked directly or used by agents. 
    - **Trigger phrases**: "finalize PR #XXXXX", "check PR description for #XXXXX", "review commit message"
    - **Used by**: Before merging any PR, when description may be stale
    - **Note**: Does NOT require agent involvement or session markdown - works on any PR
+   - **🚨 CRITICAL**: NEVER use `--approve` or `--request-changes` - only post comments. Approval is a human decision.
 
 4. **learn-from-pr** (`.github/skills/learn-from-pr/SKILL.md`)
    - **Purpose**: Analyzes completed PR to identify repository improvements (analysis only, no changes applied)

--- a/.github/skills/pr-finalize/SKILL.md
+++ b/.github/skills/pr-finalize/SKILL.md
@@ -9,6 +9,24 @@ Ensures PR title and description accurately reflect the implementation for a goo
 
 **Standalone skill** - Can be used on any PR, not just PRs created by the pr agent.
 
+---
+
+## 🚨 CRITICAL: NEVER Approve or Request Changes
+
+**AI agents must NEVER use `--approve` or `--request-changes` flags.**
+
+| Action | Allowed? | Why |
+|--------|----------|-----|
+| `gh pr review --approve` | ❌ **NEVER** | Approval is a human decision |
+| `gh pr review --request-changes` | ❌ **NEVER** | Blocking PRs is a human decision |
+
+**Only humans can approve or block PRs.** The agent's role is to:
+1. Analyze and provide findings
+2. Post comments with recommendations
+3. Let humans make the final decision
+
+---
+
 ## Core Principle: Preserve Quality
 
 **Review existing description BEFORE suggesting changes.** Many PR authors write excellent, detailed descriptions. Your job is to:


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Adds a critical safety rule to the `pr-finalize` skill: **AI agents must NEVER use `--approve` or `--request-changes` flags** when reviewing PRs.

#### Why This Matters

During testing of PR #33861, an AI agent mistakenly ran `gh pr review --approve`, which is inappropriate because:
- **Approval is a human decision** - only humans should approve PRs
- **Blocking PRs is a human decision** - only humans should request changes
- **AI agents provide analysis, not judgment** - the agent role is to post findings as comments

#### Changes Made

| File | Changes |
|------|---------|
| `.github/skills/pr-finalize/SKILL.md` | Added prominent warning section at top with allowed/forbidden actions table |
| `.github/copilot-instructions.md` | Added CRITICAL note to skill description |

#### New Warning Section

```markdown
## 🚨 CRITICAL: NEVER Approve or Request Changes

| Action | Allowed? | Why |
|--------|----------|-----|
| `gh pr review --approve` | ❌ **NEVER** | Approval is a human decision |
| `gh pr review --request-changes` | ❌ **NEVER** | Blocking PRs is a human decision |
```

### Issues Fixed

N/A - Safety improvement to agent workflow