### PR TITLE
Use wildcard versions for template dependencies in preview builds

### DIFF
--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -81,12 +81,29 @@
         DestinationFiles="%(TemplateJsonInput.RelativeDir)templatestrings.json"
         Condition="'%(TemplateJsonInput.Filename)%(TemplateJsonInput.Extension)' == 'templatestrings.en.json'" />
 
+    <!-- When not stabilized (preview builds), strip the build number and replace with a wildcard:
+         e.g. 11.0.0-preview.2.26103.111 -> 11.0.0-preview.2.*
+         MSBuild has no built-in API for semver parsing, so we use Regex to strip the trailing build segments. -->
+    <PropertyGroup Condition="'$(StabilizePackageVersion)' != 'true'">
+      <_PreviewWildcardPattern>(-[a-zA-Z][a-zA-Z0-9]*\.\d+)\.\d+\.\d+</_PreviewWildcardPattern>
+      <_TemplateLoggingDebugVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(MicrosoftExtensionsLoggingDebugVersion)', '$(_PreviewWildcardPattern)', '%241.*'))</_TemplateLoggingDebugVersion>
+      <_TemplateComponentsWebVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(MicrosoftAspNetCoreComponentsWebPackageVersion)', '$(_PreviewWildcardPattern)', '%241.*'))</_TemplateComponentsWebVersion>
+      <_TemplateComponentsWebAssemblyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion)', '$(_PreviewWildcardPattern)', '%241.*'))</_TemplateComponentsWebAssemblyVersion>
+      <_TemplateComponentsWebAssemblyServerVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)', '$(_PreviewWildcardPattern)', '%241.*'))</_TemplateComponentsWebAssemblyServerVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(StabilizePackageVersion)' == 'true'">
+      <_TemplateLoggingDebugVersion>$(MicrosoftExtensionsLoggingDebugVersion)</_TemplateLoggingDebugVersion>
+      <_TemplateComponentsWebVersion>$(MicrosoftAspNetCoreComponentsWebPackageVersion)</_TemplateComponentsWebVersion>
+      <_TemplateComponentsWebAssemblyVersion>$(MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion)</_TemplateComponentsWebAssemblyVersion>
+      <_TemplateComponentsWebAssemblyServerVersion>$(MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)</_TemplateComponentsWebAssemblyServerVersion>
+    </PropertyGroup>
+
     <!-- Replace .NET TFM versions -->
     <ReplaceFileText
         InputFilename="%(TemplateJsonInput.IntermediateLocation)"
         OutputFilename="%(TemplateJsonInput.IntermediateLocation)"
         MatchExpression="DOTNET_TFM_VALUE;DOTNET_TFM_VERSION_VALUE;DOTNET_TFM_VERSION_MAJOR_VALUE;MS_EXT_LOG_DEBUG_VERSION_VALUE;MS_COMPONENTS_WEB_VERSION_VALUE;MS_COMPONENTS_WEBASSEMBLY_VERSION_VALUE;MS_COMPONENTS_WEBASSEMBLY_SERVER_VERSION_VALUE"
-        ReplacementText="$(_MauiDotNetTfm);$(_MauiDotNetVersion);$(_MauiDotNetVersionMajor)000;$(MicrosoftExtensionsLoggingDebugVersion);$(MicrosoftAspNetCoreComponentsWebPackageVersion);$(MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion);$(MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion)" />
+        ReplacementText="$(_MauiDotNetTfm);$(_MauiDotNetVersion);$(_MauiDotNetVersionMajor)000;$(_TemplateLoggingDebugVersion);$(_TemplateComponentsWebVersion);$(_TemplateComponentsWebAssemblyVersion);$(_TemplateComponentsWebAssemblyServerVersion)" />
 
     <ItemGroup>
       <FileWrites Include="%(TemplateJsonInput.IntermediateLocation)" />


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

When `StabilizePackageVersion` is `false` (preview/non-release builds), the template version values for external ASP.NET Core and Extensions packages included specific build numbers (e.g., `11.0.0-preview.2.26103.111`). This meant template-generated projects were pinned to an exact build number during preview.

This PR strips the build number and replaces it with a wildcard (`*`) so that templates use floating versions during preview (e.g., `11.0.0-preview.2.*`). When `StabilizePackageVersion` is `true` (stable/release builds), the exact version is used as before.

### Affected version placeholders

- `MS_EXT_LOG_DEBUG_VERSION_VALUE`
- `MS_COMPONENTS_WEB_VERSION_VALUE`
- `MS_COMPONENTS_WEBASSEMBLY_VERSION_VALUE`
- `MS_COMPONENTS_WEBASSEMBLY_SERVER_VERSION_VALUE`

### How it works

Added conditional `PropertyGroup` entries inside the `_UpdateTemplateVersions` target that use `Regex.Replace` to transform versions like `11.0.0-preview.2.26103.111` → `11.0.0-preview.2.*`. The regex `(-[a-zA-Z][a-zA-Z0-9]*\.\d+)\.\d+\.\d+` matches the prerelease label and iteration, then strips the trailing build number segments. Stable versions (no prerelease label) are unaffected since the regex does not match.