### PR TITLE
[iOS] Fix SearchBar.CancelButtonColor not applied on iOS 26

### DIFF
--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Graphics;
 using UIKit;
@@ -119,25 +120,173 @@ namespace Microsoft.Maui.Platform
 		internal static bool ShouldShowCancelButton(this ISearchBar searchBar) =>
 			!string.IsNullOrEmpty(searchBar.Text);
 
+		// Tag used to identify the cancel button color overlay view added on iOS 26+.
+		// Value 0x53424343 encodes "SBCC" (SearchBarCancelColor) to avoid collisions with system-assigned tags.
+		const nint CancelButtonColorOverlayTag = unchecked((nint)0x53424343);
+
 		public static void UpdateCancelButton(this UISearchBar uiSearchBar, ISearchBar searchBar)
 		{
 			uiSearchBar.ShowsCancelButton = searchBar.ShouldShowCancelButton();
 
 			// We can't cache the cancel button reference because iOS drops it when it's not displayed
-			// and creates a brand new one when necessary, so we have to look for it each time
-			var cancelButton = uiSearchBar.FindDescendantView<UIButton>();
+			// and creates a brand new one when necessary, so we have to look for it each time.
+			// Exclude UIButton instances that are descendants of UITextField — those are the
+			// text-clear button inside the search field, not the cancel button outside it.
+			var cancelButton = uiSearchBar.FindDescendantView<UIButton>(
+				btn => btn.FindParent(v => v is UITextField) == null);
 
 			if (cancelButton == null)
+			{
+				// Cancel button is hidden — remove any overlay we previously added
+				if (OperatingSystem.IsIOSVersionAtLeast(26))
+					RemoveCancelButtonOverlay(uiSearchBar);
 				return;
+			}
 
 			if (searchBar.CancelButtonColor != null)
 			{
-				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToPlatform(), UIControlState.Normal);
-				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToPlatform(), UIControlState.Highlighted);
-				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToPlatform(), UIControlState.Disabled);
+				var platformColor = searchBar.CancelButtonColor.ToPlatform();
 
+				cancelButton.SetTitleColor(platformColor, UIControlState.Normal);
+				cancelButton.SetTitleColor(platformColor, UIControlState.Highlighted);
+				cancelButton.SetTitleColor(platformColor, UIControlState.Disabled);
+
+				// On Mac, the cancel button is rendered as an icon (X mark) rather than text,
+				// so TintColor must be used to apply the color to the icon.
 				if (cancelButton.TraitCollection.UserInterfaceIdiom == UIUserInterfaceIdiom.Mac)
