### PR TITLE
[Android] Fixed PointerGestureRecognizer not triggering PointerMoved event

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
+++ b/src/Controls/src/Core/Platform/Android/TapAndPanGestureDetector.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return true;
 
 			if (_pointerGestureHandler != null && ev?.Action is
-				MotionEventActions.Up or MotionEventActions.Down or MotionEventActions.Cancel)
+				MotionEventActions.Up or MotionEventActions.Down or MotionEventActions.Move or MotionEventActions.Cancel)
 			{
 				_pointerGestureHandler.OnTouch(ev);
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33690.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33690.cs
@@ -1,0 +1,91 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33690, "PointerGestureRecognizer does not fire off PointerMove event on Android", PlatformAffected.Android)]
+public class Issue33690 : ContentPage
+{
+	Label pointerPressedLabel;
+	Label pointerMovedLabel;
+	Label pointerReleasedLabel;
+	int pressedCount = 0;
+	int movedCount = 0;
+	int releasedCount = 0;
+
+	public Issue33690()
+	{
+		InitializeUI();
+	}
+
+	private void InitializeUI()
+	{
+		var stackLayout = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = 10
+		};
+
+		var instructionLabel = new Label
+		{
+			Text = "Tap and drag on the image below. All three event counters should increment.",
+			AutomationId = "InstructionLabel"
+		};
+
+		pointerPressedLabel = new Label
+		{
+			Text = $"Pointer Pressed: {pressedCount}",
+			AutomationId = "PointerPressedLabel"
+		};
+
+		pointerMovedLabel = new Label
+		{
+			Text = $"Pointer Moved: {movedCount}",
+			AutomationId = "PointerMovedLabel"
+		};
+
+		pointerReleasedLabel = new Label
+		{
+			Text = $"Pointer Released: {releasedCount}",
+			AutomationId = "PointerReleasedLabel"
+		};
+
+		var testImage = new Image
+		{
+			Source = "dotnet_bot.png",
+			WidthRequest = 300,
+			HeightRequest = 300,
+			BackgroundColor = Colors.LightGray,
+			AutomationId = "TestImage"
+		};
+
+		var pointerGestureRecognizer = new PointerGestureRecognizer();
+		pointerGestureRecognizer.PointerPressed += OnPointerPressed;
+		pointerGestureRecognizer.PointerMoved += OnPointerMoved;
+		pointerGestureRecognizer.PointerReleased += OnPointerReleased;
+		testImage.GestureRecognizers.Add(pointerGestureRecognizer);
+
+		stackLayout.Children.Add(instructionLabel);
+		stackLayout.Children.Add(pointerPressedLabel);
+		stackLayout.Children.Add(pointerMovedLabel);
+		stackLayout.Children.Add(pointerReleasedLabel);
+		stackLayout.Children.Add(testImage);
+
+		Content = stackLayout;
+	}
+
+	private void OnPointerPressed(object sender, PointerEventArgs e)
+	{
+		pressedCount++;
+		pointerPressedLabel.Text = $"Pointer Pressed: {pressedCount}";
+	}
+
+	private void OnPointerMoved(object sender, PointerEventArgs e)
+	{
+		movedCount++;
+		pointerMovedLabel.Text = $"Pointer Moved: {movedCount}";
+	}
+
+	private void OnPointerReleased(object sender, PointerEventArgs e)
+	{
+		releasedCount++;
+		pointerReleasedLabel.Text = $"Pointer Released: {releasedCount}";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33690.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33690.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33690 : _IssuesUITest
+{
+	public Issue33690(TestDevice device) : base(device) { }
+
+	public override string Issue => "PointerGestureRecognizer does not fire off PointerMove event on Android";
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void PointerMovedEventShouldFireOnAndroid()
+	{
+		App.WaitForElement("TestImage");
+		var pressedLabel = App.FindElement("PointerPressedLabel");
+		var movedLabel = App.FindElement("PointerMovedLabel");
+		var releasedLabel = App.FindElement("PointerReleasedLabel");
+		Assert.That(pressedLabel.GetText(), Is.EqualTo("Pointer Pressed: 0"));
+		Assert.That(movedLabel.GetText(), Is.EqualTo("Pointer Moved: 0"));
+		Assert.That(releasedLabel.GetText(), Is.EqualTo("Pointer Released: 0"));
+		var imageRect = App.WaitForElement("TestImage").GetRect();
+		var startX = imageRect.X + (imageRect.Width / 4);
+		var startY = imageRect.Y + (imageRect.Height / 4);
+		var endX = imageRect.X + (imageRect.Width * 3 / 4);
+		var endY = imageRect.Y + (imageRect.Height * 3 / 4);
+
+		App.DragCoordinates(startX, startY, endX, endY);
+		pressedLabel = App.FindElement("PointerPressedLabel");
+		movedLabel = App.FindElement("PointerMovedLabel");
+		releasedLabel = App.FindElement("PointerReleasedLabel");
+		Assert.That(pressedLabel.GetText(), Does.Not.EqualTo("Pointer Pressed: 0"),
+			"PointerPressed event should have fired");
+		Assert.That(movedLabel.GetText(), Does.Not.EqualTo("Pointer Moved: 0"),
+			"PointerMoved event should have fired");
+		Assert.That(releasedLabel.GetText(), Does.Not.EqualTo("Pointer Released: 0"),
+			"PointerReleased event should have fired");
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

The pointer moved event is not triggered of the PointerGestureRecognizer on Android platform. 
        
### Root Cause:

The PointerGestureRecognizer.PointerMoved event was not firing on Android because the TapAndPanGestureDetector.OnTouchEvent() method had an incomplete pattern match that was filtering out Move events.
 
The gesture detector was only forwarding touch events to the pointer gesture handler for these actions:
     - MotionEventActions.Up (finger released)
     - MotionEventActions.Down (finger pressed)
     - MotionEventActions.Cancel (gesture cancelled)
 
   Missing Elements: MotionEventActions.Move (finger moved while pressed)

### Description of Change:

Added MotionEventActions.Move to the pattern, the gesture detector now:
     - Captures move events from Android's touch system
     - Routes them to _pointerGestureHandler.OnTouch()
     - The handler processes them and fires the PointerMoved event.

**Tested the behavior in the following platforms:**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #33690     

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/cb3a1f4e-b3fc-4815-bc99-fecd4ddcb158" Width="300" Height="600">   |    <Video src="https://github.com/user-attachments/assets/fcea1f0c-ca82-4863-a48b-e89cd185e0bc" Width="300" Height="600">  |
