### PR TITLE
Add MoveToRegion animation control, MapSpan.FromLocations, and fix initial map animation

### DIFF
--- a/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Maui.Controls.Maps
 
 		void IMap.HideInfoWindow(IMapPin pin) => Handler?.Invoke(nameof(IMap.HideInfoWindow), pin);
 
+		void IMap.MoveToRegion(MapSpan region) => MoveToRegion(region);
+
+		void IMap.MoveToRegion(MapSpan region, bool animated) => MoveToRegion(region, animated);
+
 		MapSpan? IMap.VisibleRegion
 		{
 			get
@@ -61,7 +65,7 @@ namespace Microsoft.Maui.Controls.Maps
 		{
 			base.OnHandlerChanged();
 			//The user specified on the ctor a MapSpan we now need the handler to move to that region
-			Handler?.Invoke(nameof(IMap.MoveToRegion), _lastMoveToRegion);
+			Handler?.Invoke(nameof(IMap.MoveToRegion), new MoveToRegionRequest(_lastMoveToRegion, false));
 		}
 
 	}

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -259,16 +259,7 @@ namespace Microsoft.Maui.Controls.Maps
 		/// </summary>
 		/// <param name="mapSpan">A <see cref="MapSpan"/> object containing details on what region should be shown.</param>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="mapSpan"/> is <see langword="null"/>.</exception>
-		public void MoveToRegion(MapSpan mapSpan)
-		{
-			if (mapSpan is null)
-			{
-				throw new ArgumentNullException(nameof(mapSpan));
-			}
-
-			_lastMoveToRegion = mapSpan;
-			Handler?.Invoke(nameof(IMap.MoveToRegion), new MoveToRegionRequest(_lastMoveToRegion, true));
-		}
+		public void MoveToRegion(MapSpan mapSpan) => MoveToRegion(mapSpan, true);
 
 		/// <summary>
 		/// Adjusts the viewport of the map control to view the specified region, with control over animation.

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -267,7 +267,24 @@ namespace Microsoft.Maui.Controls.Maps
 			}
 
 			_lastMoveToRegion = mapSpan;
