### PR TITLE
[ci] Auto-trigger uitests and device-tests on darc-* branches

### DIFF
--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net*.0
     - inflight/*
+    - darc-*
   tags:
     include:
     - '*'

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net*.0
     - inflight/*
+    - darc-*
   tags:
     include:
     - '*'


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Add `darc-*` to the `trigger: branches: include:` section in `ci-uitests.yml` and `ci-device-tests.yml` so that `maui-pr-uitests` and `maui-pr-devicetests` automatically run when dotnet-maestro pushes dependency updates to `darc-*` branches.

Previously, these pipelines required manual `/azp run` comments on every maestro PR.

### Issues Fixed

N/A - CI improvement

### Files Changed

- `eng/pipelines/ci-uitests.yml` - Added `darc-*` to CI trigger branch filter
- `eng/pipelines/ci-device-tests.yml` - Added `darc-*` to CI trigger branch filter