### PR TITLE
Fix Picker selection when SelectedItem is removed from ItemsSource

### DIFF
--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
@@ -417,7 +418,11 @@ namespace Microsoft.Maui.Controls
 
 			index = GetSelectedIndexForCollectionMutation();
 
-			if (index == -1 && SelectedItem != null)
+			bool selectedItemWasRemoved =
+				e.OldItems != null &&
+				e.OldItems.Cast<object>().Contains(SelectedItem);
+
+			if (selectedItemWasRemoved)
 			{
 				ClampSelectedIndex(-1);
 				return;

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -425,7 +425,6 @@ namespace Microsoft.Maui.Controls
 			if (selectedItemWasRemoved)
 			{
 				ClampSelectedIndex(-1);
-				return;
 			}
 
 			if (removeStart <= index)

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -429,12 +429,11 @@ namespace Microsoft.Maui.Controls
 		int GetSelectedIndex()
 		{
 			if (SelectedItem is null)
-			{
 				return SelectedIndex;
-			}
 
 			int newIndex = ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1;
-			return newIndex >= 0 ? newIndex : SelectedIndex;
+
+			return newIndex >= 0 ? newIndex : -1;
 		}
 
 		void ResetItems()
@@ -461,7 +460,6 @@ namespace Microsoft.Maui.Controls
 			var picker = (Picker)bindable;
 			picker.UpdateSelectedIndex(newValue);
 		}
-
 		void ClampSelectedIndex(int selectedIndex)
 		{
 			var oldIndex = selectedIndex;

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -389,10 +389,9 @@ namespace Microsoft.Maui.Controls
 			foreach (object newItem in e.NewItems)
 				((LockableObservableListWrapper)Items).InternalInsert(index++, GetDisplayMember(newItem));
 
-			index = GetSelectedIndex();
+			index = GetSelectedIndexForCollectionMutation();
 			if (insertIndex <= index)
 			{
-				// When an item is inserted before the current selection, the selected item changes because the selected index is not properly updated.
 				ClampSelectedIndex(index);
 			}
 		}
@@ -400,18 +399,15 @@ namespace Microsoft.Maui.Controls
 		void RemoveItems(NotifyCollectionChangedEventArgs e)
 		{
 			int removeStart;
-			// Items are removed in reverse order, so index starts at the index of the last item to remove
 			int index;
 
 			if (e.OldStartingIndex < Items.Count)
 			{
-				// Remove e.OldItems.Count items starting at e.OldStartingIndex
 				removeStart = e.OldStartingIndex;
 				index = e.OldStartingIndex + e.OldItems.Count - 1;
 			}
 			else
 			{
-				// Remove e.OldItems.Count items at the end when e.OldStartingIndex is past the end of the Items collection
 				removeStart = Items.Count - e.OldItems.Count;
 				index = Items.Count - 1;
 			}
@@ -419,7 +415,14 @@ namespace Microsoft.Maui.Controls
 			foreach (object _ in e.OldItems)
 				((LockableObservableListWrapper)Items).InternalRemoveAt(index--);
 
-			index = GetSelectedIndex();
+			index = GetSelectedIndexForCollectionMutation();
+
+			if (index == -1 && SelectedItem != null)
+			{
+				ClampSelectedIndex(-1);
+				return;
+			}
+
 			if (removeStart <= index)
 			{
 				ClampSelectedIndex(index);
@@ -433,19 +436,30 @@ namespace Microsoft.Maui.Controls
 
 			int newIndex = ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1;
 
-			return newIndex >= 0 ? newIndex : -1;
+			return newIndex >= 0 ? newIndex : SelectedIndex;
+		}
+
+		int GetSelectedIndexForCollectionMutation()
+		{
+			if (SelectedItem is null)
+				return SelectedIndex;
+
+			return ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1;
 		}
 
 		void ResetItems()
 		{
 			if (ItemsSource == null)
 				return;
+
 			((LockableObservableListWrapper)Items).InternalClear();
+
 			foreach (object item in ItemsSource)
 				((LockableObservableListWrapper)Items).InternalAdd(GetDisplayMember(item));
+
 			Handler?.UpdateValue(nameof(IPicker.Items));
 
-			ClampSelectedIndex(SelectedIndex);
+			ClampSelectedIndex(GetSelectedIndexForCollectionMutation());
 		}
 
 		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -419,6 +419,7 @@ namespace Microsoft.Maui.Controls
 			index = GetSelectedIndexForCollectionMutation();
 
 			bool selectedItemWasRemoved =
+				SelectedItem != null &&
 				e.OldItems != null &&
 				e.OldItems.Cast<object>().Contains(SelectedItem);
 
@@ -426,11 +427,12 @@ namespace Microsoft.Maui.Controls
 			{
 				ClampSelectedIndex(-1);
 			}
-
-			if (removeStart <= index)
+			else if (removeStart <= index)
 			{
 				ClampSelectedIndex(index);
 			}
+
+			Handler?.UpdateValue(nameof(IPicker.Items));
 		}
 
 		int GetSelectedIndex()

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -426,8 +426,6 @@ namespace Microsoft.Maui.Controls
 			{
 				ClampSelectedIndex(index);
 			}
