### PR TITLE
[iOS] Fix: invoke MediaPicker completion handler after DismissViewController

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -487,15 +487,13 @@ namespace Microsoft.Maui.Media
 			public Action<NSDictionary> CompletedHandler { get; set; }
 
 			public override void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
-			{
-				picker.DismissViewController(true, null);
-				CompletedHandler?.Invoke(info);
-			}
+            {
+                picker.DismissViewController(true, () => CompletedHandler?.Invoke(info));
+            }
 
 			public override void Canceled(UIImagePickerController picker)
 			{
-				picker.DismissViewController(true, null);
-				CompletedHandler?.Invoke(null);
+				picker.DismissViewController(true, () => CompletedHandler?.Invoke(null));
 			}
 		}
 	}
@@ -506,8 +504,8 @@ namespace Microsoft.Maui.Media
 
 		public override void DidFinishPicking(PHPickerViewController picker, PHPickerResult[] results)
 		{
-			picker.DismissViewController(true, null);
-			CompletedHandler?.Invoke(results?.Length > 0 ? results : []);
+			var captured = results?.Length > 0 ? results : [];
+            picker.DismissViewController(true, () => CompletedHandler?.Invoke(captured));
 		}
 	}
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -140,7 +140,6 @@ namespace Microsoft.Maui.Media
 					CompletedHandler = async info =>
 					{
 						GetFileResult(info, tcs, options);
-						await picker.DismissViewControllerAsync(true);
 					}
 				};
 			}
@@ -485,10 +484,9 @@ namespace Microsoft.Maui.Media
 		class PhotoPickerDelegate : UIImagePickerControllerDelegate
 		{
 			public Action<NSDictionary> CompletedHandler { get; set; }
-
 			public override void FinishedPickingMedia(UIImagePickerController picker, NSDictionary info)
             {
-                picker.DismissViewController(true, () => CompletedHandler?.Invoke(info));
+				picker.DismissViewController(true, () => CompletedHandler?.Invoke(info));
             }
 
 			public override void Canceled(UIImagePickerController picker)

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Media
 
 				picker.Delegate = new PhotoPickerDelegate
 				{
-					CompletedHandler = async info =>
+					CompletedHandler = info =>
 					{
 						GetFileResult(info, tcs, options);
 					}


### PR DESCRIPTION
### Description of Change

On iOS, `CompletedHandler` was being invoked **before** `DismissViewController`
had finished animating. This means any code running in the handler — such as
showing an alert, opening a modal, or triggering navigation — would fire while
the picker view controller was still visible and attached to the view hierarchy.

iOS UIKit requires the presenting view controller to be fully visible and
attached before presenting any new UI (alerts, modals, sheets). If you attempt
to present something while a dismiss animation is still in progress, UIKit
silently drops the presentation or throws a warning, resulting in:

- `DisplayAlert` / `DisplayActionSheet` not appearing after picking an image
- Custom modal dialogs not showing up
- Any `await`-based UI call after `PickPhotoAsync` / `PickVideoAsync` silently failing on iOS, while working fine on Android

The root cause is that `DismissViewController(animated:completion:)` accepts a
completion callback precisely for this purpose — to run logic **after** the
animation finishes — but the original code passed `null` and called the handler
immediately after, creating a race condition.

**Fix:** Moved all `CompletedHandler` invocations into the `completion` callback
of `DismissViewController` across three call sites:

- `UIImagePickerControllerDelegate.FinishedPickingMedia`
- `UIImagePickerControllerDelegate.Canceled`
- `PHPickerViewControllerDelegate.DidFinishPicking`

### Issues Fixed

Fixes #21996

### Testing

Tested on a physical iOS device.

- Opened image picker via `MediaPicker.PickPhotoAsync()`
- After selecting an image, called `DisplayAlert` in the continuation
- **Before fix:** alert did not appear after dismissing the picker
- **After fix:** alert appears correctly after the picker is fully dismissed
