### PR TITLE
[Android] Essentials: Cancel pending picker tasks when IntermediateActivity is destroyed in SingleTask mode

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33706.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33706.cs
@@ -1,0 +1,82 @@
+using Microsoft.Maui.Media;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33706, "MediaPicker gets stuck if LaunchMode is SingleTask", PlatformAffected.Android)]
+public class Issue33706 : ContentPage
+{
+	private readonly ActivityIndicator _activityIndicator;
+	private readonly Label _statusLabel;
+
+	public Issue33706()
+	{
+		var pickButton = new Button
+		{
+			Text = "Pick Media",
+			AutomationId = "PickMediaButton"
+		};
+		pickButton.Clicked += OnPickMediaClicked;
+
+		_activityIndicator = new ActivityIndicator
+		{
+			AutomationId = "MediaPickerIndicator",
+			IsVisible = false,
+			IsRunning = false
+		};
+
+		_statusLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = "StatusLabel",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 20,
+			Children =
+			{
+				new Label
+				{
+					Text = "Test MediaPicker with LaunchMode.SingleTask",
+					FontSize = 18,
+					HorizontalOptions = LayoutOptions.Center
+				},
+				pickButton,
+				_activityIndicator,
+				_statusLabel
+			}
+		};
+	}
+
+	private async void OnPickMediaClicked(object sender, EventArgs e)
+	{
+		try
+		{
+			_activityIndicator.IsRunning = true;
+			_activityIndicator.IsVisible = true;
+			_statusLabel.Text = "Picking...";
+
+			var result = await MediaPicker.PickPhotoAsync();
+
+			_activityIndicator.IsRunning = false;
+			_activityIndicator.IsVisible = false;
+
+			if (result != null)
+			{
+				_statusLabel.Text = "Photo picked";
+			}
+			else
+			{
+				_statusLabel.Text = "Cancelled";
+			}
+		}
+		catch (Exception ex)
+		{
+			_activityIndicator.IsRunning = false;
+			_activityIndicator.IsVisible = false;
+			_statusLabel.Text = $"Error: {ex.Message}";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33706.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33706.cs
@@ -7,6 +7,7 @@ public class Issue33706 : ContentPage
 {
 	private readonly ActivityIndicator _activityIndicator;
 	private readonly Label _statusLabel;
+	private readonly Label _resumedLabel;
 
 	public Issue33706()
 	{
@@ -31,6 +32,12 @@ public class Issue33706 : ContentPage
 			HorizontalOptions = LayoutOptions.Center
 		};
 
+		_resumedLabel = new Label
+		{
+    		Text = "",
+    		AutomationId = "ResumedLabel"
+		};
+
 		Content = new VerticalStackLayout
 		{
 			Padding = 20,
@@ -45,8 +52,13 @@ public class Issue33706 : ContentPage
 				},
 				pickButton,
 				_activityIndicator,
-				_statusLabel
+				_statusLabel,
+				_resumedLabel
 			}
+		};
+		this.Loaded += (s, e) =>
+		{
+    		this.Window.Resumed += (s, e) => _resumedLabel.Text = "Resumed";
 		};
 	}
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33706.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33706.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			var initialStatus = App.FindElement("StatusLabel").GetText();
 			Assert.That(initialStatus, Is.EqualTo("Ready"), "Initial status should be 'Ready'");
 			App.Tap("PickMediaButton");
-			Task.Delay(1500).Wait();
+			Task.Delay(500).Wait();
 			App.BackgroundApp();
 			// Wait for app to background and resume