-					cancelButton.TintColor = searchBar.CancelButtonColor.ToPlatform();
+				{
+					cancelButton.TintColor = platformColor;
+				}
+
+				// On iOS 26+, UIKit overrides TintColor/UIButtonConfiguration on every layout
+				// pass, making standard color APIs ineffective for the cancel button icon.
+				// Place a colored UIImageView sibling on top of the cancel button to apply
+				// the color outside UIButton's rendering pipeline.
+				// Defer via DispatchAsync so the cancel button frame is valid after layout.
+				// Capture the search bar (not the button) to always look up the current
+				// cancel button instance — iOS 26 may recreate it during theme transitions.
+				if (OperatingSystem.IsIOSVersionAtLeast(26))
+				{
+					var capturedColor = platformColor;
+					var weakSearchBar = new WeakReference<UISearchBar>(uiSearchBar);
+					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+					{
+						if (!weakSearchBar.TryGetTarget(out var sb))
+							return;
+
+						var currentButton = sb.FindDescendantView<UIButton>(
+							btn => btn.FindParent(v => v is UITextField) == null);
+						if (currentButton != null)
+							ApplyCancelButtonOverlay(sb, currentButton, capturedColor);
+					});
+				}
+			}
+			else if (OperatingSystem.IsIOSVersionAtLeast(26))
+			{
+				// CancelButtonColor was cleared — remove any overlay we previously added
+				RemoveCancelButtonOverlay(uiSearchBar);
+			}
+		}
+
+		// Schedules a deferred retry of ApplyCancelButtonOverlay on the main queue.
+		// Used when the cancel button is not ready for layout (detached or zero-frame).
+		static void ScheduleOverlayRetry(UISearchBar uiSearchBar, UIColor color, int retryCount)
+		{
+			var weakSB = new WeakReference<UISearchBar>(uiSearchBar);
+			CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+			{
+				if (!weakSB.TryGetTarget(out var sb)) return;
+				var btn = sb.FindDescendantView<UIButton>(
+					b => b.FindParent(v => v is UITextField) == null);
+				if (btn != null)
+					ApplyCancelButtonOverlay(sb, btn, color, retryCount + 1);
+			});
+		}
+
+		static void ApplyCancelButtonOverlay(UISearchBar uiSearchBar, UIButton cancelButton, UIColor color, int retryCount = 0)
+		{
+			var parentView = cancelButton.Superview;
+			if (parentView == null)
+			{
+				// Button was detached by UIKit (e.g. mid-transition during a theme change).
+				// Retry with a fresh lookup so we always work with the current button instance.
+				if (retryCount < 2)
+					ScheduleOverlayRetry(uiSearchBar, color, retryCount);
+				return;
+			}
+
+			// Remove any overlay from a previous call (e.g. color change or re-focus)
+			parentView.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
+
+			// Find the UIImageView that UIButton uses to render the X icon.
+			// We need its frame in the parent view's coordinate space to position the overlay.
+			var iv = cancelButton.FindDescendantView<UIImageView>();
+			if (iv == null)
+				return;
+
+			// Convert the icon's frame from its local coordinate space to the parent view.
+			var iconFrameInParent = parentView.ConvertRectFromView(iv.Frame, iv.Superview);
+			if (iconFrameInParent.Width <= 0 || iconFrameInParent.Height <= 0)
+			{
+				// The cancel button hasn't been laid out yet (e.g. on initial load when
+				// CancelButtonColor is set via AppThemeBinding before the view appears).
+				// Retry once after the next layout pass so we get a valid frame.
+				if (retryCount < 2)
+					ScheduleOverlayRetry(uiSearchBar, color, retryCount);
+				return;
+			}
+
+			// Render the xmark icon in the requested color using CoreGraphics.
+			// AlwaysOriginal prevents UIKit from re-tinting the baked image.
+			var xmarkImage = UIImage.GetSystemImage("xmark");
+			if (xmarkImage == null)
+				return;
+
+			var imageSize = iconFrameInParent.Size;
+			var renderer = new UIGraphicsImageRenderer(imageSize, new UIGraphicsImageRendererFormat
+			{
+				Opaque = false,
+				Scale = 0,
+			});
+
+			var coloredImage = renderer.CreateImage(_ =>
+			{
+				xmarkImage.Draw(new CGRect(CGPoint.Empty, imageSize));
+				var ctx = UIGraphics.GetCurrentContext();
+				if (ctx != null)
+				{
+					ctx.SetBlendMode(CGBlendMode.SourceIn);
+					ctx.SetFillColor(color.CGColor);
+					ctx.FillRect(new CGRect(CGPoint.Empty, imageSize));
+				}
+			}).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+
+			// Add the overlay as the last (topmost) sibling of the cancel button so it
+			// renders on top of UIButton's layer-drawn X icon.
+			var overlay = new UIImageView(iconFrameInParent)
+			{
+				Image = coloredImage,
+				ContentMode = UIViewContentMode.ScaleAspectFit,
+				Tag = CancelButtonColorOverlayTag,
+				UserInteractionEnabled = false,
+			};
+
+			parentView.AddSubview(overlay);
+		}
+
+		static void RemoveCancelButtonOverlay(UISearchBar uiSearchBar)
+		{
+			// Walk all descendants of the search bar to find and remove the overlay.
+			// The overlay is a direct sibling of the cancel button (child of cancel button's parent).
+			var cancelButtonParent = uiSearchBar.FindDescendantView<UIButton>(
+				btn => btn.FindParent(v => v is UITextField) == null)?.Superview;
+			cancelButtonParent?.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
+
+			// Also check one level deeper in the hierarchy in case the search bar layout changes
+			foreach (var subview in uiSearchBar.Subviews)
+			{
+				foreach (var child in subview.Subviews)
+					child.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -234,10 +234,10 @@ namespace Microsoft.Maui.Platform
 			}
 
 			// Remove any overlay from a previous call (e.g. color change or re-focus)
-			parentView.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
+			uiSearchBar.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
 
 			// Find the UIImageView that UIButton uses to render the X icon.
-			// We need its frame in the parent view's coordinate space to position the overlay.
+			// We need its frame to determine the rendered image size.
 			var iv = cancelButton.FindDescendantView<UIImageView>();
 			if (iv == null)
 				return;
@@ -279,33 +279,34 @@ namespace Microsoft.Maui.Platform
 				}
 			}).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 
