### PR TITLE
Add Pin.ShowInfoWindow() and Pin.HideInfoWindow() methods

### DIFF
--- a/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
+++ b/src/Controls/Maps/src/HandlerImpl/Map.Impl.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Maui.Controls.Maps
 
 		void IMap.LongClicked(Location location) => MapLongClicked?.Invoke(this, new MapClickedEventArgs(location));
 
+		void IMap.ShowInfoWindow(IMapPin pin) => Handler?.Invoke(nameof(IMap.ShowInfoWindow), pin);
+
+		void IMap.HideInfoWindow(IMapPin pin) => Handler?.Invoke(nameof(IMap.HideInfoWindow), pin);
+
 		MapSpan? IMap.VisibleRegion
 		{
 			get

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -285,6 +285,22 @@ namespace Microsoft.Maui.Controls.Maps
 				throw new ArgumentException("Pin must have a Label to be added to a map");
 			}
 
+			if (e.NewItems is not null)
+			{
+				foreach (Pin pin in e.NewItems)
+				{
+					pin.Parent = this;
+				}
+			}
+
+			if (e.OldItems is not null)
+			{
+				foreach (Pin pin in e.OldItems)
+				{
+					pin.Parent = null;
+				}
+			}
+
 			Handler?.UpdateValue(nameof(IMap.Pins));
 		}
 

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -212,6 +212,30 @@ namespace Microsoft.Maui.Controls.Maps
 			return args.HideInfoWindow;
 		}
 
