### PR TITLE
[Windows] Fix modal page keyboard focus not shifting to newly opened modal

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -7,7 +7,6 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
-using Microsoft.UI.Xaml.Input;
 using Xunit;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 
@@ -165,7 +164,6 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
 				async (handler) =>
 				{
-					var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
 					ContentPage modalPage = new ContentPage() { Content = new Label() { Text = "Modal Page" } };
 
 					if (useColor)

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -186,16 +186,6 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(modalRootView.IsHitTestVisible,
 						"Modal page should have IsHitTestVisible=true");
 
-					// Tab should cycle within the modal (not escape to underlying page)
-					Assert.Equal(
-						Microsoft.UI.Xaml.Input.KeyboardNavigationMode.Cycle,
-						modalRootView.TabFocusNavigation);
-
-					// Underlying page's tab navigation should be restricted
-					Assert.Equal(
-						Microsoft.UI.Xaml.Input.KeyboardNavigationMode.Once,
-						rootPageRootView.TabFocusNavigation);
-
 					await navPage.CurrentPage.Navigation.PopModalAsync();
 					await OnUnloadedAsync(modalPage);
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -194,5 +194,52 @@ namespace Microsoft.Maui.DeviceTests
 						"Underlying page should have IsHitTestVisible=true after modal is dismissed");
 				});
 		}
+
+		[Fact]
+		public async Task ModalPageFocusTrapsAndRestoresCorrectly()
+		{
+			SetupBuilder();
+
+			var button = new Button() { Text = "Test Button" };
+			var rootPage = new ContentPage() { Content = button };
+			var navPage = new NavigationPage(rootPage);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+				async (handler) =>
+				{
+					var modalButton = new Button() { Text = "Modal Button" };
+					var modalPage = new ContentPage()
+					{
+						Content = modalButton,
+						BackgroundColor = Colors.Purple.WithAlpha(0.5f)
+					};
+
+					var container = (WindowRootViewContainer)handler.PlatformView.Content;
+
+					// Push modal
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					var rootPageRootView = navPage.FindMauiContext().GetNavigationRootManager().RootView;
+					var modalRootView = modalPage.FindMauiContext().GetNavigationRootManager().RootView;
+
+					// Underlying page should be non-interactive
+					Assert.False(rootPageRootView.IsHitTestVisible);
+
+					// Pop modal
+					await navPage.CurrentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPage);
+
+					// After pop, the root page should be fully interactive
+					Assert.True(rootPageRootView.IsHitTestVisible,
+						"Root page should be hit-test visible after modal pop");
+
+					// The root page should still be in the visual tree
+					Assert.Contains(rootPageRootView, container.CachedChildren);
+
+					// The modal should be removed
+					Assert.DoesNotContain(modalRootView, container.CachedChildren);
+				});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml.Input;
 using Xunit;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 
@@ -150,6 +151,50 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(windowRootView.AppTitleBarContainer.Visibility == UI.Xaml.Visibility.Visible);
 					Assert.True(windowRootView.NavigationViewControl.ButtonHolderGrid.Visibility == UI.Xaml.Visibility.Visible);
 				}));
+		}
+
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task ModalPageDisablesHitTestOnUnderlyingPage(bool useColor)
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage() { Content = new Label() { Text = "Root Page" } });
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+				async (handler) =>
+				{
+					var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
+					ContentPage modalPage = new ContentPage() { Content = new Label() { Text = "Modal Page" } };
+
+					if (useColor)
+						modalPage.BackgroundColor = Colors.Purple.WithAlpha(0.5f);
+					else
+						modalPage.Background = new SolidColorBrush(Colors.Purple.WithAlpha(0.5f));
+
+					var rootPageRootView = navPage.FindMauiContext().GetNavigationRootManager().RootView;
+
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					var modalRootView = modalPage.FindMauiContext().GetNavigationRootManager().RootView;
+
+					// The underlying page should have IsHitTestVisible disabled
+					Assert.False(rootPageRootView.IsHitTestVisible,
+						"Underlying page should have IsHitTestVisible=false when a modal is displayed");
+
+					// The modal page should have IsHitTestVisible enabled
+					Assert.True(modalRootView.IsHitTestVisible,
+						"Modal page should have IsHitTestVisible=true");
+
+					await navPage.CurrentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPage);
+
+					// After popping the modal, the underlying page should be interactive again
+					Assert.True(rootPageRootView.IsHitTestVisible,
+						"Underlying page should have IsHitTestVisible=true after modal is dismissed");
+				});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -241,5 +241,80 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.DoesNotContain(modalRootView, container.CachedChildren);
 				});
 		}
