### PR TITLE
Add correct CI pipeline names to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,6 +90,18 @@ Major test projects:
 
 Find all tests: `find . -name "*.UnitTests.csproj"`
 
+### CI Pipelines (Azure DevOps)
+
+When referencing or triggering CI pipelines, use these current pipeline names:
+
+| Pipeline | Name | Purpose |
+|----------|------|---------|
+| Overall CI | `maui-pr` | Full PR validation build |
+| Device Tests | `maui-pr-devicetests` | Helix-based device tests |
+| UI Tests | `maui-pr-uitests` | Appium-based UI tests |
+
+**⚠️ Old pipeline names** (e.g., `MAUI-UITests-public`, `MAUI-public`) are **outdated** and should NOT be used. Always use the names above.
+
 ### Code Formatting
 
 Always format code before committing:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds the current Azure DevOps CI pipeline names to `.github/copilot-instructions.md` so that Copilot agents always reference the correct pipelines:

| Pipeline | Name |
|----------|------|
| Overall CI | `maui-pr` |
| Device Tests | `maui-pr-devicetests` |
| UI Tests | `maui-pr-uitests` |

**Why:** Copilot CLI would wrongfully come up with old pipeline names (e.g., `MAUI-UITests-public`) that it picked up from historical PR comments. Adding the correct names to the instruction file ensures agents use the current pipeline names going forward.