### PR TITLE
[ci] Remove provisionator and simulator provisioning

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -55,9 +55,6 @@ steps:
     skipAndroidEmulatorImages: ${{ or(eq(parameters.buildType, 'buildOnly'), ne(parameters.platform, 'android')) }}
     skipAndroidCreateAvds: true
     androidEmulatorApiLevel: ${{ parameters.apiversion }}
-    provisionatorChannel: ${{ parameters.provisionatorChannel }}
-    ${{ if eq(parameters.skipProvisioning, false) }}:
-      skipProvisionator: false
     skipInternalFeeds: true
 
 ##################################################

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -14,16 +14,7 @@ parameters:
   androidEmulatorApiLevel: ''
   skipAndroidEmulatorImages: true # For most builds we won't need these
   skipAndroidCreateAvds: true # For most builds we won't need these
-  # Provisionator / Xcode
-  skipProvisionator: true
   checkoutDirectory: $(System.DefaultWorkingDirectory)
-  provisionatorXCodePath: $(provisionator.xcode)
-  provisionatorChannel: 'latest'
-  provisionatorExtraArguments: $(provisionator.extraArguments)
-  provisionatorUri: $(provisionator-uri)
-  gitHubToken: $(provisionator--github--pat)
-  certPass: $(maui-cert-password) # This lives on MAUI variable group
-  certName: 'MauiCert.p12'
   openSslArgs: '-legacy'
   provisioningProfileName: 'MauiProvisioningProfile.mobileprovision'
   # Enabling internal runtimes / feeds
@@ -74,17 +65,6 @@ steps:
 
 # Provisioning macOS - Xcode
 - ${{ if ne(parameters.skipXcode, 'true') }}:
-  - ${{ if ne(parameters.skipProvisionator, true) }}:
-    - task: xamops.azdevex.provisionator-task.provisionator@3
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-      displayName: 'Provision Xcode'
-      inputs:
-        provisionator_uri: ${{ parameters.provisionatorUri }}
-        provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorXCodePath }}
-        provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
-        github_token: ${{ parameters.gitHubToken }}
-      env:
-        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
 
   - script: |
       echo Remove old Xamarin Settings
@@ -157,72 +137,11 @@ steps:
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     timeoutInMinutes: 30
 
-  - ${{ if ne(parameters.skipSimulatorSetup, 'true') }}:
-    - script: |
-        echo installing simulator runtimes...
-        # Use REQUIRED_XCODE for devdiv team project or if CollectionUri contains xamarin, XCODE for others (e.g., maui-pr)
-        if [[ "$(System.TeamProject)" == "devdiv" || "$(System.CollectionUri)" == *"xamarin"* ]]; then
-          XCODE_VERSION=$(REQUIRED_XCODE)
-        else
-          XCODE_VERSION=$(XCODE)
-        fi
-        # if we're using Xcode 26.0[.?], then explicitly install the iOS 26.0 simulator (the iOS 26.0.1 simulator doesn't work for us)
-        # also install the universal simulator version, so that this bot can run x64 apps in the simulator.
-        if [[ "${XCODE_VERSION}" =~ ^26[.]0.*$ ]]; then
-          RC=0
-          sudo xcodebuild -downloadPlatform iOS -architectureVariant universal -buildVersion 26.0 || RC=$?
-          if [[ "$RC" == "70" ]]; then
-            echo "xcodebuild exited with exit code 70, which seems to mean not all is bad? Assuming things will work..."
-          elif [[ "$RC" == "0" ]]; then
-            echo "Successfully installed the requested iOS simulator"
-          else
-            echo "Failed to install simulator runtime, deleting all simulator runtimes and trying again..."
-            sudo xcrun simctl runtime delete all
-            # simulator runtimes are deleted asynchronously, so wait until they're all gone (but max 60 seconds)
-            for i in $(seq 1 60); do
-              sleep 1
-              C=$(xcrun simctl runtime list -j | jq '. | length')
-              if [[ $C == 0 ]]; then
-                echo "    still $C simulators left..."
-                break
-              fi
-            done
-            echo "Re-trying simulator runtime installation, if this doesn't work, a reboot might be required"
-            sudo xcodebuild -downloadPlatform iOS -architectureVariant universal -buildVersion 26.0
-          fi
-        else
-          sudo xcodebuild -downloadPlatform iOS
-        fi
-      displayName: Install Simulator Runtimes
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-      continueOnError: true
-      timeoutInMinutes: 30
+##################################################
+#              Provisioning Windows              #
+##################################################
 
