### PR TITLE
Add MapStyle property for custom JSON map styling (Android)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,6 +90,18 @@ Major test projects:
 
 Find all tests: `find . -name "*.UnitTests.csproj"`
 
+### CI Pipelines (Azure DevOps)
+
+When referencing or triggering CI pipelines, use these current pipeline names:
+
+| Pipeline | Name | Purpose |
+|----------|------|---------|
+| Overall CI | `maui-pr` | Full PR validation build |
+| Device Tests | `maui-pr-devicetests` | Helix-based device tests |
+| UI Tests | `maui-pr-uitests` | Appium-based UI tests |
+
+**⚠️ Old pipeline names** (e.g., `MAUI-UITests-public`, `MAUI-public`) are **outdated** and should NOT be used. Always use the names above.
+
 ### Code Formatting
 
 Always format code before committing:

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -34,6 +34,9 @@ namespace Microsoft.Maui.Controls.Maps
 		/// <summary>Bindable property for <see cref="IsClusteringEnabled"/>.</summary>
 		public static readonly BindableProperty IsClusteringEnabledProperty = BindableProperty.Create(nameof(IsClusteringEnabled), typeof(bool), typeof(Map), default(bool));
 
+		/// <summary>Bindable property for <see cref="MapStyle"/>.</summary>
+		public static readonly BindableProperty MapStyleProperty = BindableProperty.Create(nameof(MapStyle), typeof(string), typeof(Map), default(string));
+
 		/// <summary>Bindable property for <see cref="ItemsSource"/>.</summary>
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(Map), default(IEnumerable),
 			propertyChanged: (b, o, n) => ((Map)b).OnItemsSourcePropertyChanged((IEnumerable)o, (IEnumerable)n));
