### PR TITLE
Add Custom Pin Icons support for Maps

### DIFF
--- a/src/Controls/Maps/src/HandlerImpl/Pin.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Pin.Impl.cs
@@ -4,5 +4,9 @@ namespace Microsoft.Maui.Controls.Maps
 {
 	public partial class Pin : IMapPin
 	{
+		/// <summary>
+		/// Explicit implementation of IMapPin.ImageSource to convert from ImageSource to IImageSource.
+		/// </summary>
+		IImageSource? IMapPin.ImageSource => ImageSource;
 	}
 }

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Maui.Controls.Maps
 		/// </summary>
 		/// <remarks>
 		/// Supported image sources include file-based images, embedded resources, URIs, and streams.
-		/// The image will be displayed at its natural size; consider using appropriately sized images.
+		/// The image will be scaled by the underlying platform to a platform-defined size (32x32 points on iOS, 64x64 pixels on Android).
+		/// Provide images that look clear when scaled to these sizes.
 		/// </remarks>
 		public ImageSource? ImageSource
 		{

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Maui.Controls.Maps
 		/// <summary>Bindable property for <see cref="ClusteringIdentifier"/>.</summary>
 		public static readonly BindableProperty ClusteringIdentifierProperty = BindableProperty.Create(nameof(ClusteringIdentifier), typeof(string), typeof(Pin), DefaultClusteringIdentifier);
 
+		/// <summary>Bindable property for <see cref="ImageSource"/>.</summary>
+		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create(nameof(ImageSource), typeof(ImageSource), typeof(Pin), default(ImageSource));
+
 		private object? _markerId;
 
 		/// <inheritdoc />
@@ -79,6 +82,21 @@ namespace Microsoft.Maui.Controls.Maps
 		{
 			get { return (PinType)GetValue(TypeProperty); }
 			set { SetValue(TypeProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the custom image source for this pin's icon.
+		/// When set, this image will be used instead of the default platform pin icon.
+		/// This is a bindable property.
+		/// </summary>
+		/// <remarks>
+		/// Supported image sources include file-based images, embedded resources, URIs, and streams.
+		/// The image will be displayed at its natural size; consider using appropriately sized images.
+		/// </remarks>
+		public ImageSource? ImageSource
+		{
+			get { return (ImageSource?)GetValue(ImageSourceProperty); }
+			set { SetValue(ImageSourceProperty, value); }
 		}
 
 		/// <summary>

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -18,6 +18,8 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
+Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
@@ -26,3 +28,4 @@ static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Mau
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
+             x:Class="Maui.Controls.Sample.Pages.MapsGalleries.CustomPinIconGallery"
+             Title="Custom Pin Icons">
+    <Grid RowDefinitions="Auto,*">
+        <StackLayout Orientation="Horizontal" Padding="10" Spacing="10">
+            <Button Text="Add Custom Pins" Clicked="OnAddCustomPinsClicked"/>
+            <Button Text="Add Default Pin" Clicked="OnAddDefaultPinClicked"/>
+            <Button Text="Clear" Clicked="OnClearClicked"/>
+        </StackLayout>
+        
+        <maps:Map x:Name="CustomPinMap" Grid.Row="1"/>
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
@@ -18,7 +18,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 
 		void OnAddCustomPinsClicked(object sender, EventArgs e)
 		{
-			// Add pin with custom icon from embedded resource
+			// Add pin with custom icon from an image file in the app bundle
 			var customPin1 = new Pin
 			{
 				Label = "Custom Icon Pin",

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
@@ -1,0 +1,60 @@
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Devices.Sensors;
+using Microsoft.Maui.Maps;
+
+namespace Maui.Controls.Sample.Pages.MapsGalleries
+{
+	public partial class CustomPinIconGallery : ContentPage
+	{
+		public CustomPinIconGallery()
+		{
+			InitializeComponent();
+			
+			// Center on Seattle
+			CustomPinMap.MoveToRegion(MapSpan.FromCenterAndRadius(
+				new Location(47.6062, -122.3321),
+				Distance.FromMiles(5)));
+		}
+
+		void OnAddCustomPinsClicked(object sender, EventArgs e)
+		{
+			// Add pin with custom icon from embedded resource
+			var customPin1 = new Pin
+			{
+				Label = "Custom Icon Pin",
+				Address = "Using embedded image",
+				Location = new Location(47.6062, -122.3321),
+				ImageSource = ImageSource.FromFile("dotnet_bot.png")
+			};
+			CustomPinMap.Pins.Add(customPin1);
+
+			// Add another custom pin at different location
+			var customPin2 = new Pin
+			{
+				Label = "Another Custom Pin",
+				Address = "Also using custom image",
+				Location = new Location(47.62, -122.35),
+				ImageSource = ImageSource.FromFile("dotnet_bot.png")
+			};
+			CustomPinMap.Pins.Add(customPin2);
+		}
+
+		void OnAddDefaultPinClicked(object sender, EventArgs e)
+		{
+			// Add a regular pin without custom icon for comparison
+			var defaultPin = new Pin
+			{
+				Label = "Default Pin",
+				Address = "Standard marker icon",
+				Location = new Location(47.59, -122.31),
+				Type = PinType.Place
+			};
+			CustomPinMap.Pins.Add(defaultPin);
+		}
+
+		void OnClearClicked(object sender, EventArgs e)
+		{
+			CustomPinMap.Pins.Clear();
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Maps;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
@@ -22,7 +22,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			var customPin1 = new Pin
 			{
 				Label = "Custom Icon Pin",
-				Address = "Using embedded image",
+				Address = "Using app bundle image",
 				Location = new Location(47.6062, -122.3321),
 				ImageSource = ImageSource.FromFile("dotnet_bot.png")
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CustomPinIconGallery.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
@@ -13,18 +14,18 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			
 			// Center on Seattle
 			CustomPinMap.MoveToRegion(MapSpan.FromCenterAndRadius(
-				new Location(47.6062, -122.3321),
+				new Microsoft.Maui.Devices.Sensors.Location(47.6062, -122.3321),
 				Distance.FromMiles(5)));
 		}
 
-		void OnAddCustomPinsClicked(object sender, EventArgs e)
+		void OnAddCustomPinsClicked(object? sender, EventArgs e)
 		{
 			// Add pin with custom icon from an image file in the app bundle
 			var customPin1 = new Pin
 			{
 				Label = "Custom Icon Pin",
 				Address = "Using app bundle image",
-				Location = new Location(47.6062, -122.3321),
+				Location = new Microsoft.Maui.Devices.Sensors.Location(47.6062, -122.3321),
 				ImageSource = ImageSource.FromFile("dotnet_bot.png")
 			};
 			CustomPinMap.Pins.Add(customPin1);
@@ -34,26 +35,26 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			{
 				Label = "Another Custom Pin",
 				Address = "Also using custom image",
-				Location = new Location(47.62, -122.35),
+				Location = new Microsoft.Maui.Devices.Sensors.Location(47.62, -122.35),
 				ImageSource = ImageSource.FromFile("dotnet_bot.png")
 			};
 			CustomPinMap.Pins.Add(customPin2);
 		}
 
-		void OnAddDefaultPinClicked(object sender, EventArgs e)
+		void OnAddDefaultPinClicked(object? sender, EventArgs e)
 		{
 			// Add a regular pin without custom icon for comparison
 			var defaultPin = new Pin
 			{
 				Label = "Default Pin",
 				Address = "Standard marker icon",
-				Location = new Location(47.59, -122.31),
+				Location = new Microsoft.Maui.Devices.Sensors.Location(47.59, -122.31),
 				Type = PinType.Place
 			};
 			CustomPinMap.Pins.Add(defaultPin);
 		}
 
-		void OnClearClicked(object sender, EventArgs e)
+		void OnClearClicked(object? sender, EventArgs e)
 		{
 			CustomPinMap.Pins.Clear();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -18,6 +18,8 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Map Pins", () => new MapPinsGallery(), Navigation),
 						GalleryBuilder.NavButton("Pins ItemsSource", () => new PinItemsSourceGallery(), Navigation),
 						GalleryBuilder.NavButton("Pin Clustering", () => new ClusteringGallery(), Navigation),
+
+						GalleryBuilder.NavButton("Custom Pin Icons", () => new CustomPinIconGallery(), Navigation),
 						GalleryBuilder.NavButton("Circle", () => new CircleGallery(), Navigation),
 						GalleryBuilder.NavButton("Polygon", () => new PolygonsGallery(), Navigation),
 						GalleryBuilder.NavButton("Element Visibility & ZIndex", () => new MapElementVisibilityGallery(), Navigation),

--- a/src/Controls/tests/Core.UnitTests/PinTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PinTests.cs
@@ -114,5 +114,64 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(signaled);
 		}
+
+		[Fact]
+		public void ImageSourceDefaultsToNull()
+		{
+			var pin = new Pin();
+			Assert.Null(pin.ImageSource);
+		}
+
+		[Fact]
+		public void ImageSourceCanBeSet()
+		{
+			var pin = new Pin
+			{
+				ImageSource = ImageSource.FromFile("test.png")
+			};
+
+			Assert.NotNull(pin.ImageSource);
+			Assert.IsType<FileImageSource>(pin.ImageSource);
+		}
+
+		[Fact]
+		public void ImageSourcePropertyChanged()
+		{
+			var pin = new Pin();
+
+			bool signaled = false;
+			pin.PropertyChanged += (sender, args) =>
+			{
+				if (args.PropertyName == "ImageSource")
+					signaled = true;
+			};
+
+			pin.ImageSource = ImageSource.FromFile("test.png");
+
+			Assert.True(signaled);
+		}
+
+		[Fact]
+		public void ImageSourceBindableProperty()
+		{
+			var pin = new Pin();
+			pin.SetValue(Pin.ImageSourceProperty, ImageSource.FromFile("bound.png"));
+
+			Assert.NotNull(pin.ImageSource);
+			Assert.IsType<FileImageSource>(pin.ImageSource);
+		}
+
+		[Fact]
+		public void IMapPinImageSourceReturnsValue()
+		{
+			var pin = new Pin
+			{
+				ImageSource = ImageSource.FromFile("test.png")
+			};
+
+			// Access through interface to test explicit implementation
+			var mapPin = (Microsoft.Maui.Maps.IMapPin)pin;
+			Assert.NotNull(mapPin.ImageSource);
+		}
 	}
 }

--- a/src/Core/maps/src/Core/IMapPin.cs
+++ b/src/Core/maps/src/Core/IMapPin.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Maui.Maps
 		object? MarkerId { get; set; }
 
 		/// <summary>
+		/// Gets the custom image source for this pin's icon.
+		/// </summary>
+		/// <remarks>When set, this image will be used instead of the default platform pin icon.</remarks>
+		IImageSource? ImageSource { get; }
+
+		/// <summary>
 		/// Sends a marker click event.
 		/// </summary>
 		/// <returns><see langword="true"/> if the info window should be hidden; otherwise, <see langword="false"/>.</returns>

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -24,6 +24,10 @@ using ARect = Android.Graphics.Rect;
 using ACircle = Android.Gms.Maps.Model.Circle;
 using APolygon = Android.Gms.Maps.Model.Polygon;
 using APolyline = Android.Gms.Maps.Model.Polyline;
+using ABitmap = Android.Graphics.Bitmap;
+using ACanvas = Android.Graphics.Canvas;
+using ADrawable = Android.Graphics.Drawables.Drawable;
+using ABitmapDrawable = Android.Graphics.Drawables.BitmapDrawable;
 using Math = System.Math;
 
 namespace Microsoft.Maui.Maps.Handlers
@@ -666,21 +670,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			foreach (var p in pins)
 			{
 				IMapPin pin = (IMapPin)p;
-				Marker? marker;
-
-				var pinHandler = pin.ToHandler(MauiContext);
-				if (pinHandler is IMapPinHandler iMapPinHandler)
-				{
-					marker = Map.AddMarker(iMapPinHandler.PlatformView);
-					if (marker == null)
-					{
-						throw new System.Exception("Map.AddMarker returned null");
-					}
-					// associate pin with marker for later lookup in event handlers
-					pin.MarkerId = marker.Id;
-					_markers.Add(marker!);
-				}
-
+				AddPinAsync(pin).FireAndForget();
 			}
 			_pins = null;
 		}
@@ -728,6 +718,92 @@ namespace Microsoft.Maui.Maps.Handlers
 			{
 				return null;
 			}
+
+		async System.Threading.Tasks.Task AddPinAsync(IMapPin pin)
+		{
+			if (Map == null || MauiContext == null)
+				return;
+
+			var pinHandler = pin.ToHandler(MauiContext);
+			if (pinHandler is not IMapPinHandler iMapPinHandler)
+				return;
+
+			var markerOptions = iMapPinHandler.PlatformView;
+
+			// Load custom image if specified
+			if (pin.ImageSource != null)
+			{
+				try
+				{
+					var result = await pin.ImageSource.GetPlatformImageAsync(MauiContext);
+					if (result?.Value is ADrawable drawable)
+					{
+						var bitmap = DrawableToBitmap(drawable);
+						if (bitmap != null)
+						{
+							markerOptions.SetIcon(BitmapDescriptorFactory.FromBitmap(bitmap));
+						}
+					}
+				}
+				catch
+				{
+					// If image loading fails, use default pin icon
+				}
+			}
+
+			var marker = Map.AddMarker(markerOptions);
+			if (marker == null)
+			{
+				throw new System.Exception("Map.AddMarker returned null");
+			}
+			// associate pin with marker for later lookup in event handlers
+			pin.MarkerId = marker.Id;
+			
+			if (_markers == null)
+				_markers = new List<Marker>();
+			_markers.Add(marker);
+		}
+
+		static ABitmap? DrawableToBitmap(ADrawable drawable)
+		{
+			if (drawable is ABitmapDrawable bitmapDrawable && bitmapDrawable.Bitmap != null)
+			{
+				return ScaleBitmap(bitmapDrawable.Bitmap, 64, 64);  // 64dp for Android (2x density)
+			}
+
+			int width = drawable.IntrinsicWidth;
+			int height = drawable.IntrinsicHeight;
+
+			if (width <= 0 || height <= 0)
+			{
+				width = 64;
+				height = 64;
+			}
+
+			var bitmap = ABitmap.CreateBitmap(width, height, ABitmap.Config.Argb8888!);
+			if (bitmap == null)
+				return null;
+
+			var canvas = new ACanvas(bitmap);
+			drawable.SetBounds(0, 0, canvas.Width, canvas.Height);
+			drawable.Draw(canvas);
+
+			return ScaleBitmap(bitmap, 64, 64);
+		}
+
+		static ABitmap ScaleBitmap(ABitmap source, int targetWidth, int targetHeight)
+		{
+			int width = source.Width;
+			int height = source.Height;
+
+			float widthRatio = (float)targetWidth / width;
+			float heightRatio = (float)targetHeight / height;
+			float ratio = Math.Min(widthRatio, heightRatio);
+
+			int newWidth = (int)(width * ratio);
+			int newHeight = (int)(height * ratio);
+
+			return ABitmap.CreateScaledBitmap(source, newWidth, newHeight, true)!;
 		}
 
 		protected IMapPin? GetPinForMarker(Marker marker)

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -751,7 +751,11 @@ namespace Microsoft.Maui.Maps.Handlers
 				}
 			}
 
-			var marker = Map.AddMarker(markerOptions);
+			// Re-check after async operation since handler may have been disconnected
+if (Map == null || MauiContext == null)
+return;
+
+var marker = Map.AddMarker(markerOptions);
 			if (marker == null)
 			{
 				throw new System.Exception("Map.AddMarker returned null");
@@ -768,7 +772,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		{
 			if (drawable is ABitmapDrawable bitmapDrawable && bitmapDrawable.Bitmap != null)
 			{
-				return ScaleBitmap(bitmapDrawable.Bitmap, 64, 64);  // 64dp for Android (2x density)
+				return ScaleBitmap(bitmapDrawable.Bitmap, 64, 64);  // 64x64 pixels
 			}
 
 			int width = drawable.IntrinsicWidth;

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Android.Gms.Common.Apis;
 using Android.Gms.Maps;
@@ -47,6 +48,8 @@ namespace Microsoft.Maui.Maps.Handlers
 		bool _isClusteringEnabled;
 		List<MapCluster>? _clusters;
 		Dictionary<string, MapCluster>? _clusterMarkers;
+
+		CancellationTokenSource? _addPinsCts;
 
 		public GoogleMap? Map { get; private set; }
 
@@ -602,6 +605,11 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (Map == null || MauiContext == null)
 				return;
 
+			// Cancel any previously running pin additions to avoid stale markers
+			_addPinsCts?.Cancel();
+			_addPinsCts = new CancellationTokenSource();
+			var ct = _addPinsCts.Token;
+
 			if (_markers == null)
 				_markers = new List<Marker>();
 
@@ -670,7 +678,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			foreach (var p in pins)
 			{
 				IMapPin pin = (IMapPin)p;
-				AddPinAsync(pin).FireAndForget();
+				AddPinAsync(pin, ct).FireAndForget();
 			}
 			_pins = null;
 		}
@@ -719,7 +727,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				return null;
 			}
 
-		async System.Threading.Tasks.Task AddPinAsync(IMapPin pin)
+		async Task AddPinAsync(IMapPin pin, CancellationToken ct)
 		{
 			if (Map == null || MauiContext == null)
 				return;
@@ -736,27 +744,27 @@ namespace Microsoft.Maui.Maps.Handlers
 				try
 				{
 					var result = await pin.ImageSource.GetPlatformImageAsync(MauiContext);
-					if (result?.Value is ADrawable drawable)
+					if (ct.IsCancellationRequested || result?.Value is not ADrawable drawable)
+						return;
+
+					var bitmap = DrawableToBitmap(drawable);
+					if (bitmap != null)
 					{
-						var bitmap = DrawableToBitmap(drawable);
-						if (bitmap != null)
-						{
-							markerOptions.SetIcon(BitmapDescriptorFactory.FromBitmap(bitmap));
-						}
+						markerOptions.SetIcon(BitmapDescriptorFactory.FromBitmap(bitmap));
 					}
 				}
 				catch (System.Exception ex)
 				{
-					// If image loading fails, use default pin icon
-					System.Diagnostics.Debug.WriteLine($"Failed to load custom pin icon: {ex.Message}");
+					var logger = MauiContext?.Services?.GetService<ILogger<MapHandler>>();
+					logger?.LogWarning(ex, "Failed to load custom pin icon");
 				}
 			}
 
 			// Re-check after async operation since handler may have been disconnected
-if (Map == null || MauiContext == null)
-return;
+			if (ct.IsCancellationRequested || Map == null || MauiContext == null)
+				return;
 
-var marker = Map.AddMarker(markerOptions);
+			var marker = Map.AddMarker(markerOptions);
 			if (marker == null)
 			{
 				throw new System.Exception("Map.AddMarker returned null");
@@ -764,8 +772,7 @@ var marker = Map.AddMarker(markerOptions);
 			// associate pin with marker for later lookup in event handlers
 			pin.MarkerId = marker.Id;
 			
-			if (_markers == null)
-				_markers = new List<Marker>();
+			_markers ??= new List<Marker>();
 			_markers.Add(marker);
 		}
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -25,8 +25,6 @@ using ARect = Android.Graphics.Rect;
 using ACircle = Android.Gms.Maps.Model.Circle;
 using APolygon = Android.Gms.Maps.Model.Polygon;
 using APolyline = Android.Gms.Maps.Model.Polyline;
-using ABitmap = Android.Graphics.Bitmap;
-using ACanvas = Android.Graphics.Canvas;
 using ADrawable = Android.Graphics.Drawables.Drawable;
 using ABitmapDrawable = Android.Graphics.Drawables.BitmapDrawable;
 using Math = System.Math;
@@ -726,6 +724,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			{
 				return null;
 			}
+		}
 
 		async Task AddPinAsync(IMapPin pin, CancellationToken ct)
 		{

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -745,9 +745,10 @@ namespace Microsoft.Maui.Maps.Handlers
 						}
 					}
 				}
-				catch
+				catch (Exception ex)
 				{
 					// If image loading fails, use default pin icon
+					System.Diagnostics.Debug.WriteLine($"Failed to load custom pin icon: {ex.Message}");
 				}
 			}
 
