### PR TITLE
Windows: Ensure layouts without background participate in hit testing

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
@@ -26,7 +26,6 @@ public class Issue32279 : TestContentPage
 			WidthRequest = 300,
 		};
 
-		// 👉 Tap target REAL (Appium sí lo puede tocar)
 		var tapLabelNoBackground = new Label
 		{
 			Text = "Tap me (no background)",
@@ -59,7 +58,6 @@ public class Issue32279 : TestContentPage
 			BackgroundColor = Colors.LightGray,
 		};
 
-		// 👉 Tap target REAL
 		var tapLabelWithBackground = new Label
 		{
 			Text = "Tap me (with background)",

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
@@ -1,0 +1,87 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32279, "TapGestureRecognizer does not work on layouts without a Background on Windows", PlatformAffected.UWP)]
+public class Issue32279 : TestContentPage
+{
+	const string TapTargetNoBackground = "TapTargetNoBackground";
+	const string TapTargetWithBackground = "TapTargetWithBackground";
+	const string ResultLabelNoBackground = "ResultLabelNoBackground";
+	const string ResultLabelWithBackground = "ResultLabelWithBackground";
+
+	protected override void Init()
+	{
+		var layout = new StackLayout { Spacing = 20, Padding = new Thickness(20) };
+
+		// Grid with NO background
+		var resultLabelNoBackground = new Label
+		{
+			AutomationId = ResultLabelNoBackground,
+			Text = "Waiting",
+			FontSize = 18,
+		};
+
+		var gridNoBackground = new Grid
+		{
+			HeightRequest = 100,
+			WidthRequest = 300,
+		};
+
+		// 👉 Tap target REAL (Appium sí lo puede tocar)
+		var tapLabelNoBackground = new Label
+		{
+			Text = "Tap me (no background)",
+			AutomationId = TapTargetNoBackground,
+			VerticalOptions = LayoutOptions.Fill,
+			HorizontalOptions = LayoutOptions.Fill,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+		};
+
+		gridNoBackground.Children.Add(tapLabelNoBackground);
+
+		gridNoBackground.GestureRecognizers.Add(new TapGestureRecognizer
+		{
+			Command = new Command(() => resultLabelNoBackground.Text = "Tapped"),
+		});
+
+		// Grid WITH explicit background
+		var resultLabelWithBackground = new Label
+		{
+			AutomationId = ResultLabelWithBackground,
+			Text = "Waiting",
+			FontSize = 18,
+		};
+
+		var gridWithBackground = new Grid
+		{
+			HeightRequest = 100,
+			WidthRequest = 300,
+			BackgroundColor = Colors.LightGray,
+		};
+
+		// 👉 Tap target REAL
+		var tapLabelWithBackground = new Label
+		{
+			Text = "Tap me (with background)",
+			AutomationId = TapTargetWithBackground,
+			VerticalOptions = LayoutOptions.Fill,
+			HorizontalOptions = LayoutOptions.Fill,
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+		};
+
+		gridWithBackground.Children.Add(tapLabelWithBackground);
+
+		gridWithBackground.GestureRecognizers.Add(new TapGestureRecognizer
+		{
+			Command = new Command(() => resultLabelWithBackground.Text = "Tapped"),
+		});
+
+		layout.Children.Add(gridNoBackground);
+		layout.Children.Add(resultLabelNoBackground);
+		layout.Children.Add(gridWithBackground);
+		layout.Children.Add(resultLabelWithBackground);
+
+		Content = layout;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
@@ -12,7 +12,7 @@ public class Issue32279 : TestContentPage
 	{
 		var layout = new StackLayout { Spacing = 20, Padding = new Thickness(20) };
 
-		// Grid with NO background
+		// ContentView with NO background
 		var resultLabelNoBackground = new Label
 		{
 			AutomationId = ResultLabelNoBackground,
@@ -20,30 +20,27 @@ public class Issue32279 : TestContentPage
 			FontSize = 18,
 		};
 
-		var gridNoBackground = new Grid
+		var contentViewNoBackground = new ContentView
 		{
 			HeightRequest = 100,
 			WidthRequest = 300,
+			Content = new Label
+			{
+				Text = "Tap me (no background)",
+				AutomationId = TapTargetNoBackground,
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center,
+			}
 		};
 
-		var tapLabelNoBackground = new Label
-		{
-			Text = "Tap me (no background)",
-			AutomationId = TapTargetNoBackground,
-			VerticalOptions = LayoutOptions.Fill,
-			HorizontalOptions = LayoutOptions.Fill,
-			HorizontalTextAlignment = TextAlignment.Center,
-			VerticalTextAlignment = TextAlignment.Center,
-		};
-
-		gridNoBackground.Children.Add(tapLabelNoBackground);
-
-		gridNoBackground.GestureRecognizers.Add(new TapGestureRecognizer
+		contentViewNoBackground.GestureRecognizers.Add(new TapGestureRecognizer
 		{
 			Command = new Command(() => resultLabelNoBackground.Text = "Tapped"),
 		});
 
-		// Grid WITH explicit background
+		// ContentView WITH explicit background
 		var resultLabelWithBackground = new Label
 		{
 			AutomationId = ResultLabelWithBackground,
@@ -51,33 +48,30 @@ public class Issue32279 : TestContentPage
 			FontSize = 18,
 		};
 
-		var gridWithBackground = new Grid
+		var contentViewWithBackground = new ContentView
 		{
 			HeightRequest = 100,
 			WidthRequest = 300,
 			BackgroundColor = Colors.LightGray,
+			Content = new Label
+			{
+				Text = "Tap me (with background)",
+				AutomationId = TapTargetWithBackground,
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center,
+			}
 		};
 
-		var tapLabelWithBackground = new Label
-		{
-			Text = "Tap me (with background)",
-			AutomationId = TapTargetWithBackground,
-			VerticalOptions = LayoutOptions.Fill,
-			HorizontalOptions = LayoutOptions.Fill,
-			HorizontalTextAlignment = TextAlignment.Center,
-			VerticalTextAlignment = TextAlignment.Center,
-		};
-
-		gridWithBackground.Children.Add(tapLabelWithBackground);
-
-		gridWithBackground.GestureRecognizers.Add(new TapGestureRecognizer
+		contentViewWithBackground.GestureRecognizers.Add(new TapGestureRecognizer
 		{
 			Command = new Command(() => resultLabelWithBackground.Text = "Tapped"),
 		});
 
-		layout.Children.Add(gridNoBackground);
+		layout.Children.Add(contentViewNoBackground);
 		layout.Children.Add(resultLabelNoBackground);
-		layout.Children.Add(gridWithBackground);
+		layout.Children.Add(contentViewWithBackground);
 		layout.Children.Add(resultLabelWithBackground);
 
 		Content = layout;

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32279.cs
@@ -3,14 +3,18 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 32279, "TapGestureRecognizer does not work on layouts without a Background on Windows", PlatformAffected.UWP)]
 public class Issue32279 : TestContentPage
 {
-	const string TapTargetNoBackground = "TapTargetNoBackground";
-	const string TapTargetWithBackground = "TapTargetWithBackground";
+	const string TapAnchorNoBackground = "TapAnchorNoBackground";
+	const string TapAnchorWithBackground = "TapAnchorWithBackground";
 	const string ResultLabelNoBackground = "ResultLabelNoBackground";
 	const string ResultLabelWithBackground = "ResultLabelWithBackground";
 
 	protected override void Init()
 	{
-		var layout = new StackLayout { Spacing = 20, Padding = new Thickness(20) };
+		var layout = new StackLayout
+		{
+			Spacing = 20,
+			Padding = new Thickness(20)
+		};
 
 		// ContentView with NO background
 		var resultLabelNoBackground = new Label
@@ -22,16 +26,15 @@ public class Issue32279 : TestContentPage
 
 		var contentViewNoBackground = new ContentView
 		{
-			HeightRequest = 100,
+			HeightRequest = 200,
 			WidthRequest = 300,
 			Content = new Label
 			{
-				Text = "Tap me (no background)",
-				AutomationId = TapTargetNoBackground,
-				VerticalOptions = LayoutOptions.Fill,
+				Text = "Tap below me (no background)",
+				AutomationId = TapAnchorNoBackground,
+				VerticalOptions = LayoutOptions.Start,
 				HorizontalOptions = LayoutOptions.Fill,
 				HorizontalTextAlignment = TextAlignment.Center,
-				VerticalTextAlignment = TextAlignment.Center,
 			}
 		};
 
@@ -50,17 +53,16 @@ public class Issue32279 : TestContentPage
 
 		var contentViewWithBackground = new ContentView
 		{
-			HeightRequest = 100,
+			HeightRequest = 200,
 			WidthRequest = 300,
 			BackgroundColor = Colors.LightGray,
 			Content = new Label
 			{
-				Text = "Tap me (with background)",
-				AutomationId = TapTargetWithBackground,
-				VerticalOptions = LayoutOptions.Fill,
+				Text = "Tap below me (with background)",
+				AutomationId = TapAnchorWithBackground,
+				VerticalOptions = LayoutOptions.Start,
 				HorizontalOptions = LayoutOptions.Fill,
 				HorizontalTextAlignment = TextAlignment.Center,
-				VerticalTextAlignment = TextAlignment.Center,
 			}
 		};
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32279.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32279.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue32279 : _IssuesUITest
+{
+	public Issue32279(TestDevice device) : base(device) { }
+
+	public override string Issue => "TapGestureRecognizer does not work on layouts without a Background on Windows";
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void TapOnLayoutWithNoBackgroundShouldWork()
+	{
+		App.WaitForElement("TapTargetNoBackground");
+		App.Tap("TapTargetNoBackground");
+		var result = App.FindElement("ResultLabelNoBackground").GetText();
+		Assert.That(result, Is.EqualTo("Tapped"));
+	}
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void TapOnLayoutWithBackgroundShouldWork()
+	{
+		App.WaitForElement("TapTargetWithBackground");
+		App.Tap("TapTargetWithBackground");
+		var result = App.FindElement("ResultLabelWithBackground").GetText();
+		Assert.That(result, Is.EqualTo("Tapped"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32279.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32279.cs
@@ -6,6 +6,11 @@ namespace Microsoft.Maui.TestCases.Tests.Issues;
 
 public class Issue32279 : _IssuesUITest
 {
+	const string TapAnchorNoBackground = "TapAnchorNoBackground";
+	const string TapAnchorWithBackground = "TapAnchorWithBackground";
+	const string ResultLabelNoBackground = "ResultLabelNoBackground";
+	const string ResultLabelWithBackground = "ResultLabelWithBackground";
+
 	public Issue32279(TestDevice device) : base(device) { }
 
 	public override string Issue => "TapGestureRecognizer does not work on layouts without a Background on Windows";
@@ -14,9 +19,13 @@ public class Issue32279 : _IssuesUITest
 	[Category(UITestCategories.Gestures)]
 	public void TapOnLayoutWithNoBackgroundShouldWork()
 	{
-		App.WaitForElement("TapTargetNoBackground");
-		App.Tap("TapTargetNoBackground");
-		var result = App.FindElement("ResultLabelNoBackground").GetText();
+		var anchor = App.WaitForElement(TapAnchorNoBackground).GetRect();
+
+		// Tap below the label, inside the ContentView surface
+		App.TapCoordinates(anchor.CenterX(), anchor.Y + anchor.Height + 50);
+
+		var result = App.FindElement(ResultLabelNoBackground).GetText();
+
 		Assert.That(result, Is.EqualTo("Tapped"));
 	}
 
@@ -24,9 +33,13 @@ public class Issue32279 : _IssuesUITest
 	[Category(UITestCategories.Gestures)]
 	public void TapOnLayoutWithBackgroundShouldWork()
 	{
-		App.WaitForElement("TapTargetWithBackground");
-		App.Tap("TapTargetWithBackground");
-		var result = App.FindElement("ResultLabelWithBackground").GetText();
+		var anchor = App.WaitForElement(TapAnchorWithBackground).GetRect();
+
+		// Tap below the label, inside the ContentView surface
+		App.TapCoordinates(anchor.CenterX(), anchor.Y + anchor.Height + 50);
+
+		var result = App.FindElement(ResultLabelWithBackground).GetText();
+
 		Assert.That(result, Is.EqualTo("Tapped"));
 	}
 }

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Shapes;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui.Platform
 {
@@ -71,6 +72,9 @@ namespace Microsoft.Maui.Platform
 			EnsureBorderPath(containsCheck: false);
 
 			SizeChanged += ContentPanelSizeChanged;
+
+			RegisterPropertyChangedCallback(BackgroundProperty, OnBackgroundPropertyChanged);
+			EnsureHitTestBackground();
 		}
 
 		void ContentPanelSizeChanged(object sender, SizeChangedEventArgs e)
@@ -106,6 +110,22 @@ namespace Microsoft.Maui.Platform
 			else
 			{
 				CachedChildren.Add(_borderPath);
+			}
+		}
+
+		static void OnBackgroundPropertyChanged(DependencyObject dependencyObject, DependencyProperty dependencyProperty)
+		{
+			if (dependencyObject is ContentPanel contentPanel)
+			{
+				contentPanel.EnsureHitTestBackground();
+			}
+		}
+
+		void EnsureHitTestBackground()
+		{
+			if (Background == null)
+			{
+				Background = new SolidColorBrush(UI.Colors.Transparent);
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -255,15 +255,18 @@ namespace Microsoft.Maui.Platform
 				control.UpdateBackground(view.Background);
 			else if (platformView is Border border)
 				border.UpdateBackground(view.Background);
+			else if (platformView is ContentPanel contentPanel)
+			{
+				contentPanel.UpdateBackground(view.Background);
+
+				if (view.Background == null && contentPanel.Background == null)
+				{
+					contentPanel.Background = new SolidColorBrush(UI.Colors.Transparent);
+				}
+			}
 			else if (platformView is Panel panel)
 			{
 				panel.UpdateBackground(view.Background);
-
-				// Fix: ensure hit testing works when background is null
-				if (view.Background == null)
-				{
-					panel.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
-				}
 			}
 		}
 

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -256,7 +256,15 @@ namespace Microsoft.Maui.Platform
 			else if (platformView is Border border)
 				border.UpdateBackground(view.Background);
 			else if (platformView is Panel panel)
+			{
 				panel.UpdateBackground(view.Background);
+
+				// Fix: ensure hit testing works when background is null
+				if (view.Background == null)
+				{
+					panel.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+				}
+			}
 		}
 
 		internal static void UpdatePlatformViewBackground(this FrameworkElement platformView, IView view, Brush? defaultBrush = null)

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -255,19 +255,8 @@ namespace Microsoft.Maui.Platform
 				control.UpdateBackground(view.Background);
 			else if (platformView is Border border)
 				border.UpdateBackground(view.Background);
-			else if (platformView is ContentPanel contentPanel)
-			{
-				contentPanel.UpdateBackground(view.Background);
-
-				if (view.Background == null && contentPanel.Background == null)
-				{
-					contentPanel.Background = new SolidColorBrush(UI.Colors.Transparent);
-				}
-			}
 			else if (platformView is Panel panel)
-			{
 				panel.UpdateBackground(view.Background);
-			}
 		}
 
 		internal static void UpdatePlatformViewBackground(this FrameworkElement platformView, IView view, Brush? defaultBrush = null)


### PR DESCRIPTION
On Windows, panels with a null Background do not participate in hit testing.
This causes TapGestureRecognizer to not fire when layouts such as Grid, ContentView, or other panels do not explicitly define a background.

As a result, tapping on elements without a background does not trigger gesture recognizers, even though the same scenario works correctly on other platforms.

This change ensures that when a layout's background is null, a transparent background is applied internally so the element participates in hit testing. This allows gesture recognizers such as TapGestureRecognizer to function correctly without requiring developers to explicitly set a background.

The behavior now aligns with other MAUI platforms where layouts without backgrounds can still receive gestures.

Changes

Ensures Panel elements on Windows receive a transparent background when view.Background is null.

This allows layouts without explicit backgrounds to participate in hit testing and receive gesture events.

Tested scenarios

Verified using a simple repro:

Grid
 └ ContentView
     └ TapGestureRecognizer
Case A

Grid with background → Tap works.

Case B

ContentView with background → Tap works.

Case C

No background defined → Tap now works correctly.

Issue

Fixes #32279