### PR TITLE
Fix crash when closing Windows based app when using TitleBar

### DIFF
--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Maui.Platform
 				navView.Content = null;
 
 			_rootView.Content = null;
+			_rootView.AppWindowId = null;
 			_disconnected = true;
 		}
 

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Platform
 				// Clear out the toolbar that was set from the previous content
 				SetToolbar(null);
 
-				// We need to make sure to clear out the root view content 
+				// We need to make sure to clear out the root view content
 				// before creating the new view.
 				// Otherwise the new view might try to act on the old content.
 				// It might have code in the handler that retrieves this class.
@@ -147,11 +147,14 @@ namespace Microsoft.Maui.Platform
 
 			SetToolbar(null);
 
+			_rootView.SetTitleBar(null, null);
+
+			_rootView.AppWindowId = null;
+
 			if (_rootView.Content is RootNavigationView navView)
 				navView.Content = null;
 
 			_rootView.Content = null;
-			_rootView.AppWindowId = null;
 			_disconnected = true;
 		}
 


### PR DESCRIPTION
### Description of Change

The crash in #32194 occurs because `WindowRootView.UpdateTitleBarContentSize()` is called after the title bar window is already detached, but the `AppWindowId` property is still set. the fix is to reset the `AppWindowId` when the root view is cleared.

### Issues Fixed

Fixes #32194 