-			// Add the overlay as the last (topmost) sibling of the cancel button so it
-			// renders on top of UIButton's layer-drawn X icon.
-			var overlay = new UIImageView(iconFrameInParent)
+			// Add the overlay as the last (topmost) sibling of the cancel button.
+			// Use Auto Layout constraints so the overlay stays centered over the X icon
+			// on rotation, multitasking split view, or dynamic type changes.
+			var overlay = new UIImageView
 			{
 				Image = coloredImage,
 				ContentMode = UIViewContentMode.ScaleAspectFit,
 				Tag = CancelButtonColorOverlayTag,
 				UserInteractionEnabled = false,
+				TranslatesAutoresizingMaskIntoConstraints = false,
 			};
 
 			parentView.AddSubview(overlay);
+
+			NSLayoutConstraint.ActivateConstraints(new NSLayoutConstraint[]
+			{
+				overlay.CenterXAnchor.ConstraintEqualTo(cancelButton.CenterXAnchor),
+				overlay.CenterYAnchor.ConstraintEqualTo(cancelButton.CenterYAnchor),
+				overlay.WidthAnchor.ConstraintEqualTo(imageSize.Width),
+				overlay.HeightAnchor.ConstraintEqualTo(imageSize.Height),
+			});
 		}
 
 		static void RemoveCancelButtonOverlay(UISearchBar uiSearchBar)
 		{
-			// The overlay is added as a direct sibling of the cancel button (child of cancel button's parent).
-			// Find the cancel button's parent view and remove the overlay from it by tag.
-			var cancelButtonParent = uiSearchBar.FindDescendantView<UIButton>(
-				btn => btn.FindParent(v => v is UITextField) == null)?.Superview;
-			cancelButtonParent?.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
-
-			// Also check one level deeper in the hierarchy in case the search bar layout changes
-			foreach (var subview in uiSearchBar.Subviews)
-			{
-				foreach (var child in subview.Subviews)
-					child.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
-			}
+			// UIView.ViewWithTag searches the entire subtree recursively, so it finds the overlay
+			// regardless of where it was placed in the search bar's view hierarchy.
+			uiSearchBar.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();
 		}
 
 		internal static void UpdateSearchIcon(this UISearchBar uiSearchBar, ISearchBar searchBar)

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -167,17 +167,35 @@ namespace Microsoft.Maui.Platform
 				// cancel button instance — iOS 26 may recreate it during theme transitions.
 				if (OperatingSystem.IsIOSVersionAtLeast(26))
 				{
-					var capturedColor = platformColor;
 					var weakSearchBar = new WeakReference<UISearchBar>(uiSearchBar);
+					var weakVirtualView = new WeakReference<ISearchBar>(searchBar);
 					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
 					{
 						if (!weakSearchBar.TryGetTarget(out var sb))
+						{
 							return;
+						}
+
+						if (!weakVirtualView.TryGetTarget(out var virtualSearchBar))
+						{
+							return;
+						}
+
+						// Re-evaluate the desired cancel button color; it may have been
+						// changed or cleared since this callback was queued.
+						var currentColor = virtualSearchBar.CancelButtonColor;
+						if (currentColor is null)
+						{
+							RemoveCancelButtonOverlay(sb);
+							return;
+						}
 
 						var currentButton = sb.FindDescendantView<UIButton>(
 							btn => btn.FindParent(v => v is UITextField) == null);
-						if (currentButton != null)
-							ApplyCancelButtonOverlay(sb, currentButton, capturedColor);
+						if (currentButton is not null)
+						{
+							ApplyCancelButtonOverlay(sb, currentButton, currentColor.ToPlatform());
+						}
 					});
 				}
 			}
