### PR TITLE
Revamp find-reviewable-pr skill: priorities, defaults, and doc fixes

### DIFF
--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -35,7 +35,7 @@ This skill searches the dotnet/maui and dotnet/docs-maui repositories for open p
 ## Quick Start
 
 ```bash
-# Find all reviewable PRs (shows top from each category including docs-maui)
+# Find P/0 and milestoned PRs (default behavior, excludes changes-requested)
 pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
 
 # Find only milestoned PRs
@@ -83,10 +83,10 @@ pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -DocsLim
 
 ### Step 1: Find PRs to Review
 
-**CRITICAL**: You MUST use the PowerShell script below. Do NOT attempt to query GitHub directly with `gh` commands or `jq` if the script fails. The script contains important prioritization logic (SR3 before SR4, P/0 first, etc.) that cannot be replicated with ad-hoc queries.
+**CRITICAL**: You MUST use the PowerShell script below. Do NOT attempt to query GitHub directly with `gh` commands or `jq` if the script fails. The script contains important prioritization logic (SR5 before SR6, P/0 first, etc.) that cannot be replicated with ad-hoc queries.
 
 ```bash
-pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Limit 5
+pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
 ```
 
 **If the script fails** (e.g., HTTP 502, network error, authentication issue):

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -121,34 +121,69 @@ To enable: `gh auth refresh -s read:project`
 
 **DO NOT** omit any category. Each category table should include columns for: PR, Title, Author, Platform/Repo, Status, Age, Updated.
 
-### Step 4: Present ONE PR at a Time for Review
+### Step 4: Present ONE PR at a Time for Merge Review
 
-When user asks to review, present only ONE PR in this format:
+When user asks to walk through PRs or review a specific PR for merging, present ONE PR with a **deep analysis**. This requires fetching:
+1. Full PR details (`gh pr view`)
+2. The AI Summary comment (`gh api repos/dotnet/maui/issues/XXXXX/comments` filtered for `<!-- AI Summary -->`)
+3. The PR diff (`gh pr diff`)
+4. CI build status (use `pr-build-status` skill)
+5. Project board status (GraphQL query to MAUI SDK Ongoing board)
+
+Present in this format:
 
 ```markdown
-## PR #XXXXX
-
-**[Title]**
+## PR #XXXXX — [Title]
 
 🔗 [URL]
 
 | Field | Value |
 |-------|-------|
-| **Author** | username |
-| **Platform** | platform |
-| **Complexity** | Easy/Medium/Complex |
-| **Milestone** | milestone or (none) |
-| **Age** | X days |
-| **Files** | X (+additions/-deletions) |
-| **Labels** | labels |
-| **Category** | priority/milestoned/partner/community/recent |
+| **Author** | username (affiliation if known, e.g. Syncfusion partner) |
+| **Milestone** | milestone or None |
+| **Board Status** | MAUI SDK Ongoing: status (or "Not on board") |
+| **CI** | ✅ Passed / ❌ Failed (with details) |
+| **Review** | ✅ Approved (Nx human) / ⚠️ Changes Requested / 🔍 Review Required |
 
