### PR TITLE
[XSG] Fix expression binding TProperty type resolution for mismatched source/target types

### DIFF
--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -742,11 +742,8 @@ static class SetPropertyHelpers
 	static void SetExpressionBinding(IndentedTextWriter writer, ILocalValue parentVar, IFieldSymbol bpFieldSymbol, string expression, ITypeSymbol dataTypeSymbol, SourceGenContext context, ValueNode valueNode)
 	{
 		var bpName = bpFieldSymbol.ToFQDisplayString();
-		var bpTypeAndConverter = bpFieldSymbol.GetBPTypeAndConverter(context);
-		var targetType = bpTypeAndConverter?.type ?? context.Compilation.ObjectType;
 		
 		var sourceTypeName = dataTypeSymbol.ToFQDisplayString();
-		var targetTypeName = targetType.ToFQDisplayString();
 
 		// Transform quotes with semantic context - char literals stay as char only if target expects char
 		var transformedExpression = CSharpExpressionHelpers.TransformQuotesWithSemantics(
@@ -755,6 +752,13 @@ static class SetPropertyHelpers
 		// Analyze expression for mixed local+binding scenarios
 		var analysis = ExpressionAnalyzer.Analyze(transformedExpression, "__source", dataTypeSymbol, context.RootType);
 		var handlers = analysis.Handlers;
+
+		// Resolve the expression's result type for TProperty.
+		// TypedBinding<TSource, TProperty> should use the expression type (e.g., decimal for Price),
+		// NOT the target BindableProperty type (e.g., string for Entry.TextProperty).
+		// The binding infrastructure handles type conversion at runtime.
+		var expressionType = ResolveExpressionType(expression, dataTypeSymbol, context);
+		var propertyTypeName = expressionType?.ToFQDisplayString() ?? "object";
 
 		// Wrap in scoped block if we have captures to avoid duplicate variable names
 		// when multiple expressions capture the same local member
@@ -775,7 +779,7 @@ static class SetPropertyHelpers
 		{
 			writer.WriteLine($"{parentVar.ValueAccessor}.SetBinding({bpName},");
 			writer.Indent++;
-			writer.WriteLine($"new global::Microsoft.Maui.Controls.Internals.TypedBinding<{sourceTypeName}, {targetTypeName}>(");
+			writer.WriteLine($"new global::Microsoft.Maui.Controls.Internals.TypedBinding<{sourceTypeName}, {propertyTypeName}>(");
 			writer.Indent++;
 			// TransformedExpression already has identifiers prefixed with __source. where needed
 			// Add null-forgiving operator if expression contains ?. to suppress nullability warnings
@@ -831,6 +835,53 @@ static class SetPropertyHelpers
 			writer.Indent--;
 			writer.WriteLine("}");
 		}
+	}
+
+	/// <summary>
+	/// Resolves the result type of a C# expression by walking the property chain on the dataType.
+	/// For example, "Price" on SimpleViewModel resolves to decimal, "User.DisplayName" resolves to string.
+	/// For complex expressions (operators, method calls, interpolation), returns null to fall back to object.
+	/// </summary>
+	static ITypeSymbol? ResolveExpressionType(string expression, ITypeSymbol dataType, SourceGenContext context)
+	{
+		if (string.IsNullOrWhiteSpace(expression))
+			return null;
+
+		var expr = expression.Trim();
+
+		// Strip leading dot prefix (e.g., ".Name" → "Name")
+		if (expr.StartsWith(".", StringComparison.Ordinal))
+			expr = expr.Substring(1);
+
+		// Strip "BindingContext." prefix (e.g., "BindingContext.Name" → "Name")
+		if (expr.StartsWith("BindingContext.", StringComparison.Ordinal))
+			expr = expr.Substring("BindingContext.".Length);
+
+		if (string.IsNullOrEmpty(expr))
+			return null;
+
+		// Walk the dot-separated property chain (also handle ?. null-conditional access)
+		var parts = expr.Replace("?.", ".").Split('.');
+		var currentType = dataType;
+
+		foreach (var part in parts)
+		{
+			var memberName = part.Trim().TrimEnd('!');
+
+			// If it contains parens, operators, or special chars, it's not a simple property chain
+			if (memberName.Contains('(') || memberName.Contains(' ') || memberName.Contains('[') || string.IsNullOrEmpty(memberName))
+				return null;
+
+			var member = currentType.GetAllMembers(memberName, context).FirstOrDefault();
+			if (member is IPropertySymbol prop)
+				currentType = prop.Type;
+			else if (member is IFieldSymbol field)
+				currentType = field.Type;
+			else
+				return null;
+		}
+
+		return currentType;
 	}
 
 	/// <summary>

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -849,8 +849,9 @@ static class SetPropertyHelpers
 
 		var expr = expression.Trim();
 
-		// Strip leading dot prefix (e.g., ".Name" → "Name")
-		if (expr.StartsWith(".", StringComparison.Ordinal))
+		// Strip leading dot prefix (e.g., ".Name" → "Name"), but avoid the ".." range operator
+		if (expr.StartsWith(".", StringComparison.Ordinal) &&
+			!expr.StartsWith("..", StringComparison.Ordinal))
 			expr = expr.Substring(1);
 
 		// Strip "BindingContext." prefix (e.g., "BindingContext.Name" → "Name")

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml
@@ -142,6 +142,9 @@
             
             <!-- String interpolation with multiple bindings and format -->
             <Label x:Name="vmInterpolationMultiLabel" Text="{$'{Quantity}x at {Price:C2}'}" />
+            
+            <!-- Two-way binding: Entry.Text (string) to decimal property via C# expression -->
+            <Entry x:Name="twoWayDecimalEntry" Text="{Price}" />
         </VerticalStackLayout>
         
         <!-- CDATA EXPRESSION TESTS -->

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
@@ -763,5 +763,64 @@ public partial class CSharpExpressions : ContentPage
 			var page = new CSharpExpressions(XamlInflator.SourceGen);
 			Assert.Equal("\t", page.escapedTabLabel.Text);
 		}