+
+		[Fact]
+		public async Task NestedModalPagesMaintainHitTestVisibilityAndFocusTrap()
+		{
+			SetupBuilder();
+
+			var button = new Button() { Text = "Root Button" };
+			var rootPage = new ContentPage() { Content = button };
+			var navPage = new NavigationPage(rootPage);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+				async (handler) =>
+				{
+					var modalButtonA = new Button() { Text = "Modal A Button" };
+					var modalPageA = new ContentPage()
+					{
+						Content = modalButtonA,
+						BackgroundColor = Colors.Green.WithAlpha(0.5f)
+					};
+
+					var modalButtonB = new Button() { Text = "Modal B Button" };
+					var modalPageB = new ContentPage()
+					{
+						Content = modalButtonB,
+						BackgroundColor = Colors.Red.WithAlpha(0.5f)
+					};
+
+					var container = (WindowRootViewContainer)handler.PlatformView.Content;
+
+					// Push first modal (A)
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPageA);
+					await OnLoadedAsync(modalPageA);
+
+					var rootPageRootView = navPage.FindMauiContext().GetNavigationRootManager().RootView;
+					var modalARootView = modalPageA.FindMauiContext().GetNavigationRootManager().RootView;
+
+					// Underlying root page should be non-interactive while modal A is showing
+					Assert.False(rootPageRootView.IsHitTestVisible);
+					Assert.Contains(modalARootView, container.CachedChildren);
+
+					// Push second modal (B) on top of A
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPageB);
+					await OnLoadedAsync(modalPageB);
+
+					var modalBRootView = modalPageB.FindMauiContext().GetNavigationRootManager().RootView;
+
+					// Root should still be non-interactive with topmost modal B showing
+					Assert.False(rootPageRootView.IsHitTestVisible);
+					Assert.Contains(modalBRootView, container.CachedChildren);
+
+					// Pop topmost modal (B)
+					await navPage.CurrentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPageB);
+
+					// After popping B, modal A is still visible, so the root page
+					// should remain non-interactive (focus trap still active)
+					Assert.False(rootPageRootView.IsHitTestVisible);
+					Assert.Contains(modalARootView, container.CachedChildren);
+					Assert.DoesNotContain(modalBRootView, container.CachedChildren);
+
+					// Now pop modal A
+					await navPage.CurrentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPageA);
+
+					// After popping the last modal, the root page should be interactive again
+					Assert.True(rootPageRootView.IsHitTestVisible,
+						"Root page should be hit-test visible after all modals are popped");
+
+					// The root page should still be in the visual tree
+					Assert.Contains(rootPageRootView, container.CachedChildren);
+
+					// Modal A should now be removed from the visual tree
+					Assert.DoesNotContain(modalARootView, container.CachedChildren);
+				});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -186,6 +186,16 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.True(modalRootView.IsHitTestVisible,
 						"Modal page should have IsHitTestVisible=true");
 
+					// Tab should cycle within the modal (not escape to underlying page)
+					Assert.Equal(
+						Microsoft.UI.Xaml.Input.KeyboardNavigationMode.Cycle,
+						modalRootView.TabFocusNavigation);
+
+					// Underlying page's tab navigation should be restricted
+					Assert.Equal(
+						Microsoft.UI.Xaml.Input.KeyboardNavigationMode.Once,
+						rootPageRootView.TabFocusNavigation);
+
 					await navPage.CurrentPage.Navigation.PopModalAsync();
 					await OnUnloadedAsync(modalPage);
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22938.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22938.cs
@@ -46,6 +46,11 @@ public class Issue22938 : ContentPage
 								FontSize = 24,
 								HorizontalOptions = LayoutOptions.Center
 							},
+							new Entry
+							{
+								Placeholder = "Focus target on modal",
+								AutomationId = "ModalEntry"
+							},
 							new Button
 							{
 								Text = "Close Modal",
@@ -54,11 +59,6 @@ public class Issue22938 : ContentPage
 								{
 									await Navigation.PopModalAsync();
 								})
-							},
-							new Entry
-							{
-								Placeholder = "Focus target on modal",
-								AutomationId = "ModalEntry"
 							}
 						}
 					}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22938.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22938.cs
