### PR TITLE
Fix CollectionView stale index-path bind/cache crash on iOS

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -482,7 +482,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			cell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
 
-			var bindingContext = ItemsSource[indexPath];
+			if (!TryGetBindingContext(indexPath, out var bindingContext))
+			{
+				// UICollectionView can briefly request cells with stale index paths while the source is changing.
+				// In that case there is no item to bind, so skip the update for this pass.
+				cell.Unbind();
+				return;
+			}
 
 			// If we've already created a cell for this index path (for measurement), re-use the content
 			if (_measurementCells != null && _measurementCells.TryGetValue(bindingContext, out TemplatedCell measurementCell))
@@ -493,7 +499,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 			else
 			{
-				cell.Bind(ItemsView.ItemTemplate, ItemsSource[indexPath], ItemsView);
+				cell.Bind(ItemsView.ItemTemplate, bindingContext, ItemsView);
 			}
 
 			cell.LayoutAttributesChanged += CellLayoutAttributesChanged;
@@ -888,10 +894,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			UpdateTemplatedCell(templatedCell, indexPath);
 
 			// Keep this cell around, we can transfer the contents to the actual cell when the UICollectionView creates it
-			if (_measurementCells != null)
-				_measurementCells[ItemsSource[indexPath]] = templatedCell;
+			if (_measurementCells != null && TryGetBindingContext(indexPath, out var bindingContext))
+			{
+				_measurementCells[bindingContext] = templatedCell;
+			}
 
 			return templatedCell;
+		}
+
+		bool TryGetBindingContext(NSIndexPath indexPath, out object bindingContext)
+		{
+			bindingContext = null;
+
+			var itemsSource = ItemsSource;
+			if (itemsSource == null || !itemsSource.IsIndexPathValid(indexPath))
+			{
+				return false;
+			}
+
+			bindingContext = itemsSource[indexPath];
+			return bindingContext != null;
 		}
 
 		internal CGSize GetSizeForItem(NSIndexPath indexPath)

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewCacheTests.ios.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewCacheTests.ios.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using CoreGraphics;
 using Foundation;
