### PR TITLE
[Perf] Reduce allocations in inherited BindingContext propagation

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -363,7 +363,10 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
-				bindable._inheritedContext = new WeakReference(value);
+				if (bindable._inheritedContext is not null)
+					bindable._inheritedContext.Target = value;
+				else
+					bindable._inheritedContext = new WeakReference(value);
 				bindable.ApplyBindings(fromBindingContextChanged: true);
 				bindable.OnBindingContextChanged();
 			}
@@ -692,11 +695,9 @@ namespace Microsoft.Maui.Controls
 
 		void ApplyBindings(bool fromBindingContextChanged)
 		{
-			var prop = _properties.Values.ToArray();
-
-			for (int i = 0, propLength = prop.Length; i < propLength; i++)
+			foreach (var kvp in _properties)
 			{
-				BindablePropertyContext context = prop[i];
+				BindablePropertyContext context = kvp.Value;
 				if (ReferenceEquals(context.Property, BindingContextProperty))
 				{
 					// BindingContextProperty Binding is handled separately within SetInheritedBindingContext

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -695,9 +695,8 @@ namespace Microsoft.Maui.Controls
 
 		void ApplyBindings(bool fromBindingContextChanged)
 		{
-			foreach (var kvp in _properties)
+			foreach (var context in _properties.Values)
 			{
-				BindablePropertyContext context = kvp.Value;
 				if (ReferenceEquals(context.Property, BindingContextProperty))
 				{
 					// BindingContextProperty Binding is handled separately within SetInheritedBindingContext

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -695,7 +695,11 @@ namespace Microsoft.Maui.Controls
 
 		void ApplyBindings(bool fromBindingContextChanged)
 		{
-			foreach (var context in _properties.Values)
+			// Snapshot the property contexts — ApplyBinding can trigger re-entrant
+			// property changes (via callbacks) that modify _properties mid-iteration.
+			var contexts = _properties.Values.ToArray();
+
+			foreach (var context in contexts)
 			{
 				if (ReferenceEquals(context.Property, BindingContextProperty))
 				{

--- a/src/Core/tests/Benchmarks/Benchmarks/BindableObjectAllocBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/BindableObjectAllocBenchmarker.cs
@@ -6,187 +6,71 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 	[MemoryDiagnoser]
 	public class BindableObjectAllocBenchmarker
 	{
-		// --- #34092: Cached PropertyChangedEventArgs / PropertyChangingEventArgs ---
+		Label _label;
+		Label _child;
+		VerticalStackLayout _deepTreeLeaf;
+		VerticalStackLayout _flatLayout;
+		object _contextA, _contextB;
+		bool _toggle;
 
-		/// <summary>
-		/// Sets the same property repeatedly to measure PropertyChanged/Changing EventArgs allocations.
-		/// Before: new PropertyChangedEventArgs + new PropertyChangingEventArgs per call.
-		/// After: cached per BindableProperty.
-		/// </summary>
-		[Benchmark]
-		public void SetProperty_EventArgsAlloc()
+		[GlobalSetup]
+		public void Setup()
 		{
-			var label = new Label();
-			for (int i = 0; i < 1_000; i++)
+			_label = new Label();
+			_contextA = new object();
+			_contextB = new object();
+
+			// 10-level deep tree for DescendantAdded/Removed propagation
+			var root = new VerticalStackLayout();
+			var current = root;
+			for (int depth = 0; depth < 10; depth++)
 			{
-				label.Text = "a";
-				label.Text = "b";
+				var child = new VerticalStackLayout();
+				current.Add(child);
+				current = child;
 			}
+			_child = new Label();
+			_deepTreeLeaf = current;
+
+			// Flat layout with 200 children for BindingContext propagation
+			_flatLayout = new VerticalStackLayout();
+			for (int i = 0; i < 200; i++)
+				_flatLayout.Add(new Label());
 		}
 
-		/// <summary>
-		/// Sets multiple different properties to show caching benefit across properties.
-		/// </summary>
-		[Benchmark]
-		public void SetMultipleProperties_EventArgsAlloc()
+		// --- #34092: Cached PropertyChangedEventArgs / PropertyChangingEventArgs ---
+
+		[Benchmark(Description = "SetValue (EventArgs)")]
+		public void SetProperty_EventArgs()
 		{
-			var entry = new Entry();
-			for (int i = 0; i < 500; i++)
-			{
-				entry.Text = "a";
-				entry.Placeholder = "p";
-				entry.FontSize = 14 + (i % 3);
-				entry.Text = "b";
-				entry.Placeholder = "q";
-			}
+			_toggle = !_toggle;
+			_label.Text = _toggle ? "a" : "b";
 		}
 
 		// --- #34093: Reuse ElementEventArgs in tree propagation ---
 
-		/// <summary>
-		/// Adds children to a deep hierarchy, triggering DescendantAdded propagation.
-		/// Before: new ElementEventArgs at every tree level.
-		/// After: single ElementEventArgs reused through recursion.
-		/// </summary>
-		[Benchmark]
-		public void AddChildren_DeepTree_ElementEventArgs()
+		[Benchmark(Description = "Add+Remove child (10-deep tree)")]
+		public void AddRemoveChild_DeepTree()
 		{
-			// Build a 10-level deep tree
-			var root = new VerticalStackLayout();
-			var current = root;
-			for (int depth = 0; depth < 10; depth++)
-			{
-				var child = new VerticalStackLayout();
-				current.Add(child);
-				current = child;
-			}
-
-			// Add 100 leaves at the bottom — each fires DescendantAdded 10 levels up
-			for (int i = 0; i < 100; i++)
-			{
-				current.Add(new Label());
-			}
-		}
-
-		/// <summary>
-		/// Removes children from a deep hierarchy, triggering DescendantRemoved propagation.
-		/// </summary>
-		[Benchmark]
-		public void RemoveChildren_DeepTree_ElementEventArgs()
-		{
-			var root = new VerticalStackLayout();
-			var current = root;
-			for (int depth = 0; depth < 10; depth++)
-			{
-				var child = new VerticalStackLayout();
-				current.Add(child);
-				current = child;
-			}
-
-			var labels = new Label[100];
-			for (int i = 0; i < 100; i++)
-			{
-				labels[i] = new Label();
-				current.Add(labels[i]);
-			}
-
-			for (int i = 0; i < 100; i++)
-			{
-				current.Remove(labels[i]);
-			}
+			_deepTreeLeaf.Add(_child);
+			_deepTreeLeaf.Remove(_child);
 		}
 
 		// --- #34129: BindingContext propagation (WeakReference reuse + .ToArray() elimination) ---
 
-		class SimpleViewModel
-		{
-			public string Name { get; set; } = "Test";
-		}
-
-		/// <summary>
-		/// Sets BindingContext on a flat layout with many children.
-		/// Before: new WeakReference per child + .ToArray() on each child's _properties.
-		/// After: reuse WeakReference.Target + foreach on dictionary directly.
-		/// </summary>
-		[Benchmark]
+		[Benchmark(Description = "Set BindingContext (200 children)")]
 		public void SetBindingContext_FlatTree()
 		{
-			var layout = new VerticalStackLayout();
-			for (int i = 0; i < 200; i++)
-			{
-				layout.Add(new Label());
-			}
-
-			var vm = new SimpleViewModel();
-			for (int i = 0; i < 10; i++)
-			{
-				layout.BindingContext = vm;
-				layout.BindingContext = null;
-			}
-		}
-
-		/// <summary>
-		/// Sets BindingContext on a deep tree where children have bindings.
-		/// This is the worst-case hot path: ApplyBindings + WeakReference for every descendant.
-		/// </summary>
-		[Benchmark]
-		public void SetBindingContext_DeepTreeWithBindings()
-		{
-			var root = new VerticalStackLayout();
-			var current = root;
-
-			for (int depth = 0; depth < 5; depth++)
-			{
-				var child = new VerticalStackLayout();
-				current.Add(child);
-				current = child;
-			}
-
-			for (int i = 0; i < 50; i++)
-			{
-				var label = new Label();
-				label.SetBinding(Label.TextProperty, new Binding("Name"));
-				current.Add(label);
-			}
-
-			var vm = new SimpleViewModel();
-			for (int i = 0; i < 20; i++)
-			{
-				root.BindingContext = vm;
-				root.BindingContext = null;
-			}
+			_toggle = !_toggle;
+			_flatLayout.BindingContext = _toggle ? _contextA : _contextB;
 		}
 
 		// --- #34131: Lazy _triggerSpecificity dictionary ---
 
-		/// <summary>
-		/// Creates many BindableObjects (Labels) that never use triggers.
-		/// Before: each allocates Dictionary&lt;TriggerBase, SetterSpecificity&gt;.
-		/// After: dictionary is null until first trigger attachment.
-		/// </summary>
-		[Benchmark]
-		public Label[] CreateManyLabels_NoTriggers()
-		{
-			var labels = new Label[1_000];
-			for (int i = 0; i < 1_000; i++)
-			{
-				labels[i] = new Label();
-			}
-			return labels;
-		}
+		[Benchmark(Description = "new Label()")]
+		public Label CreateLabel() => new Label();
 
-		/// <summary>
-		/// Creates many Entries (more complex BindableObject) without triggers.
-		/// </summary>
-		[Benchmark]
-		public Entry[] CreateManyEntries_NoTriggers()
-		{
-			var entries = new Entry[500];
-			for (int i = 0; i < 500; i++)
-			{
-				entries[i] = new Entry();
-			}
-			return entries;
-		}
+		[Benchmark(Description = "new Entry()")]
+		public Entry CreateEntry() => new Entry();
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes https://github.com/dotnet/maui/issues/34129

## Description

Two allocation reductions on the hot `SetInheritedBindingContext` path (called recursively for every descendant when BindingContext changes):

### 1. Reuse existing `WeakReference`
Instead of `new WeakReference(value)` on every descendant, reuse the existing `WeakReference` by updating its `.Target` property.

### 2. Eliminate `.ToArray()` in `ApplyBindings`
`ApplyBindings` was calling `.ToArray()` on the properties dictionary values before iterating. Since `ApplyBinding` only reads bindings and does not modify the dictionary, direct `foreach` iteration is safe and avoids the array allocation.