@@ -29,9 +29,12 @@ public class Issue22938 : ContentPage
 			AutomationId = "OpenModalButton",
 			Command = new Command(async () =>
 			{
-				var modalPage = new ContentPage
+				// Use semi-transparent background to match the reproduction scenario.
+			// This causes the underlying page to remain in the visual tree
+			// (ModalNavigationManager does not call RemovePage for non-default backgrounds).
+			var modalPage = new ContentPage
 				{
-					BackgroundColor = Colors.Beige,
+					BackgroundColor = Color.FromArgb("#40808080"),
 					Content = new VerticalStackLayout
 					{
 						Spacing = 20,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue22938.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue22938.cs
@@ -1,0 +1,89 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 22938, "Keyboard focus does not shift to a newly opened modal page", PlatformAffected.All)]
+public class Issue22938 : ContentPage
+{
+	public Issue22938()
+	{
+		var clickCountLabel = new Label
+		{
+			Text = "0",
+			AutomationId = "ClickCountLabel",
+			FontSize = 24
+		};
+
+		var mainPageButton = new Button
+		{
+			Text = "Click Me",
+			AutomationId = "MainPageButton",
+			Command = new Command(() =>
+			{
+				int count = int.Parse(clickCountLabel.Text);
+				clickCountLabel.Text = (count + 1).ToString();
+			})
+		};
+
+		var openModalButton = new Button
+		{
+			Text = "Open Modal",
+			AutomationId = "OpenModalButton",
+			Command = new Command(async () =>
+			{
+				var modalPage = new ContentPage
+				{
+					BackgroundColor = Colors.Beige,
+					Content = new VerticalStackLayout
+					{
+						Spacing = 20,
+						Padding = new Thickness(30),
+						VerticalOptions = LayoutOptions.Center,
+						Children =
+						{
+							new Label
+							{
+								Text = "Modal Page",
+								AutomationId = "ModalPageLabel",
+								FontSize = 24,
+								HorizontalOptions = LayoutOptions.Center
+							},
+							new Button
+							{
+								Text = "Close Modal",
+								AutomationId = "CloseModalButton",
+								Command = new Command(async () =>
+								{
+									await Navigation.PopModalAsync();
+								})
+							},
+							new Entry
+							{
+								Placeholder = "Focus target on modal",
+								AutomationId = "ModalEntry"
+							}
+						}
+					}
+				};
+
+				await Navigation.PushModalAsync(modalPage);
+			})
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Padding = new Thickness(30),
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				new Label
+				{
+					Text = "Main Page - Issue 22938",
+					FontSize = 24
+				},
+				mainPageButton,
+				clickCountLabel,
+				openModalButton
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22938.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22938.cs
@@ -39,4 +39,40 @@ public class Issue22938 : _IssuesUITest
 		Assert.That(clickCount, Is.EqualTo("0"),
 			"Enter key should not activate buttons on the page beneath a modal");
 	}
+
+	[Test]
+	[Category(UITestCategories.Focus)]
+	public void TabShouldNotCycleToBehindModal()
+	{
+		App.WaitForElement("OpenModalButton");
+
+		// Open the modal page (uses semi-transparent background so underlying page stays in tree)
+		App.Tap("OpenModalButton");
+
+		// Wait for modal to appear
+		App.WaitForElement("ModalEntry");
+
+		// Tab through many times to attempt cycling past the modal into the underlying page.
+		// The modal has 2 focusable elements (Entry + CloseModalButton), so 10 tabs should
+		// cycle through them multiple times. If focus escapes to the underlying page,
+		// one of the tabs could land on MainPageButton.
+		for (int i = 0; i < 10; i++)
+		{
+			App.SendTabKey();
+		}
+
+		// Now press Enter. If focus leaked to MainPageButton, this would click it.
+		App.PressEnter();
+
+		// Close the modal
+		App.Tap("CloseModalButton");
+
+		// Wait for main page to reappear
+		App.WaitForElement("ClickCountLabel");
+
+		// Verify the main page button was NOT clicked during Tab cycling
+		var clickCount = App.WaitForElement("ClickCountLabel").GetText();
+		Assert.That(clickCount, Is.EqualTo("0"),
+			"Tab key should not cycle focus to buttons on the page beneath a modal");
+	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22938.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22938.cs
@@ -21,14 +21,14 @@ public class Issue22938 : _IssuesUITest
 		// Open the modal page
 		App.Tap("OpenModalButton");
 
-		// Wait for modal to appear
-		App.WaitForElement("ModalPageLabel");
+		// Wait for modal to appear — the Entry is the first focusable element
+		App.WaitForElement("ModalEntry");
 
-		// Press Enter — if focus is correctly on the modal, this should NOT
-		// activate the MainPage button (click count should stay at 0)
+		// Press Enter — with the fix, focus is on ModalEntry (an Entry control),
+		// so Enter should NOT activate MainPageButton on the page beneath
 		App.PressEnter();
 
-		// Close the modal
+		// Close the modal by tapping the close button explicitly
 		App.Tap("CloseModalButton");
 
 		// Wait for main page to reappear

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22938.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22938.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue22938 : _IssuesUITest
+{
+	public Issue22938(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Keyboard focus does not shift to a newly opened modal page";
+
+	[Test]
+	[Category(UITestCategories.Focus)]
+	public void ModalPageShouldReceiveKeyboardFocus()
+	{
+		App.WaitForElement("OpenModalButton");
+
+		// Open the modal page
+		App.Tap("OpenModalButton");
+
+		// Wait for modal to appear
+		App.WaitForElement("ModalPageLabel");
+
+		// Press Enter — if focus is correctly on the modal, this should NOT
+		// activate the MainPage button (click count should stay at 0)
+		App.PressEnter();
+
+		// Close the modal
+		App.Tap("CloseModalButton");
+
+		// Wait for main page to reappear
+		App.WaitForElement("ClickCountLabel");
+
+		// Verify the main page button was NOT clicked by the Enter key
+		var clickCount = App.WaitForElement("ClickCountLabel").GetText();
+		Assert.That(clickCount, Is.EqualTo("0"),
+			"Enter key should not activate buttons on the page beneath a modal");
+	}
+}

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -57,8 +57,13 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!CachedChildren.Contains(pageView))
 			{
-				// Disable interaction on the page being covered by the modal
-				_topPage?.SetValue(IsHitTestVisibleProperty, false);
+				if (_topPage is not null)
+				{
+					// Disable pointer and keyboard interaction on the page being covered
+					_topPage.SetValue(IsHitTestVisibleProperty, false);
+					// Belt-and-suspenders: prevent tab navigation into the underlying subtree
+					_topPage.SetValue(TabFocusNavigationProperty, KeyboardNavigationMode.Once);
+				}
 
 				int indexOFTopPage = 0;
 				if (_topPage is not null)
@@ -66,6 +71,13 @@ namespace Microsoft.Maui.Platform
 
 				CachedChildren.Insert(indexOFTopPage, pageView);
 				_topPage = pageView;
+
+				// Trap Tab within the modal so it cycles instead of escaping.
+				// Only do this when covering another page (i.e., this is a modal).
+				if (indexOFTopPage > 0)
+				{
+					_topPage.SetValue(TabFocusNavigationProperty, KeyboardNavigationMode.Cycle);
+				}
 
 				// Move keyboard focus to the new top page
 				TryMoveFocusToPage(_topPage);
@@ -92,6 +104,7 @@ namespace Microsoft.Maui.Platform
 				if (_topPage is not null)
 				{
 					_topPage.IsHitTestVisible = true;
+					_topPage.ClearValue(TabFocusNavigationProperty);
 					TryMoveFocusToPage(_topPage);
 				}
 			}

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui.Platform
 		bool _modalFocusTrapActive;
 		TypedEventHandler<UIElement, GettingFocusEventArgs>? _gettingFocusHandler;
 		readonly Dictionary<FrameworkElement, KeyboardNavigationMode> _originalTabNavigation = new();
+		readonly Dictionary<FrameworkElement, bool> _originalIsHitTestVisible = new();
 
 		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
 		internal UIElementCollection CachedChildren
@@ -65,6 +66,7 @@ namespace Microsoft.Maui.Platform
 				if (_topPage is not null)
 				{
 					// Block pointer/touch input on the page being covered
+					_originalIsHitTestVisible[_topPage] = _topPage.IsHitTestVisible;
 					_topPage.IsHitTestVisible = false;
 				}
 
@@ -138,8 +140,10 @@ namespace Microsoft.Maui.Platform
 
 			if (_topPage is not null)
 			{
-				// Re-enable pointer/touch on the revealed page
-				_topPage.IsHitTestVisible = true;
+				// Re-enable pointer/touch on the revealed page, restoring its original value
+				_topPage.IsHitTestVisible = _originalIsHitTestVisible.Remove(_topPage, out var originalHitTest)
+					? originalHitTest
+					: true;
 				TryMoveFocusToPage(_topPage);
 			}
 		}

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -77,6 +77,10 @@ namespace Microsoft.Maui.Platform
 				// so Tab cannot escape the modal — mirroring how WinUI ContentDialog works.
 				if (indexOFTopPage > 0)
 				{
+					// Cycle Tab within the modal so it never escapes to underlying pages
+					if (pageView is Control modalControl)
+						modalControl.TabFocusNavigation = KeyboardNavigationMode.Cycle;
+
 					EnableModalFocusTrap();
 				}
 
@@ -89,27 +93,33 @@ namespace Microsoft.Maui.Platform
 			// Clean up any pending Loaded handler to prevent memory leaks
 			pageView.Loaded -= OnPageLoadedForFocus;
 
-			int remainingCount = CachedChildren.Count - 1;
-
-			// Update _topPage and disable focus trap BEFORE removing from the collection.
-			// WinUI3 fires GettingFocus synchronously when a focused element is removed from the tree.
-			// If _topPage still references the removed modal, OnContainerGettingFocus would redirect
-			// focus to a detached element or cancel focus changes, leaving focus in a broken state.
-			if (remainingCount > 0)
+			// Find the new top page by scanning backwards through children.
+			// CachedChildren may contain non-page elements (e.g., W2DGraphicsView for visual diagnostics),
+			// so we cannot rely on simple index arithmetic. We look for the topmost page that isn't
+			// the one being removed.
+			FrameworkElement? newTopPage = null;
+			int pageCount = 0;
+			for (int i = CachedChildren.Count - 1; i >= 0; i--)
 			{
-				// The new top page is the last element that isn't being removed
-				int removeIndex = CachedChildren.IndexOf(pageView);
-				int newTopIndex = removeIndex == CachedChildren.Count - 1
-					? removeIndex - 1
-					: CachedChildren.Count - 2;
-				_topPage = (FrameworkElement)CachedChildren[newTopIndex >= 0 ? newTopIndex : 0];
+				var child = CachedChildren[i] as FrameworkElement;
+				if (child is null || child == pageView)
+					continue;
 
-				if (remainingCount <= 1)
-					DisableModalFocusTrap();
+				// Only count actual page views (WindowRootView), not overlays
+				if (child is not WindowRootView)
+					continue;
+
+				pageCount++;
+				newTopPage ??= child;
 			}
-			else
+
+			// Update _topPage BEFORE removing from the collection.
+			// WinUI3 fires GettingFocus synchronously when a focused element is removed from the tree.
+			_topPage = newTopPage;
+
+			// Disable the focus trap if we're back to a single page (no more modals)
+			if (pageCount <= 1)
 			{
-				_topPage = null;
 				DisableModalFocusTrap();
 			}
 
@@ -144,6 +154,10 @@ namespace Microsoft.Maui.Platform
 
 		void OnContainerGettingFocus(UIElement sender, GettingFocusEventArgs args)
 		{
+			// Guard: only act when trap is explicitly active
+			if (!_modalFocusTrapActive)
+				return;
+
 			if (_topPage is null || args.NewFocusedElement is not DependencyObject newElement)
 				return;
 

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Platform
 		FrameworkElement? _topPage;
 		UIElementCollection? _cachedChildren;
 		bool _modalFocusTrapActive;
+		TypedEventHandler<UIElement, GettingFocusEventArgs>? _gettingFocusHandler;
 
 		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
 		internal UIElementCollection CachedChildren
@@ -116,18 +117,17 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!_modalFocusTrapActive)
 			{
-				// Use AddHandler with handledEventsToo so we intercept focus changes
-				// even if a child element already handled the event.
-				AddHandler(GettingFocusEvent, new TypedEventHandler<UIElement, GettingFocusEventArgs>(OnContainerGettingFocus), true);
+				_gettingFocusHandler ??= new TypedEventHandler<UIElement, GettingFocusEventArgs>(OnContainerGettingFocus);
+				AddHandler(GettingFocusEvent, _gettingFocusHandler, true);
 				_modalFocusTrapActive = true;
 			}
 		}
 
 		void DisableModalFocusTrap()
 		{
-			if (_modalFocusTrapActive)
+			if (_modalFocusTrapActive && _gettingFocusHandler is not null)
 			{
-				RemoveHandler(GettingFocusEvent, new TypedEventHandler<UIElement, GettingFocusEventArgs>(OnContainerGettingFocus));
+				RemoveHandler(GettingFocusEvent, _gettingFocusHandler);
 				_modalFocusTrapActive = false;
 			}
 		}
@@ -194,7 +194,17 @@ namespace Microsoft.Maui.Platform
 					return;
 			}
 
-			page.Focus(FocusState.Programmatic);
+			if (page.Focus(FocusState.Programmatic))
+				return;
+
+			// If immediate focus failed (visual tree not ready yet), defer until after layout
+			page.DispatcherQueue?.TryEnqueue(() =>
+			{
+				if (FocusManager.FindFirstFocusableElement(page) is UIElement el)
+					el.Focus(FocusState.Programmatic);
+				else
+					page.Focus(FocusState.Programmatic);
+			});
 		}
 
 		internal void AddOverlay(FrameworkElement overlayView)

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;
 
 namespace Microsoft.Maui.Platform
@@ -56,12 +57,18 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!CachedChildren.Contains(pageView))
 			{
+				// Disable interaction on the page being covered by the modal
+				_topPage?.SetValue(IsHitTestVisibleProperty, false);
+
 				int indexOFTopPage = 0;
-				if (_topPage != null)
+				if (_topPage is not null)
 					indexOFTopPage = CachedChildren.IndexOf(_topPage) + 1;
 
 				CachedChildren.Insert(indexOFTopPage, pageView);
 				_topPage = pageView;
+
+				// Move keyboard focus to the new top page
+				TryMoveFocusToPage(_topPage);
 			}
 		}
 