@@ -143,6 +146,28 @@ namespace Microsoft.Maui.Controls.Maps
 		{
 			get { return (MapType)GetValue(MapTypeProperty); }
 			set { SetValue(MapTypeProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the custom map style as a JSON string.
+		/// This is a bindable property.
+		/// </summary>
+		/// <remarks>
+		/// This property is only supported on Android where it accepts a Google Maps style JSON string
+		/// generated from the Google Maps Styling Wizard (https://mapstyle.withgoogle.com/).
+		/// On iOS, MacCatalyst, and Windows this property has no effect as the native map controls
+		/// do not support custom JSON styling.
+		/// Set to <see langword="null"/> to revert to the default map style.
+		/// </remarks>
+#if !NETSTANDARD
+		[System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
+		[System.Runtime.Versioning.UnsupportedOSPlatform("maccatalyst")]
+		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
+#endif
+		public string? MapStyle
+		{
+			get { return (string?)GetValue(MapStyleProperty); }
+			set { SetValue(MapStyleProperty, value); }
 		}
 
 		/// <summary>

--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -12,6 +12,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,6 +35,7 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -12,6 +12,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,6 +35,7 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -12,6 +12,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,6 +35,7 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -12,6 +12,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,6 +35,7 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -12,6 +12,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,6 +35,7 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
-
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -12,6 +10,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,8 +33,10 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!
+﻿#nullable enable

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
-
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -12,6 +10,8 @@ Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabled.set -> void
 Microsoft.Maui.Controls.Maps.Map.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Controls.Maps.Map.MapLongClicked -> System.EventHandler<Microsoft.Maui.Controls.Maps.MapClickedEventArgs!>?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.get -> string?
+Microsoft.Maui.Controls.Maps.Map.MapStyle.set -> void
 Microsoft.Maui.Controls.Maps.Map.MoveToRegion(Microsoft.Maui.Maps.MapSpan! mapSpan, bool animated) -> void
 Microsoft.Maui.Controls.Maps.Map.Region.get -> Microsoft.Maui.Maps.MapSpan?
 Microsoft.Maui.Controls.Maps.Map.Region.set -> void
@@ -33,8 +33,10 @@ Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.Location.get -> Micros
 Microsoft.Maui.Controls.Maps.UserLocationChangedEventArgs.UserLocationChangedEventArgs(Microsoft.Maui.Devices.Sensors.Location! location) -> void
 const Microsoft.Maui.Controls.Maps.Pin.DefaultClusteringIdentifier = "maui_default_cluster" -> string!
 static readonly Microsoft.Maui.Controls.Maps.Map.IsClusteringEnabledProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Maps.Map.MapStyleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Map.RegionProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!
+﻿#nullable enable

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
+             x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapStyleGallery"
+             Title="Map Styles">
+    <Grid RowDefinitions="Auto,*">
+        <StackLayout Orientation="Horizontal" Spacing="5" Padding="10">
+            <Button x:Name="DefaultButton" Text="Default" Clicked="OnDefaultClicked" />
+            <Button x:Name="DarkButton" Text="Dark" Clicked="OnDarkClicked" />
+            <Button x:Name="RetroButton" Text="Retro" Clicked="OnRetroClicked" />
+            <Button x:Name="NightButton" Text="Night" Clicked="OnNightClicked" />
+        </StackLayout>
+        <maps:Map x:Name="map" Grid.Row="1" />
+    </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml.cs
@@ -1,0 +1,83 @@
+using Microsoft.Maui.Controls.Maps;
+
+namespace Maui.Controls.Sample.Pages.MapsGalleries
+{
+	public partial class MapStyleGallery : ContentPage
+	{
+		// Dark mode style - hides landmarks, dark colors
+		const string DarkStyle = """
+[
+  {"elementType":"geometry","stylers":[{"color":"#212121"}]},
+  {"elementType":"labels.text.fill","stylers":[{"color":"#757575"}]},
+  {"elementType":"labels.text.stroke","stylers":[{"color":"#212121"}]},
+  {"featureType":"road","elementType":"geometry","stylers":[{"color":"#383838"}]},
+  {"featureType":"road","elementType":"labels.text.fill","stylers":[{"color":"#9e9e9e"}]},
+  {"featureType":"water","elementType":"geometry","stylers":[{"color":"#000000"}]},
+  {"featureType":"water","elementType":"labels.text.fill","stylers":[{"color":"#3d3d3d"}]}
+]
+""";
+
+		// Retro style - muted colors, vintage feel
+		const string RetroStyle = """
+[
+  {"elementType":"geometry","stylers":[{"color":"#ebe3cd"}]},
+  {"elementType":"labels.text.fill","stylers":[{"color":"#523735"}]},
+  {"elementType":"labels.text.stroke","stylers":[{"color":"#f5f1e6"}]},
+  {"featureType":"road","elementType":"geometry","stylers":[{"color":"#f5f1e6"}]},
+  {"featureType":"road.highway","elementType":"geometry","stylers":[{"color":"#f8c967"}]},
+  {"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#e9bc62"}]},
+  {"featureType":"water","elementType":"geometry.fill","stylers":[{"color":"#b9d3c2"}]}
+]
+""";
+
+		// Night style - dark blue theme
+		const string NightStyle = """
+[
+  {"elementType":"geometry","stylers":[{"color":"#242f3e"}]},
+  {"elementType":"labels.text.fill","stylers":[{"color":"#746855"}]},
+  {"elementType":"labels.text.stroke","stylers":[{"color":"#242f3e"}]},
+  {"featureType":"road","elementType":"geometry","stylers":[{"color":"#38414e"}]},
+  {"featureType":"road","elementType":"geometry.stroke","stylers":[{"color":"#212a37"}]},
+  {"featureType":"road","elementType":"labels.text.fill","stylers":[{"color":"#9ca5b3"}]},
+  {"featureType":"road.highway","elementType":"geometry","stylers":[{"color":"#746855"}]},
+  {"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#1f2835"}]},
+  {"featureType":"road.highway","elementType":"labels.text.fill","stylers":[{"color":"#f3d19c"}]},
+  {"featureType":"water","elementType":"geometry","stylers":[{"color":"#17263c"}]},
+  {"featureType":"water","elementType":"labels.text.fill","stylers":[{"color":"#515c6d"}]}
+]
+""";
+
+		public MapStyleGallery()
+		{
+			InitializeComponent();
+		}
+
+		void OnDefaultClicked(object? sender, EventArgs e)
+		{
+#pragma warning disable CA1416 // Validate platform compatibility - MapStyle only works on Android
+			map.MapStyle = null;
+#pragma warning restore CA1416
+		}
+
+		void OnDarkClicked(object? sender, EventArgs e)
+		{
+#pragma warning disable CA1416
+			map.MapStyle = DarkStyle;
+#pragma warning restore CA1416
+		}
+
+		void OnRetroClicked(object? sender, EventArgs e)
+		{
+#pragma warning disable CA1416
+			map.MapStyle = RetroStyle;
+#pragma warning restore CA1416
+		}
+
+		void OnNightClicked(object? sender, EventArgs e)
+		{
+#pragma warning disable CA1416
+			map.MapStyle = NightStyle;
+#pragma warning restore CA1416
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapStyleGallery.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Maps;
 
 namespace Maui.Controls.Sample.Pages.MapsGalleries

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapsGallery.cs
@@ -28,6 +28,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 						GalleryBuilder.NavButton("Info Window", () => new InfoWindowGallery(), Navigation),
 						GalleryBuilder.NavButton("User Location", () => new UserLocationGallery(), Navigation),
 						GalleryBuilder.NavButton("Camera & Zoom", () => new CameraZoomGallery(), Navigation),
+						GalleryBuilder.NavButton("Map Style", () => new MapStyleGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -460,6 +460,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(polygon.IsVisible);
 			Assert.False(polyline.IsVisible);
 			Assert.False(circle.IsVisible);
+		}
+
+		[Fact]
 		public void MapStyleDefaultIsNull()
 		{
 			var map = new Map();

--- a/src/Controls/tests/Core.UnitTests/MapTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MapTests.cs
@@ -460,6 +460,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(polygon.IsVisible);
 			Assert.False(polyline.IsVisible);
 			Assert.False(circle.IsVisible);
+		public void MapStyleDefaultIsNull()
+		{
+			var map = new Map();
+			Assert.Null(map.MapStyle);
+		}
+
+		[Fact]
+		public void MapStyleCanBeSet()
+		{
+			var map = new Map();
+			var style = "[{\"featureType\":\"water\",\"stylers\":[{\"color\":\"#00ff00\"}]}]";
+			map.MapStyle = style;
+			Assert.Equal(style, map.MapStyle);
+		}
+
+		[Fact]
+		public void MapStyleCanBeCleared()
+		{
+			var map = new Map();
+			map.MapStyle = "[{\"featureType\":\"water\",\"stylers\":[{\"color\":\"#00ff00\"}]}]";
+			map.MapStyle = null;
+			Assert.Null(map.MapStyle);
 		}
 
 		// Checks if for every item in the items source there's a corresponding pin

--- a/src/Core/maps/src/Core/IMap.cs
+++ b/src/Core/maps/src/Core/IMap.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Maui.Maps
 		bool IsClusteringEnabled { get; }
 
 		/// <summary>
+		/// Gets the custom map style as a JSON string.
+		/// </summary>
+		/// <remarks>
+		/// This property is only supported on Android where it accepts a Google Maps style JSON string.
+		/// Use the Google Maps Styling Wizard (https://mapstyle.withgoogle.com/) to generate a style JSON.
+		/// On iOS, MacCatalyst, and Windows this property has no effect as the native map controls
+		/// do not support custom JSON styling.
+		/// </remarks>
+#if !NETSTANDARD
+		[System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
+		[System.Runtime.Versioning.UnsupportedOSPlatform("maccatalyst")]
+		[System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
+#endif
+		string? MapStyle { get; }
+
+		/// <summary>
 		/// The pins that are to be shown on this Map.
 		/// </summary>
 		IList<IMapPin> Pins { get; }

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Maui.Maps.Handlers
 			}
 		}
 
+		public static void MapMapStyle(IMapHandler handler, IMap map)
+		{
+			GoogleMap? googleMap = handler?.Map;
+			googleMap?.UpdateMapStyle(map);
+		}
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg)
 		{
 			if (arg is MoveToRegionRequest request && request.Region != null)
@@ -437,6 +443,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				map.UpdateIsScrollEnabled(VirtualView);
 				map.UpdateIsTrafficEnabled(VirtualView);
 				map.UpdateIsZoomEnabled(VirtualView);
+				map.UpdateMapStyle(VirtualView);
 			}
 
 			InitialUpdate();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Standard.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
+		public static void MapMapStyle(IMapHandler handler, IMap map) => throw new NotImplementedException();
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg) => throw new NotImplementedException();
 
 		public static void MapPins(IMapHandler handler, IMap map) => throw new NotImplementedException();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
+		public static void MapMapStyle(IMapHandler handler, IMap map) => throw new NotImplementedException();
+
 		public static void MapMoveToRegion(IMapHandler handler, IMap map, object? arg) => throw new NotImplementedException();
 
 		public static void MapPins(IMapHandler handler, IMap map) => throw new NotImplementedException();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Windows.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		public static void MapIsTrafficEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
+		public static void MapMapStyle(IMapHandler handler, IMap map) => throw new NotImplementedException();
+
 		public static void MapIsShowingUser(IMapHandler handler, IMap map) => throw new NotImplementedException();
 
 		public static void MapIsClusteringEnabled(IMapHandler handler, IMap map) => throw new NotImplementedException();

--- a/src/Core/maps/src/Handlers/Map/MapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Maui.Maps.Handlers
 			[nameof(IMap.IsTrafficEnabled)] = MapIsTrafficEnabled,
 			[nameof(IMap.IsZoomEnabled)] = MapIsZoomEnabled,
 			[nameof(IMap.IsClusteringEnabled)] = MapIsClusteringEnabled,
+
+			[nameof(IMap.MapStyle)] = MapMapStyle,
 			[nameof(IMap.Pins)] = MapPins,
 			[nameof(IMap.Elements)] = MapElements,
 		};

--- a/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs
@@ -81,6 +81,12 @@ namespace Microsoft.Maui.Maps.Handlers
 			handler.PlatformView.AddPins((IList)map.Pins);
 		}
 
+		public static void MapMapStyle(IMapHandler handler, IMap map)
+		{
+			// MapKit does not support custom JSON map styling.
+			// This property is marked with [UnsupportedOSPlatform] for iOS/MacCatalyst.
+		}
+
 		public static void MapPins(IMapHandler handler, IMap map)
 		{
 			handler.PlatformView.AddPins((IList)map.Pins);

--- a/src/Core/maps/src/Platform/Android/MapExtensions.cs
+++ b/src/Core/maps/src/Platform/Android/MapExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Android.Gms.Maps;
+using Android.Gms.Maps.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Maps.Handlers;
@@ -57,6 +58,22 @@ namespace Microsoft.Maui.Maps.Platform
 
 			googleMap.UiSettings.ZoomControlsEnabled = map.IsZoomEnabled;
 			googleMap.UiSettings.ZoomGesturesEnabled = map.IsZoomEnabled;
+		}
+
+		public static void UpdateMapStyle(this GoogleMap googleMap, IMap map)
+		{
+			if (googleMap == null)
+				return;
+
+			if (string.IsNullOrEmpty(map.MapStyle))
+			{
+				googleMap.SetMapStyle(null);
+			}
+			else
+			{
+				var styleOptions = new MapStyleOptions(map.MapStyle);
+				googleMap.SetMapStyle(styleOptions);
+			}
 		}
 
 		internal static async Task SetIsShowingUser(this GoogleMap googleMap, IMap map, IMauiContext? mauiContext)

--- a/src/Core/maps/src/Platform/Android/MapExtensions.cs
+++ b/src/Core/maps/src/Platform/Android/MapExtensions.cs
@@ -65,14 +65,20 @@ namespace Microsoft.Maui.Maps.Platform
 			if (googleMap == null)
 				return;
 
+			bool result;
 			if (string.IsNullOrEmpty(map.MapStyle))
 			{
-				googleMap.SetMapStyle(null);
+				result = googleMap.SetMapStyle(null);
 			}
 			else
 			{
 				var styleOptions = new MapStyleOptions(map.MapStyle);
-				googleMap.SetMapStyle(styleOptions);
+				result = googleMap.SetMapStyle(styleOptions);
+			}
+
+			if (!result)
+			{
+				System.Diagnostics.Debug.WriteLine("Failed to apply map style. The provided JSON style may be invalid.");
 			}
 		}
 

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,11 +1,10 @@
-
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -29,6 +28,9 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
+static Microsoft.Maui.Maps.Platform.MapExtensions.UpdateMapStyle(this Android.Gms.Maps.GoogleMap! googleMap, Microsoft.Maui.Maps.IMap! map) -> void
+﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,11 +1,10 @@
-
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -31,6 +30,8 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
+﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -31,6 +32,7 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -29,6 +30,7 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> voi
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -29,6 +30,7 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,11 +1,10 @@
-
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -29,6 +28,8 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
+﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,11 +1,10 @@
-
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
 Microsoft.Maui.Maps.IMap.IsClusteringEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.LastUserLocation.get -> Microsoft.Maui.Devices.Sensors.Location?
 Microsoft.Maui.Maps.IMap.LongClicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
+Microsoft.Maui.Maps.IMap.MapStyle.get -> string?
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region, bool animated) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.ShowInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -29,6 +28,8 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapIsVisible(Microsoft.Mau
 static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapZIndex(Microsoft.Maui.Maps.Handlers.IMapElementHandler! handler, Microsoft.Maui.Maps.IMapElement! mapElement) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapHideInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsClusteringEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
+﻿#nullable enable


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds a `MapStyle` property to the `Map` control that accepts a Google Maps JSON style string for customizing the visual appearance of the map on Android.

**Fixes** #10706

### What this does

- Adds `IMap.MapStyle` (`string?`) property to the core map interface
- Adds `Map.MapStyleProperty` BindableProperty on the Controls layer
- Android: Applies the JSON style via `GoogleMap.SetMapStyle(new MapStyleOptions(json))`
- iOS/MacCatalyst/Windows: Marked with `[UnsupportedOSPlatform]` — Apple MapKit does not support custom JSON map styling (only dark/light mode), so this property is Android-only

### Why Android-only?

Apple MapKit has no equivalent to Google Maps' `SetMapStyle(JSON)` API. Rather than providing a misleading partial implementation (e.g., only toggling dark/light mode based on JSON analysis), the property is marked with `[UnsupportedOSPlatform("ios")]`, `[UnsupportedOSPlatform("maccatalyst")]`, and `[UnsupportedOSPlatform("windows")]`. This gives developers a compile-time CA1416 warning when targeting unsupported platforms.

### Changes

- `IMap.cs` — Added `MapStyle` property with `[UnsupportedOSPlatform]` attributes
- `Map.cs` — Added `MapStyleProperty` BindableProperty with `[UnsupportedOSPlatform]` attributes
- `MapHandler.cs` — Added PropertyMapper entry
- `MapHandler.Android.cs` — Calls `UpdateMapStyle` on the native `GoogleMap`
- `MapHandler.iOS.cs` — No-op handler with comment
- `MapExtensions.cs` (Android) — `UpdateMapStyle()` extension method
- All handler stubs (Standard, Windows, Tizen)
- 14 PublicAPI.Unshipped.txt files updated
- 3 unit tests added
- `MapStyleGallery` sample page with Dark, Retro, and Night presets

### Verified

- ✅ Android: All 4 styles (Default, Dark, Retro, Night) visually verified
- ✅ iOS: Build succeeds, no CA1416 warnings  
- ✅ Unit tests: 32/32 map tests pass

Part of the Maps Improvements Epic: #33787