### PR TITLE
[ci] Run android on MAUI-Dnceng

### DIFF
--- a/eng/pipelines/arcade/setup-test-env.yml
+++ b/eng/pipelines/arcade/setup-test-env.yml
@@ -11,6 +11,14 @@ steps:
   fetchDepth: 1
   clean: true
 
+# Enable KVM for Android tests on Linux
+- bash: |
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+  displayName: Enable KVM
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
 - template: /eng/pipelines/common/provision.yml@self
   parameters:
     checkoutDirectory: '$(System.DefaultWorkingDirectory)'

--- a/eng/pipelines/arcade/setup-test-env.yml
+++ b/eng/pipelines/arcade/setup-test-env.yml
@@ -11,13 +11,7 @@ steps:
   fetchDepth: 1
   clean: true
 
-# Enable KVM for Android tests on Linux
-- bash: |
-    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-    sudo udevadm control --reload-rules
-    sudo udevadm trigger --name-match=kvm
-  displayName: Enable KVM
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+- template: /eng/pipelines/common/enable-kvm.yml@self
 
 - template: /eng/pipelines/common/provision.yml@self
   parameters:

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -108,6 +108,13 @@ parameters:
         - ImageOverride -equals ACES_VM_SharedPool_Tahoe
       label: macOS
 
+- name: AndroidPoolLinux
+  type: object
+  default:
+    name: MAUI-DNCENG
+    demands:
+      - ImageOverride -equals 1ESPT-Ubuntu22.04
+
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)
@@ -277,12 +284,9 @@ stages:
     # TODO: macOSTemplates and AOT template categories
     - name: mac_runandroid_tests
       ${{ if eq(variables['Build.DefinitionName'], 'maui-pr') }}:
-        pool:
-          name: AcesShared
-          demands:
-            - ImageOverride -equals ACES_arm64_Sequoia_Xcode
+        pool: ${{ parameters.AndroidPoolLinux }}
       ${{ else }}:  
-        pool: ${{ parameters.MacOSPool.internal }}
+        pool: ${{ parameters.AndroidPoolLinux }}
       timeout: 240
       testCategory: RunOnAndroid
 

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -35,14 +35,8 @@ steps:
     continueOnError: true
     timeoutInMinutes: 60
 
-# Enable KVM for Android builds on Linux
 - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
-  - bash: |
-      echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-      sudo udevadm control --reload-rules
-      sudo udevadm trigger --name-match=kvm
-    displayName: Enable KVM
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+  - template: enable-kvm.yml
 
 # Provision the various SDKs that are needed
 - template: provision.yml

--- a/eng/pipelines/common/enable-kvm.yml
+++ b/eng/pipelines/common/enable-kvm.yml
@@ -1,0 +1,8 @@
+# Enable KVM for Android tests on Linux
+steps:
+- bash: |
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+  displayName: Enable KVM
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))

--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -43,14 +43,8 @@ steps:
     continueOnError: true
     timeoutInMinutes: 60
 
-# Enable KVM for Android builds on Linux
 - ${{ if and(ne(parameters.buildType, 'buildOnly'), eq(parameters.platform, 'android')) }}:
-  - bash: |
-      echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-      sudo udevadm control --reload-rules
-      sudo udevadm trigger --name-match=kvm
-    displayName: Enable KVM
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+  - template: enable-kvm.yml
 
 - ${{ if eq(parameters.platform, 'catalyst')}}:
   - bash: |

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -78,7 +78,9 @@
     <!-- Run 'dotnet workload install' for the current running 'dotnet' install -->
     <ItemGroup>
       <_WorkloadSource Include="$(NugetArtifactsPath)" />
-      <_LocalWorkloadIds Include="maui" />
+      <!-- On Linux, install maui-android instead of maui to avoid iOS/macOS dependencies -->
+      <_LocalWorkloadIds Include="maui-android" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
+      <_LocalWorkloadIds Include="maui" Condition="!$([MSBuild]::IsOSPlatform('linux'))" />
       
       <_LocalWorkloadIds Include="tizen" Condition=" '$(IncludeTizenTargetFrameworks)' == 'true' " />
     </ItemGroup>


### PR DESCRIPTION
### Description of Change

This pull request updates the CI pipeline configuration to introduce and use a new Linux-based pool for running Android tests, replacing the previous macOS-based pools. The main changes are the addition of the `AndroidPoolLinux` parameter and updating the relevant test stage to use this new pool.

**Pipeline configuration updates:**

* Added a new `AndroidPoolLinux` parameter to `parameters:` in `eng/pipelines/ci.yml` for specifying a Linux pool (`MAUI-DNCENG`) with the `1ESPT-Ubuntu22.04` image for Android test runs.
* Updated the `mac_runandroid_tests` stage to use the new `AndroidPoolLinux` pool instead of the previous macOS-based pools, ensuring Android tests run on Linux infrastructure.