### PR TITLE
[iOS] Fix two bugs in MauiScrollView.ValidateSafeArea

### DIFF
--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -328,8 +328,9 @@ namespace Microsoft.Maui.Platform
 			//UpdateKeyboardSubscription();
 			// If nothing changed, we don't need to do anything
 
-			if (!UpdateContentInsetAdjustmentBehavior())
+			if (UpdateContentInsetAdjustmentBehavior())
 			{
+				// Edges changed - invalidate and force re-evaluation
 				InvalidateConstraintsCache();
 				_safeAreaInvalidated = true;
 			}
@@ -340,7 +341,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			// Mark the safe area as validated given that we're about to check it
-			_safeAreaInvalidated = true;
+			_safeAreaInvalidated = false;
 
 			var oldSafeArea = _safeArea;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes two bugs in `MauiScrollView.ValidateSafeArea()` that caused unnecessary safe area recomputation on every `LayoutSubviews` call — including during scrolling.

### Bug 1: Inverted condition on `UpdateContentInsetAdjustmentBehavior` check

The condition was `if (!UpdateContentInsetAdjustmentBehavior())` which enters the invalidation block when edges did **not** change, needlessly calling `InvalidateConstraintsCache()` and setting `_safeAreaInvalidated = true`. When edges **did** change (`!true = false`), it **skipped** the block — missing the required cache invalidation.

**Fix**: Changed to `if (UpdateContentInsetAdjustmentBehavior())` so we only invalidate when edges actually change.

### Bug 2: Wrong flag value after validation

The line `_safeAreaInvalidated = true` was supposed to mark the safe area as validated (the comment says "Mark the safe area as **validated**"), but it actually kept it invalidated. Combined with Bug 1, this forced a full safe area recompute on every `LayoutSubviews` call — including during scrolling (60+ times/sec).

**Fix**: Changed to `_safeAreaInvalidated = false`.

### Impact

These two bugs together meant that `MauiScrollView` was doing full safe area recomputation on **every single layout pass**, including during scrolling. This is pure wasted work that can affect scroll performance on iOS.

### Changes

- `src/Core/src/Platform/iOS/MauiScrollView.cs`: Two-line fix in `ValidateSafeArea()`

Found during analysis of PR #34024 (safe area infinite layout cycle fix).