### PR TITLE
[iOS] Fix CollectionView horizontal scroll when   empty inside RefreshView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -457,6 +457,25 @@ internal static class LayoutFactory2
 			_itemsUpdatingScrollMode = itemsUpdatingScrollMode;
 		}
 
+		// UICollectionViewCompositionalLayout can report a content width larger than the viewport
+		// after a bounds change (e.g. when inside a RefreshView). This causes UIScrollView to
+		// enable horizontal scrolling on a vertical layout. Clamp the width to the actual bounds. (#34165)
+		public override CGSize CollectionViewContentSize
+		{
+			get
+			{
+				var size = base.CollectionViewContentSize;
+				if (Configuration.ScrollDirection == UICollectionViewScrollDirection.Vertical
+					&& CollectionView is not null
+					&& size.Width > CollectionView.Bounds.Width
+					&& CollectionView.Bounds.Width > 0)
+				{
+					return new CGSize(CollectionView.Bounds.Width, size.Height);
+				}
+				return size;
+			}
+		}
+
 		public override void FinalizeCollectionViewUpdates()
 		{
 			base.FinalizeCollectionViewUpdates();

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34165.cs
@@ -1,0 +1,43 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34165, "CollectionView is scrolling left/right when the collection is empty and inside a RefreshView", PlatformAffected.iOS)]
+public class Issue34165 : ContentPage
+{
+	public const string CollectionViewId = "CollectionView";
+	public const string EmptyViewLabelId = "EmptyViewLabel";
+	public const string RefreshViewId = "RefreshView";
+
+	public Issue34165()
+	{
+		// The EmptyView label is the element we track — if horizontal scrolling occurs,
+		// its on-screen X position will change (the native scroll container moves it).
+		var emptyViewLabel = new Label
+		{
+			Text = "No items — swipe left/right here to test",
+			AutomationId = EmptyViewLabelId,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.Center,
+		};
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = CollectionViewId,
+			EmptyView = emptyViewLabel,
+		};
+
+		var refreshView = new RefreshView
+		{
+			AutomationId = RefreshViewId,
+			Content = collectionView,
+		};
+
+		refreshView.Refreshing += (s, e) =>
+		{
+			((RefreshView)s!).IsRefreshing = false;
+		};
+
+		Content = refreshView;
+
+		Console.WriteLine("ISSUE34165: Page loaded — CollectionView is empty, horizontal scroll should NOT be possible");
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34165.cs
@@ -9,8 +9,6 @@ public class Issue34165 : ContentPage
 
 	public Issue34165()
 	{
-		// The EmptyView label is the element we track — if horizontal scrolling occurs,
-		// its on-screen X position will change (the native scroll container moves it).
 		var emptyViewLabel = new Label
 		{
 			Text = "No items — swipe left/right here to test",
@@ -37,7 +35,5 @@ public class Issue34165 : ContentPage
 		};
 
 		Content = refreshView;
-
-		Console.WriteLine("ISSUE34165: Page loaded — CollectionView is empty, horizontal scroll should NOT be possible");
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34165.cs
@@ -1,6 +1,6 @@
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 34165, "CollectionView is scrolling left/right when the collection is empty and inside a RefreshView", PlatformAffected.iOS)]
+[Issue(IssueTracker.Github, 34165, "CollectionView is scrolling left/right when the collection is empty and inside a RefreshView", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue34165 : ContentPage
 {
 	public const string CollectionViewId = "CollectionView";

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
@@ -1,3 +1,4 @@
+#if ANDROID || IOS // ScrollRight with ScrollStrategy.Gesture is not supported on Windows and MacCatalyst
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -22,8 +23,9 @@ public class Issue34165 : _IssuesUITest
 
 		var rectAfter = App.WaitForElement("EmptyViewLabel").GetRect();
 
-		Assert.That(rectAfter.X, Is.EqualTo(rectBefore.X),
+		Assert.That(rectAfter.X, Is.EqualTo(rectBefore.X).Within(1),
 			$"EmptyViewLabel X position changed from {rectBefore.X} to {rectAfter.X}. " +
 			"CollectionView must NOT scroll horizontally when empty inside a RefreshView.");
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST // Issue only affects iOS
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -13,23 +12,16 @@ public class Issue34165 : _IssuesUITest
 	public override string Issue => "CollectionView is scrolling left/right when the collection is empty and inside a RefreshView";
 
 	[Test]
-	// Regression: empty CollectionView inside RefreshView should not allow horizontal scrolling on iOS.
-	// Detection strategy: measure the screen X position of the EmptyView label before and after
-	// a horizontal swipe — if the X coordinate shifts, the native scroll container moved (the bug).
 	public void EmptyCollectionViewInsideRefreshViewShouldNotScrollHorizontally()
 	{
 		App.WaitForElement("CollectionView");
 
-		// Record the EmptyView label's initial on-screen position
 		var rectBefore = App.WaitForElement("EmptyViewLabel").GetRect();
 
-		// Swipe right inside the CollectionView — this is the gesture that triggers the bug
 		App.ScrollRight("CollectionView", ScrollStrategy.Gesture, swipePercentage: 0.8, swipeSpeed: 300);
 
-		// Small wait for any scroll momentum to settle
 		Thread.Sleep(500);
 
-		// Re-measure — X must not have changed (no horizontal scroll should have occurred)
 		var rectAfter = App.WaitForElement("EmptyViewLabel").GetRect();
 
 		Assert.That(rectAfter.X, Is.EqualTo(rectBefore.X),
@@ -37,4 +29,3 @@ public class Issue34165 : _IssuesUITest
 			"CollectionView must NOT scroll horizontally when empty inside a RefreshView.");
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
@@ -1,0 +1,40 @@
+#if TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST // Issue only affects iOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+[Category(UITestCategories.RefreshView)]
+public class Issue34165 : _IssuesUITest
+{
+	public Issue34165(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "CollectionView is scrolling left/right when the collection is empty and inside a RefreshView";
+
+	[Test]
+	// Regression: empty CollectionView inside RefreshView should not allow horizontal scrolling on iOS.
+	// Detection strategy: measure the screen X position of the EmptyView label before and after
+	// a horizontal swipe — if the X coordinate shifts, the native scroll container moved (the bug).
+	public void EmptyCollectionViewInsideRefreshViewShouldNotScrollHorizontally()
+	{
+		App.WaitForElement("CollectionView");
+
+		// Record the EmptyView label's initial on-screen position
+		var rectBefore = App.WaitForElement("EmptyViewLabel").GetRect();
+
+		// Swipe right inside the CollectionView — this is the gesture that triggers the bug
+		App.ScrollRight("CollectionView", ScrollStrategy.Gesture, swipePercentage: 0.8, swipeSpeed: 300);
+
+		// Small wait for any scroll momentum to settle
+		Thread.Sleep(500);
+
+		// Re-measure — X must not have changed (no horizontal scroll should have occurred)
+		var rectAfter = App.WaitForElement("EmptyViewLabel").GetRect();
+
+		Assert.That(rectAfter.X, Is.EqualTo(rectBefore.X),
+			$"EmptyViewLabel X position changed from {rectBefore.X} to {rectAfter.X}. " +
+			"CollectionView must NOT scroll horizontally when empty inside a RefreshView.");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34165.cs
@@ -20,8 +20,6 @@ public class Issue34165 : _IssuesUITest
 
 		App.ScrollRight("CollectionView", ScrollStrategy.Gesture, swipePercentage: 0.8, swipeSpeed: 300);
 
-		Thread.Sleep(500);
-
 		var rectAfter = App.WaitForElement("EmptyViewLabel").GetRect();
 
 		Assert.That(rectAfter.X, Is.EqualTo(rectBefore.X),


### PR DESCRIPTION
### Root Cause
When `RefreshView` initializes on iOS, it attaches the native `UIRefreshControl` to the CollectionView’s scroll layer. This attachment triggers an internal layout pass. During that layout pass, iOS temporarily reports an incorrect container width to the layout engine, typically double the actual screen width.
`UICollectionViewCompositionalLayout`, which is used by the CV2 handler, uses this incorrect width to calculate the total content size and caches it. After the animation settles and the correct screen width is restored, the layout engine does not recalculate the content size and continues using the cached double-width value.
As a result, the scroll system believes the content is wider than the screen and enables horizontal scrolling.
 
### Description of Change
The fix was implemented by overriding the `CollectionViewContentSize` property inside `CustomUICollectionViewCompositionalLayout`. This property is where the scroll system queries the layout for the total content size.
The override intercepts the content size before it is returned to the scroll system. If the layout is vertical and the reported content width is greater than the actual screen width, the width is clamped to the real screen width before being returned.
By ensuring that a vertical layout never reports a content width larger than the screen, horizontal scrolling is prevented.
The change is minimal, localized to a single file, and safe because a vertical layout can never legitimately have content wider than the screen.

### Issues Fixed
Fixes #34165 
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/0acc28a6-a526-4799-8de7-99c4b0dbf4fe">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/61100874-a442-4a50-96ee-0539a2544ac3">|