### PR TITLE
[iOS/MacCatalyst] Fix CheckBox foreground color not resetting when set to null

### DIFF
--- a/src/Core/src/Platform/iOS/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/iOS/CheckBoxExtensions.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Maui.Platform
 			{
 				platformCheckBox.CheckBoxTintColor = solid.Color;
 			}
+			else if (check.Foreground is null)
+			{
+				// Color was cleared; reset to null so the view inherits the default tint color
+				platformCheckBox.CheckBoxTintColor = null;
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
@@ -64,5 +64,31 @@ namespace Microsoft.Maui.DeviceTests
 			});
 			Assert.Equal(expected, color);
 		}
+
+		[Fact(DisplayName = "Foreground Resets to Default When Set to Null")]
+		public async Task ForegroundResetsToDefaultWhenSetToNull()
+		{
+			var checkBoxStub = new CheckBoxStub
+			{
+				Foreground = new SolidPaint(Colors.Red),
+				IsChecked = true
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(checkBoxStub);
+				var native = GetNativeCheckBox(handler);
+
+				// Confirm that the red tint was applied initially
+				Assert.NotNull(native.CheckBoxTintColor);
+
+				// Simulate a dynamic Color = null (Foreground reset to default)
+				checkBoxStub.Foreground = null;
+				handler.UpdateValue(nameof(ICheckBox.Foreground));
+
+				// After reset, the native tint must be null so iOS reverts to its inherited default
+				Assert.Null(native.CheckBoxTintColor);
+			});
+		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause of the issue



- The UpdateForeground method in `CheckBoxExtensions`.cs (iOS) only handled the case where Foreground was a SolidPaint. When Foreground was set to null (e.g., dynamically clearing the color at runtime), the method returned without doing anything. This left the previously applied CheckBoxTintColor stuck on the native MauiCheckBox, so the checkbox never reverted to its default platform tint color.



### Description of Change



- when the foreground is cleared. Setting the native **CheckBoxTintColor** to null causes CheckBoxTintUIColor to also become null, allowing iOS to fall back to its inherited default tint color. This ensures that dynamically clearing CheckBox.Color at runtime correctly resets the checkbox appearance on iOS/Mac Catalyst.



### Issues Fixed



Fixes #34278 



### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot



| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/8f8948cb-e6da-4806-aafb-5a22c276afe8"> | <video src="https://github.com/user-attachments/assets/1384c980-66cc-4d6e-8216-b3dd3508662c"> |