### PR TITLE
Fix SourceGen nullability output for #34130

### DIFF
--- a/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
+++ b/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
@@ -50,7 +50,7 @@ public static class ITypeSymbolExtensions
 		var globalName = typeSymbol.ToDisplayString(FullyQualifiedNullableFormat);
 
 		// Keep nullable annotations in generic arguments but avoid nullable top-level type syntax (e.g. typeof(Foo?)).
-		if (globalName.EndsWith("?"))
+		if (globalName.EndsWith("?", StringComparison.Ordinal))
 			globalName = globalName.Substring(0, globalName.Length - 1);
 
 		return globalName;

--- a/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
+++ b/src/Controls/src/BindingSourceGen/ITypeSymbolExtensions.cs
@@ -5,6 +5,11 @@ namespace Microsoft.Maui.Controls.BindingSourceGen;
 
 public static class ITypeSymbolExtensions
 {
+	static readonly SymbolDisplayFormat FullyQualifiedNullableFormat =
+		SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+			SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions
+			| SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+
 	public static bool IsTypeNullable(this ITypeSymbol typeInfo, bool enabledNullable)
 	{
 		if (!enabledNullable && typeInfo.IsReferenceType)
@@ -39,10 +44,16 @@ public static class ITypeSymbolExtensions
 		if (isNullable && isValueType)
 		{
 			// Strips the "?" from the type name
-			return ((INamedTypeSymbol)typeSymbol).TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			return ((INamedTypeSymbol)typeSymbol).TypeArguments[0].ToDisplayString(FullyQualifiedNullableFormat);
 		}
 
-		return typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+		var globalName = typeSymbol.ToDisplayString(FullyQualifiedNullableFormat);
+
+		// Keep nullable annotations in generic arguments but avoid nullable top-level type syntax (e.g. typeof(Foo?)).
+		if (globalName.EndsWith("?"))
+			globalName = globalName.Substring(0, globalName.Length - 1);
+
+		return globalName;
 	}
 
 	/// <summary>

--- a/src/Controls/src/SourceGen/NodeSGExtensions.cs
+++ b/src/Controls/src/SourceGen/NodeSGExtensions.cs
@@ -483,7 +483,7 @@ static class NodeSGExtensions
 				if (targetType.IsReferenceType || targetType.NullableAnnotation == NullableAnnotation.Annotated)
 					return $"((global::Microsoft.Maui.Controls.IExtendedTypeConverter)new {typeConverter.ToFQDisplayString()}()).ConvertFromInvariantString(\"{valueString}\", {serviceProvider.ValueAccessor}) as {targetType.ToFQDisplayString()}";
 				else
-					return $"({targetType.ToFQDisplayString()})((global::Microsoft.Maui.Controls.IExtendedTypeConverter)new {typeConverter.ToFQDisplayString()}()).ConvertFromInvariantString(\"{valueString}\", {serviceProvider.ValueAccessor})";
+					return $"({targetType.ToFQDisplayString()})((global::Microsoft.Maui.Controls.IExtendedTypeConverter)new {typeConverter.ToFQDisplayString()}()).ConvertFromInvariantString(\"{valueString}\", {serviceProvider.ValueAccessor})!";
 			}
 			else //should never happen. there's no point to implement IExtendedTypeConverter AND accept empty service provider
 				return $"((global::Microsoft.Maui.Controls.IExtendedTypeConverter)new {typeConverter.ToFQDisplayString()}()).ConvertFromInvariantString(\"{valueString}\", null) as {targetType.ToFQDisplayString()}";

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34130.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34130.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130">
+	<VerticalStackLayout>
+		<Button x:DataType="local:Maui34130ViewModel"
+				CommandParameter="{Binding SelectedItem}" />
+		<local:Maui34130SizeBox Size="42" />
+	</VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34130.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34130.xaml.cs
@@ -21,8 +21,7 @@ public partial class Maui34130 : ContentPage
 	public class Tests
 	{
 		[Theory]
-		[InlineData(XamlInflator.Runtime)]
-		[InlineData(XamlInflator.SourceGen)]
+		[XamlInflatorData]
 		internal void ReproducesSourceGenNullabilityDiagnostics(XamlInflator inflator)
 		{
 			if (inflator == XamlInflator.SourceGen)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34130.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34130.xaml.cs
@@ -1,0 +1,184 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+#nullable enable
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui34130 : ContentPage
+{
+	public Maui34130()
+	{
+		InitializeComponent();
+		BindingContext = new Maui34130ViewModel();
+	}
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[InlineData(XamlInflator.Runtime)]
+		[InlineData(XamlInflator.SourceGen)]
+		internal void ReproducesSourceGenNullabilityDiagnostics(XamlInflator inflator)
+		{
+			if (inflator == XamlInflator.SourceGen)
+			{
+				var xaml =
+"""
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui34130SourceGenRepro : ContentPage
+{
+	public Maui34130SourceGenRepro()
+	{
+		InitializeComponent();
+		BindingContext = new Maui34130SourceGenReproViewModel();
+	}
+}
+		
+[TypeConverter(typeof(Maui34130SourceGenReproSizeConverter))]
+public readonly struct Maui34130SourceGenReproSize(double value)
+{
+	public double Value { get; } = value;
+}
+
+public class Maui34130SourceGenReproSizeConverter : TypeConverter, IExtendedTypeConverter
+{
+	public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+		=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+	public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+		=> value is string s && double.TryParse(s, NumberStyles.Any, culture, out double d)
+			? new Maui34130SourceGenReproSize(d)
+			: base.ConvertFrom(context, culture, value)!;
+
+	public object ConvertFromInvariantString(string value, IServiceProvider serviceProvider)
+		=> double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double d)
+			? new Maui34130SourceGenReproSize(d)
+			: new Maui34130SourceGenReproSize(0);
+}
+
+public class Maui34130SourceGenReproSizeBox : View
+{
+	public static readonly BindableProperty SizeProperty =
+		BindableProperty.Create(nameof(Size), typeof(Maui34130SourceGenReproSize), typeof(Maui34130SourceGenReproSizeBox), default(Maui34130SourceGenReproSize));
+
+	public Maui34130SourceGenReproSize Size
+	{
+		get => (Maui34130SourceGenReproSize)GetValue(SizeProperty);
+		set => SetValue(SizeProperty, value);
+	}
+}
+
+public class Maui34130SourceGenReproGenericWrapper<T>
+{
+	public T? Value { get; set; }
+}
+
+public class Maui34130SourceGenReproItem
+{
+	public string Name { get; set; } = string.Empty;
+}
+
+public class Maui34130SourceGenReproViewModel
+{
+	public Maui34130SourceGenReproGenericWrapper<Maui34130SourceGenReproItem?> SelectedItem { get; } = new();
+}
+""";
+
+				var xamlMarkup =
+"""
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenRepro">
+	<VerticalStackLayout>
+		<Button x:DataType="local:Maui34130SourceGenReproViewModel"
+				CommandParameter="{Binding SelectedItem}" />
+		<local:Maui34130SourceGenReproSizeBox Size="42" />
+	</VerticalStackLayout>
+</ContentPage>
+""";
+
+				var compilation = CreateMauiCompilation();
+				var csharpCompilation = (Microsoft.CodeAnalysis.CSharp.CSharpCompilation)compilation;
+				compilation = csharpCompilation.WithOptions(
+					csharpCompilation.Options.WithNullableContextOptions(Microsoft.CodeAnalysis.NullableContextOptions.Enable));
+
+				var result = compilation
+					.WithAdditionalSource(xaml, hintName: "Maui34130SourceGenRepro.xaml.cs")
+					.RunMauiSourceGenerator(new MockSourceGenerator.AdditionalXamlFile("Issues/Maui34130SourceGenRepro.xaml", xamlMarkup, TargetFramework: "net10.0"));
+				var generated = result.GeneratedInitializeComponent();
+
+				// Verify CS8605 fix: generated conversion for value-type target uses null-forgiving before unboxing
+				Assert.Contains("ConvertFromInvariantString(\"42\"", generated, StringComparison.Ordinal);
+				Assert.Contains(")!);", generated, StringComparison.Ordinal);
+
+				// Verify CS8619 fix: generated TypedBinding preserves nullable generic type argument (MyItem?)
+				Assert.Contains("TypedBinding<global::Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenReproViewModel, global::Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenReproGenericWrapper<global::Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenReproItem?>>", generated, StringComparison.Ordinal);
+				Assert.DoesNotContain("TypedBinding<global::Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenReproViewModel, global::Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenReproGenericWrapper<global::Microsoft.Maui.Controls.Xaml.UnitTests.Maui34130SourceGenReproItem>>", generated, StringComparison.Ordinal);
+				Assert.Contains("source.SelectedItem, true", generated, StringComparison.Ordinal);
+			}
+			else
+				Assert.NotNull(new Maui34130(inflator));
+		}
+	}
+}
+
+[TypeConverter(typeof(Maui34130SizeConverter))]
+public readonly record struct Maui34130Size(double Value);
+
+public class Maui34130SizeConverter : TypeConverter, IExtendedTypeConverter
+{
+	public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+		=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+	public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+		=> value is string s && double.TryParse(s, NumberStyles.Any, culture, out double d)
+			? new Maui34130Size(d)
+			: base.ConvertFrom(context, culture, value)!;
+
+	public object ConvertFromInvariantString(string value, IServiceProvider serviceProvider)
+		=> double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double d)
+			? new Maui34130Size(d)
+			: new Maui34130Size(0);
+}
+
+public class Maui34130SizeBox : View
+{
+	public static readonly BindableProperty SizeProperty =
+		BindableProperty.Create(nameof(Size), typeof(Maui34130Size), typeof(Maui34130SizeBox), default(Maui34130Size));
+
+	public Maui34130Size Size
+	{
+		get => (Maui34130Size)GetValue(SizeProperty);
+		set => SetValue(SizeProperty, value);
+	}
+}
+
+public class Maui34130GenericWrapper<T>
+{
+	public T? Value { get; set; }
+}
+
+public class Maui34130Item
+{
+	public string Name { get; set; } = string.Empty;
+}
+
+public class Maui34130ViewModel
+{
+	public Maui34130GenericWrapper<Maui34130Item?> SelectedItem { get; } = new();
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description
Fixes two SourceGen nullability issues reported in #34130:

- avoid nullable-unboxing warnings by null-forgiving `IExtendedTypeConverter` results before value-type casts
- preserve nullable generic type arguments in BindingSourceGen type names while avoiding invalid nullable top-level type syntax

Also adds `Maui34130` Xaml.UnitTest coverage across Runtime and SourceGen inflators.

## Validation
- `dotnet build src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj -nologo -v minimal`
- `dotnet test src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj --filter "FullyQualifiedName~Maui34130" -nologo -v minimal`

## fixes
- fixes #34130