### PR TITLE
Add daily template size tracking workflow

### DIFF
--- a/.github/scripts/template-size-tracking/build-and-publish.ps1
+++ b/.github/scripts/template-size-tracking/build-and-publish.ps1
@@ -1,0 +1,149 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Builds and publishes a .NET MAUI template project for size measurement.
+
+.PARAMETER ProjectPath
+    Path to the project directory.
+
+.PARAMETER Platform
+    Target platform (android, ios, maccatalyst, windows-packaged, windows-unpackaged).
+
+.PARAMETER Framework
+    Target framework (e.g., "net10.0-android").
+
+.PARAMETER Rid
+    Runtime identifier (e.g., "android-arm64", "ios-arm64", "win-x64").
+
+.PARAMETER IsAot
+    Whether to build with Native AOT ("True" or "False").
+#>
+
+param(
+    [Parameter(Mandatory)][string]$ProjectPath,
+    [Parameter(Mandatory)][string]$Platform,
+    [Parameter(Mandatory)][string]$Framework,
+    [Parameter(Mandatory)][string]$Rid,
+    [Parameter(Mandatory)][string]$IsAot
+)
+
+$ErrorActionPreference = "Stop"
+
+$isAotBool = $IsAot -eq "True"
+$startTime = Get-Date
+
+$projectFile = Get-ChildItem -Path $ProjectPath -Filter "*.csproj" -Recurse | Select-Object -First 1
+if (-not $projectFile) {
+    Write-Error "Could not find project file in $ProjectPath"
+    exit 1
+}
+
+Write-Host "Found project: $($projectFile.FullName)"
+
+switch ($Platform) {
+    "android" {
+        if ($isAotBool) {
+            Write-Host "Building Android AAB with Native AOT..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release -r $Rid `
+                -p:PublishAot=true `
+                -p:AndroidPackageFormat=aab -p:AndroidKeyStore=false `
+                -o publish /bl:build.binlog
+        } else {
+            Write-Host "Building Android AAB..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release `
+                -p:AndroidPackageFormat=aab -p:AndroidKeyStore=false `
+                -o publish /bl:build.binlog
+        }
+    }
+
+    "ios" {
+        # iOS publish requires device RID + signing. Use ad-hoc signing
+        # (CodesignKey=-) with BuildIpa=false to skip IPA creation.
+        Write-Host "Building iOS with ad-hoc signing..."
+        dotnet publish $projectFile.FullName `
+            -f $Framework -c Release -r $Rid `
+            -p:_RequireCodeSigning=false `
+            -p:EnableCodeSigning=false `
+            '-p:CodesignKey=-' `
+            -p:BuildIpa=false `
+            -p:ValidateXcodeVersion=false `
+            /bl:build.binlog
+
+        # With BuildIpa=false, the .app stays in bin/ (not copied to -o path).
+        # Find and copy it to publish/ for consistent measurement.
+        $binPath = Join-Path $ProjectPath "bin/Release/$Framework/$Rid"
+        Write-Host "Looking for .app in: $binPath"
+        $appBundle = Get-ChildItem -Path $binPath -Filter "*.app" -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($appBundle) {
+            New-Item -ItemType Directory -Path "publish" -Force | Out-Null
+            Copy-Item -Path $appBundle.FullName -Destination "publish/" -Recurse
+            Write-Host "Copied $($appBundle.Name) to publish/"
+        } else {
+            Write-Host "Warning: No .app bundle found in $binPath, listing contents:"
+            Get-ChildItem -Path $binPath -Recurse -ErrorAction SilentlyContinue |
+                Select-Object -First 20 | ForEach-Object { Write-Host "  $_" }
+        }
+    }
+
+    "maccatalyst" {
+        if ($isAotBool) {
+            Write-Host "Building MacCatalyst with Native AOT..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release -r $Rid `
+                -p:PublishAot=true `
+                -p:_RequireCodeSigning=false -p:ValidateXcodeVersion=false `
+                -o publish /bl:build.binlog
+        } else {
+            Write-Host "Building MacCatalyst (unsigned)..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release -r $Rid `
+                -p:_RequireCodeSigning=false -p:ValidateXcodeVersion=false `
+                -o publish /bl:build.binlog
+        }
+    }
+
+    "windows-packaged" {
+        if ($isAotBool) {
+            Write-Host "Building Windows MSIX with Native AOT..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release -r $Rid `
+                -p:PublishAot=true `
+                -p:WindowsPackageType=MSIX `
+                -p:GenerateAppxPackageOnBuild=true -p:AppxPackageSigningEnabled=false `
+                -o publish /bl:build.binlog
+        } else {
+            Write-Host "Building Windows MSIX..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release `
+                -p:WindowsPackageType=MSIX `
+                -p:GenerateAppxPackageOnBuild=true -p:AppxPackageSigningEnabled=false `
+                -o publish /bl:build.binlog
+        }
+    }
+
+    "windows-unpackaged" {
+        if ($isAotBool) {
+            Write-Host "Building Windows unpackaged with Native AOT..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release -r $Rid `
+                --self-contained true -p:PublishAot=true `
+                -p:WindowsPackageType=None `
+                -o publish /bl:build.binlog
+        } else {
+            # Framework-dependent publish without explicit RID.
+            # Specifying -r win-x64 forces self-contained which needs
+            # Mono.win-x64 runtime package (not available for .NET 10 GA).
+            Write-Host "Building Windows unpackaged (framework-dependent)..."
+            dotnet publish $projectFile.FullName `
+                -f $Framework -c Release `
+                -p:WindowsPackageType=None `
+                -o publish /bl:build.binlog
+        }
+    }
+}
+
+$buildTime = [math]::Round(((Get-Date) - $startTime).TotalSeconds, 2)
+Write-Host "Build completed in $buildTime seconds"
+echo "BUILD_TIME=$buildTime" >> $env:GITHUB_ENV

--- a/.github/scripts/template-size-tracking/compare-and-alert.ps1
+++ b/.github/scripts/template-size-tracking/compare-and-alert.ps1
@@ -1,0 +1,281 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Compares current metrics with previous runs and generates alerts.
+
+.PARAMETER CurrentMetricsPath
+    Path to current metrics directory.
+
+.PARAMETER PreviousMetricsPath
+    Path to previous metrics directory.
+
+.PARAMETER HistoricalMetricsPath
+    Path to historical metrics directory with dated subdirectories.
+
+.PARAMETER AlertThreshold
+    Percentage threshold for alerts (default: 10).
+
+.PARAMETER FailureThreshold
+    Percentage threshold for critical failures (default: 20).
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$CurrentMetricsPath,
+
+    [Parameter(Mandatory=$true)]
+    [string]$PreviousMetricsPath,
+
+    [Parameter(Mandatory=$false)]
+    [string]$HistoricalMetricsPath = "historical-metrics",
+
+    [Parameter(Mandatory=$false)]
+    [decimal]$AlertThreshold = 10,
+
+    [Parameter(Mandatory=$false)]
+    [decimal]$FailureThreshold = 20
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Comparing Metrics ===" -ForegroundColor Cyan
+Write-Host "Alert Threshold: $AlertThreshold%"
+Write-Host "Failure Threshold: $FailureThreshold%"
+
+# Load current metrics
+$currentMetrics = @()
+$currentFiles = Get-ChildItem -Path $CurrentMetricsPath -Filter "*.json" -Recurse
+
+foreach ($file in $currentFiles) {
+    $content = Get-Content $file.FullName -Raw | ConvertFrom-Json
+    $currentMetrics += $content
+}
+
+Write-Host "Loaded $($currentMetrics.Count) current metrics"
+
+# Load previous metrics
+$previousMetrics = @()
+if (Test-Path $PreviousMetricsPath) {
+    $previousFiles = Get-ChildItem -Path $PreviousMetricsPath -Filter "*.json" -Recurse
+
+    foreach ($file in $previousFiles) {
+        try {
+            $content = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            $previousMetrics += $content
+        } catch {
+            Write-Warning "Could not parse previous metric file: $($file.Name)"
+        }
+    }
+
+    Write-Host "Loaded $($previousMetrics.Count) previous metrics"
+} else {
+    Write-Host "No previous metrics found - this appears to be the first run"
+}
+
+# Load historical metrics
+$historicalMetrics = @{}
+$daysToLoad = @(1, 2, 3, 4, 5, 7, 30)
+
+foreach ($daysAgo in $daysToLoad) {
+    $targetDate = (Get-Date).AddDays(-$daysAgo).ToString("yyyy-MM-dd")
+    $historicalPath = Join-Path $HistoricalMetricsPath $targetDate
+
+    if (Test-Path $historicalPath) {
+        $historicalFiles = Get-ChildItem -Path $historicalPath -Filter "*.json" -Recurse
+        $metrics = @()
+
+        foreach ($file in $historicalFiles) {
+            try {
+                $content = Get-Content $file.FullName -Raw | ConvertFrom-Json
+                $metrics += $content
+            } catch {
+                Write-Warning "Could not parse historical metric file: $($file.Name)"
+            }
+        }
+
+        $historicalMetrics[$daysAgo] = $metrics
+        Write-Host "Loaded $($metrics.Count) metrics from $daysAgo day(s) ago ($targetDate)"
+    } else {
+        Write-Host "No historical metrics found for $daysAgo day(s) ago ($targetDate)"
+        $historicalMetrics[$daysAgo] = @()
+    }
+}
+
+# Compare metrics
+$comparisons = @()
+$alerts = @()
+$criticalAlerts = @()
+
+foreach ($current in $currentMetrics) {
+    $currentKey = if ($current.PSObject.Properties["description"]) { $current.description } else { $current.platform }
+
+    # Find matching previous metric
+    $previous = $previousMetrics | Where-Object {
+        $previousKey = if ($_.PSObject.Properties["description"]) { $_.description } else { $_.platform }
+        $_.dotnetVersion -eq $current.dotnetVersion -and
+        $_.template -eq $current.template -and
+        $previousKey -eq $currentKey
+    } | Select-Object -First 1
+
+    $comparison = @{
+        dotnetVersion = $current.dotnetVersion
+        template = $current.template
+        platform = $currentKey
+        currentSize = $current.packageSize
+        currentCompressedSize = $current.compressedSize
+        currentBuildTime = $current.buildTimeSeconds
+        previousSize = if ($previous) { $previous.packageSize } else { 0 }
+        previousBuildTime = if ($previous) { $previous.buildTimeSeconds } else { 0 }
+        sizeChange = 0
+        sizeChangePercent = 0
+        buildTimeChange = 0
+        buildTimeChangePercent = 0
+        status = "new"
+        historical = @{}
+    }
+
+    # Historical data
+    foreach ($daysAgo in $daysToLoad) {
+        $historical = $historicalMetrics[$daysAgo] | Where-Object {
+            $historicalKey = if ($_.PSObject.Properties["description"]) { $_.description } else { $_.platform }
+            $_.dotnetVersion -eq $current.dotnetVersion -and
+            $_.template -eq $current.template -and
+            $historicalKey -eq $currentKey
+        } | Select-Object -First 1
+
+        if ($historical) {
+            $compressedSize = if ($historical.PSObject.Properties["compressedSize"]) { $historical.compressedSize } else { 0 }
+            $percentChange = 0
+
+            if ($compressedSize -gt 0 -and $current.compressedSize -gt 0) {
+                $percentChange = [math]::Round((($current.compressedSize - $compressedSize) / $compressedSize) * 100, 2)
+            }
+
+            $comparison.historical["days_$daysAgo"] = @{
+                compressedSize = $compressedSize
+                percentChange = $percentChange
+            }
+        } else {
+            $comparison.historical["days_$daysAgo"] = @{
+                compressedSize = 0
+                percentChange = 0
+            }
+        }
+    }
+
+    if ($previous) {
+        if ($previous.packageSize -gt 0) {
+            $comparison.sizeChange = $current.packageSize - $previous.packageSize
+            $comparison.sizeChangePercent = [math]::Round(($comparison.sizeChange / $previous.packageSize) * 100, 2)
+        }
+
+        if ($previous.buildTimeSeconds -gt 0) {
+            $comparison.buildTimeChange = $current.buildTimeSeconds - $previous.buildTimeSeconds
+            $comparison.buildTimeChangePercent = [math]::Round(($comparison.buildTimeChange / $previous.buildTimeSeconds) * 100, 2)
+        }
+
+        if ($comparison.sizeChangePercent -ge $FailureThreshold) {
+            $comparison.status = "critical"
+            $criticalAlerts += $comparison
+        } elseif ($comparison.sizeChangePercent -ge $AlertThreshold) {
+            $comparison.status = "alert"
+            $alerts += $comparison
+        } elseif ($comparison.sizeChangePercent -gt 0) {
+            $comparison.status = "increased"
+        } elseif ($comparison.sizeChangePercent -lt 0) {
+            $comparison.status = "decreased"
+        } else {
+            $comparison.status = "unchanged"
+        }
+    }
+
+    $comparisons += $comparison
+}
+
+# Save comparison results
+$comparisons | ConvertTo-Json -Depth 10 | Out-File -FilePath "comparison.json" -Encoding UTF8
+
+# Generate alert report if needed
+if ($alerts.Count -gt 0 -or $criticalAlerts.Count -gt 0) {
+    Write-Host "`n⚠️  ALERTS DETECTED!" -ForegroundColor Red
+
+    $alertReport = @"
+# ⚠️ .NET MAUI Template Size Alert - $(Get-Date -Format "yyyy-MM-dd")
+
+Significant size increases detected in .NET MAUI templates.
+
+"@
+
+    if ($criticalAlerts.Count -gt 0) {
+        $alertReport += @"
+
+## 🔴 Critical Increases (>$FailureThreshold%)
+
+| Template | Platform | .NET | Previous | Current | Change |
+|----------|----------|------|----------|---------|--------|
+
+"@
+
+        foreach ($alert in $criticalAlerts) {
+            $prevMB = [math]::Round($alert.previousSize / 1MB, 2)
+            $currMB = [math]::Round($alert.currentSize / 1MB, 2)
+            $change = "+$($alert.sizeChangePercent)%"
+            $alertReport += "| $($alert.template) | $($alert.platform) | $($alert.dotnetVersion) | $prevMB MB | $currMB MB | $change 🔴 |`n"
+        }
+    }
+
+    if ($alerts.Count -gt 0) {
+        $alertReport += @"
+
+## 🟡 Notable Increases (>$AlertThreshold%)
+
+| Template | Platform | .NET | Previous | Current | Change |
+|----------|----------|------|----------|---------|--------|
+
+"@
+
+        foreach ($alert in $alerts) {
+            $prevMB = [math]::Round($alert.previousSize / 1MB, 2)
+            $currMB = [math]::Round($alert.currentSize / 1MB, 2)
+            $change = "+$($alert.sizeChangePercent)%"
+            $alertReport += "| $($alert.template) | $($alert.platform) | $($alert.dotnetVersion) | $prevMB MB | $currMB MB | $change 🟡 |`n"
+        }
+    }
+
+    $alertReport += @"
+
+## Details
+
+- **Workflow Run**: [View Details]($($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID))
+- **Alert Threshold**: $AlertThreshold%
+- **Failure Threshold**: $FailureThreshold%
+
+---
+*This issue was automatically generated by the daily template size tracking workflow.*
+"@
+
+    $alertReport | Out-File -FilePath "alert-report.md" -Encoding UTF8
+
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "alert=true"
+
+    if ($criticalAlerts.Count -gt 0) {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "critical=true"
+        Write-Host "Critical alerts: $($criticalAlerts.Count)" -ForegroundColor Red
+    } else {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "critical=false"
+    }
+} else {
+    Write-Host "`n✓ No significant size increases detected" -ForegroundColor Green
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "alert=false"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "critical=false"
+}
+
+# Summary
+Write-Host "`n=== Comparison Summary ===" -ForegroundColor Cyan
+Write-Host "Total comparisons: $($comparisons.Count)"
+Write-Host "New entries: $(($comparisons | Where-Object { $_.status -eq 'new' }).Count)"
+Write-Host "Decreased: $(($comparisons | Where-Object { $_.status -eq 'decreased' }).Count)"
+Write-Host "Unchanged: $(($comparisons | Where-Object { $_.status -eq 'unchanged' }).Count)"
+Write-Host "Increased: $(($comparisons | Where-Object { $_.status -eq 'increased' }).Count)"
+Write-Host "Alerts: $($alerts.Count)" -ForegroundColor Yellow
+Write-Host "Critical: $($criticalAlerts.Count)" -ForegroundColor Red

--- a/.github/scripts/template-size-tracking/compare-and-alert.ps1
+++ b/.github/scripts/template-size-tracking/compare-and-alert.ps1
@@ -27,7 +27,7 @@ param(
     [string]$PreviousMetricsPath,
 
     [Parameter(Mandatory=$false)]
-    [string]$HistoricalMetricsPath = "historical-metrics",
+    [string]$HistoricalMetricsPath = "metrics-history",
 
     [Parameter(Mandatory=$false)]
     [decimal]$AlertThreshold = 10,

--- a/.github/scripts/template-size-tracking/create-project.ps1
+++ b/.github/scripts/template-size-tracking/create-project.ps1
@@ -1,0 +1,81 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Creates a .NET MAUI template project configured for size measurement.
+
+.PARAMETER Template
+    Template to use (maui, maui-blazor).
+
+.PARAMETER DotNetVersion
+    .NET version (e.g., "9.0", "10.0").
+
+.PARAMETER Description
+    Platform description (e.g., "android", "ios", "windows-packaged-aot").
+
+.PARAMETER Framework
+    Target framework (e.g., "net10.0-android").
+#>
+
+param(
+    [Parameter(Mandatory)][string]$Template,
+    [Parameter(Mandatory)][string]$DotNetVersion,
+    [Parameter(Mandatory)][string]$Description,
+    [Parameter(Mandatory)][string]$Framework
+)
+
+$ErrorActionPreference = "Stop"
+
+# Project name: hyphens are fine for MSIX identity ([-.A-Za-z0-9]).
+# Remove hyphens from template name to keep it short.
+$shortTemplate = $Template -replace '-', ''
+$projectName = "Ma-$shortTemplate-$Description"
+
+# Create project in $HOME to avoid inheriting repo's Directory.Build.props
+# (which imports Arcade SDK and causes build failures)
+$buildRoot = Join-Path $HOME "template-builds"
+New-Item -ItemType Directory -Path $buildRoot -Force | Out-Null
+$projectDir = Join-Path $buildRoot $projectName
+
+# Place NuGet.config in the PARENT directory (not project dir) to avoid
+# macOS build system bundling it into .app packages
+$nugetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+"@
+$nugetConfig | Out-File -FilePath (Join-Path $buildRoot "NuGet.config") -Encoding UTF8
+
+Write-Host "Creating project: dotnet new $Template -o $projectDir --framework net$DotNetVersion"
+dotnet new $Template -o $projectDir --framework "net$DotNetVersion"
+
+# Pin SDK version to match the target .NET version.
+# Runners may have multiple SDKs installed; without pinning, the highest
+# SDK resolves workload manifests that conflict with older TFMs.
+$sdkVersion = dotnet --list-sdks `
+    | Where-Object { $_ -match "^$DotNetVersion" } `
+    | ForEach-Object { ($_ -split ' ')[0] } `
+    | Select-Object -Last 1
+
+if ($sdkVersion) {
+    Write-Host "Pinning SDK to $sdkVersion via global.json"
+    @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } `
+        | ConvertTo-Json `
+        | Out-File -FilePath (Join-Path $projectDir "global.json") -Encoding UTF8
+}
+
+# Restrict TargetFrameworks to only the platform we're building for.
+# MAUI templates target all platforms (android, ios, maccatalyst, windows).
+# Building on Ubuntu for Android would fail trying to resolve iOS workloads.
+$csproj = Get-ChildItem -Path $projectDir -Filter "*.csproj" -Recurse | Select-Object -First 1
+if ($csproj) {
+    $content = Get-Content $csproj.FullName -Raw
+    $content = $content -replace '<TargetFrameworks>[^<]+</TargetFrameworks>', "<TargetFrameworks>$Framework</TargetFrameworks>"
+    Set-Content -Path $csproj.FullName -Value $content
+    Write-Host "Restricted TargetFrameworks to: $Framework"
+}
+
+echo "PROJECT_PATH=$projectDir" >> $env:GITHUB_ENV
+echo "PROJECT_NAME=$projectName" >> $env:GITHUB_ENV

--- a/.github/scripts/template-size-tracking/create-project.ps1
+++ b/.github/scripts/template-size-tracking/create-project.ps1
@@ -4,7 +4,8 @@
     Creates a .NET MAUI template project configured for size measurement.
 
 .PARAMETER Template
-    Template to use (maui, maui-blazor).
+    Template to use (maui, maui-blazor, maui-sample).
+    "maui-sample" is a synthetic name that maps to "dotnet new maui --sample-content".
 
 .PARAMETER DotNetVersion
     .NET version (e.g., "9.0", "10.0").
@@ -48,8 +49,17 @@ $nugetConfig = @"
 "@
 $nugetConfig | Out-File -FilePath (Join-Path $buildRoot "NuGet.config") -Encoding UTF8
 
-Write-Host "Creating project: dotnet new $Template -o $projectDir --framework net$DotNetVersion"
-dotnet new $Template -o $projectDir --framework "net$DotNetVersion"
+# Map synthetic template names to actual dotnet new commands.
+# "maui-sample" → "dotnet new maui --sample-content"
+$dotnetNewTemplate = $Template
+$extraArgs = @()
+if ($Template -eq 'maui-sample') {
+    $dotnetNewTemplate = 'maui'
+    $extraArgs = @('--sample-content')
+}
+
+Write-Host "Creating project: dotnet new $dotnetNewTemplate -o $projectDir --framework net$DotNetVersion $($extraArgs -join ' ')"
+dotnet new $dotnetNewTemplate -o $projectDir --framework "net$DotNetVersion" @extraArgs
 
 # Pin SDK version to match the target .NET version.
 # Runners may have multiple SDKs installed; without pinning, the highest

--- a/.github/scripts/template-size-tracking/generate-summary.ps1
+++ b/.github/scripts/template-size-tracking/generate-summary.ps1
@@ -1,0 +1,225 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Generates a GitHub Actions summary report for .NET MAUI template size tracking.
+
+.PARAMETER MetricsPath
+    Path to current metrics directory.
+
+.PARAMETER ComparisonPath
+    Path to comparison JSON file.
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$MetricsPath,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ComparisonPath = "comparison.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Generating Summary Report ===" -ForegroundColor Cyan
+
+# Load comparisons
+$comparisons = @()
+if (Test-Path $ComparisonPath) {
+    $comparisons = Get-Content $ComparisonPath -Raw | ConvertFrom-Json
+}
+
+# Load current metrics
+$currentMetrics = @()
+$currentFiles = Get-ChildItem -Path $MetricsPath -Filter "*.json" -Recurse
+
+foreach ($file in $currentFiles) {
+    $content = Get-Content $file.FullName -Raw | ConvertFrom-Json
+    $currentMetrics += $content
+}
+
+# Group by .NET version
+$groupedByDotNet = $currentMetrics | Group-Object -Property dotnetVersion
+
+$totalSize = ($currentMetrics | Measure-Object -Property packageSize -Sum).Sum
+$avgBuildTime = ($currentMetrics | Measure-Object -Property buildTimeSeconds -Average).Average
+
+$summary = @"
+# 📊 .NET MAUI Template Size Tracking - $(Get-Date -Format "yyyy-MM-dd")
+
+## Overall Statistics
+
+- **Total Configurations**: $($currentMetrics.Count)
+- **Total Package Size**: $([math]::Round($totalSize / 1GB, 2)) GB
+- **Average Build Time**: $([math]::Round($avgBuildTime, 2)) seconds
+- **MAUI Templates Version**: $($currentMetrics[0].mauiVersion)
+
+"@
+
+foreach ($dotnetGroup in $groupedByDotNet) {
+    $dotnetVersion = $dotnetGroup.Name
+    $summary += @"
+
+## .NET $dotnetVersion
+
+| Template | Platform | Size | Compressed | Files | Assemblies | Build Time | Change | 1 day | 2 days | 3 days | 4 days | 5 days | 1 week | 1 month |
+|----------|----------|------|------------|-------|------------|------------|--------|-------|--------|--------|--------|--------|--------|---------|
+
+"@
+
+    foreach ($metric in $dotnetGroup.Group | Sort-Object template, platform) {
+        $metricKey = if ($metric.PSObject.Properties["description"]) { $metric.description } else { $metric.platform }
+
+        $comparison = $comparisons | Where-Object {
+            $_.dotnetVersion -eq $metric.dotnetVersion -and
+            $_.template -eq $metric.template -and
+            $_.platform -eq $metricKey
+        } | Select-Object -First 1
+
+        $sizeMB = [math]::Round($metric.packageSize / 1MB, 1)
+        $compressedMB = [math]::Round($metric.compressedSize / 1MB, 1)
+        if ($metric.PSObject.Properties["buildTimeFormatted"] -and $metric.buildTimeFormatted) {
+            $buildTime = $metric.buildTimeFormatted
+        } else {
+            $buildTime = "$([math]::Round($metric.buildTimeSeconds / 60, 1))m"
+        }
+
+        $changeIndicator = ""
+        if ($comparison -and $comparison.status -ne "new") {
+            $changePercent = [math]::Round($comparison.sizeChangePercent, 1)
+
+            if ($changePercent -gt 1) {
+                $changeIndicator = "+$changePercent% 🔴"
+            } elseif ($changePercent -gt 0) {
+                $changeIndicator = "+$changePercent% 🟠"
+            } elseif ($changePercent -lt -1) {
+                $changeIndicator = "$changePercent% 🟢"
+            } elseif ($changePercent -lt 0) {
+                $changeIndicator = "$changePercent% 🟠"
+            } else {
+                $changeIndicator = "—"
+            }
+        } elseif ($comparison -and $comparison.status -eq "new") {
+            $changeIndicator = "NEW ✨"
+        } else {
+            $changeIndicator = "—"
+        }
+
+        # Historical columns
+        $historicalColumns = @()
+        $daysToShow = @(1, 2, 3, 4, 5, 7, 30)
+
+        foreach ($daysAgo in $daysToShow) {
+            $histData = $null
+            $keyName = "days_$daysAgo"
+
+            if ($comparison -and $comparison.PSObject.Properties["historical"] -and $comparison.historical.PSObject.Properties[$keyName]) {
+                $histData = $comparison.historical.$keyName
+            }
+
+            if ($histData -and $histData.compressedSize -gt 0) {
+                $histSizeMB = [math]::Round($histData.compressedSize / 1MB, 1)
+                $histPercent = [math]::Round($histData.percentChange, 1)
+
+                $percentStr = if ($histPercent -gt 1) {
+                    "+$histPercent% 🔴"
+                } elseif ($histPercent -gt 0) {
+                    "+$histPercent% 🟠"
+                } elseif ($histPercent -lt -1) {
+                    "$histPercent% 🟢"
+                } elseif ($histPercent -lt 0) {
+                    "$histPercent% 🟠"
+                } else {
+                    "0%"
+                }
+
+                $historicalColumns += "$histSizeMB MB ($percentStr)"
+            } else {
+                $historicalColumns += "—"
+            }
+        }
+
+        $summary += "| $($metric.template) | $metricKey | $sizeMB MB | $compressedMB MB | $($metric.fileCount) | $($metric.assemblyCount) | $buildTime | $changeIndicator | $($historicalColumns -join ' | ') |`n"
+    }
+}
+
+# Trend analysis
+if ($comparisons.Count -gt 0) {
+    $increased = ($comparisons | Where-Object { $_.sizeChangePercent -gt 0 }).Count
+    $decreased = ($comparisons | Where-Object { $_.sizeChangePercent -lt 0 }).Count
+    $unchanged = ($comparisons | Where-Object { $_.sizeChangePercent -eq 0 }).Count
+    $new = ($comparisons | Where-Object { $_.status -eq "new" }).Count
+
+    $summary += @"
+
+## Trend Analysis
+
+- 📈 Increased: $increased
+- 📉 Decreased: $decreased
+- ➡️ Unchanged: $unchanged
+- ✨ New: $new
+
+"@
+
+    $topIncreases = $comparisons |
+        Where-Object { $_.sizeChangePercent -gt 0 } |
+        Sort-Object -Property sizeChangePercent -Descending |
+        Select-Object -First 5
+
+    if ($topIncreases.Count -gt 0) {
+        $summary += @"
+
+### Top Size Increases
+
+| Template | Platform | .NET | Change |
+|----------|----------|------|--------|
+
+"@
+
+        foreach ($increase in $topIncreases) {
+            $summary += "| $($increase.template) | $($increase.platform) | $($increase.dotnetVersion) | +$($increase.sizeChangePercent)% |`n"
+        }
+    }
+
+    $topDecreases = $comparisons |
+        Where-Object { $_.sizeChangePercent -lt 0 } |
+        Sort-Object -Property sizeChangePercent |
+        Select-Object -First 5
+
+    if ($topDecreases.Count -gt 0) {
+        $summary += @"
+
+### Top Size Decreases
+
+| Template | Platform | .NET | Change |
+|----------|----------|------|--------|
+
+"@
+
+        foreach ($decrease in $topDecreases) {
+            $summary += "| $($decrease.template) | $($decrease.platform) | $($decrease.dotnetVersion) | $($decrease.sizeChangePercent)% |`n"
+        }
+    }
+}
+
+$summary += @"
+
+## Links
+
+- 🔗 [Workflow Run]($($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID))
+- 📚 [Repository]($($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY))
+
+---
+*Generated at $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") UTC*
+"@
+
+# Write to GitHub Actions summary
+$summaryFile = $env:GITHUB_STEP_SUMMARY
+if ($summaryFile) {
+    $summary | Out-File -FilePath $summaryFile -Encoding UTF8 -Append
+    Write-Host "Summary written to GitHub Actions" -ForegroundColor Green
+} else {
+    Write-Host $summary
+}
+
+$summary | Out-File -FilePath "summary-report.md" -Encoding UTF8
+Write-Host "Summary saved to summary-report.md" -ForegroundColor Green

--- a/.github/scripts/template-size-tracking/generate-summary.ps1
+++ b/.github/scripts/template-size-tracking/generate-summary.ps1
@@ -51,7 +51,7 @@ $summary = @"
 - **Total Configurations**: $($currentMetrics.Count)
 - **Total Package Size**: $([math]::Round($totalSize / 1GB, 2)) GB
 - **Average Build Time**: $([math]::Round($avgBuildTime, 2)) seconds
-- **MAUI Templates Version**: $($currentMetrics[0].mauiVersion)
+- **MAUI Templates Version**: $(if ($currentMetrics.Count -gt 0) { $currentMetrics[0].mauiVersion } else { 'unknown' })
 
 "@
 

--- a/.github/scripts/template-size-tracking/measure-package-size.ps1
+++ b/.github/scripts/template-size-tracking/measure-package-size.ps1
@@ -1,0 +1,325 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Measures package size and collects metrics for .NET MAUI templates.
+
+.PARAMETER PublishPath
+    Path to the publish output directory.
+
+.PARAMETER Platform
+    Target platform (android, ios, maccatalyst, windows-packaged, windows-unpackaged).
+
+.PARAMETER Description
+    Full description including platform and build type (e.g., windows-packaged-aot).
+
+.PARAMETER OS
+    Runner operating system (ubuntu-latest, macos-latest, windows-latest).
+
+.PARAMETER IsAot
+    Whether this is a Native AOT build.
+
+.PARAMETER Template
+    Template type (maui, maui-blazor).
+
+.PARAMETER DotNetVersion
+    .NET version used for the build.
+
+.PARAMETER MauiVersion
+    .NET MAUI Templates version used.
+
+.PARAMETER BuildTime
+    Build time in seconds.
+
+.PARAMETER OutputPath
+    Path where the metrics JSON file will be saved.
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$PublishPath,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Platform,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Description,
+
+    [Parameter(Mandatory=$true)]
+    [string]$OS,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateSet('True', 'False', 'true', 'false', '$true', '$false')]
+    [string]$IsAot,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Template,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DotNetVersion,
+
+    [Parameter(Mandatory=$true)]
+    [string]$MauiVersion,
+
+    [Parameter(Mandatory=$true)]
+    [decimal]$BuildTime,
+
+    [Parameter(Mandatory=$true)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Measuring Package Size ===" -ForegroundColor Cyan
+Write-Host "Platform: $Platform"
+Write-Host "Description: $Description"
+Write-Host "OS: $OS"
+Write-Host "Is AOT: $IsAot"
+Write-Host "Template: $Template"
+Write-Host "Publish Path: $PublishPath"
+
+# Initialize metrics object
+$metrics = @{
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    template = $Template
+    platform = $Platform
+    description = $Description
+    os = $OS
+    dotnetVersion = $DotNetVersion
+    mauiVersion = $MauiVersion
+    buildTimeSeconds = [math]::Round($BuildTime, 2)
+    isAot = [System.Convert]::ToBoolean($IsAot)
+}
+
+function Get-DirectorySize {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return 0 }
+    $size = (Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue |
+        Measure-Object -Property Length -Sum).Sum
+    if ($null -eq $size) { return 0 }
+    return $size
+}
+
+function Get-FileCount {
+    param([string]$Path, [string]$Filter = "*")
+    if (-not (Test-Path $Path)) { return 0 }
+    return (Get-ChildItem -Path $Path -Filter $Filter -Recurse -File -ErrorAction SilentlyContinue |
+        Measure-Object).Count
+}
+
+function Get-LargestFile {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    $largest = Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue |
+        Sort-Object Length -Descending |
+        Select-Object -First 1
+    if ($largest) {
+        return @{ name = $largest.Name; size = $largest.Length }
+    }
+    return $null
+}
+
+switch ($Platform) {
+    "android" {
+        Write-Host "Measuring Android AAB package..." -ForegroundColor Yellow
+
+        $aabFile = Get-ChildItem -Path $PublishPath -Filter "*.aab" -Recurse | Select-Object -First 1
+
+        if ($aabFile) {
+            $metrics.packageSize = $aabFile.Length
+            $metrics.packagePath = $aabFile.Name
+            Write-Host "AAB Size: $([math]::Round($aabFile.Length / 1MB, 2)) MB"
+        } else {
+            # Fall back to APK
+            $apkFile = Get-ChildItem -Path $PublishPath -Filter "*-Signed.apk" -Recurse | Select-Object -First 1
+            if (-not $apkFile) {
+                $apkFile = Get-ChildItem -Path $PublishPath -Filter "*.apk" -Recurse | Select-Object -First 1
+            }
+            if ($apkFile) {
+                $metrics.packageSize = $apkFile.Length
+                $metrics.packagePath = $apkFile.Name
+                Write-Host "APK Size: $([math]::Round($apkFile.Length / 1MB, 2)) MB"
+            } else {
+                Write-Warning "No AAB or APK file found"
+                $metrics.packageSize = 0
+            }
+        }
+
+        $metrics.totalPublishSize = Get-DirectorySize -Path $PublishPath
+        $metrics.fileCount = Get-FileCount -Path $PublishPath
+        $metrics.assemblyCount = Get-FileCount -Path $PublishPath -Filter "*.dll"
+    }
+
+    "ios" {
+        Write-Host "Measuring iOS package..." -ForegroundColor Yellow
+
+        # Look for .ipa first, then .app bundle
+        $ipaFile = Get-ChildItem -Path $PublishPath -Filter "*.ipa" -Recurse | Select-Object -First 1
+
+        if ($ipaFile) {
+            $metrics.packageSize = $ipaFile.Length
+            $metrics.packagePath = $ipaFile.Name
+            Write-Host "IPA Size: $([math]::Round($ipaFile.Length / 1MB, 2)) MB"
+        } else {
+            $appBundle = Get-ChildItem -Path $PublishPath -Filter "*.app" -Recurse -Directory | Select-Object -First 1
+            if ($appBundle) {
+                $metrics.packageSize = Get-DirectorySize -Path $appBundle.FullName
+                $metrics.packagePath = $appBundle.Name
+                Write-Host "App Bundle Size: $([math]::Round($metrics.packageSize / 1MB, 2)) MB"
+            } else {
+                Write-Warning "No IPA or .app bundle found, measuring publish directory"
+                $metrics.packageSize = Get-DirectorySize -Path $PublishPath
+            }
+        }
+
+        $metrics.totalPublishSize = Get-DirectorySize -Path $PublishPath
+        $metrics.fileCount = Get-FileCount -Path $PublishPath
+        $metrics.assemblyCount = Get-FileCount -Path $PublishPath -Filter "*.dll"
+    }
+
+    "maccatalyst" {
+        Write-Host "Measuring MacCatalyst package..." -ForegroundColor Yellow
+
+        # Look for .pkg first, then .app bundle
+        $pkgFile = Get-ChildItem -Path $PublishPath -Filter "*.pkg" -Recurse | Select-Object -First 1
+
+        if ($pkgFile) {
+            $metrics.packageSize = $pkgFile.Length
+            $metrics.packagePath = $pkgFile.Name
+            Write-Host "PKG Size: $([math]::Round($pkgFile.Length / 1MB, 2)) MB"
+        } else {
+            $appBundle = Get-ChildItem -Path $PublishPath -Filter "*.app" -Recurse -Directory | Select-Object -First 1
+            if ($appBundle) {
+                $metrics.packageSize = Get-DirectorySize -Path $appBundle.FullName
+                $metrics.packagePath = $appBundle.Name
+                Write-Host "App Bundle Size: $([math]::Round($metrics.packageSize / 1MB, 2)) MB"
+            } else {
+                Write-Warning "No PKG or .app bundle found, measuring publish directory"
+                $metrics.packageSize = Get-DirectorySize -Path $PublishPath
+            }
+        }
+
+        $metrics.totalPublishSize = Get-DirectorySize -Path $PublishPath
+        $metrics.fileCount = Get-FileCount -Path $PublishPath
+        $metrics.assemblyCount = Get-FileCount -Path $PublishPath -Filter "*.dll"
+    }
+
+    "windows-packaged" {
+        Write-Host "Measuring Windows MSIX package..." -ForegroundColor Yellow
+
+        $msixFile = Get-ChildItem -Path $PublishPath -Filter "*.msix" -Recurse | Select-Object -First 1
+
+        if ($msixFile) {
+            $metrics.packageSize = $msixFile.Length
+            $metrics.packagePath = $msixFile.Name
+            Write-Host "MSIX Size: $([math]::Round($msixFile.Length / 1MB, 2)) MB"
+        } else {
+            # Fall back to msixbundle or appx
+            $bundleFile = Get-ChildItem -Path $PublishPath -Filter "*.msixbundle" -Recurse | Select-Object -First 1
+            if ($bundleFile) {
+                $metrics.packageSize = $bundleFile.Length
+                $metrics.packagePath = $bundleFile.Name
+                Write-Host "MSIX Bundle Size: $([math]::Round($bundleFile.Length / 1MB, 2)) MB"
+            } else {
+                Write-Warning "No MSIX file found, measuring publish directory"
+                $metrics.packageSize = Get-DirectorySize -Path $PublishPath
+            }
+        }
+
+        $metrics.totalPublishSize = Get-DirectorySize -Path $PublishPath
+        $metrics.fileCount = Get-FileCount -Path $PublishPath
+        $metrics.assemblyCount = Get-FileCount -Path $PublishPath -Filter "*.dll"
+    }
+
+    "windows-unpackaged" {
+        Write-Host "Measuring Windows unpackaged publish folder..." -ForegroundColor Yellow
+
+        $metrics.packageSize = Get-DirectorySize -Path $PublishPath
+        $metrics.packagePath = "publish"
+        Write-Host "Publish Folder Size: $([math]::Round($metrics.packageSize / 1MB, 2)) MB"
+
+        $metrics.totalPublishSize = $metrics.packageSize
+        $metrics.fileCount = Get-FileCount -Path $PublishPath
+
+        if ($metrics.isAot) {
+            $mainExe = Get-ChildItem -Path $PublishPath -Filter "*.exe" -File |
+                Where-Object { $_.Length -gt 1MB } |
+                Sort-Object Length -Descending |
+                Select-Object -First 1
+            if ($mainExe) {
+                $metrics.assemblyCount = 1
+                $metrics.mainExecutableSize = $mainExe.Length
+                $metrics.mainExecutableName = $mainExe.Name
+            } else {
+                $metrics.assemblyCount = 0
+            }
+        } else {
+            $metrics.assemblyCount = (Get-ChildItem -Path $PublishPath -Filter "*.dll" -Recurse -File | Measure-Object).Count
+            $mainExe = Get-ChildItem -Path $PublishPath -Filter "*.exe" -File |
+                Where-Object { $_.Length -gt 1MB } |
+                Sort-Object Length -Descending |
+                Select-Object -First 1
+            if ($mainExe) {
+                $metrics.mainExecutableSize = $mainExe.Length
+                $metrics.mainExecutableName = $mainExe.Name
+            }
+        }
+    }
+}
+
+# Common metrics
+$metrics.totalAssemblySize = (Get-ChildItem -Path $PublishPath -Filter "*.dll" -Recurse -ErrorAction SilentlyContinue |
+    Measure-Object -Property Length -Sum).Sum
+
+$largestFile = Get-LargestFile -Path $PublishPath
+if ($largestFile) {
+    $metrics.largestFile = $largestFile
+}
+
+# Compressed size
+if ($Platform -eq "android" -or $Platform -eq "ios" -or $Platform -eq "windows-packaged") {
+    # These are already compressed archives
+    $metrics.compressedSize = $metrics.packageSize
+    Write-Host "Compressed Size (same as package): $([math]::Round($metrics.compressedSize / 1MB, 2)) MB"
+} else {
+    $tempZip = Join-Path ([System.IO.Path]::GetTempPath()) "package.zip"
+    if (Test-Path $tempZip) { Remove-Item $tempZip -Force }
+    Write-Host "Creating compressed archive for measurement..." -ForegroundColor Yellow
+    try {
+        Compress-Archive -Path "$PublishPath/*" -DestinationPath $tempZip -CompressionLevel Optimal -Force
+        $metrics.compressedSize = (Get-Item $tempZip).Length
+        Write-Host "Compressed Size: $([math]::Round($metrics.compressedSize / 1MB, 2)) MB"
+        Remove-Item $tempZip -Force
+    } catch {
+        Write-Warning "Could not create compressed archive: $_"
+        $metrics.compressedSize = 0
+    }
+}
+
+if ($metrics.compressedSize -gt 0 -and $metrics.packageSize -gt 0) {
+    $metrics.compressionRatio = [math]::Round(($metrics.compressedSize / $metrics.packageSize) * 100, 2)
+}
+
+# SDK version
+try {
+    $sdkVersion = dotnet --version
+    $metrics.dotnetSdkVersion = $sdkVersion.Trim()
+} catch {
+    $metrics.dotnetSdkVersion = "unknown"
+}
+
+# Build time formatting
+$ts = [System.TimeSpan]::FromSeconds($metrics.buildTimeSeconds)
+$metrics.buildTimeFormatted = $ts.ToString("hh\:mm\:ss")
+
+# Summary
+Write-Host "`n=== Metrics Summary ===" -ForegroundColor Green
+Write-Host "Package Size: $([math]::Round($metrics.packageSize / 1MB, 2)) MB"
+Write-Host "Compressed Size: $([math]::Round($metrics.compressedSize / 1MB, 2)) MB"
+Write-Host "File Count: $($metrics.fileCount)"
+Write-Host "Assembly Count: $($metrics.assemblyCount)"
+Write-Host "Build Time: $($metrics.buildTimeFormatted)"
+
+$metricsJson = $metrics | ConvertTo-Json -Depth 10
+$metricsJson | Out-File -FilePath $OutputPath -Encoding UTF8
+
+Write-Host "`nMetrics saved to: $OutputPath" -ForegroundColor Green

--- a/.github/scripts/template-size-tracking/prepare-historical-data.ps1
+++ b/.github/scripts/template-size-tracking/prepare-historical-data.ps1
@@ -1,0 +1,65 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Prepares historical metrics data for comparison and trend analysis.
+
+.PARAMETER MetricsPath
+    Path to current metrics directory.
+
+.PARAMETER HistoryDir
+    Path to the historical metrics directory (restored from cache).
+
+.PARAMETER RetentionDays
+    Number of days of history to retain.
+#>
+
+param(
+    [string]$MetricsPath = "metrics",
+    [string]$HistoryDir = "metrics-history",
+    [int]$RetentionDays = 35
+)
+
+$ErrorActionPreference = "Stop"
+
+$today = (Get-Date).ToString("yyyy-MM-dd")
+
+if (-not (Test-Path $HistoryDir)) {
+    New-Item -ItemType Directory -Force -Path $HistoryDir | Out-Null
+    Write-Host "Created new metrics history directory"
+}
+
+# Copy current metrics into today's history slot
+$todayDir = Join-Path $HistoryDir $today
+New-Item -ItemType Directory -Force -Path $todayDir | Out-Null
+
+$metricsFiles = Get-ChildItem -Path $MetricsPath -Filter "*.json" -Recurse
+foreach ($file in $metricsFiles) {
+    Copy-Item $file.FullName -Destination $todayDir -Force
+}
+Write-Host "Saved $($metricsFiles.Count) metrics to $todayDir"
+
+# Find yesterday's metrics for comparison
+$yesterday = (Get-Date).AddDays(-1).ToString("yyyy-MM-dd")
+$yesterdayDir = Join-Path $HistoryDir $yesterday
+
+if (Test-Path $yesterdayDir) {
+    Write-Host "Found previous metrics from $yesterday"
+    Copy-Item $yesterdayDir -Destination "previous-metrics" -Recurse
+} else {
+    Write-Host "No previous metrics found for $yesterday"
+    New-Item -ItemType Directory -Force -Path "previous-metrics" | Out-Null
+}
+
+# Prune history older than retention period
+$cutoffDate = (Get-Date).AddDays(-$RetentionDays).ToString("yyyy-MM-dd")
+$historyDirs = Get-ChildItem -Path $HistoryDir -Directory | Sort-Object Name
+
+foreach ($dir in $historyDirs) {
+    if ($dir.Name -lt $cutoffDate) {
+        Write-Host "Pruning old metrics: $($dir.Name)"
+        Remove-Item $dir.FullName -Recurse -Force
+    }
+}
+
+$remaining = (Get-ChildItem -Path $HistoryDir -Directory).Count
+Write-Host "History contains $remaining day(s) of metrics"

--- a/.github/scripts/template-size-tracking/prepare-matrix.ps1
+++ b/.github/scripts/template-size-tracking/prepare-matrix.ps1
@@ -1,0 +1,143 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Generates the GitHub Actions build matrix for template size tracking.
+
+.PARAMETER DotNetVersions
+    Comma-separated .NET versions to test (e.g., "9.0,10.0").
+
+.PARAMETER Templates
+    Comma-separated templates to test (e.g., "maui,maui-blazor").
+#>
+
+param(
+    [string]$DotNetVersions = "9.0,10.0",
+    [string]$Templates = "maui,maui-blazor"
+)
+
+$ErrorActionPreference = "Stop"
+
+$dotnetVersions = $DotNetVersions.Split(',') | ForEach-Object { $_.Trim() }
+$templates = $Templates.Split(',') | ForEach-Object { $_.Trim() }
+
+$matrix = @{
+    include = @()
+}
+
+foreach ($dotnet in $dotnetVersions) {
+    foreach ($template in $templates) {
+        # Android
+        $matrix.include += @{
+            description = 'android'
+            dotnet = $dotnet
+            template = $template
+            platform = 'android'
+            os = 'ubuntu-latest'
+            framework = "net$dotnet-android"
+            rid = 'android-arm64'
+            aot = $false
+        }
+
+        # Android Native AOT (.NET 10+ only)
+        if ($dotnet -ne "9.0") {
+            $matrix.include += @{
+                description = 'android-aot'
+                dotnet = $dotnet
+                template = $template
+                platform = 'android'
+                os = 'ubuntu-latest'
+                framework = "net$dotnet-android"
+                rid = 'android-arm64'
+                aot = $true
+            }
+        }
+
+        # iOS
+        $matrix.include += @{
+            description = 'ios'
+            dotnet = $dotnet
+            template = $template
+            platform = 'ios'
+            os = 'macos-latest'
+            framework = "net$dotnet-ios"
+            rid = 'ios-arm64'
+            aot = $false
+        }
+
+        # MacCatalyst
+        $matrix.include += @{
+            description = 'maccatalyst'
+            dotnet = $dotnet
+            template = $template
+            platform = 'maccatalyst'
+            os = 'macos-latest'
+            framework = "net$dotnet-maccatalyst"
+            rid = 'maccatalyst-arm64'
+            aot = $false
+        }
+
+        # MacCatalyst Native AOT
+        $matrix.include += @{
+            description = 'maccatalyst-aot'
+            dotnet = $dotnet
+            template = $template
+            platform = 'maccatalyst'
+            os = 'macos-latest'
+            framework = "net$dotnet-maccatalyst"
+            rid = 'maccatalyst-arm64'
+            aot = $true
+        }
+
+        # Windows Packaged (MSIX)
+        $matrix.include += @{
+            description = 'windows-packaged'
+            dotnet = $dotnet
+            template = $template
+            platform = 'windows-packaged'
+            os = 'windows-latest'
+            framework = "net$dotnet-windows10.0.19041.0"
+            rid = 'win-x64'
+            aot = $false
+        }
+
+        # Windows Packaged (MSIX) Native AOT
+        $matrix.include += @{
+            description = 'windows-packaged-aot'
+            dotnet = $dotnet
+            template = $template
+            platform = 'windows-packaged'
+            os = 'windows-latest'
+            framework = "net$dotnet-windows10.0.19041.0"
+            rid = 'win-x64'
+            aot = $true
+        }
+
+        # Windows Unpackaged
+        $matrix.include += @{
+            description = 'windows-unpackaged'
+            dotnet = $dotnet
+            template = $template
+            platform = 'windows-unpackaged'
+            os = 'windows-latest'
+            framework = "net$dotnet-windows10.0.19041.0"
+            rid = 'win-x64'
+            aot = $false
+        }
+
+        # Windows Unpackaged Native AOT
+        $matrix.include += @{
+            description = 'windows-unpackaged-aot'
+            dotnet = $dotnet
+            template = $template
+            platform = 'windows-unpackaged'
+            os = 'windows-latest'
+            framework = "net$dotnet-windows10.0.19041.0"
+            rid = 'win-x64'
+            aot = $true
+        }
+    }
+}
+
+$matrixJson = $matrix | ConvertTo-Json -Compress -Depth 10
+Write-Host "Matrix: $matrixJson"
+echo "matrix=$matrixJson" >> $env:GITHUB_OUTPUT

--- a/.github/scripts/template-size-tracking/prepare-matrix.ps1
+++ b/.github/scripts/template-size-tracking/prepare-matrix.ps1
@@ -17,15 +17,17 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$dotnetVersions = $DotNetVersions.Split(',') | ForEach-Object { $_.Trim() }
-$templates = $Templates.Split(',') | ForEach-Object { $_.Trim() }
+# Use different variable names to avoid PowerShell's case-insensitive
+# variable collision with the [string]-typed parameters above.
+[array]$versions = $DotNetVersions.Split(',') | ForEach-Object { $_.Trim() }
+[array]$templateList = $Templates.Split(',') | ForEach-Object { $_.Trim() }
 
 $matrix = @{
     include = @()
 }
 
-foreach ($dotnet in $dotnetVersions) {
-    foreach ($template in $templates) {
+foreach ($dotnet in $versions) {
+    foreach ($template in $templateList) {
         # Android
         $matrix.include += @{
             description = 'android'

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -417,8 +417,21 @@ jobs:
                 -p:CodesignKey="-" `
                 -p:BuildIpa=false `
                 -p:ValidateXcodeVersion=false `
-                -o publish `
                 /bl:build.binlog
+
+              # With BuildIpa=false, the .app stays in bin/ (not copied to -o path).
+              # Find and copy it to publish/ for consistent measurement.
+              $binPath = Join-Path $projectPath "bin/Release/$framework/$rid"
+              Write-Host "Looking for .app in: $binPath"
+              $appBundle = Get-ChildItem -Path $binPath -Filter "*.app" -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
+              if ($appBundle) {
+                New-Item -ItemType Directory -Path "publish" -Force | Out-Null
+                Copy-Item -Path $appBundle.FullName -Destination "publish/" -Recurse
+                Write-Host "Copied $($appBundle.Name) to publish/"
+              } else {
+                Write-Host "Warning: No .app bundle found in $binPath, listing contents:"
+                Get-ChildItem -Path $binPath -Recurse -ErrorAction SilentlyContinue | Select-Object -First 20 | ForEach-Object { Write-Host "  $_" }
+              }
             }
 
             "maccatalyst" {

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -12,10 +12,6 @@ on:
       - '.github/scripts/template-size-tracking/**'
   workflow_dispatch:
     inputs:
-      maui_template_version:
-        description: 'Specific Microsoft.Maui.Templates version (leave empty for latest)'
-        required: false
-        type: string
       dotnet_versions:
         description: 'Comma-separated .NET versions to test (e.g., 9.0,10.0)'
         required: false
@@ -45,192 +41,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      maui-version: ${{ steps.install-templates.outputs.maui-version }}
-      maui-versions: ${{ steps.install-templates.outputs.maui-versions }}
+      maui-version: ${{ steps.detect-version.outputs.maui-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0.x'
-
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Install MAUI Templates
-        id: install-templates
+      - name: Detect MAUI Version
+        id: detect-version
         shell: pwsh
         run: |
-          $dotnetVersions = "${{ inputs.dotnet_versions || '9.0,10.0' }}".Split(',') | ForEach-Object { $_.Trim() }
-          $versions = @{}
-
-          foreach ($dotnet in $dotnetVersions) {
-            $major = $dotnet.Split('.')[0]
-            $packageId = "Microsoft.Maui.Templates.net$major"
-
-            if ("${{ inputs.maui_template_version }}" -ne "") {
-              $version = "${{ inputs.maui_template_version }}"
-            }
-            else {
-              Write-Host "Fetching latest $packageId version..."
-              $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$($packageId.ToLower())/index.json"
-              # Filter to stable versions only (no prerelease dashes)
-              $stableVersions = $response.versions | Where-Object { $_ -notmatch '-' }
-              if ($stableVersions.Count -gt 0) {
-                $version = $stableVersions[-1]
-              } else {
-                $version = $response.versions[-1]
-              }
-            }
-
-            Write-Host "Installing $packageId version $version"
-            dotnet new install "${packageId}::${version}" --nuget-source https://api.nuget.org/v3/index.json
-            $versions[$dotnet] = $version
-          }
-
-          # Output the versions as JSON
-          $versionsJson = $versions | ConvertTo-Json -Compress
-          echo "maui-versions=$versionsJson" >> $env:GITHUB_OUTPUT
-
-          # Also output a simple version for display (use the first one)
-          $firstVersion = $versions.Values | Select-Object -First 1
-          echo "maui-version=$firstVersion" >> $env:GITHUB_OUTPUT
-
-          # Verify installation
-          dotnet new list maui
+          $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/microsoft.maui.templates.net10/index.json" -ErrorAction Stop
+          $stable = $response.versions | Where-Object { $_ -notmatch '-' }
+          $version = if ($stable.Count -gt 0) { $stable[-1] } else { $response.versions[-1] }
+          Write-Host "MAUI Templates version: $version"
+          echo "maui-version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Prepare Build Matrix
         id: set-matrix
         shell: pwsh
         run: |
-          $dotnetVersions = "${{ inputs.dotnet_versions || '9.0,10.0' }}".Split(',') | ForEach-Object { $_.Trim() }
-          $templates = "${{ inputs.templates || 'maui,maui-blazor' }}".Split(',') | ForEach-Object { $_.Trim() }
-
-          $matrix = @{
-            include = @()
-          }
-
-          foreach ($dotnet in $dotnetVersions) {
-            foreach ($template in $templates) {
-              # Android
-              $matrix.include += @{
-                description = 'android'
-                dotnet = $dotnet
-                template = $template
-                platform = 'android'
-                os = 'ubuntu-latest'
-                framework = "net$dotnet-android"
-                rid = 'android-arm64'
-                aot = $false
-              }
-
-              # Android Native AOT (.NET 10+ only)
-              if ($dotnet -ne "9.0") {
-                $matrix.include += @{
-                  description = 'android-aot'
-                  dotnet = $dotnet
-                  template = $template
-                  platform = 'android'
-                  os = 'ubuntu-latest'
-                  framework = "net$dotnet-android"
-                  rid = 'android-arm64'
-                  aot = $true
-                }
-              }
-
-              # iOS
-              $matrix.include += @{
-                description = 'ios'
-                dotnet = $dotnet
-                template = $template
-                platform = 'ios'
-                os = 'macos-latest'
-                framework = "net$dotnet-ios"
-                rid = 'ios-arm64'
-                aot = $false
-              }
-
-              # MacCatalyst
-              $matrix.include += @{
-                description = 'maccatalyst'
-                dotnet = $dotnet
-                template = $template
-                platform = 'maccatalyst'
-                os = 'macos-latest'
-                framework = "net$dotnet-maccatalyst"
-                rid = 'maccatalyst-arm64'
-                aot = $false
-              }
-
-              # MacCatalyst Native AOT
-              $matrix.include += @{
-                description = 'maccatalyst-aot'
-                dotnet = $dotnet
-                template = $template
-                platform = 'maccatalyst'
-                os = 'macos-latest'
-                framework = "net$dotnet-maccatalyst"
-                rid = 'maccatalyst-arm64'
-                aot = $true
-              }
-
-              # Windows Packaged (MSIX)
-              $matrix.include += @{
-                description = 'windows-packaged'
-                dotnet = $dotnet
-                template = $template
-                platform = 'windows-packaged'
-                os = 'windows-latest'
-                framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win-x64'
-                aot = $false
-              }
-
-              # Windows Packaged (MSIX) Native AOT
-              $matrix.include += @{
-                description = 'windows-packaged-aot'
-                dotnet = $dotnet
-                template = $template
-                platform = 'windows-packaged'
-                os = 'windows-latest'
-                framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win-x64'
-                aot = $true
-              }
-
-              # Windows Unpackaged
-              $matrix.include += @{
-                description = 'windows-unpackaged'
-                dotnet = $dotnet
-                template = $template
-                platform = 'windows-unpackaged'
-                os = 'windows-latest'
-                framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win-x64'
-                aot = $false
-              }
-
-              # Windows Unpackaged Native AOT
-              $matrix.include += @{
-                description = 'windows-unpackaged-aot'
-                dotnet = $dotnet
-                template = $template
-                platform = 'windows-unpackaged'
-                os = 'windows-latest'
-                framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win-x64'
-                aot = $true
-              }
-            }
-          }
-
-          $matrixJson = $matrix | ConvertTo-Json -Compress -Depth 10
-          echo "matrix=$matrixJson" >> $env:GITHUB_OUTPUT
-          Write-Host "Matrix: $matrixJson"
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/prepare-matrix.ps1" `
+            -DotNetVersions "${{ inputs.dotnet_versions || '9.0,10.0' }}" `
+            -Templates "${{ inputs.templates || 'maui,maui-blazor' }}"
 
   build-and-measure:
     needs: prepare-matrix
@@ -248,11 +80,10 @@ jobs:
         with:
           dotnet-version: '${{ matrix.dotnet }}.x'
 
-      - name: Setup Xcode (for iOS/MacCatalyst)
-        if: matrix.platform == 'ios' || matrix.platform == 'maccatalyst'
+      - name: Setup Xcode
+        if: runner.os == 'macOS'
         shell: bash
         run: |
-          # Select latest stable Xcode available on the runner
           LATEST_XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
           if [ -n "$LATEST_XCODE" ]; then
             echo "Selecting Xcode: $LATEST_XCODE"
@@ -260,263 +91,39 @@ jobs:
           fi
           xcodebuild -version
 
-      - name: Setup Java (for Android)
+      - name: Setup Java
         if: matrix.platform == 'android'
         uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
 
-      - name: Install MAUI Templates
-        shell: pwsh
-        run: |
-          $dotnet = "${{ matrix.dotnet }}"
-          $major = $dotnet.Split('.')[0]
-          $packageId = "Microsoft.Maui.Templates.net$major"
-          $versionsJson = '${{ needs.prepare-matrix.outputs.maui-versions }}'
-          $versions = $versionsJson | ConvertFrom-Json
+      - name: Install Workloads (Linux)
+        if: runner.os == 'Linux'
+        run: dotnet workload install maui-android
 
-          $version = $versions.$dotnet
-          Write-Host "Installing $packageId version $version"
-          dotnet new install "${packageId}::${version}" --force --nuget-source https://api.nuget.org/v3/index.json
-
-      - name: Install Workloads
-        shell: pwsh
-        run: |
-          # MAUI templates create multi-TFM projects:
-          #   Linux:   android only
-          #   macOS:   android + ios + maccatalyst
-          #   Windows: android + ios + maccatalyst + windows
-          # We need all workloads for the platform's TFM set so restore succeeds.
-          $os = "${{ matrix.os }}"
-
-          if ($os -like "ubuntu*") {
-            dotnet workload install maui-android
-          } elseif ($os -like "macos*") {
-            dotnet workload install maui-android maui-ios maui-maccatalyst
-          } else {
-            dotnet workload install maui
-          }
+      - name: Install Workloads (macOS/Windows)
+        if: runner.os != 'Linux'
+        run: dotnet workload install maui
 
       - name: Create Project
         shell: pwsh
         run: |
-          $template = "${{ matrix.template }}"
-          $dotnetVersion = "${{ matrix.dotnet }}"
-          # Use hyphens (not underscores) in project name — MSIX package identity
-          # only allows [-.A-Za-z0-9] characters
-          $safePlatform = "${{ matrix.description }}"
-          # Short project name to stay within MSIX identity 50-char limit
-          # (com.companyname.$name must be ≤50 chars)
-          $shortTemplate = if ($template -eq 'maui-blazor') { 'blazor' } else { 'maui' }
-          $projectName = "Ma-$shortTemplate-$safePlatform"
-          $framework = "${{ matrix.framework }}"
-
-          # Create project in $HOME to avoid inheriting repo's Directory.Build.props
-          # (which imports Arcade SDK and causes build failures)
-          $buildRoot = Join-Path $HOME "template-builds"
-          New-Item -ItemType Directory -Path $buildRoot -Force | Out-Null
-          $projectDir = Join-Path $buildRoot $projectName
-
-          # Place NuGet.config in the PARENT directory (not project dir) to avoid
-          # macOS build system bundling it into .app packages
-          $nugetConfig = @"
-          <?xml version="1.0" encoding="utf-8"?>
-          <configuration>
-            <packageSources>
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-              <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-            </packageSources>
-          </configuration>
-          "@
-          $nugetConfig | Out-File -FilePath (Join-Path $buildRoot "NuGet.config") -Encoding UTF8
-
-          Write-Host "Creating project: dotnet new $template -o $projectDir --framework net$dotnetVersion"
-          dotnet new $template -o $projectDir --framework net$dotnetVersion
-
-          # Pin SDK version to match the target .NET version.
-          # Runners may have multiple SDKs installed; without pinning, the highest
-          # SDK resolves workload manifests that conflict with older TFMs.
-          $sdkVersion = dotnet --list-sdks | Where-Object { $_ -match "^$dotnetVersion" } | ForEach-Object { ($_ -split ' ')[0] } | Select-Object -Last 1
-          if ($sdkVersion) {
-            Write-Host "Pinning SDK to $sdkVersion via global.json"
-            @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } | ConvertTo-Json | Out-File -FilePath (Join-Path $projectDir "global.json") -Encoding UTF8
-          }
-
-          # Restrict TargetFrameworks to only the platform we're building for.
-          # MAUI templates target all platforms (android, ios, maccatalyst, windows).
-          # Building on Ubuntu for Android would fail trying to resolve iOS workloads.
-          $csproj = Get-ChildItem -Path $projectDir -Filter "*.csproj" -Recurse | Select-Object -First 1
-          if ($csproj) {
-            $content = Get-Content $csproj.FullName -Raw
-            $content = $content -replace '<TargetFrameworks>[^<]+</TargetFrameworks>', "<TargetFrameworks>$framework</TargetFrameworks>"
-            Set-Content -Path $csproj.FullName -Value $content
-            Write-Host "Restricted TargetFrameworks to: $framework"
-          }
-
-          echo "PROJECT_PATH=$projectDir" >> $env:GITHUB_ENV
-          echo "PROJECT_NAME=$projectName" >> $env:GITHUB_ENV
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/create-project.ps1" `
+            -Template "${{ matrix.template }}" `
+            -DotNetVersion "${{ matrix.dotnet }}" `
+            -Description "${{ matrix.description }}" `
+            -Framework "${{ matrix.framework }}"
 
       - name: Build and Publish
         shell: pwsh
         run: |
-          $projectPath = $env:PROJECT_PATH
-          $platform = "${{ matrix.platform }}"
-          $framework = "${{ matrix.framework }}"
-          $rid = "${{ matrix.rid }}"
-          $isAot = "${{ matrix.aot }}" -eq "True"
-
-          $startTime = Get-Date
-
-          # Find the main .csproj
-          $projectFile = Get-ChildItem -Path $projectPath -Filter "*.csproj" -Recurse | Select-Object -First 1
-
-          if (-not $projectFile) {
-            Write-Error "Could not find project file in $projectPath"
-            exit 1
-          }
-
-          Write-Host "Found project: $($projectFile.FullName)"
-
-          switch ($platform) {
-            "android" {
-              if ($isAot) {
-                Write-Host "Building Android AAB with Native AOT..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  -p:PublishAot=true `
-                  -p:AndroidPackageFormat=aab `
-                  -p:AndroidKeyStore=false `
-                  -o publish `
-                  /bl:build.binlog
-              } else {
-                Write-Host "Building Android AAB..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -p:AndroidPackageFormat=aab `
-                  -p:AndroidKeyStore=false `
-                  -o publish `
-                  /bl:build.binlog
-              }
-            }
-
-            "ios" {
-              # iOS publish blocks simulator RIDs and requires device signing.
-              # Use dotnet publish with BuildIpa=false + CodesignKey=- (ad-hoc signing)
-              # to skip IPA creation and avoid needing Apple certificates.
-              Write-Host "Building iOS with ad-hoc signing..."
-              dotnet publish $projectFile.FullName `
-                -f $framework `
-                -c Release `
-                -p:RuntimeIdentifier=$rid `
-                -p:_RequireCodeSigning=false `
-                -p:EnableCodeSigning=false `
-                -p:CodesignKey="-" `
-                -p:BuildIpa=false `
-                -p:ValidateXcodeVersion=false `
-                /bl:build.binlog
-
-              # With BuildIpa=false, the .app stays in bin/ (not copied to -o path).
-              # Find and copy it to publish/ for consistent measurement.
-              $binPath = Join-Path $projectPath "bin/Release/$framework/$rid"
-              Write-Host "Looking for .app in: $binPath"
-              $appBundle = Get-ChildItem -Path $binPath -Filter "*.app" -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
-              if ($appBundle) {
-                New-Item -ItemType Directory -Path "publish" -Force | Out-Null
-                Copy-Item -Path $appBundle.FullName -Destination "publish/" -Recurse
-                Write-Host "Copied $($appBundle.Name) to publish/"
-              } else {
-                Write-Host "Warning: No .app bundle found in $binPath, listing contents:"
-                Get-ChildItem -Path $binPath -Recurse -ErrorAction SilentlyContinue | Select-Object -First 20 | ForEach-Object { Write-Host "  $_" }
-              }
-            }
-
-            "maccatalyst" {
-              if ($isAot) {
-                Write-Host "Building MacCatalyst with Native AOT..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  -p:PublishAot=true `
-                  -p:_RequireCodeSigning=false `
-                  -p:ValidateXcodeVersion=false `
-                  -o publish `
-                  /bl:build.binlog
-              } else {
-                Write-Host "Building MacCatalyst (unsigned)..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -p:RuntimeIdentifier=$rid `
-                  -p:_RequireCodeSigning=false `
-                  -p:ValidateXcodeVersion=false `
-                  -o publish `
-                  /bl:build.binlog
-              }
-            }
-
-            "windows-packaged" {
-              if ($isAot) {
-                Write-Host "Building Windows MSIX with Native AOT..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  -p:PublishAot=true `
-                  -p:WindowsPackageType=MSIX `
-                  -p:GenerateAppxPackageOnBuild=true `
-                  -p:AppxPackageSigningEnabled=false `
-                  -o publish `
-                  /bl:build.binlog
-              } else {
-                Write-Host "Building Windows MSIX..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -p:WindowsPackageType=MSIX `
-                  -p:GenerateAppxPackageOnBuild=true `
-                  -p:AppxPackageSigningEnabled=false `
-                  -o publish `
-                  /bl:build.binlog
-              }
-            }
-
-            "windows-unpackaged" {
-              if ($isAot) {
-                Write-Host "Building Windows unpackaged with Native AOT..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -r $rid `
-                  --self-contained true `
-                  -p:PublishAot=true `
-                  -p:WindowsPackageType=None `
-                  -o publish `
-                  /bl:build.binlog
-              } else {
-                # Framework-dependent publish without explicit RID.
-                # Specifying -r win-x64 forces self-contained which needs
-                # Mono.win-x64 runtime package (not available for .NET 10 GA).
-                Write-Host "Building Windows unpackaged (framework-dependent)..."
-                dotnet publish $projectFile.FullName `
-                  -f $framework `
-                  -c Release `
-                  -p:WindowsPackageType=None `
-                  -o publish `
-                  /bl:build.binlog
-              }
-            }
-          }
-
-          $endTime = Get-Date
-          $buildTime = ($endTime - $startTime).TotalSeconds
-
-          Write-Host "Build completed in $buildTime seconds"
-          echo "BUILD_TIME=$buildTime" >> $env:GITHUB_ENV
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/build-and-publish.ps1" `
+            -ProjectPath $env:PROJECT_PATH `
+            -Platform "${{ matrix.platform }}" `
+            -Framework "${{ matrix.framework }}" `
+            -Rid "${{ matrix.rid }}" `
+            -IsAot "${{ matrix.aot }}"
 
       - name: Upload Build Binlog
         if: always()
@@ -529,13 +136,12 @@ jobs:
       - name: Measure Package Size
         shell: pwsh
         run: |
-          $scriptPath = Join-Path $env:GITHUB_WORKSPACE ".github/scripts/template-size-tracking/measure-package-size.ps1"
-          & $scriptPath `
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/measure-package-size.ps1" `
             -PublishPath "publish" `
             -Platform "${{ matrix.platform }}" `
             -Description "${{ matrix.description }}" `
             -OS "${{ matrix.os }}" `
-            -IsAot ${{ matrix.aot }} `
+            -IsAot "${{ matrix.aot }}" `
             -Template "${{ matrix.template }}" `
             -DotNetVersion "${{ matrix.dotnet }}" `
             -MauiVersion "${{ needs.prepare-matrix.outputs.maui-version }}" `
@@ -547,7 +153,7 @@ jobs:
         with:
           name: metrics-${{ matrix.dotnet }}-${{ matrix.template }}-${{ matrix.description }}
           path: metrics.json
-          retention-days: 90
+          retention-days: 31
 
   analyze-and-report:
     needs: [prepare-matrix, build-and-measure]
@@ -570,6 +176,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: metrics-history
+          # Each run saves with a unique key (GitHub Actions cache is immutable).
+          # Restore uses prefix matching to find the most recent entry.
           key: template-size-metrics-${{ github.run_id }}
           restore-keys: |
             template-size-metrics-
@@ -577,58 +185,15 @@ jobs:
       - name: Prepare Historical Data
         shell: pwsh
         run: |
-          $today = (Get-Date).ToString("yyyy-MM-dd")
-          $historyDir = "metrics-history"
-
-          # Create history directory if it doesn't exist
-          if (-not (Test-Path $historyDir)) {
-            New-Item -ItemType Directory -Force -Path $historyDir | Out-Null
-            Write-Host "Created new metrics history directory"
-          }
-
-          # Copy current metrics into today's history slot
-          $todayDir = Join-Path $historyDir $today
-          New-Item -ItemType Directory -Force -Path $todayDir | Out-Null
-
-          $metricsFiles = Get-ChildItem -Path "metrics" -Filter "*.json" -Recurse
-          foreach ($file in $metricsFiles) {
-            Copy-Item $file.FullName -Destination $todayDir -Force
-          }
-
-          Write-Host "Saved $($metricsFiles.Count) metrics to $todayDir"
-
-          # Find yesterday's metrics for comparison
-          $yesterday = (Get-Date).AddDays(-1).ToString("yyyy-MM-dd")
-          $yesterdayDir = Join-Path $historyDir $yesterday
-
-          if (Test-Path $yesterdayDir) {
-            Write-Host "Found previous metrics from $yesterday"
-            Copy-Item $yesterdayDir -Destination "previous-metrics" -Recurse
-          } else {
-            Write-Host "No previous metrics found for $yesterday"
-            New-Item -ItemType Directory -Force -Path "previous-metrics" | Out-Null
-          }
-
-          # Prune history older than 35 days
-          $cutoffDate = (Get-Date).AddDays(-35).ToString("yyyy-MM-dd")
-          $historyDirs = Get-ChildItem -Path $historyDir -Directory | Sort-Object Name
-
-          foreach ($dir in $historyDirs) {
-            if ($dir.Name -lt $cutoffDate) {
-              Write-Host "Pruning old metrics: $($dir.Name)"
-              Remove-Item $dir.FullName -Recurse -Force
-            }
-          }
-
-          $remaining = (Get-ChildItem -Path $historyDir -Directory).Count
-          Write-Host "History contains $remaining day(s) of metrics"
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/prepare-historical-data.ps1" `
+            -MetricsPath "metrics" `
+            -HistoryDir "metrics-history"
 
       - name: Compare and Generate Report
         id: compare
         shell: pwsh
         run: |
-          $scriptPath = Join-Path $env:GITHUB_WORKSPACE ".github/scripts/template-size-tracking/compare-and-alert.ps1"
-          & $scriptPath `
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/compare-and-alert.ps1" `
             -CurrentMetricsPath "metrics" `
             -PreviousMetricsPath "previous-metrics" `
             -HistoricalMetricsPath "metrics-history" `
@@ -638,8 +203,9 @@ jobs:
       - name: Generate Summary
         shell: pwsh
         run: |
-          $scriptPath = Join-Path $env:GITHUB_WORKSPACE ".github/scripts/template-size-tracking/generate-summary.ps1"
-          & $scriptPath -MetricsPath "metrics" -ComparisonPath "comparison.json"
+          & "${{ github.workspace }}/.github/scripts/template-size-tracking/generate-summary.ps1" `
+            -MetricsPath "metrics" `
+            -ComparisonPath "comparison.json"
 
       - name: Save Historical Metrics Cache
         uses: actions/cache/save@v4

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -392,6 +392,7 @@ jobs:
                 -c Release `
                 -p:RuntimeIdentifier=$rid `
                 -p:_RequireCodeSigning=false `
+                -p:ValidateXcodeVersion=false `
                 -o publish `
                 /bl:build.binlog
             }
@@ -405,6 +406,7 @@ jobs:
                   -r $rid `
                   -p:PublishAot=true `
                   -p:_RequireCodeSigning=false `
+                  -p:ValidateXcodeVersion=false `
                   -o publish `
                   /bl:build.binlog
               } else {
@@ -414,6 +416,7 @@ jobs:
                   -c Release `
                   -p:RuntimeIdentifier=$rid `
                   -p:_RequireCodeSigning=false `
+                  -p:ValidateXcodeVersion=false `
                   -o publish `
                   /bl:build.binlog
               }
@@ -427,6 +430,7 @@ jobs:
                   -c Release `
                   -r $rid `
                   -p:PublishAot=true `
+                  -p:WindowsPackageType=MSIX `
                   -p:GenerateAppxPackageOnBuild=true `
                   -p:AppxPackageSigningEnabled=false `
                   -o publish `
@@ -436,6 +440,7 @@ jobs:
                 dotnet publish $projectFile.FullName `
                   -f $framework `
                   -c Release `
+                  -p:WindowsPackageType=MSIX `
                   -p:GenerateAppxPackageOnBuild=true `
                   -p:AppxPackageSigningEnabled=false `
                   -o publish `

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -309,6 +309,15 @@ jobs:
           Write-Host "Creating project: dotnet new $template -o $projectName --framework net$dotnetVersion"
           dotnet new $template -o $projectName --framework net$dotnetVersion
 
+          # Pin SDK version to match the target .NET version.
+          # Runners may have multiple SDKs installed; without pinning, the highest
+          # SDK resolves workload manifests that conflict with older TFMs.
+          $sdkVersion = dotnet --list-sdks | Where-Object { $_ -match "^$dotnetVersion" } | ForEach-Object { ($_ -split ' ')[0] } | Select-Object -Last 1
+          if ($sdkVersion) {
+            Write-Host "Pinning SDK to $sdkVersion via global.json"
+            @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } | ConvertTo-Json | Out-File -FilePath (Join-Path $projectName "global.json") -Encoding UTF8
+          }
+
           echo "PROJECT_PATH=$projectName" >> $env:GITHUB_ENV
           echo "PROJECT_NAME=$projectName" >> $env:GITHUB_ENV
 

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -278,18 +278,24 @@ jobs:
 
           $version = $versions.$dotnet
           Write-Host "Installing $packageId version $version"
-          dotnet new install "${packageId}::${version}" --nuget-source https://api.nuget.org/v3/index.json
+          dotnet new install "${packageId}::${version}" --force --nuget-source https://api.nuget.org/v3/index.json
 
       - name: Install Workloads
         shell: pwsh
         run: |
-          $platform = "${{ matrix.platform }}"
+          # MAUI templates create multi-TFM projects:
+          #   Linux:   android only
+          #   macOS:   android + ios + maccatalyst
+          #   Windows: android + ios + maccatalyst + windows
+          # We need all workloads for the platform's TFM set so restore succeeds.
+          $os = "${{ matrix.os }}"
 
-          switch ($platform) {
-            "android" { dotnet workload install maui-android }
-            "ios" { dotnet workload install maui-ios }
-            "maccatalyst" { dotnet workload install maui-maccatalyst }
-            { $_ -like "windows*" } { dotnet workload install maui-windows }
+          if ($os -like "ubuntu*") {
+            dotnet workload install maui-android
+          } elseif ($os -like "macos*") {
+            dotnet workload install maui-android maui-ios maui-maccatalyst
+          } else {
+            dotnet workload install maui
           }
 
       - name: Create Project

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -150,7 +150,7 @@ jobs:
                 platform = 'ios'
                 os = 'macos-latest'
                 framework = "net$dotnet-ios"
-                rid = 'ios-arm64'
+                rid = 'iossimulator-arm64'
                 aot = $false
               }
 
@@ -303,8 +303,10 @@ jobs:
         run: |
           $template = "${{ matrix.template }}"
           $dotnetVersion = "${{ matrix.dotnet }}"
-          $safePlatform = "${{ matrix.description }}" -replace '-', '_'
-          $projectName = "MauiApp_$($template -replace '-', '_')_$safePlatform"
+          # Use hyphens (not underscores) in project name — MSIX package identity
+          # only allows [-.A-Za-z0-9] characters
+          $safePlatform = "${{ matrix.description }}"
+          $projectName = "MauiApp-$template-$safePlatform"
           $framework = "${{ matrix.framework }}"
 
           # Create project in $HOME to avoid inheriting repo's Directory.Build.props
@@ -324,6 +326,19 @@ jobs:
             Write-Host "Pinning SDK to $sdkVersion via global.json"
             @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } | ConvertTo-Json | Out-File -FilePath (Join-Path $projectDir "global.json") -Encoding UTF8
           }
+
+          # Add dotnet-public NuGet feed for pre-release runtime packages
+          # (e.g., Microsoft.NETCore.App.Runtime.Mono.win-x64 for .NET 10)
+          $nugetConfig = @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+            </packageSources>
+          </configuration>
+          "@
+          $nugetConfig | Out-File -FilePath (Join-Path $projectDir "NuGet.config") -Encoding UTF8
 
           # Restrict TargetFrameworks to only the platform we're building for.
           # MAUI templates target all platforms (android, ios, maccatalyst, windows).

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -404,29 +404,21 @@ jobs:
             }
 
             "ios" {
-              # iOS publish requires device RID + code signing.
-              # Use dotnet build instead — produces .app in bin/ without signing.
-              Write-Host "Building iOS (unsigned, build-only)..."
-              dotnet build $projectFile.FullName `
+              # iOS publish blocks simulator RIDs and requires device signing.
+              # Use dotnet publish with BuildIpa=false + CodesignKey=- (ad-hoc signing)
+              # to skip IPA creation and avoid needing Apple certificates.
+              Write-Host "Building iOS with ad-hoc signing..."
+              dotnet publish $projectFile.FullName `
                 -f $framework `
                 -c Release `
                 -p:RuntimeIdentifier=$rid `
                 -p:_RequireCodeSigning=false `
+                -p:EnableCodeSigning=false `
+                -p:CodesignKey="-" `
+                -p:BuildIpa=false `
                 -p:ValidateXcodeVersion=false `
+                -o publish `
                 /bl:build.binlog
-
-              # Copy .app bundle to publish/ for consistent measurement
-              $binPath = Join-Path $projectPath "bin/Release/$framework/$rid"
-              $appBundle = Get-ChildItem -Path $binPath -Filter "*.app" -Recurse -Directory | Select-Object -First 1
-              if ($appBundle) {
-                New-Item -ItemType Directory -Path "publish" -Force | Out-Null
-                Copy-Item -Path $appBundle.FullName -Destination "publish/" -Recurse
-                Write-Host "Copied $($appBundle.Name) to publish/"
-              } else {
-                Write-Host "Warning: No .app bundle found in $binPath"
-                # List what's there for debugging
-                Get-ChildItem -Path $binPath -Recurse | Select-Object -First 20
-              }
             }
 
             "maccatalyst" {
@@ -493,13 +485,13 @@ jobs:
                   -o publish `
                   /bl:build.binlog
               } else {
-                # Framework-dependent publish (Mono.win-x64 runtime may not be
-                # available on public NuGet for preview .NET versions)
+                # Framework-dependent publish without explicit RID.
+                # Specifying -r win-x64 forces self-contained which needs
+                # Mono.win-x64 runtime package (not available for .NET 10 GA).
                 Write-Host "Building Windows unpackaged (framework-dependent)..."
                 dotnet publish $projectFile.FullName `
                   -f $framework `
                   -c Release `
-                  -r $rid `
                   -p:WindowsPackageType=None `
                   -o publish `
                   /bl:build.binlog

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -229,9 +229,15 @@ jobs:
 
       - name: Setup Xcode (for iOS/MacCatalyst)
         if: matrix.platform == 'ios' || matrix.platform == 'maccatalyst'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+        shell: bash
+        run: |
+          # Select latest stable Xcode available on the runner
+          LATEST_XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$LATEST_XCODE" ]; then
+            echo "Selecting Xcode: $LATEST_XCODE"
+            sudo xcode-select -s "$LATEST_XCODE/Contents/Developer"
+          fi
+          xcodebuild -version
 
       - name: Setup Java (for Android)
         if: matrix.platform == 'android'

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -18,9 +18,9 @@ on:
         default: '9.0,10.0'
         type: string
       templates:
-        description: 'Comma-separated templates to test (maui,maui-blazor)'
+        description: 'Comma-separated templates to test (maui,maui-blazor,maui-sample)'
         required: false
-        default: 'maui,maui-blazor'
+        default: 'maui,maui-blazor,maui-sample'
         type: string
       alert_threshold:
         description: 'Alert threshold percentage for size increases'
@@ -62,7 +62,7 @@ jobs:
         run: |
           & "${{ github.workspace }}/.github/scripts/template-size-tracking/prepare-matrix.ps1" `
             -DotNetVersions "${{ inputs.dotnet_versions || '9.0,10.0' }}" `
-            -Templates "${{ inputs.templates || 'maui,maui-blazor' }}"
+            -Templates "${{ inputs.templates || 'maui,maui-blazor,maui-sample' }}"
 
   build-and-measure:
     needs: prepare-matrix

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -186,7 +186,7 @@ jobs:
                 platform = 'windows-packaged'
                 os = 'windows-latest'
                 framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win10-x64'
+                rid = 'win-x64'
                 aot = $false
               }
 
@@ -198,7 +198,7 @@ jobs:
                 platform = 'windows-packaged'
                 os = 'windows-latest'
                 framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win10-x64'
+                rid = 'win-x64'
                 aot = $true
               }
 