@@ -74,9 +81,49 @@ namespace Microsoft.Maui.Platform
 			CachedChildren.Remove(pageView);
 
 			if (indexOFTopPage >= 0)
+			{
 				_topPage = (FrameworkElement)CachedChildren[indexOFTopPage];
+
+				// Re-enable interaction on the revealed page and restore focus
+				if (_topPage is not null)
+				{
+					_topPage.IsHitTestVisible = true;
+					TryMoveFocusToPage(_topPage);
+				}
+			}
 			else
+			{
 				_topPage = null;
+			}
+		}
+
+		static void TryMoveFocusToPage(FrameworkElement page)
+		{
+			if (page.IsLoaded)
+			{
+				SetFocusToFirstElement(page);
+			}
+			else
+			{
+				page.Loaded += OnPageLoadedForFocus;
+			}
+		}
+
+		static void OnPageLoadedForFocus(object sender, RoutedEventArgs e)
+		{
+			if (sender is FrameworkElement page)
+			{
+				page.Loaded -= OnPageLoadedForFocus;
+				SetFocusToFirstElement(page);
+			}
+		}
+
+		static void SetFocusToFirstElement(FrameworkElement page)
+		{
+			if (FocusManager.FindFirstFocusableElement(page) is Control focusable)
+			{
+				focusable.Focus(FocusState.Programmatic);
+			}
 		}
 
 		internal void AddOverlay(FrameworkElement overlayView)

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -89,27 +89,37 @@ namespace Microsoft.Maui.Platform
 			// Clean up any pending Loaded handler to prevent memory leaks
 			pageView.Loaded -= OnPageLoadedForFocus;
 
