### PR TITLE
Add MauiXamlHotReload property for IDE communication

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -10,6 +10,9 @@
     <_MauiXamlInflator Condition="' $(MauiXamlInflator)' != '' ">$(MauiXamlInflator)</_MauiXamlInflator>
     <_MauiXamlInflator Condition=" '$(MauiXamlInflator)' == '' ">SourceGen</_MauiXamlInflator>
 
+    <!-- XAML Hot Reload mode for IDE communication (Legacy or SourceGen) -->
+    <MauiXamlHotReload Condition="'$(MauiXamlHotReload)' == ''">Legacy</MauiXamlHotReload>
+
     <EnableMauiXamlDiagnostics Condition=" '$(EnableMauiXamlDiagnostics)' == '' ">$(EnableMauiDiagnostics)</EnableMauiXamlDiagnostics>
     <EnableMauiXamlDiagnostics Condition=" '$(EnableMauiXamlDiagnostics)' == '' And '$(Configuration)' == 'Debug' ">$(EnableDiagnostics)</EnableMauiXamlDiagnostics>
     <EnableMauiXamlDiagnostics Condition=" '$(EnableMauiXamlDiagnostics)' == '' And '$(Configuration)' == 'Debug' ">true</EnableMauiXamlDiagnostics>
@@ -71,6 +74,13 @@
 		<Error Code="XF001"
 			Text="Microsoft.Maui targets have been imported multiple times. Please check your project file and remove the duplicate import(s)."
 			Condition="'$(_MauiTargetsImportedAgain)' == 'True'" />
+	</Target>
+
+	<!-- Warn when MauiXamlHotReload is set to SourceGen (not yet fully implemented) -->
+	<Target Name="_ValidateMauiXamlHotReload" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" Condition="'$(MauiXamlHotReload)' == 'SourceGen'">
+		<Warning 
+			Code="MAUI1002"
+			Text="MauiXamlHotReload is set to 'SourceGen'. Source generator-based XAML Hot Reload is experimental and not yet fully implemented. Use at your own risk." />
 	</Target>
 
 	<Target Name="_ValidateMSBuild" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -76,11 +76,21 @@
 			Condition="'$(_MauiTargetsImportedAgain)' == 'True'" />
 	</Target>
 
-	<!-- Warn when MauiXamlHotReload is set to SourceGen (not yet fully implemented) -->
-	<Target Name="_ValidateMauiXamlHotReload" BeforeTargets="_CheckForInvalidConfigurationAndPlatform" Condition="'$(MauiXamlHotReload)' == 'SourceGen'">
-		<Warning 
+	<!-- Validate MauiXamlHotReload values (case-insensitive) -->
+	<Target Name="_ValidateMauiXamlHotReload" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
+		<PropertyGroup>
+			<_MauiXamlHotReloadUpper>$([System.String]::Copy('$(MauiXamlHotReload)').Trim().ToUpperInvariant())</_MauiXamlHotReloadUpper>
+		</PropertyGroup>
+
+		<Warning
 			Code="MAUI1002"
-			Text="MauiXamlHotReload is set to 'SourceGen'. Source generator-based XAML Hot Reload is experimental and not yet fully implemented. Use at your own risk." />
+			Text="MauiXamlHotReload is set to 'SourceGen'. Source generator-based XAML Hot Reload is experimental and not yet fully implemented. Use at your own risk."
+			Condition="'$(_MauiXamlHotReloadUpper)' == 'SOURCEGEN'" />
+
+		<Warning
+			Code="MAUI1003"
+			Text="MauiXamlHotReload is set to an unrecognized value '$(MauiXamlHotReload)'. Supported values are 'Legacy' and 'SourceGen'."
+			Condition="'$(_MauiXamlHotReloadUpper)' != '' and '$(_MauiXamlHotReloadUpper)' != 'SOURCEGEN' and '$(_MauiXamlHotReloadUpper)' != 'LEGACY'" />
 	</Target>
 
 	<Target Name="_ValidateMSBuild" BeforeTargets="_CheckForInvalidConfigurationAndPlatform">


### PR DESCRIPTION
## Description

Introduces the `MauiXamlHotReload` MSBuild property to communicate to the IDE which type of XAML Hot Reload implementation the application expects.

### Values

| Value | Description |
|-------|-------------|
| `Legacy` (default) | Traditional XAML Hot Reload implementation |
| `SourceGen` | Source generator-based XAML Hot Reload (experimental) |

### Usage

```xml
<PropertyGroup>
  <MauiXamlHotReload>SourceGen</MauiXamlHotReload>
</PropertyGroup>
```

## IDE Behavior

### When `MauiXamlHotReload=Legacy` (Default)

The IDE should behave as it currently does:
- XAML Hot Reload enabled
- Full page refresh supported
- Incremental XAML Hot Reload supported

### When `MauiXamlHotReload=SourceGen`

The IDE **MUST**:
- Ensure C# Hot Reload is **enabled**
- Ensure legacy XAML Hot Reload is **disabled**
- Provide a mechanism to trigger the MAUI Update Handler (MUH)

The IDE **MUST NOT**:
- Trigger full page refresh (i.e., send updated XAML to the app)
- Use incremental XAML Hot Reload

The IDE **MAY** continue to support:
- VisualDiagnostics
- BindingDiagnostics

## Warning

When `MauiXamlHotReload=SourceGen` is set, warning MAUI1002 is emitted:
> MauiXamlHotReload is set to 'SourceGen'. Source generator-based XAML Hot Reload is experimental and not yet fully implemented. Use at your own risk.

## Migration Note

This property exists to facilitate migration from legacy XAML Hot Reload to the source generator-based approach. In a future release, `Legacy` may be deprecated with `SourceGen` becoming the only supported mode.

Fixes #34027