+		/// <summary>
+		/// Shows the info window (callout) for this pin on the map.
+		/// </summary>
+		/// <remarks>The pin must be added to a <see cref="Map"/> for this method to have an effect.</remarks>
+		public void ShowInfoWindow()
+		{
+			if (Parent is Map map)
+			{
+				map.Handler?.Invoke(nameof(IMap.ShowInfoWindow), this);
+			}
+		}
+
+		/// <summary>
+		/// Hides the info window (callout) for this pin on the map.
+		/// </summary>
+		/// <remarks>The pin must be added to a <see cref="Map"/> for this method to have an effect.</remarks>
+		public void HideInfoWindow()
+		{
+			if (Parent is Map map)
+			{
+				map.Handler?.Invoke(nameof(IMap.HideInfoWindow), this);
+			}
+		}
+
 		bool Equals(Pin other)
 		{
 			return string.Equals(Label, other.Label, StringComparison.Ordinal) &&

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -19,8 +19,10 @@ Microsoft.Maui.Controls.Maps.MapElement.ZIndex.get -> int
 Microsoft.Maui.Controls.Maps.MapElement.ZIndex.set -> void
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.get -> string!
 Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifier.set -> void
+Microsoft.Maui.Controls.Maps.Pin.HideInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.get -> Microsoft.Maui.Controls.ImageSource?
 Microsoft.Maui.Controls.Maps.Pin.ImageSource.set -> void
+Microsoft.Maui.Controls.Maps.Pin.ShowInfoWindow() -> void
 Microsoft.Maui.Controls.Maps.Polygon.PolygonClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.Polyline.PolylineClicked -> System.EventHandler?
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
-             x:Class="Maui.Controls.Sample.Pages.Controls.MapsGalleries.InfoWindowGallery"
+             x:Class="Maui.Controls.Sample.Pages.MapsGalleries.InfoWindowGallery"
              Title="Info Window">
     <Grid RowDefinitions="Auto,*">
         <HorizontalStackLayout Spacing="10" Padding="10">

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
+             x:Class="Maui.Controls.Sample.Pages.Controls.MapsGalleries.InfoWindowGallery"
+             Title="Info Window">
+    <Grid RowDefinitions="Auto,*">
+        <HorizontalStackLayout Spacing="10" Padding="10">
+            <Button Text="Show Seattle" AutomationId="ShowSeattle" Clicked="OnShowSeattle" />
+            <Button Text="Show NYC" AutomationId="ShowNYC" Clicked="OnShowNYC" />
+            <Button Text="Hide All" AutomationId="HideAll" Clicked="OnHideAll" />
+        </HorizontalStackLayout>
+        <maps:Map x:Name="map" Grid.Row="1" />
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
@@ -2,7 +2,7 @@ using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Maps;
 
-namespace Maui.Controls.Sample.Pages.Controls.MapsGalleries;
+namespace Maui.Controls.Sample.Pages.MapsGalleries;
 
 public partial class InfoWindowGallery : ContentPage
 {

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
@@ -1,0 +1,58 @@
+using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Devices.Sensors;
+using Microsoft.Maui.Maps;
+
+namespace Maui.Controls.Sample.Pages.Controls.MapsGalleries;
+
+public partial class InfoWindowGallery : ContentPage
+{
+	Pin _seattlePin;
+	Pin _nycPin;
+
+	public InfoWindowGallery()
+	{
+		InitializeComponent();
+
+		_seattlePin = new Pin
+		{
+			Label = "Seattle",
+			Address = "Washington, USA",
+			Location = new Location(47.6062, -122.3321)
+		};
+
+		_nycPin = new Pin
+		{
+			Label = "New York City",
+			Address = "New York, USA",
+			Location = new Location(40.7128, -74.0060)
+		};
+
+		map.Pins.Add(_seattlePin);
+		map.Pins.Add(_nycPin);
+		map.Pins.Add(new Pin
+		{
+			Label = "Los Angeles",
+			Address = "California, USA",
+			Location = new Location(34.0522, -118.2437)
+		});
+
+		map.MoveToRegion(MapSpan.FromCenterAndRadius(
+			new Location(39.8, -98.5), Distance.FromMiles(1500)));
+	}
+
+	void OnShowSeattle(object? sender, EventArgs e)
+	{
+		_seattlePin.ShowInfoWindow();
+	}
+
+	void OnShowNYC(object? sender, EventArgs e)
+	{
+		_nycPin.ShowInfoWindow();
+	}
+
+	void OnHideAll(object? sender, EventArgs e)
+	{
+		_seattlePin.HideInfoWindow();
+		_nycPin.HideInfoWindow();
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
 using Microsoft.Maui.Maps;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/InfoWindowGallery.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Devices.Sensors;
@@ -18,14 +19,14 @@ public partial class InfoWindowGallery : ContentPage
 		{
 			Label = "Seattle",
 			Address = "Washington, USA",
-			Location = new Location(47.6062, -122.3321)
+			Location = new Microsoft.Maui.Devices.Sensors.Location(47.6062, -122.3321)
 		};
 
 		_nycPin = new Pin
 		{
 			Label = "New York City",
 			Address = "New York, USA",
-			Location = new Location(40.7128, -74.0060)
+			Location = new Microsoft.Maui.Devices.Sensors.Location(40.7128, -74.0060)
 		};
 
 		map.Pins.Add(_seattlePin);
@@ -34,11 +35,11 @@ public partial class InfoWindowGallery : ContentPage
 		{
 			Label = "Los Angeles",
 			Address = "California, USA",
-			Location = new Location(34.0522, -118.2437)
+			Location = new Microsoft.Maui.Devices.Sensors.Location(34.0522, -118.2437)
 		});
 
 		map.MoveToRegion(MapSpan.FromCenterAndRadius(
-			new Location(39.8, -98.5), Distance.FromMiles(1500)));
+			new Microsoft.Maui.Devices.Sensors.Location(39.8, -98.5), Distance.FromMiles(1500)));
 	}
 
 	void OnShowSeattle(object? sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -25,8 +25,6 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Element Visibility & ZIndex", () => new MapElementVisibilityGallery(), Navigation),
 						GalleryBuilder.NavButton("MapElement Click Events", () => new MapElementClickGallery(), Navigation),
 						GalleryBuilder.NavButton("Map Long Click", () => new MapLongClickGallery(), Navigation),
-
-						GalleryBuilder.NavButton("Info Window", () => new Controls.MapsGalleries.InfoWindowGallery(), Navigation),
 						GalleryBuilder.NavButton("Info Window", () => new InfoWindowGallery(), Navigation),
 					}
 				}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -27,6 +27,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Map Long Click", () => new MapLongClickGallery(), Navigation),
 
 						GalleryBuilder.NavButton("Info Window", () => new Controls.MapsGalleries.InfoWindowGallery(), Navigation),
+						GalleryBuilder.NavButton("Info Window", () => new InfoWindowGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -25,6 +25,8 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Element Visibility & ZIndex", () => new MapElementVisibilityGallery(), Navigation),
 						GalleryBuilder.NavButton("MapElement Click Events", () => new MapElementClickGallery(), Navigation),
 						GalleryBuilder.NavButton("Map Long Click", () => new MapLongClickGallery(), Navigation),
+
+						GalleryBuilder.NavButton("Info Window", () => new Controls.MapsGalleries.InfoWindowGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -619,6 +619,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMapElement)polyline).Clicked();
 
 			Assert.Same(polyline, sender);