-			Handler?.Invoke(nameof(IMap.MoveToRegion), _lastMoveToRegion);
+			Handler?.Invoke(nameof(IMap.MoveToRegion), new MoveToRegionRequest(_lastMoveToRegion, true));
+		}
+
+		/// <summary>
+		/// Adjusts the viewport of the map control to view the specified region, with control over animation.
+		/// </summary>
+		/// <param name="mapSpan">A <see cref="MapSpan"/> object containing details on what region should be shown.</param>
+		/// <param name="animated">Whether the transition should be animated.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="mapSpan"/> is <see langword="null"/>.</exception>
+		public void MoveToRegion(MapSpan mapSpan, bool animated)
+		{
+			if (mapSpan is null)
+			{
+				throw new ArgumentNullException(nameof(mapSpan));
+			}
+
+			_lastMoveToRegion = mapSpan;
+			Handler?.Invoke(nameof(IMap.MoveToRegion), new MoveToRegionRequest(_lastMoveToRegion, animated));
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
 Microsoft.Maui.Controls.Maps.Map.UserLocationChanged -> System.EventHandler<Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs!>?

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.CameraZoomGallery"
+    Title="Camera &amp; Zoom">
+    <Grid RowDefinitions="Auto, Auto, *">
+        <HorizontalStackLayout Grid.Row="0" Spacing="5" Padding="5">
+            <Button Text="Fit All Pins" Clicked="OnFitAllPins" />
+            <Button Text="Animated" Clicked="OnMoveAnimated" />
+            <Button Text="Instant" Clicked="OnMoveInstant" />
+        </HorizontalStackLayout>
+        <Label x:Name="InfoLabel" Grid.Row="1" Padding="5" Text="Tap buttons to test camera/zoom features" />
+        <maps:Map x:Name="map" Grid.Row="2" />
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml.cs
@@ -1,0 +1,58 @@
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Devices.Sensors;
+using Microsoft.Maui.Maps;
+
+namespace Maui.Controls.Sample.Pages.MapsGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class CameraZoomGallery
+	{
+		readonly Location[] _cities =
+		{
+			new(47.6062, -122.3321),  // Seattle
+			new(37.7749, -122.4194),  // San Francisco
+			new(34.0522, -118.2437),  // Los Angeles
+			new(40.7128, -74.0060),   // New York
+			new(41.8781, -87.6298),   // Chicago
+		};
+
+		public CameraZoomGallery()
+		{
+			InitializeComponent();
+
+			foreach (var city in _cities)
+			{
+				map.Pins.Add(new Pin
+				{
+					Label = $"City ({city.Latitude:F2}, {city.Longitude:F2})",
+					Location = city,
+					Type = PinType.Place,
+				});
+			}
+		}
+
+		void OnFitAllPins(object? sender, EventArgs e)
+		{
+			var span = MapSpan.FromLocations(_cities);
+			map.MoveToRegion(span, true);
+			InfoLabel.Text = $"Best fit: center={span.Center.Latitude:F2},{span.Center.Longitude:F2} span={span.LatitudeDegrees:F2}x{span.LongitudeDegrees:F2}";
+		}
+
+		void OnMoveAnimated(object? sender, EventArgs e)
+		{
+			// Move to Seattle with animation
+			var seattle = new MapSpan(new Location(47.6062, -122.3321), 0.1, 0.1);
+			map.MoveToRegion(seattle, true);
+			InfoLabel.Text = "Animated move to Seattle";
+		}
+
+		void OnMoveInstant(object? sender, EventArgs e)
+		{
+			// Move to New York instantly
+			var newYork = new MapSpan(new Location(40.7128, -74.0060), 0.1, 0.1);
+			map.MoveToRegion(newYork, false);
+			InfoLabel.Text = "Instant move to New York";
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Devices.Sensors;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CameraZoomGallery.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Controls.Xaml;
@@ -9,7 +10,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class CameraZoomGallery
 	{
-		readonly Location[] _cities =
+		readonly Microsoft.Maui.Devices.Sensors.Location[] _cities =
 		{
 			new(47.6062, -122.3321),  // Seattle
 			new(37.7749, -122.4194),  // San Francisco
@@ -43,7 +44,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 		void OnMoveAnimated(object? sender, EventArgs e)
 		{
 			// Move to Seattle with animation
-			var seattle = new MapSpan(new Location(47.6062, -122.3321), 0.1, 0.1);
+			var seattle = new MapSpan(new Microsoft.Maui.Devices.Sensors.Location(47.6062, -122.3321), 0.1, 0.1);
 			map.MoveToRegion(seattle, true);
 			InfoLabel.Text = "Animated move to Seattle";
 		}
@@ -51,7 +52,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 		void OnMoveInstant(object? sender, EventArgs e)
 		{
 			// Move to New York instantly
-			var newYork = new MapSpan(new Location(40.7128, -74.0060), 0.1, 0.1);
+			var newYork = new MapSpan(new Microsoft.Maui.Devices.Sensors.Location(40.7128, -74.0060), 0.1, 0.1);
 			map.MoveToRegion(newYork, false);
 			InfoLabel.Text = "Instant move to New York";
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -27,6 +27,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Map Long Click", () => new MapLongClickGallery(), Navigation),
 						GalleryBuilder.NavButton("Info Window", () => new InfoWindowGallery(), Navigation),
 						GalleryBuilder.NavButton("User Location", () => new UserLocationGallery(), Navigation),
+						GalleryBuilder.NavButton("Camera & Zoom", () => new CameraZoomGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/tests/Core.UnitTests/MapSpanTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapSpanTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Maps;
@@ -41,6 +43,64 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var span = new MapSpan(new Location(0, 0), -1, -2);
 			Assert.True(span.LatitudeDegrees > 0);
 			Assert.True(span.LongitudeDegrees > 0);
+		}
+
+		[Fact]
+		public void FromLocationsThrowsOnNull()
+		{
+			Assert.Throws<ArgumentNullException>(() => MapSpan.FromLocations(null!));
+		}
+
+		[Fact]
+		public void FromLocationsThrowsOnEmpty()
+		{
+			Assert.Throws<ArgumentException>(() => MapSpan.FromLocations(Array.Empty<Location>()));
+		}
+
+		[Fact]
+		public void FromLocationsSingleUsesOneKmRadius()
+		{
+			var loc = new Location(47.6, -122.3);
+			var span = MapSpan.FromLocations(new[] { loc });
+
+			Assert.Equal(47.6, span.Center.Latitude);
+			Assert.Equal(-122.3, span.Center.Longitude);
+			Assert.True(span.Radius.Kilometers > 0.9 && span.Radius.Kilometers < 1.1);
+		}
+
+		[Fact]
+		public void FromLocationsMultipleComputesBoundingBox()
+		{
+			var locations = new[]
+			{
+				new Location(40.0, -74.0), // New York area
+				new Location(42.0, -72.0), // Boston area
+			};
+
+			var span = MapSpan.FromLocations(locations);
+
+			Assert.Equal(41.0, span.Center.Latitude, 1);
+			Assert.Equal(-73.0, span.Center.Longitude, 1);
+			// With 10% padding: lat span = 2.0 * 1.1 = 2.2, lon span = 2.0 * 1.1 = 2.2
+			Assert.Equal(2.2, span.LatitudeDegrees, 1);
+			Assert.Equal(2.2, span.LongitudeDegrees, 1);
+		}
+
+		[Fact]
+		public void FromLocationsEncompassesAllPoints()
+		{
+			var locations = new List<Location>
+			{
+				new Location(10, 20),
+				new Location(30, 40),
+				new Location(20, 30),
+			};
+
+			var span = MapSpan.FromLocations(locations);
+
+			// Center should be midpoint
+			Assert.Equal(20.0, span.Center.Latitude);
+			Assert.Equal(30.0, span.Center.Longitude);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -619,6 +619,42 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMapElement)polyline).Clicked();
 
 			Assert.Same(polyline, sender);
+		public void MoveToRegionThrowsOnNull()
+		{
+			var map = new Map();
+			Assert.Throws<ArgumentNullException>(() => map.MoveToRegion(null!));
+		}
+
+		[Fact]
+		public void MoveToRegionAnimatedThrowsOnNull()
+		{
+			var map = new Map();
+			Assert.Throws<ArgumentNullException>(() => map.MoveToRegion(null!, true));
+		}
+
+		[Fact]
+		public void MoveToRegionAnimatedOverloadExists()
+		{
+			var map = new Map();
+			var span = new MapSpan(new Location(0, 0), 1, 1);
+
+			// Should not throw - verifies the overload exists and is callable
+			map.MoveToRegion(span, false);
+			map.MoveToRegion(span, true);
+		}
+
+		[Fact]
+		public void MoveToRegionRequestProperties()
+		{
+			var span = new MapSpan(new Location(10, 20), 1, 1);
+			var request = new MoveToRegionRequest(span, true);
+
+			Assert.Same(span, request.Region);
+			Assert.True(request.Animated);
+
+			var request2 = new MoveToRegionRequest(null, false);
+			Assert.Null(request2.Region);
+			Assert.False(request2.Animated);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -619,6 +619,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMapElement)polyline).Clicked();
 
 			Assert.Same(polyline, sender);
+		}
+
+		[Fact]
 		public void MoveToRegionThrowsOnNull()
 		{
 			var map = new Map();

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -1066,5 +1066,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		#endregion
+
+		[Fact]
+		public void FromLocationsHandlesAntimeridianCrossing()
+		{
+			// Points near the antimeridian (179° and -179° should result in a small span, not 358°)
+			var locations = new[]
+			{
+				new Location(0, 179),
+				new Location(0, -179)
+			};
+
+			var span = MapSpan.FromLocations(locations);
+
+			// The span should be small (around 2-3 degrees), not 358 degrees
+			Assert.True(span.LongitudeDegrees < 10, $"Expected small longitude span for antimeridian crossing, got {span.LongitudeDegrees}");
+		}
 	}
 }

--- a/src/Core/maps/src/Core/IMap.cs
+++ b/src/Core/maps/src/Core/IMap.cs
@@ -102,5 +102,13 @@ namespace Microsoft.Maui.Maps
 		/// </summary>
 		/// <param name="pin">The pin whose info window should be hidden.</param>
 		void HideInfoWindow(IMapPin pin);
+
+		/// <summary>
+		/// Moves the map so that it displays the specified <see cref="MapSpan"/> region,
+		/// with control over whether the transition is animated.
+		/// </summary>
+		/// <param name="region">The region to display.</param>
+		/// <param name="animated">Whether the transition should be animated.</param>
+		void MoveToRegion(MapSpan region, bool animated);
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -145,9 +145,14 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg)
 		{
-			MapSpan? newRegion = arg as MapSpan;
-			if (newRegion != null)
+			if (arg is MoveToRegionRequest request && request.Region != null)
+			{
+				(handler as MapHandler)?.MoveToRegion(request.Region, request.Animated);
+			}
+			else if (arg is MapSpan newRegion)
+			{
 				(handler as MapHandler)?.MoveToRegion(newRegion, true);
+			}
 		}
 
 		public void UpdateMapElement(IMapElement element)

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -94,9 +94,14 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg)
 		{
-			MapSpan? newRegion = arg as MapSpan;
-			if (newRegion != null)
+			if (arg is MoveToRegionRequest request && request.Region != null)
+			{
+				(handler as MapHandler)?.MoveToRegion(request.Region, request.Animated);
+			}
+			else if (arg is MapSpan newRegion)
+			{
 				(handler as MapHandler)?.MoveToRegion(newRegion, true);
+			}
 		}
 
 		public void UpdateMapElement(IMapElement element)

