### PR TITLE
[Perf] Refactor SetterSpecificityList<T> from class to struct

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Maui.Controls
 				var currentValue = context.Values.GetValue();
 
 				context.Values.Remove(currentSpecificity);
-				context.Values[SetterSpecificity.FromBinding] = currentValue;
+				context.Values.SetValue(SetterSpecificity.FromBinding, currentValue);
 			}
 
 			BindingBase oldBinding = null;
@@ -322,13 +322,13 @@ namespace Microsoft.Maui.Controls
 
 			if (oldBinding != null && specificity < oldSpecificity)
 			{
-				context.Bindings[specificity] = binding;
+				context.Bindings.SetValue(specificity, binding);
 				return;
 			}
 
 			oldBinding?.Unapply();
 
-			context.Bindings[specificity] = binding ?? throw new ArgumentNullException(nameof(binding));
+			context.Bindings.SetValue(specificity, binding ?? throw new ArgumentNullException(nameof(binding)));
 
 			targetProperty.BindingChanging?.Invoke(this, oldBinding, binding);
 
@@ -637,7 +637,7 @@ namespace Microsoft.Maui.Controls
 			//We keep setter of lower specificity so we can unapply
 			if (specificity < originalSpecificity)
 			{
-				context.Values[specificity] = value;
+				context.Values.SetValue(specificity, value);
 				return;
 			}
 
@@ -655,7 +655,7 @@ namespace Microsoft.Maui.Controls
 				OnPropertyChanging(property.PropertyName);
 			}
 
-			context.Values[specificity] = value;
+			context.Values.SetValue(specificity, value);
 
 			context.Attributes &= ~BindableContextAttributes.IsDefaultValueCreated;
 
