### PR TITLE
Fixed SearchBar CursorPosition and SelectionLength not updating when typing

### DIFF
--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -3,6 +3,7 @@ using Android.Content.Res;
 using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Platform;
 using static AndroidX.AppCompat.Widget.SearchView;
 using AView = Android.Views.View;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
@@ -25,6 +26,9 @@ namespace Microsoft.Maui.Handlers
 			return _platformSearchView;
 		}
 
+		QueryEditorTouchListener? _queryEditorTouchListener;
+		QueryEditorKeyListener? _queryEditorKeyListener;
+
 		protected override void ConnectHandler(SearchView platformView)
 		{
 			FocusListener.Handler = this;
@@ -32,6 +36,20 @@ namespace Microsoft.Maui.Handlers
 
 			platformView.QueryTextChange += OnQueryTextChange;
 			platformView.QueryTextSubmit += OnQueryTextSubmit;
+
+			// QueryEditor is SearchView.SearchAutoComplete (not MauiAppCompatEditText), so there is
+			// no SelectionChanged event available. Track cursor/selection via three hooks:
+			//   1. OnQueryTextChange: fires on every keystroke (typing)
+			//   2. QueryEditorTouchListener (ACTION_UP): tap-to-reposition / drag-to-select
+			//   3. QueryEditorKeyListener (ACTION_UP): hardware keyboard navigation (Shift+Arrow, etc.)
+			if (QueryEditor is EditText queryEditor)
+			{
+				_queryEditorTouchListener = new QueryEditorTouchListener(this);
+				queryEditor.SetOnTouchListener(_queryEditorTouchListener);
+
+				_queryEditorKeyListener = new QueryEditorKeyListener(this);
+				queryEditor.SetOnKeyListener(_queryEditorKeyListener);
+			}
 		}
 
 		protected override void DisconnectHandler(SearchView platformView)
@@ -41,6 +59,17 @@ namespace Microsoft.Maui.Handlers
 
 			platformView.QueryTextChange -= OnQueryTextChange;
 			platformView.QueryTextSubmit -= OnQueryTextSubmit;
+
+			if (QueryEditor is EditText queryEditor)
+			{
+				queryEditor.SetOnTouchListener(null);
+				_queryEditorTouchListener?.Dispose();
+				_queryEditorTouchListener = null;
+
+				queryEditor.SetOnKeyListener(null);
+				_queryEditorKeyListener?.Dispose();
+				_queryEditorKeyListener = null;
+			}
 		}
 
 		public static void MapBackground(ISearchBarHandler handler, ISearchBar searchBar)
@@ -136,6 +165,18 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateCancelButtonState(searchBar);
 		}
 
