### PR TITLE
Fix phase numbering in pr-agent post-gate docs

### DIFF
--- a/.github/agents/pr/post-gate.md
+++ b/.github/agents/pr/post-gate.md
@@ -24,7 +24,7 @@ If Gate is not passed, go back to `.github/agents/pr.md` and complete phases 1-2
 
 If try-fix cannot run due to environment issues, **STOP and ask the user**. Do NOT mark attempts as "BLOCKED" and continue.
 
-### 🚨 CRITICAL: Stop on Environment Blockers (Applies to Phase 4)
+### 🚨 CRITICAL: Stop on Environment Blockers (Applies to Phase 3)
 
 The same "Stop on Environment Blockers" rule from `pr.md` applies here. If try-fix cannot run due to:
 - Missing Appium drivers
@@ -46,7 +46,7 @@ The same "Stop on Environment Blockers" rule from `pr.md` applies here. If try-f
 
 **The PR's fix has already been validated by Gate (tests FAIL without it, PASS with it).**
 
-The purpose of Phase 4 is NOT to re-test the PR's fix, but to:
+The purpose of Phase 3 is NOT to re-test the PR's fix, but to:
 1. **Generate independent fix ideas** - What would YOU do to fix this bug?
 2. **Test those ideas empirically** - Actually implement and run tests
 3. **Compare with PR's fix** - Is there a simpler/better alternative?
@@ -56,7 +56,7 @@ The purpose of Phase 4 is NOT to re-test the PR's fix, but to:
 
 ### Step 1: Multi-Model try-fix Exploration
 
-Phase 4 uses a **multi-model approach** to maximize fix diversity. Each AI model brings different perspectives and may find solutions others miss.
+Phase 3 uses a **multi-model approach** to maximize fix diversity. Each AI model brings different perspectives and may find solutions others miss.
 
 **⚠️ SEQUENTIAL ONLY**: try-fix runs MUST execute one at a time. They modify the same files and use the same test device. Never run try-fix attempts in parallel.
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Three references in the Fix (Phase 3) section of `.github/agents/pr/post-gate.md` incorrectly said "Phase 4" instead of "Phase 3". Phase 4 is the Report phase.

### Changes
- Line 27: "Applies to Phase 4" → "Applies to Phase 3"
- Line 49: "The purpose of Phase 4" → "The purpose of Phase 3"  
- Line 59: "Phase 4 uses a multi-model approach" → "Phase 3 uses a multi-model approach"

Documentation-only change, no functional impact.