@@ -753,7 +753,7 @@ namespace Microsoft.Maui.Controls
 		{
 			var defaultValueCreator = property.DefaultValueCreator;
 			var context = new BindablePropertyContext { Property = property };
-			context.Values[SetterSpecificity.DefaultValue] = defaultValueCreator != null ? defaultValueCreator(this) : property.DefaultValue;
+			context.Values.SetValue(SetterSpecificity.DefaultValue, defaultValueCreator != null ? defaultValueCreator(this) : property.DefaultValue);
 
 			if (defaultValueCreator != null)
 				context.Attributes = BindableContextAttributes.IsDefaultValueCreated;
@@ -776,7 +776,7 @@ namespace Microsoft.Maui.Controls
 				return; //used to fail;
 
 			var currentbinding = context.Bindings.GetValue();
-			var binding = context.Bindings[specificity];
+			var binding = context.Bindings.GetValue(specificity);
 			var isCurrent = binding == currentbinding;
 
 			if (isCurrent)
@@ -857,11 +857,11 @@ namespace Microsoft.Maui.Controls
 		{
 			public BindableContextAttributes Attributes;
 
-			public SetterSpecificityList<BindingBase> Bindings = new();
+			public SetterSpecificityList<BindingBase> Bindings;
 
 			public Queue<SetValueArgs> DelayedSetters;
 			public BindableProperty Property;
-			public readonly SetterSpecificityList<object> Values = new(3);
+			public SetterSpecificityList<object> Values;
 		}
 
 

--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.StyleSheets;
 using Compatibility = Microsoft.Maui.Controls.Compatibility;
 
+[assembly: InternalsVisibleTo("Core.Benchmarks")]
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Components.WebView.Maui")]
 
 [assembly: InternalsVisibleTo("iOSUnitTests")]

--- a/src/Controls/src/Core/SetterSpecificityList.cs
+++ b/src/Controls/src/Core/SetterSpecificityList.cs
@@ -1,235 +1,333 @@
-﻿#nullable disable
+﻿#nullable enable
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <summary>
 	/// Stores values for a property with different specificities.
+	/// Optimized for the common case of 1-2 entries (e.g. DefaultValue + one setter).
+	/// Value type: embeds inline in the owning context with no separate heap allocation.
 	/// </summary>
-	internal class SetterSpecificityList<T> where T : class
+	internal struct SetterSpecificityList<T>
 	{
-		const int CapacityDelta = 3;
-
-		SetterSpecificity[] _keys;
-		T[] _values;
+		Entry _top;       // highest specificity entry
+		Entry _second;    // second highest (fallback when top is removed)
+		RestList? _rest;  // overflow for 3+ entries (< 1% of instances in practice)
 		int _count;
 
-		public int Count => _count;
+		public readonly int Count => _count;
 
-		public T this[SetterSpecificity key]
+		/// <summary>Gets the highest specificity.</summary>
+		public readonly SetterSpecificity GetSpecificity()
+			=> _count >= 1 ? _top.Specificity : default;
+
+		/// <summary>Gets the value for the highest specificity.</summary>
+		public readonly T? GetValue()
+			=> _count >= 1 ? _top.Value : default;
+
+		/// <summary>Returns what the value would be if the current value was removed.</summary>
+		public readonly T? GetClearedValue()
+			=> _count >= 2 ? _second.Value : default;
+
+		/// <summary>Returns what the value would be if the given specificity was removed.</summary>
+		public readonly T? GetClearedValue(SetterSpecificity specificity)
 		{
-			set => SetValue(key, value);
-			get => GetValue(key);
+			if (_count == 0)
+				return default;
+
+			if (_top.Specificity == specificity)
+				return _count >= 2 ? _second.Value : default;
+
+			return _top.Value;
 		}
 
-		public SetterSpecificityList()
-		{
-			_keys = Array.Empty<SetterSpecificity>();
-			_values = Array.Empty<T>();
-		}
+		/// <summary>Returns what the SetterSpecificity would be if the current value was removed.</summary>
+		public readonly SetterSpecificity GetClearedSpecificity()
+			=> _count >= 2 ? _second.Specificity : default;
 
-		public SetterSpecificityList(int initialCapacity)
+		/// <summary>Gets the highest specificity and value.</summary>
+		public readonly KeyValuePair<SetterSpecificity, T> GetSpecificityAndValue()
+			=> _count >= 1
+				? new KeyValuePair<SetterSpecificity, T>(_top.Specificity, _top.Value!)
+				: default;
+
+		public void SetValue(SetterSpecificity key, T value)
 		{
-			if (initialCapacity == 0)
+			var newEntry = new Entry(value, key);
+
+			if (_count == 0)
 			{
-				_keys = Array.Empty<SetterSpecificity>();
-				_values = Array.Empty<T>();
+				_top = newEntry;
+				_count = 1;
+				return;
 			}
-			else
+
+			if (_top.Specificity == key)
 			{
-				_keys = new SetterSpecificity[initialCapacity];
-				_values = new T[initialCapacity];
+				_top = newEntry;
+				return;
 			}
-		}
 
-		/// <summary>
-		/// Gets the highest specificity
-		/// </summary>
-		/// <returns></returns>
-		public SetterSpecificity GetSpecificity()
-		{
-			var index = _count - 1;
-			return index < 0 ? default : _keys[index];
-		}
-
-		/// <summary>
-		/// Gets the value for the highest specificity
-		/// </summary>
-		/// <returns></returns>
-		public T GetValue()
-		{
-			var index = _count - 1;
-			return index < 0 ? default : _values[index];
-		}
-
-		/// <summary>
-		/// Returns what the value would be if the current value was removed
-		/// </summary>
-		public T GetClearedValue()
-		{
-			var index = _count - 2;
-			return index < 0 ? default : _values[index];
-		}
-
-		/// <summary>
-		/// Returns what the value would be if the specificity value was removed
-		/// </summary>
-		public T GetClearedValue(SetterSpecificity specificity)
-		{
-			var index = _count - 1;
-			if (index >= 0 && _keys[index] == specificity)
+			if (_count == 1)
 			{
-				--index;
-			}
-			return index < 0 ? default : _values[index];
-		}
-
-		/// <summary>
-		/// Returns what the SetterSpecificity would be if the current value was removed
-		/// </summary>
-		public SetterSpecificity GetClearedSpecificity()
-		{
-			var index = _count - 2;
-			return index < 0 ? default : _keys[index];
-		}
-
-		/// <summary>
-		/// Gets the highest specificity and value
-		/// </summary>
-		/// <returns></returns>
-		public KeyValuePair<SetterSpecificity, T> GetSpecificityAndValue()
-		{
-			var index = _count - 1;
-			return index < 0 ? default : new KeyValuePair<SetterSpecificity, T>(_keys[index], _values[index]);
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		void SetValue(SetterSpecificity key, T value)
-		{
-			var count = _count;
-			var lo = 0;
-			var hi = count - 1;
-			while (lo <= hi)
-			{
-				var index = lo + ((hi - lo) >> 1);
-
-				var indexSpecificity = _keys[index];
-				if (indexSpecificity == key)
+				if (key > _top.Specificity)
 				{
-					_values[index] = value;
-					return;
-				}
-
-				if (indexSpecificity < key)
-				{
-					lo = index + 1;
+					_second = _top;
+					_top = newEntry;
 				}
 				else
 				{
-					hi = index - 1;
+					_second = newEntry;
 				}
+
+				_count = 2;
+				return;
 			}
 
-			if (_keys.Length == count)
+			if (_second.Specificity == key)
 			{
-				SetCapacity(count, count + CapacityDelta);
+				_second = newEntry;
+				return;
 			}
 
-			if (count > lo)
+			if (key > _top.Specificity)
 			{
-				Array.Copy(_keys, lo, _keys, lo + 1, count - lo);
-				Array.Copy(_values, lo, _values, lo + 1, count - lo);
+				PushSecondToRest();
+				_second = _top;
+				_top = newEntry;
+				_count++;
+				return;
 			}
 
-			_keys[lo] = key;
-			_values[lo] = value;
-
-			++_count;
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		T GetValue(SetterSpecificity key)
-		{
-			var count = _count;
-			var lo = 0;
-			var hi = count - 1;
-			while (lo <= hi)
+			if (key > _second.Specificity)
 			{
-				var index = lo + ((hi - lo) >> 1);
-
-				var indexSpecificity = _keys[index];
-				if (indexSpecificity == key)
-				{
-					return _values[index];
-				}
-
-				if (indexSpecificity < key)
-				{
-					lo = index + 1;
-				}
-				else
-				{
-					hi = index - 1;
-				}
+				PushSecondToRest();
+				_second = newEntry;
+				_count++;
+				return;
 			}
 
-			return default;
+			_rest ??= new RestList();
+			if (_rest.SetOrInsert(newEntry))
+				_count++;
 		}
 
 		public void Remove(SetterSpecificity key)
 		{
-			var count = _count;
-			var lo = 0;
-			var hi = count - 1;
-			while (lo <= hi)
+			if (_count >= 1 && _top.Specificity == key)
 			{
-				var index = lo + ((hi - lo) >> 1);
-
-				var indexSpecificity = _keys[index];
-				if (indexSpecificity == key)
-				{
-					var nextIndex = index + 1;
-					if (nextIndex < count)
-					{
-						Array.Copy(_keys, nextIndex, _keys, index, count - nextIndex);
-						Array.Copy(_values, nextIndex, _values, index, count - nextIndex);
-						_values[count - 1] = null;
-					}
-					else
-					{
-						_values[index] = null;
-					}
-
-					--_count;
-					return;
-				}
-
-				if (indexSpecificity < key)
-				{
-					lo = index + 1;
-				}
-				else
-				{
-					hi = index - 1;
-				}
+				RemoveTop();
+			}
+			else if (_count >= 2 && _second.Specificity == key)
+			{
+				RemoveSecond();
+			}
+			else if (_count >= 3 && _rest is not null)
+			{
+				if (_rest.Remove(key))
+					_count--;
 			}
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		void SetCapacity(int currentCapacity, int capacity)
+		public readonly T? GetValue(SetterSpecificity key)
 		{
-			var newKeys = new SetterSpecificity[capacity];
-			var newValues = new T[capacity];
-			if (currentCapacity > 0)
+			if (_count >= 1 && _top.Specificity == key)
+				return _top.Value;
+			if (_count >= 2 && _second.Specificity == key)
+				return _second.Value;
+
+			if (_rest is not null && _rest.TryGetValue(key, out var value))
+				return value;
+
+			return default;
+		}
+
+		void PushSecondToRest()
+		{
+			_rest ??= new RestList();
+			_rest.Insert(_second);
+		}
+
+		void RemoveTop()
+		{
+			if (_count == 1)
 			{
-				Array.Copy(_keys, newKeys, currentCapacity);
-				Array.Copy(_values, newValues, currentCapacity);
+				_top = default;
+				_count = 0;
 			}
-			_keys = newKeys;
-			_values = newValues;
+			else if (_count == 2)
+			{
+				_top = _second;
+				_second = default;
+				_count = 1;
+			}
+			else if (_rest is not null)
+			{
+				_top = _second;
+				_second = _rest.PopLast();
+				_count--;
+			}
+		}
+
+		void RemoveSecond()
+		{
+			if (_count == 2)
+			{
+				_second = default;
+				_count = 1;
+			}
+			else if (_rest is not null)
+			{
+				_second = _rest.PopLast();
+				_count--;
+			}
+		}
+
+		struct Entry(T? value, SetterSpecificity specificity)
+		{
+			public T? Value = value;
+			public readonly SetterSpecificity Specificity = specificity;
+		}
+
+		sealed class RestList
+		{
+			Entry[]? _entries;
+			int _count;
+
+			public bool TryGetValue(SetterSpecificity key, out T? value)
+			{
+				var entries = _entries;
+				if (entries is not null)
+				{
+					for (int i = 0; i < _count; i++)
+					{
+						if (entries[i].Specificity == key)
+						{
+							value = entries[i].Value;
+							return true;
+						}
+					}
+				}
+
+				value = default;
+				return false;
+			}
+
+			/// <summary>
+			/// Updates existing entry or inserts a new one, maintaining ascending specificity order.
+			/// Returns true if a new entry was inserted; false if an existing one was updated.
+			/// </summary>
+			public bool SetOrInsert(Entry entry)
+			{
+				var entries = _entries;
+				int insertAt = _count;
+				if (entries is not null)
+				{
+					for (int i = _count - 1; i >= 0; i--)
+					{
+						var specificity = entries[i].Specificity;
+						if (specificity == entry.Specificity)
+						{
+							entries[i] = entry;
+							return false;
+						}
+
+						if (specificity < entry.Specificity)
+						{
+							insertAt = i + 1;
+							break;
+						}
+
+						insertAt = i;
+					}
+				}
+
+				InsertAt(entry, insertAt);
+				return true;
+			}
+
+			public void Insert(Entry entry)
+			{
+				var entries = _entries;
+				int insertAt = _count;
+				if (entries is not null)
+				{
+					for (int i = _count - 1; i >= 0; i--)
+					{
+						if (entries[i].Specificity <= entry.Specificity)
+						{
+							insertAt = i + 1;
+							break;
+						}
+
+						insertAt = i;
+					}
+				}
+
+				InsertAt(entry, insertAt);
+			}
+
+			public Entry PopLast()
+			{
+				var entries = _entries!;
+				var lastIndex = _count - 1;
+				var entry = entries[lastIndex];
+				entries[lastIndex] = default;
+				_count--;
+				return entry;
+			}
+
+			public bool Remove(SetterSpecificity key)
+			{
+				var entries = _entries;
+				if (entries is null)
+					return false;
+
+				for (int i = _count - 1; i >= 0; i--)
+				{
+					if (entries[i].Specificity == key)
+					{
+						var trailingCount = _count - i - 1;
+						if (trailingCount > 0)
+							Array.Copy(entries, i + 1, entries, i, trailingCount);
+
+						_count--;
+						entries[_count] = default;
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			void InsertAt(Entry entry, int insertAt)
+			{
+				EnsureCapacity(_count + 1);
+				var entries = _entries!;
+				if (insertAt < _count)
+				{
+					Array.Copy(entries, insertAt, entries, insertAt + 1, _count - insertAt);
+				}
+
+				entries[insertAt] = entry;
+				_count++;
+			}
+
+			void EnsureCapacity(int requiredLength)
+			{
+				if (_entries is null)
+				{
+					_entries = new Entry[Math.Max(requiredLength, 4)];
+				}
+				else if (_entries.Length < requiredLength)
+				{
+					var newEntries = new Entry[Math.Max(requiredLength, _entries.Length * 2)];
+					Array.Copy(_entries, 0, newEntries, 0, _count);
+					_entries = newEntries;
+				}
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/SetterSpecificityList.cs
+++ b/src/Controls/src/Core/SetterSpecificityList.cs
@@ -287,11 +287,11 @@ namespace Microsoft.Maui.Controls
 		{
 			if (_rest is null)
 			{
-				_rest = new Entry[Math.Max(requiredLength, 4)];
+				_rest = new Entry[requiredLength];
 			}
 			else if (_rest.Length < requiredLength)
 			{
-				var newEntries = new Entry[Math.Max(requiredLength, _rest.Length * 2)];
+				var newEntries = new Entry[requiredLength];
 				Array.Copy(_rest, 0, newEntries, 0, RestCount);
 				_rest = newEntries;
 			}

--- a/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SetterSpecificityListTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void OverridesValueWithSameSpecificity()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.ManualValueSetter] = "initial";
+			list.SetValue(SetterSpecificity.ManualValueSetter, "initial");
 
-			list[SetterSpecificity.ManualValueSetter] = "new";
+			list.SetValue(SetterSpecificity.ManualValueSetter, "new");
 			Assert.Equal(1, list.Count);
 
 			var pair = list.GetSpecificityAndValue();
@@ -34,14 +34,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task RemovingValueDoesNotLeak()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
-			list[SetterSpecificity.FromHandler] = nameof(SetterSpecificity.FromHandler);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
+			list.SetValue(SetterSpecificity.FromHandler, nameof(SetterSpecificity.FromHandler));
 			WeakReference weakReference;
 
 			{
 				var o = new object();
 				weakReference = new WeakReference(o);
-				list[SetterSpecificity.FromBinding] = o;
+				list.SetValue(SetterSpecificity.FromBinding, o);
 			}
 
 			list.Remove(SetterSpecificity.FromBinding);
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				var o = new object();
 				weakReference = new WeakReference(o);
-				list[SetterSpecificity.ManualValueSetter] = o;
+				list.SetValue(SetterSpecificity.ManualValueSetter, o);
 			}
 
 			list.Remove(SetterSpecificity.ManualValueSetter);
@@ -70,10 +70,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void GetValueForSpecificity()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 
-			var foundValue = list[SetterSpecificity.DefaultValue];
+			var foundValue = list.GetValue(SetterSpecificity.DefaultValue);
 			Assert.Equal(nameof(SetterSpecificity.DefaultValue), foundValue);
 		}
 
@@ -81,10 +81,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void NullWhenNoValuesMatchSpecificity()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 
-			var foundValue = list[SetterSpecificity.FromHandler];
+			var foundValue = list.GetValue(SetterSpecificity.FromHandler);
 			Assert.Null(foundValue);
 		}
 
@@ -92,14 +92,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void OneValue()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 
 			var pair = list.GetSpecificityAndValue();
 			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), pair.Value);
 			Assert.Equal(SetterSpecificity.ManualValueSetter, pair.Key);
 
 			// Add a "default" value
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
 			pair = list.GetSpecificityAndValue();
 			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), pair.Value);
 			Assert.Equal(SetterSpecificity.ManualValueSetter, pair.Key);
@@ -111,8 +111,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void TwoValues()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 
 			var pair = list.GetSpecificityAndValue();
 			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), pair.Value);
@@ -131,9 +131,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void ThreeValues()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
-			list[SetterSpecificity.FromBinding] = nameof(SetterSpecificity.FromBinding);
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
+			list.SetValue(SetterSpecificity.FromBinding, nameof(SetterSpecificity.FromBinding));
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 
 			var pair = list.GetSpecificityAndValue();
 			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), pair.Value);
