### PR TITLE
[XSG] Fix Setter.Value property element lookup for MauiGlobalUri namespace

### DIFF
--- a/src/Controls/src/SourceGen/SetterValueProvider.cs
+++ b/src/Controls/src/SourceGen/SetterValueProvider.cs
@@ -158,16 +158,20 @@ internal class SetterValueProvider : IKnownMarkupValueProvider
 
 	/// <summary>
 	/// Shared helper to get the value node from a Setter element.
-	/// Checks properties first, then collection items.
+	/// Checks properties first (matching any namespace), then collection items.
 	/// </summary>
 	private static INode? GetValueNode(ElementNode node)
 	{
-		INode? valueNode = null;
-		if (!node.Properties.TryGetValue(new XmlName("", "Value"), out valueNode) &&
-			!node.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "Value"), out valueNode) &&
-			node.CollectionItems.Count == 1)
-			valueNode = node.CollectionItems[0];
+		// Look for the "Value" property regardless of namespace URI
+		foreach (var prop in node.Properties)
+		{
+			if (prop.Key.LocalName == "Value")
+				return prop.Value;
+		}
 
-		return valueNode;
+		if (node.CollectionItems.Count == 1)
+			return node.CollectionItems[0];
+
+		return null;
 	}
 }

--- a/src/Controls/src/SourceGen/SetterValueProvider.cs
+++ b/src/Controls/src/SourceGen/SetterValueProvider.cs
@@ -158,20 +158,17 @@ internal class SetterValueProvider : IKnownMarkupValueProvider
 
 	/// <summary>
 	/// Shared helper to get the value node from a Setter element.
-	/// Checks properties first (matching any namespace), then collection items.
+	/// Checks properties first, then collection items.
 	/// </summary>
 	private static INode? GetValueNode(ElementNode node)
 	{
-		// Look for the "Value" property regardless of namespace URI
-		foreach (var prop in node.Properties)
-		{
-			if (prop.Key.LocalName == "Value")
-				return prop.Value;
-		}
+		INode? valueNode = null;
+		if (!node.Properties.TryGetValue(new XmlName("", "Value"), out valueNode) &&
+			!node.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "Value"), out valueNode) &&
+			!node.Properties.TryGetValue(new XmlName(XamlParser.MauiGlobalUri, "Value"), out valueNode) &&
+			node.CollectionItems.Count == 1)
+			valueNode = node.CollectionItems[0];
 
