### PR TITLE
Workaround CoreCLR R2R integration test build failures on macCatalyst and Windows

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -43,6 +43,24 @@ public class SimpleTemplateTest : BaseTemplateTests
 				"</Project>",
 				"<PropertyGroup><Version>1.0.0-preview.1</Version></PropertyGroup></Project>");
 
+		// Workaround for https://github.com/dotnet/maui/issues/34303
+		// CoreCLR R2R (ReadyToRun) compilation is broken for certain TFMs:
+		// - macCatalyst: R2R objects target version 15.2 but the linker expects 15.0 (fails on macOS)
+		// - iOS and macCatalyst: crossgen2 is missing for Apple cross-compilation (fails on Windows)
+		// Remove the broken TFMs per platform so the test still validates R2R for the working ones.
+		if (additionalDotNetBuildParams.Contains("UseMonoRuntime=false", StringComparison.OrdinalIgnoreCase))
+		{
+			var replacements = new Dictionary<string, string>()
+			{
+				{ ";net11.0-maccatalyst", "" },
+			};
+			if (OperatingSystem.IsWindows())
+			{
+				replacements[";net11.0-ios"] = "";
+			}
+			FileUtilities.ReplaceInFile(projectFile, replacements);
+		}
+
 		var buildProps = BuildProps;
 
 		if (additionalDotNetBuildParams is not "" and not null)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The `SimpleTemplateTest.Build` integration test with `UseMonoRuntime=false EnablePreviewFeatures=true` (CoreCLR R2R) fails to build on certain platform TFMs:

- **macOS — macCatalyst**: R2R compiled objects target macCatalyst 15.2 but the linker expects deployment target 15.0
- **Windows — iOS + macCatalyst**: crossgen2 executable is missing for Apple cross-compilation

Android, iOS (on macOS), and Windows TFMs build fine. This has been failing on every `net11.0` build since Jan 27 (46/47 tests pass, this 1 fails), and causes the Windows job to timeout after ~2 hours.

## Workaround

This PR removes only the broken TFMs per platform so the test still validates CoreCLR R2R on the working ones:

- **macOS**: Removes macCatalyst → test builds Android + iOS
- **Windows**: Removes macCatalyst + iOS → test builds Android + Windows

The underlying issue needs to be fixed upstream in the .NET SDK/runtime toolchain.

## Changes

**`SimpleTemplateTest.cs`**: When `UseMonoRuntime=false`, removes broken TFMs from the generated csproj before building. Uses `OperatingSystem.IsWindows()` to conditionally also remove iOS on Windows (where crossgen2 is missing for Apple targets).

## Issues

Workaround for #34303 — upstream fix needed in .NET SDK/runtime.