-			CachedChildren.Remove(pageView);
+			int remainingCount = CachedChildren.Count - 1;
 
-			if (CachedChildren.Count > 0)
+			// Update _topPage and disable focus trap BEFORE removing from the collection.
+			// WinUI3 fires GettingFocus synchronously when a focused element is removed from the tree.
+			// If _topPage still references the removed modal, OnContainerGettingFocus would redirect
+			// focus to a detached element or cancel focus changes, leaving focus in a broken state.
+			if (remainingCount > 0)
 			{
-				_topPage = (FrameworkElement)CachedChildren[CachedChildren.Count - 1];
+				// The new top page is the last element that isn't being removed
+				int removeIndex = CachedChildren.IndexOf(pageView);
+				int newTopIndex = removeIndex == CachedChildren.Count - 1
+					? removeIndex - 1
+					: CachedChildren.Count - 2;
+				_topPage = (FrameworkElement)CachedChildren[newTopIndex >= 0 ? newTopIndex : 0];
 
-				// Re-enable pointer/touch on the revealed page
-				_topPage.IsHitTestVisible = true;
-
-				// If only one page remains, no focus trapping is needed
-				if (CachedChildren.Count <= 1)
-				{
+				if (remainingCount <= 1)
 					DisableModalFocusTrap();
-				}
-
-				TryMoveFocusToPage(_topPage);
 			}
 			else
 			{
 				_topPage = null;
 				DisableModalFocusTrap();
+			}
+
+			CachedChildren.Remove(pageView);
+
+			if (_topPage is not null)
+			{
+				// Re-enable pointer/touch on the revealed page
+				_topPage.IsHitTestVisible = true;
+				TryMoveFocusToPage(_topPage);
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 
 namespace Microsoft.Maui.Platform
@@ -10,6 +11,7 @@ namespace Microsoft.Maui.Platform
 	{
 		FrameworkElement? _topPage;
 		UIElementCollection? _cachedChildren;
+		bool _modalFocusTrapActive;
 
 		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
 		internal UIElementCollection CachedChildren
@@ -59,10 +61,8 @@ namespace Microsoft.Maui.Platform
 			{
 				if (_topPage is not null)
 				{
-					// Disable pointer and keyboard interaction on the page being covered
-					_topPage.SetValue(IsHitTestVisibleProperty, false);
-					// Belt-and-suspenders: prevent tab navigation into the underlying subtree
-					_topPage.SetValue(TabFocusNavigationProperty, KeyboardNavigationMode.Once);
+					// Block pointer/touch input on the page being covered
+					_topPage.IsHitTestVisible = false;
 				}
 
 				int indexOFTopPage = 0;
@@ -72,46 +72,96 @@ namespace Microsoft.Maui.Platform
 				CachedChildren.Insert(indexOFTopPage, pageView);
 				_topPage = pageView;
 
-				// Trap Tab within the modal so it cycles instead of escaping.
-				// Only do this when covering another page (i.e., this is a modal).
+				// When covering another page, activate keyboard focus trapping
+				// so Tab cannot escape the modal — mirroring how WinUI ContentDialog works.
 				if (indexOFTopPage > 0)
 				{
-					_topPage.SetValue(TabFocusNavigationProperty, KeyboardNavigationMode.Cycle);
+					EnableModalFocusTrap();
 				}
 
-				// Move keyboard focus to the new top page
 				TryMoveFocusToPage(_topPage);
 			}
 		}
 
 		internal void RemovePage(FrameworkElement pageView)
 		{
-			// Unsubscribe any pending Loaded handler to prevent memory leaks
-			// and stale focus changes after the page leaves the container
+			// Clean up any pending Loaded handler to prevent memory leaks
 			pageView.Loaded -= OnPageLoadedForFocus;
-
-			int indexOFTopPage = -1;
-			if (_topPage != null)
-				indexOFTopPage = CachedChildren.IndexOf(_topPage) - 1;
 
 			CachedChildren.Remove(pageView);
 
-			if (indexOFTopPage >= 0)
+			if (CachedChildren.Count > 0)
 			{
-				_topPage = (FrameworkElement)CachedChildren[indexOFTopPage];
+				_topPage = (FrameworkElement)CachedChildren[CachedChildren.Count - 1];
 
-				// Re-enable interaction on the revealed page and restore focus
-				if (_topPage is not null)
+				// Re-enable pointer/touch on the revealed page
+				_topPage.IsHitTestVisible = true;
+
+				// If only one page remains, no focus trapping is needed
+				if (CachedChildren.Count <= 1)
 				{
-					_topPage.IsHitTestVisible = true;
-					_topPage.ClearValue(TabFocusNavigationProperty);
-					TryMoveFocusToPage(_topPage);
+					DisableModalFocusTrap();
 				}
+
+				TryMoveFocusToPage(_topPage);
 			}
 			else
 			{
 				_topPage = null;
+				DisableModalFocusTrap();
 			}
+		}
+
+		void EnableModalFocusTrap()
+		{
+			if (!_modalFocusTrapActive)
+			{
+				// Use AddHandler with handledEventsToo so we intercept focus changes
+				// even if a child element already handled the event.
+				AddHandler(GettingFocusEvent, new TypedEventHandler<UIElement, GettingFocusEventArgs>(OnContainerGettingFocus), true);
+				_modalFocusTrapActive = true;
+			}
+		}
+
+		void DisableModalFocusTrap()
+		{
+			if (_modalFocusTrapActive)
+			{
+				RemoveHandler(GettingFocusEvent, new TypedEventHandler<UIElement, GettingFocusEventArgs>(OnContainerGettingFocus));
+				_modalFocusTrapActive = false;
+			}
+		}
+
+		void OnContainerGettingFocus(UIElement sender, GettingFocusEventArgs args)
+		{
+			if (_topPage is null || args.NewFocusedElement is not DependencyObject newElement)
+				return;
+
+			// Allow focus changes within the current top (modal) page
+			if (newElement == _topPage || IsDescendantOf(newElement, _topPage))
+				return;
+
+			// Focus is trying to leave the modal — redirect it back
+			if (FocusManager.FindFirstFocusableElement(_topPage) is DependencyObject firstFocusable)
+			{
+				args.TrySetNewFocusedElement(firstFocusable);
+			}
+			else
+			{
+				args.TryCancel();
+			}
+		}
+
+		static bool IsDescendantOf(DependencyObject element, DependencyObject ancestor)
+		{
+			var current = VisualTreeHelper.GetParent(element);
+			while (current is not null)
+			{
+				if (current == ancestor)
+					return true;
+				current = VisualTreeHelper.GetParent(current);
+			}
+			return false;
 		}
 
 		static void TryMoveFocusToPage(FrameworkElement page)
@@ -122,7 +172,6 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				// Unsubscribe first to prevent duplicate subscriptions if called multiple times before load
 				page.Loaded -= OnPageLoadedForFocus;
 				page.Loaded += OnPageLoadedForFocus;
 			}
