### PR TITLE
[Android] GraphicsView: prevent TapGesture crash when previous touch points are empty

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34296.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34296.cs
@@ -1,0 +1,72 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34296, "TapGestureRecognizer on GraphicsView causes a crash on Android devices", PlatformAffected.Android)]
+public class Issue34296 : ContentPage
+{
+	readonly Label _statusLabel;
+	int _tapCount;
+
+	public Issue34296()
+	{
+		_statusLabel = new Label
+		{
+			AutomationId = "Issue34296StatusLabel",
+			Text = "TapCount:0"
+		};
+
+		var graphicsView = new GraphicsView
+		{
+			AutomationId = "Issue34296GraphicsView",
+			WidthRequest = 200,
+			HeightRequest = 200,
+			Drawable = new Issue34296Drawable(),
+			BackgroundColor = Colors.Transparent
+		};
+
+		var tapGesture = new TapGestureRecognizer
+		{
+			NumberOfTapsRequired = 1
+		};
+
+		tapGesture.Tapped += OnGraphicsViewTapped;
+		graphicsView.GestureRecognizers.Add(tapGesture);
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(20),
+			Children =
+			{
+				_statusLabel,
+				graphicsView
+			}
+		};
+	}
+
+	void OnGraphicsViewTapped(object sender, TappedEventArgs e)
+	{
+#if ANDROID
+		if (sender is GraphicsView graphicsView &&
+			graphicsView.Handler?.PlatformView is Microsoft.Maui.Platform.PlatformTouchGraphicsView platformView)
+		{
+			platformView.TouchesBegan(Array.Empty<PointF>());
+			platformView.TouchesMoved(new[] { new PointF(10, 10) });
+		}
+#endif
+
+		_tapCount++;
+		_statusLabel.Text = $"TapCount:{_tapCount}";
+	}
+}
+
+class Issue34296Drawable : IDrawable
+{
+	public void Draw(ICanvas canvas, RectF dirtyRect)
+	{
+		var size = Math.Min(dirtyRect.Width, dirtyRect.Height);
+		var radius = size / 2;
+		var center = new PointF(radius, radius);
+
+		canvas.FillColor = Colors.Purple;
+		canvas.FillCircle(center, radius);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34296.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34296.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34296 : _IssuesUITest
+{
+	public override string Issue => "TapGestureRecognizer on GraphicsView causes a crash on Android devices";
+
+	public Issue34296(TestDevice device) : base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.GraphicsView)]
+	public void TapGestureOnGraphicsViewShouldNotCrash()
+	{
+		App.WaitForElement("Issue34296StatusLabel");
+		App.WaitForElement("Issue34296GraphicsView");
+
+		App.Tap("Issue34296GraphicsView");
+		App.WaitForElement("Issue34296StatusLabel");
+
+		App.Tap("Issue34296GraphicsView");
+
+		var statusText = App.FindElement("Issue34296StatusLabel").GetText();
+		Assert.That(statusText, Is.EqualTo("TapCount:2"));
+	}
+}

--- a/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (!_dragStarted)
 			{
-				if (points.Length == 1)
+				if (_lastMovedViewPoints.Length > 0)
 				{
 					float deltaX = _lastMovedViewPoints[0].X - points[0].X;
 					float deltaY = _lastMovedViewPoints[0].Y - points[0].Y;


### PR DESCRIPTION
   ## Summary
   
   Fixes an Android crash path in `PlatformTouchGraphicsView.TouchesMoved` when previous touch points can be empty.
   
   - Updated `src/Core/src/Platform/Android/PlatformTouchGraphicsView.cs`
     - Changed guard from `points.Length == 1` to `_lastMovedViewPoints.Length > 0` before reading `_lastMovedViewPoints[0]`.
   
   ## Tests
   
   Added/updated Issue34296 UI test coverage:
   
   - `src/Controls/tests/TestCases.HostApp/Issues/Issue34296.cs`
   - `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34296.cs`
   
   Test verifies tapping the `GraphicsView` twice updates the status label to `TapCount:2` and does not crash.
   
   ## Local Validation
   
   ```bash
   ./.dotnet/dotnet tool run pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue34296"
   ```

  Result: ✅ All tests passed (SUCCESS) on Android

   ## Issues fixed
  Fixes #34296 
  
 ## Platforms Affected
- ✅  Android