### PR TITLE
[Backport to preview2] Fix empty string binding to nullable value types

### DIFF
--- a/src/Controls/src/Core/BindingExpressionHelper.cs
+++ b/src/Controls/src/Core/BindingExpressionHelper.cs
@@ -26,9 +26,20 @@ namespace Microsoft.Maui.Controls
 			object original = value;
 			try
 			{
-				convertTo = Nullable.GetUnderlyingType(convertTo) ?? convertTo;
-
+				var underlyingType = Nullable.GetUnderlyingType(convertTo);
 				var stringValue = value as string ?? string.Empty;
+
+				// Handle empty string conversion to nullable types
+				// Empty string should convert to null for nullable value types
+				// Only apply to actual string values to avoid converting non-string inputs
+				// See: https://github.com/dotnet/maui/issues/8342
+				if (underlyingType != null && value is string && string.IsNullOrEmpty(stringValue))
+				{
+					value = null!;
+					return true;
+				}
+
+				convertTo = underlyingType ?? convertTo;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
 				if (stringValue.EndsWith(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Backport of #33536 to `release/11.0.1xx-preview2`.

Cherry-pick of 4cc0dc5af8 — clean, no conflicts.