### PR TITLE
Fixed SourceGen with invalid x:DataType or invalid bindings does not emit errors

### DIFF
--- a/src/Controls/src/SourceGen/KnownMarkups.cs
+++ b/src/Controls/src/SourceGen/KnownMarkups.cs
@@ -546,10 +546,9 @@ internal class KnownMarkups
 				return false;
 			}
 
-			if (!dataType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out INamedTypeSymbol? symbol) && symbol is not null)
+			if (!dataType.TryResolveTypeSymbol(null, context.Compilation, context.XmlnsCache, context.TypeCache, out INamedTypeSymbol? symbol) || symbol is null)
 			{
-				// TODO report the right diagnostic
-				context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, location, "Cannot resolve x:DataType type"));
+				context.ReportDiagnostic(Diagnostic.Create(Descriptors.TypeResolution, location, dataTypeName));
 				return false;
 			}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue33417.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue33417.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using Xunit;
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public class Issue33417
+{
+	const string InvalidBindingXaml = """
+		<?xml version="1.0" encoding="utf-8" ?>
+		<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+		             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+		             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33417_InvalidBinding"
+		             x:DataType="local:Foo">
+		    <VerticalStackLayout>
+		        <Label Text="{Binding NonExistentProperty}" />
+		    </VerticalStackLayout>
+		</ContentPage>
+		""";
+
+	[Fact]
+	public void Issue33417_Test()
+	{
+		var result = CreateMauiCompilation()
+			.RunMauiSourceGenerator(new AdditionalXamlFile("Maui33417_InvalidBinding.xaml", InvalidBindingXaml));
+		Assert.NotEmpty(result.Diagnostics);
+		var hasTypeError = result.Diagnostics.Any(d => 
+			d.Id == "MAUIX2000" && d.GetMessage().Contains("Foo", StringComparison.Ordinal));
+		Assert.True(hasTypeError,
+			$"Should report type resolution error (MAUIX2000) for 'local:Foo'. Found diagnostics: {string.Join(", ", result.Diagnostics.Select(d => $"{d.Id}: {d.GetMessage()}"))}");
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33417.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33417.cs
@@ -5,7 +5,7 @@ using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests;
 
-public class Issue33417
+public class Maui33417
 {
 	const string InvalidBindingXaml = """
 		<?xml version="1.0" encoding="utf-8" ?>
@@ -21,7 +21,7 @@ public class Issue33417
 		""";
 
 	[Fact]
-	public void Issue33417_Test()
+	public void Maui33417_Test()
 	{
 		var result = CreateMauiCompilation()
 			.RunMauiSourceGenerator(new AdditionalXamlFile("Maui33417_InvalidBinding.xaml", InvalidBindingXaml));


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


### Issue Details:

SourceGen does not raise build errors for invalid x:DataType or bindings,
        
### Root Cause:

The condition uses && (AND), which means BOTH conditions must be true to report the error:
 
   1. TryResolveTypeSymbol returns false (type resolution failed) AND
   2. symbol is not null
 
  This is logically contradictory! When TryResolveTypeSymbol returns false, the 
  symbol is typically set to null. So both conditions are almost never true
  simultaneously, and errors were never reported.

### Description of Change:

Now the error is reported when EITHER condition is true:
 
   1. TryResolveTypeSymbol returns false (type not found) OR
   2. symbol is null (type resolution returned null)
 
  This catches all cases where the type cannot be resolved.

**Tested the behavior in the following platforms.**

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #33417     

### Screenshots
| Before  | After  |
|---------|--------|
|   <img src="https://github.com/user-attachments/assets/69f0768a-372b-4a13-b79d-58353040ea05" Width="300" Height="600">   |    <img src="https://github.com/user-attachments/assets/7a278196-3726-4865-a2c0-4dee01e20eab" Width="300" Height="600">  |
