### PR TITLE
[Perf] Reuse ElementEventArgs in tree propagation

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -1041,14 +1041,26 @@ namespace Microsoft.Maui.Controls
 
 		void OnDescendantAdded(Element child)
 		{
-			DescendantAdded?.Invoke(this, new ElementEventArgs(child));
-			RealParent?.OnDescendantAdded(child);
+			var args = new ElementEventArgs(child);
+			OnDescendantAdded(args);
+		}
+
+		void OnDescendantAdded(ElementEventArgs args)
+		{
+			DescendantAdded?.Invoke(this, args);
+			RealParent?.OnDescendantAdded(args);
 		}
 
 		void OnDescendantRemoved(Element child)
 		{
-			DescendantRemoved?.Invoke(this, new ElementEventArgs(child));
-			RealParent?.OnDescendantRemoved(child);
+			var args = new ElementEventArgs(child);
+			OnDescendantRemoved(args);
+		}
+
+		void OnDescendantRemoved(ElementEventArgs args)
+		{
+			DescendantRemoved?.Invoke(this, args);
+			RealParent?.OnDescendantRemoved(args);
 		}
 
 		void OnResourceChanged(BindableProperty property, object value, SetterSpecificity specificity)

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -1041,26 +1041,32 @@ namespace Microsoft.Maui.Controls
 
 		void OnDescendantAdded(Element child)
 		{
-			var args = new ElementEventArgs(child);
-			OnDescendantAdded(args);
+			OnDescendantAddedCore(child, null);
 		}
 
-		void OnDescendantAdded(ElementEventArgs args)
+		void OnDescendantAddedCore(Element child, ElementEventArgs? args)
 		{
-			DescendantAdded?.Invoke(this, args);
-			RealParent?.OnDescendantAdded(args);
+			if (DescendantAdded is not null)
+			{
+				args ??= new ElementEventArgs(child);
+				DescendantAdded.Invoke(this, args);
+			}
+			RealParent?.OnDescendantAddedCore(child, args);
 		}
 
 		void OnDescendantRemoved(Element child)
 		{
-			var args = new ElementEventArgs(child);
-			OnDescendantRemoved(args);
+			OnDescendantRemovedCore(child, null);
 		}
 
-		void OnDescendantRemoved(ElementEventArgs args)
+		void OnDescendantRemovedCore(Element child, ElementEventArgs? args)
 		{
-			DescendantRemoved?.Invoke(this, args);
-			RealParent?.OnDescendantRemoved(args);
+			if (DescendantRemoved is not null)
+			{
+				args ??= new ElementEventArgs(child);
+				DescendantRemoved.Invoke(this, args);
+			}
+			RealParent?.OnDescendantRemovedCore(child, args);
 		}
 
 		void OnResourceChanged(BindableProperty property, object value, SetterSpecificity specificity)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes https://github.com/dotnet/maui/issues/34093

## Description

`OnDescendantAdded` and `OnDescendantRemoved` allocate a new `ElementEventArgs` at every tree level during parent propagation. This creates O(depth) allocations per child add/remove. This PR creates the `ElementEventArgs` once at the entry point and passes it up through the recursive walk.