### PR TITLE
Fix RelayCommand binding inference for On*Async patterns

### DIFF
--- a/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
+++ b/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
@@ -101,8 +101,15 @@ public static class ITypeSymbolExtensions
 
 	private static System.Collections.Generic.IEnumerable<string> GetRelayCommandMethodNameCandidates(string methodName)
 	{
-		yield return methodName;
-		yield return methodName + "Async";
+		// CommunityToolkit strips "On" prefix: OnSave() → SaveCommand, not OnSaveCommand.
+		// So if methodName starts with "On", the base name would only match methods that generate
+		// a *different* command property (e.g., "OnLoad" method → "LoadCommand", not "OnLoadCommand").
+		// We skip these candidates to avoid false-positive diagnostic suppression.
+		if (!methodName.StartsWith("On", System.StringComparison.Ordinal))
+		{
+			yield return methodName;
+			yield return methodName + "Async";
+		}
 
 		if (methodName.Length > 0
 			&& char.IsUpper(methodName[0])

--- a/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
+++ b/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
@@ -68,29 +68,50 @@ public static class ITypeSymbolExtensions
 		// Extract the method name (property name without "Command" suffix)
 		var methodName = propertyName.Substring(0, propertyName.Length - "Command".Length);
 
-		// Look for a method with the base name - search in the type and base types
-		var methods = GetAllMethods(symbol, methodName);
-
-		foreach (var method in methods)
+		// CommunityToolkit.Mvvm command naming supports these patterns:
+		// - Save => SaveCommand
+		// - SaveAsync => SaveCommand
+		// - OnSave => SaveCommand
+		// - OnSaveAsync => SaveCommand
+		foreach (var candidateMethodName in GetRelayCommandMethodNameCandidates(methodName))
 		{
-			// Check if the method has the RelayCommand attribute
-			var hasRelayCommand = method.GetAttributes().Any(attr =>
-				attr.AttributeClass?.Name == "RelayCommandAttribute" ||
-				attr.AttributeClass?.ToDisplayString() == "CommunityToolkit.Mvvm.Input.RelayCommandAttribute");
-
-			if (hasRelayCommand)
+			var methods = GetAllMethods(symbol, candidateMethodName);
+			foreach (var method in methods)
 			{
-				// Try to find the ICommand interface type
-				var icommandType = compilation.GetTypeByMetadataName("System.Windows.Input.ICommand");
-				if (icommandType != null)
+				// Check if the method has the RelayCommand attribute
+				var hasRelayCommand = method.GetAttributes().Any(attr =>
+					attr.AttributeClass?.Name == "RelayCommandAttribute" ||
+					attr.AttributeClass?.ToDisplayString() == "CommunityToolkit.Mvvm.Input.RelayCommandAttribute");
+
+				if (hasRelayCommand)
 				{
-					commandType = icommandType;
-					return true;
+					// Try to find the ICommand interface type
+					var icommandType = compilation.GetTypeByMetadataName("System.Windows.Input.ICommand");
+					if (icommandType != null)
+					{
+						commandType = icommandType;
+						return true;
+					}
 				}
 			}
 		}
 
 		return false;
+	}
+
+	private static System.Collections.Generic.IEnumerable<string> GetRelayCommandMethodNameCandidates(string methodName)
+	{
+		yield return methodName;
+		yield return methodName + "Async";
+
+		if (methodName.Length > 0
+			&& char.IsUpper(methodName[0])
+			&& !methodName.StartsWith("On", System.StringComparison.Ordinal))
+		{
+			var onMethodName = "On" + methodName;
+			yield return onMethodName;
+			yield return onMethodName + "Async";
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary
- fix RelayCommand inference for generated command properties when source methods use `On*`, `*Async`, or `On*Async` naming
- prevent MAUIG2045 false positives for compiled bindings that target those generated command properties
- add regression coverage in BindingSourceGen and SourceGen unit tests

## Related issues
- Fixes #34029
- Duplicate issue #34086 was closed in favor of #34029

## Validation
- `dotnet test src/Controls/tests/BindingSourceGen.UnitTests/Controls.BindingSourceGen.UnitTests.csproj --filter "RelayCommandTests.DetectsRelayCommandMethodWithOnPrefixAndAsyncSuffix"`
- `dotnet test src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --filter "BindingDiagnosticsTests.BindingToRelayCommandGeneratedFromOnAsyncMethod_DoesNotReportPropertyNotFound"`