--- a/src/Core/maps/src/Primitives/MapSpan.cs
+++ b/src/Core/maps/src/Primitives/MapSpan.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Microsoft.Maui.Devices.Sensors;
 
 namespace Microsoft.Maui.Maps
@@ -88,6 +90,48 @@ namespace Microsoft.Maui.Maps
 		public static MapSpan FromCenterAndRadius(Location center, Distance radius)
 		{
 			return new MapSpan(center, 2 * DistanceToLatitudeDegrees(radius), 2 * DistanceToLongitudeDegrees(center, radius));
+		}
+
+		/// <summary>
+		/// Creates a <see cref="MapSpan"/> that encompasses all of the specified locations.
+		/// </summary>
+		/// <param name="locations">The locations to include in the span.</param>
+		/// <returns>A new <see cref="MapSpan"/> that fits all locations, with 10% padding.</returns>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="locations"/> is <see langword="null"/>.</exception>
+		/// <exception cref="ArgumentException">Thrown when <paramref name="locations"/> is empty.</exception>
+		public static MapSpan FromLocations(IEnumerable<Location> locations)
+		{
+			if (locations is null)
+				throw new ArgumentNullException(nameof(locations));
+
+			var locationList = locations.ToList();
+			if (locationList.Count == 0)
+				throw new ArgumentException("At least one location is required.", nameof(locations));
+
+			if (locationList.Count == 1)
+				return FromCenterAndRadius(locationList[0], Distance.FromKilometers(1));
+
+			double minLat = double.MaxValue, maxLat = double.MinValue;
+			double minLon = double.MaxValue, maxLon = double.MinValue;
+
+			foreach (var loc in locationList)
+			{
+				minLat = Math.Min(minLat, loc.Latitude);
+				maxLat = Math.Max(maxLat, loc.Latitude);
+				minLon = Math.Min(minLon, loc.Longitude);
+				maxLon = Math.Max(maxLon, loc.Longitude);
+			}
+
+			double centerLat = (minLat + maxLat) / 2;
+			double centerLon = (minLon + maxLon) / 2;
+			double latDegrees = (maxLat - minLat) * 1.1; // 10% padding
+			double lonDegrees = (maxLon - minLon) * 1.1;
+
+			// Ensure minimum span
+			latDegrees = Math.Max(latDegrees, MinimumRangeDegrees);
+			lonDegrees = Math.Max(lonDegrees, MinimumRangeDegrees);
+
+			return new MapSpan(new Location(centerLat, centerLon), latDegrees, lonDegrees);
 		}
 
 		/// <inheritdoc/>