@@ -142,12 +191,9 @@ namespace Microsoft.Maui.Platform
 			if (FocusManager.FindFirstFocusableElement(page) is UIElement focusableElement)
 			{
 				if (focusableElement.Focus(FocusState.Programmatic))
-				{
 					return;
-				}
 			}
 
-			// Fallback: ensure the page itself takes focus so keyboard input does not remain on the underlying content
 			page.Focus(FocusState.Programmatic);
 		}
 

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -120,10 +120,16 @@ namespace Microsoft.Maui.Platform
 
 		static void SetFocusToFirstElement(FrameworkElement page)
 		{
-			if (FocusManager.FindFirstFocusableElement(page) is Control focusable)
+			if (FocusManager.FindFirstFocusableElement(page) is UIElement focusableElement)
 			{
-				focusable.Focus(FocusState.Programmatic);
+				if (focusableElement.Focus(FocusState.Programmatic))
+				{
+					return;
+				}
 			}
+
+			// Fallback: ensure the page itself takes focus so keyboard input does not remain on the underlying content
+			page.Focus(FocusState.Programmatic);
 		}
 
 		internal void AddOverlay(FrameworkElement overlayView)

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -13,6 +14,7 @@ namespace Microsoft.Maui.Platform
 		UIElementCollection? _cachedChildren;
 		bool _modalFocusTrapActive;
 		TypedEventHandler<UIElement, GettingFocusEventArgs>? _gettingFocusHandler;
