### PR TITLE
Fix LayoutCycleException from nested Borders on Windows

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32406.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32406.cs
@@ -1,0 +1,63 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32406, "LayoutCycleException caused by nested Borders in ControlTemplates", PlatformAffected.UWP)]
+public class Issue32406 : ContentPage
+{
+	public Issue32406()
+	{
+		var resultLabel = new Label
+		{
+			Text = "Waiting",
+			AutomationId = "ResultLabel"
+		};
+
+		var container = new VerticalStackLayout();
+
+		// Create enough nested Border elements to trigger the layout cycle.
+		// The original report shows crashes at ~300 elements with 3+ nesting levels.
+		const int elementCount = 350;
+		const int nestingDepth = 3;
+
+		for (int i = 0; i < elementCount; i++)
+		{
+			View innermost = new Label { Text = $"Item {i}" };
+
+			for (int j = 0; j < nestingDepth; j++)
+			{
+				innermost = new Border
+				{
+					StrokeThickness = 1,
+					Stroke = Colors.Gray,
+					Content = new HorizontalStackLayout
+					{
+						Children = { innermost }
+					}
+				};
+			}
+
+			container.Children.Add(innermost);
+		}
+
+		var scrollView = new ScrollView { Content = container };
+
+		Content = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star)
+			},
+			Children =
+			{
+				resultLabel,
+				scrollView
+			}
+		};
+
+		Grid.SetRow(scrollView, 1);
+
+		// If we reach this point without a LayoutCycleException, the test passes.
+		// Use Loaded to confirm the page rendered successfully.
+		Loaded += (s, e) => resultLabel.Text = "Success";
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32406.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32406.cs
@@ -15,6 +15,7 @@ public class Issue32406 : ContentPage
 
 		// Create enough nested Border elements to trigger the layout cycle.
 		// The original report shows crashes at ~300 elements with 3+ nesting levels.
