### PR TITLE
[XSG] Fix SourceGen OnPlatform default View null handling

### DIFF
--- a/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
+++ b/src/Controls/src/SourceGen/Visitors/CreateValuesVisitor.cs
@@ -43,9 +43,10 @@ class CreateValuesVisitor : IXamlNodeVisitor
 		if (node.IsOnPlatformDefaultValue)
 		{
 			var variableName = NamingHelpers.CreateUniqueVariableName(Context, type);
-			writer.WriteLine($"{type.ToFQDisplayString()} {variableName} = default;");
+			// Reference-type defaults are null; use default! so generated code does not emit nullable warnings.
+			var defaultValue = type.IsReferenceType ? "default!" : "default";
+			writer.WriteLine($"{type.ToFQDisplayString()} {variableName} = {defaultValue};");
 			variables[node] = new LocalVariable(type, variableName);
-			node.RegisterSourceInfo(Context, writer);
 			return;
 		}
 

--- a/src/Controls/src/SourceGen/Visitors/SetNamescopesAndRegisterNames.cs
+++ b/src/Controls/src/SourceGen/Visitors/SetNamescopesAndRegisterNames.cs
@@ -62,6 +62,12 @@ class SetNamescopesAndRegisterNamesVisitor(SourceGenContext context) : IXamlNode
 			namesInNamescope = Context.Scopes[parentNode].namesInScope;
 		}
 
+		if (node.IsOnPlatformDefaultValue)
+		{
+			Context.Scopes[node] = (namescope, namesInNamescope);
+			return;
+		}
+
 		if (setNameScope && Context.Variables[node].Type.InheritsFrom(Context.Compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindableObject")!, Context))
 			using (PrePost.NewConditional(Writer, "!_MAUIXAML_SG_NAMESCOPE_DISABLE"))
 			{

--- a/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/OnPlatformAbstractTypes.cs
+++ b/src/Controls/tests/SourceGen.UnitTests/InitializeComponent/OnPlatformAbstractTypes.cs
@@ -284,10 +284,10 @@ public partial class TestPage : ContentPage
 		// Should NOT contain "new Brush()" - that would be a compiler error
 		Assert.DoesNotContain("new global::Microsoft.Maui.Controls.Brush()", generated, StringComparison.Ordinal);
 		
-		// Should generate default instead of trying to instantiate the type
-		// The pattern is: Brush brush0 = default;
+		// Should generate default! instead of trying to instantiate the type (reference types use default!)
+		// The pattern is: Brush brush0 = default!;
 		Assert.Contains("Brush", generated, StringComparison.Ordinal);
-		Assert.Contains("= default;", generated, StringComparison.Ordinal);
+		Assert.Contains("= default!;", generated, StringComparison.Ordinal);
 		
 		// There should be no compilation errors
 		Assert.False(result.Diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error),
@@ -339,9 +339,9 @@ public partial class TestPage : ContentPage
 		// Should NOT contain "new View()" - that would be a compiler error due to protected ctor
 		Assert.DoesNotContain("new global::Microsoft.Maui.Controls.View()", generated, StringComparison.Ordinal);
 		
-		// Should generate default instead of trying to instantiate the type
+		// Should generate default! instead of trying to instantiate the type (reference types use default!)
 		Assert.Contains("View", generated, StringComparison.Ordinal);
-		Assert.Contains("= default;", generated, StringComparison.Ordinal);
+		Assert.Contains("= default!;", generated, StringComparison.Ordinal);
 		
 		// There should be no compilation errors
 		Assert.False(result.Diagnostics.Any(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error),

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34074.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34074.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34074">
+	<OnPlatform x:TypeArguments="View">
+		<On Platform="WinUI">
+			<Label Text="WinUI only" />
+		</On>
+	</OnPlatform>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34074.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34074.xaml.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Devices;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui34074 : ContentPage
+{
+	public Maui34074() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		readonly MockDeviceInfo _mockDeviceInfo;
+
+		public Tests()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+			DeviceInfo.SetCurrent(_mockDeviceInfo = new MockDeviceInfo());
+		}
+
+		public void Dispose() => DeviceInfo.SetCurrent(null);
+
+		[Theory]
+		[XamlInflatorData]
+		internal void OnPlatformViewMissingTargetUsesNullDefault(XamlInflator inflator)
+		{
+			_mockDeviceInfo.Platform = DevicePlatform.MacCatalyst;
+			var page = new Maui34074(inflator);
+			Assert.Null(page.Content);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void OnPlatformViewMatchingTargetStillWorks(XamlInflator inflator)
+		{
+			_mockDeviceInfo.Platform = DevicePlatform.WinUI;
+			var page = new Maui34074(inflator);
+			var label = Assert.IsType<Label>(page.Content);
+			Assert.Equal("WinUI only", label.Text);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary
- fix SourceGen handling for `<OnPlatform x:TypeArguments="View">` when no matching platform/default exists
- avoid nullability and null-dereference codegen by using `default!` for reference-type placeholders
- skip namescope/source-info operations for OnPlatform default placeholder nodes
- add regression coverage for the View OnPlatform missing-platform scenario

## Related issues
- Fixes #34074

## Validation
- `dotnet test src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj --filter "SimplifyOnPlatform.OnPlatformWithMissingTargetPlatformShouldUseDefault|SimplifyOnPlatform.OnPlatformViewWithMissingTargetPlatformShouldNotEmitNullabilityWarnings"`