+		// make it public in .net 11
+		internal static void MapCursorPosition(ISearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.QueryEditor?.UpdateCursorPosition(searchBar);
+		}
+
+		// make it public in .net 11
+		internal static void MapSelectionLength(ISearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.QueryEditor?.UpdateSelectionLength(searchBar);
+		}
+
 		public static void MapCancelButtonColor(ISearchBarHandler handler, ISearchBar searchBar)
 		{
 			handler.PlatformView?.UpdateCancelButtonColor(searchBar);
@@ -174,6 +215,89 @@ namespace Microsoft.Maui.Handlers
 		{
 			VirtualView.UpdateText(e.NewText);
 			e.Handled = true;
+			// Typing always repositions the cursor; schedule a deferred cursor/selection read.
+			OnQueryEditorSelectionChanged();
+		}
+
+		internal void OnQueryEditorSelectionChanged()
+		{
+			QueryEditor?.Post(() =>
+			{
+				if (VirtualView is ISearchBar searchBar && QueryEditor is EditText queryEditor)
+				{
+					var cursorPosition = queryEditor.GetCursorPosition();
+					var selectedTextLength = queryEditor.GetSelectedTextLength();
+
+					if (searchBar.CursorPosition != cursorPosition)
+					{
+						searchBar.CursorPosition = cursorPosition;
+					}
+
+					if (searchBar.SelectionLength != selectedTextLength)
+					{
+						searchBar.SelectionLength = selectedTextLength;
+					}
+				}
+			});
+		}
+
+		class QueryEditorTouchListener : Java.Lang.Object, AView.IOnTouchListener
+		{
+			readonly SearchBarHandler _handler;
+
+			public QueryEditorTouchListener(SearchBarHandler handler)
+			{
+				_handler = handler;
+			}
+
+			public bool OnTouch(AView? v, MotionEvent? e)
+			{
+				// After ACTION_UP the gesture is complete and the cursor/selection is finalized.
+				if (e?.Action == MotionEventActions.Up)
+					_handler.OnQueryEditorSelectionChanged();
+				return false;
+			}
+		}
+
+		class QueryEditorKeyListener : Java.Lang.Object, AView.IOnKeyListener
+		{
+			readonly SearchBarHandler _handler;
+
+			public QueryEditorKeyListener(SearchBarHandler handler)
+			{
+				_handler = handler;
+			}
+
+			public bool OnKey(AView? v, Keycode keyCode, KeyEvent? e)
+			{
+				// Fire for navigation keys (arrow, Home, End, PageUp/Down) that can reposition
+				// the cursor, and for Ctrl+A (select-all) which changes the selection range.
+				// Text-modifying keys are already handled by OnQueryTextChange; modifier-only
+				// keys (Shift, Ctrl, …) alone cannot move the cursor.
+				if (e?.Action == KeyEventActions.Up &&
+					(IsNavigationKey(keyCode) || IsSelectAllShortcut(keyCode, e)))
+				{
+					_handler.OnQueryEditorSelectionChanged();
+				}
+
+				return false;
+			}
+
+			// Returns true for keys that can reposition the cursor or change the
+			// selection range without altering the text content.
+			static bool IsNavigationKey(Keycode keyCode) =>
+				keyCode == Keycode.DpadLeft ||
+				keyCode == Keycode.DpadRight ||
+				keyCode == Keycode.DpadUp ||
+				keyCode == Keycode.DpadDown ||
+				keyCode == Keycode.MoveHome ||
+				keyCode == Keycode.MoveEnd ||
+				keyCode == Keycode.PageUp ||
+				keyCode == Keycode.PageDown;
+
+			// Returns true for Ctrl+A which selects all text without modifying it.
+			static bool IsSelectAllShortcut(Keycode keyCode, KeyEvent e) =>
+				keyCode == Keycode.A && e.IsCtrlPressed;
 		}
 
 		class FocusChangeListener : Java.Lang.Object, SearchView.IOnFocusChangeListener

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
@@ -38,5 +38,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapKeyboard(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapReturnType(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapCursorPosition(ISearchBarHandler handler, ISearchBar searchBar) { }
+		public static void MapSelectionLength(ISearchBarHandler handler, ISearchBar searchBar) { }
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapKeyboard(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapReturnType(IViewHandler handler, ISearchBar searchBar) { }
-		public static void MapCursorPosition(ISearchBarHandler handler, ISearchBar searchBar) { }
-		public static void MapSelectionLength(ISearchBarHandler handler, ISearchBar searchBar) { }
+		internal static void MapCursorPosition(ISearchBarHandler handler, ISearchBar searchBar) { }
+		internal static void MapSelectionLength(ISearchBarHandler handler, ISearchBar searchBar) { }
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		public AutoSuggestBox? QueryEditor => null;
 
+		TextBox? _queryTextBox;
+
 		protected override AutoSuggestBox CreatePlatformView() => new AutoSuggestBox
 		{
 			AutoMaximizeSuggestionArea = false,
@@ -33,6 +35,12 @@ namespace Microsoft.Maui.Handlers
 			platformView.TextChanged -= OnTextChanged;
 			platformView.GotFocus -= OnGotFocus;
 			platformView.LostFocus -= OnLostFocus;
+
+			if (_queryTextBox is not null)
+			{
+				_queryTextBox.SelectionChanged -= OnPlatformSelectionChanged;
+				_queryTextBox = null;
+			}
 		}
 
 		public static void MapBackground(ISearchBarHandler handler, ISearchBar searchBar)
@@ -107,6 +115,24 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateIsReadOnly(searchBar);
 		}
 
+		// make it public in .net 11
+		internal static void MapCursorPosition(ISearchBarHandler handler, ISearchBar searchBar)
+		{
+			if (handler is SearchBarHandler searchBarHandler && searchBarHandler._queryTextBox is TextBox textBox)
+			{
+				textBox.UpdateCursorPosition(searchBar);
+			}
+		}
+
+		// make it public in .net 11
+		internal static void MapSelectionLength(ISearchBarHandler handler, ISearchBar searchBar)
+		{
+			if (handler is SearchBarHandler searchBarHandler && searchBarHandler._queryTextBox is TextBox textBox)
+			{
+				textBox.UpdateSelectionLength(searchBar);
+			}
+		}
+
 		public static void MapCancelButtonColor(ISearchBarHandler handler, ISearchBar searchBar)
 		{
 			handler.PlatformView?.UpdateCancelButtonColor(searchBar);
@@ -143,6 +169,17 @@ namespace Microsoft.Maui.Handlers
 				PlatformView?.UpdateKeyboard(VirtualView);
 				PlatformView?.UpdateReturnType(VirtualView);
 			}
+
+			if (PlatformView?.GetFirstDescendant<TextBox>() is TextBox queryTextBox)
+			{
+				if (_queryTextBox is not null)
+				{
+					_queryTextBox.SelectionChanged -= OnPlatformSelectionChanged;
+				}
+
+				_queryTextBox = queryTextBox;
+				_queryTextBox.SelectionChanged += OnPlatformSelectionChanged;
+			}
 		}
 
 		void OnQuerySubmitted(AutoSuggestBox? sender, AutoSuggestBoxQuerySubmittedEventArgs e)
@@ -177,6 +214,27 @@ namespace Microsoft.Maui.Handlers
 		void OnLostFocus(object sender, UI.Xaml.RoutedEventArgs e)
 		{
 			UpdateIsFocused(false);
+		}
+
+		void OnPlatformSelectionChanged(object sender, UI.Xaml.RoutedEventArgs e)
+		{
+			if (VirtualView is null || _queryTextBox is null)
+			{
+				return;
+			}
+
+			var cursorPosition = _queryTextBox.GetCursorPosition();
+			var selectedTextLength = _queryTextBox.SelectionLength;
+
+			if (VirtualView.CursorPosition != cursorPosition)
+			{
+				VirtualView.CursorPosition = cursorPosition;
+			}
+
+			if (VirtualView.SelectionLength != selectedTextLength)
+			{
+				VirtualView.SelectionLength = selectedTextLength;
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ISearchBar.PlaceholderColor)] = MapPlaceholderColor,
 			[nameof(ISearchBar.Text)] = MapText,
 			[nameof(ISearchBar.TextColor)] = MapTextColor,
+			[nameof(ISearchBar.CursorPosition)] = MapCursorPosition,
+			[nameof(ISearchBar.SelectionLength)] = MapSelectionLength,
 			[nameof(ISearchBar.CancelButtonColor)] = MapCancelButtonColor,
 			[nameof(ISearchBar.SearchIconColor)] = MapSearchIconColor,
 			[nameof(ISearchBar.Keyboard)] = MapKeyboard,

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -139,6 +139,18 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateIsReadOnly(searchBar);
 		}
 
+		// make it public in .net 11
+		internal static void MapCursorPosition(ISearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.QueryEditor?.UpdateCursorPosition(searchBar);
+		}
+
+		// make it public in .net 11
+		internal static void MapSelectionLength(ISearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.QueryEditor?.UpdateSelectionLength(searchBar);
+		}
+
 		public static void MapCancelButtonColor(ISearchBarHandler handler, ISearchBar searchBar)
 		{
 			handler.PlatformView?.UpdateCancelButton(searchBar);
@@ -185,6 +197,7 @@ namespace Microsoft.Maui.Handlers
 				platformView.ShouldChangeTextInRange += ShouldChangeText;
 				platformView.OnEditingStarted += OnEditingStarted;
 				platformView.OnEditingStopped += OnEditingStopped;
+				platformView.SelectionChanged += OnSelectionChanged;
 
 				if (handler.QueryEditor is UITextField editor)
 					editor.EditingChanged += OnEditingChanged;
@@ -202,6 +215,7 @@ namespace Microsoft.Maui.Handlers
 				platformView.OnMovedToWindow -= OnMovedToWindow;
 				platformView.OnEditingStarted -= OnEditingStarted;
 				platformView.OnEditingStopped -= OnEditingStopped;
+				platformView.SelectionChanged -= OnSelectionChanged;
 
 				if (editor is not null)
 					editor.EditingChanged -= OnEditingChanged;
@@ -255,7 +269,7 @@ namespace Microsoft.Maui.Handlers
 
 			void OnEditingChanged(object? sender, EventArgs e)
 			{
-				if (sender is UITextField textField && VirtualView is ISearchBar virtualView)
+				if (Handler?.QueryEditor is UITextField textField && VirtualView is ISearchBar virtualView)
 				{
 					virtualView.UpdateText(textField.Text);
 				}
@@ -263,6 +277,29 @@ namespace Microsoft.Maui.Handlers
 				if (Handler is SearchBarHandler handler)
 				{
 					handler.UpdateCancelButtonVisibility();
+				}
+			}
+
+			void OnSelectionChanged(object? sender, EventArgs e)
+			{
+				if (Handler is SearchBarHandler handler && VirtualView is ISearchBar virtualView)
+				{
+					var editor = handler.QueryEditor;
+					if (editor != null && editor.SelectedTextRange != null && editor.IsFirstResponder)
+					{
+						var cursorPosition = editor.GetCursorPosition();
+						var selectedTextLength = editor.GetSelectedTextLength();
+
+						if (virtualView.CursorPosition != cursorPosition)
+						{
+							virtualView.CursorPosition = cursorPosition;
+						}
+
+						if (virtualView.SelectionLength != selectedTextLength)
+						{
+							virtualView.SelectionLength = selectedTextLength;
+						}
+					}
 				}
 			}
 

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -292,7 +292,10 @@ namespace Microsoft.Maui.Platform
 					{
 						if (editText.IsAlive())
 						{
-							editText.SetSelection(start, end);
+							var length = editText.Length();
+							var clampedStart = Math.Min(start, length);
+							var clampedEnd = Math.Min(end, length);
+							editText.SetSelection(clampedStart, clampedEnd);
 						}
 					});
 				}
