### PR TITLE
[iOS] Fix VerticalOffset Update When Modifying CollectionView.ItemsSource While Scrolled

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -29,12 +29,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
-			if (!visibleItems)
-				return;
-
 			var contentInset = scrollView.ContentInset;
-			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
-			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
+			var contentOffsetX = !visibleItems ? 0 : scrollView.ContentOffset.X + contentInset.Left;
+			var contentOffsetY = !visibleItems ? 0 : scrollView.ContentOffset.Y + contentInset.Top;
 
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			PreviousVerticalOffset = (float)contentOffsetY;
 
 			if (!visibleItems)
+			{
 				return;
+			}
 
 			switch (itemsView.RemainingItemsThreshold)
 			{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
 
+			if (!visibleItems)
+				return;
+
 			switch (itemsView.RemainingItemsThreshold)
 			{
 				case -1:

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -30,12 +30,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			var (visibleItems, firstVisibleItemIndex, centerItemIndex, lastVisibleItemIndex) = GetVisibleItemsIndex();
 
-			if (!visibleItems)
-				return;
-
 			var contentInset = scrollView.ContentInset;
-			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
-			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
+			var contentOffsetX = !visibleItems ? 0 : scrollView.ContentOffset.X + contentInset.Left;
+			var contentOffsetY = !visibleItems ? 0 : scrollView.ContentOffset.Y + contentInset.Top;
 
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			PreviousVerticalOffset = (float)contentOffsetY;
 
 			if (!visibleItems)
+			{
 				return;
+			}
 
 			switch (itemsView.RemainingItemsThreshold)
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
 
+			if (!visibleItems)
+				return;
+
 			switch (itemsView.RemainingItemsThreshold)
 			{
 				case -1:

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			       xmlns:controls="clr-namespace:Maui.Controls.Sample.Issues"
+             x:Class="Maui.Controls.Sample.Issues.Issue21708">
+
+	<Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition />
+            <ColumnDefinition />
+			<ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Button
+            Grid.Row="0"
+            Grid.Column="0"
+            Margin="10"
+			AutomationId="Fill"
+            Clicked="FillButton_OnClicked"
+            Text="Fill" />
+
+        <Button
+            Grid.Row="0"
+            Grid.Column="2"
+            Margin="10"
+			AutomationId="Empty"
+            Clicked="EmptyButton_OnClicked"
+            Text="Empty" />
+
+                   <Label
+        Grid.Row="1"
+        Grid.Column="0"
+        AutomationId="VerticalOffsetLabel"
+        Text="VerticalOffset: " />
+        
+    <Label AutomationId="Label"
+        Grid.ColumnSpan="2"
+        Grid.Row="1"
+        HorizontalTextAlignment="Start"
+        Grid.Column="1"
+        Text="{Binding VerticalOffset}" />
+
+        <CollectionView AutomationId="CollectionView"
+            x:Name="CollectionView"
+            Grid.Row="2"
+            Grid.Column="0"
+            Grid.ColumnSpan="3"
+            ItemsSource="{Binding Items}"
+            Scrolled="CollectionView_OnScrolled">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Label
+                        Margin="10"
+                        FontSize="Default"
+                        HeightRequest="20"
+                        HorizontalTextAlignment="Center"
+                        Text="{Binding .}"
+                        TextColor="RoyalBlue" />
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+		
+</ContentPage>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21708.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Issue(IssueTracker.Github, 21708, "CollectionView.Scrolled event offset isn't correctly reset when items change", PlatformAffected.All)]
+	public partial class Issue21708 : ContentPage
+	{
+		ObservableCollection<int> _items;
+        double _verticalOffset;
+
+        public Issue21708()
+        {
+            InitializeComponent();
+            _items = new ObservableCollection<int>();
+            AddItemsToCollectionView();
+            CollectionView.ItemsSource = _items;
+			BindingContext = this;
+        }
+
+        public double VerticalOffset
+        {
+            get => _verticalOffset;
+            set
+            {
+                _verticalOffset = value;
+                OnPropertyChanged(nameof(VerticalOffset));
+            }
+        }
+
+        void CollectionView_OnScrolled(object sender, ItemsViewScrolledEventArgs e)
+        {
+            VerticalOffset = e.VerticalOffset;
+        }
+
+        void EmptyButton_OnClicked(object sender, EventArgs e)
+        {
+            _items.Clear();
+        }
+
+        void FillButton_OnClicked(object sender, EventArgs e)
+		{
+			AddItemsToCollectionView();
+		}
+
+		void AddItemsToCollectionView()
+		{
+			foreach (var i in Enumerable.Range(0, 50))
+				_items.Add(i);
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21708.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue21708 : _IssuesUITest
+{
+	public Issue21708(TestDevice device) : base(device) { }
+
+	public override string Issue => "CollectionView.Scrolled event offset isn't correctly reset when items change";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void VerifyCollectionViewVerticalOffset()
+	{
+		App.WaitForElement("Fill");
+		App.ScrollDown("CollectionView");
+		Assert.That(App.FindElement("Label").GetText(), Is.GreaterThan("0"));
+		App.Tap("Empty");
+		Assert.That(App.FindElement("Label").GetText(), Is.EqualTo("0"));
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
The offsets (VerticalOffset and HorizontalOffset) were being calculated incrementally and did not reset properly when the ItemsSource changed, leading to incorrect offset values.

### Description of Change

<!-- Enter description of the fix in this section -->
The change resets the VerticalOffset and HorizontalOffset to 0 when the ItemsSource is updated. This ensures correct offset values after adding or removing items, fixing the issue of incorrect offsets while scrolling.

### Regarding test case
The test case was added in PR #26782 , so this PR includes only the iOS fix.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #26798 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
