### PR TITLE
Fix for Binding failure in RadioButton after .NET 10 upgrade

### DIFF
--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -68,8 +68,11 @@ namespace Microsoft.Maui.Controls
 		{
 			if (Binding is Binding { Source: var source, DataType: Type dataType })
 			{
-				// Do not check type mismatch if this is a binding with Source and compilation of bindings with Source is disabled
-				bool skipTypeMismatchCheck = source is not null && !RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled;
+				// Skip the type-mismatch check when an explicit concrete Source is provided (e.g. Source={x:Reference}).
+  				// In a DataTemplate, x:DataType describes the item context - not the type of the referenced element.
+   				// RelativeBindingSource is excluded: a mismatch against its source type must still be reported.
+				bool skipTypeMismatchCheck = (source is not null && source is not RelativeBindingSource)
+					|| !RuntimeFeature.IsXamlCBindingWithSourceCompilationEnabled;
 				if (!skipTypeMismatchCheck)
 				{
 					if (sourceObject != null && !dataType.IsAssignableFrom(sourceObject.GetType()))

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33293.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33293.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33293">
+    <VerticalStackLayout x:Name="ProductStack" Spacing="5">
+        <BindableLayout.ItemTemplate>
+            <DataTemplate x:DataType="local:Maui33293Product">
+                <RadioButton x:Name="ProductRadioButton"
+                             IsChecked="{Binding IsSelected}"
+                             GroupName="ProductGroup">
+                    <RadioButton.Content>
+                        <HorizontalStackLayout
+                            BindingContext="{Binding BindingContext, Source={x:Reference ProductRadioButton}}"
+                            Spacing="8">
+                            <Label x:Name="PriceLabel" Text="{Binding Price}" />
+                            <Label x:Name="NameLabel" Text="{Binding Name}" />
+                        </HorizontalStackLayout>
+                    </RadioButton.Content>
+                </RadioButton>
+            </DataTemplate>
+        </BindableLayout.ItemTemplate>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33293.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33293.xaml.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Controls.Xaml.Diagnostics;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+public class Maui33293Product
+{
+	public string Name { get; set; } = string.Empty;
+	public string Price { get; set; } = string.Empty;
+	public bool IsSelected { get; set; }
+}
+
+public partial class Maui33293
+{
+	public Maui33293() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Maui33293Tests : IDisposable
+	{
+		bool bindingFailureReported = false;
+
+		public Maui33293Tests()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+			RuntimeFeature.EnableMauiDiagnostics = true;
+			BindingDiagnostics.BindingFailed += BindingFailed;
+		}
+
+		public void Dispose()
+		{
+			BindingDiagnostics.BindingFailed -= BindingFailed;
+			DispatcherProvider.SetCurrent(null);
+			AppInfo.SetCurrent(null);
+		}
+
+		void BindingFailed(object sender, BindingBaseErrorEventArgs args) =>
+			bindingFailureReported = true;
+
+		[Theory]
+		[XamlInflatorData]
+		internal void RadioButtonXReferenceBindingInDataTemplateShouldResolve(XamlInflator inflator)
+		{
+			if (inflator == XamlInflator.SourceGen)
+			{
+				// SourceGen is out of scope for this runtime fix
+				return;
+			}
+
+			var page = new Maui33293(inflator);
+
+			// Provide one product so the DataTemplate instantiates a RadioButton
+			var product = new Maui33293Product { Name = "Option 1", Price = "$0.99", IsSelected = true };
+			BindableLayout.SetItemsSource(page.ProductStack, new[] { product });
+
+			// Walk the visual tree: ProductStack → RadioButton → Content (HorizontalStackLayout) → Labels
+			var radioButton = (RadioButton)page.ProductStack.Children[0];
+			var hsl = (HorizontalStackLayout)radioButton.Content;
+			var priceLabel = (Label)hsl.Children[0];
+			var nameLabel = (Label)hsl.Children[1];
+
+			// Labels must show product data — binding resolved successfully through x:Reference
+			Assert.Equal("$0.99", priceLabel.Text);
+			Assert.Equal("Option 1", nameLabel.Text);
+
+			// No false-positive type-mismatch diagnostic must be raised
+			Assert.False(bindingFailureReported);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root cause

The issue occurs because of stricter source-type validation introduced when MauiEnableXamlCBindingWithSourceCompilation=true is enabled, which activates compiled binding checks inside BindingExpression.Apply(). When a binding uses Source={x:Reference ...}, the resolved source at runtime is a concrete UI element rather than the ambient data context type defined by the surrounding DataTemplate’s x:DataType.
 
However, the validation logic incorrectly compared the resolved element’s type against this ambient x:DataType and treated it as a mismatch, causing the binding to be skipped or fail to resolve. As a result, bindings inside RadioButton.Content did not populate values even though they were syntactically correct.

### Description of Issue Fix

The fix involves refining the type-mismatch skip logic in BindingExpression.Apply() to bypass x:DataType validation when an explicit concrete source, such as one resolved through x:Reference, is supplied, since the ambient x:DataType represents the template’s data context rather than the explicit source’s type.
 
The RelativeBindingSource is intentionally excluded from this bypass to preserve valid developer-specified type contracts and maintain diagnostic accuracy. This targeted adjustment prevents false-positive mismatches for explicit sources while ensuring existing validation behavior and regression safety for all other binding scenarios.

Tested the behavior in the following platforms.
 
- [x] Windows
- [x] Mac
- [x] iOS
- [x] Android

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/dotnet/maui/issues/33293

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

### Output

Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="100" height="100" alt="Before Fix" src="https://github.com/user-attachments/assets/3b73e138-16c4-4601-88a4-005daf1092be">|<video width="100" height="100" alt="After Fix" src="https://github.com/user-attachments/assets/21a798e8-72e6-4bc6-a708-6cdd00f8f981">|