@@ -329,9 +332,15 @@ namespace Microsoft.Maui.Platform
 			int end = Math.Max(start, Math.Min(editText.Length(), start + selectionLength));
 			int newSelectionLength = Math.Max(0, end - start);
 
-			// If 'start > editText.SelectionEnd', it indicates a reverse selection (right-to-left selection),
-			// where the user selected text starting from the right and moving to the left.
-			if (start > editText.SelectionEnd && selectionLength > 0)
+			// When the native EditText has a right-to-left selection (anchor > extent) that
+			// exactly matches our start position and requested length, preserve the native
+			// selection end to maintain the selection direction. We verify the native state
+			// matches to avoid using stale values (e.g., during initial focus when
+			// SelectionEnd is 0 and SelectionStart hasn't been updated yet).
+			if (selectionLength > 0 &&
+				start > editText.SelectionEnd &&
+				editText.SelectionStart == start &&
+				(start - editText.SelectionEnd) == selectionLength)
 			{
 				end = editText.SelectionEnd;
 				newSelectionLength = selectionLength;

--- a/src/Core/src/Platform/iOS/MauiSearchBar.cs
+++ b/src/Core/src/Platform/iOS/MauiSearchBar.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiSearchBar : UISearchBar, IUIViewLifeCycleEvents
 	{
+		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Proven safe: delegate is cleared in WillMoveToWindow(null) before view is released")]
+		SearchEditorDelegate? _searchEditorDelegate;
+
 		public MauiSearchBar() : this(RectangleF.Empty)
 		{
 		}
@@ -56,6 +59,11 @@ namespace Microsoft.Maui.Platform
 		internal event EventHandler? OnMovedToWindow;
 		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
 		internal event EventHandler? EditingChanged;
+		// Fires whenever the cursor position or text selection changes in the search field,
+		// including user-initiated cursor repositioning (tap, long-press) and keyboard navigation.
+		// Mirrors the MauiTextField.SelectionChanged pattern for Entry.
+		[UnconditionalSuppressMessage("Memory", "MEM0001", Justification = "Proven safe in test: MemoryTests.HandlerDoesNotLeak")]
+		internal event EventHandler? SelectionChanged;
 
 		public override void WillMoveToWindow(UIWindow? window)
 		{
@@ -66,8 +74,18 @@ namespace Microsoft.Maui.Platform
 			if (editor != null)
 			{
 				editor.EditingChanged -= OnEditingChanged;
+				editor.Delegate = null!; // UITextField.Delegate binding is non-nullable, but the underlying ObjC property accepts nil to clear the delegate
+				_searchEditorDelegate = null;
+
 				if (window != null)
+				{
 					editor.EditingChanged += OnEditingChanged;
+					// UISearchBar manages its behavior via UISearchBarDelegate (separate hierarchy from
+					// UITextFieldDelegate). Setting our own delegate on the internal editor is safe;
+					// we only observe DidChangeSelection without interfering with search bar behavior.
+					_searchEditorDelegate = new SearchEditorDelegate(this);
+					editor.Delegate = _searchEditorDelegate;
+				}
 			}
 
 			if (window != null)
@@ -78,6 +96,27 @@ namespace Microsoft.Maui.Platform
 		void OnEditingChanged(object? sender, EventArgs e)
 		{
 			EditingChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		// Delegate that detects selection/cursor changes on the internal UITextField.
+		// UITextFieldDelegate.DidChangeSelection (iOS 13+) fires for tap-to-reposition,
+		// long-press selection, keyboard arrow navigation, and text input.
+		class SearchEditorDelegate : UITextFieldDelegate
+		{
+			readonly WeakReference<MauiSearchBar> _owner;
+
+			public SearchEditorDelegate(MauiSearchBar owner)
+			{
+				_owner = new(owner);
+			}
+
+			public override void DidChangeSelection(UITextField textField)
+			{
+				if (_owner.TryGetTarget(out var owner))
+				{
+					owner.SelectionChanged?.Invoke(owner, EventArgs.Empty);
+				}
+			}
 		}
 
 		[UnconditionalSuppressMessage("Memory", "MEM0002", Justification = IUIViewLifeCycleEvents.UnconditionalSuppressMessage)]

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -384,5 +384,81 @@ namespace Microsoft.Maui.Platform
 		{
 			uiSearchBar.ReturnKeyType = searchBar.ReturnType.ToPlatform();
 		}
+
+		internal static void UpdateCursorPosition(this UITextField textField, ISearchBar searchBar)
+		{
+			var selectedTextRange = textField.SelectedTextRange;
+			if (selectedTextRange is null)
+			{
+				return;
+			}
+
+			if (textField.GetOffsetFromPosition(textField.BeginningOfDocument, selectedTextRange.Start) != searchBar.CursorPosition)
+			{
+				UpdateCursorSelection(textField, searchBar);
+			}
+		}
+
+		internal static void UpdateSelectionLength(this UITextField textField, ISearchBar searchBar)
+		{
+			var selectedTextRange = textField.SelectedTextRange;
+			if (selectedTextRange is null)
+			{
+				return;
+			}
+
+			if (textField.GetOffsetFromPosition(selectedTextRange.Start, selectedTextRange.End) != searchBar.SelectionLength)
+			{
+				UpdateCursorSelection(textField, searchBar);
+			}
+		}
+
+		// Updates the UITextField.SelectedTextRange based on ISearchBar.CursorPosition and ISearchBar.SelectionLength.
+		static void UpdateCursorSelection(this UITextField textField, ISearchBar searchBar)
+		{
+			if (searchBar.IsReadOnly)
+			{
+				return;
+			}
+
+			// Capture current values to avoid reading stale values after async dispatch
+			int cursorPosition = searchBar.CursorPosition;
+			int selectionLength = searchBar.SelectionLength;
+
+			void UpdateSelection()
+			{
+				if (textField is not null && textField.Handle != IntPtr.Zero)
+				{
+					UITextPosition start = GetSelectionStart(textField, cursorPosition, out int startOffset);
+					UITextPosition end = GetSelectionEnd(textField, start, startOffset, selectionLength);
+					textField.SelectedTextRange = textField.GetTextRange(start, end);
+				}
+			}
+
+			if (searchBar.IsFocused)
+			{
+				CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(UpdateSelection);
+			}
+			else
+			{
+				UpdateSelection();
+			}
+		}
+
+		static UITextPosition GetSelectionStart(this UITextField textField, int cursorPosition, out int startOffset)
+		{
+			int textLength = textField.Text?.Length ?? 0;
+
+			startOffset = Math.Max(0, Math.Min(textLength, cursorPosition));
+			return textField.GetPosition(textField.BeginningOfDocument, startOffset) ?? textField.BeginningOfDocument;
+		}
+
+		static UITextPosition GetSelectionEnd(UITextField textField, UITextPosition start, int startOffset, int selectionLength)
+		{
+			int textLength = textField.Text?.Length ?? 0;
+			int endOffset = Math.Max(startOffset, Math.Min(textLength, startOffset + selectionLength));
+			var end = textField.GetPosition(start, endOffset - startOffset);
+			return end ?? start;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -3,10 +3,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Android.Text;
 using Android.Text.Method;
+using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 using AColor = Android.Graphics.Color;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
@@ -14,6 +16,108 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarHandlerTests
 	{
+		// Regression tests for https://github.com/dotnet/maui/issues/30779
+		// SearchBar.CursorPosition and SelectionLength were not updated when the user typed
+
+		[Fact(DisplayName = "CursorPosition Updates After SetQuery (Issue 30779)")]
+		public async Task CursorPositionUpdatesAfterSetQuery()
+		{
+			var searchBar = new SearchBarStub();
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				// Simulate user typing by calling the native SetQuery method
+				var searchView = GetNativeSearchBar(handler);
+				searchView.SetQuery("Hello", false);
+
+				// The fix uses Post() to defer cursor reads (SearchView timing quirk: setQuery()
+				// calls setText() before setSelection()). Wait for the deferred update.
+				await AssertEventually(() => searchBar.CursorPosition == 5);
+			});
+
+			// After SetQuery("Hello"), cursor should be at position 5 (end of text),
+			// not stuck at 0 as it was before the fix
+			Assert.Equal(5, searchBar.CursorPosition);
+		}
+
+		[Fact(DisplayName = "SelectionLength Updates When Text Is Selected Natively (Issue 30779)")]
+		public async Task SelectionLengthUpdatesWhenTextIsSelectedNatively()
+		{
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				var control = GetNativeSearchBar(handler);
+				var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
+
+				// Simulate a native selection gesture: set native selection then trigger
+				// the handler's selection-change reader (mirrors what touch/key listeners do).
+				editText?.SetSelection(0, 5);
+				handler.OnQueryEditorSelectionChanged();
+
+				// The fix uses Post() to defer cursor reads; wait for the deferred update.
+				await AssertEventually(() => searchBar.SelectionLength == 5);
+			});
+
+			// Selection of 5 characters starting at position 0 should be reflected in the VirtualView
+			Assert.Equal(0, searchBar.CursorPosition);
+			Assert.Equal(5, searchBar.SelectionLength);
+		}
+
+		[Fact(DisplayName = "CursorPosition Set Programmatically Updates Native Cursor (Issue 30779)")]
+		public async Task CursorPositionSetProgrammaticallyUpdatesNativeCursor()
+		{
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				var control = GetNativeSearchBar(handler);
+				var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
+
+				// Set cursor position via MAUI property (programmatic MAUI → native direction).
+				// UpdateCursorSelection uses Post() when EditText is focused, deferring SetSelection
+				// to the next UI cycle — use AssertEventually to wait for it.
+				searchBar.CursorPosition = 3;
+				SearchBarHandler.MapCursorPosition(handler, searchBar);
+
+				await AssertEventually(() => editText?.SelectionStart == 3);
+			});
+		}
+
+		[Fact(DisplayName = "SelectionLength Updates When Text Is Selected Via Keyboard (Issue 30779)")]
+		public async Task SelectionLengthUpdatesWhenTextIsSelectedViaKeyboard()
+		{
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				var control = GetNativeSearchBar(handler);
+				var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
+
+				// Simulate Shift+Arrow keyboard selection:
+				// 1. Set the native selection as if the user had selected with Shift+Arrow
+				editText?.SetSelection(0, 5);
+
+				// 2. Dispatch a DpadRight KEY_UP which triggers QueryEditorKeyListener.
+				//    The listener checks IsNavigationKey() — arrow/Home/End/PageUp/Down are
+				//    the keys that actually fire OnQueryEditorSelectionChanged(). Modifier-only
+				//    keys like ShiftLeft are intentionally ignored by the listener.
+				//    Using only KEY_UP (no preceding KEY_DOWN) means the EditText won't
+				//    modify the selection; our listener just reads the current state.
+				if (editText != null)
+				{
+					var keyEvent = new KeyEvent(KeyEventActions.Up, Keycode.DpadRight);
+					editText.DispatchKeyEvent(keyEvent);
+				}
+
+				// QueryEditorKeyListener.OnKey fires on ACTION_UP and schedules a Post() read.
+				await AssertEventually(() => searchBar.SelectionLength == 5);
+			});
+
+			Assert.Equal(0, searchBar.CursorPosition);
+			Assert.Equal(5, searchBar.SelectionLength);
+		}
+
 		[Fact(DisplayName = "ReturnType Initializes Correctly")]
 		public async Task ReturnTypeInitializesCorrectly()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Windows.cs
