### PR TITLE
[Android] Fix SafeAreaShouldWorkOnAllShellTabs test failure on API 36

### DIFF
--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -131,11 +131,22 @@ internal static class SafeAreaExtensions
 					var screenWidth = realMetrics.WidthPixels;
 					var screenHeight = realMetrics.HeightPixels;
 
-					// Detect if view is off-screen horizontally BEFORE margin adjustment
-					// clamps negative positions to zero via Math.Max, destroying the signal.
-					// Example: during Shell tab animation, viewLeft=-1 gets clamped to 0,
+					// Detect if view is off-screen BEFORE margin adjustment clamps negative positions
+					// to zero via Math.Max, destroying the animation signal.
+					// Horizontal: during Shell tab animation, viewLeft=-1 gets clamped to 0,
 					// making it impossible to detect animation for the RIGHT edge afterward.
 					var isAnimatingHorizontally = viewLeft < 0 || viewRight > screenWidth;
+
+					// Vertical: During Shell navigation animations, the view may be positioned
+					// beyond the status bar area (e.g., Y=126 when status bar is 63px) and also
+					// extend beyond the screen bottom. This happens because the fragment animation
+					// slides the view in from off-screen. We detect this animating state by checking:
+					// 1. viewTop > top (view is below the status bar area - normal case would be viewTop <= top)
+					// 2. viewBottom > screenHeight (view extends beyond screen - confirms it's not just a small view)
+					// 3. viewTop > 0 (view is not at origin)
+					// This is DIFFERENT from ScrollView where viewTop = 0 (at origin, not animating).
+					// When we detect animation state, apply the full top inset since view will settle at Y=0.
+					var viewIsAnimating = viewTop > top && viewTop > 0 && viewBottom > screenHeight;
 
 					// Adjust for view's position relative to parent (including margins) to calculate
 					// safe area insets relative to the parent's position, not the view's visual position.
@@ -155,22 +166,6 @@ internal static class SafeAreaExtensions
 					// Top: how much the view extends into the top safe area
 					// If the viewTop is < 0 that means that it's most likely
 					// panned off the top of the screen so we don't want to apply any top inset