--- a/src/Core/maps/src/Primitives/MapSpan.cs
+++ b/src/Core/maps/src/Primitives/MapSpan.cs
@@ -123,9 +123,27 @@ namespace Microsoft.Maui.Maps
 			}
 
 			double centerLat = (minLat + maxLat) / 2;
-			double centerLon = (minLon + maxLon) / 2;
 			double latDegrees = (maxLat - minLat) * 1.1; // 10% padding
-			double lonDegrees = (maxLon - minLon) * 1.1;
+
+			// Handle antimeridian crossing: if the direct span exceeds 180°,
+			// it's likely shorter to go the other way around
+			double lonSpan = maxLon - minLon;
+			double wrappedLonSpan = 360 - lonSpan;
+			double centerLon, lonDegrees;
+
+			if (lonSpan <= wrappedLonSpan)
+			{
+				// Normal case: all points are on the same side
+				centerLon = (minLon + maxLon) / 2;
+				lonDegrees = lonSpan * 1.1;
+			}
+			else
+			{
+				// Antimeridian crossing: wrap around
+				centerLon = (maxLon + minLon) / 2 + 180;
+				if (centerLon > 180) centerLon -= 360;
+				lonDegrees = wrappedLonSpan * 1.1;
+			}
 
 			// Ensure minimum span
 			latDegrees = Math.Max(latDegrees, MinimumRangeDegrees);