-# Provision Additional Software
-- ${{ if or(eq(variables['System.TeamProject'], 'DevDiv'), ne(parameters.skipProvisionator, true)) }}:
-  # Prepare macOS
-  - task: InstallAppleCertificate@2
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-    displayName: 'Install Apple Certificate ${{ parameters.certName }}'
-    continueOnError: true
-    inputs:
-      certSecureFile: '${{ parameters.certName }}'
-      certPwd: ${{ parameters.certPass }}
-      keychain: 'temp'
-      opensslPkcsArgs: '${{ parameters.openSslArgs }}'
-
-  - task: InstallAppleProvisioningProfile@1
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-    displayName: 'Install Apple Provisioning Profile ${{ parameters.provisioningProfileName }}'
-    continueOnError: true
-    inputs:
-      provisioningProfileLocation: 'secureFiles'
-      provProfileSecureFile: '${{ parameters.provisioningProfileName }}'
-  ##################################################
-  #              Provisioning Windows              #
-  ##################################################
-
-  # Provisioning Windows - Set dump file location
+# Provisioning Windows - Set dump file location
 - pwsh: |
     $errorPath = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"
     New-ItemProperty -Path $errorPath -Name DumpFolder -PropertyType String -Value "$(Build.ArtifactStagingDirectory)/crash-dumps" -Force

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -16,7 +16,6 @@ parameters:
   skipAndroidCreateAvds: true # For most builds we won't need these
   checkoutDirectory: $(System.DefaultWorkingDirectory)
   openSslArgs: '-legacy'
-  provisioningProfileName: 'MauiProvisioningProfile.mobileprovision'
   # Enabling internal runtimes / feeds
   federatedServiceConnection: 'dotnetbuilds-internal-read'
   outputVariableName: 'dotnetbuilds-internal-container-read-token'

--- a/eng/pipelines/common/ui-tests-build-sample.yml
+++ b/eng/pipelines/common/ui-tests-build-sample.yml
@@ -25,11 +25,6 @@ steps:
   parameters:
     skipAndroidSdks: false
     skipXcode: ${{ or(eq(parameters.platform, 'android'), eq(parameters.platform, 'windows')) }}
-    provisionatorChannel: ${{ parameters.provisionatorChannel }}
-    ${{ if parameters.skipProvisioning }}:
-      skipProvisionator: true
-    ${{ else }}:
-      skipProvisionator: false
 
 - task: PowerShell@2
   condition: ne('${{ parameters.platform }}' , 'windows')


### PR DESCRIPTION
### Description of Change

This pull request removes all usage of Provisionator and related macOS provisioning steps from the shared pipeline YAML files. The changes simplify the provisioning logic by eliminating parameters, tasks, and scripts related to Provisionator, Xcode provisioning, and Apple certificate/profile installation.

Key removals by theme:

**Provisionator and Xcode provisioning removal:**
* Removed all Provisionator-related parameters (e.g., `provisionatorChannel`, `provisionatorUri`, `provisionatorXCodePath`, etc.) from `provision.yml` parameters section.
* Deleted the Provisionator Xcode provisioning task and its conditional logic from the macOS provisioning steps in `provision.yml`.
* Removed the `provisionatorChannel` parameter and conditional logic from device and UI test pipeline step files. [[1]](diffhunk://#diff-b69b78f4a2fcf116ee0e1d0bfc8ffa31a05469eb6a3585e486af367aeddf498bL58-L60) [[2]](diffhunk://#diff-5d0763fa79fb5e8f8d535acf38d8796d9450d36e0e320f41f99c38f686641840L28-L32)

**Simulator and Apple certificate/profile setup removal:**
* Removed the script for installing simulator runtimes and the tasks for installing Apple certificates and provisioning profiles from the macOS provisioning steps in `provision.yml`.