@@ -210,7 +210,7 @@ jobs:
                 platform = 'windows-unpackaged'
                 os = 'windows-latest'
                 framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win10-x64'
+                rid = 'win-x64'
                 aot = $false
               }
 
@@ -222,7 +222,7 @@ jobs:
                 platform = 'windows-unpackaged'
                 os = 'windows-latest'
                 framework = "net$dotnet-windows10.0.19041.0"
-                rid = 'win10-x64'
+                rid = 'win-x64'
                 aot = $true
               }
             }

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -150,7 +150,7 @@ jobs:
                 platform = 'ios'
                 os = 'macos-latest'
                 framework = "net$dotnet-ios"
-                rid = 'iossimulator-arm64'
+                rid = 'ios-arm64'
                 aot = $false
               }
 
@@ -306,7 +306,10 @@ jobs:
           # Use hyphens (not underscores) in project name — MSIX package identity
           # only allows [-.A-Za-z0-9] characters
           $safePlatform = "${{ matrix.description }}"
-          $projectName = "MauiApp-$template-$safePlatform"
+          # Short project name to stay within MSIX identity 50-char limit
+          # (com.companyname.$name must be ≤50 chars)
+          $shortTemplate = if ($template -eq 'maui-blazor') { 'blazor' } else { 'maui' }
+          $projectName = "Ma-$shortTemplate-$safePlatform"
           $framework = "${{ matrix.framework }}"
 
           # Create project in $HOME to avoid inheriting repo's Directory.Build.props
