### PR TITLE
[ci] Improve resilience for iOS simulator runtime and JDK provisioning

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -203,7 +203,10 @@ steps:
             echo "Successfully installed the requested iOS simulator"
           elif [[ "$RC" == "70" ]]; then
             echo "xcodebuild exited with exit code 70 - verifying simulator runtime was actually installed..."
-            if ! verify_simulator_installed; then
+            if verify_simulator_installed; then
+              echo "Simulator runtime is available despite exit code 70, continuing..."
+              RC=0
+            else
               echo "Simulator runtime not available despite exit code 70, retrying..."
               RC=1
             fi

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -169,26 +169,62 @@ steps:
         # if we're using Xcode 26.0[.?], then explicitly install the iOS 26.0 simulator (the iOS 26.0.1 simulator doesn't work for us)
         # also install the universal simulator version, so that this bot can run x64 apps in the simulator.
         if [[ "${XCODE_VERSION}" =~ ^26[.]0.*$ ]]; then
+          install_simulator() {
+            local RC=0
+            sudo xcodebuild -downloadPlatform iOS -architectureVariant universal -buildVersion 26.0 || RC=$?
+            echo "xcodebuild exited with code $RC"
+            return $RC
+          }
+
+          verify_simulator_installed() {
+            # Get the SDK build version prefix (e.g., "23A" from SDK version "23A339")
+            local sdk_version=$(xcrun --sdk iphonesimulator --show-sdk-build-version 2>/dev/null || echo "")
+            local sdk_prefix="${sdk_version:0:3}"
+            echo "iOS Simulator SDK build version: $sdk_version (prefix: $sdk_prefix)"
+            if [[ -z "$sdk_prefix" ]]; then
+              echo "Warning: Could not determine SDK build version, skipping verification"
+              return 0
+            fi
+            # Verify that a simulator runtime matching the SDK build version prefix is available
+            local count=$(xcrun simctl runtime list -j 2>/dev/null | jq --arg prefix "$sdk_prefix" '[.[] | select(.identifier | contains("iOS")) | select(.buildversion | startswith($prefix))] | length' 2>/dev/null || echo "0")
+            if [[ "$count" -gt "0" ]]; then
+              echo "Verified: Compatible iOS simulator runtime is available ($count matching prefix $sdk_prefix)"
+              return 0
+            else
+              echo "Warning: No iOS simulator runtime matching SDK prefix $sdk_prefix found"
+              xcrun simctl runtime list 2>/dev/null || true
+              return 1
+            fi
+          }
+
           RC=0
-          sudo xcodebuild -downloadPlatform iOS -architectureVariant universal -buildVersion 26.0 || RC=$?
-          if [[ "$RC" == "70" ]]; then
-            echo "xcodebuild exited with exit code 70, which seems to mean not all is bad? Assuming things will work..."
-          elif [[ "$RC" == "0" ]]; then
+          install_simulator || RC=$?
+          if [[ "$RC" == "0" ]]; then
             echo "Successfully installed the requested iOS simulator"
-          else
-            echo "Failed to install simulator runtime, deleting all simulator runtimes and trying again..."
+          elif [[ "$RC" == "70" ]]; then
+            echo "xcodebuild exited with exit code 70 - verifying simulator runtime was actually installed..."
+            if ! verify_simulator_installed; then
+              echo "Simulator runtime not available despite exit code 70, retrying..."
+              RC=1
+            fi
+          fi
+
+          if [[ "$RC" != "0" ]]; then
+            echo "Failed to install simulator runtime (exit code $RC), deleting all simulator runtimes and trying again..."
             sudo xcrun simctl runtime delete all
             # simulator runtimes are deleted asynchronously, so wait until they're all gone (but max 60 seconds)
             for i in $(seq 1 60); do
               sleep 1
               C=$(xcrun simctl runtime list -j | jq '. | length')
               if [[ $C == 0 ]]; then
-                echo "    still $C simulators left..."
+                echo "All simulator runtimes deleted"
                 break
               fi
+              echo "    still $C simulators left..."
             done
             echo "Re-trying simulator runtime installation, if this doesn't work, a reboot might be required"
-            sudo xcodebuild -downloadPlatform iOS -architectureVariant universal -buildVersion 26.0
+            install_simulator || true
+            verify_simulator_installed || echo "##vso[task.logissue type=warning]Simulator runtime installation failed - iOS integration tests may fail"
           fi
         else
           sudo xcodebuild -downloadPlatform iOS

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -346,7 +346,17 @@
 	</Target>
 
 	<Target Name="ProvisionJdkMacOS" DependsOnTargets="DetectJdkVersion" Condition=" '$(IsMacOS)' == 'True' AND '$(_AndroidJdkRequiresProvisioning)' == 'True' ">
