### PR TITLE
[tests] Move Graphics to Helix

### DIFF
--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -35,6 +35,7 @@
     <XUnitProject Include="$(RepoRoot)src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Core/tests/UnitTests/Core.UnitTests.csproj" />
     <XUnitProject Include="$(RepoRoot)src/Essentials/test/UnitTests/Essentials.UnitTests.csproj" />
+    <XUnitProject Include="$(RepoRoot)src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj" />
   </ItemGroup>
 
   <!-- Prepare the staging directory for MSBuild test payloads - runs early during Restore -->

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -186,31 +186,6 @@ stages:
         skipProvisioning: true
         skipXcode: false
 
-- template: /eng/pipelines/arcade/stage-unit-tests.yml@self
-  parameters:
-    jobMatrix:
-    - name: win_unit_tests
-      displayName: Windows Unit Tests
-      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
-        pool: ${{ parameters.WindowsPool.public }}
-        runAsPublic: true
-      ${{ else }}:
-        pool: ${{ parameters.WindowsPool.internal }}
-        runAsPublic: false
-      timeout: 90
-      testOS: Windows
-      buildscript: $(_buildScript)
-    - name: mac_unit_tests
-      displayName: macOS Unit Tests
-      ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
-        pool: ${{ parameters.MacOSPool.public }}
-      ${{ else }}:
-        pool: ${{ parameters.MacOSPool.internal }}
-      timeout: 90
-      testOS: macOS
-      buildscript: $(_buildScriptMacOS)
-    publishTaskPrefix: ''
-
 - template: /eng/pipelines/arcade/stage-integration-tests.yml@self
   parameters:
     stageDependsOn: Pack

--- a/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
+++ b/src/Graphics/tests/Graphics.Tests/Graphics.Tests.csproj
@@ -30,10 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="TestImages\**" />
-    <None Update="TestImages\Windows\**" CopyToOutputDirectory="PreserveNewest" Condition="$([MSBuild]::IsOSPlatform('windows'))" />
-    <None Update="TestImages\Mac\**" CopyToOutputDirectory="PreserveNewest" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
-    <None Update="TestImages\Linux\**" CopyToOutputDirectory="PreserveNewest" Condition="!$([MSBuild]::IsOSPlatform('windows')) and !$([MSBuild]::IsOSPlatform('osx'))" />
+    <None Include="TestImages\**" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Errors\**" CopyToOutputDirectory="Never" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change

This pull request primarily updates the test configuration for the project. The most significant changes involve adding new graphics unit tests to the test suite and removing the explicit configuration for unit test stages in the CI pipeline.

Unit test configuration updates:

* Added `Graphics.Tests.csproj` to the list of XUnit projects in `helix.proj`, enabling graphics unit tests to be run as part of the test suite.

CI pipeline simplification:

* Removed the explicit unit test stage template and job matrix from `ci.yml`, which previously defined Windows and macOS unit test jobs. This may indicate a shift to a more streamlined or automated approach for running unit tests.