+		// Each element creates nestingDepth Borders (350 * 3 = 1050 total Borders).
 		const int elementCount = 350;
 		const int nestingDepth = 3;
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs
@@ -1,0 +1,20 @@
+namespace Microsoft.Maui.TestCases.Shared.Tests.Tests.Issues;
+
+public class Issue32406 : _IssuesUITest
+{
+	public override string Issue => "LayoutCycleException caused by nested Borders in ControlTemplates";
+
+	public Issue32406(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.Border)]
+	public void NestedBordersShouldNotCauseLayoutCycle()
+	{
+		// If the app crashes with a LayoutCycleException, we'll never reach this point.
+		// Wait for the page to load and verify the success label.
+		App.WaitForElement("ResultLabel", timeout: TimeSpan.FromSeconds(30));
+
+		var text = App.FindElement("ResultLabel").GetText();
+		Assert.That(text, Is.EqualTo("Success"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs
@@ -1,4 +1,8 @@
-namespace Microsoft.Maui.TestCases.Shared.Tests.Tests.Issues;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue32406 : _IssuesUITest
 {

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs
@@ -15,10 +15,7 @@ public class Issue32406 : _IssuesUITest
 	public void NestedBordersShouldNotCauseLayoutCycle()
 	{
 		// If the app crashes with a LayoutCycleException, we'll never reach this point.
-		// Wait for the page to load and verify the success label.
-		App.WaitForElement("ResultLabel", timeout: TimeSpan.FromSeconds(30));
-
-		var text = App.FindElement("ResultLabel").GetText();
-		Assert.That(text, Is.EqualTo("Success"));
+		// Wait for the Loaded handler to set "Success" text, avoiding a race with element existence.
+		App.WaitForTextToBePresentInElement("ResultLabel", "Success", timeout: TimeSpan.FromSeconds(30));
 	}
 }

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -44,7 +44,9 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
+#if !WINDOWS
 		private Size _lastSize;
+#endif
 
 		public BorderHandler() : base(Mapper, CommandMapper)
 		{
@@ -65,6 +67,11 @@ namespace Microsoft.Maui.Handlers
 
 		PlatformView IBorderHandler.PlatformView => PlatformView;
 
+#if !WINDOWS
+		// On Windows, ContentPanel.ContentPanelSizeChanged already handles size-based
+		// shape updates. Calling UpdateValue(Shape) during PlatformArrange on Windows
+		// causes Path.Data to be set during the WinUI arrange pass, which invalidates
+		// layout and can cause LayoutCycleException with many nested Borders (#32406).
 		/// <inheritdoc />
 		public override void PlatformArrange(Rect rect)
 		{
@@ -76,6 +83,7 @@ namespace Microsoft.Maui.Handlers
 				UpdateValue(nameof(IBorderStroke.Shape));
 			}
 		}
+#endif
 
 		/// <summary>
 		/// Maps the abstract <see cref="IView.Background"/> property to the platform-specific implementations.

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -71,19 +71,19 @@ namespace Microsoft.Maui.Handlers
 		// shape updates. Calling UpdateValue(Shape) during PlatformArrange on Windows
 		// causes Path.Data to be set during the WinUI arrange pass, which invalidates
 		// layout and can cause LayoutCycleException with many nested Borders (#32406).
-#if !WINDOWS
 		/// <inheritdoc />
 		public override void PlatformArrange(Rect rect)
 		{
 			base.PlatformArrange(rect);
 
+#if !WINDOWS
 			if (_lastSize != rect.Size)
 			{
 				_lastSize = rect.Size;
 				UpdateValue(nameof(IBorderStroke.Shape));
 			}
-		}
 #endif
+		}
 
 		/// <summary>
 		/// Maps the abstract <see cref="IView.Background"/> property to the platform-specific implementations.

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Maui.Handlers
 
 		PlatformView IBorderHandler.PlatformView => PlatformView;
 
-#if !WINDOWS
 		// On Windows, ContentPanel.ContentPanelSizeChanged already handles size-based
 		// shape updates. Calling UpdateValue(Shape) during PlatformArrange on Windows
 		// causes Path.Data to be set during the WinUI arrange pass, which invalidates
 		// layout and can cause LayoutCycleException with many nested Borders (#32406).
+#if !WINDOWS
 		/// <inheritdoc />
 		public override void PlatformArrange(Rect rect)
 		{

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-*REMOVED*override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+*REMOVED*override Microsoft.Maui.Handlers.BorderHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #32406

On Windows, deeply nested `Border` elements (300+ at 3+ nesting depth) in ControlTemplates cause an unrecoverable `LayoutCycleException`. This is a regression from PR #24844 which moved Border shape updates from `OnPropertyChanged` (Width/Height) into `BorderHandler.PlatformArrange`.

### Root Cause

The layout cycle is caused by **double shape-geometry updates during the WinUI arrange pass**:

1. `ContentPanel.ContentPanelSizeChanged` (pre-existing) fires during WinUI's arrange pass and sets `Path.Data`
2. `BorderHandler.PlatformArrange` (added by #24844) also calls `UpdateValue(Shape)` during arrange, which sets `Path.Data` again

Setting `Path.Data` on a WinUI `Path` element invalidates layout (triggers re-measure/arrange). With two invalidations per Border per arrange pass, and hundreds of deeply nested Borders, the cascading invalidations exceed WinUI's layout cycle detection threshold.

### Fix

Skip the `PlatformArrange` shape update on Windows (`#if !WINDOWS`), since `ContentPanel.ContentPanelSizeChanged` already handles size-based shape updates during the layout pass. Non-Windows platforms retain `PlatformArrange` behavior since they have no equivalent `SizeChanged` handler.

### Changes

- `src/Core/src/Handlers/Border/BorderHandler.cs` — Wrap `PlatformArrange` override and `_lastSize` field with `#if !WINDOWS`
- `src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt` — Mark removed API
- `src/Controls/tests/TestCases.HostApp/Issues/Issue32406.cs` — HostApp page with 350 nested Borders at depth 3
- `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32406.cs` — UI test verifying no crash