### PR TITLE
[ci] Run devicetests on ACES

### DIFF
--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -88,16 +88,16 @@ parameters:
 - name: macOSTestPoolPublic
   type: object
   default:
-    name: Azure Pipelines
-    vmImage: macOS-15-arm64
+    name: AcesShared
+    demands:
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
 - name: macOSPoolPublic
   type: object
   default:
-    name: MAUI
-    vmImage: MAUI
+    name: AcesShared
     demands:
-      - Agent.OSArchitecture -equals ARM64
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
 - name: targetFrameworkVersions
   type: object


### PR DESCRIPTION
### Description of Change

This pull request updates the configuration for macOS test pools in the `ci-device-tests.yml` pipeline. The main change is switching the agent pool from specific VM images to a shared pool with explicit demands, standardizing the environment for macOS CI jobs.

**Pipeline configuration updates:**

* Changed the `macOSTestPoolPublic` and `macOSPoolPublic` parameters to use the `AcesShared` agent pool and set the `ImageOverride` demand to `ACES_VM_SharedPool_Tahoe`, replacing previous pool names and VM image specifications.