-
-			Handler?.UpdateValue(nameof(IPicker.Items));
 		}
 
 		int GetSelectedIndex()

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Maui.Controls
 					RemoveItems(e);
 					break;
 				default: //Move, Replace, Reset
-					ResetItems();
+					ResyncItemsAndReconcileSelection();
 					break;
 			}
 
@@ -414,14 +414,12 @@ namespace Microsoft.Maui.Controls
 				index = Items.Count - 1;
 			}
 
-			bool selectedItemWasRemoved = SelectedItem is not null && e.OldItems.Contains(SelectedItem);
-
 			foreach (object _ in e.OldItems)
 				((LockableObservableListWrapper)Items).InternalRemoveAt(index--);
 
-			if (selectedItemWasRemoved)
+			if (SelectedItem is not null)
 			{
-				ClampSelectedIndex(ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1);
+				ClampSelectedIndex(ItemsSource?.IndexOf(SelectedItem) ?? -1);
 			}
 			else
 			{
@@ -431,6 +429,28 @@ namespace Microsoft.Maui.Controls
 				{
 					ClampSelectedIndex(index);
 				}
+			}
+		}
+
+		void ResyncItemsAndReconcileSelection()
+		{
+			if (ItemsSource == null)
+				return;
+
+			((LockableObservableListWrapper)Items).InternalClear();
+
+			foreach (object item in ItemsSource)
+				((LockableObservableListWrapper)Items).InternalAdd(GetDisplayMember(item));
+
+			Handler?.UpdateValue(nameof(IPicker.Items));
+
+			if (SelectedItem is not null)
+			{
+				ClampSelectedIndex(ItemsSource.IndexOf(SelectedItem));
+			}
+			else
+			{
+				ClampSelectedIndex(SelectedIndex);
 			}
 		}
 
@@ -456,8 +476,7 @@ namespace Microsoft.Maui.Controls
 
 			Handler?.UpdateValue(nameof(IPicker.Items));
 
-			var index = SelectedItem is null ? SelectedIndex : ItemsSource.IndexOf(SelectedItem);
-			ClampSelectedIndex(index);
+			ClampSelectedIndex(SelectedIndex);
 		}
 
 		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -387,10 +387,12 @@ namespace Microsoft.Maui.Controls
 		{
 			int insertIndex = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;
 			int index = insertIndex;
+
 			foreach (object newItem in e.NewItems)
 				((LockableObservableListWrapper)Items).InternalInsert(index++, GetDisplayMember(newItem));
 
-			index = GetSelectedIndexForCollectionMutation();
+			index = GetSelectedIndex();
+
 			if (insertIndex <= index)
 			{
 				ClampSelectedIndex(index);
@@ -413,18 +415,23 @@ namespace Microsoft.Maui.Controls
 				index = Items.Count - 1;
 			}
 
+			bool selectedItemWasRemoved = SelectedItem is not null && e.OldItems.Contains(SelectedItem);
+
 			foreach (object _ in e.OldItems)
 				((LockableObservableListWrapper)Items).InternalRemoveAt(index--);
 
-			index = GetSelectedIndexForCollectionMutation();
-
-			if (index == -1)
+			if (selectedItemWasRemoved)
 			{
-				ClampSelectedIndex(-1);
+				ClampSelectedIndex(ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1);
 			}
-			else if (removeStart <= index)
+			else
 			{
-				ClampSelectedIndex(index);
+				index = GetSelectedIndex();
+
+				if (removeStart <= index)
+				{
+					ClampSelectedIndex(index);
+				}
 			}
 		}
 
