### PR TITLE
Fix ContentPage memory leak on Android when using NavigationPage modally (fixes #33918)

### DIFF
--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -838,7 +838,6 @@ namespace Microsoft.Maui.Controls
 						Owner.FireDisappearing(currentPage);
 						Owner.RemoveFromInnerChildren(currentPage);
 						Owner.CurrentPage = newCurrentPage;
-						Owner.RemoveFromInnerChildren(currentPage);
 						if (currentPage.TitleView != null)
 						{
 							currentPage.RemoveLogicalChild(currentPage.TitleView);

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -9,8 +9,10 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -85,23 +87,27 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotNull(tab2SnManager);
 
 				tabbedPage.CurrentPage = tab2Nav;
-				await Task.Delay(100);
+				await OnLoadedAsync(tab2Content);
 
 				await baseNavPage.Navigation.PopModalAsync(animated: false);
-				await Task.Delay(100);
 
 				var flags = BindingFlags.NonPublic | BindingFlags.Instance;
 				var currentPageField = typeof(StackNavigationManager).GetField("_currentPage", flags);
 				var fragmentContainerViewField = typeof(StackNavigationManager).GetField("_fragmentContainerView", flags);
 				var fragmentManagerField = typeof(StackNavigationManager).GetField("_fragmentManager", flags);
+				
+				Assert.NotNull(currentPageField);
+				Assert.NotNull(fragmentContainerViewField);
+				Assert.NotNull(fragmentManagerField);
 
-				Assert.Null(currentPageField.GetValue(tab1SnManager));
-				Assert.Null(fragmentContainerViewField.GetValue(tab1SnManager));
-				Assert.Null(fragmentManagerField.GetValue(tab1SnManager));
-
-				Assert.Null(currentPageField.GetValue(tab2SnManager));
-				Assert.Null(fragmentContainerViewField.GetValue(tab2SnManager));
-				Assert.Null(fragmentManagerField.GetValue(tab2SnManager));
+				await AssertEventually(() =>
+					currentPageField.GetValue(tab1SnManager) == null &&
+					fragmentContainerViewField.GetValue(tab1SnManager) == null &&
+					fragmentManagerField.GetValue(tab1SnManager) == null &&
+					currentPageField.GetValue(tab2SnManager) == null &&
+					fragmentContainerViewField.GetValue(tab2SnManager) == null &&
+					fragmentManagerField.GetValue(tab2SnManager) == null,
+					message: "StackNavigationManager fields were not cleared after Disconnect()");
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -9,7 +9,6 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Google.Android.Material.AppBar;
@@ -8,6 +9,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
 
@@ -45,6 +47,62 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.False(failed);
 				await navPage.Navigation.PopAsync();
 				Assert.False(failed);
+			});
+		}
+
+		[Fact(DisplayName = "StackNavigationManager Clears References On Disconnect (Issue 33918)")]
+		public async Task StackNavigationManagerClearsReferencesOnDisconnect()
+		{
+			SetupBuilder();
+
+			var mainPage = new ContentPage { Title = "Main Page" };
+			var baseNavPage = new NavigationPage(mainPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(baseNavPage), async (handler) =>
+			{
+				var tab1Content = new ContentPage { Title = "Tab 1", Content = new Label { Text = "Tab 1 Content" } };
+				var tab2Content = new ContentPage { Title = "Tab 2", Content = new Label { Text = "Tab 2 Content" } };
+
+				var tab1Nav = new NavigationPage(tab1Content) { Title = "Tab 1" };
+				var tab2Nav = new NavigationPage(tab2Content) { Title = "Tab 2" };
+
+				var tabbedPage = new TabbedPage
+				{
+					Title = "Tabbed Modal",
+					Children = { tab1Nav, tab2Nav }
+				};
+
+				await baseNavPage.Navigation.PushModalAsync(tabbedPage, animated: false);
+				await OnLoadedAsync(tab1Content);
+
+				var tab1Handler = tab1Nav.Handler as NavigationViewHandler;
+				var tab2Handler = tab2Nav.Handler as NavigationViewHandler;
+				Assert.NotNull(tab1Handler);
+				Assert.NotNull(tab2Handler);
+
+				var tab1SnManager = tab1Handler.StackNavigationManager;
+				var tab2SnManager = tab2Handler.StackNavigationManager;
+				Assert.NotNull(tab1SnManager);
+				Assert.NotNull(tab2SnManager);
+
+				tabbedPage.CurrentPage = tab2Nav;
+				await Task.Delay(100);
+
+				await baseNavPage.Navigation.PopModalAsync(animated: false);
+				await Task.Delay(100);
+
+				var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+				var currentPageField = typeof(StackNavigationManager).GetField("_currentPage", flags);
+				var fragmentContainerViewField = typeof(StackNavigationManager).GetField("_fragmentContainerView", flags);
+				var fragmentManagerField = typeof(StackNavigationManager).GetField("_fragmentManager", flags);
+
+				Assert.Null(currentPageField.GetValue(tab1SnManager));
+				Assert.Null(fragmentContainerViewField.GetValue(tab1SnManager));
+				Assert.Null(fragmentManagerField.GetValue(tab1SnManager));
+
+				Assert.Null(currentPageField.GetValue(tab2SnManager));
+				Assert.Null(fragmentContainerViewField.GetValue(tab2SnManager));
+				Assert.Null(fragmentManagerField.GetValue(tab2SnManager));
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Controls/tests/DeviceTests/Memory/MemoryTests.cs
@@ -99,10 +99,8 @@ public class MemoryTests : ControlsHandlerTestBase
 
 	[Theory("Pages Do Not Leak")]
 	[InlineData(typeof(ContentPage))]
-#if !ANDROID
 	[InlineData(typeof(NavigationPage))]
-	//https://github.com/dotnet/maui/issues/27411
-#endif
+	// Issue #27411 (partially) and #33918 have been fixed - NavigationPage no longer leaks on Android
 	[InlineData(typeof(TabbedPage))]
 	public async Task PagesDoNotLeak([DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
 	{

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -317,6 +317,10 @@ namespace Microsoft.Maui.Platform
 			NavigationView = null;
 			SetNavHost(null);
 			_fragmentNavigator = null;
+			_currentPage = null;
+			NavigationStack = [];
+			_fragmentContainerView = null;
+			_fragmentManager = null;
 		}
 
 		public virtual void Connect(IView navigationView)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

On Android, navigating modally with a `NavigationPage` (including as children of a `TabbedPage`) caused a memory leak. After the modal was dismissed, `StackNavigationManager` held onto three references that prevented the pages from being garbage collected:

- `_currentPage` — the last active page
- `_fragmentContainerView` — the Android fragment container
- `_fragmentManager` — the Android fragment manager

These were never cleared in `Disconnect()`, so even after the modal stack was fully dismissed and the handler was disconnected, the managed objects remained reachable.

### `NavigationPage.cs` — Fix

Removed a duplicate `RemoveFromInnerChildren(currentPage)` call that was invoked twice in succession during pop navigation.
This seemed to be accidentally added in June 2025 by commit 850f52d9df8, and was flagged by Copilot in #27888 but it appears no action was taken on that. Ultimately, this line ended up duplicated for unknown reasons.

### `MemoryTests.cs` — Re-enable `NavigationPage` leak test on Android

`PagesDoNotLeak` excluded `NavigationPage` on Android under `#if !ANDROID` (referencing issue #27411) because `NavigationPage` leaked there. The exclusion has been removed, as the test passes.

### `NavigationPageTests.Android.cs` — New device test

Added `StackNavigationManagerClearsReferencesOnDisconnect`, which:

1. Pushes a `TabbedPage` with two `NavigationPage` children modally
2. Switches tabs to ensure both `NavigationPage` handlers are activated
3. Pops the modal

## Testing

- [x] `StackNavigationManagerClearsReferencesOnDisconnect` — new device test; fails without fix, passes with fix (verified on Pixel 8a, Android 15)
- [x] `PagesDoNotLeak(NavigationPage)` — re-enabled on Android; passes with fix
- [x] `PushingAndPoppingDoesntFireBackButtonVisibleToolbarEvents` — existing test; still passes

### Issues Fixed

Fixes #33918 
