### PR TITLE
[net12.0] [Perf] Cache PropertyChanged/ChangingEventArgs on BindableProperty

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			if (changed)
 			{
 				property.PropertyChanging?.Invoke(this, original.Value, newValue);
-				OnPropertyChanging(property.PropertyName);
+				OnPropertyChanging(property.GetPropertyChangingEventArgs());
 			}
 
 			bpcontext.Values.Remove(specificity);
@@ -402,11 +402,25 @@ namespace Microsoft.Maui.Controls
 			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
 		/// <summary>
+		/// Raises the <see cref="PropertyChanged"/> event using a cached PropertyChangedEventArgs.
+		/// </summary>
+		/// <param name="args">The cached PropertyChangedEventArgs to use.</param>
+		internal void OnPropertyChanged(PropertyChangedEventArgs args)
+			=> PropertyChanged?.Invoke(this, args);
+
+		/// <summary>
 		/// Raises the <see cref="PropertyChanging"/> event.
 		/// </summary>
 		/// <param name="propertyName">The name of the property that is changing.</param>
 		protected virtual void OnPropertyChanging([CallerMemberName] string propertyName = null)
 			=> PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+
+		/// <summary>
+		/// Raises the <see cref="PropertyChanging"/> event using a cached PropertyChangingEventArgs.
+		/// </summary>
+		/// <param name="args">The cached PropertyChangingEventArgs to use.</param>
+		internal void OnPropertyChanging(PropertyChangingEventArgs args)
+			=> PropertyChanging?.Invoke(this, args);
 
 		/// <summary>
 		/// Removes all current bindings from the current context.
@@ -652,7 +666,7 @@ namespace Microsoft.Maui.Controls
 			{
 				property.PropertyChanging?.Invoke(this, original, value);
 
-				OnPropertyChanging(property.PropertyName);
+				OnPropertyChanging(property.GetPropertyChangingEventArgs());
 			}
 
 			context.Values.SetValue(specificity, value);
@@ -685,7 +699,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (willFirePropertyChanged)
 			{
-				OnPropertyChanged(property.PropertyName);
+				OnPropertyChanged(property.GetPropertyChangedEventArgs());
 				property.PropertyChanged?.Invoke(this, original, value);
 			}
 		}

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			if (changed)
 			{
 				property.PropertyChanging?.Invoke(this, original.Value, newValue);
-				OnPropertyChanging(property.CachedPropertyChangingEventArgs);
+				OnPropertyChanging(property.PropertyName);
 			}
 
 			bpcontext.Values.Remove(specificity);
@@ -399,28 +399,14 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		/// <param name="propertyName">The name of the property that has changed.</param>
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-		/// <summary>
-		/// Raises the <see cref="PropertyChanged"/> event using a cached PropertyChangedEventArgs.
-		/// </summary>
-		/// <param name="args">The cached PropertyChangedEventArgs to use.</param>
-		internal void OnPropertyChanged(PropertyChangedEventArgs args)
-			=> PropertyChanged?.Invoke(this, args);
+			=> PropertyChanged?.Invoke(this, BindableProperty.GetCachedPropertyChangedEventArgs(propertyName));
 
 		/// <summary>
 		/// Raises the <see cref="PropertyChanging"/> event.
 		/// </summary>
 		/// <param name="propertyName">The name of the property that is changing.</param>
 		protected virtual void OnPropertyChanging([CallerMemberName] string propertyName = null)
-			=> PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
-
-		/// <summary>
-		/// Raises the <see cref="PropertyChanging"/> event using a cached PropertyChangingEventArgs.
-		/// </summary>
-		/// <param name="args">The cached PropertyChangingEventArgs to use.</param>
-		internal void OnPropertyChanging(PropertyChangingEventArgs args)
-			=> PropertyChanging?.Invoke(this, args);
+			=> PropertyChanging?.Invoke(this, BindableProperty.GetCachedPropertyChangingEventArgs(propertyName));
 
 		/// <summary>
 		/// Removes all current bindings from the current context.
@@ -666,7 +652,7 @@ namespace Microsoft.Maui.Controls
 			{
 				property.PropertyChanging?.Invoke(this, original, value);
 
-				OnPropertyChanging(property.CachedPropertyChangingEventArgs);
+				OnPropertyChanging(property.PropertyName);
 			}
 
 			context.Values.SetValue(specificity, value);
