### PR TITLE
Fix Android emulator boot: launch once in fixture, not per-test

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AndroidTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AndroidTemplateTests.cs
@@ -17,10 +17,11 @@ namespace Microsoft.Maui.IntegrationTests
 	public class AndroidEmulatorFixture : IDisposable
 	{
 		public Emulator TestAvd { get; } = new Emulator();
+		private readonly string _emulatorLogPath;
 
 		public AndroidEmulatorFixture()
 		{
-			// One-time setup: prepare Android emulator
+			// One-time setup: prepare and launch Android emulator
 			if (TestEnvironment.IsMacOS && RuntimeInformation.OSArchitecture == Architecture.Arm64)
 				TestAvd.Abi = "arm64-v8a";
 
@@ -29,6 +30,11 @@ namespace Microsoft.Maui.IntegrationTests
 			
 			if (!TestAvd.InstallAvd(out var installOutput))
 				throw new Exception($"Failed to install Test AVD.\n{installOutput}");
+
+			// Launch the emulator once for all tests in this collection
+			_emulatorLogPath = Path.Combine(TestEnvironment.GetLogDirectory(), $"emulator-launch-{DateTime.UtcNow.ToFileTimeUtc()}.log");
+			if (!TestAvd.LaunchAndWaitForAvd(600, _emulatorLogPath))
+				throw new Exception($"Failed to launch Test AVD. See log: {_emulatorLogPath}");
 		}
 
 		public void Dispose()
@@ -57,11 +63,7 @@ namespace Microsoft.Maui.IntegrationTests
 			: base(fixture, output)
 		{
 			_emulatorFixture = emulatorFixture;
-			
-			// Per-test setup: launch emulator
-			var emulatorLog = Path.Combine(TestDirectory, $"emulator-launch-{DateTime.UtcNow.ToFileTimeUtc()}.log");
-			if (!_emulatorFixture.TestAvd.LaunchAndWaitForAvd(600, emulatorLog))
-				throw new Exception("Failed to launch Test AVD.");
+			// Emulator is already launched by the fixture - no per-test launch needed
 		}
 
 		public override void Dispose()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

The Android integration tests (`RunOnAndroid`) were failing with "Failed to launch Test AVD" because the emulator was being launched in every test's constructor instead of once in the shared fixture.

**Root Cause:**
The `AndroidTemplateTests` constructor was calling `LaunchAndWaitForAvd()` for each test, which caused:
1. Multiple attempts to launch the same emulator 
2. Possible race conditions between tests
3. Each test waiting 600 seconds for an emulator that may have already failed to boot in a previous test

**Fix:**
Moved the emulator launch from the test constructor to `AndroidEmulatorFixture` constructor (one-time setup), matching how `IOSSimulatorFixture` handles the simulator.

The collection fixture now:
1. Accepts SDK licenses
2. Installs the AVD
3. **Launches and waits for the emulator to boot (NEW)**

Individual tests no longer attempt to launch the emulator - they use the already-running emulator from the shared fixture.

### Issues Fixed
Fixes Android integration test failures on CI