### PR TITLE
[build] clean up old `$(DebugType)` MSBuild settings

### DIFF
--- a/src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj
+++ b/src/Controls/tests/SourceGen.UnitTests/SourceGen.UnitTests.csproj
@@ -13,13 +13,6 @@
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests.csproj
@@ -21,13 +21,6 @@
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="$(NSubstitutePackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />

--- a/src/Essentials/test/UnitTests/Essentials.UnitTests.csproj
+++ b/src/Essentials/test/UnitTests/Essentials.UnitTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Maui.Essentials.UnitTests</AssemblyName>
-    <DebugType>portable</DebugType>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 


### PR DESCRIPTION
These likely came over from the migration from xamarin/Xamarin.Forms -> dotnet/maui.

`$(DebugType)=full` seems be causing the error at:

* https://github.com/dotnet/maui/pull/34201

```
    src\Controls\tests\Xaml.UnitTests\Issues\Gh2007.rtxc.xaml(3,9): XamlC warning XC0022: Binding could be compiled to improve runtime performance if x:DataType is specified. See https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings for more information. [D:\a\_work\1\s\src\Controls\tests\Xaml.UnitTests\Controls.Xaml.UnitTests.csproj]
    Fatal error.
    0xC0000005
    at Mono.Cecil.Pdb.ISymUnmanagedWriter2.Close()
    at Mono.Cecil.Pdb.SymWriter.Close()
    at Mono.Cecil.Pdb.NativePdbWriter.Write()
    at Mono.Cecil.ModuleWriter.Write(Mono.Cecil.ModuleDefinition, Mono.Disposable`1<System.IO.Stream>, Mono.Cecil.WriterParameters)
    at Mono.Cecil.ModuleWriter.WriteModule(Mono.Cecil.ModuleDefinition, Mono.Disposable`1<System.IO.Stream>, Mono.Cecil.WriterParameters)
    at Mono.Cecil.ModuleDefinition.Write(System.IO.Stream, Mono.Cecil.WriterParameters)
    at Mono.Cecil.ModuleDefinition.Write(Mono.Cecil.WriterParameters)
    at Mono.Cecil.AssemblyDefinition.Write(Mono.Cecil.WriterParameters)
    at Microsoft.Maui.Controls.Build.Tasks.XamlCTask.Execute(System.Collections.Generic.IList`1<System.Exception> ByRef)
    at Microsoft.Maui.Controls.Build.Tasks.XamlTask.Execute()
    at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteInstantiatedTask>d__25.MoveNext()
    at Microsoft.Build.BackEnd.TaskBuilder+<InitializeAndExecuteTask>d__23.MoveNext()
    at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[Microsoft.Build.BackEnd.TaskBuilder+<InitializeAndExecuteTask>d__23, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]](<InitializeAndExecuteTask>d__23 ByRef)
    at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteBucket>d__19.MoveNext()
    at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteTask>d__18.MoveNext()
    at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteTask>d__13.MoveNext()
    at Microsoft.Build.BackEnd.TargetEntry+<ProcessBucket>d__50.MoveNext()
    at Microsoft.Build.BackEnd.TargetEntry+<ExecuteTarget>d__43.MoveNext()
    at Microsoft.Build.BackEnd.TargetBuilder+<ProcessTargetStack>d__24.MoveNext()
    at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib, Version=11.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Build.BackEnd.TargetBuilder+<ProcessTargetStack>d__24, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]].MoveNext()
    at System.Threading.Tasks.TaskSchedulerAwaitTaskContinuation+<>c.<Run>b__2_0(System.Object)
    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef, System.Threading.Thread)
    at System.Threading.Tasks.Task.ExecuteEntry()
    at Microsoft.Build.BackEnd.RequestBuilder+DedicatedThreadsTaskScheduler.<InjectThread>b__6_0()
    at System.Threading.Thread+StartHelper.Callback(System.Object)
    at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
    at System.Threading.Thread.StartCallback()
    Build failed with exit code 57005. Check errors above.
```

We shouldn't be using Windows-specific debug settings in a cross-platform project -- the `$(DebugType)` setting is not needed.

I went through a couple projects and found old debugging settings that would have been needed in non-SDK-style projects, but are not needed in SDK-style projects. Removing those settings to cleanup the repo.