### PR TITLE
[ci] fix branding

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <SdkBandVersion>11.0.100</SdkBandVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <!-- Essentials.AI preview versioning — bump this for new AI previews -->
     <EssentialsAIPreviewVersionIteration>1</EssentialsAIPreviewVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->


### PR DESCRIPTION
This pull request contains a minor update to the versioning configuration for pre-release builds. The change increments the `PreReleaseVersionIteration` from 1 to 2 to reflect a new iteration of the pre-release version.

- Incremented the `PreReleaseVersionIteration` property from 1 to 2 in `eng/Versions.props` to update the pre-release version number.