### PR TITLE
Windows: Fix PanGestureRecognizer not starting when drag begins near control edge

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Windows.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			SwipeComplete(true);
 
-			if (!_isPanning)
+			if (!_isPanning && !_isPinching && !_isSwiping)
 			{
 				_fingers.Remove(e.Pointer.PointerId);
 			}


### PR DESCRIPTION
Fixes #34119

When dragging from the edge of a control on Windows, `PointerExited` can fire before the manipulation begins.

In this scenario the pointer ID is removed from the `_fingers` collection before `HandlePan` runs, resulting in `_fingers.Count == 0`. Since `PanGestureRecognizer` typically expects `TouchPoints == 1`, the recognizer never matches and `PanUpdated` is not raised.

This change prevents removing the pointer prematurely when a gesture interaction has not fully completed, ensuring `_fingers` remains consistent until the gesture lifecycle finishes.

After this change, dragging from the edge of a control correctly triggers `PanUpdated` as expected.

### Tested

Reproduced using a simple `AbsoluteLayout` with a draggable view and `PanGestureRecognizer`.

Before fix:
- Starting the drag from the edge of the control sometimes prevented `PanUpdated` from firing.

After fix:
- `PanUpdated` fires consistently when dragging from any part of the control, including edges.