### PR TITLE
Enable packing and independent preview versioning for Essentials.AI

### DIFF
--- a/src/AI/samples/Essentials.AI.Sample/Essentials.AI.Sample.csproj
+++ b/src/AI/samples/Essentials.AI.Sample/Essentials.AI.Sample.csproj
@@ -12,6 +12,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);MAUIAI0001</NoWarn>
     <MauiXamlInflator>SourceGen</MauiXamlInflator>
     <!-- Disable multi-RID builds to workaround a parallel build issue -->
     <RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>

--- a/src/AI/src/Essentials.AI/DiagnosticIds.cs
+++ b/src/AI/src/Essentials.AI/DiagnosticIds.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Maui.Essentials.AI;
+
+/// <summary>
+/// Diagnostic IDs for the Microsoft.Maui.Essentials.AI package.
+/// </summary>
+internal static class DiagnosticIds
+{
+	/// <summary>
+	/// Experimental API diagnostic IDs.
+	/// </summary>
+	/// <remarks>
+	/// All Essentials.AI experiments share a single diagnostic ID so consumers
+	/// only need one suppression to opt in: <c>&lt;NoWarn&gt;MAUIAI0001&lt;/NoWarn&gt;</c>.
+	/// Individual constants exist per feature area so that APIs can be graduated
+	/// to stable independently in the future by assigning distinct IDs.
+	/// </remarks>
+	internal static class Experiments
+	{
+		internal const string EssentialsAI = "MAUIAI0001";
+	}
+}

--- a/src/AI/src/Essentials.AI/Essentials.AI.csproj
+++ b/src/AI/src/Essentials.AI/Essentials.AI.csproj
@@ -12,8 +12,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- NuGet package information -->
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <PackageId>Microsoft.Maui.Essentials.AI</PackageId>
+    <!-- Keep this package always preview — it is experimental and should not ship stable
+         even when the rest of the repo stabilizes. Bump PreReleaseVersionIteration for new previews. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <PackageTags>$(DefaultPackageTags);essentials;ai</PackageTags>
     <Description>.NET Multi-platform App UI (.NET MAUI) is a cross-platform framework for creating native mobile and desktop apps with C# and XAML. This package contains a collection of cross-platform APIs for working with device AI and local models.</Description>
   </PropertyGroup>

--- a/src/AI/src/Essentials.AI/Essentials.AI.csproj
+++ b/src/AI/src/Essentials.AI/Essentials.AI.csproj
@@ -15,10 +15,12 @@
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.Maui.Essentials.AI</PackageId>
     <!-- Keep this package always preview — it is experimental and should not ship stable
-         even when the rest of the repo stabilizes. Bump PreReleaseVersionIteration for new previews. -->
+         even when the rest of the repo stabilizes. Bump PreReleaseVersionIteration for new previews.
+         The label/iteration only activate during stable builds (DotNetFinalVersionKind=release).
+         During preview builds, the AI package uses the same label as the rest of the repo. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel Condition="'$(DotNetFinalVersionKind)' == 'release'">preview</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration Condition="'$(DotNetFinalVersionKind)' == 'release'">1</PreReleaseVersionIteration>
     <PackageTags>$(DefaultPackageTags);essentials;ai</PackageTags>
     <Description>.NET Multi-platform App UI (.NET MAUI) is a cross-platform framework for creating native mobile and desktop apps with C# and XAML. This package contains a collection of cross-platform APIs for working with device AI and local models.</Description>
   </PropertyGroup>

--- a/src/AI/src/Essentials.AI/Polyfills/ExperimentalAttribute.cs
+++ b/src/AI/src/Essentials.AI/Polyfills/ExperimentalAttribute.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET8_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Indicates that an API element is experimental and subject to change without notice.
+/// </summary>
+[AttributeUsage(
+	AttributeTargets.Class |
+	AttributeTargets.Struct |
+	AttributeTargets.Enum |
+	AttributeTargets.Interface |
+	AttributeTargets.Delegate |
+	AttributeTargets.Method |
+	AttributeTargets.Constructor |
+	AttributeTargets.Property |
+	AttributeTargets.Field |
+	AttributeTargets.Event |
+	AttributeTargets.Assembly)]
+internal sealed class ExperimentalAttribute : Attribute
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExperimentalAttribute"/> class.
+	/// </summary>
+	/// <param name="diagnosticId">The diagnostic ID associated with this experimental API.</param>
+	public ExperimentalAttribute(string diagnosticId)
+	{
+		DiagnosticId = diagnosticId;
+	}
+
+	/// <summary>
+	/// Gets the ID that the compiler will use when reporting a use of the API the attribute applies to.
+	/// </summary>
+	public string DiagnosticId { get; }
+
+	/// <summary>
+	/// Gets or sets the URL for corresponding documentation.
+	/// The API accepts a format string instead of an actual URL, creating a generic URL that includes the diagnostic ID.
+	/// </summary>
+	public string? UrlFormat { get; set; }
+}
+
+#endif

