### PR TITLE
Remove EnablePreviewFeatures requirement for XAML C# Expressions

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.Common.targets
@@ -30,6 +30,5 @@
     <CompilerVisibleProperty Include="MauiXamlLineInfo" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="LineInfo" />
     <CompilerVisibleProperty Include="Configuration" />
-    <CompilerVisibleProperty Include="EnablePreviewFeatures" />
 	</ItemGroup>
 </Project>

--- a/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
+++ b/src/Controls/src/SourceGen/AnalyzerReleases.Unshipped.md
@@ -27,5 +27,4 @@ MAUIX2008 | XamlParsing | Error | AmbiguousMemberExpression
 MAUIX2009 | XamlParsing | Error | MemberNotFound
 MAUIX2010 | XamlParsing | Info | ExpressionNotSettable
 MAUIX2011 | XamlParsing | Warning | AmbiguousMemberWithStaticType
-MAUIX2012 | XamlParsing | Error | CSharpExpressionsRequirePreviewFeatures
 MAUIX2013 | XamlParsing | Error | AsyncLambdaNotSupported

--- a/src/Controls/src/SourceGen/Descriptors.cs
+++ b/src/Controls/src/SourceGen/Descriptors.cs
@@ -301,14 +301,6 @@ namespace Microsoft.Maui.Controls.SourceGen
 			defaultSeverity: DiagnosticSeverity.Info,
 			isEnabledByDefault: true);
 
-		public static DiagnosticDescriptor CSharpExpressionsRequirePreviewFeatures = new DiagnosticDescriptor(
-			id: "MAUIX2012",
-			title: "C# Expressions require EnablePreviewFeatures",
-			messageFormat: "XAML C# Expressions are an experimental feature. Add '<EnablePreviewFeatures>true</EnablePreviewFeatures>' to your project file to enable them.",
-			category: "XamlParsing",
-			defaultSeverity: DiagnosticSeverity.Error,
-			isEnabledByDefault: true);
-
 		public static DiagnosticDescriptor AsyncLambdaNotSupported = new DiagnosticDescriptor(
 			id: "MAUIX2013",
 			title: "Async lambda event handlers are not supported",

--- a/src/Controls/src/SourceGen/ProjectItem.cs
+++ b/src/Controls/src/SourceGen/ProjectItem.cs
@@ -77,7 +77,4 @@ record ProjectItem(AdditionalText AdditionalText, AnalyzerConfigOptions Options)
 
 	public string? TargetPath
 		=> Options.GetValueOrDefault("build_metadata.additionalfiles.TargetPath", AdditionalText.Path);
-
-	public bool EnablePreviewFeatures
-		=> Options.IsTrue("build_property.EnablePreviewFeatures");
 }

--- a/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/CSharpExpressionDiagnosticsTests.cs
@@ -627,41 +627,6 @@ public partial class SyncLambdaPage : ContentPage
 	}
 
 	[Fact]
-	public void CSharpExpression_WithoutPreviewFeatures_ReportsMAUIX2012()
-	{
-		// C# expressions require EnablePreviewFeatures=true
-		var xaml =
-"""
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="TestApp.NoPreviewPage">
-    <Label Text="{GetText()}" />
-</ContentPage>
-""";
-
-		var codeBehind =
-"""
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
-
-namespace TestApp;
-
-[XamlProcessing(XamlInflator.SourceGen)]
-public partial class NoPreviewPage : ContentPage
-{
-	public string GetText() => "Hello";
-	public NoPreviewPage() => InitializeComponent();
-}
-""";
-
-		var (result, _) = RunGenerator(xaml, codeBehind, enablePreviewFeatures: false);
-
-		// Should report MAUIX2012 error about preview features required
-		Assert.Contains(result.Diagnostics, d => d.Id == "MAUIX2012");
-	}
-
-	[Fact]
 	public void SingleQuotedLiteral_MethodExpectsString_GeneratesStringLiteral()
 	{
 		// When a method expects string, 'x' should become "x"

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SourceGenXamlInitializeComponentTests.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SourceGenXamlInitializeComponentTests.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
 
 public class SourceGenXamlInitializeComponentTestBase : SourceGenTestsBase
 {
-	protected record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, string? NoWarn = null, string Lineinfo = "enable", bool EnablePreviewFeatures = true)
-		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, NoWarn: NoWarn, LineInfo: Lineinfo, EnablePreviewFeatures: EnablePreviewFeatures);
+	protected record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, string? NoWarn = null, string Lineinfo = "enable")
+		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, NoWarn: NoWarn, LineInfo: Lineinfo);
 
