### PR TITLE
[Windows] Fix for inconsistent PanGestureRecognizer behavior on Windows compared to other platforms.

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -463,6 +463,11 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
+			if (e.Handled)
+			{
+				return;
+			}
+
 			_isPanning = true;
 
 			foreach (IPanGestureController recognizer in view.GestureRecognizers.GetGesturesFor<PanGestureRecognizer>().Where(g => g.TouchPoints == _fingers.Count))
@@ -472,6 +477,7 @@ namespace Microsoft.Maui.Controls.Platform
 					recognizer.SendPanStarted(view, PanGestureRecognizer.CurrentId.Value);
 				}
 				recognizer.SendPan(view, e.Delta.Translation.X + e.Cumulative.Translation.X, e.Delta.Translation.Y + e.Cumulative.Translation.Y, PanGestureRecognizer.CurrentId.Value);
+				e.Handled = true;
 			}
 			_wasPanGestureStartedSent = true;
 		}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -453,17 +453,13 @@ namespace Microsoft.Maui.Controls.Platform
 			foreach (SwipeGestureRecognizer recognizer in view.GestureRecognizers.GetGesturesFor<SwipeGestureRecognizer>())
 			{
 				((ISwipeGestureController)recognizer).SendSwipe(view, e.Delta.Translation.X + e.Cumulative.Translation.X, e.Delta.Translation.Y + e.Cumulative.Translation.Y);
+				e.Handled = true;
 			}
 		}
 
 		void HandlePan(ManipulationDeltaRoutedEventArgs e, View view)
 		{
 			if (view == null)
-			{
-				return;
-			}
-
-			if (e.Handled)
 			{
 				return;
 			}
@@ -503,6 +499,7 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 
 					recognizer.SendPinch(view, e.Delta.Scale, scaleOriginPoint);
+					e.Handled = true;
 				}
 
 				_wasPinchGestureStartedSent = true;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
