### PR TITLE
[Testing] Fix flaky EntryClearButtonShouldBeVisibleOnDarkTheme test

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32886.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32886.cs
@@ -3,6 +3,8 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 32886, "[Android, iOS, Mac] Entry ClearButton not visible on dark theme", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue32886 : TestContentPage
 {
+	Label _themeLabel;
+
 	protected override void Init()
 	{
 		Title = "Issue32886";
@@ -25,9 +27,18 @@ public class Issue32886 : TestContentPage
 		};
 		button.Clicked += Button_Clicked;
 
+		_themeLabel = new Label
+		{
+			Text = "Light",
+			AutomationId = "ThemeLabel",
+			HeightRequest = 0,
+			Opacity = 0
+		};
+
 		var layout = new VerticalStackLayout();
 		layout.Children.Add(entry);
 		layout.Children.Add(button);
+		layout.Children.Add(_themeLabel);
 
 		Content = layout;
 
@@ -39,7 +50,9 @@ public class Issue32886 : TestContentPage
 	{
 		if (Application.Current is not null)
 		{
-			Application.Current.UserAppTheme = Application.Current.UserAppTheme != AppTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+			var newTheme = Application.Current.UserAppTheme != AppTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+			Application.Current.UserAppTheme = newTheme;
+			_themeLabel.Text = newTheme == AppTheme.Dark ? "Dark" : "Light";
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32886.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32886.cs
@@ -40,6 +40,10 @@ public class Issue32886 : _IssuesUITest
 	{
 		App.WaitForElement("TestEntry");
 		App.Tap("ThemeButton");
+
+		// Wait for the theme change to propagate through the UI
+		App.WaitForTextToBePresentInElement("ThemeLabel", "Dark");
+
 #if WINDOWS // On Windows, the clear button isn't visible when Entry loses focus, so manually focused to check its icon color.
         App.Tap("TestEntry");
 #endif
@@ -47,9 +51,9 @@ public class Issue32886 : _IssuesUITest
 #if IOS
 		// On iOS, the virtual keyboard appears inconsistent with keyboard characters casing, can cause flaky test results. As this test verifying only the entry clear button color, crop the bottom portion of the screenshot to exclude the keyboard.
 		// Using DismissKeyboard() would unfocus the control in iOS, so we're using cropping instead to maintain focus during testing.
-		VerifyScreenshot(cropBottom: 1550);
+		VerifyScreenshot(cropBottom: 1550, retryTimeout: TimeSpan.FromSeconds(3));
 #else
-		VerifyScreenshot();
+		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(3));
 #endif
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes the flaky `EntryClearButtonShouldBeVisibleOnDarkTheme` test which fails in **67% of PR builds** (61 out of 91 failed builds in the last week) with a consistent 13% screenshot difference.

### Root Cause

The test taps a button to switch from light to dark theme, then immediately takes a screenshot. On Windows, the WinUI theme transition (`Application.Current.UserAppTheme = AppTheme.Dark`) triggers asynchronous UI updates across all visual elements. The screenshot captures the page mid-transition, producing a consistent 13% difference from the baseline.

### Fix

1. **Added a hidden ThemeLabel** to the HostApp page (`HeightRequest=0, Opacity=0`) that updates its text when the theme changes. This provides a deterministic signal that the theme change handler has executed.

2. **Wait for theme change completion** in the test using `WaitForTextToBePresentInElement("ThemeLabel", "Dark")` before proceeding to screenshot.

3. **Added `retryTimeout: TimeSpan.FromSeconds(3)`** to `VerifyScreenshot()` calls for the dark theme test, following the same pattern used by `AppThemeFeatureTests` which also uses `retryTimeout` for theme-change screenshots.

### Impact

This single test is responsible for the `Controls Entry` job failing in 61/91 PR builds. Fixing it should significantly reduce the overall UI test failure rate.