### PR TITLE
Fix ci-official Xcode provisioning for FoundationModels Swift compilation

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -103,7 +103,7 @@ extends:
             skipAndroidEmulatorImages: true
             skipAndroidCreateAvds: true
             skipProvisioning: true
-            skipXcode: true
+            skipXcode: false
             base64Encode: true
             outputVariableName: dotnetbuilds-internal-container-read-token-base64
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The internal `dotnet-maui` pipeline (ci-official.yml) fails to compile Swift files in `src/AI/src/AppleNative/EssentialsAI/` with:

```
error: no such module 'FoundationModels'
import FoundationModels
```

### Root Cause

`ci-official.yml` was the **only** pipeline that set `skipXcode: true` in the provision step for the Pack stage. This caused macOS agents to use the default Xcode on the macOS-15 image (Xcode 16.4) instead of selecting the required Xcode 26.0.1 via the `XCODE`/`REQUIRED_XCODE` variables.

The `FoundationModels` Swift module (Apple Intelligence APIs) requires Xcode 26.0+.

Every other pipeline (`ci.yml`, `ci-device-tests.yml`, `device-tests.yml`, `handlers.yml`) correctly uses `skipXcode: false`.

### Fix

One-line change: `skipXcode: true` → `skipXcode: false` in the Pack stage provision step of `ci-official.yml`.