@@ -9,6 +9,72 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarHandlerTests
 	{
+		// Regression tests for https://github.com/dotnet/maui/issues/30779
+		// SearchBar.CursorPosition and SelectionLength were not updated when the user typed
+
+		[Fact(DisplayName = "CursorPosition Updates After Setting Native Text (Issue 30779)")]
+		public async Task CursorPositionUpdatesAfterSettingNativeText()
+		{
+			var searchBar = new SearchBarStub();
+			int virtualViewCursorPosition = -1;
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				await AssertEventually(() => handler.PlatformView.IsLoaded());
+
+				// Simulate user typing by setting text on the native AutoSuggestBox
+				GetNativeSearchBar(handler).Text = "Hello";
+
+				// Wait for the SelectionChanged event to propagate back to the VirtualView.
+				// On Windows the update is synchronous, but AssertEventually is used as a
+				// safety net in case of any scheduling differences in the test environment.
+				await AssertEventually(() => searchBar.CursorPosition == 5,
+					message: "CursorPosition should update to 5 after setting native text to 'Hello'");
+
+				virtualViewCursorPosition = searchBar.CursorPosition;
+			});
+
+			// After setting "Hello", cursor should be at position 5 (end of text),
+			// not stuck at 0 as it was before the fix
+			Assert.Equal(5, virtualViewCursorPosition);
+		}
+
+		[Fact(DisplayName = "SelectionLength Updates When Text Is Selected Natively (Issue 30779)")]
+		public async Task SelectionLengthUpdatesWhenTextIsSelectedNatively()
+		{
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+			int virtualSelectionLength = -1;
+			int virtualCursorPosition = -1;
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				await AssertEventually(() => handler.PlatformView.IsLoaded());
+
+				var platformSearchBar = GetNativeSearchBar(handler);
+				var textBox = platformSearchBar.GetFirstDescendant<TextBox>();
+
+				// The inner TextBox must exist after the AutoSuggestBox is loaded
+				Assert.NotNull(textBox);
+
+				// Programmatically select the word "Hello" (chars 0–5)
+				textBox.SelectionStart = 0;
+				textBox.SelectionLength = 5;
+
+				// Wait for the SelectionChanged event to propagate back to the VirtualView.
+				// On Windows the update is synchronous, but AssertEventually is used as a
+				// safety net in case of any scheduling differences in the test environment.
+				await AssertEventually(() => searchBar.SelectionLength == 5,
+					message: "SelectionLength should update to 5 after selecting text natively");
+
+				virtualSelectionLength = searchBar.SelectionLength;
+				virtualCursorPosition = searchBar.CursorPosition;
+			});
+
+			// Selection of 5 characters starting at position 0 should be reflected in the VirtualView
+			Assert.Equal(0, virtualCursorPosition);
+			Assert.Equal(5, virtualSelectionLength);
+		}
+
 		[Theory(DisplayName = "CancelButtonColor Initializes Correctly")]
 		[InlineData(0xFFFF0000)]
 		[InlineData(0xFF00FF00)]

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -498,6 +498,33 @@ namespace Microsoft.Maui.DeviceTests
 
 			protected override void UpdateCursorStartPosition(SearchBarHandler searchBarHandler, int position) =>
 				SearchBarHandlerTests.UpdateCursorStartPosition(searchBarHandler, position);
