### PR TITLE
Fix misplaced #nullable enable in Maps PublicAPI.Unshipped.txt files

### DIFF
--- a/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void

--- a/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -39,4 +40,3 @@ static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Mic
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!
-﻿#nullable enable

--- a/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/Maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Controls.Maps.Circle.CircleClicked -> System.EventHandler?
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs
 Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs.ClusterClickedEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Controls.Maps.Pin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> void
@@ -39,4 +40,3 @@ static readonly Microsoft.Maui.Controls.Maps.MapElement.IsVisibleProperty -> Mic
 static readonly Microsoft.Maui.Controls.Maps.MapElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ClusteringIdentifierProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.Maps.Pin.ImageSourceProperty -> Microsoft.Maui.Controls.BindableProperty!
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -33,4 +34,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
 static Microsoft.Maui.Maps.Platform.MapExtensions.UpdateMapStyle(this Android.Gms.Maps.GoogleMap! googleMap, Microsoft.Maui.Maps.IMap! map) -> void
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -34,4 +35,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.H
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void

--- a/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
+﻿#nullable enable
 
-#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void

--- a/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -32,4 +33,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.H
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
-﻿#nullable enable

--- a/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+﻿#nullable enable
 Microsoft.Maui.Maps.IMap.ClusterClicked(System.Collections.Generic.IReadOnlyList<Microsoft.Maui.Maps.IMapPin!>! pins, Microsoft.Maui.Devices.Sensors.Location! location) -> bool
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin pin) -> void
 Microsoft.Maui.Maps.IMap.HideInfoWindow(Microsoft.Maui.Maps.IMapPin! pin) -> void
@@ -32,4 +33,3 @@ static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapStyle(Microsoft.Maui.Maps.H
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapShowInfoWindow(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapPinHandler.MapImageSource(Microsoft.Maui.Maps.Handlers.IMapPinHandler! handler, Microsoft.Maui.Maps.IMapPin! mapPin) -> void
 static Microsoft.Maui.Maps.MapSpan.FromLocations(System.Collections.Generic.IEnumerable<Microsoft.Maui.Devices.Sensors.Location!>! locations) -> Microsoft.Maui.Maps.MapSpan!
-﻿#nullable enable


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The BOM-prefixed `#nullable enable` line in 14 Maps `PublicAPI.Unshipped.txt` files was at the bottom of the file instead of line 1, causing RS0017 analyzer errors:

```
Symbol '#nullable enable' is part of the declared API, but is either not public or could not be found
```

This was likely caused by a prior sort operation that treated the BOM byte as a regular character, sorting the line after all API entries.

## Changes

Moved `#nullable enable` back to line 1 (with BOM) in all 14 affected files:
- 7 files in `src/Core/maps/src/PublicAPI/`
- 7 files in `src/Controls/Maps/src/PublicAPI/`