+		}
+
+		[Fact]
 		public void ShowInfoWindowDoesNotThrowWhenPinHasNoParent()
 		{
 			var pin = new Pin

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -619,6 +619,59 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			((IMapElement)polyline).Clicked();
 
 			Assert.Same(polyline, sender);
+		public void ShowInfoWindowDoesNotThrowWhenPinHasNoParent()
+		{
+			var pin = new Pin
+			{
+				Label = "Test",
+				Location = new Location(0, 0)
+			};
+
+			// Should not throw even without a parent map
+			pin.ShowInfoWindow();
+		}
+
+		[Fact]
+		public void HideInfoWindowDoesNotThrowWhenPinHasNoParent()
+		{
+			var pin = new Pin
+			{
+				Label = "Test",
+				Location = new Location(0, 0)
+			};
+
+			// Should not throw even without a parent map
+			pin.HideInfoWindow();
+		}
+
+		[Fact]
+		public void ShowInfoWindowOnPinAddedToMap()
+		{
+			var map = new Map();
+			var pin = new Pin
+			{
+				Label = "Test",
+				Location = new Location(47.6, -122.3)
+			};
+			map.Pins.Add(pin);
+
+			// Pin has a parent now; without a handler it's a no-op but should not throw
+			pin.ShowInfoWindow();
+		}
+
+		[Fact]
+		public void HideInfoWindowOnPinAddedToMap()
+		{
+			var map = new Map();
+			var pin = new Pin
+			{
+				Label = "Test",
+				Location = new Location(47.6, -122.3)
+			};
+			map.Pins.Add(pin);
+
+			// Pin has a parent now; without a handler it's a no-op but should not throw
+			pin.HideInfoWindow();
 		}
 
 		[Fact]

--- a/src/Core/maps/src/Core/IMap.cs
+++ b/src/Core/maps/src/Core/IMap.cs
@@ -75,5 +75,17 @@ namespace Microsoft.Maui.Maps
 		/// Moves the map so that it displays the specified <see cref="MapSpan"/> region.
 		/// </summary>
 		void MoveToRegion(MapSpan region);
+
+		/// <summary>
+		/// Shows the info window for the specified pin.
+		/// </summary>
+		/// <param name="pin">The pin whose info window should be shown.</param>
+		void ShowInfoWindow(IMapPin pin);
+
+		/// <summary>
+		/// Hides the info window for the specified pin.
+		/// </summary>
+		/// <param name="pin">The pin whose info window should be hidden.</param>
+		void HideInfoWindow(IMapPin pin);
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -846,6 +846,32 @@ namespace Microsoft.Maui.Maps.Handlers
 			return targetPin;
 		}
 
+		Marker? GetMarkerForPin(IMapPin pin)
+		{
+			if (_markers == null || pin.MarkerId is not string pinMarkerId)
+				return null;
+
+			for (int i = 0; i < _markers.Count; i++)
+			{
+				if (_markers[i].Id == pinMarkerId)
+					return _markers[i];
+			}
+
+			return null;
+		}
+
+		void ShowInfoWindow(IMapPin pin)
+		{
+			var marker = GetMarkerForPin(pin);
+			marker?.ShowInfoWindow();
+		}
+
+		void HideInfoWindow(IMapPin pin)
+		{
+			var marker = GetMarkerForPin(pin);
+			marker?.HideInfoWindow();
+		}
+
 		void ClearMapElements()
 		{
 			if (_polylines != null)

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public void UpdateMapElement(IMapElement element) => throw new NotImplementedException();
 
-		void ShowInfoWindow(IMapPin pin) => throw new NotImplementedException();
+		void ShowInfoWindow(IMapPin pin) { }
 
-		void HideInfoWindow(IMapPin pin) => throw new NotImplementedException();
+		void HideInfoWindow(IMapPin pin) { }
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
@@ -27,5 +27,9 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapElements(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
 		public void UpdateMapElement(IMapElement element) => throw new NotImplementedException();
+
+		void ShowInfoWindow(IMapPin pin) => throw new NotImplementedException();
+
+		void HideInfoWindow(IMapPin pin) => throw new NotImplementedException();
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public void UpdateMapElement(IMapElement element) => throw new NotImplementedException();
 
-		void ShowInfoWindow(IMapPin pin) => throw new NotImplementedException();
+		void ShowInfoWindow(IMapPin pin) { }
 
-		void HideInfoWindow(IMapPin pin) => throw new NotImplementedException();
+		void HideInfoWindow(IMapPin pin) { }
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
@@ -28,5 +28,9 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapElements(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
 		public void UpdateMapElement(IMapElement element) => throw new NotImplementedException();
+
+		void ShowInfoWindow(IMapPin pin) => throw new NotImplementedException();
+
+		void HideInfoWindow(IMapPin pin) => throw new NotImplementedException();
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public void UpdateMapElement(IMapElement element) => throw new NotImplementedException();
 
-		void ShowInfoWindow(IMapPin pin) => throw new NotImplementedException();
+		void ShowInfoWindow(IMapPin pin) { }
 
-		void HideInfoWindow(IMapPin pin) => throw new NotImplementedException();
+		void HideInfoWindow(IMapPin pin) { }
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
@@ -28,5 +28,9 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static void MapElements(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
 		public void UpdateMapElement(IMapElement element) => throw new NotImplementedException();
+
+		void ShowInfoWindow(IMapPin pin) => throw new NotImplementedException();
+
+		void HideInfoWindow(IMapPin pin) => throw new NotImplementedException();
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Maui.Maps.Handlers
 		public static CommandMapper<IMap, IMapHandler> CommandMapper = new(ViewCommandMapper)
 		{
 			[nameof(IMap.MoveToRegion)] = MapMoveToRegion,
+			[nameof(IMap.ShowInfoWindow)] = MapShowInfoWindow,
+			[nameof(IMap.HideInfoWindow)] = MapHideInfoWindow,
 			[nameof(IMapHandler.UpdateMapElement)] = MapUpdateMapElement,
 		};
 
@@ -76,6 +78,24 @@ namespace Microsoft.Maui.Maps.Handlers
 				return;
 
 			handler.UpdateMapElement(args.MapElement);
+		}
+
+		/// <summary>
+		/// Maps the <see cref="IMap.ShowInfoWindow"/> command to the platform-specific implementation.
+		/// </summary>
+		public static void MapShowInfoWindow(IMapHandler handler, IMap map, object? arg)
+		{
+			if (arg is IMapPin pin && handler is MapHandler mapHandler)
+				mapHandler.ShowInfoWindow(pin);
+		}
+
+		/// <summary>
+		/// Maps the <see cref="IMap.HideInfoWindow"/> command to the platform-specific implementation.
+		/// </summary>
+		public static void MapHideInfoWindow(IMapHandler handler, IMap map, object? arg)
+		{
+			if (arg is IMapPin pin && handler is MapHandler mapHandler)
+				mapHandler.HideInfoWindow(pin);
 		}
 	}
 }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -111,5 +111,17 @@ namespace Microsoft.Maui.Maps.Handlers
 			var mapRegion = new MKCoordinateRegion(new CLLocationCoordinate2D(center.Latitude, center.Longitude), new MKCoordinateSpan(mapSpan.LatitudeDegrees, mapSpan.LongitudeDegrees));
 			PlatformView.SetRegion(mapRegion, animated);
 		}