-		<Exec Command="brew install --cask microsoft-openjdk@$(_AndroidJdkMajorVersion)" />
+		<!-- Retry JDK installation up to 3 times to handle transient network failures (e.g., curl transfer closed) -->
+		<Exec Command="brew install --cask microsoft-openjdk@$(_AndroidJdkMajorVersion)" IgnoreExitCode="true">
+			<Output TaskParameter="ExitCode" PropertyName="_JdkInstallExitCode1" />
+		</Exec>
+		<Message Text="JDK install attempt 1 exit code: $(_JdkInstallExitCode1)" Importance="high" />
+		<!-- Retry on failure after cleaning brew cache -->
+		<Exec Condition=" '$(_JdkInstallExitCode1)' != '0' " Command="echo 'JDK install failed, cleaning cache and retrying...' &amp;&amp; brew cleanup microsoft-openjdk@$(_AndroidJdkMajorVersion) 2>/dev/null; sleep 5 &amp;&amp; brew install --cask microsoft-openjdk@$(_AndroidJdkMajorVersion)" IgnoreExitCode="true">
+			<Output TaskParameter="ExitCode" PropertyName="_JdkInstallExitCode2" />
+		</Exec>
+		<Message Condition=" '$(_JdkInstallExitCode1)' != '0' " Text="JDK install attempt 2 exit code: $(_JdkInstallExitCode2)" Importance="high" />
+		<Error Condition=" '$(_JdkInstallExitCode1)' != '0' AND '$(_JdkInstallExitCode2)' != '0' " Text="Failed to install microsoft-openjdk@$(_AndroidJdkMajorVersion) after 2 attempts" />
 	</Target>
 
 	<Target Name="ProvisionJdkLinux" DependsOnTargets="DetectJdkVersion" Condition=" '$(IsLinux)' == 'True' AND '$(_AndroidJdkRequiresProvisioning)' == 'True' ">

--- a/src/Provisioning/Provisioning.csproj
+++ b/src/Provisioning/Provisioning.csproj
@@ -346,7 +346,7 @@
 	</Target>
 
 	<Target Name="ProvisionJdkMacOS" DependsOnTargets="DetectJdkVersion" Condition=" '$(IsMacOS)' == 'True' AND '$(_AndroidJdkRequiresProvisioning)' == 'True' ">
-		<!-- Retry JDK installation up to 3 times to handle transient network failures (e.g., curl transfer closed) -->
+		<!-- Retry JDK installation (2 attempts) to handle transient network failures (e.g., curl transfer closed) -->
 		<Exec Command="brew install --cask microsoft-openjdk@$(_AndroidJdkMajorVersion)" IgnoreExitCode="true">
 			<Output TaskParameter="ExitCode" PropertyName="_JdkInstallExitCode1" />
 		</Exec>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes transient CI failures in RunOniOS integration tests caused by two infrastructure issues:

**1. Simulator runtime install silently fails (exit code 70)**

When `xcodebuild -downloadPlatform iOS` exits with code 70 ("Unable to connect to simulator"), the current code assumes "not all is bad" and continues. But the runtime was never installed, causing downstream `actool` errors:

```
actool error: No simulator runtime version from ["23B86", "23C54"] available 
to use with iphonesimulator SDK version 23A339
```

**Fix:** After exit code 70, verify the simulator runtime was actually installed by checking `xcrun simctl runtime list` for a runtime matching the SDK build version prefix. If not found, retry with the existing delete-all-and-reinstall fallback.

**2. JDK download fails mid-transfer**

`brew install --cask microsoft-openjdk@17` fails with `curl: (18) transfer closed with 52083792 bytes remaining to read` — a transient network error with no retry.

**Fix:** Added retry with `brew cleanup` between attempts.

**Evidence of impact:** Found the same exit code 70 → actool error pattern in multiple builds:
- Build 1284723 (PR #28983) — 3 RunOniOS jobs failed
- Build 1284765 (inflight/candidate) — 2 RunOniOS jobs failed (both macOS pool agents)

Also fixed a minor logging bug where "still 0 simulators left..." was printed instead of "All simulator runtimes deleted" on successful cleanup.

### Issues Fixed

Fixes transient CI infrastructure failures (no GitHub issue)