### PR TITLE
Fix SwipeItem and SwipeItemView AppTheme binding not updating on theme change

### DIFF
--- a/src/Controls/src/Core/SwipeView/SwipeItem.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeItem.cs
@@ -11,7 +11,14 @@ namespace Microsoft.Maui.Controls
 	public partial class SwipeItem : MenuItem, Controls.ISwipeItem, Maui.ISwipeItemMenuItem
 	{
 		/// <summary>Bindable property for <see cref="BackgroundColor"/>.</summary>
-		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(SwipeItem), null);
+		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(SwipeItem), null,
+			propertyChanged: OnBackgroundColorPropertyChanged);
+
+		static void OnBackgroundColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is SwipeItem swipeItem)
+				swipeItem.Handler?.UpdateValue(nameof(ISwipeItemMenuItem.Background));
+		}
 
 		/// <summary>Bindable property for <see cref="IsVisible"/>.</summary>
 		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(SwipeItem), true);
@@ -36,7 +43,16 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler<EventArgs> Invoked;
 
-		Paint ISwipeItemMenuItem.Background => new SolidPaint(BackgroundColor);
+		Paint ISwipeItemMenuItem.Background
+		{
+			get
+			{
+				if (BackgroundColor.IsNotDefault())
+					return new SolidPaint(BackgroundColor);
+
+				return null;
+			}
+		}
 
 		Visibility ISwipeItemMenuItem.Visibility => this.IsVisible ? Visibility.Visible : Visibility.Collapsed;
 
@@ -51,6 +67,25 @@ namespace Microsoft.Maui.Controls
 
 		void IImageSourcePart.UpdateIsLoading(bool isLoading)
 		{
+		}
+
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChangingCore(args);
+
+			if (Application.Current is null)
+				return;
+
+			if (args.NewHandler is null || args.OldHandler is not null)
+				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
+			if (args.NewHandler is not null && args.OldHandler is null)
+				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
+		}
+
+		private void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+		{
+			// Force refresh/re-evaluate AppTheme binding
+			this.RefreshPropertyValue(BackgroundColorProperty, BackgroundColor);
 		}
 	}
 }

--- a/src/Controls/src/Core/SwipeView/SwipeItemView.cs
+++ b/src/Controls/src/Core/SwipeView/SwipeItemView.cs
@@ -82,5 +82,24 @@ namespace Microsoft.Maui.Controls
 		{
 			IsEnabled = Command.CanExecute(CommandParameter);
 		}
