### PR TITLE
Skip flaky BlazorWebView header interception test

### DIFF
--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.RequestInterception.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.RequestInterception.cs
@@ -154,7 +154,7 @@ public partial class BlazorWebViewTests
 			Assert.Equal("Hello Matthew (param1=value1, param2=value2)", responseObject.message);
 		});
 
-	[Theory]
+	[Theory(Skip = "Flaky due to external service dependency (echo.free.beeceptor.com). See https://github.com/dotnet/maui/issues/33927")]
 #if !ANDROID // Custom schemes are not supported on Android
 #if !WINDOWS // TODO: There seems to be a bug with the implementation in the WASDK version of WebView2
 	[InlineData("app://echoservice/")]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Skips the flaky `RequestsCanBeInterceptedAndHeadersAddedForDifferentHosts` BlazorWebView device test which depends on an external echo service (`echo.free.beeceptor.com`), making it unreliable in CI.

The test failed on CoreCLR MacCatalyst with `Assert.NotNull() Failure: Value is null` while passing on Mono MacCatalyst in the same build:
- **Build**: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1282686&view=ms.vss-test-web.build-test-results-tab&runId=35819496&resultId=100136&paneView=debug

## Issues Fixed

Related #33927