@@ -230,7 +248,7 @@ namespace Microsoft.Maui.Platform
 			{
 				// The cancel button hasn't been laid out yet (e.g. on initial load when
 				// CancelButtonColor is set via AppThemeBinding before the view appears).
-				// Retry once after the next layout pass so we get a valid frame.
+				// Retry after the next layout pass (up to two times) so we get a valid frame.
 				if (retryCount < 2)
 					ScheduleOverlayRetry(uiSearchBar, color, retryCount);
 				return;
@@ -276,8 +294,8 @@ namespace Microsoft.Maui.Platform
 
 		static void RemoveCancelButtonOverlay(UISearchBar uiSearchBar)
 		{
-			// Walk all descendants of the search bar to find and remove the overlay.
-			// The overlay is a direct sibling of the cancel button (child of cancel button's parent).
+			// The overlay is added as a direct sibling of the cancel button (child of cancel button's parent).
+			// Find the cancel button's parent view and remove the overlay from it by tag.
 			var cancelButtonParent = uiSearchBar.FindDescendantView<UIButton>(
 				btn => btn.FindParent(v => v is UITextField) == null)?.Superview;
 			cancelButtonParent?.ViewWithTag(CancelButtonColorOverlayTag)?.RemoveFromSuperview();


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Detail
SearchBar.CancelButtonColor has no effect on iOS 26 (Liquid Glass design). On iOS 18.x, the cancel button shows "Cancel" text and CancelButtonColor is correctly applied via SetTitleColor. On iOS 26, Apple redesigned the cancel button — it now shows an "xmark" icon (a UIButton with accessibility label "Close") instead of text. All standard color APIs (SetTitleColor, TintColor, UIButtonConfiguration.BaseForegroundColor) are silently overridden by UIButton's Liquid Glass compositor on every layout pass, so the X icon always renders in the system default color regardless of CancelButtonColor.

### Root Cause
UIButton on iOS 26 renders the X icon through its own Liquid Glass compositor — a system-level final rendering pass that runs after all UIKit APIs, CALayer, and CALayer.Filters. The compositor is scoped to UIButton's own view subtree, meaning any color applied inside the button (text color, tint, image, configuration, sublayer) is overridden before it reaches the screen.

### Description of Change
On iOS 26, UIButton renders the X icon through the Liquid Glass compositor, which runs after all UIKit APIs and overrides any color set on the button or its subviews. To work around this, instead of coloring the button itself, the fix renders a colored "xmark" icon image using UIGraphicsImageRenderer with CGBlendMode.SourceIn (baking the color into the pixels so UIKit cannot override it) and places it in a separate UIImageView next to the cancel button in the view hierarchy — completely outside UIButton's rendering scope. The overlay is positioned to sit exactly on top of the X icon and has UserInteractionEnabled = false so taps still reach the real cancel button underneath.
The cancel button lookup uses FindDescendantView<UIButton> with a predicate btn.FindParent(v => v is UITextField) == null to ensure only the cancel button is matched, excluding the clear button inside the text field. The overlay is deferred via DispatchAsync so the cancel button frame is valid after layout, and a WeakReference<UISearchBar> is used to avoid retain cycles and always look up the current cancel button instance across theme transitions.

### Issues Fixed
Fixes #33964

**Regarding the test case:** The [AppTheme feature matrix](https://github.com/dotnet/maui/tree/main/src/Controls/tests/TestCases.HostApp/FeatureMatrix/AppTheme) already covers the SearchBar cancel button color in both light and dark themes through LightTheme_SearchBar_VerifyVisualState and DarkTheme_SearchBar_VerifyVisualState. Therefore, no additional tests are added.

### Files Changed

- `src/Core/src/Platform/iOS/SearchBarExtensions.cs` — iOS 26 overlay fix

### Key Technical Details
- `CGBlendMode.SourceIn` recolors only the xmark pixels while preserving the icon shape and transparency
- `UIImageRenderingMode.AlwaysOriginal` prevents UIKit from re-tinting the baked image after placement
- `UserInteractionEnabled = false` on the overlay ensures taps fall through to the real cancel button
- `CancelButtonColorOverlayTag = 0x53424343` (encodes "SBCC") identifies the overlay for cleanup on color change or cancel button removal
- `WeakReference<UISearchBar>` avoids retain cycles; the cancel button itself is looked up fresh on each dispatch since iOS 26 may recreate it during theme transitions
- This change only applies to `OperatingSystem.IsIOSVersionAtLeast(26)` — pre-iOS 26 behavior is unchanged

### Screenshots

Light Theme:
| Before Issue Fix | After Issue Fix |
|----------|----------|
|<img width="762" height="1682" alt="Image" src="https://github.com/user-attachments/assets/24e30082-096a-4fc3-b75d-51ca8994e8f5" />|<img width="762" height="1682" alt="Image" src="https://github.com/user-attachments/assets/66c83175-a4a8-40d1-9a9f-6bddb21857e2" />| 

Dark Theme:
| Before Issue Fix | After Issue Fix |
|----------|----------|
|<img width="762" height="1682" alt="Image" src="https://github.com/user-attachments/assets/1aeb1bac-9c51-4df0-8afe-d189f7fec46c" />|<img width="762" height="1682" alt="Image" src="https://github.com/user-attachments/assets/584b1cd2-ab53-4631-bb1b-626554000591" />| 