+
+			// Regression test for https://github.com/dotnet/maui/issues/30779
+			// SearchBar.CursorPosition was not updated when the user typed (native text changed)
+			[Fact(DisplayName = "CursorPosition Updates After Typing Via Native Input")]
+			public async Task CursorPositionUpdatesAfterTypingViaNativeInput()
+			{
+				var searchBar = new SearchBarStub();
+
+				await AttachAndRun(searchBar, async (handler) =>
+				{
+#if IOS || MACCATALYST
+					// On iOS/Mac, CursorPosition only updates when the SearchBar is focused
+					// (IsFirstResponder = true). Focus the QueryEditor before setting text
+					// to simulate the real user flow: tap → type.
+					handler.QueryEditor.BecomeFirstResponder();
+#endif
+					// Simulate user typing by setting text via the native platform method
+					SetNativeText(handler, "Hello");
+
+					// On Android the fix uses Post() to defer cursor reads; wait for it.
+					// On iOS/Windows the update fires via DidChangeSelection on the focused field.
+					await AssertEventually(() => searchBar.CursorPosition == 5);
+				});
+
+				// After typing "Hello" (5 chars), the cursor should be at the end
+				Assert.Equal(5, searchBar.CursorPosition);
+			}
 		}
 
 		// TODO: only iOS is working with the search bar focus tests

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -7,11 +7,141 @@ using Microsoft.Maui.Hosting;
 using ObjCRuntime;
 using UIKit;
 using Xunit;