@@ -436,14 +443,6 @@ namespace Microsoft.Maui.Controls
 			int newIndex = ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1;
 
 			return newIndex >= 0 ? newIndex : SelectedIndex;
-		}
-
-		int GetSelectedIndexForCollectionMutation()
-		{
-			if (SelectedItem is null)
-				return SelectedIndex;
-
-			return ItemsSource?.IndexOf(SelectedItem) ?? Items?.IndexOf(SelectedItem) ?? -1;
 		}
 
 		void ResetItems()
@@ -458,7 +457,7 @@ namespace Microsoft.Maui.Controls
 
 			Handler?.UpdateValue(nameof(IPicker.Items));
 
-			ClampSelectedIndex(GetSelectedIndexForCollectionMutation());
+			ClampSelectedIndex(SelectedIndex);
 		}
 
 		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -6,7 +6,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
@@ -457,7 +456,8 @@ namespace Microsoft.Maui.Controls
 
 			Handler?.UpdateValue(nameof(IPicker.Items));
 
-			ClampSelectedIndex(SelectedIndex);
+			var index = SelectedItem is null ? SelectedIndex : ItemsSource.IndexOf(SelectedItem);
+			ClampSelectedIndex(index);
 		}
 
 		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/Picker/Picker.cs
+++ b/src/Controls/src/Core/Picker/Picker.cs
@@ -418,12 +418,7 @@ namespace Microsoft.Maui.Controls
 
 			index = GetSelectedIndexForCollectionMutation();
 
-			bool selectedItemWasRemoved =
-				SelectedItem != null &&
-				e.OldItems != null &&
-				e.OldItems.Cast<object>().Contains(SelectedItem);
-
-			if (selectedItemWasRemoved)
+			if (index == -1)
 			{
 				ClampSelectedIndex(-1);
 			}

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -852,5 +852,81 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Dog", picker.SelectedItem);
 			Assert.Equal(2, picker.SelectedIndex);
 		}
+
+		// https://github.com/dotnet/maui/issues/33307
+		[Fact]
+		public void PickerClearsSelectionWhenSelectedItemIsRemovedFromItemsSource()
+		{
+			// Arrange
+			var items = new ObservableCollection<string> { "A", "B", "C" };
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedItem = "B"
+			};
+
+			Assert.Equal("B", picker.SelectedItem);
+			Assert.Equal(1, picker.SelectedIndex);
+
+			// Act: Remove the selected item
+			items.Remove("B");
+
+			// Assert: Selection should be cleared
+			Assert.Equal(-1, picker.SelectedIndex);
+			Assert.Null(picker.SelectedItem);
+		}
+
+		// https://github.com/dotnet/maui/issues/33307
+		[Fact]
+		public void PickerRetainsSelectionWhenUnselectedItemIsRemovedFromItemsSource()
+		{
+			// Arrange
+			var items = new ObservableCollection<string> { "A", "B", "C" };
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedItem = "C"
+			};
+
+			Assert.Equal("C", picker.SelectedItem);
+			Assert.Equal(2, picker.SelectedIndex);
+
+			// Act: Remove an item that is not selected
+			items.Remove("A");
+
+			// Assert: SelectedItem should still be "C", index adjusted
+			Assert.Equal("C", picker.SelectedItem);
+			Assert.Equal(1, picker.SelectedIndex);
+		}
+
+		// https://github.com/dotnet/maui/issues/33307
+		[Fact]
+		public void PickerRetainsSelectionAfterInsertReorderingItemsSource()
+		{
+			// Arrange
+			var items = new ObservableCollection<string> { "X", "Y", "Z" };
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedItem = "Y"
+			};
+
+			Assert.Equal("Y", picker.SelectedItem);
+			Assert.Equal(1, picker.SelectedIndex);
+
+			// Act: Insert an item before the selected item
+			items.Insert(0, "W");
+
+			// Assert: SelectedItem should still be "Y", index shifted
+			Assert.Equal("Y", picker.SelectedItem);
+			Assert.Equal(2, picker.SelectedIndex);
+
+			// Act: Insert an item after the selected item
+			items.Insert(4, "V");
+
+			// Assert: SelectedItem and index remain unchanged
+			Assert.Equal("Y", picker.SelectedItem);
+			Assert.Equal(2, picker.SelectedIndex);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -471,8 +471,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			items.RemoveRange(4 - removeCount, removeCount);
 
 			Assert.Equal(4 - removeCount, picker.Items.Count);