-					// 
-					// Special case: During Shell navigation animations, the view may be positioned
-					// beyond the status bar area (e.g., Y=126 when status bar is 63px) and also
-					// extend beyond the screen bottom. This happens because the fragment animation
-					// slides the view in from off-screen. We detect this animating state by checking:
-					// 1. viewTop > top (view is below the status bar area - normal case would be viewTop <= top)
-					// 2. viewBottom > screenHeight (view extends beyond screen - confirms it's not just a small view)
-					// 3. viewTop > 0 (view is not at origin)
-					// 
-					// This is DIFFERENT from ScrollView where:
-					// - viewTop = 0 (view is at origin, not animating)
-					// - Content extends beyond screen (but view position is stable)
-					//
-					// When we detect animation state, apply the full top inset since the view
-					// will eventually settle at Y=0.
-					var viewIsAnimating = viewTop > top && viewTop > 0 && viewBottom > screenHeight;
 
 					if (top > 0 && viewTop < top && viewTop >= 0)
 					{

--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -153,7 +153,7 @@ internal static class SafeAreaExtensions
 					// This ensures margins and safe area insets are additive rather than overlapping.
 					// For example: 20px margin + 30px safe area = 50px total offset
 					// We only take the margins into account if the Width and Height are set
-					// If the Width and Height aren't set it means the layout pass hasn't happen yet
+					// If the Width and Height aren't set it means the layout pass hasn't happened yet
 					if (view.Width > 0 && view.Height > 0)
 					{
 						viewTop = Math.Max(0, viewTop - (int)context.ToPixels(margins.Top));

--- a/src/Core/src/Platform/Android/SafeAreaExtensions.cs
+++ b/src/Core/src/Platform/Android/SafeAreaExtensions.cs
@@ -135,7 +135,7 @@ internal static class SafeAreaExtensions
 					// to zero via Math.Max, destroying the animation signal.
 					// Horizontal: during Shell tab animation, viewLeft=-1 gets clamped to 0,
 					// making it impossible to detect animation for the RIGHT edge afterward.
-					var isAnimatingHorizontally = viewLeft < 0 || viewRight > screenWidth;
+					var viewIsAnimatingHorizontally = viewLeft < 0 || viewRight > screenWidth;
 
 					// Vertical: During Shell navigation animations, the view may be positioned
 					// beyond the status bar area (e.g., Y=126 when status bar is 63px) and also
@@ -146,7 +146,7 @@ internal static class SafeAreaExtensions
 					// 3. viewTop > 0 (view is not at origin)
 					// This is DIFFERENT from ScrollView where viewTop = 0 (at origin, not animating).
 					// When we detect animation state, apply the full top inset since view will settle at Y=0.
-					var viewIsAnimating = viewTop > top && viewTop > 0 && viewBottom > screenHeight;
+					var viewIsAnimatingVertically = viewTop > top && viewTop > 0 && viewBottom > screenHeight;
 
 					// Adjust for view's position relative to parent (including margins) to calculate
 					// safe area insets relative to the parent's position, not the view's visual position.
@@ -172,7 +172,7 @@ internal static class SafeAreaExtensions
 						// Calculate the actual overlap amount
 						top = Math.Min(top - viewTop, top);
 					}
-					else if (top > 0 && viewIsAnimating)
+					else if (top > 0 && viewIsAnimatingVertically)
 					{
 						// View is animating - positioned beyond status bar but extends off-screen
 						// Apply full top inset since view will settle at Y=0
@@ -206,7 +206,7 @@ internal static class SafeAreaExtensions
 					// During Shell navigation animations, the view slides in from off-screen.
 					// We must check animation FIRST because near the end of animation
 					// (e.g., viewLeft=1), the overlap check would incorrectly reduce the inset.
-					if (left > 0 && isAnimatingHorizontally && viewLeft > 0)
+					if (left > 0 && viewIsAnimatingHorizontally && viewLeft > 0)
 					{
 						// View is animating - keep full inset since view will settle at X=0
 					}
@@ -226,7 +226,7 @@ internal static class SafeAreaExtensions
 					// Right: how much the view extends into the right safe area
 					// During animation, viewRight may be near screenWidth (e.g., 2991 vs 2992)
 					// causing incorrect partial overlap. Check animation before overlap.
-					if (right > 0 && isAnimatingHorizontally)
+					if (right > 0 && viewIsAnimatingHorizontally)
 					{
 						// View is animating - keep full inset
 					}


### PR DESCRIPTION
### Root Cause
During Shell tab navigation animations, views move from off-screen into their final positions (for example, `viewLeft < 0` during horizontal movement or elevated viewTop values during vertical movement). The existing logic applied `Math.Max(0, position - margin)` to account for margins, which clamped negative or small positive values to zero. This erased the signal used to detect that a view was still animating, causing the safe area logic to treat animating views as already settled. As a result, safe area padding was reduced too early during the final animation frames, leading to visible padding jumps.
 
### Description of Change
To preserve correct animation detection, the animation state is now calculated using raw view position values before any margin clamping is applied, ensuring off-screen and in-transition states are not lost. The safe area calculation logic was also reordered so animation checks are evaluated before overlap checks for the left and right edges. This prevents partial padding from being applied when a view is near its final position but still animating. Finally, the animation flags were renamed to `viewIsAnimatingHorizontally` and `viewIsAnimatingVertically` for clarity.

### Note
 The test case `SafeAreaShouldWorkOnAllShellTabs` already exists on the main branch (`Issue33034.cs`). It was validated locally on an **API 36 emulator** to confirm the regression. Before the fix, the test failed due to incorrect safe area padding during Shell tab animations. After applying the fix, the test passes, confirming that safe area padding is correctly maintained throughout the animation cycle.
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/5ddd040d-674f-4118-b393-8c83b544222e">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/67bb9044-002d-4b3a-a8cd-870d5d79d652">|