@@ -699,7 +685,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (willFirePropertyChanged)
 			{
-				OnPropertyChanged(property.CachedPropertyChangedEventArgs);
+				OnPropertyChanged(property.PropertyName);
 				property.PropertyChanged?.Invoke(this, original, value);
 			}
 		}

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			if (changed)
 			{
 				property.PropertyChanging?.Invoke(this, original.Value, newValue);
-				OnPropertyChanging(property.GetPropertyChangingEventArgs());
+				OnPropertyChanging(property.CachedPropertyChangingEventArgs);
 			}
 
 			bpcontext.Values.Remove(specificity);
@@ -666,7 +666,7 @@ namespace Microsoft.Maui.Controls
 			{
 				property.PropertyChanging?.Invoke(this, original, value);
 
-				OnPropertyChanging(property.GetPropertyChangingEventArgs());
+				OnPropertyChanging(property.CachedPropertyChangingEventArgs);
 			}
 
 			context.Values.SetValue(specificity, value);
@@ -699,7 +699,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (willFirePropertyChanged)
 			{
-				OnPropertyChanged(property.GetPropertyChangedEventArgs());
+				OnPropertyChanged(property.CachedPropertyChangedEventArgs);
 				property.PropertyChanged?.Invoke(this, original, value);
 			}
 		}

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -252,6 +252,15 @@ namespace Microsoft.Maui.Controls
 
 		internal ValidateValueDelegate ValidateValue { get; private set; }
 
+		PropertyChangedEventArgs _cachedPropertyChangedEventArgs;
+		PropertyChangingEventArgs _cachedPropertyChangingEventArgs;
+
+		internal PropertyChangedEventArgs GetPropertyChangedEventArgs()
+			=> _cachedPropertyChangedEventArgs ??= new PropertyChangedEventArgs(PropertyName);
+
+		internal PropertyChangingEventArgs GetPropertyChangingEventArgs()
+			=> _cachedPropertyChangingEventArgs ??= new PropertyChangingEventArgs(PropertyName);
+
 		// Properties that this property depends on - when getting this property's value,
 		// if the dependency has a pending binding, return the default value instead.
 		// This is used to fix timing issues where one property binding resolves before another.

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -252,14 +252,11 @@ namespace Microsoft.Maui.Controls
 
 		internal ValidateValueDelegate ValidateValue { get; private set; }
 
-		PropertyChangedEventArgs _cachedPropertyChangedEventArgs;
-		PropertyChangingEventArgs _cachedPropertyChangingEventArgs;
+		internal PropertyChangedEventArgs CachedPropertyChangedEventArgs
+			=> field ??= new PropertyChangedEventArgs(PropertyName);
 
-		internal PropertyChangedEventArgs GetPropertyChangedEventArgs()
-			=> _cachedPropertyChangedEventArgs ??= new PropertyChangedEventArgs(PropertyName);
-
-		internal PropertyChangingEventArgs GetPropertyChangingEventArgs()
-			=> _cachedPropertyChangingEventArgs ??= new PropertyChangingEventArgs(PropertyName);
+		internal PropertyChangingEventArgs CachedPropertyChangingEventArgs
+			=> field ??= new PropertyChangingEventArgs(PropertyName);
 
 		// Properties that this property depends on - when getting this property's value,
 		// if the dependency has a pending binding, return the default value instead.

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -252,11 +253,14 @@ namespace Microsoft.Maui.Controls
 
 		internal ValidateValueDelegate ValidateValue { get; private set; }
 
-		internal PropertyChangedEventArgs CachedPropertyChangedEventArgs
-			=> field ??= new PropertyChangedEventArgs(PropertyName);
+		private static readonly ConcurrentDictionary<string, PropertyChangedEventArgs> s_changedArgsCache = new();
+		private static readonly ConcurrentDictionary<string, PropertyChangingEventArgs> s_changingArgsCache = new();
 