@@ -791,8 +792,12 @@ var marker = Map.AddMarker(markerOptions);
 			var canvas = new ACanvas(bitmap);
 			drawable.SetBounds(0, 0, canvas.Width, canvas.Height);
 			drawable.Draw(canvas);
+			canvas.Dispose();
 
-			return ScaleBitmap(bitmap, 64, 64);
+			var scaled = ScaleBitmap(bitmap, 64, 64);
+			if (scaled != bitmap)
+				bitmap.Dispose();
+			return scaled;
 		}
 
 		static ABitmap ScaleBitmap(ABitmap source, int targetWidth, int targetHeight)

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -745,7 +745,7 @@ namespace Microsoft.Maui.Maps.Handlers
 						}
 					}
 				}
-				catch (Exception ex)
+				catch (System.Exception ex)
 				{
 					// If image loading fails, use default pin icon
 					System.Diagnostics.Debug.WriteLine($"Failed to load custom pin icon: {ex.Message}");

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Android.cs
@@ -1,5 +1,4 @@
-﻿using Android.Gms.Maps;
-using Android.Gms.Maps.Model;
+﻿using Android.Gms.Maps.Model;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Maps.Handlers
@@ -22,6 +21,13 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapAddress(IMapPinHandler handler, IMapPin mapPin)
 		{
 			handler.PlatformView.SetSnippet(mapPin.Address);
+		}
+
+		// Note: ImageSource is handled in MapHandler.AddPinAsync
+		// because the icon must be set on MarkerOptions BEFORE calling Map.AddMarker()
+		public static void MapImageSource(IMapPinHandler handler, IMapPin mapPin)
+		{
+			// No-op: Image is applied when the marker is created in MapHandler.AddPinAsync
 		}
 	}
 }

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Standard.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Standard.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapLabel(IMapPinHandler handler, IMapPin mapPin) { }
 
 		public static void MapAddress(IMapPinHandler handler, IMapPin mapPin) { }