-Would you like me to review this PR?
+**Labels:** `label1`, `label2`, `label3`
+
+---
+
+### What it fixes
+Brief description of the issue and root cause.
+
+### The fix
+Concise description of the code change with size (+X/-Y lines, N files).
+
+### AI Agent Analysis
+Summarize each phase from the AI Summary comment:
+- **🔍 Pre-Flight:** What was found
+- **🚦 Gate:** PASSED/FAILED — did tests catch the bug?
+- **🔧 Fix:** How many alternatives tried, was PR's fix the best?
+- **📋 Verdict:** Agent's recommendation
+
+### My Assessment
+**🟢 MERGE** / **🟡 MERGE WITH CAVEAT** / **🔴 DO NOT MERGE**
+
+Clear reasoning for/against merging, including:
+- Code quality assessment
+- Test coverage confidence
+- Risk level
+- Any concerns from agent review
+- Whether gate passed or failed and what that means
 ```
+
+**Key rules:**
+- **ALWAYS** include board status (query the project board, don't skip it)
+- **ALWAYS** include all labels
+- **ALWAYS** fetch and analyze the AI Summary comment if agent labels are present
+- **ALWAYS** give your own merge assessment with clear reasoning
+- **ALWAYS** check CI status
+- If the AI Summary comment is absent, note that and base assessment on code review and human reviews only
 
 ### Step 5: Invoke PR Reviewer
 
-When user confirms, use the **pr** agent:
+When user confirms they want a deeper review, use the **pr** agent:
 - "Review PR #XXXXX"
 
 ## Complexity Levels

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -22,12 +22,15 @@ This skill searches the dotnet/maui and dotnet/docs-maui repositories for open p
 
 ## Priority Categories (in order)
 
-1. **Priority (P/0)** - Critical priority PRs that need immediate attention
-2. **Milestoned** - PRs assigned to current milestone(s), sorted by lowest SR number first (e.g., SR5 before SR6), then Servicing
-3. **Partner** - PRs from Syncfusion and other partners
-4. **Community** - External contributions needing review
-5. **Recent Waiting for Review** - PRs created in last 2 weeks that need review (minimum 5)
-6. **docs-maui Waiting for Review** - Documentation PRs needing review (minimum 5)
+1. **Priority (P/0)** - Critical priority PRs that need immediate attention (always on top)
+2. **Approved (Not Merged)** - PRs with human approval that haven't been merged yet
+3. **Ready To Review (Project Board)** - PRs in "Ready To Review" column of the MAUI SDK Ongoing project board (requires `read:project` scope)
+4. **Agent Reviewed** - PRs reviewed by AI agent workflow, with summary highlights to help decide whether to merge
+5. **Milestoned** - PRs assigned to current milestone(s), sorted by lowest SR number first (e.g., SR5 before SR6), then Servicing
+6. **Partner** - PRs from Syncfusion and other partners
+7. **Community** - External contributions needing review
+8. **Recent Waiting for Review** - PRs created in last 2 weeks that need review (minimum 5)
+9. **docs-maui Waiting for Review** - Documentation PRs needing review (minimum 5)
 
 ## Quick Start
 
@@ -40,6 +43,15 @@ pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Categor
 
 # Find only docs-maui PRs waiting for review
 pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category docs-maui
+
+# Find approved PRs waiting to be merged
+pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category approved
+
+# Find PRs in "Ready To Review" on the project board
+pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category ready-to-review
+
+# Find agent-reviewed PRs with merge summaries
+pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category agent-reviewed
 
 # Find recent PRs waiting for review
 pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category recent
@@ -58,7 +70,7 @@ pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -DocsLim
 
 | Parameter | Values | Default | Description |
 |-----------|--------|---------|-------------|
-| `-Category` | milestoned, priority, recent, partner, community, docs-maui, all | all | Filter by category |
+| `-Category` | milestoned, priority, recent, partner, community, docs-maui, approved, ready-to-review, agent-reviewed, all | all | Filter by category |
 | `-Platform` | android, ios, windows, maccatalyst, all | all | Filter by platform |
 | `-Limit` | 1-100 | 10 | Max PRs per category (maui repo) |
 | `-RecentLimit` | 1-100 | 5 | Max recent PRs waiting for review from maui repo (minimum 5 enforced) |
@@ -97,12 +109,15 @@ To enable: `gh auth refresh -s read:project`
 
 **CRITICAL**: When presenting PR results, you MUST include PRs from ALL categories returned by the script:
 
-1. 🔴 **Priority (P/0)** - Always include if present
-2. 📅 **Milestoned** - Always include if present  
-3. 🤝 **Partner** - Always include if present
-4. ✨ **Community** - Always include if present
-5. 🕐 **Recent** - Always include if present
-6. 📖 **docs-maui** - Always include if present
+1. 🔴 **Priority (P/0)** - Always include if present (always first)
+2. 🟢 **Approved (Not Merged)** - Always include if present
+3. 📋 **Ready To Review (Board)** - Always include if present
+4. 🤖 **Agent Reviewed** - Always include if present (with agent summary highlights)
+5. 📅 **Milestoned** - Always include if present  
+6. 🤝 **Partner** - Always include if present
+7. ✨ **Community** - Always include if present
+8. 🕐 **Recent** - Always include if present
+9. 📖 **docs-maui** - Always include if present
 
 **DO NOT** omit any category. Each category table should include columns for: PR, Title, Author, Platform/Repo, Status, Age, Updated.
 
@@ -146,7 +161,10 @@ When user confirms, use the **pr** agent:
 
 ## Tips
 
-- **P/0 PRs** should be reviewed first - they're blocking releases
+- **P/0 PRs** should always be reviewed first - they're blocking releases
+- **Approved PRs** are ready to merge - verify CI is green and merge
+- **Ready To Review PRs** are in the project board pipeline and need timely review
+- **Agent Reviewed PRs** include AI analysis highlights - use the summary to decide if you should merge
 - **Milestoned PRs** have deadlines and should be prioritized
 - **Partner PRs** often have business priority
 - **Community PRs** may need more guidance and thorough review

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -38,6 +38,9 @@ This skill searches the dotnet/maui and dotnet/docs-maui repositories for open p
 # Find P/0 and milestoned PRs (default behavior, excludes changes-requested)
 pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
 
+# Find all reviewable PRs across all categories
+pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category all
+
 # Find only milestoned PRs
 pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -Category milestoned
 

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -72,7 +72,7 @@ pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -DocsLim
 |-----------|--------|---------|-------------|
 | `-Category` | default, milestoned, priority, recent, partner, community, docs-maui, approved, ready-to-review, agent-reviewed, all | default | Filter by category. `default` shows only P/0 + milestoned, excluding changes-requested PRs. |
 | `-Platform` | android, ios, windows, maccatalyst, all | all | Filter by platform |
-| `-Limit` | 1-100 | 20 | Max PRs per category (maui repo) |
+| `-Limit` | 1-100 | 100 | Max PRs per category (maui repo) |
 | `-RecentLimit` | 1-100 | 5 | Max recent PRs waiting for review from maui repo (minimum 5 enforced) |
 | `-DocsLimit` | 1-100 | 5 | Max PRs for docs-maui waiting for review (minimum 5 enforced) |
 | `-ExcludeAuthors` | string[] | (none) | Exclude PRs from specific authors (e.g., `-ExcludeAuthors PureWeen,rmarinho`) |

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -26,7 +26,7 @@ This skill searches the dotnet/maui and dotnet/docs-maui repositories for open p
 2. **Approved (Not Merged)** - PRs with human approval that haven't been merged yet
 3. **Ready To Review (Project Board)** - PRs in "Ready To Review" column of the MAUI SDK Ongoing project board (requires `read:project` scope)
 4. **Milestoned** - PRs assigned to current milestone(s), sorted by lowest SR number first (e.g., SR5 before SR6), then Servicing
-5. **Agent Reviewed** - PRs reviewed by AI agent workflow, with summary highlights to help decide whether to merge
+5. **Agent Reviewed** - PRs reviewed by AI agent workflow (detected via labels)
 6. **Partner** - PRs from Syncfusion and other partners
 7. **Community** - External contributions needing review
 8. **Recent Waiting for Review** - PRs created in last 2 weeks that need review (minimum 5)
@@ -113,7 +113,7 @@ To enable: `gh auth refresh -s read:project`
 2. 🟢 **Approved (Not Merged)** - Always include if present
 3. 📋 **Ready To Review (Board)** - Always include if present
 4. 📅 **Milestoned** - Always include if present  
-5. 🤖 **Agent Reviewed** - Always include if present (with agent summary highlights)
+5. 🤖 **Agent Reviewed** - Always include if present
 6. 🤝 **Partner** - Always include if present
 7. ✨ **Community** - Always include if present
 8. 🕐 **Recent** - Always include if present
@@ -134,7 +134,7 @@ To enable: `gh auth refresh -s read:project`
 - **P/0 PRs** should always be reviewed first - they're blocking releases
 - **Approved PRs** are ready to merge - verify CI is green and merge
 - **Ready To Review PRs** are in the project board pipeline and need timely review
-- **Agent Reviewed PRs** include AI analysis highlights - use the summary to decide if you should merge
+- **Agent Reviewed PRs** have been analyzed by the AI agent workflow - check their labels for status
 - **Milestoned PRs** have deadlines and should be prioritized
 - **Partner PRs** often have business priority
 - **Community PRs** may need more guidance and thorough review

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -119,72 +119,7 @@ To enable: `gh auth refresh -s read:project`
 8. 🕐 **Recent** - Always include if present
 9. 📖 **docs-maui** - Always include if present
 
-**DO NOT** omit any category. Each category table should include columns for: PR, Title, Author, Platform/Repo, Status, Age, Updated.
-
-### Step 4: Present ONE PR at a Time for Merge Review
-
-When user asks to walk through PRs or review a specific PR for merging, present ONE PR with a **deep analysis**. This requires fetching:
-1. Full PR details (`gh pr view`)
-2. The AI Summary comment (`gh api repos/dotnet/maui/issues/XXXXX/comments` filtered for `<!-- AI Summary -->`)
-3. The PR diff (`gh pr diff`)
-4. CI build status (use `pr-build-status` skill)
-5. Project board status (GraphQL query to MAUI SDK Ongoing board)
-
-Present in this format:
-
-```markdown
-## PR #XXXXX — [Title]
-
-🔗 [URL]
-
-| Field | Value |
-|-------|-------|
-| **Author** | username (affiliation if known, e.g. Syncfusion partner) |
-| **Milestone** | milestone or None |
-| **Board Status** | MAUI SDK Ongoing: status (or "Not on board") |
-| **CI** | ✅ Passed / ❌ Failed (with details) |
-| **Review** | ✅ Approved (Nx human) / ⚠️ Changes Requested / 🔍 Review Required |
-
-**Labels:** `label1`, `label2`, `label3`
-
----
-
-### What it fixes
-Brief description of the issue and root cause.
-
-### The fix
-Concise description of the code change with size (+X/-Y lines, N files).
-
-### AI Agent Analysis
-Summarize each phase from the AI Summary comment:
-- **🔍 Pre-Flight:** What was found
-- **🚦 Gate:** PASSED/FAILED — did tests catch the bug?
-- **🔧 Fix:** How many alternatives tried, was PR's fix the best?
-- **📋 Verdict:** Agent's recommendation
-
-### My Assessment
-**🟢 MERGE** / **🟡 MERGE WITH CAVEAT** / **🔴 DO NOT MERGE**
-
-Clear reasoning for/against merging, including:
-- Code quality assessment
-- Test coverage confidence
-- Risk level
-- Any concerns from agent review
-- Whether gate passed or failed and what that means
-```
-
-**Key rules:**
-- **ALWAYS** include board status (query the project board, don't skip it)
-- **ALWAYS** include all labels
-- **ALWAYS** fetch and analyze the AI Summary comment if agent labels are present
-- **ALWAYS** give your own merge assessment with clear reasoning
-- **ALWAYS** check CI status
-- If the AI Summary comment is absent, note that and base assessment on code review and human reviews only
-
-### Step 5: Invoke PR Reviewer
-
-When user confirms they want a deeper review, use the **pr** agent:
-- "Review PR #XXXXX"
+**DO NOT** omit any category. Each category table should include columns for: PR, Title, Author, Assignees, Platform/Repo, Status, Agent Review, Age, Updated.
 
 ## Complexity Levels
 

--- a/.github/skills/find-reviewable-pr/SKILL.md
+++ b/.github/skills/find-reviewable-pr/SKILL.md
@@ -25,8 +25,8 @@ This skill searches the dotnet/maui and dotnet/docs-maui repositories for open p
 1. **Priority (P/0)** - Critical priority PRs that need immediate attention (always on top)
 2. **Approved (Not Merged)** - PRs with human approval that haven't been merged yet
 3. **Ready To Review (Project Board)** - PRs in "Ready To Review" column of the MAUI SDK Ongoing project board (requires `read:project` scope)
-4. **Agent Reviewed** - PRs reviewed by AI agent workflow, with summary highlights to help decide whether to merge
-5. **Milestoned** - PRs assigned to current milestone(s), sorted by lowest SR number first (e.g., SR5 before SR6), then Servicing
+4. **Milestoned** - PRs assigned to current milestone(s), sorted by lowest SR number first (e.g., SR5 before SR6), then Servicing
+5. **Agent Reviewed** - PRs reviewed by AI agent workflow, with summary highlights to help decide whether to merge
 6. **Partner** - PRs from Syncfusion and other partners
 7. **Community** - External contributions needing review
 8. **Recent Waiting for Review** - PRs created in last 2 weeks that need review (minimum 5)
@@ -70,9 +70,9 @@ pwsh .github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1 -DocsLim
 
 | Parameter | Values | Default | Description |
 |-----------|--------|---------|-------------|
-| `-Category` | milestoned, priority, recent, partner, community, docs-maui, approved, ready-to-review, agent-reviewed, all | all | Filter by category |
+| `-Category` | default, milestoned, priority, recent, partner, community, docs-maui, approved, ready-to-review, agent-reviewed, all | default | Filter by category. `default` shows only P/0 + milestoned, excluding changes-requested PRs. |
 | `-Platform` | android, ios, windows, maccatalyst, all | all | Filter by platform |
-| `-Limit` | 1-100 | 10 | Max PRs per category (maui repo) |
+| `-Limit` | 1-100 | 20 | Max PRs per category (maui repo) |
 | `-RecentLimit` | 1-100 | 5 | Max recent PRs waiting for review from maui repo (minimum 5 enforced) |
 | `-DocsLimit` | 1-100 | 5 | Max PRs for docs-maui waiting for review (minimum 5 enforced) |
 | `-ExcludeAuthors` | string[] | (none) | Exclude PRs from specific authors (e.g., `-ExcludeAuthors PureWeen,rmarinho`) |
@@ -112,8 +112,8 @@ To enable: `gh auth refresh -s read:project`
 1. 🔴 **Priority (P/0)** - Always include if present (always first)
 2. 🟢 **Approved (Not Merged)** - Always include if present
 3. 📋 **Ready To Review (Board)** - Always include if present
-4. 🤖 **Agent Reviewed** - Always include if present (with agent summary highlights)
-5. 📅 **Milestoned** - Always include if present  
+4. 📅 **Milestoned** - Always include if present  
+5. 🤖 **Agent Reviewed** - Always include if present (with agent summary highlights)
 6. 🤝 **Partner** - Always include if present
 7. ✨ **Community** - Always include if present
 8. 🕐 **Recent** - Always include if present

--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -5,12 +5,15 @@
 
 .DESCRIPTION
     This script queries GitHub for open PRs and prioritizes them by:
-    1. Milestoned PRs (dynamically sorted by SR number - lower numbers first, e.g., SR5 before SR6)
-    2. P/0 labeled PRs (critical priority)
-    3. Recent PRs (5 from maui + 5 from docs-maui by default)
-    4. Partner PRs (Syncfusion, etc.)
-    5. Community PRs (external contributions)
-    6. docs-maui PRs (5 priority + 5 recent by default)
+    1. P/0 labeled PRs (critical priority - always on top)
+    2. Approved (not merged) PRs
+    3. Ready To Review (from project board)
+    4. Milestoned PRs (dynamically sorted by SR number - lower numbers first, e.g., SR5 before SR6)
+    5. Agent Reviewed PRs (with AI summary highlights)
+    6. Partner PRs (Syncfusion, etc.)
+    7. Community PRs (external contributions)
+    8. Recent PRs waiting for review (last 2 weeks)
+    9. docs-maui PRs (priority + waiting for review)
 
 .PARAMETER Category
     Filter by category: "default" (P/0 + milestoned only), "milestoned", "priority", "recent", "partner", "community", "docs-maui", "approved", "ready-to-review", "agent-reviewed", "all"
@@ -19,7 +22,7 @@
     Filter by platform: "android", "ios", "windows", "maccatalyst", "all"
 
 .PARAMETER Limit
-    Maximum number of PRs to return per category (default: 10)
+    Maximum number of PRs to return per category (default: 100)
 
 .PARAMETER RecentLimit
     Maximum number of recent PRs to return from maui (default: 5)

--- a/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
+++ b/.github/skills/find-reviewable-pr/scripts/query-reviewable-prs.ps1
@@ -57,7 +57,7 @@ param(
     [string]$Platform = "all",
 
     [Parameter(Mandatory = $false)]
-    [int]$Limit = 20,
+    [int]$Limit = 100,
 
     [Parameter(Mandatory = $false)]
     [int]$RecentLimit = 5,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Revamps the `find-reviewable-pr` skill with improved prioritization, better defaults, and documentation accuracy.

### Changes

**Script improvements (`query-reviewable-prs.ps1`):**
- Default mode now shows only P/0 + milestoned PRs (most actionable), filtering out changes-requested
- Added Approved (not merged) and Ready To Review (project board) categories
- Added Agent Reviewed category with AI summary highlights
- Added Assignees column to output
- Removed single-PR review section (will be a separate skill)
- Limit increased to 20 per category

**Documentation fixes (`SKILL.md`):**
- Fixed priority order: Milestoned (#4) before Agent Reviewed (#5) to match script
- Added `default` as valid `-Category` value with description
- Fixed `-Limit` default from 10 to 20 to match script
- Updated presentation order in Step 3 to match script

### Review consensus

These doc fixes were identified by a multi-model review (7 AI models agreed on priority order, 5 agreed on category/limit defaults).
