### PR TITLE
Move Essentials.AI preview iteration to eng/Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,6 +9,8 @@
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
+    <!-- Essentials.AI preview versioning — bump this for new AI previews -->
+    <EssentialsAIPreviewVersionIteration>1</EssentialsAIPreviewVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->
     <IsServicingBuild Condition=" '$(PreReleaseVersionLabel)' == 'servicing' ">true</IsServicingBuild>
     <!-- Enable to remove prerelease label and produce stable package versions. -->

--- a/src/AI/src/Essentials.AI/Essentials.AI.csproj
+++ b/src/AI/src/Essentials.AI/Essentials.AI.csproj
@@ -15,12 +15,13 @@
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.Maui.Essentials.AI</PackageId>
     <!-- Keep this package always preview — it is experimental and should not ship stable
-         even when the rest of the repo stabilizes. Bump PreReleaseVersionIteration for new previews.
+         even when the rest of the repo stabilizes. Bump EssentialsAIPreviewVersionIteration
+         in eng/Versions.props for new previews.
          The label/iteration only activate during stable builds (DotNetFinalVersionKind=release).
          During preview builds, the AI package uses the same label as the rest of the repo. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PreReleaseVersionLabel Condition="'$(DotNetFinalVersionKind)' == 'release'">preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration Condition="'$(DotNetFinalVersionKind)' == 'release'">1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration Condition="'$(DotNetFinalVersionKind)' == 'release'">$(EssentialsAIPreviewVersionIteration)</PreReleaseVersionIteration>
     <PackageTags>$(DefaultPackageTags);essentials;ai</PackageTags>
     <Description>.NET Multi-platform App UI (.NET MAUI) is a cross-platform framework for creating native mobile and desktop apps with C# and XAML. This package contains a collection of cross-platform APIs for working with device AI and local models.</Description>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Moves the hardcoded `PreReleaseVersionIteration` value (`1`) from `Essentials.AI.csproj` into a centralized `EssentialsAIPreviewVersionIteration` property in `eng/Versions.props`, making it easier to bump for future AI preview releases.

Follow-up to #33976.

### Changes

- **`eng/Versions.props`**: Add `EssentialsAIPreviewVersionIteration` property (default `1`)
- **`Essentials.AI.csproj`**: Reference `$(EssentialsAIPreviewVersionIteration)` instead of hardcoded `1`; update comment to point to `eng/Versions.props`

No functional change — version output is identical.