### PR TITLE
[Android] Fix crash in GraphicsView when using TapGestureRecognizer

### DIFF
--- a/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!_dragStarted)
 			{
-				if (points.Length == 1)
+				if (points.Length == 1 && _lastMovedViewPoints.Length == 1)
 				{
 					float deltaX = _lastMovedViewPoints[0].X - points[0].X;
 					float deltaY = _lastMovedViewPoints[0].Y - points[0].Y;

--- a/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!_dragStarted)
 			{
-				if (points.Length == 1 && _lastMovedViewPoints.Length == 1)
+				if (points.Length == 1 && _lastMovedViewPoints.Length > 0)
 				{
 					float deltaX = _lastMovedViewPoints[0].X - points[0].X;
 					float deltaY = _lastMovedViewPoints[0].Y - points[0].Y;


### PR DESCRIPTION
### Description of Change

Fixes a crash on Android when using `TapGestureRecognizer` with `GraphicsView`.

### Root Cause

`PlatformTouchGraphicsView.TouchesMoved` assumed that `_lastMovedViewPoints`
always contained at least one element.

In certain touch event sequences (triggered when a TapGestureRecognizer is attached),
`_lastMovedViewPoints` could be empty while `points.Length == 1`,
leading to an IndexOutOfRangeException.

### Fix

Added a length check before accessing `_lastMovedViewPoints[0]`
to prevent out-of-range access.

### Verified Scenarios

- TapGestureRecognizer no longer causes a crash
- Tap events fire correctly
- Drag interaction remains functional
- Multitouch does not crash

Fixes #34296 