### PR TITLE
Fix Loaded event not called for MAUI View added to native View

### DIFF
--- a/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.Platform.cs
@@ -47,6 +47,33 @@ namespace Microsoft.Maui.Controls
 					}
 				}
 			}
+			// This VisualElement has a handler with MauiContext but no MAUI Window.
+			// This happens when the view is hosted inside a native container via ToPlatform().
+			// We still need to fire Loaded/Unloaded based on the platform view's attach state.
+			else if (Window is null &&
+				Handler?.MauiContext is not null &&
+				Handler?.PlatformView is PlatformView nativeHostedView)
+			{
+				if (nativeHostedView.IsLoaded())
+				{
+					SendLoaded(false);
+
+					// If SendLoaded caused the unloaded tokens to wire up
+					_loadedUnloadedToken?.Dispose();
+					_loadedUnloadedToken = null;
+					_loadedUnloadedToken = this.OnUnloaded(SendUnloaded);
+				}
+				else
+				{
+					// Not yet attached to a native parent; wait for the platform loaded event
+					_loadedUnloadedToken?.Dispose();
+					_loadedUnloadedToken = null;
+					if (Handler is not null)
+					{
+						_loadedUnloadedToken = this.OnLoaded(SendLoaded);
+					}
+				}
+			}
 			else
 			{
 				// My handler is still set but the window handler isn't set.

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -2411,8 +2411,10 @@ namespace Microsoft.Maui.Controls
 		{
 			// If I'm not attached to a window and I haven't started watching any platform events
 			// then it's not useful to wire anything up. We will just wait until
-			// This VE gets connected to the xplat Window before wiring up any events
-			if (!_watchingPlatformLoaded && newWindow is null)
+			// This VE gets connected to the xplat Window before wiring up any events.
+			// Exception: if a handler with a MauiContext is present (e.g., added to a native view via
+			// ToPlatform), we still wire up so the Loaded/Unloaded events can fire correctly.
+			if (!_watchingPlatformLoaded && newWindow is null && Handler?.MauiContext is null)
 				return;
 
 			if (_unloaded is null && _loaded is null)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
@@ -5,6 +5,7 @@ using AFrameLayout = Android.Widget.FrameLayout;
 #elif IOS || MACCATALYST
 using UIKit;
 #elif WINDOWS
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 #endif
 #nullable enable
@@ -61,7 +62,6 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 {
 	AView? _nativeChild;
 	View? _previousHostedView;
-	IElementHandler? _hostedViewHandler;
 
 	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
 		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
@@ -101,15 +101,8 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 			return;
 		}
 
-		// Dispose the handler before removing the view
-		if (_hostedViewHandler is IDisposable disposable)
-		{
-			disposable.Dispose();
-		}
-
 		PlatformView.RemoveView(_nativeChild);
 		_nativeChild = null;
-		_hostedViewHandler = null;
 	}
 
 	void UpdateHostedView()
@@ -135,8 +128,7 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 			return;
 		}
 
-		_hostedViewHandler = hosted.ToHandler(MauiContext);
-		var native = _hostedViewHandler.PlatformView as AView;
+		var native = hosted.ToPlatform(MauiContext) as AView;
 		if (native is null)
 		{
 			return;
@@ -154,7 +146,6 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 {
 	UIView? _nativeChild;
 	View? _previousHostedView;
-	IElementHandler? _hostedViewHandler;
 
 	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
 		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
@@ -187,15 +178,8 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 		if (_nativeChild is null)
 			return;
 
-		// Dispose the handler before removing the view
-		if (_hostedViewHandler is IDisposable disposable)
-		{
-			disposable.Dispose();
-		}
-
 		_nativeChild.RemoveFromSuperview();
 		_nativeChild = null;
-		_hostedViewHandler = null;
 	}
 
 	void UpdateHostedView()
@@ -221,8 +205,7 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 			return;
 		}
 