+
+		public static void MapImageSource(IMapPinHandler handler, IMapPin mapPin) { }
 	}
 }

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Tizen.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapLabel(IMapPinHandler handler, IMapPin mapPin) { }
 
 		public static void MapAddress(IMapPinHandler handler, IMapPin mapPin) { }
+
+		public static void MapImageSource(IMapPinHandler handler, IMapPin mapPin) { }
 	}
 }

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Windows.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Windows.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapLabel(IMapPinHandler handler, IMapPin mapPin) { }
 
 		public static void MapAddress(IMapPinHandler handler, IMapPin mapPin) { }
+
+		public static void MapImageSource(IMapPinHandler handler, IMapPin mapPin) { }
 	}
 }

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			[nameof(IMapPin.Location)] = MapLocation,
 			[nameof(IMapPin.Label)] = MapLabel,
 			[nameof(IMapPin.Address)] = MapAddress,
+			[nameof(IMapPin.ImageSource)] = MapImageSource,
 		};
 
 		/// <summary>

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.iOS.cs
@@ -26,5 +26,12 @@ namespace Microsoft.Maui.Maps.Handlers
 			if (handler.PlatformView is MKPointAnnotation mKPointAnnotation)
 				mKPointAnnotation.Subtitle = mapPin.Address;
 		}