@@ -1,0 +1,62 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 24252, "PanGestureRecognizer behaves differently on Windows to other platforms", PlatformAffected.UWP)]
+public class Issue24252 : ContentPage
+{
+	public Issue24252()
+	{
+		var statusLabel = new Label
+		{
+			Text = "None",
+			AutomationId = "StatusLabel"
+		};
+
+		// Parent: large blue area with PanGestureRecognizer
+		var parent = new Grid
+		{
+			BackgroundColor = Colors.LightBlue,
+			WidthRequest = 300,
+			HeightRequest = 300,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center
+		};
+
+		var parentPan = new PanGestureRecognizer();
+		parentPan.PanUpdated += (s, e) =>
+		{
+			if (e.StatusType == GestureStatus.Started)
+			{
+				statusLabel.Text = "Parent triggered";
+			}
+		};
+		parent.GestureRecognizers.Add(parentPan);
+
+		var child = new Image
+		{
+			Source = "dotnet_bot.png",
+			WidthRequest = 100,
+			HeightRequest = 100,
+			BackgroundColor = Colors.Orange,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			AutomationId = "ChildImage"
+		};
+
+		var childPan = new PanGestureRecognizer();
+		childPan.PanUpdated += (s, e) =>
+		{
+			if (e.StatusType == GestureStatus.Started)
+			{
+				statusLabel.Text = "Child triggered";
+			}
+		};
+		child.GestureRecognizers.Add(childPan);
+
+		parent.Children.Add(child);
+
+		Content = new VerticalStackLayout
+		{
+			Children = { statusLabel, parent }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
@@ -5,18 +5,15 @@ public class Issue24252 : ContentPage
 {
 	public Issue24252()
 	{
-		Content = new ScrollView
+		Content = new VerticalStackLayout
 		{
-			Content = new VerticalStackLayout
+			Padding = 20,
+			Spacing = 15,
+			Children =
 			{
-				Padding = 20,
-				Spacing = 15,
-				Children =
-				{
-					CreatePanSection(),
-					CreateSwipeSection(),
-					CreatePinchSection()
-				}
+				CreatePanSection(),
+				CreateSwipeSection(),
+				CreatePinchSection()
 			}
 		};
 	}
@@ -29,7 +26,7 @@ public class Issue24252 : ContentPage
 		{
 			BackgroundColor = Colors.LightBlue,
 			WidthRequest = 250,
-			HeightRequest = 200,
+			HeightRequest = 150,
 			HorizontalOptions = LayoutOptions.Center
 		};
 
@@ -86,7 +83,7 @@ public class Issue24252 : ContentPage
 		{
 			BackgroundColor = Colors.LightGreen,
 			WidthRequest = 250,
-			HeightRequest = 200,
+			HeightRequest = 150,
 			HorizontalOptions = LayoutOptions.Center
 		};
 
@@ -131,7 +128,7 @@ public class Issue24252 : ContentPage
 		{
 			BackgroundColor = Colors.LightCoral,
 			WidthRequest = 250,
-			HeightRequest = 200,
+			HeightRequest = 150,
 			HorizontalOptions = LayoutOptions.Center
 		};
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
@@ -1,62 +1,174 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 24252, "PanGestureRecognizer behaves differently on Windows to other platforms", PlatformAffected.UWP)]
+[Issue(IssueTracker.Github, 24252, "Overlapping gesture recognizers should only fire on the topmost child view on Windows", PlatformAffected.UWP)]
 public class Issue24252 : ContentPage
 {
 	public Issue24252()
 	{
-		var statusLabel = new Label
+		Content = new ScrollView
 		{
-			Text = "None",
-			AutomationId = "StatusLabel"
+			Content = new VerticalStackLayout
+			{
+				Padding = 20,
+				Spacing = 15,
+				Children =
+				{
+					CreatePanSection(),
+					CreateSwipeSection(),
+					CreatePinchSection()
+				}
+			}
 		};
+	}
 
-		// Parent: large blue area with PanGestureRecognizer
+	static View CreatePanSection()
+	{
+		var statusLabel = new Label { Text = "None", AutomationId = "PanStatusLabel" };
+
 		var parent = new Grid
 		{
 			BackgroundColor = Colors.LightBlue,
-			WidthRequest = 300,
-			HeightRequest = 300,
-			HorizontalOptions = LayoutOptions.Center,
-			VerticalOptions = LayoutOptions.Center
+			WidthRequest = 250,
+			HeightRequest = 200,
+			HorizontalOptions = LayoutOptions.Center
 		};
 
 		var parentPan = new PanGestureRecognizer();
 		parentPan.PanUpdated += (s, e) =>
 		{
 			if (e.StatusType == GestureStatus.Started)
-			{
 				statusLabel.Text = "Parent triggered";
-			}
 		};
 		parent.GestureRecognizers.Add(parentPan);
 
 		var child = new Image
 		{
 			Source = "dotnet_bot.png",
-			WidthRequest = 100,
+			WidthRequest = 120,
 			HeightRequest = 100,
 			BackgroundColor = Colors.Orange,
 			HorizontalOptions = LayoutOptions.Center,
 			VerticalOptions = LayoutOptions.Center,
-			AutomationId = "ChildImage"
+			AutomationId = "PanChildBox"
 		};
 
 		var childPan = new PanGestureRecognizer();
 		childPan.PanUpdated += (s, e) =>
 		{
 			if (e.StatusType == GestureStatus.Started)
-			{
 				statusLabel.Text = "Child triggered";
-			}
 		};
 		child.GestureRecognizers.Add(childPan);
 
 		parent.Children.Add(child);
 
-		Content = new VerticalStackLayout
+		return new VerticalStackLayout
 		{
-			Children = { statusLabel, parent }
+			Spacing = 5,
+			Children =
+			{
+				new Label { Text = "Pan: Drag on orange child", FontAttributes = FontAttributes.Bold },
+				statusLabel,
+				parent
+			}
+		};
+	}
+
+	static View CreateSwipeSection()
+	{
+		var statusLabel = new Label { Text = "None", AutomationId = "SwipeStatusLabel" };
+
+		var parent = new Grid
+		{
+			BackgroundColor = Colors.LightGreen,
+			WidthRequest = 250,
+			HeightRequest = 200,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		var parentSwipe = new SwipeGestureRecognizer { Direction = SwipeDirection.Right };
+		parentSwipe.Swiped += (s, e) => statusLabel.Text = "Parent triggered";
+		parent.GestureRecognizers.Add(parentSwipe);
+
+		var child = new Image
+		{
+			Source = "dotnet_bot.png",
+			WidthRequest = 120,
+			HeightRequest = 100,
+			BackgroundColor = Colors.Orange,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			AutomationId = "SwipeChildBox"
+		};
+
+		var childSwipe = new SwipeGestureRecognizer { Direction = SwipeDirection.Right };
+		childSwipe.Swiped += (s, e) => statusLabel.Text = "Child triggered";
+		child.GestureRecognizers.Add(childSwipe);
+
+		parent.Children.Add(child);
+
+		return new VerticalStackLayout
+		{
+			Spacing = 5,
+			Children =
+			{
+				new Label { Text = "Swipe: Swipe right on orange child", FontAttributes = FontAttributes.Bold },
+				statusLabel,
+				parent
+			}
+		};
+	}
+
+	static View CreatePinchSection()
+	{
+		var statusLabel = new Label { Text = "None", AutomationId = "PinchStatusLabel" };
+
+		var parent = new Grid
+		{
+			BackgroundColor = Colors.LightCoral,
+			WidthRequest = 250,
+			HeightRequest = 200,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		var parentPinch = new PinchGestureRecognizer();
+		parentPinch.PinchUpdated += (s, e) =>
+		{
+			if (e.Status == GestureStatus.Started)
+				statusLabel.Text = "Parent triggered";
+		};
+		parent.GestureRecognizers.Add(parentPinch);
+
+		var child = new Image
+		{
+			Source = "dotnet_bot.png",
+			WidthRequest = 150,
+			HeightRequest = 150,
+			BackgroundColor = Colors.Orange,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+			AutomationId = "PinchChildBox"
+		};
+
+		var childPinch = new PinchGestureRecognizer();
+		childPinch.PinchUpdated += (s, e) =>
+		{
+			if (e.Status == GestureStatus.Started)
+				statusLabel.Text = "Child triggered";
+		};
+		child.GestureRecognizers.Add(childPinch);
+
+		parent.Children.Add(child);
+
+		return new VerticalStackLayout
+		{
+			Spacing = 5,
+			Children =
+			{
+				new Label { Text = "Pinch: Pinch on orange child", FontAttributes = FontAttributes.Bold },
+				statusLabel,
+				parent
+			}
 		};
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue24252.cs
@@ -37,7 +37,9 @@ public class Issue24252 : ContentPage
 		parentPan.PanUpdated += (s, e) =>
 		{
 			if (e.StatusType == GestureStatus.Started)
+			{
 				statusLabel.Text = "Parent triggered";
+			}
 		};
 		parent.GestureRecognizers.Add(parentPan);
 
@@ -56,7 +58,9 @@ public class Issue24252 : ContentPage
 		childPan.PanUpdated += (s, e) =>
 		{
 			if (e.StatusType == GestureStatus.Started)
+			{
 				statusLabel.Text = "Child triggered";
+			}
 		};
 		child.GestureRecognizers.Add(childPan);
 
@@ -135,7 +139,9 @@ public class Issue24252 : ContentPage
 		parentPinch.PinchUpdated += (s, e) =>
 		{
 			if (e.Status == GestureStatus.Started)
+			{
 				statusLabel.Text = "Parent triggered";
+			}
 		};
 		parent.GestureRecognizers.Add(parentPinch);
 
@@ -154,7 +160,9 @@ public class Issue24252 : ContentPage
 		childPinch.PinchUpdated += (s, e) =>
 		{
 			if (e.Status == GestureStatus.Started)
+			{
 				statusLabel.Text = "Child triggered";
+			}
 		};
 		child.GestureRecognizers.Add(childPinch);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24252.cs
@@ -1,4 +1,4 @@
-#if WINDOWS
+#if TEST_FAILS_ON_CATALYST //The test fails on Mac because PinchToZoomIn does not work.                     
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24252.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue24252 : _IssuesUITest
+{
+	public override string Issue => "PanGestureRecognizer behaves differently on Windows to other platforms";
+
+	public Issue24252(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void OverlappingPanGesturesShouldOnlyFireChild()
+	{
+		App.WaitForElement("StatusLabel");
+		var childImage = App.WaitForElement("ChildImage");
+		var rect = childImage.GetRect();
+
+		// Drag on the child
+		App.DragCoordinates(rect.CenterX(), rect.CenterY(), rect.CenterX() + 50, rect.CenterY() + 50);
+
+		var statusText = App.WaitForElement("StatusLabel").GetText();
+
+		Assert.That(statusText, Is.EqualTo("Child triggered"),
+		 "Only the child PanGestureRecognizer should fire when dragging the child view.");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24252.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue24252.cs
@@ -1,3 +1,4 @@
+#if WINDOWS
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -6,24 +7,36 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue24252 : _IssuesUITest
 {
-	public override string Issue => "PanGestureRecognizer behaves differently on Windows to other platforms";
+	public override string Issue => "Overlapping gesture recognizers should only fire on the topmost child view on Windows";
 
 	public Issue24252(TestDevice device) : base(device) { }
 
 	[Test]
 	[Category(UITestCategories.Gestures)]
-	public void OverlappingPanGesturesShouldOnlyFireChild()
+	public void OverlappingGesturesShouldOnlyFireChild()
 	{
-		App.WaitForElement("StatusLabel");
-		var childImage = App.WaitForElement("ChildImage");
-		var rect = childImage.GetRect();
+		// Pan: drag on the child box
+		App.WaitForElement("PanStatusLabel");
+		var panChild = App.WaitForElement("PanChildBox");
+		var panRect = panChild.GetRect();
+		App.DragCoordinates(panRect.CenterX(), panRect.CenterY(), panRect.CenterX() + 50, panRect.CenterY() + 50);
 
-		// Drag on the child
-		App.DragCoordinates(rect.CenterX(), rect.CenterY(), rect.CenterX() + 50, rect.CenterY() + 50);
-
-		var statusText = App.WaitForElement("StatusLabel").GetText();
-
-		Assert.That(statusText, Is.EqualTo("Child triggered"),
+		Assert.That(App.WaitForElement("PanStatusLabel").GetText(), Is.EqualTo("Child triggered"),
 		 "Only the child PanGestureRecognizer should fire when dragging the child view.");
+
+		//// Swipe: swipe right on the child box
+		App.WaitForElement("SwipeStatusLabel");
+		App.SwipeLeftToRight("SwipeChildBox", swipePercentage: 1.5, swipeSpeed: 100);
+
+		Assert.That(App.WaitForElement("SwipeStatusLabel").GetText(), Is.EqualTo("Child triggered"),
+		 "Only the child SwipeGestureRecognizer should fire when swiping on the child view.");
+
+		// Pinch: pinch on the child box
+		App.WaitForElement("PinchStatusLabel");
+		App.PinchToZoomIn("PinchChildBox");
+
+		Assert.That(App.WaitForElement("PinchStatusLabel").GetText(), Is.EqualTo("Child triggered"),
+		 "Only the child PinchGestureRecognizer should fire when pinching on the child view.");
 	}
 }
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- PanGestureRecognizer, SwipeGestureRecognizer, and PinchGestureRecognizer exhibit different behavior on Windows compared to other platforms. On macOS, iOS, and Android, when overlapping views contain these gesture recognizers, only the topmost (child) view’s recognizer is invoked, whereas on Windows both parent and child recognizers are invoked simultaneously.

### Root Cause of the issue

- On Windows, ManipulationDelta is a bubbling routed event that fires on the child first and then travels to the parent; since HandlePan, HandleSwipe, and HandlePinch were not setting e.Handled = true, both the child's and parent's gesture recognizers fired — unlike OnTap, which already marks the event as handled in ProcessGestureRecognizers

### Description of Change
Gesture handling improvements:

* Updated `HandleSwipe`, `HandlePan`, and `HandlePinch` methods in `GesturePlatformManager.Windows.cs` to mark gesture events as handled (`e.Handled = true`), preventing parent gesture recognizers from firing when a child view's recognizer is triggered. 

Testing enhancements:

* Added a new sample page `Issue24252.cs` to demonstrate and manually verify that only the child gesture recognizer fires when interacting with the child view for pan, swipe, and pinch gestures.
* Introduced a UI test in `Issue24252.cs` (shared tests) to automatically validate that only the child gesture recognizer fires for each gesture type, with assertions for each scenario.

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #24252 

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/e8e76aa3-61e1-4a6e-b3c5-e45fa176d647"> | <video src="https://github.com/user-attachments/assets/1498621d-d115-4e00-afc8-1f38995404c1"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