-		_hostedViewHandler = hosted.ToHandler(MauiContext);
-		var native = _hostedViewHandler.PlatformView as UIView;
+		var native = hosted.ToPlatform(MauiContext) as UIView;
 		if (native is null)
 		{
 			return;
@@ -236,9 +219,8 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 #elif WINDOWS
 public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, Grid>
 {
-	Grid? _nativeChild;
+	UIElement? _nativeChild;
 	View? _previousHostedView;
-	IElementHandler? _hostedViewHandler;
 
 	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
 		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
@@ -273,15 +255,8 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 			return;
 		}
 
-		// Dispose the handler before removing the view
-		if (_hostedViewHandler is IDisposable disposable)
-		{
-			disposable.Dispose();
-		}
-
 		PlatformView.Children.Remove(_nativeChild);
 		_nativeChild = null;
-		_hostedViewHandler = null;
 	}
 
 	void UpdateHostedView()
@@ -307,8 +282,7 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 			return;
 		}
 
-		_hostedViewHandler = hosted.ToHandler(MauiContext);
-		var native = _hostedViewHandler.PlatformView as Grid;
+		var native = hosted.ToPlatform(MauiContext) as UIElement;
 		if (native is null)
 		{
 			return;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
@@ -1,0 +1,164 @@
+#if ANDROID
+using AView = Android.Views.View;
+using AViewGroup = Android.Views.ViewGroup;
+using AFrameLayout = Android.Widget.FrameLayout;
+#elif IOS || MACCATALYST
+using UIKit;
+#endif
+#nullable enable
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34310, "Loaded event not called for MAUI View added to native View", PlatformAffected.All)]
+public class Issue34310 : ContentPage
+{
+	public Issue34310()
+	{
+		var statusLabel = new Label
+		{
+			Text = "Not Loaded",
+			AutomationId = "LoadedStatus",
+			FontSize = 18,
+		};
+
+		var hostedLabel = new Label { Text = "Hosted Content" };
+		hostedLabel.Loaded += (s, e) => statusLabel.Text = "Loaded";
+
+		var nativeHostView = new Issue34310NativeHostView
+		{
+			HostedView = hostedLabel,
+			HeightRequest = 80,
+			BackgroundColor = Colors.LightBlue,
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children = { statusLabel, nativeHostView }
+		};
+	}
+}
+
+public class Issue34310NativeHostView : View
+{
+	public static readonly BindableProperty HostedViewProperty =
+		BindableProperty.Create(nameof(HostedView), typeof(View), typeof(Issue34310NativeHostView));
+
+	public View? HostedView
+	{
+		get => (View?)GetValue(HostedViewProperty);
+		set => SetValue(HostedViewProperty, value);
+	}
+}
+
+#if ANDROID
+public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, AFrameLayout>
+{
+	AView? _nativeChild;
+
+	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
+		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
+		{
+			[nameof(Issue34310NativeHostView.HostedView)] = MapHostedView,
+		};
+
+	public Issue34310NativeHostViewHandler() : base(Mapper) { }
+
+	protected override AFrameLayout CreatePlatformView()
+		=> new AFrameLayout(Context)
+		{
+			LayoutParameters = new AFrameLayout.LayoutParams(
+				AViewGroup.LayoutParams.MatchParent,
+				AViewGroup.LayoutParams.WrapContent)
+		};
+
+	protected override void ConnectHandler(AFrameLayout platformView)
+	{
+		base.ConnectHandler(platformView);
+		UpdateHostedView();
+	}
+
+	protected override void DisconnectHandler(AFrameLayout platformView)
+	{
+		RemoveNativeChild();
+		base.DisconnectHandler(platformView);
+	}
+
+	static void MapHostedView(Issue34310NativeHostViewHandler handler, Issue34310NativeHostView view)
+		=> handler.UpdateHostedView();
+
+	void RemoveNativeChild()
+	{
+		if (PlatformView is null || _nativeChild is null) return;
+		PlatformView.RemoveView(_nativeChild);
+		_nativeChild = null;
+	}
+
+	void UpdateHostedView()
+	{
+		if (MauiContext is null || PlatformView is null) return;
+		RemoveNativeChild();
+		var hosted = VirtualView?.HostedView;
+		if (hosted is null) return;
+		var native = hosted.ToPlatform(MauiContext);
+		native.LayoutParameters = new AFrameLayout.LayoutParams(
+			AViewGroup.LayoutParams.MatchParent,
+			AViewGroup.LayoutParams.WrapContent);
+		PlatformView.AddView(native);
+		_nativeChild = native;
+	}
+}
+#elif IOS || MACCATALYST
+public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, UIView>
+{
+	UIView? _nativeChild;
+
+	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
+		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
+		{
+			[nameof(Issue34310NativeHostView.HostedView)] = MapHostedView,
+		};
+
+	public Issue34310NativeHostViewHandler() : base(Mapper) { }
+
+	protected override UIView CreatePlatformView()
+		=> new UIView { AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight };
+
+	protected override void ConnectHandler(UIView platformView)
+	{
+		base.ConnectHandler(platformView);
+		UpdateHostedView();
+	}
+
+	protected override void DisconnectHandler(UIView platformView)
+	{
+		RemoveNativeChild();
+		base.DisconnectHandler(platformView);
+	}
+
+	static void MapHostedView(Issue34310NativeHostViewHandler handler, Issue34310NativeHostView view)
+		=> handler.UpdateHostedView();
+
+	void RemoveNativeChild()
+	{
+		if (_nativeChild is null) return;
+		_nativeChild.RemoveFromSuperview();
+		_nativeChild = null;
+	}
+
+	void UpdateHostedView()
+	{
+		if (MauiContext is null || PlatformView is null) return;
+		RemoveNativeChild();
+		var hosted = VirtualView?.HostedView;
+		if (hosted is null) return;
+		var native = hosted.ToPlatform(MauiContext);
+		native.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+		PlatformView.AddSubview(native);
+		_nativeChild = native;
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
@@ -4,6 +4,8 @@ using AViewGroup = Android.Views.ViewGroup;
 using AFrameLayout = Android.Widget.FrameLayout;
 #elif IOS || MACCATALYST
 using UIKit;
+#elif WINDOWS
+using Microsoft.UI.Xaml.Controls;
 #endif
 #nullable enable
 using Microsoft.Maui.Handlers;
@@ -58,6 +60,8 @@ public class Issue34310NativeHostView : View
 public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, AFrameLayout>
 {
 	AView? _nativeChild;
+	View? _previousHostedView;
+	IElementHandler? _hostedViewHandler;
 
 	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
 		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
@@ -92,18 +96,52 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 
 	void RemoveNativeChild()
 	{
-		if (PlatformView is null || _nativeChild is null) return;
+		if (PlatformView is null || _nativeChild is null)
+		{
+			return;
+		}
+
+		// Dispose the handler before removing the view
+		if (_hostedViewHandler is IDisposable disposable)
+		{
+			disposable.Dispose();
+		}
+
 		PlatformView.RemoveView(_nativeChild);
 		_nativeChild = null;
+		_hostedViewHandler = null;
 	}
 
 	void UpdateHostedView()
 	{
-		if (MauiContext is null || PlatformView is null) return;
-		RemoveNativeChild();
+		if (MauiContext is null || PlatformView is null)
+		{
+			return;
+		}
+
 		var hosted = VirtualView?.HostedView;
-		if (hosted is null) return;
-		var native = hosted.ToPlatform(MauiContext);
+
+		// Change detection - only update if the view actually changed
+		if (hosted == _previousHostedView)
+		{
+			return;
+		}
+
+		RemoveNativeChild();
+		_previousHostedView = hosted;
+
+		if (hosted is null)
+		{
+			return;
+		}
+
+		_hostedViewHandler = hosted.ToHandler(MauiContext);
+		var native = _hostedViewHandler.PlatformView as AView;
+		if (native is null)
+		{
+			return;
+		}
+
 		native.LayoutParameters = new AFrameLayout.LayoutParams(
 			AViewGroup.LayoutParams.MatchParent,
 			AViewGroup.LayoutParams.WrapContent);
@@ -115,6 +153,8 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, UIView>
 {
 	UIView? _nativeChild;
+	View? _previousHostedView;
+	IElementHandler? _hostedViewHandler;
 
 	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
 		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
@@ -144,20 +184,137 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 
 	void RemoveNativeChild()
 	{
-		if (_nativeChild is null) return;
+		if (_nativeChild is null)
+			return;
+
+		// Dispose the handler before removing the view
+		if (_hostedViewHandler is IDisposable disposable)
+		{
+			disposable.Dispose();
+		}
+
 		_nativeChild.RemoveFromSuperview();
 		_nativeChild = null;
+		_hostedViewHandler = null;
 	}
 
 	void UpdateHostedView()
 	{
-		if (MauiContext is null || PlatformView is null) return;
-		RemoveNativeChild();
+		if (MauiContext is null || PlatformView is null)
+		{
+			return;
+		}
+
 		var hosted = VirtualView?.HostedView;
-		if (hosted is null) return;
-		var native = hosted.ToPlatform(MauiContext);
+
+		// Change detection - only update if the view actually changed
+		if (hosted == _previousHostedView)
+		{
+			return;
+		}
+
+		RemoveNativeChild();
+		_previousHostedView = hosted;
+
+		if (hosted is null)
+		{
+			return;
+		}
+
+		_hostedViewHandler = hosted.ToHandler(MauiContext);
+		var native = _hostedViewHandler.PlatformView as UIView;
+		if (native is null)
+		{
+			return;
+		}
+
 		native.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
 		PlatformView.AddSubview(native);
+		_nativeChild = native;
+	}
+}
+#elif WINDOWS
+public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, Grid>
+{
+	Grid? _nativeChild;
+	View? _previousHostedView;
+	IElementHandler? _hostedViewHandler;
+
+	public static readonly IPropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler> Mapper =
+		new PropertyMapper<Issue34310NativeHostView, Issue34310NativeHostViewHandler>(ViewHandler.ViewMapper)
+		{
+			[nameof(Issue34310NativeHostView.HostedView)] = MapHostedView,
+		};
+
+	public Issue34310NativeHostViewHandler() : base(Mapper) { }
+
+	protected override Grid CreatePlatformView()
+		=> new Grid();
+
+	protected override void ConnectHandler(Grid platformView)
+	{
+		base.ConnectHandler(platformView);
+		UpdateHostedView();
+	}
+
+	protected override void DisconnectHandler(Grid platformView)
+	{
+		RemoveNativeChild();
+		base.DisconnectHandler(platformView);
+	}
+
+	static void MapHostedView(Issue34310NativeHostViewHandler handler, Issue34310NativeHostView view)
+		=> handler.UpdateHostedView();
+
+	void RemoveNativeChild()
+	{
+		if (PlatformView is null || _nativeChild is null)
+		{
+			return;
+		}
+
+		// Dispose the handler before removing the view
+		if (_hostedViewHandler is IDisposable disposable)
+		{
+			disposable.Dispose();
+		}
+
+		PlatformView.Children.Remove(_nativeChild);
+		_nativeChild = null;
+		_hostedViewHandler = null;
+	}
+
+	void UpdateHostedView()
+	{
+		if (MauiContext is null || PlatformView is null)
+		{
+			return;
+		}
+
+		var hosted = VirtualView?.HostedView;
+
+		// Change detection - only update if the view actually changed
+		if (hosted == _previousHostedView)
+		{
+			return;
+		}
+
+		RemoveNativeChild();
+		_previousHostedView = hosted;
+
+		if (hosted is null)
+		{
+			return;
+		}
+
+		_hostedViewHandler = hosted.ToHandler(MauiContext);
+		var native = _hostedViewHandler.PlatformView as Grid;
+		if (native is null)
+		{
+			return;
+		}
+
+		PlatformView.Children.Add(native);
 		_nativeChild = native;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -65,6 +65,9 @@ namespace Maui.Controls.Sample
 #if IOS
 				handlers.AddHandler(typeof(Issue30147CustomScrollView), typeof(Issue30147CustomScrollViewHandler));
 #endif
+#if IOS || MACCATALYST || ANDROID
+				handlers.AddHandler(typeof(Issue34310NativeHostView), typeof(Issue34310NativeHostViewHandler));
+#endif
 			});
 
 			appBuilder.Services.AddTransient<TransientPage>();

--- a/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
+++ b/src/Controls/tests/TestCases.HostApp/MauiProgram.cs
@@ -46,7 +46,7 @@ namespace Maui.Controls.Sample
 #if IOS || MACCATALYST
 			appBuilder.ConfigureCollectionViewHandlers();
 #endif
-			
+
 			// Register the custom handler
 			appBuilder.ConfigureMauiHandlers(handlers =>
 			{
@@ -65,7 +65,7 @@ namespace Maui.Controls.Sample
 #if IOS
 				handlers.AddHandler(typeof(Issue30147CustomScrollView), typeof(Issue30147CustomScrollViewHandler));
 #endif
-#if IOS || MACCATALYST || ANDROID
+#if IOS || MACCATALYST || ANDROID || WINDOWS
 				handlers.AddHandler(typeof(Issue34310NativeHostView), typeof(Issue34310NativeHostViewHandler));
 #endif
 			});

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34310.cs
@@ -1,4 +1,3 @@
-#if !TIZEN
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -20,4 +19,3 @@ public class Issue34310 : _IssuesUITest
 			"Loaded event should fire for a MAUI View added to a native container via ToPlatform().");
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34310.cs
@@ -1,4 +1,4 @@
-#if !WINDOWS && !TIZEN
+#if !TIZEN
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34310.cs
@@ -1,0 +1,23 @@
+#if !WINDOWS && !TIZEN
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34310 : _IssuesUITest
+{
+	public override string Issue => "Loaded event not called for MAUI View added to native View";
+
+	public Issue34310(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.LifeCycle)]
+	public void LoadedEventFiresForNativeHostedView()
+	{
+		App.WaitForElement("LoadedStatus");
+		Assert.That(App.FindElement("LoadedStatus").GetText(), Is.EqualTo("Loaded"),
+			"Loaded event should fire for a MAUI View added to a native container via ToPlatform().");
+	}
+}
+#endif


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

  ### Root Cause

  `UpdatePlatformUnloadedLoadedWiring` in VisualElement.cs had this early-exit guard:

  ```c#
 if (!_watchingPlatformLoaded && newWindow is null)
       return;
```

  This unconditionally skipped event wiring for any view without a MAUI Window. Native-hosted views (via ToPlatform()) never have a MAUI Window, so they were silently excluded.

  Additionally, HandlePlatformUnloadedLoaded had no case for native-hosted views — they fell through to the else detaching branch, which fired SendUnloaded immediately instead of wiring Loaded.

  ### Description of Change

  VisualElement.cs — Relax the guard using MauiContext as the discriminator:

   ```c# 
if (!_watchingPlatformLoaded && newWindow is null && Handler?.MauiContext is null)
     return;
```

  VisualElement.Platform.cs — New else if branch for native-hosted views:

   ```c# 
if (Window is null && Handler?.MauiContext is not null &&
            Handler?.PlatformView is PlatformView nativeHostedView)
   {
       if (nativeHostedView.IsLoaded())
       {
           SendLoaded(false);
           _loadedUnloadedToken = this.OnUnloaded(SendUnloaded);
       }
       else
       {
           _loadedUnloadedToken = this.OnLoaded(SendLoaded);
       }
   }
   
```
> [!NOTE]
  > no SendUnloaded in the not-yet-loaded path — native-hosted views have no prior loaded state.

  What NOT to Do (for future agents)

   - ❌ Don't use Window is null alone — detaching views also have Window is null
   - ❌ Don't fire SendUnloaded for not-yet-loaded native-hosted views — no prior loaded state
   - ❌ Don't add _isNativeHosted flag — Handler?.MauiContext is not null is the canonical signal

  Issues Fixed

  Fixes #34310

  Platforms Tested

   - [X]  Android
   - [X]  iOS 
   - [X]  Windows 
   - [X]  MacCatalyst