@@ -314,6 +317,19 @@ jobs:
           $buildRoot = Join-Path $HOME "template-builds"
           New-Item -ItemType Directory -Path $buildRoot -Force | Out-Null
           $projectDir = Join-Path $buildRoot $projectName
+
+          # Place NuGet.config in the PARENT directory (not project dir) to avoid
+          # macOS build system bundling it into .app packages
+          $nugetConfig = @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+            </packageSources>
+          </configuration>
+          "@
+          $nugetConfig | Out-File -FilePath (Join-Path $buildRoot "NuGet.config") -Encoding UTF8
 
           Write-Host "Creating project: dotnet new $template -o $projectDir --framework net$dotnetVersion"
           dotnet new $template -o $projectDir --framework net$dotnetVersion
@@ -326,19 +342,6 @@ jobs:
             Write-Host "Pinning SDK to $sdkVersion via global.json"
             @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } | ConvertTo-Json | Out-File -FilePath (Join-Path $projectDir "global.json") -Encoding UTF8
           }
-
-          # Add dotnet-public NuGet feed for pre-release runtime packages
-          # (e.g., Microsoft.NETCore.App.Runtime.Mono.win-x64 for .NET 10)
-          $nugetConfig = @"
-          <?xml version="1.0" encoding="utf-8"?>
-          <configuration>
-            <packageSources>
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-              <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-            </packageSources>
-          </configuration>
-          "@
-          $nugetConfig | Out-File -FilePath (Join-Path $projectDir "NuGet.config") -Encoding UTF8
 
           # Restrict TargetFrameworks to only the platform we're building for.
           # MAUI templates target all platforms (android, ios, maccatalyst, windows).
