### PR TITLE
[iOS 26] Stepper: Fix not reaching min/max when increment exceeds remaining range

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33769.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33769.cs
@@ -36,10 +36,8 @@ public class Issue33769 : ContentPage
 
 		stepper.ValueChanged += (sender, e) =>
 		{
-			if (stepper.Value == stepper.Maximum)
-			{
-				stepperStatusLabel.Text = "Success";
-			}
+			stepperStatusLabel.Text = (stepper.Value == stepper.Maximum || stepper.Value == stepper.Minimum)
+			? "Success" : "Failure";
 		};
 
 		Content = new VerticalStackLayout

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33769.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33769.cs
@@ -1,0 +1,57 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 33769, "Stepper control fails to reach maximum value when increment exceeds remaining threshold", PlatformAffected.iOS)]
+public class Issue33769 : ContentPage
+{
+	Label descriptionLabel;
+	Label stepperStatusLabel;
+	Stepper stepper;
+	public Issue33769()
+	{
+		descriptionLabel = new Label
+		{
+			Text = "The test passes if the stepper is able to reach the maximum and minimum value when increment exceeds remaining threshold",
+			FontSize = 16,
+			HorizontalOptions = LayoutOptions.Center,
+			HorizontalTextAlignment = TextAlignment.Center
+		};
+
+		stepper = new Stepper
+		{
+			AutomationId = "Issue33769_Stepper",
+			Minimum = 0,
+			Increment = 3,
+			Maximum = 2,
+			Value = 1,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		stepperStatusLabel = new Label
+		{
+			AutomationId = "Issue33769_StepperStatusLabel",
+			Text = "Failure",
+			FontSize = 16,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		stepper.ValueChanged += (sender, e) =>
+		{
+			if (stepper.Value == stepper.Maximum)
+			{
+				stepperStatusLabel.Text = "Success";
+			}
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 15,
+			Children =
+			{
+				descriptionLabel,
+				stepper,
+				stepperStatusLabel
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33769.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33769.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue33769 : _IssuesUITest
+{
+	public Issue33769(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Stepper control fails to reach maximum value when increment exceeds remaining threshold";
+
+	[Test]
+	[Category(UITestCategories.Stepper)]
+	public void ValidateStepperReachesMinMax()
+	{
+		App.WaitForElement("Issue33769_StepperStatusLabel");
+#if MACCATALYST
+		// On macOS, the XCUITest driver enumerates stepper buttons in reverse order,
+		// so IncreaseStepper actually decreases and vice versa. Use DecreaseStepper as a workaround.
+		App.DecreaseStepper("Issue33769_Stepper");
+#else
+		App.IncreaseStepper("Issue33769_Stepper");
+#endif
+		var result = App.WaitForElement("Issue33769_StepperStatusLabel").GetText();
+		Assert.That(result, Is.EqualTo("Success"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33769.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33769.cs
@@ -17,13 +17,7 @@ public class Issue33769 : _IssuesUITest
 	public void ValidateStepperReachesMinMax()
 	{
 		App.WaitForElement("Issue33769_StepperStatusLabel");
-#if MACCATALYST
-		// On macOS, the XCUITest driver enumerates stepper buttons in reverse order,
-		// so IncreaseStepper actually decreases and vice versa. Use DecreaseStepper as a workaround.
-		App.DecreaseStepper("Issue33769_Stepper");
-#else
 		App.IncreaseStepper("Issue33769_Stepper");
-#endif
 		var result = App.WaitForElement("Issue33769_StepperStatusLabel").GetText();
 		Assert.That(result, Is.EqualTo("Success"));
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33769.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33769.cs
@@ -20,5 +20,9 @@ public class Issue33769 : _IssuesUITest
 		App.IncreaseStepper("Issue33769_Stepper");
 		var result = App.WaitForElement("Issue33769_StepperStatusLabel").GetText();
 		Assert.That(result, Is.EqualTo("Success"));
+
+		App.DecreaseStepper("Issue33769_Stepper");
+		result = App.WaitForElement("Issue33769_StepperStatusLabel").GetText();
+		Assert.That(result, Is.EqualTo("Success"));
 	}
 }

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateIncrement(stepper);
 			
-			// When increment changes, Adjust stepValue for boundary handling
+			// iOS 26+ fix: Adjust stepValue for boundary handling when increment changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
 				&& NeedsStepValueAdjustment(stepper, platformView))
 			{

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -70,6 +70,10 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+		// iOS 26+ Workaround: UIStepper behavior changed to prevent button clicks when increment would exceed boundaries
+		// instead of clamping to boundary values like previous iOS versions. This method dynamically adjusts
+		// the stepValue to match available space to boundaries, allowing users to reach exact min/max values.
+		// Reference: https://developer.apple.com/forums/thread/802452
 		static void AdjustStepValueForBoundaries(IStepper virtualView, UIStepper platformView)
 		{
 			var originalIncrement = virtualView.Interval;

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using ObjCRuntime;
 using UIKit;
@@ -32,7 +32,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateMinimum(stepper);
 
-			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
+				&& NeedsStepValueAdjustment(stepper, platformView))
 			{
 				AdjustStepValueForBoundaries(stepper, platformView);
 			}
@@ -42,7 +43,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateMaximum(stepper);
 
-			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
+				&& NeedsStepValueAdjustment(stepper, platformView))
 			{
 				AdjustStepValueForBoundaries(stepper, platformView);
 			}
@@ -53,7 +55,8 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateIncrement(stepper);
 			
 			// When increment changes, Adjust stepValue for boundary handling
-			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
+				&& NeedsStepValueAdjustment(stepper, platformView))
 			{
 				AdjustStepValueForBoundaries(stepper, platformView);
 			}
@@ -64,10 +67,19 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateValue(stepper);
 
 			// iOS 26+ fix: Adjust stepValue for boundary handling
-			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
+				&& NeedsStepValueAdjustment(stepper, platformView))
 			{
 				AdjustStepValueForBoundaries(stepper, platformView);
 			}
+		}
+
+		// Checks whether the step value needs adjustment due to boundary proximity or a previously modified step value.
+		static bool NeedsStepValueAdjustment(IStepper stepper, UIStepper platformView)
+		{
+			return stepper.Value + stepper.Interval > stepper.Maximum
+				|| stepper.Value - stepper.Interval < stepper.Minimum
+				|| platformView.StepValue != stepper.Interval;
 		}
 
 		// iOS 26+ Workaround: UIStepper behavior changed to prevent button clicks when increment would exceed boundaries
@@ -146,7 +158,8 @@ namespace Microsoft.Maui.Handlers
 				if (VirtualView is IStepper virtualView && sender is UIStepper platformView)
 				{
 					// iOS 26+ fix: Adjust stepValue for boundary handling
-					if (OperatingSystem.IsIOSVersionAtLeast(26))
+					if (OperatingSystem.IsIOSVersionAtLeast(26)
+						&& NeedsStepValueAdjustment(virtualView, platformView))
 					{
 						AdjustStepValueForBoundaries(virtualView, platformView);
 					}

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateMinimum(stepper);
 
+			// iOS 26+ fix: Adjust stepValue for boundary handling when minimum changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
 				&& NeedsStepValueAdjustment(stepper, platformView))
 			{
@@ -43,6 +44,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateMaximum(stepper);
 
+			// iOS 26+ fix: Adjust stepValue for boundary handling when maximum changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
 				&& NeedsStepValueAdjustment(stepper, platformView))
 			{

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using ObjCRuntime;
 using UIKit;
@@ -31,21 +31,93 @@ namespace Microsoft.Maui.Handlers
 		public static void MapMinimum(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateMinimum(stepper);
+
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			{
+				AdjustStepValueForBoundaries(stepper, platformView);
+			}
 		}
 
 		public static void MapMaximum(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateMaximum(stepper);
+
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			{
+				AdjustStepValueForBoundaries(stepper, platformView);
+			}
 		}
 
 		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateIncrement(stepper);
+			
+			// When increment changes, Adjust stepValue for boundary handling
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			{
+				AdjustStepValueForBoundaries(stepper, platformView);
+			}
 		}
 
 		public static void MapValue(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateValue(stepper);
+
+			// iOS 26+ fix: Adjust stepValue for boundary handling
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView)
+			{
+				AdjustStepValueForBoundaries(stepper, platformView);
+			}
+		}
+
+		static void AdjustStepValueForBoundaries(IStepper virtualView, UIStepper platformView)
+		{
+			var originalIncrement = virtualView.Interval;
+
+			// Only proceed if we have a valid positive increment
+			if (originalIncrement <= 0)
+			{
+				return;
+			}
+
+			var currentValue = virtualView.Value;
+			var minimum = virtualView.Minimum;
+			var maximum = virtualView.Maximum;
+
+			// Validate range configuration - if invalid, fallback to original increment
+			if (maximum <= minimum)
+			{
+				platformView.StepValue = originalIncrement;
+				return;
+			}
+
+			// Clamp current value to valid range if needed
+			currentValue = Math.Max(minimum, Math.Min(maximum, currentValue));
+
+			var spaceToMax = maximum - currentValue;
+			var spaceToMin = currentValue - minimum;
+
+			// Use small epsilon for floating-point comparison precision
+			const double epsilon = 1e-10;
+
+			// Store current stepValue to minimize property access
+			var currentStepValue = platformView.StepValue;
+
+			// If we're close to boundaries and increment would exceed them,
+			// temporarily reduce stepValue to allow reaching exact boundary
+			if (spaceToMax > epsilon && spaceToMax < originalIncrement && Math.Abs(currentStepValue - spaceToMax) > epsilon)
+			{
+				platformView.StepValue = spaceToMax;
+			}
+			else if (spaceToMin > epsilon && spaceToMin < originalIncrement && Math.Abs(currentStepValue - spaceToMin) > epsilon)
+			{
+				platformView.StepValue = spaceToMin;
+			}
+			else if (Math.Abs(currentStepValue - originalIncrement) > epsilon)
+			{
+				// Restore original increment when not near boundaries
+				platformView.StepValue = originalIncrement;
+			}
 		}
 
 		class StepperProxy
@@ -68,7 +140,15 @@ namespace Microsoft.Maui.Handlers
 			void OnValueChanged(object? sender, EventArgs e)
 			{
 				if (VirtualView is IStepper virtualView && sender is UIStepper platformView)
+				{
+					// iOS 26+ fix: Adjust stepValue for boundary handling
+					if (OperatingSystem.IsIOSVersionAtLeast(26))
+					{
+						AdjustStepValueForBoundaries(virtualView, platformView);
+					}
+
 					virtualView.Value = platformView.Value;
+				}
 			}
 		}
 	}

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateIncrement(stepper);
-			
+
 			// iOS 26+ fix: Adjust stepValue for boundary handling when increment changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) && handler.PlatformView is UIStepper platformView
 				&& NeedsStepValueAdjustment(stepper, platformView))
@@ -79,9 +79,10 @@ namespace Microsoft.Maui.Handlers
 		// Checks whether the step value needs adjustment due to boundary proximity or a previously modified step value.
 		static bool NeedsStepValueAdjustment(IStepper stepper, UIStepper platformView)
 		{
+			const double epsilon = 1e-10;
 			return stepper.Value + stepper.Interval > stepper.Maximum
 				|| stepper.Value - stepper.Interval < stepper.Minimum
-				|| platformView.StepValue != stepper.Interval;
+				|| Math.Abs(platformView.StepValue - stepper.Interval) > epsilon;
 		}
 
 		// iOS 26+ Workaround: UIStepper behavior changed to prevent button clicks when increment would exceed boundaries


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- On the iOS 26 platform, the stepper control does not update to the defined maximum value
- For example, if the current value is 9, the maximum is 10, and the increment is 3, clicking the increment button does not update the value to 10 — it remains at 9. This behavior differs from other platforms (e.g., Android, iOS 18, MacCatalyst), where the same configuration correctly updates the value to 10.

### Root Cause

- iOS 26 changes UIStepper behavior to disable buttons when an increment would exceed bounds, which prevents reaching exact min/max values if the step size is larger than the remaining space.

### Description of Change

- Added logic in StepperHandler.iOS.cs to dynamically adjust UIStepper.StepValue when the increment exceeds the remaining distance to the minimum or maximum value, allowing the control to reach the exact boundary values on iOS 26+.
- Introduced helper methods NeedsStepValueAdjustment and AdjustStepValueForBoundaries to encapsulate the boundary adjustment logic for clarity and reuse.

> **Reference:** [Apple Developer Forums: UIStepper behavior change in iOS 26](https://developer.apple.com/forums/thread/802452)

### Issues Fixed
Fixes #33769

### Validated the behaviour in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/ef57288f-d6f1-4805-9322-9ebb7e820064"> | <video src="https://github.com/user-attachments/assets/fab9dd4b-adf9-4df8-97dc-54a590ac495e"> |