### PR TITLE
[ci] Copilot CI: Android device tests, emulator robustness, and snapshot fallback

### DIFF
--- a/.github/scripts/BuildAndRunHostApp.ps1
+++ b/.github/scripts/BuildAndRunHostApp.ps1
@@ -232,6 +232,28 @@ if ($Category) {
 if ($Platform -eq "android") {
     Write-Info "Clearing Android logcat buffer before test..."
     & adb -s $DeviceUdid logcat -c
+
+    # Dismiss any ANR dialogs that may have appeared during build/deploy.
+    # The emulator can sit idle during long builds, causing SystemUI ANR.
+    Write-Info "Dismissing any system dialogs before test..."
+    & adb -s $DeviceUdid shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>$null
+    & adb -s $DeviceUdid shell input keyevent KEYCODE_ENTER 2>$null
+    & adb -s $DeviceUdid shell input keyevent KEYCODE_BACK 2>$null
+    Start-Sleep -Seconds 1
+    & adb -s $DeviceUdid shell input keyevent KEYCODE_WAKEUP 2>$null
+    & adb -s $DeviceUdid shell input keyevent KEYCODE_MENU 2>$null
+    Start-Sleep -Seconds 1
+
+    # Check for lingering ANR dialogs via window dump
+    $windowDump = & adb -s $DeviceUdid shell dumpsys window 2>$null | Select-String "Application Not Responding|ANR"
+    if ($windowDump) {
+        Write-Warn "ANR dialog detected — force-dismissing..."
+        & adb -s $DeviceUdid shell input keyevent KEYCODE_HOME 2>$null
+        Start-Sleep -Seconds 2
+        & adb -s $DeviceUdid shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>$null
+        & adb -s $DeviceUdid shell input keyevent KEYCODE_BACK 2>$null
+        Start-Sleep -Seconds 1
+    }
 }
 
 # Capture test start time for iOS logs

--- a/.github/scripts/Review-PR.ps1
+++ b/.github/scripts/Review-PR.ps1
@@ -131,12 +131,14 @@ if (-not $ghVersion) {
 }
 Write-Host "  ✅ GitHub CLI: $ghVersion" -ForegroundColor Green
 
-# Check Copilot CLI
-$copilotVersion = copilot --version 2>$null
-if (-not $copilotVersion) {
+# Check Copilot CLI - use Get-Command (reliable) then get version with merged streams
+$copilotCmd = Get-Command copilot -ErrorAction SilentlyContinue
+if (-not $copilotCmd) {
     Write-Error "Copilot CLI is not installed. Install with: npm install -g @github/copilot"
     exit 1
 }
+$copilotVersion = (& copilot --version 2>&1 | Out-String).Trim()
+if (-not $copilotVersion) { $copilotVersion = $copilotCmd.Source }
 Write-Host "  ✅ Copilot CLI: $copilotVersion" -ForegroundColor Green
 
 # Check PR exists

--- a/.github/scripts/shared/Build-AndDeploy.ps1
+++ b/.github/scripts/shared/Build-AndDeploy.ps1
@@ -85,19 +85,56 @@ if ($Platform -eq "android") {
     Write-Info "Build command: dotnet build $($buildArgs -join ' ')"
     
     $buildStartTime = Get-Date
+    $maxAttempts = 2
+    $buildExitCode = 1
     
-    # Build and deploy in one step (Run target handles both)
-    & dotnet build @buildArgs
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+        if ($attempt -gt 1) {
+            Write-Warn "Retrying build/deploy (attempt $attempt of $maxAttempts)..."
+            
+            # Uninstall any MAUI test packages to clear bad state
+            $installedPkg = & adb shell pm list packages 2>$null | Select-String "maui" | ForEach-Object { ($_ -replace "package:", "").Trim() }
+            if ($installedPkg) {
+                foreach ($pkg in $installedPkg) {
+                    Write-Info "Uninstalling $pkg before retry..."
+                    & adb uninstall $pkg 2>$null
+                }
+            }
+            
+            # Restart ADB server to recover from broken pipe / transient errors
+            Write-Info "Restarting ADB server..."
+            & adb kill-server 2>$null
+            Start-Sleep -Seconds 2
+            & adb start-server
+            Start-Sleep -Seconds 2
+            & adb wait-for-device
+            Start-Sleep -Seconds 3
+        }
+        
+        & dotnet build @buildArgs
+        $buildExitCode = $LASTEXITCODE
+        
+        if ($buildExitCode -eq 0) {
+            break
+        }
+        
+        if ($attempt -lt $maxAttempts) {
+            Write-Warn "Build/deploy failed (attempt $attempt). ADB0010/broken-pipe errors are transient on API 30 — will retry."
+        }
+    }
     
-    $buildExitCode = $LASTEXITCODE
     $buildDuration = (Get-Date) - $buildStartTime
     
     if ($buildExitCode -ne 0) {
-        Write-Error "Build/deploy failed with exit code $buildExitCode"
+        Write-Error "Build/deploy failed after $maxAttempts attempts with exit code $buildExitCode"
         exit $buildExitCode
     }
     
-    Write-Success "Build and deploy completed in $($buildDuration.TotalSeconds) seconds"
+    if ($attempt -gt 1) {
+        Write-Success "Build and deploy succeeded on attempt $attempt in $($buildDuration.TotalSeconds) seconds"
+    } else {
+        Write-Success "Build and deploy completed in $($buildDuration.TotalSeconds) seconds"
+    }
     
     #endregion
     

--- a/.github/scripts/shared/Start-Emulator.ps1
+++ b/.github/scripts/shared/Start-Emulator.ps1
@@ -65,7 +65,8 @@ if ($Platform -eq "android") {
     # Check if DeviceUdid is an AVD name (not an emulator-XXXX format)
     if ($DeviceUdid -and $DeviceUdid -notmatch "^emulator-\d+$") {
         # DeviceUdid is likely an AVD name - check if it's in the AVD list
-        $avdList = emulator -list-avds 2>$null
+        # Force array output - single AVD returns a string which breaks -contains
+        [string[]]$avdList = @(emulator -list-avds 2>$null)
         if ($avdList -contains $DeviceUdid) {
             Write-Info "DeviceUdid '$DeviceUdid' is an AVD name. Will boot this emulator..."
             $selectedAvd = $DeviceUdid
@@ -103,7 +104,8 @@ if ($Platform -eq "android") {
             
             # Get list of available AVDs (if not already set from parameter)
             if (-not $selectedAvd) {
-                $avdList = emulator -list-avds 2>$null
+                # Force array output - single AVD returns a string which breaks indexing
+                [string[]]$avdList = @(emulator -list-avds 2>$null)
                 
                 if (-not $avdList -or $avdList.Count -eq 0) {
                     Write-Error "No Android emulators found. Please create an Android Virtual Device (AVD) using Android Studio."
@@ -119,7 +121,7 @@ if ($Platform -eq "android") {
                 # Selection priority:
                 # 1. API 34 device (matches CI provisioning)
                 # 2. API 30 Nexus device
-                # 3. Any API 30 device
+                # 3. Any API 30 device (matches names like "Emulator_30", "API_30_xxx", etc.)
                 # 4. Any Nexus device
                 # 5. First available device
                 
@@ -132,16 +134,16 @@ if ($Platform -eq "android") {
                 
                 # Try to find API 30 Nexus device
                 if (-not $selectedAvd) {
-                    $api30Nexus = $avdList | Where-Object { $_ -match "API.*30" -and $_ -match "Nexus" } | Select-Object -First 1
+                    $api30Nexus = $avdList | Where-Object { $_ -match "30" -and $_ -match "Nexus" } | Select-Object -First 1
                     if ($api30Nexus) {
                         $selectedAvd = $api30Nexus
                         Write-Info "Selected API 30 Nexus device: $selectedAvd"
                     }
                 }
                 
-                # Try to find any API 30 device
+                # Try to find any API 30 device (match "30" anywhere in name)
                 if (-not $selectedAvd) {
-                    $api30Device = $avdList | Where-Object { $_ -match "API.*30" } | Select-Object -First 1
+                    $api30Device = $avdList | Where-Object { $_ -match "30" } | Select-Object -First 1
                     if ($api30Device) {
                         $selectedAvd = $api30Device
                         Write-Info "Selected API 30 device: $selectedAvd"

--- a/.github/scripts/shared/Start-Emulator.ps1
+++ b/.github/scripts/shared/Start-Emulator.ps1
@@ -339,12 +339,7 @@ if ($Platform -eq "android") {
         exit 1
     }
     
-    # Get device UDID if not provided - check env var first
-    if (-not $DeviceUdid -and $env:DEVICE_UDID) {
-        Write-Info "Using DEVICE_UDID from environment: $($env:DEVICE_UDID)"
-        $DeviceUdid = $env:DEVICE_UDID
-    }
-
+    # Get device UDID if not provided
     if (-not $DeviceUdid) {
         Write-Info "Auto-detecting iOS simulator..."
         $simList = xcrun simctl list devices available --json | ConvertFrom-Json
@@ -459,19 +454,6 @@ if ($Platform -eq "android") {
     
     Write-Success "iOS simulator: $deviceName ($DeviceUdid)"
     
-    # Shutdown any OTHER booted simulators to avoid Appium connecting to the wrong device
-    $bootedSims = xcrun simctl list devices --json | ConvertFrom-Json
-    $otherBooted = $bootedSims.devices.PSObject.Properties.Value |
-        ForEach-Object { $_ } |
-        Where-Object { $_.state -eq "Booted" -and $_.udid -ne $DeviceUdid }
-    
-    if ($otherBooted) {
-        foreach ($sim in $otherBooted) {
-            Write-Info "Shutting down other booted simulator: $($sim.name) ($($sim.udid))"
-            xcrun simctl shutdown $sim.udid 2>$null
-        }
-    }
-
     # Boot simulator if not already booted
     Write-Info "Booting simulator (if not already running)..."
     xcrun simctl boot $DeviceUdid 2>$null
@@ -488,7 +470,7 @@ if ($Platform -eq "android") {
         exit 1
     }
     
-    Write-Success "Simulator is booted and ready: $deviceName"
+    Write-Success "Simulator is booted and ready"
     
     #endregion
 }

--- a/.github/scripts/shared/Start-Emulator.ps1
+++ b/.github/scripts/shared/Start-Emulator.ps1
@@ -339,7 +339,12 @@ if ($Platform -eq "android") {
         exit 1
     }
     
-    # Get device UDID if not provided
+    # Get device UDID if not provided - check env var first
+    if (-not $DeviceUdid -and $env:DEVICE_UDID) {
+        Write-Info "Using DEVICE_UDID from environment: $($env:DEVICE_UDID)"
+        $DeviceUdid = $env:DEVICE_UDID
+    }
+
     if (-not $DeviceUdid) {
         Write-Info "Auto-detecting iOS simulator..."
         $simList = xcrun simctl list devices available --json | ConvertFrom-Json
@@ -454,6 +459,19 @@ if ($Platform -eq "android") {
     
     Write-Success "iOS simulator: $deviceName ($DeviceUdid)"
     
+    # Shutdown any OTHER booted simulators to avoid Appium connecting to the wrong device
+    $bootedSims = xcrun simctl list devices --json | ConvertFrom-Json
+    $otherBooted = $bootedSims.devices.PSObject.Properties.Value |
+        ForEach-Object { $_ } |
+        Where-Object { $_.state -eq "Booted" -and $_.udid -ne $DeviceUdid }
+    
+    if ($otherBooted) {
+        foreach ($sim in $otherBooted) {
+            Write-Info "Shutting down other booted simulator: $($sim.name) ($($sim.udid))"
+            xcrun simctl shutdown $sim.udid 2>$null
+        }
+    }
+
     # Boot simulator if not already booted
     Write-Info "Booting simulator (if not already running)..."
     xcrun simctl boot $DeviceUdid 2>$null
@@ -470,7 +488,7 @@ if ($Platform -eq "android") {
         exit 1
     }
     
-    Write-Success "Simulator is booted and ready"
+    Write-Success "Simulator is booted and ready: $deviceName"
     
     #endregion
 }

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -218,11 +218,18 @@ stages:
                 echo "##vso[task.logissue type=error]GH_CLI_TOKEN is not set. Please configure the pipeline variable."
                 exit 1
               fi
-              echo "$(GH_CLI_TOKEN)" | gh auth login --with-token
-              if ! gh auth status; then
-                echo "##vso[task.logissue type=error]GitHub CLI authentication failed"
-                exit 1
+              # Use GH_TOKEN env var to avoid scope validation issues with newer gh versions
+              export GH_TOKEN="$(GH_CLI_TOKEN)"
+              gh auth status
+              if [ $? -ne 0 ]; then
+                # Fallback: try direct login
+                echo "$(GH_CLI_TOKEN)" | gh auth login --with-token 2>/dev/null || true
+                if ! gh auth status; then
+                  echo "##vso[task.logissue type=error]GitHub CLI authentication failed"
+                  exit 1
+                fi
               fi
+              echo "GitHub CLI authenticated successfully"
             displayName: 'Authenticate GitHub CLI'
             env:
               GH_CLI_TOKEN: $(GH_CLI_TOKEN)

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -2,9 +2,6 @@
 # This pipeline installs the Copilot CLI and invokes the PR reviewer agent
 # to conduct automated code reviews on pull requests.
 #
-# Environment setup follows the same patterns as ui-tests-steps.yml and
-# device-tests-steps.yml: enable-kvm → provision → dotnet install → appium.
-#
 # For more information, see:
 # https://github.com/dotnet/maui/wiki/PR-Reviewer-Agent
 
@@ -30,8 +27,6 @@ parameters:
     type: object
     default:
       name: AcesShared
-      demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
 variables:
   - template: /eng/pipelines/common/variables.yml@self
@@ -41,6 +36,8 @@ variables:
     value: true
   - name: APPIUM_HOME
     value: $(System.DefaultWorkingDirectory)/.appium/
+  - name: LogDirectory
+    value: $(Build.ArtifactStagingDirectory)/logs
 
 stages:
   - stage: ReviewPR
@@ -48,13 +45,7 @@ stages:
     jobs:
       - job: CopilotReview
         displayName: 'Run Copilot PR Reviewer Agent'
-        # Android needs Linux (KVM for emulator), iOS needs macOS (Xcode/simulators)
-        ${{ if eq(parameters.Platform, 'android') }}:
-          pool:
-            name: Azure Pipelines
-            vmImage: ubuntu-22.04
-        ${{ else }}:
-          pool: ${{ parameters.pool }}
+        pool: ${{ parameters.pool }}
         timeoutInMinutes: 180
         steps:
           - checkout: self
@@ -74,17 +65,7 @@ stages:
               echo "##vso[build.updatebuildnumber]PR ${{ parameters.PRNumber }} ${{ parameters.Platform }}"
             displayName: 'Set Pipeline Run Title'
 
-          # Create artifact directories early (prevents publish failures if steps are skipped)
-          - script: |
-              mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs
-              mkdir -p $(Build.ArtifactStagingDirectory)/logs
-            displayName: 'Create Artifact Directories'
-
-          ##################################################
-          #         Provision Machine (same as uitests)    #
-          ##################################################
-
-          # Enable KVM for Android emulator on Linux (same as ui-tests-steps.yml and device-tests-steps.yml)
+          # Enable KVM for Android emulator on Linux (same as ui-tests-steps.yml / device-tests-steps.yml)
           - ${{ if eq(parameters.Platform, 'android') }}:
             - template: common/enable-kvm.yml
 
@@ -103,12 +84,9 @@ stages:
               skipSimulatorSetup: ${{ eq(parameters.Platform, 'android') }}
               skipCertificates: true
 
-          ##################################################
-          #         Install .NET (same as uitests)         #
-          ##################################################
-
+          # Install .NET and workloads via build.ps1
           - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
-            displayName: 'Install .NET'
+            displayName: 'Install .NET and workloads'
             retryCountOnTaskFailure: 2
             env:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
@@ -124,16 +102,12 @@ stages:
             env:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
               PRIVATE_BUILD: $(PrivateBuild)
-
+            
           # Restore .NET tools (includes xharness)
           - script: dotnet tool restore
             displayName: 'Restore .NET Tools'
 
-          ##################################################
-          #     Boot Android Emulator via Cake (same as    #
-          #     device-tests-steps.yml / uitests)          #
-          ##################################################
-
+          # Boot Android Emulator via Cake (same as device-tests-steps.yml / ui-tests-steps.yml)
           - ${{ if eq(parameters.Platform, 'android') }}:
             - script: dotnet cake eng/devices/android.cake --target=boot --device="android-emulator-64_30" --apiversion="30" --verbosity=diagnostic
               displayName: 'Boot Android Emulator (Cake)'
@@ -150,12 +124,8 @@ stages:
                 echo "✅ Emulator running: $DEVICE_ID"
                 echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
               displayName: 'Capture Emulator UDID'
-              timeoutInMinutes: 5
 
-          ##################################################
-          #     Install Node.js + Appium (same as uitests) #
-          ##################################################
-
+          # Install Node.js and Appium (same as ui-tests-steps.yml)
           - task: UseNode@1
             inputs:
               version: "20.3.1"
@@ -170,114 +140,220 @@ stages:
             env:
               APPIUM_HOME: $(APPIUM_HOME)
 
-          ##################################################
-          #     Copilot-specific setup and execution       #
-          ##################################################
-
-          # Install GitHub CLI (cross-platform: apt on Linux, brew on macOS)
           - script: |
               echo "Installing GitHub CLI..."
-              if [ "$(uname)" = "Linux" ]; then
-                (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-                  && sudo mkdir -p -m 755 /etc/apt/keyrings \
-                  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-                  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-                  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-                  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-                  && sudo apt update \
-                  && sudo apt install gh -y
-              else
-                brew install gh
-              fi
-              gh --version
-            displayName: 'Install GitHub CLI'
-
-          # Authenticate GitHub CLI
-          - script: |
-              mkdir -p "$HOME/.config/gh"
-              printf 'github.com:\n    oauth_token: %s\n    git_protocol: https\n' "$GH_CLI_TOKEN" > "$HOME/.config/gh/hosts.yml"
-              LOGIN=$(gh api user --jq '.login' 2>&1)
-              if [ $? -ne 0 ]; then
-                echo "##vso[task.logissue type=error]GitHub CLI authentication failed: $LOGIN"
+              brew install gh
+              if ! gh --version; then
+                echo "##vso[task.logissue type=error]Failed to install GitHub CLI"
                 exit 1
               fi
-              echo "GitHub CLI authenticated as: $LOGIN"
+              echo "GitHub CLI installed successfully"
+            displayName: 'Install GitHub CLI'
+
+          - script: |
+              echo "Authenticating with GitHub CLI..."
+              if [ -z "$(GH_CLI_TOKEN)" ]; then
+                echo "##vso[task.logissue type=error]GH_CLI_TOKEN is not set. Please configure the pipeline variable."
+                exit 1
+              fi
+              echo "$(GH_CLI_TOKEN)" | gh auth login --with-token
+              if ! gh auth status; then
+                echo "##vso[task.logissue type=error]GitHub CLI authentication failed"
+                exit 1
+              fi
             displayName: 'Authenticate GitHub CLI'
             env:
               GH_CLI_TOKEN: $(GH_CLI_TOKEN)
 
-          # Install and authenticate Copilot CLI
           - script: |
+              echo "Installing GitHub Copilot CLI..."
               npm install -g @github/copilot
-              copilot --version
-            displayName: 'Install GitHub Copilot CLI'
-
-          - script: |
-              if [ -z "$COPILOT_GITHUB_TOKEN" ]; then
-                echo "##vso[task.logissue type=error]COPILOT_GITHUB_TOKEN is not set"
+              if ! which copilot; then
+                echo "##vso[task.logissue type=error]Failed to install GitHub Copilot CLI"
                 exit 1
               fi
-              echo "✅ Copilot CLI authentication configured"
-            displayName: 'Authenticate Copilot CLI'
-            env:
-              COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
-              GH_TOKEN: $(GH_CLI_TOKEN)
+              echo "Copilot CLI installed successfully"
+            displayName: 'Install GitHub Copilot CLI'
 
-          # Run the PR Reviewer Agent
+
+          # Boot iOS Simulator (only for iOS platform)
+          # UI test baseline screenshots are captured on iPhone Xs - must use same device
           - script: |
-              echo "Reviewing PR #${{ parameters.PRNumber }}..."
+              echo "=== Booting iOS Simulator ==="
+              
+              # Find the latest stable iOS runtime (prefer 18.x, fallback to 17.x)
+              RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
+                [.runtimes[] | select(.name | test("iOS 18"))] | sort_by(.version) | last | .identifier // empty
+              ')
+              if [ -z "$RUNTIME" ]; then
+                RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
+                  [.runtimes[] | select(.name | test("iOS 17"))] | sort_by(.version) | last | .identifier // empty
+                ')
+              fi
+              echo "Selected iOS runtime: $RUNTIME"
+              
+              # Look for iPhone Xs (matches UI test baselines - required for snapshot tests)
+              UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" '
+                .devices[$rt] // [] |
+                map(select(.name == "iPhone Xs")) |
+                .[0].udid // empty
+              ')
+              
+              # If iPhone Xs doesn't exist, try iPhone 11 Pro (same 1125×2436 resolution)
+              if [ -z "$UDID" ]; then
+                UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" '
+                  .devices[$rt] // [] |
+                  map(select(.name == "iPhone 11 Pro")) |
+                  .[0].udid // empty
+                ')
+                if [ -n "$UDID" ]; then
+                  echo "Found existing iPhone 11 Pro (same resolution as iPhone Xs): $UDID"
+                fi
+              else
+                echo "Found existing iPhone Xs: $UDID"
+              fi
+              
+              # If neither exists, try to create them
+              if [ -z "$UDID" ]; then
+                echo "No matching device found - attempting to create one for runtime $RUNTIME..."
+                
+                # Try iPhone Xs first
+                UDID=$(xcrun simctl create "iPhone Xs" com.apple.CoreSimulator.SimDeviceType.iPhone-Xs "$RUNTIME" 2>&1)
+                if [ $? -ne 0 ]; then
+                  echo "iPhone Xs device type unavailable: $UDID"
+                  # Try iPhone 11 Pro (same 1125×2436 resolution)
+                  UDID=$(xcrun simctl create "iPhone 11 Pro" com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro "$RUNTIME" 2>&1)
+                  if [ $? -ne 0 ]; then
+                    echo "##vso[task.logissue type=warning]Failed to create iPhone 11 Pro: $UDID"
+                    # Last resort: first available iPhone
+                    UDID=$(xcrun simctl list devices available --json | jq -r '
+                      .devices | to_entries |
+                      map(.value) | flatten |
+                      map(select(.name | test("iPhone"))) |
+                      .[0].udid
+                    ')
+                  else
+                    echo "Created iPhone 11 Pro simulator: $UDID"
+                  fi
+                else
+                  echo "Created iPhone Xs simulator: $UDID"
+                fi
+              fi
+              
+              if [ -z "$UDID" ]; then
+                echo "##vso[task.logissue type=error]No iOS simulator found"
+                exit 1
+              fi
+              
+              # Shutdown any other booted simulators to avoid Appium connecting to wrong device
+              xcrun simctl list devices booted --json | jq -r '
+                .devices | to_entries | map(.value) | flatten |
+                map(select(.state == "Booted" and .udid != "'"$UDID"'")) |
+                .[].udid
+              ' | while read OTHER_UDID; do
+                echo "Shutting down other simulator: $OTHER_UDID"
+                xcrun simctl shutdown "$OTHER_UDID" 2>/dev/null || true
+              done
+              
+              echo "Booting simulator: $UDID"
+              xcrun simctl boot "$UDID" 2>/dev/null || echo "Simulator may already be booted"
+              sleep 10
+              
+              echo "Booted simulators:"
+              xcrun simctl list devices booted
+              
+              echo "##vso[task.setvariable variable=DEVICE_UDID]$UDID"
+              echo "iOS Simulator UDID: $UDID"
+            displayName: 'Boot iOS Simulator'
+            condition: eq('${{ parameters.Platform }}', 'ios')
+            timeoutInMinutes: 5
 
-              # Configure git identity
+          - script: |
+              echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."
+              echo "Reviewing PR #${{ parameters.PRNumber }}..."
+              
+              # Configure git identity (required for merge operations on self-hosted agents)
               git config user.email "copilot-ci@microsoft.com"
               git config user.name "Copilot CI"
-
-              # Skip Xcode version check
+              echo "Git identity configured"
+              
+              # Create Directory.Build.Override.props to skip Xcode version check
+              # AcesShared agents may have a newer Xcode than the .NET iOS SDK expects
               cp Directory.Build.Override.props.in Directory.Build.Override.props
-              if [ "$(uname)" = "Linux" ]; then
-                sed -i 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
-              else
-                sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
-              fi
-
+              # Insert ValidateXcodeVersion before closing </Project> tag
+              sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
+              
+              # Create artifacts directory for Copilot outputs
               mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs
-
-              # Invoke the PR reviewer
+              
+              # Invoke the PR reviewer using our PowerShell script
+              # The script will merge the PR into the current branch
+              # -PostSummaryComment and -RunFinalize handle posting comments
               set +e
               pwsh .github/scripts/Review-PR.ps1 -PRNumber ${{ parameters.PRNumber }} -Platform ${{ parameters.Platform }} -RunFinalize -PostSummaryComment -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
               COPILOT_EXIT_CODE=$?
               set -e
-
+              
               echo "Review-PR.ps1 exit code: $COPILOT_EXIT_CODE"
-
-              # Cleanup orphaned copilot processes
+              
+              # Terminate any orphaned copilot CLI processes that could hold this step's
+              # stdout fd open and prevent the bash step from exiting.
+              # Only target processes whose command line includes the copilot CLI path.
+              echo "Cleaning up orphaned copilot processes..."
+              SELF_PID=$$
               for proc in $(pgrep -f "[c]opilot" 2>/dev/null || true); do
-                if [ -n "$proc" ] && [ "$proc" != "$$" ]; then
-                  kill "$proc" 2>/dev/null || true
+                if [ -n "$proc" ] && [ "$proc" != "$SELF_PID" ]; then
+                  PROC_CMD=$(ps -p "$proc" -o args= 2>/dev/null || true)
+                  if echo "$PROC_CMD" | grep -q "copilot"; then
+                    echo "  Stopping copilot process $proc: $PROC_CMD"
+                    kill "$proc" 2>/dev/null || true
+                  fi
                 fi
               done
-
-              # Collect artifacts
-              cp -r "$HOME/.copilot" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot-session-state 2>/dev/null || true
-              cp -r CustomAgentLogsTmp $(Build.ArtifactStagingDirectory)/copilot-logs/ 2>/dev/null || true
+              
+              # Copy any Copilot session files
+              if [ -d "$HOME/.copilot" ]; then
+                echo "Copying Copilot session state..."
+                cp -r "$HOME/.copilot" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot-session-state || true
+              fi
+              
+              # Copy CustomAgentLogsTmp if it exists
+              if [ -d "CustomAgentLogsTmp" ]; then
+                echo "Copying CustomAgentLogsTmp..."
+                cp -r CustomAgentLogsTmp $(Build.ArtifactStagingDirectory)/copilot-logs/ || true
+              fi
+              
+              # Copy any Review_Feedback files
               find . -name "Review_Feedback_*.md" -type f -exec cp {} $(Build.ArtifactStagingDirectory)/copilot-logs/ \; 2>/dev/null || true
-              cp -r .github/agent-pr-session $(Build.ArtifactStagingDirectory)/copilot-logs/ 2>/dev/null || true
-
+              
+              # Copy any .github/agent-pr-session files
+              if [ -d ".github/agent-pr-session" ]; then
+                echo "Copying agent-pr-session..."
+                cp -r .github/agent-pr-session $(Build.ArtifactStagingDirectory)/copilot-logs/ || true
+              fi
+              
+              # Check for failure indicators in output
               if [ $COPILOT_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error]Review-PR.ps1 exited with code $COPILOT_EXIT_CODE"
+                # Don't exit yet - let artifacts be published first
                 echo "##vso[task.setvariable variable=CopilotFailed]true"
               fi
+              
+              # Check output for common failure patterns
+              if grep -qi "error\|failed\|exception" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md 2>/dev/null; then
+                if grep -qi "simulator.*not\|emulator.*not\|workload.*not\|sdk.*not found" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md 2>/dev/null; then
+                  echo "##vso[task.logissue type=warning]Copilot encountered environment issues. Check artifacts for details."
+                fi
+              fi
+              
+              echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
             displayName: 'Run PR Reviewer Agent'
             env:
               COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
               GH_TOKEN: $(GH_COMMENT_TOKEN)
-              GITHUB_TOKEN: $(GH_CLI_TOKEN)
               DEVICE_UDID: $(DEVICE_UDID)
-              APPIUM_HOME: $(APPIUM_HOME)
 
-          ##################################################
-          #                    Publish                     #
-          ##################################################
-
+          # Publish Copilot logs and session artifacts
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Copilot Logs'
             inputs:
@@ -286,6 +362,7 @@ stages:
               publishLocation: 'pipeline'
             condition: succeededOrFailed()
 
+          # Publish build logs if they exist
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Build Logs'
             inputs:
@@ -294,9 +371,11 @@ stages:
               publishLocation: 'pipeline'
             condition: and(succeededOrFailed(), ne(variables['LogDirectory'], ''))
 
+          # Fail the pipeline if Copilot failed
           - script: |
               if [ "$(CopilotFailed)" = "true" ]; then
                 echo "##vso[task.logissue type=error]Copilot PR review failed. Check CopilotLogs artifact for details."
                 exit 1
               fi
             displayName: 'Check Copilot Result'
+            condition: succeededOrFailed()

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -116,6 +116,11 @@ stages:
 
             # Wait for emulator to fully boot (Cake boot fires emulator in background)
             - script: |
+                # Add Android SDK tools to PATH (provision.yml sets ANDROID_SDK_ROOT variable)
+                export PATH="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/platform-tools:${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/emulator:$PATH"
+                echo "Using ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
+                echo "adb location: $(which adb 2>/dev/null || echo 'not found')"
+
                 echo "Waiting for emulator device to appear..."
                 timeout=120
                 waited=0
@@ -158,6 +163,9 @@ stages:
                 DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
                 echo "✅ Emulator fully booted: $DEVICE_ID"
                 echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
+                # Persist PATH for subsequent steps
+                echo "##vso[task.prependpath]${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/platform-tools"
+                echo "##vso[task.prependpath]${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/emulator"
               displayName: 'Wait for Emulator Boot and Capture UDID'
               timeoutInMinutes: 10
 

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -26,7 +26,8 @@ parameters:
   - name: pool
     type: object
     default:
-      name: AcesShared
+      name: Azure Pipelines
+      vmImage: ubuntu-22.04
 
 variables:
   - template: /eng/pipelines/common/variables.yml@self

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -190,7 +190,7 @@ stages:
           # Install Node.js and Appium (same as ui-tests-steps.yml)
           - task: UseNode@1
             inputs:
-              version: "20.3.1"
+              version: "24.x"
             displayName: 'Install Node.js'
 
           - pwsh: |

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -350,7 +350,12 @@ stages:
               # AcesShared agents may have a newer Xcode than the .NET iOS SDK expects
               cp Directory.Build.Override.props.in Directory.Build.Override.props
               # Insert ValidateXcodeVersion before closing </Project> tag
-              sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
+              # GNU sed (Linux) uses -i without suffix; BSD sed (macOS) uses -i ''
+              if [[ "$(uname)" == "Linux" ]]; then
+                sed -i 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
+              else
+                sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
+              fi
               
               # Create artifacts directory for Copilot outputs
               mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -237,10 +237,11 @@ stages:
           - script: |
               echo "Installing GitHub Copilot CLI..."
               npm install -g @github/copilot
-              if ! which copilot; then
-                echo "##vso[task.logissue type=error]Failed to install GitHub Copilot CLI"
-                exit 1
-              fi
+              # Ensure npm global bin is on PATH for subsequent steps (Linux UseNode installs to toolcache)
+              COPILOT_BIN_DIR=$(dirname "$(which copilot)")
+              echo "Copilot binary at: $COPILOT_BIN_DIR/copilot"
+              echo "##vso[task.prependpath]$COPILOT_BIN_DIR"
+              copilot --version || true
               echo "Copilot CLI installed successfully"
             displayName: 'Install GitHub Copilot CLI'
 

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -135,6 +135,19 @@ stages:
                   sed -i 's/disk.dataPartition.size=.*/disk.dataPartition.size=2048m/' "$AVD_CONFIG"
                   echo "Updated disk.dataPartition.size to 2048m"
                 fi
+
+                # Pre-authorize ADB keys (mirrors android.cake HandleVirtualDevice)
+                echo "=== Pre-authorizing ADB keys ==="
+                mkdir -p "$HOME/.android"
+                if [ ! -f "$HOME/.android/adbkey" ]; then
+                  adb keygen "$HOME/.android/adbkey" 2>/dev/null || true
+                fi
+                ADB_KEY_PUB="$HOME/.android/adbkey.pub"
+                AVD_DIR="$HOME/.android/avd/Emulator_30.avd"
+                if [ -f "$ADB_KEY_PUB" ] && [ -d "$AVD_DIR" ]; then
+                  cp "$ADB_KEY_PUB" "$AVD_DIR/adbkey.pub"
+                  echo "ADB key pre-authorized for emulator"
+                fi
                 
                 echo "=== Starting Emulator ==="
                 # Kill any stale adb server and restart
@@ -165,6 +178,15 @@ stages:
                     echo "##vso[task.logissue type=error]Emulator did not finish booting after ${timeout}s"
                     exit 1
                   fi
+                  # At 90 seconds, restart ADB server to recover from auth issues (mirrors android.cake)
+                  if [ $waited -eq 90 ]; then
+                    echo "Boot taking longer than expected (90/${timeout}s). Restarting ADB server..."
+                    adb kill-server 2>/dev/null || true
+                    sleep 2
+                    adb start-server
+                    sleep 2
+                    echo "ADB server restarted. Continuing to wait..."
+                  fi
                 done
                 echo "Boot completed, waiting for package manager..."
 
@@ -181,6 +203,25 @@ stages:
 
                 DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
                 echo "✅ Emulator fully booted: $DEVICE_ID"
+
+                # Prepare emulator for CI use — keeps device responsive during idle period
+                echo "=== Preparing emulator for CI ==="
+                # Disable all animations (reduces CPU load and flakiness)
+                adb -s $DEVICE_ID shell settings put global window_animation_scale 0.0
+                adb -s $DEVICE_ID shell settings put global transition_animation_scale 0.0
+                adb -s $DEVICE_ID shell settings put global animator_duration_scale 0.0
+                # Prevent screen from turning off (emulator simulates AC charging)
+                adb -s $DEVICE_ID shell settings put system screen_off_timeout 2147483647
+                adb -s $DEVICE_ID shell svc power stayon true
+                # Wake screen and dismiss any lock screen
+                adb -s $DEVICE_ID shell input keyevent 82
+                sleep 1
+                # Dismiss any "System UI has stopped" or crash dialogs
+                adb -s $DEVICE_ID shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
+                # Clear logcat buffer so agent sees only fresh logs
+                adb -s $DEVICE_ID logcat -c 2>/dev/null || true
+                echo "Emulator preparation complete"
+
                 echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
                 echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/platform-tools"
                 echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/emulator"

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -206,6 +206,14 @@ stages:
 
                 # Prepare emulator for CI use — keeps device responsive during idle period
                 echo "=== Preparing emulator for CI ==="
+                # Wait for device to stabilize after boot (transient offline state)
+                for i in $(seq 1 10); do
+                  if adb -s $DEVICE_ID shell echo ok 2>/dev/null | grep -q ok; then
+                    break
+                  fi
+                  echo "Device offline, retrying ($i/10)..."
+                  sleep 3
+                done
                 # Disable all animations (reduces CPU load and flakiness)
                 adb -s $DEVICE_ID shell settings put global window_animation_scale 0.0
                 adb -s $DEVICE_ID shell settings put global transition_animation_scale 0.0
@@ -378,6 +386,57 @@ stages:
             displayName: 'Boot iOS Simulator'
             condition: eq('${{ parameters.Platform }}', 'ios')
             timeoutInMinutes: 5
+
+          # Warm up the emulator right before the agent runs.
+          # The emulator may have been idle for 15-30 min while Appium/Node/CLI were installed.
+          # Without this, SystemUI can ANR when the agent first touches it.
+          - script: |
+              set -e
+              DEVICE_ID="$(DEVICE_UDID)"
+              if [ -z "$DEVICE_ID" ]; then
+                echo "No DEVICE_UDID set — skipping warmup"
+                exit 0
+              fi
+
+              echo "=== Emulator warmup before agent ==="
+              # Verify device is still connected
+              if ! adb -s "$DEVICE_ID" shell getprop sys.boot_completed 2>/dev/null | grep -q "1"; then
+                echo "Device not responding. Restarting ADB server..."
+                adb kill-server 2>/dev/null || true
+                sleep 2
+                adb start-server
+                sleep 2
+                timeout 60 adb wait-for-device
+              fi
+
+              # Wake screen and dismiss lock
+              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_WAKEUP 2>/dev/null || true
+              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_MENU 2>/dev/null || true
+              sleep 2
+
+              # Force-stop any ANR'd system processes and dismiss dialogs
+              adb -s "$DEVICE_ID" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
+              # Press ENTER and BACK to dismiss any remaining dialogs
+              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_ENTER 2>/dev/null || true
+              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_BACK 2>/dev/null || true
+              sleep 1
+
+              # Open and close Settings to exercise the system and confirm responsiveness
+              adb -s "$DEVICE_ID" shell am start -a android.settings.SETTINGS 2>/dev/null || true
+              sleep 3
+              adb -s "$DEVICE_ID" shell am force-stop com.android.settings 2>/dev/null || true
+
+              # Final ANR dialog sweep
+              adb -s "$DEVICE_ID" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
+              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_BACK 2>/dev/null || true
+
+              # Clear logcat so agent gets clean logs
+              adb -s "$DEVICE_ID" logcat -c 2>/dev/null || true
+
+              echo "✅ Emulator warmed up and responsive"
+            displayName: 'Warm Up Android Emulator'
+            condition: and(succeeded(), eq('${{ parameters.Platform }}', 'android'))
+            timeoutInMinutes: 3
 
           - script: |
               echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -2,6 +2,9 @@
 # This pipeline installs the Copilot CLI and invokes the PR reviewer agent
 # to conduct automated code reviews on pull requests.
 #
+# Environment setup follows the same patterns as ui-tests-steps.yml and
+# device-tests-steps.yml: enable-kvm → provision → dotnet install → appium.
+#
 # For more information, see:
 # https://github.com/dotnet/maui/wiki/PR-Reviewer-Agent
 
@@ -36,6 +39,8 @@ variables:
     value: false
   - name: Codeql.SkipTaskAutoInjection
     value: true
+  - name: APPIUM_HOME
+    value: $(System.DefaultWorkingDirectory)/.appium/
 
 stages:
   - stage: ReviewPR
@@ -75,248 +80,35 @@ stages:
               mkdir -p $(Build.ArtifactStagingDirectory)/logs
             displayName: 'Create Artifact Directories'
 
-          # Provision environment (Xcode, .NET SDK, Android SDK, etc.)
+          ##################################################
+          #         Provision Machine (same as uitests)    #
+          ##################################################
+
+          # Enable KVM for Android emulator on Linux (same as ui-tests-steps.yml and device-tests-steps.yml)
+          - ${{ if eq(parameters.Platform, 'android') }}:
+            - template: common/enable-kvm.yml
+
+          # Provision SDKs (same parameters as ui-tests-steps.yml)
           - template: common/provision.yml
             parameters:
               skipXcode: ${{ eq(parameters.Platform, 'android') }}
               skipProvisionator: true
-              skipAndroidCommonSdks: ${{ eq(parameters.Platform, 'ios') }}
-              skipAndroidPlatformApis: ${{ eq(parameters.Platform, 'ios') }}
-              skipJdk: ${{ eq(parameters.Platform, 'ios') }}
+              skipJdk: ${{ ne(parameters.Platform, 'android') }}
+              skipAndroidCommonSdks: ${{ ne(parameters.Platform, 'android') }}
+              skipAndroidPlatformApis: true
+              onlyAndroidPlatformDefaultApis: true
+              skipAndroidEmulatorImages: ${{ ne(parameters.Platform, 'android') }}
+              skipAndroidCreateAvds: true
+              androidEmulatorApiLevel: '30'
               skipSimulatorSetup: ${{ eq(parameters.Platform, 'android') }}
               skipCertificates: true
-              # Android emulator setup (skip for iOS)
-              skipAndroidEmulatorImages: ${{ eq(parameters.Platform, 'ios') }}
-              skipAndroidCreateAvds: ${{ eq(parameters.Platform, 'ios') }}
-              androidEmulatorApiLevel: '30'
 
-          # Configure AVD for hardware acceleration (AcesShared ARM64 macOS agents have HVF)
-          # Match maui-pr Cake script: no GPU override on macOS (uses default hw GPU)
-          - script: |
-              echo "=== Configuring AVD for hardware-accelerated emulation ==="
-              AVD_CONFIG="$HOME/.android/avd/Emulator_30.avd/config.ini"
-              if [ -f "$AVD_CONFIG" ]; then
-                echo "Found AVD config: $AVD_CONFIG"
-                cat "$AVD_CONFIG"
-              else
-                echo "##vso[task.logissue type=warning]AVD config not found at: $AVD_CONFIG"
-                ls -la "$HOME/.android/avd/" 2>/dev/null || echo "AVD directory not found"
-              fi
-            displayName: 'Configure AVD'
-            condition: eq('${{ parameters.Platform }}', 'android')
+          ##################################################
+          #         Install .NET (same as uitests)         #
+          ##################################################
 
-          # Set up Android SDK PATH (required on self-hosted agents)
-          - pwsh: |
-              if ($env:ANDROID_SDK_ROOT) {
-                $platformTools = Join-Path $env:ANDROID_SDK_ROOT "platform-tools"
-                $emulatorPath = Join-Path $env:ANDROID_SDK_ROOT "emulator"
-                $cmdlineTools = Join-Path $env:ANDROID_SDK_ROOT "cmdline-tools/latest/bin"
-                
-                # Use Azure Pipelines' prependpath command to persist across steps
-                Write-Host "##vso[task.prependpath]$platformTools"
-                Write-Host "##vso[task.prependpath]$emulatorPath"
-                Write-Host "##vso[task.prependpath]$cmdlineTools"
-                
-                Write-Host "Added to PATH (will apply to subsequent steps):"
-                Write-Host "  platform-tools: $platformTools"
-                Write-Host "  emulator: $emulatorPath"
-                Write-Host "  cmdline-tools: $cmdlineTools"
-                
-                # Verify the tools exist
-                if (Test-Path (Join-Path $platformTools "adb")) {
-                  Write-Host "✅ adb found at: $platformTools/adb"
-                } else {
-                  Write-Host "⚠️ adb NOT found at expected location"
-                }
-                if (Test-Path (Join-Path $emulatorPath "emulator")) {
-                  Write-Host "✅ emulator found at: $emulatorPath/emulator"
-                } else {
-                  Write-Host "⚠️ emulator NOT found at expected location"
-                }
-              } else {
-                Write-Host "##vso[task.logissue type=warning]ANDROID_SDK_ROOT not set, skipping PATH setup"
-              }
-              
-              # Auto-detect and set JAVA_HOME if not already set
-              if (-not $env:JAVA_HOME) {
-                if ($IsLinux) {
-                  # On Linux, look for JDK in standard locations
-                  $jvmDirs = @("/usr/lib/jvm", "/usr/java")
-                  foreach ($jvmDir in $jvmDirs) {
-                    $jdk = Get-ChildItem "$jvmDir/java-17*" -ErrorAction SilentlyContinue | Select-Object -First 1
-                    if (-not $jdk) {
-                      $jdk = Get-ChildItem "$jvmDir/microsoft-*17*" -ErrorAction SilentlyContinue | Select-Object -First 1
-                    }
-                    if (-not $jdk) {
-                      $jdk = Get-ChildItem "$jvmDir/temurin-17*" -ErrorAction SilentlyContinue | Select-Object -First 1
-                    }
-                    if ($jdk) {
-                      Write-Host "##vso[task.setvariable variable=JAVA_HOME]$($jdk.FullName)"
-                      Write-Host "Set JAVA_HOME to: $($jdk.FullName)"
-                      break
-                    }
-                  }
-                } else {
-                  # macOS
-                  $jvmDir = "/Library/Java/JavaVirtualMachines"
-                  $msJdk = Get-ChildItem "$jvmDir/microsoft-*.jdk" -ErrorAction SilentlyContinue | Select-Object -First 1
-                  if ($msJdk) {
-                    $javaHome = "$($msJdk.FullName)/Contents/Home"
-                    Write-Host "##vso[task.setvariable variable=JAVA_HOME]$javaHome"
-                    Write-Host "Set JAVA_HOME to: $javaHome"
-                  }
-                }
-              }
-            displayName: 'Configure Android SDK PATH'
-            condition: eq('${{ parameters.Platform }}', 'android')
-            env:
-              ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
-
-          # Start Android Emulator directly
-          # On Linux CI (Azure Pipelines Ubuntu): AVDs may be in ~/.config/.android/avd/
-          # We set ANDROID_AVD_HOME so emulator can find them
-          - script: |
-              echo "=== Starting Android Emulator ==="
-              echo "ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
-              echo "JAVA_HOME: $JAVA_HOME"
-              
-              # Fix KVM permissions (Azure Pipelines Ubuntu user not in kvm group by default)
-              echo "=== Fixing KVM permissions ==="
-              if [ -e /dev/kvm ]; then
-                echo "KVM device exists, checking group membership..."
-                echo "Current groups: $(groups)"
-                echo "KVM group: $(grep kvm /etc/group)"
-                sudo gpasswd -a $USER kvm
-                echo "Added $USER to kvm group"
-                # Also set permissions directly (group change needs relogin)
-                sudo chmod 666 /dev/kvm
-                echo "Set /dev/kvm permissions to 666"
-                ls -la /dev/kvm
-              fi
-              
-              # Install missing shared libraries (libpulse needed by emulator)
-              echo "=== Installing emulator dependencies ==="
-              sudo apt-get update -qq
-              sudo apt-get install -y -qq libpulse0 > /dev/null 2>&1 || true
-              
-              EMULATOR_BIN="$ANDROID_SDK_ROOT/emulator/emulator"
-              echo "Emulator binary: $EMULATOR_BIN"
-              $EMULATOR_BIN -version 2>&1 | head -3
-              
-              # Find AVD location - check multiple possible paths
-              AVD_HOME=""
-              for candidate in "$HOME/.android/avd" "$HOME/.config/.android/avd"; do
-                if [ -d "$candidate/Emulator_30.avd" ]; then
-                  AVD_HOME="$candidate"
-                  echo "Found AVD at: $candidate/Emulator_30.avd"
-                  break
-                fi
-              done
-              
-              if [ -z "$AVD_HOME" ]; then
-                echo "##[error]Could not find Emulator_30 AVD in any known location"
-                find /home -name "Emulator_30.avd" -type d 2>/dev/null || true
-                exit 1
-              fi
-              
-              export ANDROID_AVD_HOME="$AVD_HOME"
-              echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME"
-              
-              # Verify emulator can see the AVD
-              echo "Available AVDs:"
-              $EMULATOR_BIN -list-avds 2>/dev/null || true
-              
-              # Check KVM access
-              echo "=== Hardware acceleration check ==="
-              $EMULATOR_BIN -accel-check 2>&1 || true
-              
-              # Start the emulator
-              echo "=== Starting emulator ==="
-              EMULATOR_LOG="/tmp/emulator-Emulator_30.log"
-              nohup $EMULATOR_BIN -avd Emulator_30 -no-window -no-snapshot -no-audio -no-boot-anim -gpu swiftshader_indirect -no-metrics > "$EMULATOR_LOG" 2>&1 &
-              EMULATOR_PID=$!
-              echo "Emulator PID: $EMULATOR_PID"
-              
-              # Wait briefly and check if process is still alive
-              sleep 5
-              if ! kill -0 $EMULATOR_PID 2>/dev/null; then
-                echo "##[error]Emulator process died immediately"
-                cat "$EMULATOR_LOG" 2>/dev/null | tail -50
-                exit 1
-              fi
-              echo "Emulator process is running"
-              
-              # Wait for ADB device
-              echo "=== Waiting for ADB device ==="
-              adb start-server 2>/dev/null || true
-              device_timeout=120
-              device_waited=0
-              while ! adb devices 2>/dev/null | grep -q "emulator.*device"; do
-                if adb devices 2>/dev/null | grep -q "emulator.*offline"; then
-                  echo "Device found but offline, waiting..."
-                fi
-                sleep 5
-                device_waited=$((device_waited + 5))
-                if [ $device_waited -ge $device_timeout ]; then
-                  echo "##[error]Emulator device did not appear after ${device_timeout}s"
-                  cat "$EMULATOR_LOG" 2>/dev/null | tail -30
-                  exit 1
-                fi
-                if ! kill -0 $EMULATOR_PID 2>/dev/null; then
-                  echo "##[error]Emulator process died while waiting for device"
-                  cat "$EMULATOR_LOG" 2>/dev/null | tail -30
-                  exit 1
-                fi
-              done
-              
-              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
-              echo "✅ Emulator detected: $DEVICE_ID"
-              
-              # Wait for boot completion
-              echo "=== Waiting for boot ==="
-              boot_timeout=300
-              boot_waited=0
-              while [ "$(adb -s $DEVICE_ID shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
-                sleep 5
-                boot_waited=$((boot_waited + 5))
-                if [ $boot_waited -ge $boot_timeout ]; then
-                  echo "##[error]Boot timeout after ${boot_timeout}s"
-                  exit 1
-                fi
-              done
-              echo "✅ Emulator fully booted: $DEVICE_ID"
-              
-              # Wait for package manager
-              echo "Waiting for package manager service..."
-              pm_timeout=60
-              pm_waited=0
-              while ! adb -s $DEVICE_ID shell pm list packages 2>/dev/null | grep -q "package:"; do
-                sleep 3
-                pm_waited=$((pm_waited + 3))
-                if [ $pm_waited -ge $pm_timeout ]; then
-                  echo "⚠️ Package manager not ready (non-fatal)"
-                  break
-                fi
-              done
-              if [ $pm_waited -lt $pm_timeout ]; then
-                echo "✅ Package manager service is ready"
-              fi
-              
-              echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
-              echo ""
-              echo "=== ✅ Android Emulator Started Successfully ==="
-              adb devices -l
-            displayName: 'Start Android Emulator'
-            condition: eq('${{ parameters.Platform }}', 'android')
-            timeoutInMinutes: 15
-            env:
-              ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
-              JAVA_HOME: $(JAVA_HOME)
-
-          # Install .NET and workloads via Cake (build.ps1 works on both Linux and macOS via pwsh)
-          - pwsh: |
-              ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
-            displayName: 'Install .NET and workloads'
+          - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
+            displayName: 'Install .NET'
             retryCountOnTaskFailure: 2
             env:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
@@ -326,408 +118,61 @@ stages:
             displayName: 'Add .NET to PATH'
 
           # Build MSBuild tasks (required for MAUI builds)
-          - pwsh: |
-              ./build.ps1 --target=dotnet-buildtasks --configuration="Release" --verbosity=diagnostic
+          - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release" --verbosity=diagnostic
             displayName: 'Build MSBuild Tasks'
             retryCountOnTaskFailure: 1
             env:
               DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
               PRIVATE_BUILD: $(PrivateBuild)
-            
-          # Verify environment is ready
-          - script: |
-              echo "=== Verifying Build Environment ==="
-              ERRORS=""
-              
-              # Check .NET SDK
-              echo "Checking .NET SDK..."
-              if ! dotnet --version; then
-                ERRORS="${ERRORS}\n- .NET SDK not available"
-              else
-                echo "✓ .NET SDK: $(dotnet --version)"
-              fi
-              
-              # Check Android SDK (only for Android platform)
-              if [ "${{ parameters.Platform }}" = "android" ]; then
-                echo "Checking Android SDK..."
-                if [ -z "$ANDROID_HOME" ] && [ -z "$ANDROID_SDK_ROOT" ]; then
-                  ERRORS="${ERRORS}\n- ANDROID_HOME/ANDROID_SDK_ROOT not set"
-                else
-                  SDK_PATH="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
-                  if [ ! -d "$SDK_PATH" ]; then
-                    ERRORS="${ERRORS}\n- Android SDK directory not found: $SDK_PATH"
-                  else
-                    echo "✓ Android SDK: $SDK_PATH"
-                  fi
-                fi
-                
-                # Check emulator binary
-                echo "Checking Android Emulator..."
-                if which emulator > /dev/null 2>&1; then
-                  echo "✓ emulator: $(which emulator)"
-                  emulator -version 2>&1 | head -1 || true
-                else
-                  echo "⚠️ emulator not in PATH (may be at \$ANDROID_SDK_ROOT/emulator/emulator)"
-                fi
-                
-                # Check adb
-                echo "Checking adb..."
-                if which adb > /dev/null 2>&1; then
-                  echo "✓ adb: $(which adb)"
-                else
-                  echo "⚠️ adb not in PATH"
-                fi
-                
-                # Check KVM (Linux) or HVF (macOS) hardware acceleration
-                echo "Checking hardware virtualization..."
-                if [ "$(uname)" = "Linux" ]; then
-                  if [ -e /dev/kvm ]; then
-                    echo "✓ KVM available (/dev/kvm exists)"
-                    ls -la /dev/kvm
-                  else
-                    ERRORS="${ERRORS}\n- KVM not available (/dev/kvm missing)"
-                  fi
-                fi
-              fi
-              
-              # Check Xcode (macOS only, iOS only)
-              if [ "$(uname)" = "Darwin" ] && [ "${{ parameters.Platform }}" = "ios" ]; then
-                echo "Checking Xcode..."
-                if ! xcodebuild -version; then
-                  ERRORS="${ERRORS}\n- Xcode not available"
-                else
-                  echo "✓ Xcode available"
-                fi
-                
-                # Check iOS simulators
-                echo "Checking iOS simulators..."
-                if ! xcrun simctl list devices available | grep -q "iPhone"; then
-                  ERRORS="${ERRORS}\n- No iOS simulators available"
-                else
-                  echo "✓ iOS simulators available"
-                fi
-              fi
-              
-              # Check Java/JDK (only for Android platform)
-              if [ "${{ parameters.Platform }}" = "android" ]; then
-                echo "Checking JDK..."
-                if ! java -version 2>&1; then
-                  ERRORS="${ERRORS}\n- JDK not available"
-                else
-                  echo "✓ JDK available"
-                fi
-              fi
-              
-              # Report errors
-              if [ -n "$ERRORS" ]; then
-                echo ""
-                echo "##vso[task.logissue type=error]=== Environment Verification FAILED ==="
-                echo -e "Missing dependencies:$ERRORS"
-                echo "##vso[task.logissue type=error]Build environment is not properly configured. See above for details."
-                exit 1
-              fi
-              
-              echo ""
-              echo "=== Environment Verification PASSED ==="
-            displayName: 'Verify Build Environment'
-
 
           # Restore .NET tools (includes xharness)
-          - script: |
-              echo "Restoring .NET tools..."
-              dotnet tool restore
-              echo "Tools restored successfully"
+          - script: dotnet tool restore
             displayName: 'Restore .NET Tools'
 
-          # Verify Android emulator is running
-          - script: |
-              echo "=== Verifying Android Emulator ==="
-              adb devices -l
-              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
-              if [ -z "$DEVICE_ID" ]; then
-                echo "##vso[task.logissue type=error]No emulator device found"
-                exit 1
-              fi
-              echo "✅ Emulator running: $DEVICE_ID"
-              echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
-            displayName: 'Verify Android Emulator'
-            condition: eq('${{ parameters.Platform }}', 'android')
-            timeoutInMinutes: 5
+          ##################################################
+          #     Boot Android Emulator via Cake (same as    #
+          #     device-tests-steps.yml / uitests)          #
+          ##################################################
 
-          # Install Node.js (cross-platform: apt on Linux, brew on macOS)
-          - script: |
-              echo "Installing Node.js..."
-              if [ "$(uname)" = "Linux" ]; then
-                # Use NodeSource for Node.js 22 on Linux
-                curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-                sudo apt-get install -y nodejs
-              else
-                brew install node@22
-                brew link --overwrite node@22
-              fi
-              if ! node --version; then
-                echo "##vso[task.logissue type=error]Failed to install Node.js"
-                exit 1
-              fi
-              npm --version
-              echo "Node.js installed successfully"
+          - ${{ if eq(parameters.Platform, 'android') }}:
+            - script: dotnet cake eng/devices/android.cake --target=boot --device="android-emulator-64_30" --apiversion="30" --verbosity=diagnostic
+              displayName: 'Boot Android Emulator (Cake)'
+              timeoutInMinutes: 15
+
+            # Capture emulator device ID for Copilot agent
+            - script: |
+                DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
+                if [ -z "$DEVICE_ID" ]; then
+                  echo "##vso[task.logissue type=error]No emulator device found after Cake boot"
+                  adb devices -l
+                  exit 1
+                fi
+                echo "✅ Emulator running: $DEVICE_ID"
+                echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
+              displayName: 'Capture Emulator UDID'
+              timeoutInMinutes: 5
+
+          ##################################################
+          #     Install Node.js + Appium (same as uitests) #
+          ##################################################
+
+          - task: UseNode@1
+            inputs:
+              version: "20.3.1"
             displayName: 'Install Node.js'
 
-          # Install Appium and platform drivers
-          - script: |
-              echo "Installing Appium and platform drivers..."
-
-              # Get npm global bin directory and add to PATH
-              NPM_BIN=$(npm config get prefix)/bin
-              echo "NPM global bin directory: $NPM_BIN"
-              export PATH="$NPM_BIN:$PATH"
-
-              # Install Appium globally
-              npm install -g appium
-
-              # Install both drivers
-              echo "Installing UiAutomator2 driver for Android..."
-              appium driver install uiautomator2
-              echo "Installing XCUITest driver for iOS..."
-              appium driver install xcuitest
-
-              # Verify installation
-              if ! which appium; then
-                echo "##vso[task.logissue type=error]Failed to install Appium"
-                exit 1
-              fi
-
-              APPIUM_PATH=$(which appium)
-              echo "Appium path: $APPIUM_PATH"
-              echo "Appium version: $(appium --version)"
-              echo "Appium drivers installed:"
-              appium driver list --installed
-
-              # Export PATH for subsequent steps
-              echo "##vso[task.prependpath]$NPM_BIN"
-
-              echo "Appium installed successfully"
+          - pwsh: |
+              $skipAppiumDoctor = if ($IsMacOS -or $IsLinux) { "true" } else { "false" }
+              dotnet build ./src/Provisioning/Provisioning.csproj -t:ProvisionAppium -p:SkipAppiumDoctor="$skipAppiumDoctor" -bl:"$(LogDirectory)/provision-appium.binlog"
             displayName: 'Install Appium'
-
-
-          # Verify/refresh Android Emulator before PR Reviewer runs
-          # Reuses the already-running emulator if healthy (avoids disk space issues on hosted agents)
-          - script: |
-              echo "=== Checking Android Emulator for PR Reviewer ==="
-
-              # Check if emulator is still running and healthy
-              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
-              if [ -n "$DEVICE_ID" ]; then
-                BOOT_DONE=$(adb -s "$DEVICE_ID" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
-                if [ "$BOOT_DONE" = "1" ]; then
-                  echo "✅ Emulator $DEVICE_ID is running and booted"
-                  # Verify package manager is still responsive
-                  if adb -s "$DEVICE_ID" shell pm list packages 2>/dev/null | grep -q "package:"; then
-                    echo "✅ Package manager is responsive"
-                    echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
-                    echo "=== Android Emulator Ready (reused) ==="
-                    adb devices -l
-                    exit 0
-                  fi
-                fi
-              fi
-
-              echo "⚠️ Emulator not healthy, attempting restart..."
-
-              # Find AVD home (same logic as Start step)
-              AVD_HOME=""
-              for candidate in "$HOME/.android/avd" "$HOME/.config/.android/avd"; do
-                if [ -d "$candidate/Emulator_30.avd" ]; then
-                  AVD_HOME="$candidate"
-                  break
-                fi
-              done
-              export ANDROID_AVD_HOME="${AVD_HOME:-$HOME/.android/avd}"
-
-              # Kill any existing emulator
-              adb devices | grep emulator | awk '{print $1}' | xargs -I{} adb -s {} emu kill 2>/dev/null || true
-              sleep 5
-
-              # Restart ADB server
-              adb kill-server
-              sleep 2
-              adb start-server
-              sleep 2
-
-              # Start fresh emulator
-              EMULATOR_LOG="/tmp/emulator-fresh.log"
-              nohup $ANDROID_SDK_ROOT/emulator/emulator -avd Emulator_30 -no-window -no-snapshot -no-audio -no-boot-anim -gpu swiftshader_indirect -no-metrics > "$EMULATOR_LOG" 2>&1 &
-
-              # Wait for device
-              device_timeout=300
-              device_waited=0
-              while ! adb devices | grep -q "emulator.*device"; do
-                sleep 5
-                device_waited=$((device_waited + 5))
-                if [ $device_waited -ge $device_timeout ]; then
-                  echo "##vso[task.logissue type=error]Emulator device did not appear in time"
-                  cat "$EMULATOR_LOG" 2>/dev/null | tail -30
-                  exit 1
-                fi
-              done
-
-              # Wait for boot
-              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
-              boot_timeout=600
-              boot_waited=0
-              while [ "$(adb -s $DEVICE_ID shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
-                sleep 5
-                boot_waited=$((boot_waited + 5))
-                if [ $boot_waited -ge $boot_timeout ]; then
-                  echo "##vso[task.logissue type=error]Emulator did not boot in time"
-                  exit 1
-                fi
-              done
-
-              echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
-              echo "=== Fresh Android Emulator Ready! ==="
-              adb devices -l
-            displayName: 'Restart Android Emulator (Fresh)'
-            condition: eq('${{ parameters.Platform }}', 'android')
-            continueOnError: true
-            timeoutInMinutes: 15
+            retryCountOnTaskFailure: 2
+            timeoutInMinutes: 10
             env:
-              ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
-              JAVA_HOME: $(JAVA_HOME)
+              APPIUM_HOME: $(APPIUM_HOME)
 
-          # Boot iOS Simulator (only for iOS platform)
-          - script: |
-              echo "=== Booting iOS Simulator ==="
-              echo "Available runtimes:"
-              xcrun simctl list runtimes available
-
-              # Find iOS runtime in priority order: 18.x > 17.x > 26.x
-              # iOS 26.x comes with Xcode 26 and may be the only runtime available
-              RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
-                [.runtimes[] | select(.name | test("iOS 18"))] | sort_by(.version) | last | .identifier // empty
-              ')
-              if [ -z "$RUNTIME" ]; then
-                RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
-                  [.runtimes[] | select(.name | test("iOS 17"))] | sort_by(.version) | last | .identifier // empty
-                ')
-              fi
-              if [ -z "$RUNTIME" ]; then
-                RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
-                  [.runtimes[] | select(.name | test("iOS 26"))] | sort_by(.version) | last | .identifier // empty
-                ')
-              fi
-
-              if [ -z "$RUNTIME" ]; then
-                echo "##vso[task.logissue type=error]No iOS runtime found (tried iOS 18, 17, 26)"
-                xcrun simctl list runtimes available
-                exit 1
-              fi
-              echo "Selected iOS runtime: $RUNTIME"
-
-              # Determine the correct device type based on runtime version
-              # iOS 26.x → iPhone 11 Pro (matches UITest.cs ios-26 environment and snapshot baselines)
-              # iOS 18.x/17.x → iPhone Xs (matches UITest.cs ios environment and snapshot baselines)
-              # Both devices have the same screen resolution: 375×812 pt, 1125×2436 px @3x
-              IS_IOS26=false
-              if echo "$RUNTIME" | grep -q "iOS-26"; then
-                IS_IOS26=true
-              fi
-
-              if [ "$IS_IOS26" = "true" ]; then
-                PRIMARY_DEVICE="iPhone 11 Pro"
-                PRIMARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro"
-                SECONDARY_DEVICE="iPhone Xs"
-                SECONDARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-XS"
-              else
-                PRIMARY_DEVICE="iPhone Xs"
-                PRIMARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-XS"
-                SECONDARY_DEVICE="iPhone 11 Pro"
-                SECONDARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro"
-              fi
-              echo "Target device: $PRIMARY_DEVICE (fallback: $SECONDARY_DEVICE)"
-
-              # Look for existing primary device
-              UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" --arg name "$PRIMARY_DEVICE" '
-                .devices[$rt] // [] |
-                map(select(.name == $name)) |
-                .[0].udid // empty
-              ')
-
-              # Fallback to secondary device (same resolution)
-              if [ -z "$UDID" ]; then
-                UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" --arg name "$SECONDARY_DEVICE" '
-                  .devices[$rt] // [] |
-                  map(select(.name == $name)) |
-                  .[0].udid // empty
-                ')
-                if [ -n "$UDID" ]; then
-                  echo "Found existing $SECONDARY_DEVICE: $UDID"
-                fi
-              else
-                echo "Found existing $PRIMARY_DEVICE: $UDID"
-              fi
-
-              # If neither exists, try to create one
-              if [ -z "$UDID" ]; then
-                echo "No matching device found - creating $PRIMARY_DEVICE for runtime $RUNTIME..."
-                UDID=$(xcrun simctl create "$PRIMARY_DEVICE" "$PRIMARY_DEVICE_TYPE" "$RUNTIME" 2>&1)
-                if [ $? -ne 0 ]; then
-                  echo "$PRIMARY_DEVICE device type unavailable: $UDID"
-                  echo "Trying $SECONDARY_DEVICE..."
-                  UDID=$(xcrun simctl create "$SECONDARY_DEVICE" "$SECONDARY_DEVICE_TYPE" "$RUNTIME" 2>&1)
-                  if [ $? -ne 0 ]; then
-                    echo "##vso[task.logissue type=warning]Failed to create $SECONDARY_DEVICE: $UDID"
-                    echo "Falling back to any available iPhone..."
-                    UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" '
-                      .devices[$rt] // [] |
-                      map(select(.name | test("iPhone"))) |
-                      .[0].udid // empty
-                    ')
-                  else
-                    echo "Created $SECONDARY_DEVICE simulator: $UDID"
-                  fi
-                else
-                  echo "Created $PRIMARY_DEVICE simulator: $UDID"
-                fi
-              fi
-
-              if [ -z "$UDID" ]; then
-                echo "##vso[task.logissue type=error]No iOS simulator found"
-                echo "Available devices:"
-                xcrun simctl list devices available
-                exit 1
-              fi
-
-              # Shutdown any other booted simulators to avoid resource contention
-              xcrun simctl list devices booted --json | jq -r '
-                .devices | to_entries | map(.value) | flatten |
-                map(select(.state == "Booted" and .udid != "'"$UDID"'")) |
-                .[].udid
-              ' | while read OTHER_UDID; do
-                echo "Shutting down other simulator: $OTHER_UDID"
-                xcrun simctl shutdown "$OTHER_UDID" 2>/dev/null || true
-              done
-
-              echo "Booting simulator: $UDID"
-              xcrun simctl boot "$UDID" 2>/dev/null || echo "Simulator may already be booted"
-              sleep 10
-
-              # Log the selected device details for debugging
-              echo "=== Selected Simulator Details ==="
-              DEVICE_INFO=$(xcrun simctl list devices --json | jq -r --arg udid "$UDID" '
-                .devices | to_entries[] | .value[] | select(.udid == $udid) | "\(.name) (\(.udid))"
-              ')
-              echo "Device: $DEVICE_INFO"
-              echo "Runtime: $RUNTIME"
-              echo "iOS 26 mode: $IS_IOS26"
-              echo "Booted simulators:"
-              xcrun simctl list devices booted
-
-              echo "##vso[task.setvariable variable=DEVICE_UDID]$UDID"
-              echo "iOS Simulator UDID: $UDID"
-            displayName: 'Boot iOS Simulator'
-            condition: eq('${{ parameters.Platform }}', 'ios')
-            timeoutInMinutes: 5
+          ##################################################
+          #     Copilot-specific setup and execution       #
+          ##################################################
 
           # Install GitHub CLI (cross-platform: apt on Linux, brew on macOS)
           - script: |
@@ -744,63 +189,34 @@ stages:
               else
                 brew install gh
               fi
-              if ! gh --version; then
-                echo "##vso[task.logissue type=error]Failed to install GitHub CLI"
-                exit 1
-              fi
-              echo "GitHub CLI installed successfully"
+              gh --version
             displayName: 'Install GitHub CLI'
 
-          # Authenticate GitHub CLI by writing token directly to gh config
-          # (bypasses read:org scope validation that gh auth login requires)
+          # Authenticate GitHub CLI
           - script: |
-              echo "Authenticating with GitHub CLI..."
-              if [ -z "$GH_CLI_TOKEN" ]; then
-                echo "##vso[task.logissue type=error]GH_CLI_TOKEN is not set. Please configure the pipeline variable."
-                exit 1
-              fi
-              # Write token to gh config directly (avoids read:org scope check)
               mkdir -p "$HOME/.config/gh"
               printf 'github.com:\n    oauth_token: %s\n    git_protocol: https\n' "$GH_CLI_TOKEN" > "$HOME/.config/gh/hosts.yml"
-              # Verify token works with a simple API call
               LOGIN=$(gh api user --jq '.login' 2>&1)
               if [ $? -ne 0 ]; then
                 echo "##vso[task.logissue type=error]GitHub CLI authentication failed: $LOGIN"
                 exit 1
               fi
-              echo "GitHub CLI authenticated successfully as: $LOGIN"
+              echo "GitHub CLI authenticated as: $LOGIN"
             displayName: 'Authenticate GitHub CLI'
             env:
               GH_CLI_TOKEN: $(GH_CLI_TOKEN)
 
-          # Install GitHub Copilot CLI
+          # Install and authenticate Copilot CLI
           - script: |
-              echo "Installing GitHub Copilot CLI..."
               npm install -g @github/copilot
-              if ! which copilot; then
-                echo "##vso[task.logissue type=error]Failed to install GitHub Copilot CLI"
-                exit 1
-              fi
               copilot --version
-              echo "Copilot CLI installed successfully"
             displayName: 'Install GitHub Copilot CLI'
 
-          # Authenticate Copilot CLI
           - script: |
-              echo "Authenticating Copilot CLI..."
               if [ -z "$COPILOT_GITHUB_TOKEN" ]; then
-                echo "##vso[task.logissue type=error]COPILOT_GITHUB_TOKEN is not set. Please configure the COPILOT_TOKEN pipeline variable with a fine-grained PAT."
+                echo "##vso[task.logissue type=error]COPILOT_GITHUB_TOKEN is not set"
                 exit 1
               fi
-              echo "COPILOT_GITHUB_TOKEN is set (${#COPILOT_GITHUB_TOKEN} chars)"
-
-              # Verify gh CLI auth is available for copilot's fallback path
-              if gh auth status >/dev/null 2>&1; then
-                echo "✅ GitHub CLI is authenticated"
-              else
-                echo "⚠️ GitHub CLI not authenticated, copilot will use env var only"
-              fi
-
               echo "✅ Copilot CLI authentication configured"
             displayName: 'Authenticate Copilot CLI'
             env:
@@ -809,24 +225,20 @@ stages:
 
           # Run the PR Reviewer Agent
           - script: |
-              echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."
               echo "Reviewing PR #${{ parameters.PRNumber }}..."
 
               # Configure git identity
               git config user.email "copilot-ci@microsoft.com"
               git config user.name "Copilot CI"
-              echo "Git identity configured"
 
-              # Create Directory.Build.Override.props to skip Xcode version check
+              # Skip Xcode version check
               cp Directory.Build.Override.props.in Directory.Build.Override.props
-              # sed -i syntax differs: Linux uses sed -i, macOS uses sed -i ''
               if [ "$(uname)" = "Linux" ]; then
                 sed -i 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
               else
                 sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
               fi
 
-              # Create artifacts directory for Copilot outputs
               mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs
 
               # Invoke the PR reviewer
@@ -837,55 +249,35 @@ stages:
 
               echo "Review-PR.ps1 exit code: $COPILOT_EXIT_CODE"
 
-              # Terminate any orphaned copilot CLI processes
-              echo "Cleaning up orphaned copilot processes..."
-              SELF_PID=$$
+              # Cleanup orphaned copilot processes
               for proc in $(pgrep -f "[c]opilot" 2>/dev/null || true); do
-                if [ -n "$proc" ] && [ "$proc" != "$SELF_PID" ]; then
-                  PROC_CMD=$(ps -p "$proc" -o args= 2>/dev/null || true)
-                  if echo "$PROC_CMD" | grep -q "copilot"; then
-                    echo "  Stopping copilot process $proc: $PROC_CMD"
-                    kill "$proc" 2>/dev/null || true
-                  fi
+                if [ -n "$proc" ] && [ "$proc" != "$$" ]; then
+                  kill "$proc" 2>/dev/null || true
                 fi
               done
 
-              # Copy Copilot session files
-              if [ -d "$HOME/.copilot" ]; then
-                echo "Copying Copilot session state..."
-                cp -r "$HOME/.copilot" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot-session-state || true
-              fi
-
-              # Copy CustomAgentLogsTmp if it exists
-              if [ -d "CustomAgentLogsTmp" ]; then
-                echo "Copying CustomAgentLogsTmp..."
-                cp -r CustomAgentLogsTmp $(Build.ArtifactStagingDirectory)/copilot-logs/ || true
-              fi
-
-              # Copy any Review_Feedback files
+              # Collect artifacts
+              cp -r "$HOME/.copilot" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot-session-state 2>/dev/null || true
+              cp -r CustomAgentLogsTmp $(Build.ArtifactStagingDirectory)/copilot-logs/ 2>/dev/null || true
               find . -name "Review_Feedback_*.md" -type f -exec cp {} $(Build.ArtifactStagingDirectory)/copilot-logs/ \; 2>/dev/null || true
+              cp -r .github/agent-pr-session $(Build.ArtifactStagingDirectory)/copilot-logs/ 2>/dev/null || true
 
-              # Copy any .github/agent-pr-session files
-              if [ -d ".github/agent-pr-session" ]; then
-                echo "Copying agent-pr-session..."
-                cp -r .github/agent-pr-session $(Build.ArtifactStagingDirectory)/copilot-logs/ || true
-              fi
-
-              # Check for failure
               if [ $COPILOT_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error]Review-PR.ps1 exited with code $COPILOT_EXIT_CODE"
                 echo "##vso[task.setvariable variable=CopilotFailed]true"
               fi
-
-              echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
             displayName: 'Run PR Reviewer Agent'
             env:
               COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
               GH_TOKEN: $(GH_COMMENT_TOKEN)
               GITHUB_TOKEN: $(GH_CLI_TOKEN)
               DEVICE_UDID: $(DEVICE_UDID)
+              APPIUM_HOME: $(APPIUM_HOME)
 
-          # Publish Copilot logs and session artifacts
+          ##################################################
+          #                    Publish                     #
+          ##################################################
+
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Copilot Logs'
             inputs:
@@ -894,7 +286,6 @@ stages:
               publishLocation: 'pipeline'
             condition: succeededOrFailed()
 
-          # Publish build logs if they exist
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Build Logs'
             inputs:
@@ -903,7 +294,6 @@ stages:
               publishLocation: 'pipeline'
             condition: and(succeededOrFailed(), ne(variables['LogDirectory'], ''))
 
-          # Fail the pipeline if Copilot failed
           - script: |
               if [ "$(CopilotFailed)" = "true" ]; then
                 echo "##vso[task.logissue type=error]Copilot PR review failed. Check CopilotLogs artifact for details."

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -120,6 +120,13 @@ stages:
                 echo "=== Creating AVD ==="
                 echo "no" | avdmanager create avd -n Emulator_30 -k "system-images;android-30;google_apis_playstore;x86_64" --device "Nexus 5X" --force
                 
+                # Reduce userdata partition to fit on hosted agents (~4.2GB free)
+                AVD_CONFIG="$HOME/.android/avd/Emulator_30.avd/config.ini"
+                if [ -f "$AVD_CONFIG" ]; then
+                  sed -i 's/disk.dataPartition.size=.*/disk.dataPartition.size=2048m/' "$AVD_CONFIG"
+                  echo "Updated disk.dataPartition.size to 2048m"
+                fi
+                
                 echo "=== Starting Emulator ==="
                 nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim -partition-size 2048 &
                 EMULATOR_PID=$!

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -110,9 +110,18 @@ stages:
 
           # Create AVD and boot Android Emulator
           - ${{ if eq(parameters.Platform, 'android') }}:
-            # Use Cake to create the AVD (connectToDevice handles AVD creation + emulator launch)
-            # but uitest-prepare is the only target that skips Teardown cleanup.
-            # Since uitest-prepare also builds the test app (which we don't need), launch the emulator manually.
+            # Free disk space on hosted agents (emulator needs ~7GB for userdata partition)
+            - script: |
+                echo "=== Disk space before cleanup ==="
+                df -h /home
+                echo "Removing unnecessary tools to free space..."
+                sudo rm -rf /usr/share/dotnet /usr/local/share/powershell /usr/local/share/chromium 2>/dev/null || true
+                sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/go /opt/hostedtoolcache/Python 2>/dev/null || true
+                sudo rm -rf /usr/share/swift 2>/dev/null || true
+                echo "=== Disk space after cleanup ==="
+                df -h /home
+              displayName: 'Free Disk Space for Emulator'
+
             - script: |
                 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
                 export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -108,19 +108,23 @@ stages:
           - script: dotnet tool restore
             displayName: 'Restore .NET Tools'
 
-          # Boot Android Emulator via Cake (creates AVD and launches emulator in background)
+          # Create AVD and boot Android Emulator
           - ${{ if eq(parameters.Platform, 'android') }}:
-            - script: dotnet cake eng/devices/android.cake --target=boot --device="android-emulator-64_30" --apiversion="30" --verbosity=diagnostic
-              displayName: 'Boot Android Emulator (Cake)'
-              timeoutInMinutes: 15
-
-            # Wait for emulator to fully boot (Cake boot fires emulator in background)
+            # Use Cake to create the AVD (connectToDevice handles AVD creation + emulator launch)
+            # but uitest-prepare is the only target that skips Teardown cleanup.
+            # Since uitest-prepare also builds the test app (which we don't need), launch the emulator manually.
             - script: |
-                # Add Android SDK tools to PATH (provision.yml sets ANDROID_SDK_ROOT variable)
-                export PATH="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/platform-tools:${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/emulator:$PATH"
-                echo "Using ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
-                echo "adb location: $(which adb 2>/dev/null || echo 'not found')"
+                export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}"
+                export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
 
+                echo "=== Creating AVD ==="
+                echo "no" | avdmanager create avd -n Emulator_30 -k "system-images;android-30;google_apis_playstore;x86_64" --device "Nexus 5X" --force
+                
+                echo "=== Starting Emulator ==="
+                nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim &
+                EMULATOR_PID=$!
+                echo "Emulator PID: $EMULATOR_PID"
+                
                 echo "Waiting for emulator device to appear..."
                 timeout=120
                 waited=0
@@ -143,7 +147,6 @@ stages:
                   waited=$((waited + 5))
                   if [ $waited -ge $timeout ]; then
                     echo "##vso[task.logissue type=error]Emulator did not finish booting after ${timeout}s"
-                    adb shell getprop sys.boot_completed 2>/dev/null || true
                     exit 1
                   fi
                 done
@@ -163,11 +166,10 @@ stages:
                 DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
                 echo "✅ Emulator fully booted: $DEVICE_ID"
                 echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
-                # Persist PATH for subsequent steps
-                echo "##vso[task.prependpath]${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/platform-tools"
-                echo "##vso[task.prependpath]${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}/emulator"
-              displayName: 'Wait for Emulator Boot and Capture UDID'
-              timeoutInMinutes: 10
+                echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/platform-tools"
+                echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/emulator"
+              displayName: 'Create AVD and Boot Android Emulator'
+              timeoutInMinutes: 15
 
           # Install Node.js and Appium (same as ui-tests-steps.yml)
           - task: UseNode@1

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -108,26 +108,58 @@ stages:
           - script: dotnet tool restore
             displayName: 'Restore .NET Tools'
 
-          # Boot Android Emulator via Cake (same as device-tests-steps.yml / ui-tests-steps.yml)
+          # Boot Android Emulator via Cake (creates AVD and launches emulator in background)
           - ${{ if eq(parameters.Platform, 'android') }}:
             - script: dotnet cake eng/devices/android.cake --target=boot --device="android-emulator-64_30" --apiversion="30" --verbosity=diagnostic
               displayName: 'Boot Android Emulator (Cake)'
               timeoutInMinutes: 15
 
-            # Capture emulator device ID for Copilot agent
+            # Wait for emulator to fully boot (Cake boot fires emulator in background)
             - script: |
-                export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$PATH"
+                echo "Waiting for emulator device to appear..."
+                timeout=120
+                waited=0
+                while ! adb devices | grep -q "emulator.*device"; do
+                  sleep 5
+                  waited=$((waited + 5))
+                  if [ $waited -ge $timeout ]; then
+                    echo "##vso[task.logissue type=error]Emulator device did not appear after ${timeout}s"
+                    adb devices -l
+                    exit 1
+                  fi
+                  echo "  Waiting for device... ($waited/${timeout}s)"
+                done
+                echo "Emulator device detected, waiting for boot_completed..."
+
+                timeout=300
+                waited=0
+                while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+                  sleep 5
+                  waited=$((waited + 5))
+                  if [ $waited -ge $timeout ]; then
+                    echo "##vso[task.logissue type=error]Emulator did not finish booting after ${timeout}s"
+                    adb shell getprop sys.boot_completed 2>/dev/null || true
+                    exit 1
+                  fi
+                done
+                echo "Boot completed, waiting for package manager..."
+
+                timeout=120
+                waited=0
+                while ! adb shell pm list packages 2>/dev/null | grep -q "package:"; do
+                  sleep 5
+                  waited=$((waited + 5))
+                  if [ $waited -ge $timeout ]; then
+                    echo "##vso[task.logissue type=error]Package manager not ready after ${timeout}s"
+                    exit 1
+                  fi
+                done
+
                 DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
-                if [ -z "$DEVICE_ID" ]; then
-                  echo "##vso[task.logissue type=error]No emulator device found after Cake boot"
-                  adb devices -l
-                  exit 1
-                fi
-                echo "✅ Emulator running: $DEVICE_ID"
+                echo "✅ Emulator fully booted: $DEVICE_ID"
                 echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
-                echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/platform-tools"
-                echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/emulator"
-              displayName: 'Capture Emulator UDID'
+              displayName: 'Wait for Emulator Boot and Capture UDID'
+              timeoutInMinutes: 10
 
           # Install Node.js and Appium (same as ui-tests-steps.yml)
           - task: UseNode@1

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -342,14 +342,18 @@ stages:
               echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."
               echo "Reviewing PR #${{ parameters.PRNumber }}..."
               
-              # Ensure copilot CLI is on PATH (npm global bin from UseNode@1)
+              # Ensure copilot CLI is accessible to pwsh subprocess.
+              # npm global install on Linux goes to UseNode@1 toolcache path which may not
+              # be on PATH inside pwsh even when exported from bash. Create a symlink in
+              # /usr/local/bin which is universally on PATH for all shells.
               COPILOT_PATH=$(which copilot 2>/dev/null || find /opt/hostedtoolcache/node -name copilot -type f 2>/dev/null | head -1)
-              if [ -n "$COPILOT_PATH" ]; then
-                export PATH="$(dirname "$COPILOT_PATH"):$PATH"
-                echo "Added $(dirname "$COPILOT_PATH") to PATH"
+              if [ -n "$COPILOT_PATH" ] && [ ! -f /usr/local/bin/copilot ]; then
+                sudo ln -sf "$COPILOT_PATH" /usr/local/bin/copilot
+                echo "Symlinked copilot to /usr/local/bin/copilot"
               fi
-              echo "PATH=$PATH"
               echo "copilot location: $(which copilot 2>/dev/null || echo 'not found')"
+              # Verify pwsh can find it
+              pwsh -NoProfile -c 'Write-Host "pwsh sees copilot at: $(Get-Command copilot -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)"'
               
               # Configure git identity (required for merge operations on self-hosted agents)
               git config user.email "copilot-ci@microsoft.com"
@@ -374,7 +378,7 @@ stages:
               # The script will merge the PR into the current branch
               # -PostSummaryComment and -RunFinalize handle posting comments
               set +e
-              pwsh .github/scripts/Review-PR.ps1 -PRNumber ${{ parameters.PRNumber }} -Platform ${{ parameters.Platform }} -RunFinalize -PostSummaryComment -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
+              pwsh -NoProfile .github/scripts/Review-PR.ps1 -PRNumber ${{ parameters.PRNumber }} -Platform ${{ parameters.Platform }} -RunFinalize -PostSummaryComment -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
               COPILOT_EXIT_CODE=$?
               set -e
               

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -409,24 +409,36 @@ stages:
                 timeout 60 adb wait-for-device
               fi
 
-              # Wake screen and dismiss lock
-              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_WAKEUP 2>/dev/null || true
-              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_MENU 2>/dev/null || true
-              sleep 2
+              # Dismiss ANR dialogs and wake screen — run twice for reliability
+              for PASS in 1 2; do
+                echo "--- Warmup pass $PASS ---"
+                adb -s "$DEVICE_ID" shell input keyevent KEYCODE_WAKEUP 2>/dev/null || true
+                adb -s "$DEVICE_ID" shell input keyevent KEYCODE_MENU 2>/dev/null || true
+                sleep 1
 
-              # Force-stop any ANR'd system processes and dismiss dialogs
-              adb -s "$DEVICE_ID" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
-              # Press ENTER and BACK to dismiss any remaining dialogs
-              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_ENTER 2>/dev/null || true
-              adb -s "$DEVICE_ID" shell input keyevent KEYCODE_BACK 2>/dev/null || true
-              sleep 1
+                # Dismiss system dialogs (ANR, crash, etc.)
+                adb -s "$DEVICE_ID" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
+                adb -s "$DEVICE_ID" shell input keyevent KEYCODE_ENTER 2>/dev/null || true
+                adb -s "$DEVICE_ID" shell input keyevent KEYCODE_BACK 2>/dev/null || true
+                sleep 1
+              done
+
+              # Check for lingering ANR in window state
+              if adb -s "$DEVICE_ID" shell dumpsys window 2>/dev/null | grep -qi "Application Not Responding\|ANR"; then
+                echo "⚠️  ANR dialog still present — force-dismissing with HOME + BACK"
+                adb -s "$DEVICE_ID" shell input keyevent KEYCODE_HOME 2>/dev/null || true
+                sleep 2
+                adb -s "$DEVICE_ID" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
+                adb -s "$DEVICE_ID" shell input keyevent KEYCODE_BACK 2>/dev/null || true
+                sleep 1
+              fi
 
               # Open and close Settings to exercise the system and confirm responsiveness
               adb -s "$DEVICE_ID" shell am start -a android.settings.SETTINGS 2>/dev/null || true
               sleep 3
               adb -s "$DEVICE_ID" shell am force-stop com.android.settings 2>/dev/null || true
 
-              # Final ANR dialog sweep
+              # Final dialog sweep
               adb -s "$DEVICE_ID" shell am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS 2>/dev/null || true
               adb -s "$DEVICE_ID" shell input keyevent KEYCODE_BACK 2>/dev/null || true
 

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -121,7 +121,7 @@ stages:
                 echo "no" | avdmanager create avd -n Emulator_30 -k "system-images;android-30;google_apis_playstore;x86_64" --device "Nexus 5X" --force
                 
                 echo "=== Starting Emulator ==="
-                nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim &
+                nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim -partition-size 2048 &
                 EMULATOR_PID=$!
                 echo "Emulator PID: $EMULATOR_PID"
                 

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -115,6 +115,7 @@ stages:
 
             # Capture emulator device ID for Copilot agent
             - script: |
+                export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$PATH"
                 DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
                 if [ -z "$DEVICE_ID" ]; then
                   echo "##vso[task.logissue type=error]No emulator device found after Cake boot"
@@ -123,6 +124,8 @@ stages:
                 fi
                 echo "✅ Emulator running: $DEVICE_ID"
                 echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
+                echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/platform-tools"
+                echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/emulator"
               displayName: 'Capture Emulator UDID'
 
           # Install Node.js and Appium (same as ui-tests-steps.yml)

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -137,24 +137,24 @@ stages:
                 fi
                 
                 echo "=== Starting Emulator ==="
-                nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim -partition-size 2048 &
+                # Kill any stale adb server and restart
+                adb kill-server 2>/dev/null || true
+                sleep 1
+                adb start-server
+                
+                nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim -partition-size 2048 > /tmp/emulator.log 2>&1 &
                 EMULATOR_PID=$!
                 echo "Emulator PID: $EMULATOR_PID"
                 
-                echo "Waiting for emulator device to appear..."
-                timeout=120
-                waited=0
-                while ! adb devices | grep -q "emulator.*device"; do
-                  sleep 5
-                  waited=$((waited + 5))
-                  if [ $waited -ge $timeout ]; then
-                    echo "##vso[task.logissue type=error]Emulator device did not appear after ${timeout}s"
-                    adb devices -l
-                    exit 1
-                  fi
-                  echo "  Waiting for device... ($waited/${timeout}s)"
-                done
-                echo "Emulator device detected, waiting for boot_completed..."
+                echo "Waiting for emulator device (adb wait-for-device)..."
+                timeout 120 adb wait-for-device
+                if [ $? -ne 0 ]; then
+                  echo "##vso[task.logissue type=error]adb wait-for-device timed out after 120s"
+                  adb devices -l
+                  cat /tmp/emulator.log | tail -30
+                  exit 1
+                fi
+                echo "Device detected: $(adb devices -l | grep emulator)"
 
                 timeout=300
                 waited=0

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -342,6 +342,15 @@ stages:
               echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."
               echo "Reviewing PR #${{ parameters.PRNumber }}..."
               
+              # Ensure copilot CLI is on PATH (npm global bin from UseNode@1)
+              COPILOT_PATH=$(which copilot 2>/dev/null || find /opt/hostedtoolcache/node -name copilot -type f 2>/dev/null | head -1)
+              if [ -n "$COPILOT_PATH" ]; then
+                export PATH="$(dirname "$COPILOT_PATH"):$PATH"
+                echo "Added $(dirname "$COPILOT_PATH") to PATH"
+              fi
+              echo "PATH=$PATH"
+              echo "copilot location: $(which copilot 2>/dev/null || echo 'not found')"
+              
               # Configure git identity (required for merge operations on self-hosted agents)
               git config user.email "copilot-ci@microsoft.com"
               git config user.name "Copilot CI"

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -155,19 +155,46 @@ stages:
                 sleep 1
                 adb start-server
                 
-                nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim -partition-size 2048 > /tmp/emulator.log 2>&1 &
-                EMULATOR_PID=$!
-                echo "Emulator PID: $EMULATOR_PID"
-                
-                echo "Waiting for emulator device (adb wait-for-device)..."
-                timeout 120 adb wait-for-device
-                if [ $? -ne 0 ]; then
-                  echo "##vso[task.logissue type=error]adb wait-for-device timed out after 120s"
+                # Retry loop: emulator sometimes fails to connect ADB on first launch
+                MAX_LAUNCH_ATTEMPTS=2
+                EMULATOR_PID=""
+                for LAUNCH_ATTEMPT in $(seq 1 $MAX_LAUNCH_ATTEMPTS); do
+                  echo "--- Emulator launch attempt $LAUNCH_ATTEMPT of $MAX_LAUNCH_ATTEMPTS ---"
+
+                  if [ $LAUNCH_ATTEMPT -gt 1 ]; then
+                    echo "Cleaning up before retry..."
+                    if [ -n "$EMULATOR_PID" ] && kill -0 "$EMULATOR_PID" 2>/dev/null; then
+                      kill "$EMULATOR_PID" 2>/dev/null || true
+                      sleep 2
+                      kill -0 "$EMULATOR_PID" 2>/dev/null && kill -9 "$EMULATOR_PID" 2>/dev/null || true
+                    fi
+                    sleep 3
+                    adb kill-server 2>/dev/null || true
+                    sleep 2
+                    adb start-server
+                    sleep 2
+                  fi
+
+                  nohup emulator -avd Emulator_30 -gpu swiftshader_indirect -no-window -no-snapshot -no-audio -no-boot-anim -partition-size 2048 > /tmp/emulator.log 2>&1 &
+                  EMULATOR_PID=$!
+                  echo "Emulator PID: $EMULATOR_PID"
+                  
+                  echo "Waiting for emulator device (adb wait-for-device, 120s timeout)..."
+                  timeout 120 adb wait-for-device
+                  if [ $? -eq 0 ]; then
+                    echo "Device detected: $(adb devices -l | grep emulator)"
+                    break
+                  fi
+
+                  echo "##vso[task.logissue type=warning]adb wait-for-device timed out (attempt $LAUNCH_ATTEMPT)"
                   adb devices -l
-                  cat /tmp/emulator.log | tail -30
-                  exit 1
-                fi
-                echo "Device detected: $(adb devices -l | grep emulator)"
+                  tail -30 /tmp/emulator.log
+
+                  if [ $LAUNCH_ATTEMPT -eq $MAX_LAUNCH_ATTEMPTS ]; then
+                    echo "##vso[task.logissue type=error]Emulator failed to connect after $MAX_LAUNCH_ATTEMPTS attempts"
+                    exit 1
+                  fi
+                done
 
                 timeout=300
                 waited=0
@@ -186,6 +213,12 @@ stages:
                     adb start-server
                     sleep 2
                     echo "ADB server restarted. Continuing to wait..."
+                  fi
+                  # Re-ensure ADB keys every 60s during boot (mirrors android.cake PrepareDevice)
+                  if [ $((waited % 60)) -eq 0 ] && [ $waited -gt 0 ]; then
+                    if [ -f "$ADB_KEY_PUB" ] && [ -d "$AVD_DIR" ]; then
+                      cp "$ADB_KEY_PUB" "$AVD_DIR/adbkey.pub" 2>/dev/null || true
+                    fi
                   fi
                 done
                 echo "Boot completed, waiting for package manager..."
@@ -234,6 +267,7 @@ stages:
                 echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/platform-tools"
                 echo "##vso[task.prependpath]$ANDROID_SDK_ROOT/emulator"
               displayName: 'Create AVD and Boot Android Emulator'
+              retryCountOnTaskFailure: 1
               timeoutInMinutes: 15
 
           # Install Node.js and Appium (same as ui-tests-steps.yml)

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -27,6 +27,8 @@ parameters:
     type: object
     default:
       name: AcesShared
+      demands:
+        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
 variables:
   - template: /eng/pipelines/common/variables.yml@self
@@ -41,7 +43,13 @@ stages:
     jobs:
       - job: CopilotReview
         displayName: 'Run Copilot PR Reviewer Agent'
-        pool: ${{ parameters.pool }}
+        # Android needs Linux (KVM for emulator), iOS needs macOS (Xcode/simulators)
+        ${{ if eq(parameters.Platform, 'android') }}:
+          pool:
+            name: Azure Pipelines
+            vmImage: ubuntu-22.04
+        ${{ else }}:
+          pool: ${{ parameters.pool }}
         timeoutInMinutes: 180
         steps:
           - checkout: self
@@ -61,15 +69,21 @@ stages:
               echo "##vso[build.updatebuildnumber]PR ${{ parameters.PRNumber }} ${{ parameters.Platform }}"
             displayName: 'Set Pipeline Run Title'
 
+          # Create artifact directories early (prevents publish failures if steps are skipped)
+          - script: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs
+              mkdir -p $(Build.ArtifactStagingDirectory)/logs
+            displayName: 'Create Artifact Directories'
+
           # Provision environment (Xcode, .NET SDK, Android SDK, etc.)
           - template: common/provision.yml
             parameters:
-              skipXcode: false
-              skipProvisionator: false
+              skipXcode: ${{ eq(parameters.Platform, 'android') }}
+              skipProvisionator: true
               skipAndroidCommonSdks: ${{ eq(parameters.Platform, 'ios') }}
               skipAndroidPlatformApis: ${{ eq(parameters.Platform, 'ios') }}
               skipJdk: ${{ eq(parameters.Platform, 'ios') }}
-              skipSimulatorSetup: false
+              skipSimulatorSetup: ${{ eq(parameters.Platform, 'android') }}
               skipCertificates: true
               # Android emulator setup (skip for iOS)
               skipAndroidEmulatorImages: ${{ eq(parameters.Platform, 'ios') }}
@@ -125,12 +139,32 @@ stages:
               
               # Auto-detect and set JAVA_HOME if not already set
               if (-not $env:JAVA_HOME) {
-                $jvmDir = "/Library/Java/JavaVirtualMachines"
-                $msJdk = Get-ChildItem "$jvmDir/microsoft-*.jdk" -ErrorAction SilentlyContinue | Select-Object -First 1
-                if ($msJdk) {
-                  $javaHome = "$($msJdk.FullName)/Contents/Home"
-                  Write-Host "##vso[task.setvariable variable=JAVA_HOME]$javaHome"
-                  Write-Host "Set JAVA_HOME to: $javaHome"
+                if ($IsLinux) {
+                  # On Linux, look for JDK in standard locations
+                  $jvmDirs = @("/usr/lib/jvm", "/usr/java")
+                  foreach ($jvmDir in $jvmDirs) {
+                    $jdk = Get-ChildItem "$jvmDir/java-17*" -ErrorAction SilentlyContinue | Select-Object -First 1
+                    if (-not $jdk) {
+                      $jdk = Get-ChildItem "$jvmDir/microsoft-*17*" -ErrorAction SilentlyContinue | Select-Object -First 1
+                    }
+                    if (-not $jdk) {
+                      $jdk = Get-ChildItem "$jvmDir/temurin-17*" -ErrorAction SilentlyContinue | Select-Object -First 1
+                    }
+                    if ($jdk) {
+                      Write-Host "##vso[task.setvariable variable=JAVA_HOME]$($jdk.FullName)"
+                      Write-Host "Set JAVA_HOME to: $($jdk.FullName)"
+                      break
+                    }
+                  }
+                } else {
+                  # macOS
+                  $jvmDir = "/Library/Java/JavaVirtualMachines"
+                  $msJdk = Get-ChildItem "$jvmDir/microsoft-*.jdk" -ErrorAction SilentlyContinue | Select-Object -First 1
+                  if ($msJdk) {
+                    $javaHome = "$($msJdk.FullName)/Contents/Home"
+                    Write-Host "##vso[task.setvariable variable=JAVA_HOME]$javaHome"
+                    Write-Host "Set JAVA_HOME to: $javaHome"
+                  }
                 }
               }
             displayName: 'Configure Android SDK PATH'
@@ -138,61 +172,150 @@ stages:
             env:
               ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
 
-          # Start Android Emulator EARLY (using Start-Emulator.ps1 script)
-          - pwsh: |
-              Write-Host "=== Starting Android Emulator ==="
-              Write-Host "Working directory: $(Get-Location)"
-              Write-Host "ANDROID_SDK_ROOT: $env:ANDROID_SDK_ROOT"
-              Write-Host "JAVA_HOME: $env:JAVA_HOME"
-              Write-Host "PATH (first 500 chars): $($env:PATH.Substring(0, [Math]::Min(500, $env:PATH.Length)))"
+          # Start Android Emulator directly
+          # On Linux CI (Azure Pipelines Ubuntu): AVDs may be in ~/.config/.android/avd/
+          # We set ANDROID_AVD_HOME so emulator can find them
+          - script: |
+              echo "=== Starting Android Emulator ==="
+              echo "ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
+              echo "JAVA_HOME: $JAVA_HOME"
               
-              # Verify adb is in path
-              $adbPath = Get-Command adb -ErrorAction SilentlyContinue
-              if ($adbPath) {
-                Write-Host "adb found at: $($adbPath.Source)"
-              } else {
-                Write-Host "adb NOT in PATH, checking manually..."
-                $manualAdb = Join-Path $env:ANDROID_SDK_ROOT "platform-tools/adb"
-                if (Test-Path $manualAdb) {
-                  Write-Host "adb exists at $manualAdb but not in PATH"
-                }
-              }
+              # Fix KVM permissions (Azure Pipelines Ubuntu user not in kvm group by default)
+              echo "=== Fixing KVM permissions ==="
+              if [ -e /dev/kvm ]; then
+                echo "KVM device exists, checking group membership..."
+                echo "Current groups: $(groups)"
+                echo "KVM group: $(grep kvm /etc/group)"
+                sudo gpasswd -a $USER kvm
+                echo "Added $USER to kvm group"
+                # Also set permissions directly (group change needs relogin)
+                sudo chmod 666 /dev/kvm
+                echo "Set /dev/kvm permissions to 666"
+                ls -la /dev/kvm
+              fi
               
-              $scriptPath = ".github/scripts/shared/Start-Emulator.ps1"
-              Write-Host "Script path: $scriptPath"
+              # Install missing shared libraries (libpulse needed by emulator)
+              echo "=== Installing emulator dependencies ==="
+              sudo apt-get update -qq
+              sudo apt-get install -y -qq libpulse0 > /dev/null 2>&1 || true
               
-              if (-not (Test-Path $scriptPath)) {
-                Write-Host "##vso[task.logissue type=error]Script not found: $scriptPath"
+              EMULATOR_BIN="$ANDROID_SDK_ROOT/emulator/emulator"
+              echo "Emulator binary: $EMULATOR_BIN"
+              $EMULATOR_BIN -version 2>&1 | head -3
+              
+              # Find AVD location - check multiple possible paths
+              AVD_HOME=""
+              for candidate in "$HOME/.android/avd" "$HOME/.config/.android/avd"; do
+                if [ -d "$candidate/Emulator_30.avd" ]; then
+                  AVD_HOME="$candidate"
+                  echo "Found AVD at: $candidate/Emulator_30.avd"
+                  break
+                fi
+              done
+              
+              if [ -z "$AVD_HOME" ]; then
+                echo "##[error]Could not find Emulator_30 AVD in any known location"
+                find /home -name "Emulator_30.avd" -type d 2>/dev/null || true
                 exit 1
-              }
-              Write-Host "Script exists: OK"
+              fi
               
-              $ErrorActionPreference = "Continue"
-              try {
-                Write-Host "Invoking Start-Emulator.ps1 -Platform android -DeviceUdid Emulator_30..."
-                & "./$scriptPath" -Platform android -DeviceUdid Emulator_30 2>&1 | ForEach-Object { Write-Host $_ }
-                $exitCode = $LASTEXITCODE
-                Write-Host "Script returned exit code: $exitCode"
-              } catch {
-                Write-Host "##vso[task.logissue type=error]Exception: $_"
-                Write-Host $_.ScriptStackTrace
-                $exitCode = 1
-              }
+              export ANDROID_AVD_HOME="$AVD_HOME"
+              echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME"
               
-              if ($exitCode -ne 0) {
-                Write-Host "##vso[task.logissue type=error]Start-Emulator failed with code $exitCode"
-                exit $exitCode
-              }
+              # Verify emulator can see the AVD
+              echo "Available AVDs:"
+              $EMULATOR_BIN -list-avds 2>/dev/null || true
               
-              Write-Host "=== Android Emulator Started Successfully ==="
+              # Check KVM access
+              echo "=== Hardware acceleration check ==="
+              $EMULATOR_BIN -accel-check 2>&1 || true
+              
+              # Start the emulator
+              echo "=== Starting emulator ==="
+              EMULATOR_LOG="/tmp/emulator-Emulator_30.log"
+              nohup $EMULATOR_BIN -avd Emulator_30 -no-window -no-snapshot -no-audio -no-boot-anim -gpu swiftshader_indirect -no-metrics > "$EMULATOR_LOG" 2>&1 &
+              EMULATOR_PID=$!
+              echo "Emulator PID: $EMULATOR_PID"
+              
+              # Wait briefly and check if process is still alive
+              sleep 5
+              if ! kill -0 $EMULATOR_PID 2>/dev/null; then
+                echo "##[error]Emulator process died immediately"
+                cat "$EMULATOR_LOG" 2>/dev/null | tail -50
+                exit 1
+              fi
+              echo "Emulator process is running"
+              
+              # Wait for ADB device
+              echo "=== Waiting for ADB device ==="
+              adb start-server 2>/dev/null || true
+              device_timeout=120
+              device_waited=0
+              while ! adb devices 2>/dev/null | grep -q "emulator.*device"; do
+                if adb devices 2>/dev/null | grep -q "emulator.*offline"; then
+                  echo "Device found but offline, waiting..."
+                fi
+                sleep 5
+                device_waited=$((device_waited + 5))
+                if [ $device_waited -ge $device_timeout ]; then
+                  echo "##[error]Emulator device did not appear after ${device_timeout}s"
+                  cat "$EMULATOR_LOG" 2>/dev/null | tail -30
+                  exit 1
+                fi
+                if ! kill -0 $EMULATOR_PID 2>/dev/null; then
+                  echo "##[error]Emulator process died while waiting for device"
+                  cat "$EMULATOR_LOG" 2>/dev/null | tail -30
+                  exit 1
+                fi
+              done
+              
+              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
+              echo "✅ Emulator detected: $DEVICE_ID"
+              
+              # Wait for boot completion
+              echo "=== Waiting for boot ==="
+              boot_timeout=300
+              boot_waited=0
+              while [ "$(adb -s $DEVICE_ID shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+                sleep 5
+                boot_waited=$((boot_waited + 5))
+                if [ $boot_waited -ge $boot_timeout ]; then
+                  echo "##[error]Boot timeout after ${boot_timeout}s"
+                  exit 1
+                fi
+              done
+              echo "✅ Emulator fully booted: $DEVICE_ID"
+              
+              # Wait for package manager
+              echo "Waiting for package manager service..."
+              pm_timeout=60
+              pm_waited=0
+              while ! adb -s $DEVICE_ID shell pm list packages 2>/dev/null | grep -q "package:"; do
+                sleep 3
+                pm_waited=$((pm_waited + 3))
+                if [ $pm_waited -ge $pm_timeout ]; then
+                  echo "⚠️ Package manager not ready (non-fatal)"
+                  break
+                fi
+              done
+              if [ $pm_waited -lt $pm_timeout ]; then
+                echo "✅ Package manager service is ready"
+              fi
+              
+              echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
+              echo ""
+              echo "=== ✅ Android Emulator Started Successfully ==="
+              adb devices -l
             displayName: 'Start Android Emulator'
             condition: eq('${{ parameters.Platform }}', 'android')
-            timeoutInMinutes: 35
+            timeoutInMinutes: 15
             env:
               ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
+              JAVA_HOME: $(JAVA_HOME)
 
-          # Install .NET and workloads via build.ps1
-          - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
+          # Install .NET and workloads via Cake (build.ps1 works on both Linux and macOS via pwsh)
+          - pwsh: |
+              ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
             displayName: 'Install .NET and workloads'
             retryCountOnTaskFailure: 2
             env:
@@ -203,7 +326,8 @@ stages:
             displayName: 'Add .NET to PATH'
 
           # Build MSBuild tasks (required for MAUI builds)
-          - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release" --verbosity=diagnostic
+          - pwsh: |
+              ./build.ps1 --target=dotnet-buildtasks --configuration="Release" --verbosity=diagnostic
             displayName: 'Build MSBuild Tasks'
             retryCountOnTaskFailure: 1
             env:
@@ -236,10 +360,38 @@ stages:
                     echo "✓ Android SDK: $SDK_PATH"
                   fi
                 fi
+                
+                # Check emulator binary
+                echo "Checking Android Emulator..."
+                if which emulator > /dev/null 2>&1; then
+                  echo "✓ emulator: $(which emulator)"
+                  emulator -version 2>&1 | head -1 || true
+                else
+                  echo "⚠️ emulator not in PATH (may be at \$ANDROID_SDK_ROOT/emulator/emulator)"
+                fi
+                
+                # Check adb
+                echo "Checking adb..."
+                if which adb > /dev/null 2>&1; then
+                  echo "✓ adb: $(which adb)"
+                else
+                  echo "⚠️ adb not in PATH"
+                fi
+                
+                # Check KVM (Linux) or HVF (macOS) hardware acceleration
+                echo "Checking hardware virtualization..."
+                if [ "$(uname)" = "Linux" ]; then
+                  if [ -e /dev/kvm ]; then
+                    echo "✓ KVM available (/dev/kvm exists)"
+                    ls -la /dev/kvm
+                  else
+                    ERRORS="${ERRORS}\n- KVM not available (/dev/kvm missing)"
+                  fi
+                fi
               fi
               
-              # Check Xcode (macOS only)
-              if [ "$(uname)" = "Darwin" ]; then
+              # Check Xcode (macOS only, iOS only)
+              if [ "$(uname)" = "Darwin" ] && [ "${{ parameters.Platform }}" = "ios" ]; then
                 echo "Checking Xcode..."
                 if ! xcodebuild -version; then
                   ERRORS="${ERRORS}\n- Xcode not available"
@@ -287,94 +439,32 @@ stages:
               echo "Tools restored successfully"
             displayName: 'Restore .NET Tools'
 
-          # Boot Android emulator for UI tests
+          # Verify Android emulator is running
           - script: |
-              echo "=== Booting Android Emulator ==="
-              
-              # Match maui-pr Cake script: on macOS use default GPU (hardware-accelerated),
-              # only use swiftshader on Linux. AcesShared agents are ARM64 macOS with HVF.
-              # Start emulator in background with logging for debugging
-              EMULATOR_LOG="/tmp/emulator-boot.log"
-              nohup $ANDROID_SDK_ROOT/emulator/emulator -avd Emulator_30 -no-window -no-snapshot -no-audio -no-boot-anim > "$EMULATOR_LOG" 2>&1 &
-              EMULATOR_PID=$!
-              echo "Emulator started with PID: $EMULATOR_PID"
-              
-              # Give emulator a moment to start and verify process is running
-              sleep 3
-              if ! pgrep -f 'qemu-system' > /dev/null; then
-                echo "##vso[task.logissue type=error]Emulator process did not start"
-                echo "=== Emulator Log ==="
-                cat "$EMULATOR_LOG" 2>/dev/null || echo "No log available"
+              echo "=== Verifying Android Emulator ==="
+              adb devices -l
+              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
+              if [ -z "$DEVICE_ID" ]; then
+                echo "##vso[task.logissue type=error]No emulator device found"
                 exit 1
               fi
-              echo "Emulator process verified running"
-              
-              # Wait for device to appear with timeout (don't use adb wait-for-device - can hang forever)
-              echo "Waiting for emulator device..."
-              device_timeout=60
-              device_waited=0
-              while ! adb devices | grep -q "emulator.*device"; do
-                sleep 2
-                device_waited=$((device_waited + 2))
-                if [ $device_waited -ge $device_timeout ]; then
-                  echo "##vso[task.logissue type=error]Emulator device did not appear in time"
-                  echo "=== Emulator Log (last 50 lines) ==="
-                  tail -50 "$EMULATOR_LOG" 2>/dev/null || echo "No log available"
-                  adb devices -l
-                  exit 1
-                fi
-              done
-              echo "Emulator device detected"
-              
-              # Wait for boot_completed
-              echo "Waiting for emulator to finish booting..."
-              timeout=600
-              waited=0
-              while [ "$(adb shell getprop sys.boot_completed 2>/dev/null)" != "1" ]; do
-                sleep 2
-                waited=$((waited + 2))
-                echo "Waiting for boot... ($waited/$timeout seconds)"
-                if [ $waited -ge $timeout ]; then
-                  echo "##vso[task.logissue type=error]Emulator did not boot in time"
-                  echo "=== Emulator Log (last 50 lines) ==="
-                  tail -50 "$EMULATOR_LOG" 2>/dev/null || echo "No log available"
-                  adb devices -l
-                  exit 1
-                fi
-              done
-              echo "Boot completed flag set"
-              
-              # Wait for package manager service to be available (critical for app installation)
-              echo "Waiting for package manager service..."
-              pm_timeout=120
-              pm_waited=0
-              while ! adb shell pm list packages 2>/dev/null | grep -q "package:"; do
-                sleep 3
-                pm_waited=$((pm_waited + 3))
-                echo "Waiting for package manager... ($pm_waited/$pm_timeout seconds)"
-                if [ $pm_waited -ge $pm_timeout ]; then
-                  echo "##vso[task.logissue type=error]Package manager service did not start"
-                  echo "=== Checking services ==="
-                  adb shell service list 2>/dev/null | head -20 || echo "Cannot list services"
-                  exit 1
-                fi
-              done
-              echo "Package manager service is ready"
-              
-              echo "=== Emulator booted successfully! ==="
-              adb devices -l
-            displayName: 'Boot Android Emulator'
+              echo "✅ Emulator running: $DEVICE_ID"
+              echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
+            displayName: 'Verify Android Emulator'
             condition: eq('${{ parameters.Platform }}', 'android')
-            continueOnError: true
-            timeoutInMinutes: 15
-            env:
-              ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
-              JAVA_HOME: $(JAVA_HOME_17_X64)
+            timeoutInMinutes: 5
 
+          # Install Node.js (cross-platform: apt on Linux, brew on macOS)
           - script: |
-              echo "Installing Node.js 22..."
-              brew install node@22
-              brew link --overwrite node@22
+              echo "Installing Node.js..."
+              if [ "$(uname)" = "Linux" ]; then
+                # Use NodeSource for Node.js 22 on Linux
+                curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+                sudo apt-get install -y nodejs
+              else
+                brew install node@22
+                brew link --overwrite node@22
+              fi
               if ! node --version; then
                 echo "##vso[task.logissue type=error]Failed to install Node.js"
                 exit 1
@@ -383,103 +473,92 @@ stages:
               echo "Node.js installed successfully"
             displayName: 'Install Node.js'
 
+          # Install Appium and platform drivers
           - script: |
-              echo "Installing Appium and platform driver..."
-              
+              echo "Installing Appium and platform drivers..."
+
               # Get npm global bin directory and add to PATH
               NPM_BIN=$(npm config get prefix)/bin
               echo "NPM global bin directory: $NPM_BIN"
               export PATH="$NPM_BIN:$PATH"
-              
+
               # Install Appium globally
               npm install -g appium
-              
-              # Install both drivers — the agent may switch platforms if the bug
-              # only affects one platform (e.g., iOS bug triggered via Android run)
+
+              # Install both drivers
               echo "Installing UiAutomator2 driver for Android..."
               appium driver install uiautomator2
               echo "Installing XCUITest driver for iOS..."
               appium driver install xcuitest
-              
+
               # Verify installation
               if ! which appium; then
                 echo "##vso[task.logissue type=error]Failed to install Appium"
                 exit 1
               fi
-              
+
               APPIUM_PATH=$(which appium)
               echo "Appium path: $APPIUM_PATH"
               echo "Appium version: $(appium --version)"
               echo "Appium drivers installed:"
               appium driver list --installed
-              
-              # Export PATH for subsequent steps (Azure DevOps specific)
+
+              # Export PATH for subsequent steps
               echo "##vso[task.prependpath]$NPM_BIN"
-              
+
               echo "Appium installed successfully"
             displayName: 'Install Appium'
 
-          - script: |
-              echo "Installing GitHub CLI..."
-              brew install gh
-              if ! gh --version; then
-                echo "##vso[task.logissue type=error]Failed to install GitHub CLI"
-                exit 1
-              fi
-              echo "GitHub CLI installed successfully"
-            displayName: 'Install GitHub CLI'
 
+          # Verify/refresh Android Emulator before PR Reviewer runs
+          # Reuses the already-running emulator if healthy (avoids disk space issues on hosted agents)
           - script: |
-              echo "Authenticating with GitHub CLI..."
-              if [ -z "$(GH_CLI_TOKEN)" ]; then
-                echo "##vso[task.logissue type=error]GH_CLI_TOKEN is not set. Please configure the pipeline variable."
-                exit 1
-              fi
-              echo "$(GH_CLI_TOKEN)" | gh auth login --with-token
-              if ! gh auth status; then
-                echo "##vso[task.logissue type=error]GitHub CLI authentication failed"
-                exit 1
-              fi
-            displayName: 'Authenticate GitHub CLI'
-            env:
-              GH_CLI_TOKEN: $(GH_CLI_TOKEN)
+              echo "=== Checking Android Emulator for PR Reviewer ==="
 
-          - script: |
-              echo "Installing GitHub Copilot CLI..."
-              npm install -g @github/copilot
-              if ! which copilot; then
-                echo "##vso[task.logissue type=error]Failed to install GitHub Copilot CLI"
-                exit 1
+              # Check if emulator is still running and healthy
+              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
+              if [ -n "$DEVICE_ID" ]; then
+                BOOT_DONE=$(adb -s "$DEVICE_ID" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+                if [ "$BOOT_DONE" = "1" ]; then
+                  echo "✅ Emulator $DEVICE_ID is running and booted"
+                  # Verify package manager is still responsive
+                  if adb -s "$DEVICE_ID" shell pm list packages 2>/dev/null | grep -q "package:"; then
+                    echo "✅ Package manager is responsive"
+                    echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
+                    echo "=== Android Emulator Ready (reused) ==="
+                    adb devices -l
+                    exit 0
+                  fi
+                fi
               fi
-              echo "Copilot CLI installed successfully"
-            displayName: 'Install GitHub Copilot CLI'
 
-          # Restart Android emulator to ensure it's fresh before PR Reviewer runs
-          # The emulator can become unstable after running for a long time
-          - script: |
-              echo "=== Restarting Android Emulator for PR Reviewer ==="
-              
+              echo "⚠️ Emulator not healthy, attempting restart..."
+
+              # Find AVD home (same logic as Start step)
+              AVD_HOME=""
+              for candidate in "$HOME/.android/avd" "$HOME/.config/.android/avd"; do
+                if [ -d "$candidate/Emulator_30.avd" ]; then
+                  AVD_HOME="$candidate"
+                  break
+                fi
+              done
+              export ANDROID_AVD_HOME="${AVD_HOME:-$HOME/.android/avd}"
+
               # Kill any existing emulator
-              echo "Killing existing emulator..."
-              pkill -f 'qemu-system' 2>/dev/null || true
+              adb devices | grep emulator | awk '{print $1}' | xargs -I{} adb -s {} emu kill 2>/dev/null || true
               sleep 5
-              
+
               # Restart ADB server
-              echo "Restarting ADB server..."
               adb kill-server
               sleep 2
               adb start-server
               sleep 2
-              
+
               # Start fresh emulator
               EMULATOR_LOG="/tmp/emulator-fresh.log"
-              echo "Starting fresh emulator..."
-              nohup $ANDROID_SDK_ROOT/emulator/emulator -avd Emulator_30 -no-window -no-snapshot -no-audio -no-boot-anim > "$EMULATOR_LOG" 2>&1 &
-              EMULATOR_PID=$!
-              echo "Emulator started with PID: $EMULATOR_PID"
-              
-              # Wait for device to appear
-              echo "Waiting for emulator device..."
+              nohup $ANDROID_SDK_ROOT/emulator/emulator -avd Emulator_30 -no-window -no-snapshot -no-audio -no-boot-anim -gpu swiftshader_indirect -no-metrics > "$EMULATOR_LOG" 2>&1 &
+
+              # Wait for device
               device_timeout=300
               device_waited=0
               while ! adb devices | grep -q "emulator.*device"; do
@@ -490,15 +569,13 @@ stages:
                   cat "$EMULATOR_LOG" 2>/dev/null | tail -30
                   exit 1
                 fi
-                echo "Waiting for device... ($device_waited/$device_timeout seconds)"
               done
-              echo "Emulator device detected"
-              
-              # Wait for boot_completed
-              echo "Waiting for boot_completed..."
+
+              # Wait for boot
+              DEVICE_ID=$(adb devices | grep "emulator.*device" | awk '{print $1}')
               boot_timeout=600
               boot_waited=0
-              while [ "$(adb shell getprop sys.boot_completed 2>/dev/null)" != "1" ]; do
+              while [ "$(adb -s $DEVICE_ID shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
                 sleep 5
                 boot_waited=$((boot_waited + 5))
                 if [ $boot_waited -ge $boot_timeout ]; then
@@ -506,37 +583,26 @@ stages:
                   exit 1
                 fi
               done
-              echo "Boot completed"
-              
-              # Wait for package manager
-              echo "Waiting for package manager service..."
-              pm_timeout=120
-              pm_waited=0
-              while ! adb shell pm list packages 2>/dev/null | grep -q "package:"; do
-                sleep 5
-                pm_waited=$((pm_waited + 5))
-                if [ $pm_waited -ge $pm_timeout ]; then
-                  echo "##vso[task.logissue type=error]Package manager service did not start"
-                  adb shell service list 2>/dev/null | head -20
-                  exit 1
-                fi
-                echo "Waiting for package manager... ($pm_waited/$pm_timeout seconds)"
-              done
-              
+
+              echo "##vso[task.setvariable variable=DEVICE_UDID]$DEVICE_ID"
               echo "=== Fresh Android Emulator Ready! ==="
               adb devices -l
             displayName: 'Restart Android Emulator (Fresh)'
             condition: eq('${{ parameters.Platform }}', 'android')
+            continueOnError: true
             timeoutInMinutes: 15
             env:
               ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
+              JAVA_HOME: $(JAVA_HOME)
 
           # Boot iOS Simulator (only for iOS platform)
-          # UI test baseline screenshots are captured on iPhone Xs - must use same device
           - script: |
               echo "=== Booting iOS Simulator ==="
-              
-              # Find the latest stable iOS runtime (prefer 18.x, fallback to 17.x)
+              echo "Available runtimes:"
+              xcrun simctl list runtimes available
+
+              # Find iOS runtime in priority order: 18.x > 17.x > 26.x
+              # iOS 26.x comes with Xcode 26 and may be the only runtime available
               RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
                 [.runtimes[] | select(.name | test("iOS 18"))] | sort_by(.version) | last | .identifier // empty
               ')
@@ -545,62 +611,94 @@ stages:
                   [.runtimes[] | select(.name | test("iOS 17"))] | sort_by(.version) | last | .identifier // empty
                 ')
               fi
+              if [ -z "$RUNTIME" ]; then
+                RUNTIME=$(xcrun simctl list runtimes available --json | jq -r '
+                  [.runtimes[] | select(.name | test("iOS 26"))] | sort_by(.version) | last | .identifier // empty
+                ')
+              fi
+
+              if [ -z "$RUNTIME" ]; then
+                echo "##vso[task.logissue type=error]No iOS runtime found (tried iOS 18, 17, 26)"
+                xcrun simctl list runtimes available
+                exit 1
+              fi
               echo "Selected iOS runtime: $RUNTIME"
-              
-              # Look for iPhone Xs (matches UI test baselines - required for snapshot tests)
-              UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" '
+
+              # Determine the correct device type based on runtime version
+              # iOS 26.x → iPhone 11 Pro (matches UITest.cs ios-26 environment and snapshot baselines)
+              # iOS 18.x/17.x → iPhone Xs (matches UITest.cs ios environment and snapshot baselines)
+              # Both devices have the same screen resolution: 375×812 pt, 1125×2436 px @3x
+              IS_IOS26=false
+              if echo "$RUNTIME" | grep -q "iOS-26"; then
+                IS_IOS26=true
+              fi
+
+              if [ "$IS_IOS26" = "true" ]; then
+                PRIMARY_DEVICE="iPhone 11 Pro"
+                PRIMARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro"
+                SECONDARY_DEVICE="iPhone Xs"
+                SECONDARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-XS"
+              else
+                PRIMARY_DEVICE="iPhone Xs"
+                PRIMARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-XS"
+                SECONDARY_DEVICE="iPhone 11 Pro"
+                SECONDARY_DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro"
+              fi
+              echo "Target device: $PRIMARY_DEVICE (fallback: $SECONDARY_DEVICE)"
+
+              # Look for existing primary device
+              UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" --arg name "$PRIMARY_DEVICE" '
                 .devices[$rt] // [] |
-                map(select(.name == "iPhone Xs")) |
+                map(select(.name == $name)) |
                 .[0].udid // empty
               ')
-              
-              # If iPhone Xs doesn't exist, try iPhone 11 Pro (same 1125×2436 resolution)
+
+              # Fallback to secondary device (same resolution)
               if [ -z "$UDID" ]; then
-                UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" '
+                UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" --arg name "$SECONDARY_DEVICE" '
                   .devices[$rt] // [] |
-                  map(select(.name == "iPhone 11 Pro")) |
+                  map(select(.name == $name)) |
                   .[0].udid // empty
                 ')
                 if [ -n "$UDID" ]; then
-                  echo "Found existing iPhone 11 Pro (same resolution as iPhone Xs): $UDID"
+                  echo "Found existing $SECONDARY_DEVICE: $UDID"
                 fi
               else
-                echo "Found existing iPhone Xs: $UDID"
+                echo "Found existing $PRIMARY_DEVICE: $UDID"
               fi
-              
-              # If neither exists, try to create them
+
+              # If neither exists, try to create one
               if [ -z "$UDID" ]; then
-                echo "No matching device found - attempting to create one for runtime $RUNTIME..."
-                
-                # Try iPhone Xs first
-                UDID=$(xcrun simctl create "iPhone Xs" com.apple.CoreSimulator.SimDeviceType.iPhone-Xs "$RUNTIME" 2>&1)
+                echo "No matching device found - creating $PRIMARY_DEVICE for runtime $RUNTIME..."
+                UDID=$(xcrun simctl create "$PRIMARY_DEVICE" "$PRIMARY_DEVICE_TYPE" "$RUNTIME" 2>&1)
                 if [ $? -ne 0 ]; then
-                  echo "iPhone Xs device type unavailable: $UDID"
-                  # Try iPhone 11 Pro (same 1125×2436 resolution)
-                  UDID=$(xcrun simctl create "iPhone 11 Pro" com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro "$RUNTIME" 2>&1)
+                  echo "$PRIMARY_DEVICE device type unavailable: $UDID"
+                  echo "Trying $SECONDARY_DEVICE..."
+                  UDID=$(xcrun simctl create "$SECONDARY_DEVICE" "$SECONDARY_DEVICE_TYPE" "$RUNTIME" 2>&1)
                   if [ $? -ne 0 ]; then
-                    echo "##vso[task.logissue type=warning]Failed to create iPhone 11 Pro: $UDID"
-                    # Last resort: first available iPhone
-                    UDID=$(xcrun simctl list devices available --json | jq -r '
-                      .devices | to_entries |
-                      map(.value) | flatten |
+                    echo "##vso[task.logissue type=warning]Failed to create $SECONDARY_DEVICE: $UDID"
+                    echo "Falling back to any available iPhone..."
+                    UDID=$(xcrun simctl list devices available --json | jq -r --arg rt "$RUNTIME" '
+                      .devices[$rt] // [] |
                       map(select(.name | test("iPhone"))) |
-                      .[0].udid
+                      .[0].udid // empty
                     ')
                   else
-                    echo "Created iPhone 11 Pro simulator: $UDID"
+                    echo "Created $SECONDARY_DEVICE simulator: $UDID"
                   fi
                 else
-                  echo "Created iPhone Xs simulator: $UDID"
+                  echo "Created $PRIMARY_DEVICE simulator: $UDID"
                 fi
               fi
-              
+
               if [ -z "$UDID" ]; then
                 echo "##vso[task.logissue type=error]No iOS simulator found"
+                echo "Available devices:"
+                xcrun simctl list devices available
                 exit 1
               fi
-              
-              # Shutdown any other booted simulators to avoid Appium connecting to wrong device
+
+              # Shutdown any other booted simulators to avoid resource contention
               xcrun simctl list devices booted --json | jq -r '
                 .devices | to_entries | map(.value) | flatten |
                 map(select(.state == "Booted" and .udid != "'"$UDID"'")) |
@@ -609,51 +707,137 @@ stages:
                 echo "Shutting down other simulator: $OTHER_UDID"
                 xcrun simctl shutdown "$OTHER_UDID" 2>/dev/null || true
               done
-              
+
               echo "Booting simulator: $UDID"
               xcrun simctl boot "$UDID" 2>/dev/null || echo "Simulator may already be booted"
               sleep 10
-              
+
+              # Log the selected device details for debugging
+              echo "=== Selected Simulator Details ==="
+              DEVICE_INFO=$(xcrun simctl list devices --json | jq -r --arg udid "$UDID" '
+                .devices | to_entries[] | .value[] | select(.udid == $udid) | "\(.name) (\(.udid))"
+              ')
+              echo "Device: $DEVICE_INFO"
+              echo "Runtime: $RUNTIME"
+              echo "iOS 26 mode: $IS_IOS26"
               echo "Booted simulators:"
               xcrun simctl list devices booted
-              
+
               echo "##vso[task.setvariable variable=DEVICE_UDID]$UDID"
               echo "iOS Simulator UDID: $UDID"
             displayName: 'Boot iOS Simulator'
             condition: eq('${{ parameters.Platform }}', 'ios')
             timeoutInMinutes: 5
 
+          # Install GitHub CLI (cross-platform: apt on Linux, brew on macOS)
+          - script: |
+              echo "Installing GitHub CLI..."
+              if [ "$(uname)" = "Linux" ]; then
+                (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+                  && sudo mkdir -p -m 755 /etc/apt/keyrings \
+                  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+                  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+                  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+                  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+                  && sudo apt update \
+                  && sudo apt install gh -y
+              else
+                brew install gh
+              fi
+              if ! gh --version; then
+                echo "##vso[task.logissue type=error]Failed to install GitHub CLI"
+                exit 1
+              fi
+              echo "GitHub CLI installed successfully"
+            displayName: 'Install GitHub CLI'
+
+          # Authenticate GitHub CLI by writing token directly to gh config
+          # (bypasses read:org scope validation that gh auth login requires)
+          - script: |
+              echo "Authenticating with GitHub CLI..."
+              if [ -z "$GH_CLI_TOKEN" ]; then
+                echo "##vso[task.logissue type=error]GH_CLI_TOKEN is not set. Please configure the pipeline variable."
+                exit 1
+              fi
+              # Write token to gh config directly (avoids read:org scope check)
+              mkdir -p "$HOME/.config/gh"
+              printf 'github.com:\n    oauth_token: %s\n    git_protocol: https\n' "$GH_CLI_TOKEN" > "$HOME/.config/gh/hosts.yml"
+              # Verify token works with a simple API call
+              LOGIN=$(gh api user --jq '.login' 2>&1)
+              if [ $? -ne 0 ]; then
+                echo "##vso[task.logissue type=error]GitHub CLI authentication failed: $LOGIN"
+                exit 1
+              fi
+              echo "GitHub CLI authenticated successfully as: $LOGIN"
+            displayName: 'Authenticate GitHub CLI'
+            env:
+              GH_CLI_TOKEN: $(GH_CLI_TOKEN)
+
+          # Install GitHub Copilot CLI
+          - script: |
+              echo "Installing GitHub Copilot CLI..."
+              npm install -g @github/copilot
+              if ! which copilot; then
+                echo "##vso[task.logissue type=error]Failed to install GitHub Copilot CLI"
+                exit 1
+              fi
+              copilot --version
+              echo "Copilot CLI installed successfully"
+            displayName: 'Install GitHub Copilot CLI'
+
+          # Authenticate Copilot CLI
+          - script: |
+              echo "Authenticating Copilot CLI..."
+              if [ -z "$COPILOT_GITHUB_TOKEN" ]; then
+                echo "##vso[task.logissue type=error]COPILOT_GITHUB_TOKEN is not set. Please configure the COPILOT_TOKEN pipeline variable with a fine-grained PAT."
+                exit 1
+              fi
+              echo "COPILOT_GITHUB_TOKEN is set (${#COPILOT_GITHUB_TOKEN} chars)"
+
+              # Verify gh CLI auth is available for copilot's fallback path
+              if gh auth status >/dev/null 2>&1; then
+                echo "✅ GitHub CLI is authenticated"
+              else
+                echo "⚠️ GitHub CLI not authenticated, copilot will use env var only"
+              fi
+
+              echo "✅ Copilot CLI authentication configured"
+            displayName: 'Authenticate Copilot CLI'
+            env:
+              COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
+              GH_TOKEN: $(GH_CLI_TOKEN)
+
+          # Run the PR Reviewer Agent
           - script: |
               echo "Running Copilot PR Reviewer Agent via Review-PR.ps1..."
               echo "Reviewing PR #${{ parameters.PRNumber }}..."
-              
-              # Configure git identity (required for merge operations on self-hosted agents)
+
+              # Configure git identity
               git config user.email "copilot-ci@microsoft.com"
               git config user.name "Copilot CI"
               echo "Git identity configured"
-              
+
               # Create Directory.Build.Override.props to skip Xcode version check
-              # AcesShared agents may have a newer Xcode than the .NET iOS SDK expects
               cp Directory.Build.Override.props.in Directory.Build.Override.props
-              # Insert ValidateXcodeVersion before closing </Project> tag
-              sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
-              
+              # sed -i syntax differs: Linux uses sed -i, macOS uses sed -i ''
+              if [ "$(uname)" = "Linux" ]; then
+                sed -i 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
+              else
+                sed -i '' 's|</Project>|  <PropertyGroup><ValidateXcodeVersion>false</ValidateXcodeVersion></PropertyGroup>\n</Project>|' Directory.Build.Override.props
+              fi
+
               # Create artifacts directory for Copilot outputs
               mkdir -p $(Build.ArtifactStagingDirectory)/copilot-logs
-              
-              # Invoke the PR reviewer using our PowerShell script
-              # The script will merge the PR into the current branch
-              # -PostSummaryComment and -RunFinalize handle posting comments
+
+              # Invoke the PR reviewer
               set +e
               pwsh .github/scripts/Review-PR.ps1 -PRNumber ${{ parameters.PRNumber }} -Platform ${{ parameters.Platform }} -RunFinalize -PostSummaryComment -LogFile "$(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md"
               COPILOT_EXIT_CODE=$?
               set -e
-              
+
               echo "Review-PR.ps1 exit code: $COPILOT_EXIT_CODE"
-              
-              # Terminate any orphaned copilot CLI processes that could hold this step's
-              # stdout fd open and prevent the bash step from exiting.
-              # Only target processes whose command line includes the copilot CLI path.
+
+              # Terminate any orphaned copilot CLI processes
               echo "Cleaning up orphaned copilot processes..."
               SELF_PID=$$
               for proc in $(pgrep -f "[c]opilot" 2>/dev/null || true); do
@@ -665,47 +849,40 @@ stages:
                   fi
                 fi
               done
-              
-              # Copy any Copilot session files
+
+              # Copy Copilot session files
               if [ -d "$HOME/.copilot" ]; then
                 echo "Copying Copilot session state..."
                 cp -r "$HOME/.copilot" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot-session-state || true
               fi
-              
+
               # Copy CustomAgentLogsTmp if it exists
               if [ -d "CustomAgentLogsTmp" ]; then
                 echo "Copying CustomAgentLogsTmp..."
                 cp -r CustomAgentLogsTmp $(Build.ArtifactStagingDirectory)/copilot-logs/ || true
               fi
-              
+
               # Copy any Review_Feedback files
               find . -name "Review_Feedback_*.md" -type f -exec cp {} $(Build.ArtifactStagingDirectory)/copilot-logs/ \; 2>/dev/null || true
-              
+
               # Copy any .github/agent-pr-session files
               if [ -d ".github/agent-pr-session" ]; then
                 echo "Copying agent-pr-session..."
                 cp -r .github/agent-pr-session $(Build.ArtifactStagingDirectory)/copilot-logs/ || true
               fi
-              
-              # Check for failure indicators in output
+
+              # Check for failure
               if [ $COPILOT_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error]Review-PR.ps1 exited with code $COPILOT_EXIT_CODE"
-                # Don't exit yet - let artifacts be published first
                 echo "##vso[task.setvariable variable=CopilotFailed]true"
               fi
-              
-              # Check output for common failure patterns
-              if grep -qi "error\|failed\|exception" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md 2>/dev/null; then
-                if grep -qi "simulator.*not\|emulator.*not\|workload.*not\|sdk.*not found" $(Build.ArtifactStagingDirectory)/copilot-logs/copilot_review_output.md 2>/dev/null; then
-                  echo "##vso[task.logissue type=warning]Copilot encountered environment issues. Check artifacts for details."
-                fi
-              fi
-              
+
               echo "Review output saved to $(Build.ArtifactStagingDirectory)/copilot-logs/"
             displayName: 'Run PR Reviewer Agent'
             env:
               COPILOT_GITHUB_TOKEN: $(COPILOT_TOKEN)
               GH_TOKEN: $(GH_COMMENT_TOKEN)
+              GITHUB_TOKEN: $(GH_CLI_TOKEN)
               DEVICE_UDID: $(DEVICE_UDID)
 
           # Publish Copilot logs and session artifacts
@@ -733,4 +910,3 @@ stages:
                 exit 1
               fi
             displayName: 'Check Copilot Result'
-            condition: succeededOrFailed()

--- a/eng/pipelines/ci-copilot.yml
+++ b/eng/pipelines/ci-copilot.yml
@@ -47,7 +47,7 @@ stages:
       - job: CopilotReview
         displayName: 'Run Copilot PR Reviewer Agent'
         pool: ${{ parameters.pool }}
-        timeoutInMinutes: 180
+        timeoutInMinutes: 360
         steps:
           - checkout: self
             fetchDepth: 0


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

This PR brings together three improvements to the Copilot CI infrastructure:

1. **Auto-trigger uitests and device-tests on `darc-*` branches** — Major rework of `ci-copilot.yml` to support UI tests and device tests triggered on darc branches.

2. **Make emulator startup and provisioning more robust** — Improvements to `Start-Emulator.ps1` and `provision.yml` for more reliable Android emulator handling.

3. **Support fallback environment for snapshots** — Changes to `UITest.cs` and `VisualRegressionTester.cs` to support snapshot environment fallback.

## Changes

- `eng/pipelines/ci-copilot.yml` — Reworked CI pipeline for Android device test support
- `.github/scripts/shared/Start-Emulator.ps1` — More robust emulator startup
- `eng/pipelines/common/provision.yml` — Provisioning improvements
- `src/Controls/tests/TestCases.Shared.Tests/UITest.cs` — Snapshot fallback support
- `src/TestUtils/src/VisualTestUtils/VisualRegressionTester.cs` — Snapshot fallback support