--- a/src/AI/src/Essentials.AI/Properties/AssemblyInfo.cs
+++ b/src/AI/src/Essentials.AI/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Maui.Essentials.AI;
+
+[assembly: Experimental(DiagnosticIds.Experiments.EssentialsAI)]

--- a/src/AI/tests/Essentials.AI.Benchmarks/Essentials.AI.Benchmarks.csproj
+++ b/src/AI/tests/Essentials.AI.Benchmarks/Essentials.AI.Benchmarks.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Essentials.AI.Benchmarks</AssemblyName>
     <RootNamespace>Microsoft.Maui.Essentials.AI.Benchmarks</RootNamespace>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);MAUIAI0001</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/AI/tests/Essentials.AI.DeviceTests/Essentials.AI.DeviceTests.csproj
+++ b/src/AI/tests/Essentials.AI.DeviceTests/Essentials.AI.DeviceTests.csproj
@@ -13,6 +13,7 @@
     <ExcludeMicrosoftNetTestSdk>true</ExcludeMicrosoftNetTestSdk>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);MAUIAI0001</NoWarn>
     <UserSecretsId>808cc184-141a-409e-addd-565c973dbce6</UserSecretsId>
   </PropertyGroup>
 

--- a/src/AI/tests/Essentials.AI.UnitTests/Essentials.AI.UnitTests.csproj
+++ b/src/AI/tests/Essentials.AI.UnitTests/Essentials.AI.UnitTests.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.Maui.Essentials.AI.UnitTests</RootNamespace>
     <IsPackable>false</IsPackable>
     <MauiTestProject>true</MauiTestProject>
+    <NoWarn>$(NoWarn);MAUIAI0001</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The `Microsoft.Maui.Essentials.AI` package is experimental and must always ship as preview, even when the rest of the repo goes stable. This PR enables NuGet packaging and configures independent preview versioning using arcade SDK properties.

### Changes

- **`IsPackable`**: `false` → `true` to enable NuGet package production
- **`SuppressFinalPackageVersion=true`**: Arcade SDK property that prevents the prerelease suffix from being stripped during stable builds
- **`PreReleaseVersionLabel=preview`**: Overrides the repo-level label so the AI package always uses `preview` regardless of repo state
- **`PreReleaseVersionIteration=1`**: Controls the preview iteration — bump to `2`, `3`, etc. for new previews

### Version Behavior

| Scenario | Essentials.AI | Other packages (e.g., Core) |
|----------|--------------|----------------------------|
| Dev build | `10.0.40-dev` | `10.0.40-dev` |
| Stable official build | `10.0.40-preview.1.XXXXX.X` ✅ | `10.0.40` |

### How to Bump Preview Versions

Change `PreReleaseVersionIteration` in `Essentials.AI.csproj`:
- `1` → `10.0.40-preview.1.XXXXX.X`
- `2` → `10.0.40-preview.2.XXXXX.X`

### How to Verify

```bash
# Simulated stable official build — AI stays preview
dotnet msbuild src/AI/src/Essentials.AI/Essentials.AI.csproj \
  /p:TargetFramework=netstandard2.1 \
  /p:StabilizePackageVersion=true /p:OfficialBuildId=20260209.1 \
  -getProperty:PackageVersion
# Result: 10.0.40-preview.1.26109.1

# Core goes stable
dotnet msbuild src/Core/src/Core.csproj \
  /p:TargetFramework=netstandard2.1 \
  /p:StabilizePackageVersion=true /p:OfficialBuildId=20260209.1 \
  -getProperty:PackageVersion
# Result: 10.0.40
```