### PR TITLE
[Perf] Cache InvalidationEventArgs for known trigger values

### DIFF
--- a/src/Controls/src/Core/InvalidationEventArgs.cs
+++ b/src/Controls/src/Core/InvalidationEventArgs.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using Microsoft.Maui.Controls.Internals;
 
@@ -6,11 +5,31 @@ namespace Microsoft.Maui.Controls
 {
 	internal class InvalidationEventArgs : EventArgs
 	{
+		static InvalidationEventArgs? s_undefined;
+		static InvalidationEventArgs? s_measureChanged;
+		static InvalidationEventArgs? s_horizontalOptionsChanged;
+		static InvalidationEventArgs? s_verticalOptionsChanged;
+		static InvalidationEventArgs? s_sizeRequestChanged;
+		static InvalidationEventArgs? s_rendererReady;
+		static InvalidationEventArgs? s_marginChanged;
+
 		public InvalidationEventArgs(InvalidationTrigger trigger)
 		{
 			Trigger = trigger;
 		}
 
 		public InvalidationTrigger Trigger { get; private set; }
+
+		internal static InvalidationEventArgs GetCached(InvalidationTrigger trigger) => trigger switch
+		{
+			InvalidationTrigger.Undefined => s_undefined ??= new InvalidationEventArgs(trigger),
+			InvalidationTrigger.MeasureChanged => s_measureChanged ??= new InvalidationEventArgs(trigger),
+			InvalidationTrigger.HorizontalOptionsChanged => s_horizontalOptionsChanged ??= new InvalidationEventArgs(trigger),
+			InvalidationTrigger.VerticalOptionsChanged => s_verticalOptionsChanged ??= new InvalidationEventArgs(trigger),
+			InvalidationTrigger.SizeRequestChanged => s_sizeRequestChanged ??= new InvalidationEventArgs(trigger),
+			InvalidationTrigger.RendererReady => s_rendererReady ??= new InvalidationEventArgs(trigger),
+			InvalidationTrigger.MarginChanged => s_marginChanged ??= new InvalidationEventArgs(trigger),
+			_ => new InvalidationEventArgs(trigger),
+		};
 	}
 }

--- a/src/Controls/src/Core/LegacyLayouts/Layout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Layout.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			SetNeedsLayout();
 			InvalidateMeasureCache();
 
-			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+			OnChildMeasureInvalidated(child, InvalidationEventArgs.GetCached(trigger));
 
 			var propagatedTrigger = GetPropagatedTrigger(trigger);
 			InvokeMeasureInvalidated(propagatedTrigger);

--- a/src/Controls/src/Core/Page/Page.cs
+++ b/src/Controls/src/Core/Page/Page.cs
@@ -522,7 +522,7 @@ namespace Microsoft.Maui.Controls
 
 		internal override void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
 		{
-			OnChildMeasureInvalidated(child, new InvalidationEventArgs(trigger));
+			OnChildMeasureInvalidated(child, InvalidationEventArgs.GetCached(trigger));
 			var propagatedTrigger = GetPropagatedTrigger(trigger);
 			InvokeMeasureInvalidated(propagatedTrigger);
 		}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1505,7 +1505,7 @@ namespace Microsoft.Maui.Controls
 
 		private protected void InvokeMeasureInvalidated(InvalidationTrigger trigger)
 		{
-			MeasureInvalidated?.Invoke(this, new InvalidationEventArgs(trigger));
+			MeasureInvalidated?.Invoke(this, InvalidationEventArgs.GetCached(trigger));
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #34094

## Description

Cache `InvalidationEventArgs` instances for each known `InvalidationTrigger` enum value. `InvalidationTrigger` is a `[Flags]` enum with 7 defined values (`Undefined`, `MeasureChanged`, `HorizontalOptionsChanged`, `VerticalOptionsChanged`, `SizeRequestChanged`, `RendererReady`, `MarginChanged`), but no call site in the codebase ever combines flags — every caller passes a single value.

The new `InvalidationEventArgs.GetCached(trigger)` method returns a lazily-cached static instance for each known value and falls back to `new` for any unexpected combined value.

### Changes

- **`InvalidationEventArgs.cs`**: Added 7 static lazy fields and a `GetCached` switch method
- **`VisualElement.cs`**: `InvokeMeasureInvalidated` uses `GetCached` instead of `new`
- **`Page.cs`**: `OnChildMeasureInvalidated` uses `GetCached` instead of `new`
- **`Layout.cs`** (legacy): `OnChildMeasureInvalidatedInternal` uses `GetCached` instead of `new`

### Benchmark

```
| Method                     | Mean     | Gen0   | Allocated | Alloc Ratio |
|--------------------------- |---------:|-------:|----------:|------------:|
| Current_NewPerInvalidation | 3.773 ns | 0.0038 |      24 B |        1.00 |
| Optimized_CachedPerTrigger | 2.893 ns |      - |       0 B |        0.00 |
```

**1.3x faster, 24 B → 0 B per invalidation.** Measure invalidation fires hundreds of times per layout pass, so the cumulative allocation savings are significant.