-			Assert.Equal(items.Count - 1, picker.SelectedIndex);
-			Assert.Equal(items[^1], picker.SelectedItem);
+			// When the selected item is removed, selection should be cleared
+			Assert.Equal(-1, picker.SelectedIndex);
+			Assert.Null(picker.SelectedItem);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -902,7 +902,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		// https://github.com/dotnet/maui/issues/33307
 		[Fact]
-		public void PickerRetainsSelectionAfterInsertReorderingItemsSource()
+		public void PickerRetainsSelectionWhenItemsAreInsertedBeforeAndAfterSelection()
 		{
 			// Arrange
 			var items = new ObservableCollection<string> { "X", "Y", "Z" };
@@ -930,7 +930,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(2, picker.SelectedIndex);
 		}
 
-
 		// https://github.com/dotnet/maui/issues/33307
 		[Fact]
 		public void PickerRetainsSelectionWhenDuplicateSelectedItemIsRemoved()
@@ -953,6 +952,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Assert: Selection should remain because another equal item still exists
 			Assert.Equal("B", picker.SelectedItem);
 			Assert.Equal(1, picker.SelectedIndex);
+		}
+
+		// https://github.com/dotnet/maui/issues/33307
+		[Fact]
+		public void PickerRetainsSelectionWhenSelectedItemIsMoved()
+		{
+			// Arrange
+			var items = new ObservableCollection<string> { "A", "B", "C" };
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedItem = "B"
+			};
+
+			Assert.Equal("B", picker.SelectedItem);
+			Assert.Equal(1, picker.SelectedIndex);
+
+			// Act: Move the selected item
+			items.Move(1, 2);
+
+			// Assert: SelectedItem should still be "B", index updated
+			Assert.Equal("B", picker.SelectedItem);
+			Assert.Equal(2, picker.SelectedIndex);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -929,5 +929,30 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal("Y", picker.SelectedItem);
 			Assert.Equal(2, picker.SelectedIndex);
 		}
+
+
+		// https://github.com/dotnet/maui/issues/33307
+		[Fact]
+		public void PickerRetainsSelectionWhenDuplicateSelectedItemIsRemoved()
+		{
+			// Arrange
+			var items = new ObservableCollection<string> { "A", "B", "B" };
+
+			var picker = new Picker
+			{
+				ItemsSource = items,
+				SelectedItem = "B"
+			};
+
+			Assert.Equal("B", picker.SelectedItem);
+			Assert.Equal(1, picker.SelectedIndex);
+
+			// Act: Remove the first matching selected item
+			items.RemoveAt(1);
+
+			// Assert: Selection should remain because another equal item still exists
+			Assert.Equal("B", picker.SelectedItem);
+			Assert.Equal(1, picker.SelectedIndex);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Fixes incorrect `Picker` selection behavior when the selected item is removed from `ItemsSource`.

Previously, when the selected item was removed, the picker could keep the old `SelectedIndex`, causing a different item at the same index to become selected after the collection shifted.

This PR scopes the selection reconciliation to collection mutation paths:

- `RemoveItems()` now resolves the current `SelectedItem` against the post-removal `ItemsSource`.
  - If the selected item no longer exists, selection is cleared.
  - If an equal/duplicate item still exists, selection is preserved at the surviving index.
- `Move`, `Replace`, and `Reset` notifications from the same collection now rebuild the display items and reconcile selection by `SelectedItem` identity.
- Full `ItemsSource` replacement keeps the existing positional clamping behavior via `ResetItems()`.

### Tests

Added/updated unit tests covering:

- Selected item removal clears selection.
- Removing an unrelated item preserves selection and updates the index.
- Inserting items before/after selection preserves selection.
- Removing one duplicate selected value preserves selection if another equal value remains.
- Moving the selected item preserves selection and updates `SelectedIndex`.

Fixes #33307 