### PR TITLE
Fix build.ps1 to propagate exit codes

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -112,6 +112,7 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
 
 Write-Host "& `"$PSScriptRoot/common/build.ps1`" $arguments"
 Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $arguments"
+$buildExitCode = $LASTEXITCODE
 
 
 # Perform code coverage as the last operation, this enables the following scenarios:
@@ -143,4 +144,8 @@ if ($testCoverage) {
   }
 }
 
+# Exit with the build exit code (don't always exit 0)
+if ($buildExitCode -ne 0) {
+  exit $buildExitCode
+}
 exit 0

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -450,8 +450,8 @@ stages:
           - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
             displayName: 'Add .NET to PATH'
 
-          # Build BuildTasks first
-          - script: ./build.cmd -build -configuration Release -projects Microsoft.Maui.BuildTasks.slnf
+          # Build BuildTasks first (need -restore to ensure SDK is available)
+          - script: ./build.cmd -restore -build -configuration Release -projects Microsoft.Maui.BuildTasks.slnf
             displayName: Build the MSBuild Tasks
 
           # Build Windows device tests using Cake script (Packaged/MSIX builds)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes an issue where `eng/build.ps1` always exited with code 0 regardless of whether the underlying build succeeded or failed. This caused Azure Pipelines to show steps as "succeeded" even when they failed.

### Problem

When running `./build.cmd -build` (without `-restore`), if the .NET SDK is not found, the script would:
1. Print "Unable to find dotnet with SDK version..."
2. Call `ExitWithExitCode 1` in `tools.ps1`
3. But `eng/build.ps1` would still exit with 0 (line 146: `exit 0`)

This caused Azure Pipelines to show the step as green/succeeded when it should have been red/failed.

### Fix

- Capture `$LASTEXITCODE` after `Invoke-Expression` call to `common/build.ps1`
- Use the captured exit code instead of always exiting 0

### Testing

This fix was identified while investigating Windows Helix device test failures where the "Build the MSBuild Tasks" step was showing as succeeded but had actually failed to find the SDK.

Build with the issue: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1279950
