### PR TITLE
Clarify git workflow: push to PR branch, don't create separate branches

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,9 +136,11 @@ When working with public API changes:
 
 1. **NEVER commit directly to `main`** - Always create a feature branch for your work. Direct commits to `main` are strictly prohibited.
 
-2. **Do NOT rebase, squash, or force-push** unless explicitly requested by the user. These operations rewrite git history and can cause problems for other contributors. Default behavior should be regular commits and pushes.
+2. **When fixing CI or amending an existing PR, commit directly to the PR's branch** - Do NOT create a separate branch. The PR branch already IS a feature branch. Creating a new branch off a PR branch means CI won't run on the PR, defeating the purpose. Checkout the PR branch, commit, and push to it.
 
-3. **When amending an existing PR, do NOT automatically push** - After making changes to an existing PR branch, ask the user before pushing. This allows the user to review the changes locally first. Exception: If the user's instructions explicitly include pushing, proceed without asking.
+3. **Do NOT rebase, squash, or force-push** unless explicitly requested by the user. These operations rewrite git history and can cause problems for other contributors. Default behavior should be regular commits and pushes.
+
+4. **When amending an existing PR, do NOT automatically push** - After making changes to an existing PR branch, ask the user before pushing. This allows the user to review the changes locally first. Exception: If the user's instructions explicitly include pushing, proceed without asking.
 
 **Safe Git Workflow:**
 ```bash
@@ -153,6 +155,17 @@ git commit -m "Fix: Description of the change"
 git push -u origin feature/issue-12345
 
 # For subsequent pushes on the same branch
+git push
+```
+
+**When fixing CI or contributing to an existing PR:**
+```bash
+# Checkout the PR branch directly (do NOT create a new branch off it)
+gh pr checkout 12345
+
+# Make fixes, commit, and push to the PR branch
+git add .
+git commit -m "Fix: Description of the change"
 git push
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,7 +136,7 @@ When working with public API changes:
 
 1. **NEVER commit directly to `main`** - Always create a feature branch for your work. Direct commits to `main` are strictly prohibited.
 
-2. **When fixing CI or amending an existing PR, commit directly to the PR's branch** - Do NOT create a separate branch. The PR branch already IS a feature branch. Creating a new branch off a PR branch means CI won't run on the PR, defeating the purpose. Checkout the PR branch, commit, and push to it.
+2. **When amending an existing PR, work on the PR's branch directly** - Do NOT create a separate branch off a PR branch. The PR branch already IS a feature branch. Creating a new branch off it means CI won't run on the original PR, defeating the purpose. Use `gh pr checkout` to switch to the PR branch and commit there.
 
 3. **Do NOT rebase, squash, or force-push** unless explicitly requested by the user. These operations rewrite git history and can cause problems for other contributors. Default behavior should be regular commits and pushes.
 
@@ -158,15 +158,15 @@ git push -u origin feature/issue-12345
 git push
 ```
 
-**When fixing CI or contributing to an existing PR:**
+**When amending an existing PR:**
 ```bash
-# Checkout the PR branch directly (do NOT create a new branch off it)
+# Check out the PR branch directly (do NOT create a new branch off it)
 gh pr checkout 12345
 
-# Make fixes, commit, and push to the PR branch
+# Make fixes and commit to the PR branch
 git add .
 git commit -m "Fix: Description of the change"
-git push
+# Do NOT push automatically; ask the user before running: git push
 ```
 
 **When asked to update an existing PR:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,11 +136,9 @@ When working with public API changes:
 
 1. **NEVER commit directly to `main`** - Always create a feature branch for your work. Direct commits to `main` are strictly prohibited.
 
-2. **When amending an existing PR, work on the PR's branch directly** - Do NOT create a separate branch off a PR branch. The PR branch already IS a feature branch. Creating a new branch off it means CI won't run on the original PR, defeating the purpose. Use `gh pr checkout` to switch to the PR branch, make your changes, and commit (but see rule #4 before pushing).
+2. **When amending an existing PR, work on the PR's branch directly** - Do NOT create a separate branch off a PR branch. The PR branch already IS a feature branch. Creating a new branch off it means CI won't run on the original PR, defeating the purpose. Use `gh pr checkout` to switch to the PR branch, make your changes, commit, **then** ask before pushing so the user can review locally first.
 
 3. **Do NOT rebase, squash, or force-push** unless explicitly requested by the user. These operations rewrite git history and can cause problems for other contributors. Default behavior should be regular commits and pushes.
-
-4. **When amending an existing PR, do NOT automatically push** - After making changes to an existing PR branch, ask the user before pushing. This allows the user to review the changes locally first. Exception: If the user's instructions explicitly include pushing, proceed without asking.
 
 **Safe Git Workflow:**
 ```bash
@@ -158,7 +156,7 @@ git push -u origin feature/issue-12345
 git push
 ```
 
-**When amending an existing PR:**
+**When asked to update an existing PR:**
 ```bash
 # Check out the PR branch directly (do NOT create a new branch off it)
 gh pr checkout 12345
@@ -166,13 +164,9 @@ gh pr checkout 12345
 # Make fixes and commit to the PR branch
 git add .
 git commit -m "Fix: Description of the change"
-# Do NOT push automatically; ask the user before running: git push
 ```
-
-**When asked to update an existing PR:**
-1. Make the requested changes
-2. Stage and commit the changes
-3. **STOP and ask the user** before pushing: "Changes are committed locally. Would you like me to push these changes to the PR?"
+1. **STOP and ask the user** before pushing: "Changes are committed locally. Would you like me to push these changes to the PR?"
+2. Exception: If the user's instructions explicitly include pushing, proceed without asking.
 
 ### Documentation
 - Update XML documentation for public APIs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,7 +136,7 @@ When working with public API changes:
 
 1. **NEVER commit directly to `main`** - Always create a feature branch for your work. Direct commits to `main` are strictly prohibited.
 
-2. **When amending an existing PR, work on the PR's branch directly** - Do NOT create a separate branch off a PR branch. The PR branch already IS a feature branch. Creating a new branch off it means CI won't run on the original PR, defeating the purpose. Use `gh pr checkout` to switch to the PR branch and commit there.
+2. **When amending an existing PR, work on the PR's branch directly** - Do NOT create a separate branch off a PR branch. The PR branch already IS a feature branch. Creating a new branch off it means CI won't run on the original PR, defeating the purpose. Use `gh pr checkout` to switch to the PR branch, make your changes, and commit (but see rule #4 before pushing).
 
 3. **Do NOT rebase, squash, or force-push** unless explicitly requested by the user. These operations rewrite git history and can cause problems for other contributors. Default behavior should be regular commits and pushes.
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds rule #2 to the Git Workflow section in copilot-instructions.md:

**When fixing CI or amending an existing PR, commit directly to the PR branch.** Do not create a separate branch off a PR branch — the PR branch already IS a feature branch. Creating a new branch means CI will not run on the PR, defeating the purpose.

Also adds a code example showing the correct workflow (`gh pr checkout` → commit → push).

## Motivation

Copilot CLI was incorrectly creating separate branches when asked to fix CI on existing PRs, because rule #1 ("never commit to main, create a feature branch") was being over-generalized to PR branches. This caused wasted time since CI only runs on PR branches.