+
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChangingCore(args);
+
+			if (Application.Current is null)
+				return;
+
+			if (args.NewHandler is null || args.OldHandler is not null)
+				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
+			if (args.NewHandler is not null && args.OldHandler is null)
+				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
+		}
+
+		private void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+		{
+			// Force refresh/re-evaluate AppTheme binding
+			this.RefreshPropertyValue(BackgroundColorProperty, BackgroundColor);
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31917.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31917.cs
@@ -1,0 +1,97 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 31917, "SwipeItemView and SwipeItem background doesn't update on AppTheme change (Light/Dark)", PlatformAffected.iOS | PlatformAffected.Android | PlatformAffected.macOS)]
+public class Issue31917 : ContentPage
+{
+	readonly SwipeItem _swipeItem;
+	readonly SwipeItemView _swipeItemView;
+	readonly Label _swipeItemColorLabel;
+	readonly Label _swipeItemViewColorLabel;
+
+	public Issue31917()
+	{
+		_swipeItem = new SwipeItem
+		{
+			Text = "Action",
+			AutomationId = "TestSwipeItem"
+		};
+		_swipeItem.SetAppThemeColor(SwipeItem.BackgroundColorProperty, Colors.Yellow, Colors.Purple);
+
+		_swipeItemView = new SwipeItemView
+		{
+			AutomationId = "TestSwipeItemView",
+			Content = new Label
+			{
+				Text = "Custom",
+				TextColor = Colors.White,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			}
+		};
+		_swipeItemView.SetAppThemeColor(SwipeItemView.BackgroundColorProperty, Colors.Blue, Colors.Red);
+
+		var swipeView = new SwipeView
+		{
+			LeftItems = new SwipeItems { _swipeItem },
+			RightItems = new SwipeItems { _swipeItemView },
+			Content = new Label
+			{
+				Text = "Swipe left or right to reveal items",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			},
+			HeightRequest = 60
+		};
+
+		_swipeItemColorLabel = new Label
+		{
+			AutomationId = "SwipeItemColorLabel",
+			Text = "Not checked"
+		};
+
+		_swipeItemViewColorLabel = new Label
+		{
+			AutomationId = "SwipeItemViewColorLabel",
+			Text = "Not checked"
+		};
+
+		var changeThemeButton = new Button
+		{
+			Text = "Change Theme",
+			AutomationId = "changeThemeButton",
+			Command = new Command(() =>
+			{
+				Application.Current!.UserAppTheme = Application.Current!.UserAppTheme != AppTheme.Dark
+					? AppTheme.Dark
+					: AppTheme.Light;
+				UpdateColorLabels();
+			})
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(20),
+			Spacing = 10,
+			Children =
+			{
+				swipeView,
+				changeThemeButton,
+				_swipeItemColorLabel,
+				_swipeItemViewColorLabel
+			}
+		};
+	}
+
+	void UpdateColorLabels()
+	{
+		var isDark = Application.Current?.RequestedTheme == AppTheme.Dark;
+
+		var expectedSwipeItemColor = isDark ? Colors.Purple : Colors.Yellow;
+		var actualSwipeItemColor = _swipeItem.BackgroundColor;
+		_swipeItemColorLabel.Text = actualSwipeItemColor == expectedSwipeItemColor ? "PASS" : "FAIL";
+
+		var expectedSwipeItemViewColor = isDark ? Colors.Red : Colors.Blue;
+		var actualSwipeItemViewColor = _swipeItemView.BackgroundColor;
+		_swipeItemViewColorLabel.Text = actualSwipeItemViewColor == expectedSwipeItemViewColor ? "PASS" : "FAIL";
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31917.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31917.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue31917 : _IssuesUITest
+{
+	public Issue31917(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "SwipeItemView and SwipeItem background doesn't update on AppTheme change (Light/Dark)";
+
+	[Test]
+	[Category(UITestCategories.SwipeView)]
+	public void SwipeItemBackgroundShouldUpdateOnAppThemeChange()
+	{
+		App.WaitForElement("changeThemeButton");
+		App.Tap("changeThemeButton");
+
+		Assert.That(App.FindElement("SwipeItemColorLabel").GetText(), Is.EqualTo("PASS"),
+			"SwipeItem background should update when app theme changes");
+		Assert.That(App.FindElement("SwipeItemViewColorLabel").GetText(), Is.EqualTo("PASS"),
+			"SwipeItemView background should update when app theme changes");
+	}
+}

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -28,9 +28,7 @@ namespace Microsoft.Maui.Platform
 
 			if (thumbColor is not null)
 			{
-				// Use ThumbTintList instead of SetColorFilter to preserve the thumb shadow
-				// SetColorFilter flattens the drawable and removes the shadow effect
-				aSwitch.ThumbTintList = ColorStateListExtensions.CreateDefault(thumbColor.ToPlatform());
+				aSwitch.ThumbDrawable?.SetColorFilter(thumbColor, FilterMode.SrcAtop);
 			}
 		}
 

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Maui.Platform
 
 			if (thumbColor is not null)
 			{
-				aSwitch.ThumbDrawable?.SetColorFilter(thumbColor, FilterMode.SrcAtop);
+				// Use ThumbTintList instead of SetColorFilter to preserve the thumb shadow
+				// SetColorFilter flattens the drawable and removes the shadow effect
+				aSwitch.ThumbTintList = ColorStateListExtensions.CreateDefault(thumbColor.ToPlatform());
 			}
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #31917 — `SwipeItemView` and `SwipeItem` backgrounds do not update when the app theme changes between Light and Dark.

## Root Cause

`SwipeItem` (a `MenuItem` subclass, not `VisualElement`) had no `propertyChanged` callback on `BackgroundColorProperty`, so the platform handler was never notified to update the background when the color value changed. Additionally, the `AppThemeBinding` re-evaluation was not being triggered reliably for these elements on theme change.

## Fix

**`SwipeItem.cs`:**
- Added `propertyChanged: OnBackgroundColorPropertyChanged` to `BackgroundColorProperty`
- Fixed `ISwipeItemMenuItem.Background` to return `null` when `BackgroundColor` is default
- Added `OnHandlerChangingCore` that subscribes to `Application.Current.RequestedThemeChanged`
- `OnRequestedThemeChanged` calls `RefreshPropertyValue` to force `AppThemeBinding` re-evaluation

**`SwipeItemView.cs`:**
- Added same `OnHandlerChangingCore` + `OnRequestedThemeChanged` pattern

This matches the existing fix pattern used for `SearchBar` (Issue #30601) and `InputView`.

## Test

Added `Issue31917` UI test that verifies both `SwipeItem` and `SwipeItemView` backgrounds update correctly after a theme toggle, using label-based verification (no screenshot baseline required).