@@ -152,11 +152,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void ManyValues()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
-			list[SetterSpecificity.FromBinding] = nameof(SetterSpecificity.FromBinding);
-			list[SetterSpecificity.DynamicResourceSetter] = nameof(SetterSpecificity.DynamicResourceSetter);
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
-			list[SetterSpecificity.Trigger] = nameof(SetterSpecificity.Trigger);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
+			list.SetValue(SetterSpecificity.FromBinding, nameof(SetterSpecificity.FromBinding));
+			list.SetValue(SetterSpecificity.DynamicResourceSetter, nameof(SetterSpecificity.DynamicResourceSetter));
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
+			list.SetValue(SetterSpecificity.Trigger, nameof(SetterSpecificity.Trigger));
 
 			var pair = list.GetSpecificityAndValue();
 			Assert.Equal(nameof(SetterSpecificity.Trigger), pair.Value);
@@ -175,10 +175,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void GetClearedValue()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
 			Assert.Equal(default, list.GetClearedValue());
 			Assert.Equal(default, list.GetClearedSpecificity());
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 			Assert.Equal(nameof(SetterSpecificity.DefaultValue), list.GetClearedValue());
 			Assert.Equal(SetterSpecificity.DefaultValue, list.GetClearedSpecificity());
 		}
@@ -187,9 +187,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void GetClearedValueForSpecificity()
 		{
 			var list = new SetterSpecificityList<object>();
-			list[SetterSpecificity.DefaultValue] = nameof(SetterSpecificity.DefaultValue);
+			list.SetValue(SetterSpecificity.DefaultValue, nameof(SetterSpecificity.DefaultValue));
 			Assert.Equal(default, list.GetClearedValue(SetterSpecificity.DefaultValue));
-			list[SetterSpecificity.ManualValueSetter] = nameof(SetterSpecificity.ManualValueSetter);
+			list.SetValue(SetterSpecificity.ManualValueSetter, nameof(SetterSpecificity.ManualValueSetter));
 			Assert.Equal(nameof(SetterSpecificity.DefaultValue), list.GetClearedValue(SetterSpecificity.ManualValueSetter));
 			Assert.Equal(nameof(SetterSpecificity.ManualValueSetter), list.GetClearedValue(SetterSpecificity.FromHandler));
 		}