@@ -22,9 +23,9 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		class CacheTestItemsViewController : ItemsViewController<CacheTestCollectionView>
-		{
-			protected override bool IsHorizontal { get; }
+			class CacheTestItemsViewController : ItemsViewController<CacheTestCollectionView>
+			{
+				protected override bool IsHorizontal { get; }
 
 			public UICollectionViewDelegateFlowLayout DelegateFlowLayout { get; private set; }
 
@@ -32,12 +33,22 @@ namespace Microsoft.Maui.DeviceTests
 			{
 			}
 
-			protected override UICollectionViewDelegateFlowLayout CreateDelegator()
-			{
-				DelegateFlowLayout = new CacheMissCountingDelegate(ItemsViewLayout, this);
-				return DelegateFlowLayout;
+				protected override UICollectionViewDelegateFlowLayout CreateDelegator()
+				{
+					DelegateFlowLayout = new CacheMissCountingDelegate(ItemsViewLayout, this);
+					return DelegateFlowLayout;
+				}
+
+				internal void UpdateTemplatedCellForTests(TemplatedCell cell, NSIndexPath indexPath)
+				{
+					UpdateTemplatedCell(cell, indexPath);
+				}
+
+				internal UICollectionViewCell CreateMeasurementCellForTests(NSIndexPath indexPath)
+				{
+					return CreateMeasurementCell(indexPath);
+				}
 			}
-		}
 
 		internal class CacheMissCountingDelegate : ItemsViewDelegator<CacheTestCollectionView, ItemsViewController<CacheTestCollectionView>>
 		{
@@ -84,9 +95,9 @@ namespace Microsoft.Maui.DeviceTests
 			public double HeightRequest => 40 * (Index + 1);
 		}
 
-		[Fact]
-		public async Task EnsureCellSizesAreCached()
-		{
+			[Fact]
+			public async Task EnsureCellSizesAreCached()
+			{
 			SetupBuilder();
 
 			var collectionView = new CacheTestCollectionView()
@@ -152,8 +163,84 @@ namespace Microsoft.Maui.DeviceTests
 					// Something went wrong with this test
 					Assert.Fail("Wrong controller type in the test; is the handler registration broken?");
 				}
-			});
+				});
+			}
+
+			[Fact]
+			public async Task UpdateTemplatedCellWithStaleIndexPathDoesNotCrash()
+			{
+				SetupBuilder();
+
+				var collectionView = new CacheTestCollectionView
+				{
+					ItemTemplate = new DataTemplate(() => new Label()),
+					ItemsSource = new ObservableCollection<string> { "item-0" }
+				};
+
+				await CreateHandlerAndAddToWindow<CacheTestCollectionViewHandler>(collectionView, async handler =>
+				{
+					await WaitForUIUpdate(collectionView.Frame, collectionView);
+
+					var controller = Assert.IsType<CacheTestItemsViewController>(handler.Controller);
+					var staleIndexPath = NSIndexPath.FromItemSection(99, 0);
+					var cell = new VerticalCell(CGRect.Empty);
+
+					var exception = Record.Exception(() => controller.UpdateTemplatedCellForTests(cell, staleIndexPath));
+					Assert.Null(exception);
+				});
+			}
+
+			[Fact]
+			public async Task UpdateTemplatedCellWithNullItemDoesNotCrash()
+			{
+				SetupBuilder();
+
+				var collectionView = new CacheTestCollectionView
+				{
+					ItemTemplate = new DataTemplate(() => new Label()),
+					ItemsSource = new ObservableCollection<object> { null }
+				};
+
+				await CreateHandlerAndAddToWindow<CacheTestCollectionViewHandler>(collectionView, async handler =>
+				{
+					await WaitForUIUpdate(collectionView.Frame, collectionView);
+
+					var controller = Assert.IsType<CacheTestItemsViewController>(handler.Controller);
+					var cell = new VerticalCell(CGRect.Empty);
+					var indexPath = NSIndexPath.FromItemSection(0, 0);
+
+					var exception = Record.Exception(() => controller.UpdateTemplatedCellForTests(cell, indexPath));
+					Assert.Null(exception);
+				});
+			}
+
+			[Fact]
+			public async Task UpdateTemplatedCellStillBindsForValidItem()
+			{
+				SetupBuilder();
+
+				var expectedItem = "item-0";
+
+				var collectionView = new CacheTestCollectionView
+				{
+					ItemTemplate = new DataTemplate(() => new Label()),
+					ItemsSource = new ObservableCollection<string> { expectedItem }
+				};
+
+				await CreateHandlerAndAddToWindow<CacheTestCollectionViewHandler>(collectionView, async handler =>
+				{
+					await WaitForUIUpdate(collectionView.Frame, collectionView);
+
+					var controller = Assert.IsType<CacheTestItemsViewController>(handler.Controller);
+					var cell = new VerticalCell(CGRect.Empty);
+					var indexPath = NSIndexPath.FromItemSection(0, 0);
+
+					controller.UpdateTemplatedCellForTests(cell, indexPath);
+
+					var boundView = Assert.IsType<Label>((View)cell.PlatformHandler?.VirtualView);
+					Assert.Equal(expectedItem, boundView.BindingContext);
+				});
+			}
 		}
-	}
-#endif
+	#endif
 }


### PR DESCRIPTION
## Summary
- Guard stale/invalid index paths before templated-cell bind/cache updates in `ItemsViewController`
- Add `TryGetBindingContext(...)` and use it in measurement-cell caching to avoid stale/null bindings
- Add regression/safety tests for stale index path, null item, and valid-item bind behavior

## Validation
- `dotnet build src/Controls/src/Core/Controls.Core.csproj -c Release -f net10.0-maccatalyst26.0`
- `dotnet build src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj -c Debug -f net10.0-maccatalyst -p:RuntimeIdentifier=maccatalyst-arm64 -p:BuildIpa=false -p:EnableCodeSigning=false -p:CodesignRequireProvisioningProfile=false`

## Notes
- Local iOS-specific verification is currently blocked by local xattr/codesign environment constraints, not by this patch.

Fixes #34261