-	protected (GeneratorDriverRunResult result, string? text) RunGenerator(string xaml, string code, string noWarn = "", string targetFramework = "", string? path = null, string lineinfo = "enable", bool assertNoCompilationErrors = true, bool enablePreviewFeatures = true)
+	protected (GeneratorDriverRunResult result, string? text) RunGenerator(string xaml, string code, string noWarn = "", string targetFramework = "", string? path = null, string lineinfo = "enable", bool assertNoCompilationErrors = true)
 	{
 		var compilation = CreateMauiCompilation();
 		compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(code));
 		var workingDirectory = Environment.CurrentDirectory;
-		var xamlFile = new AdditionalXamlFile(Path.Combine(workingDirectory, path ?? "Test.xaml"), xaml, RelativePath: path ?? "Test.xaml", TargetFramework: targetFramework, NoWarn: noWarn, ManifestResourceName: $"{compilation.AssemblyName}.Test.xaml", Lineinfo: lineinfo, EnablePreviewFeatures: enablePreviewFeatures);
+		var xamlFile = new AdditionalXamlFile(Path.Combine(workingDirectory, path ?? "Test.xaml"), xaml, RelativePath: path ?? "Test.xaml", TargetFramework: targetFramework, NoWarn: noWarn, ManifestResourceName: $"{compilation.AssemblyName}.Test.xaml", Lineinfo: lineinfo);
 		var result = RunGenerator<XamlGenerator>(compilation, xamlFile, assertNoCompilationErrors);
 		var generated = result.Results.SingleOrDefault().GeneratedSources.SingleOrDefault(gs => gs.HintName.EndsWith(".xsg.cs")).SourceText?.ToString();
 

--- a/src/Controls/tests/SourceGen.UnitTests/SourceGeneratorDriver.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGeneratorDriver.cs
@@ -18,7 +18,7 @@ public static class SourceGeneratorDriver
 {
 	private static MetadataReference[]? MauiReferences;
 
-	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework, string? NoWarn, string LineInfo="enable", bool EnablePreviewFeatures = true);
+	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework, string? NoWarn, string LineInfo="enable");
 	public static GeneratorDriverRunResult RunGenerator<T>(Compilation compilation, AdditionalFile additionalFile, bool assertNoCompilationErrors = true)
 		where T : IIncrementalGenerator, new()
 		=> RunGenerator<T>(compilation, additionalFiles: [additionalFile], assertNoCompilationErrors);
@@ -185,7 +185,6 @@ public static class SourceGeneratorDriver
 					"build_property.EnableMauiXamlDiagnostics" => "true",
 					"build_property.MauiXamlLineInfo" => _additionalFile.LineInfo != "default" ?  _additionalFile.LineInfo : null,
 					"build_property.MauiXamlNoWarn" => _additionalFile.NoWarn,
-					"build_property.EnablePreviewFeatures" => _additionalFile.EnablePreviewFeatures ? "true" : null,
 
 					_ => null
 				};

--- a/src/Controls/tests/Xaml.Benchmarks/Microsoft.Maui.Controls.Xaml.Benchmarks.csproj
+++ b/src/Controls/tests/Xaml.Benchmarks/Microsoft.Maui.Controls.Xaml.Benchmarks.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Microsoft.Maui.Controls.Xaml.Benchmarks</AssemblyName>
     <Nullable>enable</Nullable>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <DefineConstants>$(DefineConstants);_MAUIXAML_SG_NAMESCOPE_DISABLE</DefineConstants>
     <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -18,7 +18,6 @@
     
     <EmitCompilerGeneratedFiles Condition="'$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Controls/tests/Xaml.UnitTests/MockSourceGenerator.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MockSourceGenerator.cs
