### PR TITLE
[build] Fix YAML error: remove duplicate AndroidPoolLinux parameter in ci.yml

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -121,20 +121,6 @@ parameters:
     demands:
       - ImageOverride -equals 1ESPT-Ubuntu22.04
 
-- name: AndroidPoolLinux
-  type: object
-  default:
-    name: MAUI-DNCENG
-    demands:
-      - ImageOverride -equals 1ESPT-Ubuntu22.04
-
-- name: AndroidPoolLinux
-  type: object
-  default:
-    name: MAUI-DNCENG
-    demands:
-      - ImageOverride -equals 1ESPT-Ubuntu22.04
-
 
 # Condition for MacOSPool comparison lanes (non-ARM64)
 # Currently disabled - both pools use MAUI self-hosted since Xcode 26.2 isn't available on Azure Pipelines x64.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The `AndroidPoolLinux` parameter was defined **three times** in `eng/pipelines/ci.yml` on the `net11.0` branch, causing Azure DevOps to reject the YAML with:

> "This is an informational run. There was a YAML error preventing Azure Pipelines from determining if the pipeline should run."

This resulted in the `maui-pr` pipeline being canceled as an informational run on every `net11.0` push (builds [1311444](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1311444), [1310760](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1310760), [1310272](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1310272)).

## Changes

Removed 2 duplicate `AndroidPoolLinux` parameter definitions, keeping only one. All three were identical.

## Testing

- Verified no other duplicate parameter names exist in the file
- The fix is a pure deletion of exact duplicates — no behavioral change