+
+		// Note: ImageSource is handled in MauiMKMapView.GetViewForAnnotation
+		// because the image is set on the MKAnnotationView, not on the IMKAnnotation
+		public static void MapImageSource(IMapPinHandler handler, IMapPin mapPin)
+		{
+			// No-op: Image is applied when the annotation view is created in GetViewForAnnotation
+		}
 	}
 }

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -102,21 +102,34 @@ namespace Microsoft.Maui.Maps.Platform
 
 			const string defaultPinId = "defaultPin";
 			mapPin = mapView.DequeueReusableAnnotation(defaultPinId);
+
+			// Find the IMapPin associated with this annotation
+			IMapPin? pin = GetPinForAnnotation(annotation);
+
+			// Determine if we need a custom image view or the default marker view
+			bool hasCustomImage = pin?.ImageSource != null;
+			string reuseId = hasCustomImage ? "customPin" : "defaultPin";
+
+			mapPin = mapView.DequeueReusableAnnotation(reuseId);
 			if (mapPin == null)
 			{
-				if (OperatingSystem.IsIOSVersionAtLeast(11))
+				if (hasCustomImage)
 				{
-					mapPin = new MKMarkerAnnotationView(annotation, defaultPinId);
+					// Use MKAnnotationView for custom images
+					mapPin = new MKAnnotationView(annotation, reuseId);
+				}
+				else if (OperatingSystem.IsIOSVersionAtLeast(11))
+				{
+					mapPin = new MKMarkerAnnotationView(annotation, reuseId);
 				}
 				else
 				{
-					mapPin = new MKPinAnnotationView(annotation, defaultPinId);
-
+					mapPin = new MKPinAnnotationView(annotation, reuseId);
 				}
 
 				mapPin.CanShowCallout = true;
 
-				if (OperatingSystem.IsIOSVersionAtLeast(11))
+				if (!hasCustomImage && OperatingSystem.IsIOSVersionAtLeast(11))
 				{
 					// Need to set this to get the callout bubble to show up
 					// Without this no callout is shown, it's displayed differently
@@ -129,8 +142,6 @@ namespace Microsoft.Maui.Maps.Platform
 			// Set clustering identifier if clustering is enabled
 			if (_isClusteringEnabled && OperatingSystem.IsIOSVersionAtLeast(11))
 			{
-				// Get the clustering identifier from the pin
-				var pin = GetPinForAnnotation(annotation);
 				if (pin != null)
 				{
 					mapPin.ClusteringIdentifier = pin.ClusteringIdentifier;
@@ -143,7 +154,13 @@ namespace Microsoft.Maui.Maps.Platform
 				// re-applied from GetPinForAnnotation when clustering is re-enabled.
 				mapPin.ClusteringIdentifier = null;
 			}
-			
+
+			// Apply custom image if present
+			if (hasCustomImage && pin?.ImageSource != null)
+			{
+				ApplyCustomImageAsync(mapPin, pin).FireAndForget();
+			}
+
 			AttachGestureToPin(mapPin, annotation);
 
 			return mapPin;
@@ -222,6 +239,44 @@ namespace Microsoft.Maui.Maps.Platform
 				rect.Height * 1.2);
 
 			SetVisibleMapRect(paddedRect, true);
+
+		async System.Threading.Tasks.Task ApplyCustomImageAsync(MKAnnotationView annotationView, IMapPin pin)
+		{
+			_handlerRef.TryGetTarget(out IMapHandler? handler);
+			if (handler?.MauiContext == null || pin.ImageSource == null)
+				return;
+
+			try
+			{
+				var result = await pin.ImageSource.GetPlatformImageAsync(handler.MauiContext);
+				if (result?.Value is UIImage image)
+				{
+					// Scale image to appropriate pin size (32x32 points)
+					var scaledImage = ScaleImage(image, new CoreGraphics.CGSize(32, 32));
+					annotationView.Image = scaledImage;
+				}
+			}
+			catch
+			{
+				// If image loading fails, leave the annotation view as-is
+			}
+		}
+
+		static UIImage ScaleImage(UIImage image, CoreGraphics.CGSize targetSize)
+		{
+			var size = image.Size;
+			var widthRatio = targetSize.Width / size.Width;
+			var heightRatio = targetSize.Height / size.Height;
+			var ratio = (nfloat)Math.Min(widthRatio, heightRatio);
+
+			var newSize = new CoreGraphics.CGSize(size.Width * ratio, size.Height * ratio);
+
+			UIGraphics.BeginImageContextWithOptions(newSize, false, image.CurrentScale);
+			image.Draw(new CoreGraphics.CGRect(0, 0, newSize.Width, newSize.Height));
+			var scaledImage = UIGraphics.GetImageFromCurrentImageContext();
+			UIGraphics.EndImageContext();
+
+			return scaledImage ?? image;
 		}
 
 		internal void AddPins(IList pins)

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Maui.Maps.Platform
 			// Apply custom image if present
 			if (hasCustomImage && pin?.ImageSource != null)
 			{
+				// Clear any existing image on a reused annotation view before loading the new one
+				mapPin.Image = null;
 				ApplyCustomImageAsync(mapPin, pin).FireAndForget();
 			}
 
@@ -246,9 +248,17 @@ namespace Microsoft.Maui.Maps.Platform
 			if (handler?.MauiContext == null || pin.ImageSource == null)
 				return;
 
+			// Capture the annotation before the async operation to detect reuse
+			var targetAnnotation = annotationView.Annotation;
+
 			try
 			{
 				var result = await pin.ImageSource.GetPlatformImageAsync(handler.MauiContext);
+
+				// Verify the annotation view hasn't been reused for a different pin
+				if (annotationView.Annotation != targetAnnotation)
+					return;
+
 				if (result?.Value is UIImage image)
 				{
 					// Scale image to appropriate pin size (32x32 points)
@@ -256,9 +266,9 @@ namespace Microsoft.Maui.Maps.Platform
 					annotationView.Image = scaledImage;
 				}
 			}
-			catch
+			catch (Exception ex)
 			{
-				// If image loading fails, leave the annotation view as-is
+				System.Diagnostics.Debug.WriteLine($"Failed to load custom pin icon: {ex.Message}");
 			}
 		}
 

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using CoreLocation;
 using MapKit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Maps.Handlers;
 using Microsoft.Maui.Platform;
 using ObjCRuntime;
@@ -268,7 +270,11 @@ namespace Microsoft.Maui.Maps.Platform
 			}
 			catch (Exception ex)
 			{
-				System.Diagnostics.Debug.WriteLine($"Failed to load custom pin icon: {ex.Message}");
+				if (_handlerRef.TryGetTarget(out var handler))
+				{
+					var logger = handler.MauiContext?.Services?.GetService<ILogger<MauiMKMapView>>();
+					logger?.LogWarning(ex, "Failed to load custom pin icon");
+				}
 			}
 		}
 