+using static Microsoft.Maui.DeviceTests.AssertHelpers;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarHandlerTests
 	{
+		// Regression tests for https://github.com/dotnet/maui/issues/30779
+		// SearchBar.CursorPosition and SelectionLength were not updated when the user typed
+
+		[Fact(DisplayName = "CursorPosition Updates When SearchBar Gains Focus (Issue 30779)")]
+		public async Task CursorPositionUpdatesWhenSearchBarGainsFocus()
+		{
+			// The actual issue #30779 scenario: user taps SearchBar to focus it,
+			// which causes UIKit to position cursor at end of existing text.
+			// DidChangeSelection fires → CursorPosition should update to text.Length.
+			// Before the fix (no DidChangeSelection handler), CursorPosition stayed at 0.
+			var searchBar = new SearchBarStub { Text = "Hello" };
+
+			await AttachAndRun(searchBar, async (handler) =>
+			{
+				// Simulate user tapping the SearchBar to focus it
+				handler.QueryEditor.BecomeFirstResponder();
+
+				// UIKit fires DidChangeSelection after focus; OnSelectionChanged should update CursorPosition.
+				await AssertEventually(() => searchBar.CursorPosition == 5);
+			});
+
+			// Cursor should be at position 5 (end of "Hello") after focus
+			Assert.Equal(5, searchBar.CursorPosition);
+		}
+
+		[Fact(DisplayName = "CursorPosition Does Not Change When Text Set Programmatically Without Focus (Issue 30779)")]
+		public async Task CursorPositionDoesNotChangeWhenTextSetProgrammaticallyWithoutFocus()
+		{
+			// Verifies the CORRECT behavior: programmatic UISearchBar.Text change on an
+			// unfocused SearchBar must NOT update CursorPosition. The user may have
+			// intentionally positioned the cursor somewhere; a background data-binding
+			// update should not silently reset it.
+			var searchBar = new SearchBarStub();
+			// CursorPosition default is 0; it must remain 0 after programmatic text set
+
+			await AttachAndRun(searchBar, (handler) =>
+			{
+				// Set text programmatically — SearchBar is NOT focused (not first responder)
+				GetNativeSearchBar(handler).Text = "Hello";
+
+				// Cursor position must stay at 0; it should NOT jump to 5
+				Assert.Equal(0, searchBar.CursorPosition);
+			});
+
+			Assert.Equal(0, searchBar.CursorPosition);
+		}
+
+		[Fact(DisplayName = "SelectionLength Updates When Text Is Selected Natively (Issue 30779)")]
+		public async Task SelectionLengthUpdatesWhenTextIsSelectedNatively()
+		{
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+			int virtualSelectionLength = -1;
+			int virtualCursorPosition = -1;
+
+			await AttachAndRun(searchBar, (handler) =>
+			{
+				var control = handler.QueryEditor;
+				// Must be focused: OnSelectionChanged only updates cursor/selection when IsFirstResponder.
+				control.BecomeFirstResponder();
+
+				// Select the word "Hello" (chars 0–5)
+				var startPosition = control.GetPosition(control.BeginningOfDocument, 0);
+				var endPosition = control.GetPosition(control.BeginningOfDocument, 5);
+				// SelectedTextRange assignment fires DidChangeSelection synchronously
+				control.SelectedTextRange = control.GetTextRange(startPosition, endPosition);
+
+				virtualSelectionLength = searchBar.SelectionLength;
+				virtualCursorPosition = searchBar.CursorPosition;
+			});
+
+			// Selection of 5 characters starting at position 0 should be reflected in the VirtualView
+			Assert.Equal(0, virtualCursorPosition);
+			Assert.Equal(5, virtualSelectionLength);
+		}
+
+		[Fact(DisplayName = "CursorPosition Updates When Cursor Is Repositioned Without Text Change (Issue 30779)")]
+		public async Task CursorPositionUpdatesWhenRepositionedWithoutTextChange()
+		{
+			// Verifies: manually re-positioning the cursor updates CursorPosition (the gap fixed for iOS)
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+			int cursorAfterReposition = -1;
+
+			await AttachAndRun(searchBar, (handler) =>
+			{
+				var control = handler.QueryEditor;
+				// Must be focused: OnSelectionChanged only updates cursor when IsFirstResponder.
+				control.BecomeFirstResponder();
+
+				// Move cursor to position 5 (between "Hello" and " World"), no text change
+				var pos = control.GetPosition(control.BeginningOfDocument, 5);
+				// SelectedTextRange assignment fires DidChangeSelection synchronously
+				control.SelectedTextRange = control.GetTextRange(pos, pos);
+
+				cursorAfterReposition = searchBar.CursorPosition;
+			});
+
+			// Cursor should be at position 5 (no text was typed, just repositioned)
+			Assert.Equal(5, cursorAfterReposition);
+		}
+
+		[Fact(DisplayName = "SelectionLength And CursorPosition Both Update On Text Selection (Issue 30779)")]
+		public async Task SelectionLengthAndCursorPositionBothUpdateOnSelection()
+		{
+			// Verifies: selection length gets the correct selected value (the gap fixed for iOS)
+			var searchBar = new SearchBarStub { Text = "Hello World" };
+			int cursorAfterSelect = -1;
+			int selectionAfterSelect = -1;
+
+			await AttachAndRun(searchBar, (handler) =>
+			{
+				var control = handler.QueryEditor;
+				// Must be focused: OnSelectionChanged only updates cursor/selection when IsFirstResponder.
+				control.BecomeFirstResponder();
+
+				// Select " World" (6 chars starting at position 5)
+				var start = control.GetPosition(control.BeginningOfDocument, 5);
+				var end = control.GetPosition(control.BeginningOfDocument, 11);
+				// SelectedTextRange assignment fires DidChangeSelection synchronously
+				control.SelectedTextRange = control.GetTextRange(start, end);
+
+				cursorAfterSelect = searchBar.CursorPosition;
+				selectionAfterSelect = searchBar.SelectionLength;
+			});
+
+			Assert.Equal(5, cursorAfterSelect);
+			Assert.Equal(6, selectionAfterSelect);
+		}
+
+
 		[Theory(DisplayName = "Gradient Background Initializes Correctly")]
 		[InlineData(0xFFFF0000, 0xFFFE2500)]
 		[InlineData(0xFF00FF00, 0xFF04F800)]


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
SearchBar.CursorPosition and SelectionLength properties don't work correctly.


### Root Cause
**Android:**
QueryEditor is implemented using SearchView.SearchAutoComplete instead of MauiAppCompatEditText. Because of this, it does not expose a SelectionChanged event, and the handler was not tracking cursor or selection updates.

**iOS / MacCatalyst:**
The TextFieldEditingChanged handler updated VirtualView.Text, but it did not read back the CursorPosition or SelectionLength from the native UITextField, resulting in the virtual view not being synchronized with the platform cursor state.

**Windows:**
AutoSuggestBox internally wraps a TextBox. The handler did not subscribe to the inner TextBox.SelectionChanged event, so cursor and selection updates were not propagated to the VirtualView.

 
### Description of Change
**Android:**

- Added QueryEditorTouchListener to read the cursor position on ACTION_UP.
- Added QueryEditorKeyListener to read the cursor position on key ACTION_UP.
- OnQueryTextChange now invokes OnQueryEditorSelectionChanged(), which posts a deferred read of GetCursorPosition() and GetSelectedTextLength()
- Implemented MapCursorPosition and MapSelectionLength mappers that delegate to QueryEditor.UpdateCursorPosition and QueryEditor.UpdateSelectionLength.
- Updated EditTextExtensions.UpdateCursorSelection to wrap SetSelection in a Post() when the control is focused, preventing race conditions with SearchView.setQuery().
- Updated GetSelectedTextLength() to use Math.Abs() to correctly handle RTL selections.
- 

**iOS / MacCatalyst:**

- Added property mappers to synchronize cursor and selection values from the VirtualView to the platform editor. These mappers ensure that when CursorPosition or SelectionLength changes on the SearchBar, the corresponding values are updated on the underlying UITextField.
- Introduced SearchEditorDelegate (UITextFieldDelegate) with DidChangeSelection override to detect cursor repositioning and selection changes.
- In WillMoveToWindow, assign the delegate when attached to the window and clear it when removed.
- Handler proxy subscribes to platformView.SelectionChanged → OnSelectionChanged, following the pattern used in EntryHandler.iOS.
- Added MapCursorPosition and MapSelectionLength to update the native editor using SetTextRange().
-

**Windows:**

- In the OnGotFocus handler (after PlatformView is loaded), locate the inner TextBox using GetFirstDescendant<TextBox>().
- Subscribe to TextBox.SelectionChanged.
- OnPlatformSelectionChanged reads _queryTextBox.GetCursorPosition() and _queryTextBox.SelectionLength and syncs them to VirtualView.
- DisconnectHandler now unsubscribes from the event and clears _queryTextBox.
- Added MapCursorPosition and MapSelectionLength that delegate to _queryTextBox.UpdateCursorPosition and _queryTextBox.UpdateSelectionLength.


### Validated the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Issues Fixed:
Fixes #30779 

### Screenshots

| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/8a62a1b1-cfab-4e89-a4a6-07094b62ba19"> |   <video src="https://github.com/user-attachments/assets/275fa165-59ed-4e98-b45c-2b445789ee2e">  |