### PR TITLE
Fix dogfood scripts: workflow trigger, build detection, and in-progress handling

### DIFF
--- a/.github/workflows/dogfood-comment.yml
+++ b/.github/workflows/dogfood-comment.yml
@@ -1,9 +1,16 @@
 name: Add Dogfooding Comment
 
 on:
-  # Trigger when the maui-pr build check completes
-  check_run:
-    types: [completed]
+  # Use pull_request_target to run in the context of the base branch
+  # This allows commenting on PRs from forks
+  # Note: check_run trigger doesn't work because Azure DevOps check runs
+  # don't populate the pull_requests[] field, so we can't get the PR number.
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - 'main'
+      - 'net*'
+      - 'release/**'
 
   # Allow manual triggering
   workflow_dispatch:
@@ -15,23 +22,13 @@ on:
 
 # Ensure only one instance runs at a time per PR to prevent duplicate comments
 concurrency:
-  group: dogfood-comment-${{ github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number || 'unknown' }}
+  group: dogfood-comment-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   add-dogfood-comment:
-    # Only run on the dotnet org, for the maui-pr check, when it completes successfully
-    if: |
-      github.repository_owner == 'dotnet' && 
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event_name == 'check_run' &&
-          github.event.check_run.name == 'maui-pr (Pack .NET MAUI Pack Windows)' &&
-          github.event.check_run.conclusion == 'success' &&
-          github.event.check_run.pull_requests[0] != null
-        )
-      )
+    # Only run on the dotnet org to avoid running on forks
+    if: ${{ github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -41,8 +38,8 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            // Get PR number from either the check_run event or manual input
-            const prNumber = context.payload.check_run?.pull_requests?.[0]?.number || context.payload.inputs?.pr_number;
+            // Get PR number from either the PR event or manual input
+            const prNumber = context.payload.pull_request?.number || context.payload.inputs?.pr_number;
 
             const bashScript = 'https://raw.githubusercontent.com/dotnet/maui/main/eng/scripts/get-maui-pr.sh';
             const psScript = 'https://raw.githubusercontent.com/dotnet/maui/main/eng/scripts/get-maui-pr.ps1';


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Three fixes for the dogfooding infrastructure that was merged in #33198 but never worked correctly:

### 1. Workflow trigger fix (`dogfood-comment.yml`)
The workflow was changed from `pull_request_target` to `check_run` trigger in #33198, but Azure DevOps check runs **never populate the `pull_requests[]` array**. This means `github.event.check_run.pull_requests[0] != null` was **always false**, and the workflow never ran.

**Fix**: Reverted to `pull_request_target` trigger with a comment explaining why `check_run` does not work.

### 2. AzDO direct fallback (both scripts)
When the GitHub Checks API does not return build info (which can happen for merge commits or in certain timing windows), the scripts now fall back to querying the Azure DevOps API directly using `refs/pull/{PR}/merge` branch name.

This approach is modeled after the working implementation in [maui-version](https://github.com/jfversluis/maui-version).

### 3. In-progress build detection (both scripts)
When no completed build is found, the scripts now query AzDO for builds with `status in ("inProgress", "notStarted", "postponed")`. Instead of the generic "no build found" error, users now see:
- **Build in progress**: "A build is currently in progress. Please wait for it to complete."
- **Stale artifacts**: When an older build has artifacts but a newer build is running, warns users

### Additional improvements
- Build ID numeric validation to prevent URL injection
- PR number validation in bash script  
- Protection against `set -e` crashes on invalid `jq` input
- Better error messages for all failure scenarios

## Testing

Tested locally with multiple real PRs across both scripts:
- ✅ PR #34216 (completed, successful) - both scripts find build and apply artifacts
- ✅ PR #34250 (in-progress build) - correctly finds existing artifacts with warning
- ✅ PR #99999999 (non-existent) - proper error handling
- ✅ Invalid PR number ("abc") - input validation works
- ✅ Multi-model code review (Claude Sonnet 4.5, GPT-5.1, Gemini 3 Pro) - all findings addressed
