### PR TITLE
Gate GesturePlatformManager invoke by IPlatformViewHandler check

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Platform.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Platform.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	internal partial class GestureManager
+	{
+		static partial void IsPlatformHandlerCore(IElementHandler handler, ref bool result)
+		{
+			if (handler is not IPlatformViewHandler)
+				result = false;
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -10,7 +10,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	internal class GestureManager
+	internal partial class GestureManager
 	{
 		readonly IControlsView _view;
 		object? _containerView;
@@ -76,11 +76,25 @@ namespace Microsoft.Maui.Controls.Platform
 			if (GesturePlatformManager != null)
 				return;
 
+			// Skip platform gesture setup when the handler doesn't provide a native view.
+			// GesturePlatformManager's constructor casts to IPlatformViewHandler.
+			if (!IsPlatformHandler(handler))
+				return;
+
 			GesturePlatformManager = new GesturePlatformManager(handler);
 			_handler = handler;
 			_containerView = handler.ContainerView;
 			_platformView = handler.PlatformView;
 			_didHaveWindow = _view.Window != null;
+		}
+
+		static partial void IsPlatformHandlerCore(IElementHandler handler, ref bool result);
+
+		static bool IsPlatformHandler(IElementHandler handler)
+		{
+			bool result = true;
+			IsPlatformHandlerCore(handler, ref result);
+			return result;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Maui.Controls.Platform
 			if (GesturePlatformManager != null)
 				return;
 
-			// Skip platform gesture setup when the handler doesn't provide a native view.
-			// GesturePlatformManager's constructor casts to IPlatformViewHandler.
+			// Skip platform gesture setup when the handler does not meet the IPlatformViewHandler
+			// requirement enforced by IsPlatformHandler (e.g., for non-platform or virtual handlers).
 			if (!IsPlatformHandler(handler))
 				return;
 


### PR DESCRIPTION
This PR adds a platform gate check around GesturePlatformManager. In the .NETStandard version, GesturePlatformManager is a no-op, so it gets made but isn't used. On the Platform TFMs, it is built for the specific platform layouts, but if you've overridden those platform views with your own (Like, for Avalonia views) it ends up causing casting issues. There's no way that I can see to change this. We have our own gesture manager support, so we don't strictly need this one to work, so having a way to no-op it on platform TFMs where the are different platform views bound to IMO should work fine here.
