### PR TITLE
Fix Flex layout child ordering with correct LINQ stable sort

### DIFF
--- a/src/Controls/tests/Core.UnitTests/FlexOrderTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexOrderTests.cs
@@ -45,5 +45,124 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(label1.Bounds, new Rect(0, 40, 912, 20));
 			Assert.Equal(label0.Bounds, new Rect(0, 60, 912, 20));
 		}
+
+		[Fact]
+		public void TestReverseOrderingElements()
+		{
+			// Children inserted in order 0..3, but Order values are reversed (3, 2, 1, 0)
+			// so layout should place label0 last and label3 first
+			var label0 = MockPlatformSizeService.Sub<Label>();
+			var label1 = MockPlatformSizeService.Sub<Label>();
+			var label2 = MockPlatformSizeService.Sub<Label>();
+			var label3 = MockPlatformSizeService.Sub<Label>();
+
+			FlexLayout.SetOrder(label0, 3);
+			FlexLayout.SetOrder(label1, 2);
+			FlexLayout.SetOrder(label2, 1);
+			FlexLayout.SetOrder(label3, 0);
+
+			var layout = new FlexLayout
+			{
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+				Children = { label0, label1, label2, label3 }
+			};
+
+			layout.Layout(new Rect(0, 0, 912, 912));
+
+			// label3 (Order=0), label2 (Order=1), label1 (Order=2), label0 (Order=3)
+			Assert.Equal(new Rect(0, 0, 912, 20), label3.Bounds);
+			Assert.Equal(new Rect(0, 20, 912, 20), label2.Bounds);
+			Assert.Equal(new Rect(0, 40, 912, 20), label1.Bounds);
+			Assert.Equal(new Rect(0, 60, 912, 20), label0.Bounds);
+		}
+
+		[Fact]
+		public void TestStableSortPreservesInsertionOrder()
+		{
+			// When multiple children share the same Order value,
+			// they must keep their original insertion order (stable sort)
+			var label0 = MockPlatformSizeService.Sub<Label>();
+			var label1 = MockPlatformSizeService.Sub<Label>();
+			var label2 = MockPlatformSizeService.Sub<Label>();
+			var label3 = MockPlatformSizeService.Sub<Label>();
+
+			// label0 has high Order, label1-3 share Order=0 → stability matters
+			FlexLayout.SetOrder(label0, 1);
+			FlexLayout.SetOrder(label1, 0);
+			FlexLayout.SetOrder(label2, 0);
+			FlexLayout.SetOrder(label3, 0);
+
+			var layout = new FlexLayout
+			{
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+				Children = { label0, label1, label2, label3 }
+			};
+
+			layout.Layout(new Rect(0, 0, 912, 912));
+
+			// label1, label2, label3 all have Order=0 → preserve insertion order
+			// label0 has Order=1 → comes last
+			Assert.Equal(new Rect(0, 0, 912, 20), label1.Bounds);
+			Assert.Equal(new Rect(0, 20, 912, 20), label2.Bounds);
+			Assert.Equal(new Rect(0, 40, 912, 20), label3.Bounds);
+			Assert.Equal(new Rect(0, 60, 912, 20), label0.Bounds);
+		}
+
+		[Fact]
+		public void TestNegativeOrderValues()
+		{
+			// Negative Order values should sort before zero
+			var label0 = MockPlatformSizeService.Sub<Label>();
+			var label1 = MockPlatformSizeService.Sub<Label>();
+			var label2 = MockPlatformSizeService.Sub<Label>();
+
+			FlexLayout.SetOrder(label0, 1);
+			FlexLayout.SetOrder(label1, 0);
+			FlexLayout.SetOrder(label2, -1);
+
+			var layout = new FlexLayout
+			{
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Column,
+				Children = { label0, label1, label2 }
+			};
+
+			layout.Layout(new Rect(0, 0, 912, 912));
+
+			// label2 (Order=-1), label1 (Order=0), label0 (Order=1)
+			Assert.Equal(new Rect(0, 0, 912, 20), label2.Bounds);
+			Assert.Equal(new Rect(0, 20, 912, 20), label1.Bounds);
+			Assert.Equal(new Rect(0, 40, 912, 20), label0.Bounds);
+		}
+
+		[Fact]
+		public void TestOrderWithRowDirection()
+		{
+			// Verify ordering works in Row direction too (horizontal layout)
+			var label0 = MockPlatformSizeService.Sub<Label>();
+			var label1 = MockPlatformSizeService.Sub<Label>();
+			var label2 = MockPlatformSizeService.Sub<Label>();
+
+			FlexLayout.SetOrder(label0, 2);
+			FlexLayout.SetOrder(label1, 0);
+			FlexLayout.SetOrder(label2, 1);
+
+			var layout = new FlexLayout
+			{
+				IsPlatformEnabled = true,
+				Direction = FlexDirection.Row,
+				Children = { label0, label1, label2 }
+			};
+
+			layout.Layout(new Rect(0, 0, 912, 912));
+
+			// label1 (Order=0), label2 (Order=1), label0 (Order=2)
+			// In row direction, x position changes
+			Assert.Equal(0d, label1.Bounds.X);
+			Assert.True(label2.Bounds.X > label1.Bounds.X);
+			Assert.True(label0.Bounds.X > label2.Bounds.X);
+		}
 	}
 }

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Maui.Layouts.Flex
 {
@@ -990,28 +991,12 @@ namespace Microsoft.Maui.Layouts.Flex
 				ordered_indices = null;
 				if (item.ShouldOrderChildren && item.Count > 0)
 				{
-					var indices = new int[item.Count];
-					// Creating a list of item indices sorted using the children's `order'
-					// attribute values. We are using a simple insertion sort as we need
-					// stability (insertion order must be preserved) and cross-platform
-					// support. We should eventually switch to merge sort (or something
-					// else) if the number of items becomes significant enough.
-					for (int i = 0; i < item.Count; i++)
-					{
-						indices[i] = i;
-						for (int j = i; j > 0; j--)
-						{
-							int prev = indices[j - 1];
-							int curr = indices[j];
-							if (item[prev].Order <= item[curr].Order)
-							{
-								break;
-							}
-							indices[j - 1] = curr;
-							indices[j] = prev;
-						}
-					}
-					ordered_indices = indices;
+					// Sort original indices by each child's Order using a stable sort.
+					// OrderBy is guaranteed stable in .NET, preserving insertion order
+					// for children with equal Order values.
+					ordered_indices = Enumerable.Range(0, item.Count)
+						.OrderBy(i => item[i].Order)
+						.ToArray();
 				}
 
 				flex_dim = 0;


### PR DESCRIPTION
## Summary

Replaces the manual insertion sort in `Flex.cs` with `Enumerable.Range(0, item.Count).OrderBy(i => item[i].Order)` — a correct, readable, and stable LINQ sort.

## Problem

PR #21961 attempted this optimization but introduced a **correctness bug**:

```csharp
// ❌ BROKEN — always produces [0, 1, 2, ...] regardless of Order values
var indices = item.OrderBy(x => x.Order)
                  .Select((value, index) => index)
                  .ToArray();
```

After `OrderBy` sorts the items, `.Select((value, index) => index)` returns the position in the *sorted* sequence (always `0, 1, 2, …`), not the original child indices. This makes `ordered_indices` a no-op identity mapping.

## Fix

```csharp
// ✅ CORRECT — sorts original indices by child Order, stable sort guaranteed
ordered_indices = Enumerable.Range(0, item.Count)
    .OrderBy(i => item[i].Order)
    .ToArray();
```

This creates indices `[0, 1, 2, …]` then reorders them by the `Order` property of the corresponding child. LINQ's `OrderBy` is guaranteed stable in .NET.

## Tests Added

4 new tests in `FlexOrderTests.cs`:
- **TestReverseOrderingElements** — reversed Order values
- **TestStableSortPreservesInsertionOrder** — children with equal Order retain insertion order
- **TestNegativeOrderValues** — negative Order sorts before zero
- **TestOrderWithRowDirection** — ordering works in horizontal layout

All 5 FlexOrder tests pass ✅

## Performance

This change provides the same algorithmic improvement as #21961 (O(n log n) vs O(n²) insertion sort) while being **correct**. The allocation profile is similar — one `int[]` array via `ToArray()`.

Relates to #21961
/cc @symbiogenesis @mattleibow @jonathanpeppers