-		if (node.CollectionItems.Count == 1)
-			return node.CollectionItems[0];
-
-		return null;
+		return valueNode;
 	}
 }

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterValueInTrigger.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/SetterValueInTrigger.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.SourceGen.SourceGeneratorDriver;
+
+namespace Microsoft.Maui.Controls.SourceGen.UnitTests;
+
+public class SetterValueInTrigger : SourceGenXamlInitializeComponentTestBase
+{
+	const string TestXaml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage x:Class="Test.TestPage">
+	<Button>
+		<Button.Style>
+			<Style TargetType="Button">
+				<Style.Triggers>
+					<Trigger TargetType="Button" Property="IsEnabled" Value="True">
+						<Setter Property="ImageSource">
+							<Setter.Value>
+								<FontImageSource FontFamily="Arial" Glyph="A" Size="16" />
+							</Setter.Value>
+						</Setter>
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+		</Button.Style>
+	</Button>
+</ContentPage>
+""";
+
+	const string TestCode = """
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Test;
+
+[XamlProcessing(XamlInflator.SourceGen)]
+public partial class TestPage : ContentPage
+{
+	public TestPage()
+	{
+		InitializeComponent();
+	}
+}
+""";
+
+	[Fact]
+	public void SetterWithComplexValueInTriggerIsAdded()
+	{
+		// Reproduction from https://github.com/dotnet/maui/issues/34039
+		// When <Setter.Value> is a property element, GetValueNode() must find it
+		// regardless of the namespace URI on the property element.
+		var compilation = CreateMauiCompilation()
+			.AddSyntaxTrees(CSharpSyntaxTree.ParseText(TestCode))
+			.AddSyntaxTrees(CSharpSyntaxTree.ParseText("[assembly: global::Microsoft.Maui.Controls.Xaml.Internals.AllowImplicitXmlnsDeclaration]"));
+
+		var workingDirectory = Environment.CurrentDirectory;
+		var xamlFile = new AdditionalXamlFile(
+			System.IO.Path.Combine(workingDirectory, "Test.xaml"), TestXaml,
+			RelativePath: "Test.xaml",
+			ManifestResourceName: $"{compilation.AssemblyName}.Test.xaml");
+		var result = RunGenerator<XamlGenerator>(compilation, xamlFile);
+		var generated = result.Results.SingleOrDefault().GeneratedSources
+			.SingleOrDefault(gs => gs.HintName.EndsWith(".xsg.cs")).SourceText?.ToString();
+
+		Assert.NotNull(generated);
+		Assert.False(result.Diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error),
+			$"Generator produced errors: {string.Join(", ", result.Diagnostics.Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error))}");
+
+		// The setter must be added to the trigger's Setters collection.
+		// Without the fix, GetValueNode() fails to find the Value property element,
+		// causing the setter to be removed from Variables and the .Add() call to be skipped.
+		Assert.Contains("Setters).Add(", generated, StringComparison.Ordinal);
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34039.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34039.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34039">
+    <Button x:Name="button">
+        <Button.Style>
+            <Style TargetType="Button">
+                <Style.Triggers>
+                    <Trigger TargetType="Button" Property="IsEnabled" Value="True">
+                        <Setter Property="ImageSource">
+                            <Setter.Value>
+                                <FontImageSource FontFamily="Arial" Glyph="A" Size="16" />
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Button.Style>
+    </Button>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34039.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34039.xaml.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui34039 : ContentPage
+{
+	public Maui34039() => InitializeComponent();
+
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void SetterWithPropertyElementValueInTriggerIsAdded(XamlInflator inflator)
+		{
+			var page = new Maui34039(inflator);
+			Assert.NotNull(page);
+			// Verify the trigger has a setter with a FontImageSource value
+			var style = page.button.Style;
+			Assert.NotNull(style);
+			Assert.Single(style.Triggers);
+			var trigger = (Trigger)style.Triggers[0];
+			Assert.Single(trigger.Setters);
+			Assert.IsType<FontImageSource>(trigger.Setters[0].Value);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34039.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34039.xaml.cs
@@ -6,6 +6,7 @@ public partial class Maui34039 : ContentPage
 {
 	public Maui34039() => InitializeComponent();
 
+	[Collection("Issue")]
 	public class Tests
 	{
 		[Theory]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #34039

When `<Setter.Value>` is used as a property element, `GetValueNode()` in `SetterValueProvider.cs` looked up the `Value` property only by two specific namespace URIs (`""` and `MauiUri`). When the property element resolved to `MauiGlobalUri` instead, the lookup returned null. Since PR #33681 changed the null-return behavior to a skip sentinel, this caused the Setter to be removed from `Variables` entirely, preventing the `.Add()` call from being generated.

### Root Cause

`GetValueNode()` checked only two namespace URIs:
```csharp
node.Properties.TryGetValue(new XmlName("", "Value"), out valueNode)
node.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "Value"), out valueNode)
```

Property elements like `<Setter.Value>` inherit their namespace URI from the XML reader, which varies depending on the xmlns declaration used. When the XAML used `MauiGlobalUri`, neither existing check matched, so `GetValueNode()` returned null, triggering the skip sentinel introduced in #33681, which suppressed the `Setters.Add()` call.

### Fix

Added `MauiGlobalUri` as a third namespace to check in the `GetValueNode()` lookup chain:

```csharp
!node.Properties.TryGetValue(new XmlName("", "Value"), out valueNode) &&
!node.Properties.TryGetValue(new XmlName(XamlParser.MauiUri, "Value"), out valueNode) &&
!node.Properties.TryGetValue(new XmlName(XamlParser.MauiGlobalUri, "Value"), out valueNode) &&
```

### Testing

- Added XAML unit test (`Maui34039`) verifying Setter with property element value in a Trigger
- Added SourceGen unit test (`SetterValueInTrigger`) verifying correct codegen
- Tests fail without fix, pass with fix
