### PR TITLE
Bumps Syncfusion.Maui.Toolkit dependency to version 1.0.9

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -91,7 +91,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
-		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.8" />
+		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.9" />
 	</ItemGroup>
 	
 <!--#endif -->


### PR DESCRIPTION
### Description of Change

Updated the Syncfusion Toolkit version from 1.0.8 to 1.0.9