+		readonly Dictionary<FrameworkElement, KeyboardNavigationMode> _originalTabNavigation = new();
 
 		[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "Panel.Children property is banned to enforce use of this CachedChildren property.")]
 		internal UIElementCollection CachedChildren
@@ -79,7 +81,10 @@ namespace Microsoft.Maui.Platform
 				{
 					// Cycle Tab within the modal so it never escapes to underlying pages
 					if (pageView is Control modalControl)
+					{
+						_originalTabNavigation[pageView] = modalControl.TabFocusNavigation;
 						modalControl.TabFocusNavigation = KeyboardNavigationMode.Cycle;
+					}
 
 					EnableModalFocusTrap();
 				}
@@ -92,6 +97,12 @@ namespace Microsoft.Maui.Platform
 		{
 			// Clean up any pending Loaded handler to prevent memory leaks
 			pageView.Loaded -= OnPageLoadedForFocus;
+
+			// Restore the original TabFocusNavigation value that was overridden in AddPage
+			if (_originalTabNavigation.Remove(pageView, out var originalMode) && pageView is Control control)
+			{
+				control.TabFocusNavigation = originalMode;
+			}
 
 			// Find the new top page by scanning backwards through children.
 			// CachedChildren may contain non-page elements (e.g., W2DGraphicsView for visual diagnostics),

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -74,6 +74,10 @@ namespace Microsoft.Maui.Platform
 
 		internal void RemovePage(FrameworkElement pageView)
 		{
+			// Unsubscribe any pending Loaded handler to prevent memory leaks
+			// and stale focus changes after the page leaves the container
+			pageView.Loaded -= OnPageLoadedForFocus;
+
 			int indexOFTopPage = -1;
 			if (_topPage != null)
 				indexOFTopPage = CachedChildren.IndexOf(_topPage) - 1;
@@ -105,6 +109,8 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
+				// Unsubscribe first to prevent duplicate subscriptions if called multiple times before load
+				page.Loaded -= OnPageLoadedForFocus;
 				page.Loaded += OnPageLoadedForFocus;
 			}
 		}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #22938 - Modal page keyboard focus not shifting on Windows