--- a/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
+++ b/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
@@ -1,45 +1,49 @@
 #nullable enable
 using System;
 using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
 
 namespace Microsoft.Maui.Handlers.Benchmarks;
 
 /// <summary>
 /// Head-to-head comparison of SetterSpecificityList implementations:
-/// - OldClassSSL: copy of the original class-based, parallel-array + binary-search implementation
-/// - NewStructSSL: the new struct-based, inline _top/_second + lazy _rest implementation
-///
-/// Both use a self-contained copy of SetterSpecificity so the benchmark is standalone.
+/// - Legacy: copy of the original class-based, parallel-array + binary-search implementation
+/// - Current: the real struct-based SetterSpecificityList from the project
 /// </summary>
 [MemoryDiagnoser]
 [ShortRunJob]
 public class SetterSpecificityListBenchmarks
 {
+	static readonly SetterSpecificity DefaultValue = default;
+	static readonly SetterSpecificity FromHandler = SetterSpecificity.FromHandler;
+	static readonly SetterSpecificity ManualValueSetter = new(0, 0, 0, 1, 0, 0, 0, 0);
+	static readonly SetterSpecificity Style = new(0, 1, 0, 0, 0, 0, 0, 0);
+
 	// --- Create contexts and set 2 entries (the 99% hot path) ---
 
 	[Benchmark(Baseline = true)]
-	public object OldClass_Create100_Set2()
+	public object Legacy_Create100_Set2()
 	{
-		OldContext? last = null;
+		LegacyContext? last = null;
 		for (int i = 0; i < 100; i++)
 		{
-			var ctx = new OldContext();
-			ctx.Values[Specificity.DefaultValue] = "default";
-			ctx.Values[Specificity.FromHandler] = "handler";
+			var ctx = new LegacyContext();
+			ctx.Values[DefaultValue] = "default";
+			ctx.Values[FromHandler] = "handler";
 			last = ctx;
 		}
 		return last!;
 	}
 
 	[Benchmark]
-	public object NewStruct_Create100_Set2()
+	public object Current_Create100_Set2()
 	{
-		NewContext? last = null;
+		CurrentContext? last = null;
 		for (int i = 0; i < 100; i++)
 		{
-			var ctx = new NewContext();
-			ctx.Values.SetValue(Specificity.DefaultValue, "default");
-			ctx.Values.SetValue(Specificity.FromHandler, "handler");
+			var ctx = new CurrentContext();
+			ctx.Values.SetValue(DefaultValue, "default");
+			ctx.Values.SetValue(FromHandler, "handler");
 			last = ctx;
 		}
 		return last!;
@@ -48,30 +52,30 @@ public class SetterSpecificityListBenchmarks
 	// --- Create contexts and set 3 entries (the < 1% cold path) ---
 
 	[Benchmark]
-	public object OldClass_Create100_Set3()
+	public object Legacy_Create100_Set3()
 	{
-		OldContext? last = null;
+		LegacyContext? last = null;
 		for (int i = 0; i < 100; i++)
 		{
-			var ctx = new OldContext();
-			ctx.Values[Specificity.DefaultValue] = "default";
-			ctx.Values[Specificity.Style] = "style";
-			ctx.Values[Specificity.ManualValueSetter] = "manual";
+			var ctx = new LegacyContext();
+			ctx.Values[DefaultValue] = "default";
+			ctx.Values[Style] = "style";
+			ctx.Values[ManualValueSetter] = "manual";
 			last = ctx;
 		}
 		return last!;
 	}
 
 	[Benchmark]
-	public object NewStruct_Create100_Set3()
+	public object Current_Create100_Set3()
 	{
-		NewContext? last = null;
+		CurrentContext? last = null;
 		for (int i = 0; i < 100; i++)
 		{
-			var ctx = new NewContext();
-			ctx.Values.SetValue(Specificity.DefaultValue, "default");
-			ctx.Values.SetValue(Specificity.Style, "style");
-			ctx.Values.SetValue(Specificity.ManualValueSetter, "manual");
+			var ctx = new CurrentContext();
+			ctx.Values.SetValue(DefaultValue, "default");
+			ctx.Values.SetValue(Style, "style");
+			ctx.Values.SetValue(ManualValueSetter, "manual");
 			last = ctx;
 		}
 		return last!;
@@ -80,195 +84,100 @@ public class SetterSpecificityListBenchmarks
 	// --- Allocate 1000 empty contexts ---
 
 	[Benchmark]
-	public int OldClass_Alloc1000()
+	public int Legacy_Alloc1000()
 	{
 		int sum = 0;
 		for (int i = 0; i < 1000; i++)
-			sum += new OldContext().Values.Count;
+			sum += new LegacyContext().Values.Count;
 		return sum;
 	}
 
 	[Benchmark]
-	public int NewStruct_Alloc1000()
+	public int Current_Alloc1000()
 	{
 		int sum = 0;
 		for (int i = 0; i < 1000; i++)
-			sum += new NewContext().Values.Count;
+			sum += new CurrentContext().Values.Count;
 		return sum;
 	}
 
 	// --- Update existing value 1000× ---
 
 	[Benchmark]
-	public object OldClass_Update1000()
+	public object Legacy_Update1000()
 	{
-		var ctx = new OldContext();
-		ctx.Values[Specificity.DefaultValue] = "default";
-		ctx.Values[Specificity.ManualValueSetter] = "v0";
+		var ctx = new LegacyContext();
+		ctx.Values[DefaultValue] = "default";
+		ctx.Values[ManualValueSetter] = "v0";
 		for (int i = 0; i < 1000; i++)
-			ctx.Values[Specificity.ManualValueSetter] = "v" + i;
+			ctx.Values[ManualValueSetter] = "v" + i;
 		return ctx;
 	}
 
 	[Benchmark]
-	public object NewStruct_Update1000()
+	public object Current_Update1000()
 	{
-		var ctx = new NewContext();
-		ctx.Values.SetValue(Specificity.DefaultValue, "default");
-		ctx.Values.SetValue(Specificity.ManualValueSetter, "v0");
+		var ctx = new CurrentContext();
+		ctx.Values.SetValue(DefaultValue, "default");
+		ctx.Values.SetValue(ManualValueSetter, "v0");
 		for (int i = 0; i < 1000; i++)
-			ctx.Values.SetValue(Specificity.ManualValueSetter, "v" + i);
+			ctx.Values.SetValue(ManualValueSetter, "v" + i);
 		return ctx;
-	}
-
-	// ==================================================================
-	// Minimal SetterSpecificity — just a ulong for ordering
-	// ==================================================================
-	readonly struct Specificity(ulong value)
-	{
-		readonly ulong _value = value;
-		public static readonly Specificity DefaultValue = new(0);
-		public static readonly Specificity FromHandler = new(0xFFFFFFFFFFFFFFFF);
-		public static readonly Specificity ManualValueSetter = new(0x0000000010000000);
-		public static readonly Specificity Style = new(0x0010000000000000);
-		public static bool operator ==(Specificity a, Specificity b) => a._value == b._value;
-		public static bool operator !=(Specificity a, Specificity b) => a._value != b._value;
-		public static bool operator >(Specificity a, Specificity b) => a._value > b._value;
-		public static bool operator <(Specificity a, Specificity b) => a._value < b._value;
-		public static bool operator >=(Specificity a, Specificity b) => a._value >= b._value;
-		public static bool operator <=(Specificity a, Specificity b) => a._value <= b._value;
-		public override bool Equals(object? obj) => obj is Specificity s && s._value == _value;
-		public override int GetHashCode() => _value.GetHashCode();
 	}
 
 	// ==================================================================
 	// Context wrappers
 	// ==================================================================
-	sealed class OldContext
+
+	sealed class LegacyContext
 	{
-		public readonly OldClassSSL<object> Values = new(3);
-		public readonly OldClassSSL<object> Bindings = new();
+		public readonly LegacySetterSpecificityList<object> Values = new(3);
 	}
 
-	sealed class NewContext
+	sealed class CurrentContext
 	{
-		public NewStructSSL<object> Values;
-#pragma warning disable CS0649 // benchmark only uses Values
-		public NewStructSSL<object> Bindings;
-#pragma warning restore CS0649
+		public SetterSpecificityList<object> Values;
 	}
 
 	// ==================================================================
-	// NEW: struct-based SetterSpecificityList (matches the PR implementation)
+	// Legacy: copy of the original class-based SetterSpecificityList
 	// ==================================================================
-	struct NewStructSSL<T>
-	{
-		Entry _top;
-		Entry _second;
-		RestList? _rest;
-		int _count;
-
-		public readonly int Count => _count;
-		public readonly T? GetValue() => _count >= 1 ? _top.Value : default;
-
-		public void SetValue(Specificity key, T value)
-		{
-			var e = new Entry(value, key);
-			if (_count == 0) { _top = e; _count = 1; return; }
-			if (_top.Key == key) { _top = e; return; }
-			if (_count == 1) { if (key > _top.Key) { _second = _top; _top = e; } else { _second = e; } _count = 2; return; }
-			if (_second.Key == key) { _second = e; return; }
-			if (key > _top.Key) { Push(_second); _second = _top; _top = e; _count++; return; }
-			if (key > _second.Key) { Push(_second); _second = e; _count++; return; }
-			_rest ??= new RestList();
-			if (_rest.Insert(e)) _count++;
-		}
-
-		public void Remove(Specificity key)
-		{
-			if (_count >= 1 && _top.Key == key) { if (_count == 1) { _top = default; _count = 0; } else if (_count == 2) { _top = _second; _second = default; _count = 1; } else { _top = _second; _second = _rest!.PopLast(); _count--; } }
-			else if (_count >= 2 && _second.Key == key) { if (_count == 2) { _second = default; _count = 1; } else { _second = _rest!.PopLast(); _count--; } }
-			else if (_count >= 3 && _rest?.Remove(key) == true) { _count--; }
-		}
-
-		void Push(Entry entry) { _rest ??= new RestList(); _rest.InsertSorted(entry); }
-
-		struct Entry(T? value, Specificity key) { public T? Value = value; public readonly Specificity Key = key; }
-
-		sealed class RestList
-		{
-			Entry[] _entries = new Entry[4];
-			int _count;
-			public bool Insert(Entry e)
-			{
-				for (int i = 0; i < _count; i++) { if (_entries[i].Key == e.Key) { _entries[i] = e; return false; } }
-				InsertSorted(e);
-				return true;
-			}
-			public void InsertSorted(Entry e)
-			{
-				if (_count == _entries.Length) Array.Resize(ref _entries, _count * 2);
-				int i = _count;
-				while (i > 0 && _entries[i - 1].Key > e.Key) { _entries[i] = _entries[i - 1]; i--; }
-				_entries[i] = e;
-				_count++;
-			}
-			public Entry PopLast() { var e = _entries[--_count]; _entries[_count] = default; return e; }
-			public bool Remove(Specificity key)
-			{
-				for (int i = 0; i < _count; i++)
-				{
-					if (_entries[i].Key == key)
-					{
-						Array.Copy(_entries, i + 1, _entries, i, _count - i - 1);
-						_entries[--_count] = default;
-						return true;
-					}
-				}
-				return false;
-			}
-		}
-	}
-
-	// ==================================================================
-	// OLD: class-based SetterSpecificityList (copy of original implementation)
-	// ==================================================================
-	sealed class OldClassSSL<T> where T : class
+	sealed class LegacySetterSpecificityList<T> where T : class
 	{
 		const int Delta = 3;
-		Specificity[] _keys;
+		SetterSpecificity[] _keys;
 		T[] _values;
 		int _count;
 
 		public int Count => _count;
-		public T this[Specificity key] { set => Set(key, value); get => Get(key); }
+		public T this[SetterSpecificity key] { set => Set(key, value); get => Get(key); }
 
-		public OldClassSSL() { _keys = []; _values = []; }
-		public OldClassSSL(int cap)
+		public LegacySetterSpecificityList() { _keys = []; _values = []; }
+		public LegacySetterSpecificityList(int cap)
 		{
 			if (cap == 0) { _keys = []; _values = []; }
-			else { _keys = new Specificity[cap]; _values = new T[cap]; }
+			else { _keys = new SetterSpecificity[cap]; _values = new T[cap]; }
 		}
 
 		public T GetValue() { var i = _count - 1; return i < 0 ? default! : _values[i]; }
 
-		void Set(Specificity key, T value)
+		void Set(SetterSpecificity key, T value)
 		{
 			int lo = 0, hi = _count - 1;
 			while (lo <= hi) { int m = lo + ((hi - lo) >> 1); if (_keys[m] == key) { _values[m] = value; return; } if (_keys[m] < key) lo = m + 1; else hi = m - 1; }
-			if (_keys.Length == _count) { var nk = new Specificity[_count + Delta]; var nv = new T[_count + Delta]; if (_count > 0) { Array.Copy(_keys, nk, _count); Array.Copy(_values, nv, _count); } _keys = nk; _values = nv; }
+			if (_keys.Length == _count) { var nk = new SetterSpecificity[_count + Delta]; var nv = new T[_count + Delta]; if (_count > 0) { Array.Copy(_keys, nk, _count); Array.Copy(_values, nv, _count); } _keys = nk; _values = nv; }
 			if (_count > lo) { Array.Copy(_keys, lo, _keys, lo + 1, _count - lo); Array.Copy(_values, lo, _values, lo + 1, _count - lo); }
 			_keys[lo] = key; _values[lo] = value; _count++;
 		}
 
-		T Get(Specificity key)
+		T Get(SetterSpecificity key)
 		{
 			int lo = 0, hi = _count - 1;
 			while (lo <= hi) { int m = lo + ((hi - lo) >> 1); if (_keys[m] == key) return _values[m]; if (_keys[m] < key) lo = m + 1; else hi = m - 1; }
 			return default!;
 		}
 
-		public void Remove(Specificity key)
+		public void Remove(SetterSpecificity key)
 		{
 			int lo = 0, hi = _count - 1;
 			while (lo <= hi)

--- a/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
+++ b/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
@@ -21,17 +21,13 @@ public class SetterSpecificityListBenchmarks
 	LegacyContext _legacyCtx = null!;
 	CurrentContext _currentCtx = null!;
 
-	[IterationSetup(Target = nameof(Legacy_Update))]
-	public void SetupLegacyUpdate()
+	[GlobalSetup]
+	public void Setup()
 	{
 		_legacyCtx = new LegacyContext();
 		_legacyCtx.Values[DefaultValue] = "default";
 		_legacyCtx.Values[ManualValueSetter] = "initial";
-	}
 
-	[IterationSetup(Target = nameof(Current_Update))]
-	public void SetupCurrentUpdate()
-	{
 		_currentCtx = new CurrentContext();
 		_currentCtx.Values.SetValue(DefaultValue, "default");
 		_currentCtx.Values.SetValue(ManualValueSetter, "initial");

--- a/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
+++ b/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
@@ -1,0 +1,282 @@
+#nullable enable
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Maui.Handlers.Benchmarks;
+
+/// <summary>
+/// Head-to-head comparison of SetterSpecificityList implementations:
+/// - OldClassSSL: copy of the original class-based, parallel-array + binary-search implementation
+/// - NewStructSSL: the new struct-based, inline _top/_second + lazy _rest implementation
+///
+/// Both use a self-contained copy of SetterSpecificity so the benchmark is standalone.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class SetterSpecificityListBenchmarks
+{
+	// --- Create contexts and set 2 entries (the 99% hot path) ---
+
+	[Benchmark(Baseline = true)]
+	public object OldClass_Create100_Set2()
+	{
+		OldContext? last = null;
+		for (int i = 0; i < 100; i++)
+		{
+			var ctx = new OldContext();
+			ctx.Values[Specificity.DefaultValue] = "default";
+			ctx.Values[Specificity.FromHandler] = "handler";
+			last = ctx;
+		}
+		return last!;
+	}
+
+	[Benchmark]
+	public object NewStruct_Create100_Set2()
+	{
+		NewContext? last = null;
+		for (int i = 0; i < 100; i++)
+		{
+			var ctx = new NewContext();
+			ctx.Values.SetValue(Specificity.DefaultValue, "default");
+			ctx.Values.SetValue(Specificity.FromHandler, "handler");
+			last = ctx;
+		}
+		return last!;
+	}
+
+	// --- Create contexts and set 3 entries (the < 1% cold path) ---
+
+	[Benchmark]
+	public object OldClass_Create100_Set3()
+	{
+		OldContext? last = null;
+		for (int i = 0; i < 100; i++)
+		{
+			var ctx = new OldContext();
+			ctx.Values[Specificity.DefaultValue] = "default";
+			ctx.Values[Specificity.Style] = "style";
+			ctx.Values[Specificity.ManualValueSetter] = "manual";
+			last = ctx;
+		}
+		return last!;
+	}
+
+	[Benchmark]
+	public object NewStruct_Create100_Set3()
+	{
+		NewContext? last = null;
+		for (int i = 0; i < 100; i++)
+		{
+			var ctx = new NewContext();
+			ctx.Values.SetValue(Specificity.DefaultValue, "default");
+			ctx.Values.SetValue(Specificity.Style, "style");
+			ctx.Values.SetValue(Specificity.ManualValueSetter, "manual");
+			last = ctx;
+		}
+		return last!;
+	}
+
+	// --- Allocate 1000 empty contexts ---
+
+	[Benchmark]
+	public int OldClass_Alloc1000()
+	{
+		int sum = 0;
+		for (int i = 0; i < 1000; i++)
+			sum += new OldContext().Values.Count;
+		return sum;
+	}
+
+	[Benchmark]
+	public int NewStruct_Alloc1000()
+	{
+		int sum = 0;
+		for (int i = 0; i < 1000; i++)
+			sum += new NewContext().Values.Count;
+		return sum;
+	}
+
+	// --- Update existing value 1000× ---
+
+	[Benchmark]
+	public object OldClass_Update1000()
+	{
+		var ctx = new OldContext();
+		ctx.Values[Specificity.DefaultValue] = "default";
+		ctx.Values[Specificity.ManualValueSetter] = "v0";
+		for (int i = 0; i < 1000; i++)
+			ctx.Values[Specificity.ManualValueSetter] = "v" + i;
+		return ctx;
+	}
+
+	[Benchmark]
+	public object NewStruct_Update1000()
+	{
+		var ctx = new NewContext();
+		ctx.Values.SetValue(Specificity.DefaultValue, "default");
+		ctx.Values.SetValue(Specificity.ManualValueSetter, "v0");
+		for (int i = 0; i < 1000; i++)
+			ctx.Values.SetValue(Specificity.ManualValueSetter, "v" + i);
+		return ctx;
+	}
+
+	// ==================================================================
+	// Minimal SetterSpecificity — just a ulong for ordering
+	// ==================================================================
+	readonly struct Specificity(ulong value)
+	{
+		readonly ulong _value = value;
+		public static readonly Specificity DefaultValue = new(0);
+		public static readonly Specificity FromHandler = new(0xFFFFFFFFFFFFFFFF);
+		public static readonly Specificity ManualValueSetter = new(0x0000000010000000);
+		public static readonly Specificity Style = new(0x0010000000000000);
+		public static bool operator ==(Specificity a, Specificity b) => a._value == b._value;
+		public static bool operator !=(Specificity a, Specificity b) => a._value != b._value;
+		public static bool operator >(Specificity a, Specificity b) => a._value > b._value;
+		public static bool operator <(Specificity a, Specificity b) => a._value < b._value;
+		public static bool operator >=(Specificity a, Specificity b) => a._value >= b._value;
+		public static bool operator <=(Specificity a, Specificity b) => a._value <= b._value;
+		public override bool Equals(object? obj) => obj is Specificity s && s._value == _value;
+		public override int GetHashCode() => _value.GetHashCode();
+	}
+
+	// ==================================================================
+	// Context wrappers
+	// ==================================================================
+	sealed class OldContext
+	{
+		public readonly OldClassSSL<object> Values = new(3);
+		public readonly OldClassSSL<object> Bindings = new();
+	}
+
+	sealed class NewContext
+	{
+		public NewStructSSL<object> Values;
+#pragma warning disable CS0649 // benchmark only uses Values
+		public NewStructSSL<object> Bindings;
+#pragma warning restore CS0649
+	}
+
+	// ==================================================================
+	// NEW: struct-based SetterSpecificityList (matches the PR implementation)
+	// ==================================================================
+	struct NewStructSSL<T>
+	{
+		Entry _top;
+		Entry _second;
+		RestList? _rest;
+		int _count;
+
+		public readonly int Count => _count;
+		public readonly T? GetValue() => _count >= 1 ? _top.Value : default;
+
+		public void SetValue(Specificity key, T value)
+		{
+			var e = new Entry(value, key);
+			if (_count == 0) { _top = e; _count = 1; return; }
+			if (_top.Key == key) { _top = e; return; }
+			if (_count == 1) { if (key > _top.Key) { _second = _top; _top = e; } else { _second = e; } _count = 2; return; }
+			if (_second.Key == key) { _second = e; return; }
+			if (key > _top.Key) { Push(_second); _second = _top; _top = e; _count++; return; }
+			if (key > _second.Key) { Push(_second); _second = e; _count++; return; }
+			_rest ??= new RestList();
+			if (_rest.Insert(e)) _count++;
+		}
+
+		public void Remove(Specificity key)
+		{
+			if (_count >= 1 && _top.Key == key) { if (_count == 1) { _top = default; _count = 0; } else if (_count == 2) { _top = _second; _second = default; _count = 1; } else { _top = _second; _second = _rest!.PopLast(); _count--; } }
+			else if (_count >= 2 && _second.Key == key) { if (_count == 2) { _second = default; _count = 1; } else { _second = _rest!.PopLast(); _count--; } }
+			else if (_count >= 3 && _rest?.Remove(key) == true) { _count--; }
+		}
+
+		void Push(Entry entry) { _rest ??= new RestList(); _rest.InsertSorted(entry); }
+
+		struct Entry(T? value, Specificity key) { public T? Value = value; public readonly Specificity Key = key; }
+
+		sealed class RestList
+		{
+			Entry[] _entries = new Entry[4];
+			int _count;
+			public bool Insert(Entry e)
+			{
+				for (int i = 0; i < _count; i++) { if (_entries[i].Key == e.Key) { _entries[i] = e; return false; } }
+				InsertSorted(e);
+				return true;
+			}
+			public void InsertSorted(Entry e)
+			{
+				if (_count == _entries.Length) Array.Resize(ref _entries, _count * 2);
+				int i = _count;
+				while (i > 0 && _entries[i - 1].Key > e.Key) { _entries[i] = _entries[i - 1]; i--; }
+				_entries[i] = e;
+				_count++;
+			}
+			public Entry PopLast() { var e = _entries[--_count]; _entries[_count] = default; return e; }
+			public bool Remove(Specificity key)
+			{
+				for (int i = 0; i < _count; i++)
+				{
+					if (_entries[i].Key == key)
+					{
+						Array.Copy(_entries, i + 1, _entries, i, _count - i - 1);
+						_entries[--_count] = default;
+						return true;
+					}
+				}
+				return false;
+			}
+		}
+	}
+
+	// ==================================================================
+	// OLD: class-based SetterSpecificityList (copy of original implementation)
+	// ==================================================================
+	sealed class OldClassSSL<T> where T : class
+	{
+		const int Delta = 3;
+		Specificity[] _keys;
+		T[] _values;
+		int _count;
+
+		public int Count => _count;
+		public T this[Specificity key] { set => Set(key, value); get => Get(key); }
+
+		public OldClassSSL() { _keys = []; _values = []; }
+		public OldClassSSL(int cap)
+		{
+			if (cap == 0) { _keys = []; _values = []; }
+			else { _keys = new Specificity[cap]; _values = new T[cap]; }
+		}
+
+		public T GetValue() { var i = _count - 1; return i < 0 ? default! : _values[i]; }
+
+		void Set(Specificity key, T value)
+		{
+			int lo = 0, hi = _count - 1;
+			while (lo <= hi) { int m = lo + ((hi - lo) >> 1); if (_keys[m] == key) { _values[m] = value; return; } if (_keys[m] < key) lo = m + 1; else hi = m - 1; }
+			if (_keys.Length == _count) { var nk = new Specificity[_count + Delta]; var nv = new T[_count + Delta]; if (_count > 0) { Array.Copy(_keys, nk, _count); Array.Copy(_values, nv, _count); } _keys = nk; _values = nv; }
+			if (_count > lo) { Array.Copy(_keys, lo, _keys, lo + 1, _count - lo); Array.Copy(_values, lo, _values, lo + 1, _count - lo); }
+			_keys[lo] = key; _values[lo] = value; _count++;
+		}
+
+		T Get(Specificity key)
+		{
+			int lo = 0, hi = _count - 1;
+			while (lo <= hi) { int m = lo + ((hi - lo) >> 1); if (_keys[m] == key) return _values[m]; if (_keys[m] < key) lo = m + 1; else hi = m - 1; }
+			return default!;
+		}
+
+		public void Remove(Specificity key)
+		{
+			int lo = 0, hi = _count - 1;
+			while (lo <= hi)
+			{
+				int m = lo + ((hi - lo) >> 1);
+				if (_keys[m] == key) { int n = m + 1; if (n < _count) { Array.Copy(_keys, n, _keys, m, _count - n); Array.Copy(_values, n, _values, m, _count - n); _values[_count - 1] = null!; } else { _values[m] = null!; } _count--; return; }
+				if (_keys[m] < key) lo = m + 1; else hi = m - 1;
+			}
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
+++ b/src/Core/tests/Benchmarks/SetterSpecificityListBenchmarks.cs
@@ -15,8 +15,10 @@ public class SetterSpecificityListBenchmarks
 {
 	static readonly SetterSpecificity DefaultValue = default;
 	static readonly SetterSpecificity FromHandler = SetterSpecificity.FromHandler;
-	static readonly SetterSpecificity ManualValueSetter = new(0, 0, 0, 1, 0, 0, 0, 0);
-	static readonly SetterSpecificity Style = new(0, 1, 0, 0, 0, 0, 0, 0);
+	static readonly SetterSpecificity ManualValueSetter = SetterSpecificity.ManualValueSetter;
+	static readonly SetterSpecificity Style = new(SetterSpecificity.StyleLocal, 0, 0, 0);
+	static readonly SetterSpecificity FromBinding = SetterSpecificity.FromBinding;
+	static readonly SetterSpecificity DynamicResource = SetterSpecificity.DynamicResourceSetter;
 
 	LegacyContext _legacyCtx = null!;
 	CurrentContext _currentCtx = null!;
@@ -72,6 +74,56 @@ public class SetterSpecificityListBenchmarks
 		ctx.Values.SetValue(DefaultValue, "default");
 		ctx.Values.SetValue(Style, "style");
 		ctx.Values.SetValue(ManualValueSetter, "manual");
+		return ctx;
+	}
+
+	// --- Create context and set 4 entries ---
+
+	[Benchmark]
+	public object Legacy_CreateAndSet4()
+	{
+		var ctx = new LegacyContext();
+		ctx.Values[DefaultValue] = "default";
+		ctx.Values[Style] = "style";
+		ctx.Values[ManualValueSetter] = "manual";
+		ctx.Values[FromHandler] = "handler";
+		return ctx;
+	}
+
+	[Benchmark]
+	public object Current_CreateAndSet4()
+	{
+		var ctx = new CurrentContext();
+		ctx.Values.SetValue(DefaultValue, "default");
+		ctx.Values.SetValue(Style, "style");
+		ctx.Values.SetValue(ManualValueSetter, "manual");
+		ctx.Values.SetValue(FromHandler, "handler");
+		return ctx;
+	}
+
+	// --- Create context and set 5 entries ---
+
+	[Benchmark]
+	public object Legacy_CreateAndSet5()
+	{
+		var ctx = new LegacyContext();
+		ctx.Values[DefaultValue] = "default";
+		ctx.Values[Style] = "style";
+		ctx.Values[FromBinding] = "binding";
+		ctx.Values[ManualValueSetter] = "manual";
+		ctx.Values[DynamicResource] = "dynamic";
+		return ctx;
+	}
+
+	[Benchmark]
+	public object Current_CreateAndSet5()
+	{
+		var ctx = new CurrentContext();
+		ctx.Values.SetValue(DefaultValue, "default");
+		ctx.Values.SetValue(Style, "style");
+		ctx.Values.SetValue(FromBinding, "binding");
+		ctx.Values.SetValue(ManualValueSetter, "manual");
+		ctx.Values.SetValue(DynamicResource, "dynamic");
 		return ctx;
 	}
 


### PR DESCRIPTION
## Summary

Refactors `SetterSpecificityList` from a heap-allocated `class` to an inline `struct`, eliminating thousands of small GC-tracked allocations during page load.

## Changes

- **`SetterSpecificityList`**: `class` → `struct`
- **Removed `where T : class` constraint** — enables future unboxed value-type storage
- **Replaced parallel-array + binary-search** with inline `_top`/`_second` fields + lazy `_rest` overflow list
  - 99.3% of instances hold ≤2 entries (measured via runtime diagnostics) — zero array allocations for the common case
  - `_rest` overflow allocated only for 3+ entries (< 1% of cases)
- **Removed indexer** — callers use `SetValue()`/`GetValue()` directly
- **`BindablePropertyContext`**: removed `readonly` and `= new()` from `Values`/`Bindings` fields (struct default-initializes to empty)

## Motivation

Part of #34080. `SetterSpecificityList` instances were previously heap-allocated objects — two per `BindablePropertyContext` (Values + Bindings). On a typical page load, this meant thousands of small GC-tracked objects. As a struct, both lists embed inline in the context with no separate allocation.

## Benchmark (BenchmarkDotNet, Apple M1 Max, .NET 11.0.0-preview.2)

The implementation is optimized for the 2-values case which is the most common one (99.3% of instances). Even for larger lists, both performance and allocations are lower than the previous implementation.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---|---|---|---|
| Legacy_CreateAndSet2 | 29.76 ns | 1.000 | 160 B | 1.00 |
| **Current_CreateAndSet2** | **8.55 ns** | **0.287** | **64 B** | **0.40** |
| Legacy_CreateAndSet3 | 39.68 ns | 1.000 | 160 B | 1.00 |
| **Current_CreateAndSet3** | **22.90 ns** | **0.577** | **104 B** | **0.65** |
| Legacy_CreateAndSet4 | 63.38 ns | 1.000 | 304 B | 1.00 |
| **Current_CreateAndSet4** | **40.55 ns** | **0.640** | **160 B** | **0.53** |
| Legacy_CreateAndSet5 | 79.04 ns | 1.000 | 304 B | 1.00 |
| **Current_CreateAndSet5** | **60.06 ns** | **0.760** | **232 B** | **0.76** |
| Legacy_Alloc | 17.96 ns | 1.000 | 160 B | 1.00 |
| **Current_Alloc** | **4.55 ns** | **0.253** | **64 B** | **0.40** |
| Legacy_Update | 3.94 ns | 1.000 | - | - |
| **Current_Update** | **0.36 ns** | **0.092** | **-** | **-** |

Key improvements (struct vs class, per single operation):
- **Create + set 2 entries** (99% hot path): 3.5× faster, 60% less memory
- **Create + set 3 entries**: 1.7× faster, 35% less memory
- **Create + set 4 entries**: 1.6× faster, 47% less memory
- **Create + set 5 entries**: 1.3× faster, 24% less memory
- **Allocate empty context**: 4.0× faster, 60% less memory
- **Update existing value**: 11× faster, zero allocation

## Test results

All existing tests pass — 12 SetterSpecificityList + 96 BindableObject + 589 Binding + 164 Style tests green.