-			Task.Delay(2000).Wait();
+			Task.Delay(500).Wait();
 			App.ForegroundApp();
 			App.WaitForElement("StatusLabel");
 			App.WaitForElement("PickMediaButton");

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33706.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33706.cs
@@ -1,0 +1,37 @@
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue33706 : _IssuesUITest
+	{
+		public override string Issue => "MediaPicker gets stuck if LaunchMode is SingleTask";
+
+		public Issue33706(TestDevice device) : base(device) { }
+
+		[Test]
+		[Category(UITestCategories.LifeCycle)]
+		public void Issue33706Test()
+		{
+			// Wait for the page to load
+			App.WaitForElement("PickMediaButton");
+			App.WaitForElement("StatusLabel");
+			var initialStatus = App.FindElement("StatusLabel").GetText();
+			Assert.That(initialStatus, Is.EqualTo("Ready"), "Initial status should be 'Ready'");
+			App.Tap("PickMediaButton");
+			Task.Delay(1500).Wait();
+			App.BackgroundApp();
+			// Wait for app to background and resume
+			Task.Delay(2000).Wait();
+			App.ForegroundApp();
+			App.WaitForElement("StatusLabel");
+			App.WaitForElement("PickMediaButton");
+			var finalStatus = App.FindElement("StatusLabel").GetText();
+			Assert.That(finalStatus, Is.Not.EqualTo("Picking..."), 
+				"Status should not still be 'Picking...' after returning from background - this indicates MediaPicker async call is stuck");
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33706.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33706.cs
@@ -21,11 +21,9 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			var initialStatus = App.FindElement("StatusLabel").GetText();
 			Assert.That(initialStatus, Is.EqualTo("Ready"), "Initial status should be 'Ready'");
 			App.Tap("PickMediaButton");
-			Task.Delay(500).Wait();
 			App.BackgroundApp();
-			// Wait for app to background and resume
-			Task.Delay(500).Wait();
 			App.ForegroundApp();
+			App.WaitForElement("ResumedLabel");
 			App.WaitForElement("StatusLabel");
 			App.WaitForElement("PickMediaButton");
 			var finalStatus = App.FindElement("StatusLabel").GetText();

--- a/src/Essentials/src/Platform/IntermediateActivity.android.cs
+++ b/src/Essentials/src/Platform/IntermediateActivity.android.cs
@@ -104,11 +104,10 @@ namespace Microsoft.Maui.ApplicationModel
 			// (it won't exist if OnActivityResult already processed it)
 			if (GetIntermediateTask(guid, true) is IntermediateTask task)
 			{
-				// Only cancel picker tasks (FilePicker, MediaPicker, MediaCapture)
-				// Other tasks like WebAuthenticator may have different behavior expectations
 				if (task.RequestCode == PlatformUtils.requestCodeFilePicker ||
 					task.RequestCode == PlatformUtils.requestCodeMediaPicker ||
-					task.RequestCode == PlatformUtils.requestCodeMediaCapture)
+					task.RequestCode == PlatformUtils.requestCodeMediaCapture ||
+					task.RequestCode == PlatformUtils.requestCodePickContact)
 				{
 					task.TaskCompletionSource.TrySetCanceled();
 				}

--- a/src/Essentials/src/Platform/IntermediateActivity.android.cs
+++ b/src/Essentials/src/Platform/IntermediateActivity.android.cs
@@ -96,13 +96,32 @@ namespace Microsoft.Maui.ApplicationModel
 			}
 		}
 
+		protected override void OnDestroy()
+		{
+			base.OnDestroy();
+
+			// Cancel the task if it still exists
+			// (it won't exist if OnActivityResult already processed it)
+			if (GetIntermediateTask(guid, true) is IntermediateTask task)
+			{
+				// Only cancel picker tasks (FilePicker, MediaPicker, MediaCapture)
+				// Other tasks like WebAuthenticator may have different behavior expectations
+				if (task.RequestCode == PlatformUtils.requestCodeFilePicker ||
+					task.RequestCode == PlatformUtils.requestCodeMediaPicker ||
+					task.RequestCode == PlatformUtils.requestCodeMediaCapture)
+				{
+					task.TaskCompletionSource.TrySetCanceled();
+				}
+			}
+		}
+
 		public static Task<Intent> StartAsync(Intent intent, int requestCode, Action<Intent>? onCreate = null, Action<Intent>? onResult = null)
 		{
 			// make sure we have the activity
 			var activity = ActivityStateManager.Default.GetCurrentActivity(true)!;
 
 			// create a new task
-			var data = new IntermediateTask(onCreate, onResult);
+			var data = new IntermediateTask(requestCode, onCreate, onResult);
 			pendingTasks[data.Id] = data;
 
 			// create the intermediate intent, and add the real intent to it
@@ -134,9 +153,10 @@ namespace Microsoft.Maui.ApplicationModel
 
 		class IntermediateTask
 		{
-			public IntermediateTask(Action<Intent>? onCreate, Action<Intent>? onResult)
+			public IntermediateTask(int requestCode, Action<Intent>? onCreate, Action<Intent>? onResult)
 			{
 				Id = Guid.NewGuid().ToString();
+				RequestCode = requestCode;
 				TaskCompletionSource = new TaskCompletionSource<Intent>();
 
 				OnCreate = onCreate;
@@ -144,6 +164,8 @@ namespace Microsoft.Maui.ApplicationModel
 			}
 
 			public string Id { get; }
+			
+			public int RequestCode { get; }
 
 			public TaskCompletionSource<Intent> TaskCompletionSource { get; }
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


### Issue Details:

In SingleTask launch mode the application is hang when open the file picker / media picker and presses the home button and return back to app in android platform. 
        
### Root Cause:

When an Android app uses SingleTask launch mode and the user opens a picker (FilePicker, MediaPicker, ContactPicker or MediaCapture), the picker UI runs in a separate IntermediateActivity. If the main activity gets recreated while the picker is open (e.g., due to a deep link, notification tap, or system killing the activity for memory), the IntermediateActivity is destroyed without calling OnActivityResult. This leaves the pending TaskCompletionSource in the IntermediateActivity.pendingTasks dictionary forever unresolved, causing the await FilePicker.PickAsync() or await MediaPicker.PickPhotoAsync() call to hang indefinitely. The app appears frozen because the async operation never completes.

### Description of Change:

When the activity is destroyed and the task hasn't been processed by OnActivityResult, the OnDestroy method now invokes an optional callback and cancels the TaskCompletionSource by calling TrySetCanceled(). This cancellation is specifically limited to picker-related tasks (FilePicker, MediaPicker, MediaCapture, ContactPicker) 

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #33706    

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/0f6c1695-a88e-4ea7-b3cd-f84234651d6f" Width="300" Height="600">   |    <Video src="https://github.com/user-attachments/assets/40b4d0b0-3f88-4b5a-816a-82581f164ba2" Width="300" Height="600">  |