When a modal page is pushed via `Navigation.PushModalAsync` on Windows, keyboard focus stays on the underlying page. This causes:
1. **Enter key activates buttons beneath the modal** — a serious UX and accessibility bug
2. **Tab navigation cycles through ALL stacked pages** — not just the topmost modal

### Root Cause

`WindowRootViewContainer` (the WinUI Panel that stacks pages) had **zero focus management**. Pages were layered by z-order but keyboard focus was completely unmanaged.

### Fix

Three coordinated changes in `WindowRootViewContainer`:

1. **IsHitTestVisible toggling** — When pushing a modal, sets `IsHitTestVisible = false` on the underlying page to block pointer/touch input. Restores on pop.

2. **GettingFocus event trap** — Registers a `GettingFocus` handler (with `handledEventsToo=true`) on the container that intercepts any focus attempt leaving the modal page and redirects it back. This mirrors how WinUI3's `ContentDialog` implements modal focus trapping.

3. **Focus restoration** — `SetFocusToFirstElement` moves focus to the first focusable element in the new top page, with a `DispatcherQueue` fallback for cases where the visual tree isn't ready.

**Critical ordering fix**: State (`_topPage`, focus trap) is updated BEFORE `CachedChildren.Remove()` because WinUI3 fires `GettingFocus` synchronously when removing a focused element. Without this, the handler would see stale state pointing to the removed modal.

### Testing

- **Device test**: `ModalPageDisablesHitTestOnUnderlyingPage` — verifies IsHitTestVisible toggling
- **Device test**: `ModalPageFocusTrapsAndRestoresCorrectly` — verifies full push/pop cycle
- **UI test**: `Issue22938` — End-to-end test with semi-transparent modal
- **Unit tests**: 69/69 existing modal tests pass
- **Manual testing**: Verified with MauiApp1 reproduction app (3 push/pop cycles, buttons functional after each pop)