-		internal PropertyChangingEventArgs CachedPropertyChangingEventArgs
-			=> field ??= new PropertyChangingEventArgs(PropertyName);
+		internal static PropertyChangedEventArgs GetCachedPropertyChangedEventArgs(string propertyName)
+			=> s_changedArgsCache.GetOrAdd(propertyName, static name => new PropertyChangedEventArgs(name));
+
+		internal static PropertyChangingEventArgs GetCachedPropertyChangingEventArgs(string propertyName)
+			=> s_changingArgsCache.GetOrAdd(propertyName, static name => new PropertyChangingEventArgs(name));
 
 		// Properties that this property depends on - when getting this property's value,
 		// if the dependency has a pending binding, return the default value instead.

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -670,6 +670,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		HashSet<string> _pendingHandlerUpdatesFromBPSet = new HashSet<string>();
+		BindableProperty _currentPropertyBeingSet;
+
 		private protected override void OnBindablePropertySet(BindableProperty property, object original, object value, bool changed, bool willFirePropertyChanged)
 		{
 			if (willFirePropertyChanged)
@@ -677,7 +679,9 @@ namespace Microsoft.Maui.Controls
 				_pendingHandlerUpdatesFromBPSet.Add(property.PropertyName);
 			}
 
+			_currentPropertyBeingSet = property;
 			base.OnBindablePropertySet(property, original, value, changed, willFirePropertyChanged);
+			_currentPropertyBeingSet = null;
 			_pendingHandlerUpdatesFromBPSet.Remove(property.PropertyName);
 			UpdateHandlerValue(property.PropertyName, changed);
 
@@ -704,7 +708,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_effects?.Count > 0)
 			{
-				var args = new PropertyChangedEventArgs(propertyName);
+				var args = _currentPropertyBeingSet?.GetPropertyChangedEventArgs() ?? new PropertyChangedEventArgs(propertyName);
 				foreach (Effect effect in _effects)
 				{
 					effect?.SendOnElementPropertyChanged(args);

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -670,8 +670,6 @@ namespace Microsoft.Maui.Controls
 		}
 
 		HashSet<string> _pendingHandlerUpdatesFromBPSet = new HashSet<string>();
-		BindableProperty _currentPropertyBeingSet;
-
 		private protected override void OnBindablePropertySet(BindableProperty property, object original, object value, bool changed, bool willFirePropertyChanged)
 		{
 			if (willFirePropertyChanged)
@@ -679,9 +677,7 @@ namespace Microsoft.Maui.Controls
 				_pendingHandlerUpdatesFromBPSet.Add(property.PropertyName);
 			}
 
-			_currentPropertyBeingSet = property;
 			base.OnBindablePropertySet(property, original, value, changed, willFirePropertyChanged);
-			_currentPropertyBeingSet = null;
 			_pendingHandlerUpdatesFromBPSet.Remove(property.PropertyName);
 			UpdateHandlerValue(property.PropertyName, changed);
 
@@ -708,7 +704,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_effects?.Count > 0)
 			{
-				var args = _currentPropertyBeingSet?.CachedPropertyChangedEventArgs ?? new PropertyChangedEventArgs(propertyName);
+				var args = new PropertyChangedEventArgs(propertyName);
 				foreach (Effect effect in _effects)
 				{
 					effect?.SendOnElementPropertyChanged(args);

--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Maui.Controls
 
 			if (_effects?.Count > 0)
 			{
-				var args = _currentPropertyBeingSet?.GetPropertyChangedEventArgs() ?? new PropertyChangedEventArgs(propertyName);
+				var args = _currentPropertyBeingSet?.CachedPropertyChangedEventArgs ?? new PropertyChangedEventArgs(propertyName);
 				foreach (Effect effect in _effects)
 				{
 					effect?.SendOnElementPropertyChanged(args);


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes https://github.com/dotnet/maui/issues/34092

## Description

Every `SetValue` call allocates new `PropertyChangedEventArgs` and `PropertyChangingEventArgs` objects. Since `BindableProperty.PropertyName` is immutable, these are now cached on the `BindableProperty` instance via lazy `field ??=` fields.

### Changes

- **`BindableProperty.cs`** — two new cached fields: `CachedPropertyChangedEventArgs` and `CachedPropertyChangingEventArgs`, lazily initialized on first access
- **`BindableObject.cs`** — new internal `OnPropertyChanged(PropertyChangedEventArgs)` and `OnPropertyChanging(PropertyChangingEventArgs)` overloads that accept pre-allocated args; `SetValueCore` and `ClearValue` updated to use the cached args

### Benchmark

| Method | Mean | Gen0 | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Current (new per call) | 5,105 ns | 3.8223 | 24,000 B | 1.00 |
| **Cached on BindableProperty** | **1,142 ns** | **-** | **0 B** | **0.00** |

**4.5× faster, zero allocation** for PropertyChanged args.