+
+		[Fact]
+		public void TwoWayDecimalBinding_VMToUI()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 42.5m };
+				page.BindingContext = vm;
+
+				// Use decimal.Parse to handle locale-specific decimal separators
+				Assert.Equal(42.5m, decimal.Parse(page.twoWayDecimalEntry.Text));
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TwoWayDecimalBinding_UIToVM()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 0m };
+				page.BindingContext = vm;
+
+				page.twoWayDecimalEntry.SetValueFromRenderer(Entry.TextProperty, "100");
+				Assert.Equal(100m, vm.Price);
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
+
+		[Fact]
+		public void TwoWayDecimalBinding_INPC()
+		{
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			try
+			{
+				var page = new CSharpExpressions(XamlInflator.SourceGen);
+				var vm = new SimpleViewModel { Price = 10m };
+				page.BindingContext = vm;
+
+				Assert.Equal(10m, decimal.Parse(page.twoWayDecimalEntry.Text));
+
+				vm.Price = 25.75m;
+				Assert.Equal(25.75m, decimal.Parse(page.twoWayDecimalEntry.Text));
+			}
+			finally
+			{
+				DispatcherProvider.SetCurrent(null);
+			}
+		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CSharpExpressions.sgen.xaml.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Maui.Dispatching;
@@ -775,7 +776,7 @@ public partial class CSharpExpressions : ContentPage
 				page.BindingContext = vm;
 
 				// Use decimal.Parse to handle locale-specific decimal separators
-				Assert.Equal(42.5m, decimal.Parse(page.twoWayDecimalEntry.Text));
+				Assert.Equal(42.5m, decimal.Parse(page.twoWayDecimalEntry.Text, CultureInfo.InvariantCulture));
 			}
 			finally
 			{
@@ -812,10 +813,10 @@ public partial class CSharpExpressions : ContentPage
 				var vm = new SimpleViewModel { Price = 10m };
 				page.BindingContext = vm;
 
-				Assert.Equal(10m, decimal.Parse(page.twoWayDecimalEntry.Text));
+				Assert.Equal(10m, decimal.Parse(page.twoWayDecimalEntry.Text, CultureInfo.InvariantCulture));
 
 				vm.Price = 25.75m;
-				Assert.Equal(25.75m, decimal.Parse(page.twoWayDecimalEntry.Text));
+				Assert.Equal(25.75m, decimal.Parse(page.twoWayDecimalEntry.Text, CultureInfo.InvariantCulture));
 			}
 			finally
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes https://github.com/dotnet/maui/issues/33992

When using XAML C# expression syntax to bind a property whose type differs from the target BindableProperty type (e.g., `Entry.Text` string to a `decimal` VM property), the source generator used the **target BP type** as `TProperty` in `TypedBinding<TSource, TProperty>`, causing `CS0029` compilation errors.

```xml
<!-- This failed to compile with XSG -->
<Entry Text="{Price}" />
```

### Root Cause

`SetExpressionBinding()` called `bpFieldSymbol.GetBPTypeAndConverter()` and used the result (`string` for `Entry.TextProperty`) as `TProperty`. The getter lambda `(__source) => __source.Price` returns `decimal`, which cannot implicitly convert to `string`.

### Fix

Added `ResolveExpressionType()` that walks the property chain on the `x:DataType` symbol to determine the expression's result type (e.g., `decimal` for `Price`, `string` for `User.DisplayName`). This matches how XamlC resolves property types via `TryParsePath()`.

The `TypedBinding` infrastructure already handles type conversion at runtime via `BindingExpressionHelper.TryConvert()`, so using the correct source type is all that's needed.

Handles: bare identifiers (`Price`), dot-prefixed (`.Name`), `BindingContext.` prefix, null-conditional (`User?.Name`). Falls back to `object` for complex expressions (operators, method calls).

### Tests

Added 3 tests for two-way decimal binding via C# expression syntax:
- **VM to UI**: Setting `vm.Price = 42.5m` updates `Entry.Text`
- **UI to VM**: `SetValueFromRenderer("100")` updates `vm.Price` to `100m`
- **INPC**: Changing `vm.Price` after initial binding updates `Entry.Text`

All 1874 Xaml.UnitTests pass (0 failures, 8 skipped).
