### PR TITLE
[Testing] Fix for flaky UITests in CI - 4

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
@@ -21,8 +21,23 @@ public class Issue18896 : _IssuesUITest
 		App.WaitForElement("WaitForStubControl");
 
 		App.ScrollDown(ListView);
-
 		App.ScrollUp(ListView);
+
+		// Scroll until "Baboon" is visible, with bounded attempts to avoid flakiness
+		var attempts = 0;
+		const int maxAttempts = 5;
+		while (attempts++ < maxAttempts)
+		{
+			try
+			{
+				App.WaitForElement("Baboon");
+				break;
+			}
+			catch
+			{
+				App.ScrollUp(ListView, swipeSpeed: 50);
+			}
+		}
 
 		// Load images and hide scrollbar.
 		// The test passes if you are able to see the image, name, and location of each monkey.

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue18896.cs
@@ -21,24 +21,11 @@ public class Issue18896 : _IssuesUITest
 		App.WaitForElement("WaitForStubControl");
 
 		App.ScrollDown(ListView);
+#if ANDROID
+		App.ScrollUp(ListView, ScrollStrategy.Gesture, 0.9);
+#else
 		App.ScrollUp(ListView);
-
-		// Scroll until "Baboon" is visible, with bounded attempts to avoid flakiness
-		var attempts = 0;
-		const int maxAttempts = 5;
-		while (attempts++ < maxAttempts)
-		{
-			try
-			{
-				App.WaitForElement("Baboon");
-				break;
-			}
-			catch
-			{
-				App.ScrollUp(ListView, swipeSpeed: 50);
-			}
-		}
-
+#endif
 		// Load images and hide scrollbar.
 		// The test passes if you are able to see the image, name, and location of each monkey.
 		VerifyScreenshot(retryDelay: TimeSpan.FromSeconds(2));


### PR DESCRIPTION
This pull request adds a platform-specific adjustment to the `Issue18896Test` test case to improve scrolling behavior on Android. The change ensures that the test scrolls up correctly on both Android and other platforms.

Platform-specific test adjustment:

* Updated the `Issue18896Test` method in `Issue18896.cs` to use a different `ScrollUp` method signature with `ScrollStrategy.Gesture` and a velocity parameter when running on Android, ensuring consistent test behavior across platforms.

Fixes : https://github.com/dotnet/maui/issues/34017