@@ -33,9 +33,9 @@ public static class MockSourceGenerator
 	public static Compilation WithAdditionalSource(this Compilation compilation, string sourceCode, string hintName = "File.Xaml.cs") =>
 		compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(sourceCode, path: hintName));
 
-	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework, bool EnablePreviewFeatures = true);
-	public record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null, bool EnablePreviewFeatures = true)
-		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework, EnablePreviewFeatures: EnablePreviewFeatures);
+	public record AdditionalFile(AdditionalText Text, string Kind, string RelativePath, string? TargetPath, string? ManifestResourceName, string? TargetFramework);
+	public record AdditionalXamlFile(string Path, string Content, string? RelativePath = null, string? TargetPath = null, string? ManifestResourceName = null, string? TargetFramework = null)
+		: AdditionalFile(Text: ToAdditionalText(Path, Content), Kind: "Xaml", RelativePath: RelativePath ?? Path, TargetPath: TargetPath, ManifestResourceName: ManifestResourceName, TargetFramework: TargetFramework);
 
 	public static AdditionalText ToAdditionalText(string path, string text) => CustomAdditionalText.From(path, text);
 
@@ -218,7 +218,6 @@ public static class MockSourceGenerator
 					"build_metadata.additionalfiles.RelativePath" => _additionalFile.RelativePath,
 					"build_metadata.additionalfiles.Inflator" => "SourceGen",
 					"build_property.targetFramework" => _additionalFile.TargetFramework,
-					"build_property.EnablePreviewFeatures" => _additionalFile.EnablePreviewFeatures ? "true" : null,
 					_ => null
 				};
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -17,7 +17,7 @@ public class SimpleTemplateTest : BaseTemplateTests
 	[InlineData("maui", DotNetCurrent, "Release", false, "--sample-content", "TrimMode=partial")]
 	//Debug not ready yet
 	//[InlineData("maui", DotNetCurrent, "Debug", false, "--sample-content", "UseMonoRuntime=false")]
-	[InlineData("maui", DotNetCurrent, "Release", false, "--sample-content", "UseMonoRuntime=false EnablePreviewFeatures=true")]
+	[InlineData("maui", DotNetCurrent, "Release", false, "--sample-content", "UseMonoRuntime=false")]
 	// [InlineData("maui-blazor", DotNetPrevious, "Debug", false, "", "")]
 	// [InlineData("maui-blazor", DotNetPrevious, "Release", false, "", "")]
 	[InlineData("maui-blazor", DotNetCurrent, "Debug", false, "", "")]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

XAML C# Expressions were introduced in #33693 as an experimental feature gated behind `<EnablePreviewFeatures>true</EnablePreviewFeatures>`. For .NET 11, this feature graduates to GA — users no longer need to opt in.

## Changes

- **Remove MAUIX2012 diagnostic** (`CSharpExpressionsRequirePreviewFeatures`) — no longer emitted
- **Remove `EnablePreviewFeatures` checks** in `ExpandMarkupsVisitor` — C# expressions and ambiguity detection work unconditionally
- **Remove `EnablePreviewFeatures` property** from `ProjectItem` (no remaining consumers)
- **Remove `CompilerVisibleProperty`** for `EnablePreviewFeatures` from `Common.targets`
- **Update test infrastructure** — remove `EnablePreviewFeatures` parameter from test driver records and helpers
- **Remove `EnablePreviewFeatures`** from `Controls.Xaml.UnitTests.csproj` and `Xaml.Benchmarks.csproj`
- **Update integration test** — remove `EnablePreviewFeatures=true` from sample content test case

## Impact

After this change, any XAML using C# expression syntax (e.g., `{Username}`, `{!IsHidden}`, `{(s, e) => Count++}`) will work without requiring `EnablePreviewFeatures` in the project file.