### PR TITLE
Remove InternalsVisibleTo attributes for .NET MAUI Community Toolkit

### DIFF
--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -51,14 +51,6 @@ using Compatibility = Microsoft.Maui.Controls.Compatibility;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 [assembly: InternalsVisibleTo("Controls.TestCases.HostApp")]
 
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Embedding")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
-[assembly: InternalsVisibleTo("Controls.TestCases.HostApp")]
-
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 [assembly: Preserve]

--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -37,13 +37,6 @@ using Microsoft.Maui.Controls.Internals;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 [assembly: InternalsVisibleTo("Controls.TestCases.HostApp")]
 
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Embedding")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
-
 [assembly: InternalsVisibleTo("Core.Benchmarks")]
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
@@ -13,12 +13,7 @@ using Microsoft.Maui.Controls.Internals;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.HotReload.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.SourceGen")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Embedding")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
+
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 
 [assembly: Preserve]

--- a/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
@@ -13,12 +13,6 @@ using Microsoft.Maui.Controls.Internals;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.HotReload.Forms")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.HotReload.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.SourceGen")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Embedding")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 
 [assembly: Preserve]

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -34,11 +34,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Core.Benchmarks")]
 [assembly: InternalsVisibleTo("Comet")]
 [assembly: InternalsVisibleTo("Comet.Tests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
+
 [assembly: InternalsVisibleTo("Reloadify-emit")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests.Runners")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests")]

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -24,11 +24,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Core.Benchmarks")]
 [assembly: InternalsVisibleTo("Comet")]
 [assembly: InternalsVisibleTo("Comet.Tests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
+
 [assembly: InternalsVisibleTo("Reloadify-emit")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests.Runners")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests")]

--- a/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
+++ b/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
@@ -7,11 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsUWP")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsShared")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsiOS")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
+
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Core.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Compatibility.Core.UnitTests")]

--- a/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
+++ b/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
@@ -8,11 +8,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsUWP")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsShared")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsiOS")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
-[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
+
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Core.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Xaml.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils")]


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Removes all `InternalsVisibleTo` attributes that grant the .NET MAUI Community Toolkit access to internal APIs. This is the same change as #33442 (which was reverted in #34047 for .NET 10 SR4), now targeting **net11.0** to give the toolkit team time to migrate.

**Previous attempts:**
- #28994 — First removal (reverted in #29321 because toolkit wasn't updated)
- #29443 — Made some types public (`ITextElement`, `ICornerElement`, etc.)
- #33442 — Second removal in SR4 (reverted in #34047 because toolkit still wasn't updated)

### Files Modified

| File | Entries Removed |
|------|----------------|
| `src/Controls/src/Core/Properties/AssemblyInfo.cs` | 6 |
| `src/Controls/src/Xaml/Properties/AssemblyInfo.cs` | 6 |
| `src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs` | 5 |
| `src/Core/src/Properties/AssemblyInfo.cs` | 5 |

Total: 22 `InternalsVisibleTo` declarations removed for `CommunityToolkit.Maui`, `.Core`, `.Embedding`, `.UnitTests`, `.Markup`, `.Markup.UnitTests`.

> `CommunityToolkit.Maui.Embedding` has never been published to NuGet, so that grant was already dead.

### Impact on CommunityToolkit.Maui 15.0.0 (verified — see verification comment below)

The toolkit has made great progress: everything the older tables in this PR used to describe (`AvatarView`/`FontElement`/`TextElement`/`ImageElement`, `GravatarImageSource`/`ImageSource.CancellationTokenSource`, `AppThemeResourceExtension`/`IResourcesProvider`, `StreamWrapper`, `RequireFontManager`, `InvalidateMeasureInternal`, …) is **already resolved in 15.0.0**. Mac Catalyst builds completely clean.

What remains is **Android-only**. Building pristine `CommunityToolkit.Maui` 15.0.0 sources against this PR's packages produces 5 errors:

| # | MAUI internal API | Toolkit call site | Error |
|---|---|---|---|
| 1 | `Microsoft.Maui.ApplicationModel.IntermediateActivity` (internal type, Essentials) | `FileSaverImplementation.android.cs:40`, `FolderPickerImplementation.android.cs:37` | `CS0122` ×2 |
| 2 | `Microsoft.Maui.Platform.ElementExtensions.ToPlatform(this IElement)` — the **1-arg internal** overload | `Snackbar.android.cs:43` | `CS1929` |
| 3 | `Microsoft.Maui.JavaObjectExtensions.IsDisposed` (internal static class) | `Snackbar.android.cs:91` | `CS1061` |
| 4 | `Microsoft.Maui.JavaObjectExtensions.IsAlive` (internal static class) | `TouchBehavior.android.cs:109` | `CS1061` |
| 5 | `Microsoft.Maui.Platform.ViewExtensions.GetParentOfType<T>` (internal method) | `TouchBehavior.android.cs:44` | `CS1061` |

Plus one **binary-only** break that the compiler hides:

| # | MAUI internal API | Toolkit call site | Notes |
|---|---|---|---|
| 6 | `Microsoft.Maui.Controls.DispatcherExtensions.DispatchIfRequiredAsync` | `UserStoppedTypingBehavior.shared.cs:108,113` | The toolkit has its own 3-arg `DispatchIfRequiredAsync(IDispatcher, Action, CancellationToken = default)`. With IVT the 2-arg call sites bind to **MAUI's** internal one; without IVT a source rebuild silently rebinds to the toolkit's own. Prebuilt 15.0.0 assemblies therefore carry an IL memberref to MAUI's internal method and would throw `MethodAccessException`. A toolkit rebuild fixes it. |

Suggested resolution — items 2–5 are all trivially re-implementable inside the toolkit (a handful of lines each), and item 1 can be replaced with the toolkit's own activity-result plumbing over `Platform.CurrentActivity`. None of these require MAUI to make anything public.

### Consumer note: `CommunityToolkit.Maui.Markup` must be ≥ 8.0.0

`CommunityToolkit.Maui.Markup` **7.0.1** contains **45** IL references to MAUI internals (`FontElement`, `TextElement`, `ImageElement`, `PaddingElement`, `PlaceholderElement`, `SetterSpecificity`, `BindingExpression`, `TypedBindingBase..ctor`, `BindableObject.SetValueCore`, `BindingBase.Apply`/`Unapply`/`GetSourceValue`, …) and hard-crashes without IVT. **8.0.0 already has zero** — it's clean. Anyone still on 7.0.1 must upgrade.

### Issues Fixed

Context: #29444, #34048

cc @TheCodeTraveler