### PR TITLE
Fix XAML C# expression setter generation for read-only properties

### DIFF
--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -963,7 +963,8 @@ static class SetPropertyHelpers
 			}
 			else if (member is IFieldSymbol field)
 			{
-				// Fields are writable (unless readonly, but that's a different check)
+				if (field.IsReadOnly)
+					return false;
 				lastProperty = null;
 				currentType = field.Type;
 			}

--- a/src/Controls/src/SourceGen/SetPropertyHelpers.cs
+++ b/src/Controls/src/SourceGen/SetPropertyHelpers.cs
@@ -853,8 +853,10 @@ static class SetPropertyHelpers
 			!expr.StartsWith("..", StringComparison.Ordinal))
 			expr = expr.Substring(1);
 
-		// Strip "BindingContext." prefix (e.g., "BindingContext.Name" → "Name")
-		if (expr.StartsWith("BindingContext.", StringComparison.Ordinal))
+		// Strip "BindingContext." prefix only when it refers to BindableObject.BindingContext,
+		// not a user-defined member with the same name (e.g., a POCO with `public Person BindingContext;`)
+		if (expr.StartsWith("BindingContext.", StringComparison.Ordinal)
+			&& !dataType.GetAllMembers("BindingContext", context).Any())
 			expr = expr.Substring("BindingContext.".Length);
 
 		if (string.IsNullOrEmpty(expr))
@@ -935,8 +937,10 @@ static class SetPropertyHelpers
 			!expr.StartsWith("..", StringComparison.Ordinal))
 			expr = expr.Substring(1);
 
-		// Strip "BindingContext." prefix (e.g., "BindingContext.Name" → "Name")
-		if (expr.StartsWith("BindingContext.", StringComparison.Ordinal))
+		// Strip "BindingContext." prefix only when it refers to BindableObject.BindingContext,
+		// not a user-defined member with the same name (e.g., a POCO with `public Person BindingContext;`)
+		if (expr.StartsWith("BindingContext.", StringComparison.Ordinal)
+			&& !dataType.GetAllMembers("BindingContext", context).Any())
 			expr = expr.Substring("BindingContext.".Length);
 
 		if (string.IsNullOrEmpty(expr))

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34075.sgen.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34075.sgen.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34075"
+             x:DataType="local:Maui34075ViewModel">
+    <!-- Binding to a getter-only property via C# expression should not generate a setter -->
+    <VerticalStackLayout>
+        <Label x:Name="readOnlyLabel" Text="{ReadOnlyText}" />
+        <Button x:Name="commandButton" Command="{MyCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34075.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34075.xaml.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+/// <summary>
+/// ViewModel with read-only properties to reproduce issue #34075.
+/// C# expression source gen should not generate setters for these.
+/// </summary>
+public class Maui34075ViewModel : INotifyPropertyChanged
+{
+	// Getter-only property (expression-bodied) - common for commands
+	public ICommand MyCommand => new Command(() => { });
+
+	// Getter-only property - common for computed/display values
+	public string ReadOnlyText => "Hello";
+
+#pragma warning disable CS0067 // Event is never used
+	public event PropertyChangedEventHandler? PropertyChanged;
+#pragma warning restore CS0067
+}
+
+public partial class Maui34075 : ContentPage
+{
+	public Maui34075() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		/// <summary>
+		/// Verifies that C# expression bindings to getter-only properties
+		/// compile and inflate without errors (no setter generated for read-only props).
+		/// See: https://github.com/dotnet/maui/issues/34075
+		/// </summary>
+		[Fact]
+		public void ReadOnlyPropertyExpressionBindingCompilesSuccessfully()
+		{
+			var page = new Maui34075(XamlInflator.SourceGen);
+			page.BindingContext = new Maui34075ViewModel();
+
+			Assert.NotNull(page);
+			Assert.Equal("Hello", page.readOnlyLabel.Text);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #34075

The XAML source generator was generating setter assignments (e.g., `__source.ReadOnlyText = __value`) for getter-only properties when using C# expression bindings like `{ReadOnlyText}`. This caused CS0200 build errors at compile time.

### Root Cause

`ExpressionAnalyzer.IsSimplePropertyChain()` only checks whether the expression is syntactically a simple property chain (member access, identifier), but does not verify whether the terminal property actually has a public setter. So `{ReadOnlyText}` where `ReadOnlyText` is `string ReadOnlyText => "Hello"` was incorrectly marked as settable.

### Fix

Added `IsExpressionWritable()` in `SetPropertyHelpers.cs` that walks the property chain on the `dataType` symbol and checks whether the terminal property has a public, non-init setter. The setter lambda is only generated when both the syntactic check (`IsSettable`) and the semantic check (`IsExpressionWritable`) pass.

### Changes

- `src/Controls/src/SourceGen/SetPropertyHelpers.cs` — Added `IsExpressionWritable()` helper and gated setter generation on it
- `src/Controls/tests/Xaml.UnitTests/Issues/Maui34075.*` — Regression test with getter-only properties bound via C# expressions

### Testing

- New `.sgen.xaml` test inflates successfully via SourceGen with read-only property bindings
- Existing `NullConditionalSettable` test (two-way binding to writable properties) still passes
- Existing `TwoWayDecimalBinding_UIToVM` test still passes (setter works for writable properties)
