### PR TITLE
Run RunOnAndroid on Tahoe for HVF debugging

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -277,10 +277,7 @@ stages:
     # TODO: macOSTemplates and AOT template categories
     - name: mac_runandroid_tests
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
-        pool:
-          name: AcesShared
-          demands:
-            - ImageOverride -equals ACES_arm64_Sequoia_Xcode
+        pool: ${{ parameters.MacOSPool.public }}
       ${{ else }}:  
         pool: ${{ parameters.MacOSPool.internal }}
       timeout: 240


### PR DESCRIPTION
Reverts the Sequoia image override for RunOnAndroid PR builds back to the default Tahoe pool (MacOSPool.public → ACES_VM_SharedPool_Tahoe) so we can continue debugging the HVF nested virtualization issue.

This is expected to fail — the purpose is to reproduce the HVF_UNSUPPORTED error on Tahoe and investigate further.