### PR TITLE
Removed PhotosAddOnly permission request within MediaPicker.ios

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -98,11 +98,6 @@ namespace Microsoft.Maui.Media
 			}
 			else
 			{
-				if (!pickExisting)
-				{
-					await Permissions.EnsureGrantedAsync<Permissions.PhotosAddOnly>();
-				}
-
 				var sourceType = pickExisting
 					? UIImagePickerControllerSourceType.PhotoLibrary
 					: UIImagePickerControllerSourceType.Camera;


### PR DESCRIPTION
### Description of Change

Removed permission request for adding photos to the devices library on iOS, inside MediaPicker.ios, which doesn't need this permission at this spot inside the code as it does not add the newly captured photo to the device's library here.

Given the [official documentation](https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/device-media/picker?view=net-maui-10.0&tabs=windows#take-a-photo), adding the picture to the device's library is an action given in the example _after_ the CapturePhotoAsync is called, if the task's result contains a value. 
This action is completely optional, the developer could implement different logic for handling the picture data after calling CapturePhotoAsync, meaning the permission request becomes unnecessary and redundant.

It is up to the developer to save the image to the device, which then requires the permission, meaning the developer should implement the permission request within their own logic.

### Issues Fixed

Fixes #34246 
Fixes #34661 