--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Maui.Maps.Platform
 				rect.Height * 1.2);
 
 			SetVisibleMapRect(paddedRect, true);
+		}
 
 		async System.Threading.Tasks.Task ApplyCustomImageAsync(MKAnnotationView annotationView, IMapPin pin)
 		{
@@ -270,9 +271,9 @@ namespace Microsoft.Maui.Maps.Platform
 			}
 			catch (Exception ex)
 			{
-				if (_handlerRef.TryGetTarget(out var handler))
+				if (_handlerRef.TryGetTarget(out var currentHandler))
 				{
-					var logger = handler.MauiContext?.Services?.GetService<ILogger<MauiMKMapView>>();
+					var logger = currentHandler.MauiContext?.Services?.GetService<ILogger<MauiMKMapView>>();
 					logger?.LogWarning(ex, "Failed to load custom pin icon");
 				}
 			}

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -15,3 +16,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.get -> bool
@@ -17,3 +18,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.get -> bool
@@ -17,3 +18,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -15,3 +16,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -15,3 +16,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -15,3 +16,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
 Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
+Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -15,3 +16,4 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentMode
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds the ability to use custom images for map pins instead of the default platform markers.

Fixes #10400

## Changes

### API Changes
- Added `IImageSource? ImageSource` property to `IMapPin` interface
- Added `ImageSource` bindable property to `Pin` class

### Platform Implementation
- **iOS/MacCatalyst**: Uses `MKAnnotationView` with custom image (scaled to 32x32 points)
- **Android**: Loads image before marker creation via `BitmapDescriptorFactory.FromBitmap()` (scaled to 64x64 pixels)
- Both platforms maintain aspect ratio when scaling

### Usage
```csharp
var pin = new Pin
{
    Label = "Custom Pin",
    Location = new Location(47.6062, -122.3321),
    ImageSource = "my_custom_icon.png"
};
map.Pins.Add(pin);
```

## Testing
- Added 5 unit tests for `ImageSource` property
- Added `CustomPinIconGallery` sample page
- Verified on Android emulator and MacCatalyst