@@ -401,15 +404,29 @@ jobs:
             }
 
             "ios" {
-              Write-Host "Building iOS (unsigned)..."
-              dotnet publish $projectFile.FullName `
+              # iOS publish requires device RID + code signing.
+              # Use dotnet build instead — produces .app in bin/ without signing.
+              Write-Host "Building iOS (unsigned, build-only)..."
+              dotnet build $projectFile.FullName `
                 -f $framework `
                 -c Release `
                 -p:RuntimeIdentifier=$rid `
                 -p:_RequireCodeSigning=false `
                 -p:ValidateXcodeVersion=false `
-                -o publish `
                 /bl:build.binlog
+
+              # Copy .app bundle to publish/ for consistent measurement
+              $binPath = Join-Path $projectPath "bin/Release/$framework/$rid"
+              $appBundle = Get-ChildItem -Path $binPath -Filter "*.app" -Recurse -Directory | Select-Object -First 1
+              if ($appBundle) {
+                New-Item -ItemType Directory -Path "publish" -Force | Out-Null
+                Copy-Item -Path $appBundle.FullName -Destination "publish/" -Recurse
+                Write-Host "Copied $($appBundle.Name) to publish/"
+              } else {
+                Write-Host "Warning: No .app bundle found in $binPath"
+                # List what's there for debugging
+                Get-ChildItem -Path $binPath -Recurse | Select-Object -First 20
+              }
             }
 
             "maccatalyst" {
@@ -476,12 +493,13 @@ jobs:
                   -o publish `
                   /bl:build.binlog
               } else {
-                Write-Host "Building Windows unpackaged (self-contained)..."
+                # Framework-dependent publish (Mono.win-x64 runtime may not be
+                # available on public NuGet for preview .NET versions)
+                Write-Host "Building Windows unpackaged (framework-dependent)..."
                 dotnet publish $projectFile.FullName `
                   -f $framework `
                   -c Release `
                   -r $rid `
-                  --self-contained true `
                   -p:WindowsPackageType=None `
                   -o publish `
                   /bl:build.binlog

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -46,6 +46,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       maui-version: ${{ steps.install-templates.outputs.maui-version }}
+      maui-versions: ${{ steps.install-templates.outputs.maui-versions }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,20 +65,40 @@ jobs:
         id: install-templates
         shell: pwsh
         run: |
-          if ("${{ inputs.maui_template_version }}" -ne "") {
-            $version = "${{ inputs.maui_template_version }}"
-            Write-Host "Installing Microsoft.Maui.Templates version $version"
-            dotnet new install Microsoft.Maui.Templates::$version
-            echo "maui-version=$version" >> $env:GITHUB_OUTPUT
+          $dotnetVersions = "${{ inputs.dotnet_versions || '9.0,10.0' }}".Split(',') | ForEach-Object { $_.Trim() }
+          $versions = @{}
+
+          foreach ($dotnet in $dotnetVersions) {
+            $major = $dotnet.Split('.')[0]
+            $packageId = "Microsoft.Maui.Templates.net$major"
+
+            if ("${{ inputs.maui_template_version }}" -ne "") {
+              $version = "${{ inputs.maui_template_version }}"
+            }
+            else {
+              Write-Host "Fetching latest $packageId version..."
+              $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$($packageId.ToLower())/index.json"
+              # Filter to stable versions only (no prerelease dashes)
+              $stableVersions = $response.versions | Where-Object { $_ -notmatch '-' }
+              if ($stableVersions.Count -gt 0) {
+                $version = $stableVersions[-1]
+              } else {
+                $version = $response.versions[-1]
+              }
+            }
+
+            Write-Host "Installing $packageId version $version"
+            dotnet new install "${packageId}::${version}" --nuget-source https://api.nuget.org/v3/index.json
+            $versions[$dotnet] = $version
           }
-          else {
-            Write-Host "Fetching latest Microsoft.Maui.Templates version..."
-            $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/microsoft.maui.templates/index.json"
-            $latestVersion = $response.versions[-1]
-            Write-Host "Latest version found: $latestVersion"
-            dotnet new install Microsoft.Maui.Templates::$latestVersion
-            echo "maui-version=$latestVersion" >> $env:GITHUB_OUTPUT
-          }
+
+          # Output the versions as JSON
+          $versionsJson = $versions | ConvertTo-Json -Compress
+          echo "maui-versions=$versionsJson" >> $env:GITHUB_OUTPUT
+
+          # Also output a simple version for display (use the first one)
+          $firstVersion = $versions.Values | Select-Object -First 1
+          echo "maui-version=$firstVersion" >> $env:GITHUB_OUTPUT
 
           # Verify installation
           dotnet new list maui
@@ -249,9 +270,15 @@ jobs:
       - name: Install MAUI Templates
         shell: pwsh
         run: |
-          $version = "${{ needs.prepare-matrix.outputs.maui-version }}"
-          Write-Host "Installing Microsoft.Maui.Templates version $version"
-          dotnet new install Microsoft.Maui.Templates::$version
+          $dotnet = "${{ matrix.dotnet }}"
+          $major = $dotnet.Split('.')[0]
+          $packageId = "Microsoft.Maui.Templates.net$major"
+          $versionsJson = '${{ needs.prepare-matrix.outputs.maui-versions }}'
+          $versions = $versionsJson | ConvertFrom-Json
+
+          $version = $versions.$dotnet
+          Write-Host "Installing $packageId version $version"
+          dotnet new install "${packageId}::${version}" --nuget-source https://api.nuget.org/v3/index.json
 
       - name: Install Workloads
         shell: pwsh

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -1,0 +1,561 @@
+name: Daily Template Size Tracking
+
+on:
+  schedule:
+    # Daily at midnight ET (5 AM UTC)
+    - cron: '0 5 * * *'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/daily-template-size-tracking.yml'
+      - '.github/scripts/template-size-tracking/**'
+  workflow_dispatch:
+    inputs:
+      maui_template_version:
+        description: 'Specific Microsoft.Maui.Templates version (leave empty for latest)'
+        required: false
+        type: string
+      dotnet_versions:
+        description: 'Comma-separated .NET versions to test (e.g., 9.0,10.0)'
+        required: false
+        default: '9.0,10.0'
+        type: string
+      templates:
+        description: 'Comma-separated templates to test (maui,maui-blazor)'
+        required: false
+        default: 'maui,maui-blazor'
+        type: string
+      alert_threshold:
+        description: 'Alert threshold percentage for size increases'
+        required: false
+        default: '10'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  ALERT_THRESHOLD: ${{ inputs.alert_threshold || '10' }}
+  FAILURE_THRESHOLD: '20'
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      maui-version: ${{ steps.install-templates.outputs.maui-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install MAUI Templates
+        id: install-templates
+        shell: pwsh
+        run: |
+          if ("${{ inputs.maui_template_version }}" -ne "") {
+            $version = "${{ inputs.maui_template_version }}"
+            Write-Host "Installing Microsoft.Maui.Templates version $version"
+            dotnet new install Microsoft.Maui.Templates::$version
+            echo "maui-version=$version" >> $env:GITHUB_OUTPUT
+          }
+          else {
+            Write-Host "Fetching latest Microsoft.Maui.Templates version..."
+            $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/microsoft.maui.templates/index.json"
+            $latestVersion = $response.versions[-1]
+            Write-Host "Latest version found: $latestVersion"
+            dotnet new install Microsoft.Maui.Templates::$latestVersion
+            echo "maui-version=$latestVersion" >> $env:GITHUB_OUTPUT
+          }
+
+          # Verify installation
+          dotnet new list maui
+
+      - name: Prepare Build Matrix
+        id: set-matrix
+        shell: pwsh
+        run: |
+          $dotnetVersions = "${{ inputs.dotnet_versions || '9.0,10.0' }}".Split(',') | ForEach-Object { $_.Trim() }
+          $templates = "${{ inputs.templates || 'maui,maui-blazor' }}".Split(',') | ForEach-Object { $_.Trim() }
+
+          $matrix = @{
+            include = @()
+          }
+
+          foreach ($dotnet in $dotnetVersions) {
+            foreach ($template in $templates) {
+              # Android
+              $matrix.include += @{
+                description = 'android'
+                dotnet = $dotnet
+                template = $template
+                platform = 'android'
+                os = 'ubuntu-latest'
+                framework = "net$dotnet-android"
+                rid = 'android-arm64'
+                aot = $false
+              }
+
+              # Android Native AOT (.NET 10+ only)
+              if ($dotnet -ne "9.0") {
+                $matrix.include += @{
+                  description = 'android-aot'
+                  dotnet = $dotnet
+                  template = $template
+                  platform = 'android'
+                  os = 'ubuntu-latest'
+                  framework = "net$dotnet-android"
+                  rid = 'android-arm64'
+                  aot = $true
+                }
+              }
+
+              # iOS
+              $matrix.include += @{
+                description = 'ios'
+                dotnet = $dotnet
+                template = $template
+                platform = 'ios'
+                os = 'macos-latest'
+                framework = "net$dotnet-ios"
+                rid = 'ios-arm64'
+                aot = $false
+              }
+
+              # MacCatalyst
+              $matrix.include += @{
+                description = 'maccatalyst'
+                dotnet = $dotnet
+                template = $template
+                platform = 'maccatalyst'
+                os = 'macos-latest'
+                framework = "net$dotnet-maccatalyst"
+                rid = 'maccatalyst-arm64'
+                aot = $false
+              }
+
+              # MacCatalyst Native AOT
+              $matrix.include += @{
+                description = 'maccatalyst-aot'
+                dotnet = $dotnet
+                template = $template
+                platform = 'maccatalyst'
+                os = 'macos-latest'
+                framework = "net$dotnet-maccatalyst"
+                rid = 'maccatalyst-arm64'
+                aot = $true
+              }
+
+              # Windows Packaged (MSIX)
+              $matrix.include += @{
+                description = 'windows-packaged'
+                dotnet = $dotnet
+                template = $template
+                platform = 'windows-packaged'
+                os = 'windows-latest'
+                framework = "net$dotnet-windows10.0.19041.0"
+                rid = 'win10-x64'
+                aot = $false
+              }
+
+              # Windows Packaged (MSIX) Native AOT
+              $matrix.include += @{
+                description = 'windows-packaged-aot'
+                dotnet = $dotnet
+                template = $template
+                platform = 'windows-packaged'
+                os = 'windows-latest'
+                framework = "net$dotnet-windows10.0.19041.0"
+                rid = 'win10-x64'
+                aot = $true
+              }
+
+              # Windows Unpackaged
+              $matrix.include += @{
+                description = 'windows-unpackaged'
+                dotnet = $dotnet
+                template = $template
+                platform = 'windows-unpackaged'
+                os = 'windows-latest'
+                framework = "net$dotnet-windows10.0.19041.0"
+                rid = 'win10-x64'
+                aot = $false
+              }
+
+              # Windows Unpackaged Native AOT
+              $matrix.include += @{
+                description = 'windows-unpackaged-aot'
+                dotnet = $dotnet
+                template = $template
+                platform = 'windows-unpackaged'
+                os = 'windows-latest'
+                framework = "net$dotnet-windows10.0.19041.0"
+                rid = 'win10-x64'
+                aot = $true
+              }
+            }
+          }
+
+          $matrixJson = $matrix | ConvertTo-Json -Compress -Depth 10
+          echo "matrix=$matrixJson" >> $env:GITHUB_OUTPUT
+          Write-Host "Matrix: $matrixJson"
+
+  build-and-measure:
+    needs: prepare-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET ${{ matrix.dotnet }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '${{ matrix.dotnet }}.x'
+
+      - name: Setup Xcode (for iOS/MacCatalyst)
+        if: matrix.platform == 'ios' || matrix.platform == 'maccatalyst'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Setup Java (for Android)
+        if: matrix.platform == 'android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
+
+      - name: Install MAUI Templates
+        shell: pwsh
+        run: |
+          $version = "${{ needs.prepare-matrix.outputs.maui-version }}"
+          Write-Host "Installing Microsoft.Maui.Templates version $version"
+          dotnet new install Microsoft.Maui.Templates::$version
+
+      - name: Install Workloads
+        shell: pwsh
+        run: |
+          $platform = "${{ matrix.platform }}"
+
+          switch ($platform) {
+            "android" { dotnet workload install maui-android }
+            "ios" { dotnet workload install maui-ios }
+            "maccatalyst" { dotnet workload install maui-maccatalyst }
+            { $_ -like "windows*" } { dotnet workload install maui-windows }
+          }
+
+      - name: Create Project
+        shell: pwsh
+        run: |
+          $template = "${{ matrix.template }}"
+          $dotnetVersion = "${{ matrix.dotnet }}"
+          $safePlatform = "${{ matrix.description }}" -replace '-', '_'
+          $projectName = "MauiApp_$($template -replace '-', '_')_$safePlatform"
+
+          Write-Host "Creating project: dotnet new $template -o $projectName --framework net$dotnetVersion"
+          dotnet new $template -o $projectName --framework net$dotnetVersion
+
+          echo "PROJECT_PATH=$projectName" >> $env:GITHUB_ENV
+          echo "PROJECT_NAME=$projectName" >> $env:GITHUB_ENV
+
+      - name: Build and Publish
+        shell: pwsh
+        run: |
+          $projectPath = $env:PROJECT_PATH
+          $platform = "${{ matrix.platform }}"
+          $framework = "${{ matrix.framework }}"
+          $rid = "${{ matrix.rid }}"
+          $isAot = "${{ matrix.aot }}" -eq "True"
+
+          $startTime = Get-Date
+
+          # Find the main .csproj
+          $projectFile = Get-ChildItem -Path $projectPath -Filter "*.csproj" -Recurse | Select-Object -First 1
+
+          if (-not $projectFile) {
+            Write-Error "Could not find project file in $projectPath"
+            exit 1
+          }
+
+          Write-Host "Found project: $($projectFile.FullName)"
+
+          switch ($platform) {
+            "android" {
+              if ($isAot) {
+                Write-Host "Building Android AAB with Native AOT..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -r $rid `
+                  -p:PublishAot=true `
+                  -p:AndroidPackageFormat=aab `
+                  -p:AndroidKeyStore=false `
+                  -o publish `
+                  /bl:build.binlog
+              } else {
+                Write-Host "Building Android AAB..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -p:AndroidPackageFormat=aab `
+                  -p:AndroidKeyStore=false `
+                  -o publish `
+                  /bl:build.binlog
+              }
+            }
+
+            "ios" {
+              Write-Host "Building iOS (unsigned)..."
+              dotnet publish $projectFile.FullName `
+                -f $framework `
+                -c Release `
+                -p:RuntimeIdentifier=$rid `
+                -p:_RequireCodeSigning=false `
+                -o publish `
+                /bl:build.binlog
+            }
+
+            "maccatalyst" {
+              if ($isAot) {
+                Write-Host "Building MacCatalyst with Native AOT..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -r $rid `
+                  -p:PublishAot=true `
+                  -p:_RequireCodeSigning=false `
+                  -o publish `
+                  /bl:build.binlog
+              } else {
+                Write-Host "Building MacCatalyst (unsigned)..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -p:RuntimeIdentifier=$rid `
+                  -p:_RequireCodeSigning=false `
+                  -o publish `
+                  /bl:build.binlog
+              }
+            }
+
+            "windows-packaged" {
+              if ($isAot) {
+                Write-Host "Building Windows MSIX with Native AOT..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -r $rid `
+                  -p:PublishAot=true `
+                  -p:GenerateAppxPackageOnBuild=true `
+                  -p:AppxPackageSigningEnabled=false `
+                  -o publish `
+                  /bl:build.binlog
+              } else {
+                Write-Host "Building Windows MSIX..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -p:GenerateAppxPackageOnBuild=true `
+                  -p:AppxPackageSigningEnabled=false `
+                  -o publish `
+                  /bl:build.binlog
+              }
+            }
+
+            "windows-unpackaged" {
+              if ($isAot) {
+                Write-Host "Building Windows unpackaged with Native AOT..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -r $rid `
+                  --self-contained true `
+                  -p:PublishAot=true `
+                  -p:WindowsPackageType=None `
+                  -o publish `
+                  /bl:build.binlog
+              } else {
+                Write-Host "Building Windows unpackaged (self-contained)..."
+                dotnet publish $projectFile.FullName `
+                  -f $framework `
+                  -c Release `
+                  -r $rid `
+                  --self-contained true `
+                  -p:WindowsPackageType=None `
+                  -o publish `
+                  /bl:build.binlog
+              }
+            }
+          }
+
+          $endTime = Get-Date
+          $buildTime = ($endTime - $startTime).TotalSeconds
+
+          Write-Host "Build completed in $buildTime seconds"
+          echo "BUILD_TIME=$buildTime" >> $env:GITHUB_ENV
+
+      - name: Upload Build Binlog
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: binlog-${{ matrix.dotnet }}-${{ matrix.template }}-${{ matrix.description }}
+          path: build.binlog
+          retention-days: 14
+
+      - name: Measure Package Size
+        shell: pwsh
+        run: |
+          $scriptPath = Join-Path $env:GITHUB_WORKSPACE ".github/scripts/template-size-tracking/measure-package-size.ps1"
+          & $scriptPath `
+            -PublishPath "publish" `
+            -Platform "${{ matrix.platform }}" `
+            -Description "${{ matrix.description }}" `
+            -OS "${{ matrix.os }}" `
+            -IsAot ${{ matrix.aot }} `
+            -Template "${{ matrix.template }}" `
+            -DotNetVersion "${{ matrix.dotnet }}" `
+            -MauiVersion "${{ needs.prepare-matrix.outputs.maui-version }}" `
+            -BuildTime $env:BUILD_TIME `
+            -OutputPath "metrics.json"
+
+      - name: Upload Metrics
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-${{ matrix.dotnet }}-${{ matrix.template }}-${{ matrix.description }}
+          path: metrics.json
+          retention-days: 90
+
+  analyze-and-report:
+    needs: [prepare-matrix, build-and-measure]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download All Metrics
+        uses: actions/download-artifact@v4
+        with:
+          pattern: metrics-*
+          path: metrics
+
+      - name: Restore Historical Metrics Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: metrics-history
+          key: template-size-metrics-${{ github.run_id }}
+          restore-keys: |
+            template-size-metrics-
+
+      - name: Prepare Historical Data
+        shell: pwsh
+        run: |
+          $today = (Get-Date).ToString("yyyy-MM-dd")
+          $historyDir = "metrics-history"
+
+          # Create history directory if it doesn't exist
+          if (-not (Test-Path $historyDir)) {
+            New-Item -ItemType Directory -Force -Path $historyDir | Out-Null
+            Write-Host "Created new metrics history directory"
+          }
+
+          # Copy current metrics into today's history slot
+          $todayDir = Join-Path $historyDir $today
+          New-Item -ItemType Directory -Force -Path $todayDir | Out-Null
+
+          $metricsFiles = Get-ChildItem -Path "metrics" -Filter "*.json" -Recurse
+          foreach ($file in $metricsFiles) {
+            Copy-Item $file.FullName -Destination $todayDir -Force
+          }
+
+          Write-Host "Saved $($metricsFiles.Count) metrics to $todayDir"
+
+          # Find yesterday's metrics for comparison
+          $yesterday = (Get-Date).AddDays(-1).ToString("yyyy-MM-dd")
+          $yesterdayDir = Join-Path $historyDir $yesterday
+
+          if (Test-Path $yesterdayDir) {
+            Write-Host "Found previous metrics from $yesterday"
+            Copy-Item $yesterdayDir -Destination "previous-metrics" -Recurse
+          } else {
+            Write-Host "No previous metrics found for $yesterday"
+            New-Item -ItemType Directory -Force -Path "previous-metrics" | Out-Null
+          }
+
+          # Prune history older than 35 days
+          $cutoffDate = (Get-Date).AddDays(-35).ToString("yyyy-MM-dd")
+          $historyDirs = Get-ChildItem -Path $historyDir -Directory | Sort-Object Name
+
+          foreach ($dir in $historyDirs) {
+            if ($dir.Name -lt $cutoffDate) {
+              Write-Host "Pruning old metrics: $($dir.Name)"
+              Remove-Item $dir.FullName -Recurse -Force
+            }
+          }
+
+          $remaining = (Get-ChildItem -Path $historyDir -Directory).Count
+          Write-Host "History contains $remaining day(s) of metrics"
+
+      - name: Compare and Generate Report
+        id: compare
+        shell: pwsh
+        run: |
+          $scriptPath = Join-Path $env:GITHUB_WORKSPACE ".github/scripts/template-size-tracking/compare-and-alert.ps1"
+          & $scriptPath `
+            -CurrentMetricsPath "metrics" `
+            -PreviousMetricsPath "previous-metrics" `
+            -HistoricalMetricsPath "metrics-history" `
+            -AlertThreshold $env:ALERT_THRESHOLD `
+            -FailureThreshold $env:FAILURE_THRESHOLD
+
+      - name: Generate Summary
+        shell: pwsh
+        run: |
+          $scriptPath = Join-Path $env:GITHUB_WORKSPACE ".github/scripts/template-size-tracking/generate-summary.ps1"
+          & $scriptPath -MetricsPath "metrics" -ComparisonPath "comparison.json"
+
+      - name: Save Historical Metrics Cache
+        uses: actions/cache/save@v4
+        with:
+          path: metrics-history
+          key: template-size-metrics-${{ github.run_id }}
+
+      - name: Create Issue on Alert
+        if: steps.compare.outputs.alert == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const alertContent = fs.readFileSync('alert-report.md', 'utf8');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `⚠️ Template Size Alert - ${new Date().toISOString().split('T')[0]}`,
+              body: alertContent,
+              labels: ['size-alert', 'automated']
+            });
+
+      - name: Fail on Critical Size Increase
+        if: steps.compare.outputs.critical == 'true'
+        run: |
+          echo "::error::Critical size increase detected (>${{ env.FAILURE_THRESHOLD }}%)"
+          exit 1

--- a/.github/workflows/daily-template-size-tracking.yml
+++ b/.github/workflows/daily-template-size-tracking.yml
@@ -305,9 +305,16 @@ jobs:
           $dotnetVersion = "${{ matrix.dotnet }}"
           $safePlatform = "${{ matrix.description }}" -replace '-', '_'
           $projectName = "MauiApp_$($template -replace '-', '_')_$safePlatform"
+          $framework = "${{ matrix.framework }}"
 
-          Write-Host "Creating project: dotnet new $template -o $projectName --framework net$dotnetVersion"
-          dotnet new $template -o $projectName --framework net$dotnetVersion
+          # Create project in $HOME to avoid inheriting repo's Directory.Build.props
+          # (which imports Arcade SDK and causes build failures)
+          $buildRoot = Join-Path $HOME "template-builds"
+          New-Item -ItemType Directory -Path $buildRoot -Force | Out-Null
+          $projectDir = Join-Path $buildRoot $projectName
+
+          Write-Host "Creating project: dotnet new $template -o $projectDir --framework net$dotnetVersion"
+          dotnet new $template -o $projectDir --framework net$dotnetVersion
 
           # Pin SDK version to match the target .NET version.
           # Runners may have multiple SDKs installed; without pinning, the highest
@@ -315,10 +322,21 @@ jobs:
           $sdkVersion = dotnet --list-sdks | Where-Object { $_ -match "^$dotnetVersion" } | ForEach-Object { ($_ -split ' ')[0] } | Select-Object -Last 1
           if ($sdkVersion) {
             Write-Host "Pinning SDK to $sdkVersion via global.json"
-            @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } | ConvertTo-Json | Out-File -FilePath (Join-Path $projectName "global.json") -Encoding UTF8
+            @{ sdk = @{ version = $sdkVersion; rollForward = "latestPatch" } } | ConvertTo-Json | Out-File -FilePath (Join-Path $projectDir "global.json") -Encoding UTF8
           }
 
-          echo "PROJECT_PATH=$projectName" >> $env:GITHUB_ENV
+          # Restrict TargetFrameworks to only the platform we're building for.
+          # MAUI templates target all platforms (android, ios, maccatalyst, windows).
+          # Building on Ubuntu for Android would fail trying to resolve iOS workloads.
+          $csproj = Get-ChildItem -Path $projectDir -Filter "*.csproj" -Recurse | Select-Object -First 1
+          if ($csproj) {
+            $content = Get-Content $csproj.FullName -Raw
+            $content = $content -replace '<TargetFrameworks>[^<]+</TargetFrameworks>', "<TargetFrameworks>$framework</TargetFrameworks>"
+            Set-Content -Path $csproj.FullName -Value $content
+            Write-Host "Restricted TargetFrameworks to: $framework"
+          }
+
+          echo "PROJECT_PATH=$projectDir" >> $env:GITHUB_ENV
           echo "PROJECT_NAME=$projectName" >> $env:GITHUB_ENV
 
       - name: Build and Publish


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds a GitHub Actions workflow that tracks .NET MAUI template package sizes daily across all platforms. This is adapted from the [Uno Platform performance workflow](https://github.com/unoplatform/performance/blob/master/.github/workflows/daily-template-size-tracking.yml) but tailored for .NET MAUI.

### What it does

1. **Creates apps** from `maui` and `maui-blazor` templates
2. **Publishes** for each platform (Android, iOS, MacCatalyst, Windows packaged/unpackaged) with AOT variants
3. **Measures package sizes** (AAB, .app bundles, MSIX, publish folders)
4. **Compares against historical data** (1, 2, 3, 4, 5, 7, 30 days ago)
5. **Alerts** via GitHub Issues when size increases exceed thresholds (10% warning, 20% critical)
6. **Generates summary reports** in GitHub Actions workflow summary

### Architecture

```
prepare-matrix → build-and-measure (parallel matrix) → analyze-and-report
```

### Platform Matrix

| Platform | Output | AOT Variant |
|----------|--------|-------------|
| Android | `.aab` | ✅ (.NET 10+) |
| iOS | `.app` (unsigned) | — |
| MacCatalyst | `.app` (unsigned) | ✅ |
| Windows Packaged | `.msix` (unsigned) | ✅ |
| Windows Unpackaged | publish folder | ✅ |

### Key Design Decisions

- **No secrets required**: iOS/MacCatalyst use `_RequireCodeSigning=false`, Windows uses `AppxPackageSigningEnabled=false`
- **GitHub Actions Cache** for historical metrics (no Azure Blob Storage needed)
- **Zero external infrastructure** dependencies
- Templates installed from NuGet (`Microsoft.Maui.Templates`)

### Files Added

- `.github/workflows/daily-template-size-tracking.yml` — Main workflow
- `.github/scripts/template-size-tracking/measure-package-size.ps1` — Size measurement
- `.github/scripts/template-size-tracking/compare-and-alert.ps1` — Comparison & alerting
- `.github/scripts/template-size-tracking/generate-summary.ps1` — Summary report