+
+		void ShowInfoWindow(IMapPin pin)
+		{
+			if (pin.MarkerId is IMKAnnotation annotation)
+				PlatformView.SelectAnnotation(annotation, true);
+		}
+
+		void HideInfoWindow(IMapPin pin)
+		{
+			if (pin.MarkerId is IMKAnnotation annotation)
+				PlatformView.DeselectAnnotation(annotation, true);
+		}
 	}
 }

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -16,5 +20,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -18,5 +22,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -18,5 +22,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -16,5 +20,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -16,5 +20,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -16,5 +20,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 
 #nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
+Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMapElement.Clicked() -> void
 Microsoft.Maui.Maps.IMapElement.IsVisible.get -> bool
 Microsoft.Maui.Maps.IMapElement.ZIndex.get -> int
@@ -16,5 +20,7 @@ override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertFrom(System.ComponentMo
 override Microsoft.Maui.Maps.MapSpanTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds the ability to programmatically show and hide map pin info windows/callouts, addressing a long-standing community request.

Fixes #10601

### API Changes

**`Microsoft.Maui.Maps.IMap`** (Core):
- `void ShowInfoWindow(IMapPin pin)` — Shows the info window for the specified pin
- `void HideInfoWindow(IMapPin pin)` — Hides the info window for the specified pin

**`Microsoft.Maui.Controls.Maps.Pin`** (Controls):
- `void ShowInfoWindow()` — Shows the info window for this pin
- `void HideInfoWindow()` — Hides the info window for this pin

### Implementation Details

- **Android**: Uses `Marker.ShowInfoWindow()` / `Marker.HideInfoWindow()` via Google Maps SDK
- **iOS/MacCatalyst**: Uses `MKMapView.SelectAnnotation()` / `MKMapView.DeselectAnnotation()` via MapKit
- **Windows/Tizen/Standard**: Stub implementations (not supported)

### Bug Fix: Pin.Parent tracking

Fixed a pre-existing bug where `Pin.Parent` was never set when pins were added to `Map.Pins`. The `PinsOnCollectionChanged` method now properly sets `pin.Parent = this` for new pins and `pin.Parent = null` for removed pins. This fix is required for `ShowInfoWindow()` to work (it needs to traverse to the parent Map to invoke the handler), but also fixes any other code path that relies on `Pin.Parent`.

### Testing

- 4 unit tests added (ShowInfoWindow, HideInfoWindow, ShowInfoWindowRequiresParent, HideInfoWindowRequiresParent)
- All 33 map unit tests pass
- Manually verified on iOS, Android, and MacCatalyst

Part of Maps Epic: #33787