--- a/src/Core/maps/src/Primitives/MoveToRegionRequest.cs
+++ b/src/Core/maps/src/Primitives/MoveToRegionRequest.cs
@@ -1,0 +1,29 @@
+namespace Microsoft.Maui.Maps
+{
+	/// <summary>
+	/// Represents a request to move the map to a specific region, with optional animation control.
+	/// </summary>
+	public sealed class MoveToRegionRequest
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MoveToRegionRequest"/> class.
+		/// </summary>
+		/// <param name="region">The target region.</param>
+		/// <param name="animated">Whether the transition should be animated.</param>
+		public MoveToRegionRequest(MapSpan? region, bool animated)
+		{
+			Region = region;
+			Animated = animated;
+		}
+
+		/// <summary>
+		/// Gets the target region.
+		/// </summary>
+		public MapSpan? Region { get; }
+
+		/// <summary>
+		/// Gets whether the transition should be animated.
+		/// </summary>
+		public bool Animated { get; }
+	}
+}

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
@@ -26,3 +31,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.set -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -28,3 +33,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.Platform.MauiMKMapView.IsClusteringEnabled.set -> void
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
@@ -28,3 +33,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
@@ -26,3 +31,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
@@ -26,3 +31,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
@@ -26,3 +31,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.UserLocationUpdated(Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -16,6 +17,10 @@ Microsoft.Maui.Maps.IMapPin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Maps.IMapPin.ImageSource.get -> Microsoft.Maui.IImageSource?
 Microsoft.Maui.Maps.MapSpanTypeConverter
 Microsoft.Maui.Maps.MapSpanTypeConverter.MapSpanTypeConverter() -> void
+Microsoft.Maui.Maps.MoveToRegionRequest
+Microsoft.Maui.Maps.MoveToRegionRequest.Animated.get -> bool
+Microsoft.Maui.Maps.MoveToRegionRequest.MoveToRegionRequest(Microsoft.Maui.Maps.MapSpan? region, bool animated) -> void
+Microsoft.Maui.Maps.MoveToRegionRequest.Region.get -> Microsoft.Maui.Maps.MapSpan?
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
@@ -26,3 +31,4 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
+static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR adds camera and zoom control improvements to the Maps control:

### 1. MoveToRegion Animation Control (Fixes #21046)
- Adds `MoveToRegion(MapSpan region, bool animated)` overload to `IMap` and `Map`
- Android: Uses `AnimateCamera` when animated=true, `MoveCamera` when animated=false
- iOS: Passes animated parameter to `MKMapView.SetRegion`
- **Fixes the Maui island fly-in animation**: `OnHandlerChanged` now uses `animated: false`, so when you set an initial region, it appears instantly without the jarring animation from the Maui island default position

### 2. MapSpan.FromLocations - Best Fit Zoom (Fixes #10718)
- Adds `MapSpan.FromLocations(IEnumerable<Location>)` static method
- Computes a bounding box encompassing all provided locations with 10% padding
- Single location falls back to 1km radius
- Enables easy "zoom to fit all pins" scenarios

### 3. MoveToRegionRequest
- New `MoveToRegionRequest` class wrapping `MapSpan` + `bool Animated` for handler communication
- Backward compatible: handlers accept both `MoveToRegionRequest` and raw `MapSpan`

### Related: Zoom Level Property (#11332)
- The combination of `MoveToRegion(animated)` + `MapSpan.FromLocations()` + existing `VisibleRegion` provides comprehensive camera/zoom control
- A dedicated `ZoomLevel` property may be added as a future enhancement

## New Public API

```csharp
// IMap (Core)
void MoveToRegion(MapSpan region, bool animated);

// Map (Controls)
public void MoveToRegion(MapSpan region, bool animated);

// MapSpan
public static MapSpan FromLocations(IEnumerable<Location> locations);

// MoveToRegionRequest (new class)
public MoveToRegionRequest(MapSpan? region, bool animated);
public MapSpan? Region { get; }
public bool Animated { get; }
```

## Testing

- 9 new unit tests (38 total map tests pass)
- CameraZoomGallery sample page added
- Verified on MacCatalyst and Android with visual confirmation

## Part of [Epic: Maps Control Improvements for .NET 11](https://github.com/dotnet/maui/issues/33787)

Fixes #21046
Fixes #10718
Fixes #11332