### PR TITLE
[ci] Use MAUI self-hosted pool for macOS builds

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -48,8 +48,8 @@ parameters:
 - name: MacOSPool
   type: object
   default:
-    name: MAUI
-    vmImage: MAUI
+    name: Azure Pipelines
+    vmImage: macOS-15
     os: macOS
 
 resources:

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -48,8 +48,8 @@ parameters:
 - name: MacOSPool
   type: object
   default:
-    name: Azure Pipelines
-    vmImage: macOS-15
+    name: MAUI
+    vmImage: MAUI
     os: macOS
 
 resources:

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -59,8 +59,8 @@ parameters:
     os: Windows
     buildScript: $(_buildScript)
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui.sln'
-  - name: Azure Pipelines
-    vmImage: $(HostedMacImage)
+  - name: MAUI
+    vmImage: MAUI
     os: macOS
     buildScript: $(_buildScriptMacOS)
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui-mac.slnf'
@@ -74,9 +74,8 @@ parameters:
     os: Windows
     buildScript: $(_buildScript)
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui.sln'
-  - name: AcesShared
-    demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+  - name: MAUI
+    vmImage: MAUI
     os: macOS
     buildScript: $(_buildScriptMacOS)
     sln: '$(Build.SourcesDirectory)/Microsoft.Maui-mac.slnf'
@@ -99,15 +98,15 @@ parameters:
   type: object
   default:
     internal:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImage)
-      label: macOS
+      name: MAUI
+      vmImage: MAUI
+      os: macOS
+      label: macOS-arm64
     public:
       name: AcesShared
       demands:
         - ImageOverride -equals ACES_VM_SharedPool_Tahoe
       label: macOS
-
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Runs on: (non-PR on main/net*.0/release/*/inflight/*) OR (PR targeting net*.0/release/*/inflight/*)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Azure Pipelines hosted macOS pools (`Azure Pipelines` with `macOS-15`) do not have Xcode 26.2 installed, causing internal and public macOS builds to fail. This switches all macOS CI jobs to the `MAUI` self-hosted pool which has the required Xcode version.

### Changes

- **`ci.yml`**: Update `BuildPlatforms` (internal), `BuildPlatformsPublic`, and `MacOSPool.internal` to use `name: MAUI, vmImage: MAUI`
- **`ci-official.yml`**: Update `MacOSPool` parameter to use `name: MAUI, vmImage: MAUI`

### Context

This matches the fix already applied on the `merge/main-to-net10.0` branch (commits `e43e983ecb` and `493c1765d8`). Once Azure Pipelines hosted images are updated with Xcode 26.2, these can be switched back.