### PR TITLE
[iOS] Fix MediaPicker.PickPhotosAsync returning empty list when selecting 4+ images with CompressionQuality set

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -744,7 +744,7 @@ namespace Microsoft.Maui.Media
 	/// Wrapper that applies compression lazily when the stream is opened.
 	/// This avoids iOS resource limits when processing multiple photos.
 	/// </summary>
-	class PHPickerProcessedFileResult : FileResult
+	class PHPickerProcessedFileResult : FileResult, IDisposable
 	{
 		readonly FileResult _originalResult;
 		readonly int? _maximumWidth;
@@ -753,7 +753,11 @@ namespace Microsoft.Maui.Media
 		readonly bool _rotateImage;
 		readonly bool _preserveMetaData;
 
+		// Cached result of the first call to PlatformOpenReadAsync to avoid re-processing
+		byte[] _cachedData;
+
 		internal PHPickerProcessedFileResult(FileResult originalResult, int? maximumWidth, int? maximumHeight, int compressionQuality, bool rotateImage, bool preserveMetaData)
+			: base()
 		{
 			_originalResult = originalResult;
 			_maximumWidth = maximumWidth;
@@ -762,38 +766,96 @@ namespace Microsoft.Maui.Media
 			_rotateImage = rotateImage;
 			_preserveMetaData = preserveMetaData;
 
-			// Copy metadata from original
-			FileName = originalResult.FileName;
-			FullPath = originalResult.FullPath;
-			ContentType = originalResult.ContentType;
+			// Copy metadata from original, adjusting extension for compressed output
+			var originalFileName = originalResult.FileName;
+			var originalFullPath = originalResult.FullPath;
+			var originalContentType = originalResult.ContentType;
+
+			// Preserve the original format: PNG stays PNG, everything else compresses to JPEG.
+			// When no compression is applied (quality == 100), preserve the original extension as-is.
+			var originalWasPng = !string.IsNullOrEmpty(originalFileName) &&
+				Path.GetExtension(originalFileName).Equals(".png", StringComparison.OrdinalIgnoreCase);
+			string outputExtension;
+			if (compressionQuality == 100)
+				outputExtension = Path.GetExtension(originalFileName ?? string.Empty);
+			else if (originalWasPng)
+				outputExtension = ".png";
+			else
+				outputExtension = ".jpg";
+
+			FileName = !string.IsNullOrEmpty(originalFileName) && !string.IsNullOrEmpty(outputExtension)
+				? Path.ChangeExtension(originalFileName, outputExtension)
+				: originalFileName;
+
+			FullPath = !string.IsNullOrEmpty(originalFullPath) && !string.IsNullOrEmpty(outputExtension)
+				? Path.ChangeExtension(originalFullPath, outputExtension)
+				: originalFullPath;
+
+			ContentType = string.Equals(outputExtension, ".png", StringComparison.OrdinalIgnoreCase)
+				? "image/png"
+				: string.Equals(outputExtension, ".jpg", StringComparison.OrdinalIgnoreCase) || string.Equals(outputExtension, ".jpeg", StringComparison.OrdinalIgnoreCase)
+					? "image/jpeg"
+					: originalContentType;
 		}
 
 		internal override async Task<Stream> PlatformOpenReadAsync()
 		{
-			// Load the original stream
-			using var originalStream = await _originalResult.OpenReadAsync();
+			// Return cached result on subsequent calls to avoid re-processing
+			if (_cachedData is not null)
+				return new MemoryStream(_cachedData, writable: false);
 
-			// Apply processing (compression/resizing)
-			using var processedStream = await ImageProcessor.ProcessImageAsync(
-				originalStream,
-				_maximumWidth,
-				_maximumHeight,
-				_compressionQuality,
-				_originalResult.FileName,
-				_rotateImage,
-				_preserveMetaData);
-
-			// If processing failed, return original stream
-			if (processedStream == null)
+			// Load the original stream into memory once to avoid multiple expensive NSItemProvider loads.
+			byte[] originalData;
+			using (var originalStream = await _originalResult.OpenReadAsync())
+			using (var buffer = new MemoryStream())
 			{
-				return await _originalResult.OpenReadAsync();
+				await originalStream.CopyToAsync(buffer);
+				originalData = buffer.ToArray();
 			}
 
-			// Read processed stream into memory and return
-			var memoryStream = new MemoryStream();
-			await processedStream.CopyToAsync(memoryStream);
-			memoryStream.Position = 0;
-			return memoryStream;
+			Stream processedStream = null;
+			try
+			{
+				// processedStream is always an independent MemoryStream from ImageProcessor.ProcessImageAsync;
+				// it does not reference or depend on originalStream after this call completes.
+				using var originalForProcessing = new MemoryStream(originalData, writable: false);
+				processedStream = await ImageProcessor.ProcessImageAsync(
+					originalForProcessing,
+					_maximumWidth,
+					_maximumHeight,
+					_compressionQuality,
+					_originalResult.FileName,
+					_rotateImage,
+					_preserveMetaData);
+			}
+			catch
+			{
+				// Swallow processing exceptions and fall back to the original data.
+				processedStream = null;
+			}
+
+			if (processedStream is null)
+			{
+				// Fall back to the original data if processing failed or returned null.
+				_cachedData = originalData;
+			}
+			else
+			{
+				using (processedStream)
+				using (var buffer = new MemoryStream())
+				{
+					await processedStream.CopyToAsync(buffer);
+					_cachedData = buffer.ToArray();
+				}
+			}
+
+			return new MemoryStream(_cachedData, writable: false);
+		}
+
+		public void Dispose()
+		{
+			(_originalResult as IDisposable)?.Dispose();
+			GC.SuppressFinalize(this);
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could test the resulting artifacts from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
On iOS, when using MediaPicker.PickPhotosAsync() with CompressionQuality enabled and SelectionLimit = 0 (unlimited), selecting several photos returns an empty list instead of the selected photos.

### Root Cause
When compression is enabled, the original implementation eagerly loads and processes all selected photos immediately after the picker is dismissed by calling NSItemProvider.LoadDataRepresentationAsync() sequentially in a tight loop.
When four or more items are processed in rapid succession, these data loads fail or time out on iOS. As a result, the operation fails and returns an empty list. This occurs because multiple instances cannot reliably load data simultaneously or immediately after the picker view controller is dismissed.
 
### Description of Change
The fix introduces a lazy compression approach using a new PHPickerProcessedFileResult wrapper. Image processing is deferred until the stream is actually opened, avoiding iOS resource constraints caused by eager loading of multiple instances in quick succession.
The changes now aligns with MAUI Graphics limitations: image.SaveAsync supports only JPEG and PNG output formats. Therefore, when a non-PNG image is compressed, JPEG is the only valid output format.

### Issues Fixed
Fixes #33954

### Tested platforms

- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

**Regarding the test case:** MediaPicker invokes the native iOS photo picker, which is a system-level UI running outside the app process. Because of this, it cannot be controlled or captured by Appium or other automated test frameworks. Therefore, the test case is ignored.

**Key changes in `MediaPicker.ios.cs`:**
- Added `PHPickerProcessedFileResult` class (~67 lines) — wraps a `FileResult` and defers all NSItemProvider I/O to stream-open time
- Modified `PickerResultsToMediaFiles()` — wraps results in `PHPickerProcessedFileResult` instead of eagerly compressing

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/18e6f361-0ba4-4176-9f25-5c0e07a32b3c"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/435083d5-301b-4e8f-9daf-94b324f63356">) |