### PR TITLE
[iOS] Fixed CollectionView Scroll Jitter for TextType HTML Labels

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Items2;
 using Microsoft.Maui.Controls.Internals;
 using ObjCRuntime;
 using UIKit;
@@ -16,22 +17,39 @@ namespace Microsoft.Maui.Controls.Platform
 			switch (label.TextType)
 			{
 				case TextType.Html:
-					// NOTE: Setting HTML text this will crash with some sort of consistency error.
+					// NOTE: Setting HTML text this will crash with some sort of consistency error
+					// when inside a CV1 (CollectionView/CarouselView handler v1) layout pass.
 					// https://github.com/dotnet/maui/issues/25946
-					// Here we have to dispatch back the the main queue to avoid the crash.
-					// This is observed with CarouselView 1 but not with 2, so hopefully this
-					// will be just disappear once we switch.
-					CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+					// CV2 (the default handler in .NET 10) does NOT have this crash.
+					// Applying HTML synchronously in CV2 prevents the jitter caused by the
+					// deferred measurement (measure with no text → HTML applied → remeasure).
+					// https://github.com/dotnet/maui/issues/33065
+					if (IsLabelInsideCV2Handler(label))
 					{
+						// Synchronous: inside a CV2 layout pass — no InvalidateMeasure needed.
 						platformLabel.UpdateTextHtml(text);
 
-						if (label.Handler is LabelHandler labelHandler)
-							Label.MapFormatting(labelHandler, label);
+						if (label.Handler is LabelHandler labelHandlerSync)
+						{
+							Label.MapFormatting(labelHandlerSync, label);
+						}
+					}
+					else
+					{
+						CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+						{
+							platformLabel.UpdateTextHtml(text);
 
-						// NOTE: Because we are updating text outside the normal layout
-						// pass, we need to invalidate the measure for the next pass.
-						label.InvalidateMeasure();
-					});
+							if (label.Handler is LabelHandler labelHandler)
+							{
+								Label.MapFormatting(labelHandler, label);
+							}
+
+							// NOTE: Because we are updating text outside the normal layout
+							// pass, we need to invalidate the measure for the next pass.
+							label.InvalidateMeasure();
+						});
+					}
 					break;
 
 				default:
@@ -48,6 +66,21 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					break;
 			}
+		}
+
+		// Walks the MAUI logical parent tree to determine if this Label lives inside a CV2 handler
+		static bool IsLabelInsideCV2Handler(Label label)
+		{
+			var parent = label.Parent;
+			while (parent is not null)
+			{
+				if (parent is ItemsView itemsView)
+				{
+					return itemsView.Handler is CollectionViewHandler2;
+				}
+				parent = parent.Parent;
+			}
+			return false;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Platform
 			switch (label.TextType)
 			{
 				case TextType.Html:
-					// NOTE: Setting HTML text this will crash with some sort of consistency error
+					// NOTE: Setting HTML text like this will crash with some sort of consistency error.
 					// when inside a CV1 (CollectionView/CarouselView handler v1) layout pass.
 					// https://github.com/dotnet/maui/issues/25946
 					// CV2 (the default handler in .NET 10) does NOT have this crash.

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -21,12 +21,10 @@ namespace Microsoft.Maui.Controls.Platform
 					// when inside a CV1 (CollectionView/CarouselView handler v1) layout pass.
 					// https://github.com/dotnet/maui/issues/25946
 					// CV2 (the default handler in .NET 10) does NOT have this crash.
-					// Applying HTML synchronously in CV2 prevents the jitter caused by the
-					// deferred measurement (measure with no text → HTML applied → remeasure).
-					// https://github.com/dotnet/maui/issues/33065
-					if (IsLabelInsideCV2Handler(label))
+					if (IsPlatformLabelInsideCV2Cell(platformLabel))
 					{
-						// Synchronous: inside a CV2 layout pass — no InvalidateMeasure needed.
+						// Synchronous: safe in CV2, avoids the two-pass jitter.
+						// No InvalidateMeasure needed — text is already correct when measured.
 						platformLabel.UpdateTextHtml(text);
 
 						if (label.Handler is LabelHandler labelHandlerSync)
@@ -68,17 +66,17 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		// Walks the MAUI logical parent tree to determine if this Label lives inside a CV2 handler
-		static bool IsLabelInsideCV2Handler(Label label)
+		// Walks the native UIKit superview chain to determine if this UILabel lives inside a CV2 cell.
+		static bool IsPlatformLabelInsideCV2Cell(UILabel platformLabel)
 		{
-			var parent = label.Parent;
-			while (parent is not null)
+			var superview = platformLabel.Superview;
+			while (superview is not null)
 			{
-				if (parent is ItemsView itemsView)
+				if (superview is ItemsViewCell2)
 				{
-					return itemsView.Handler is CollectionViewHandler2;
+					return true;
 				}
-				parent = parent.Parent;
+				superview = superview.Superview;
 			}
 			return false;
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause:
HTML text is applied asynchronously in .NET MAUI on iOS, causing the CollectionView cell to render first and then re-measure after the HTML is applied, which leads to visible resizing (scroll jitter).
### Description of Change
Improvements to HTML text handling in CollectionView:

* Updated `UpdateText` method in `LabelExtensions.cs` to check if the `UILabel` is inside a CV2 cell using the new `IsPlatformLabelInsideCV2Cell` method, allowing synchronous HTML text updates when safe and avoiding unnecessary layout passes.
* Added the `IsPlatformLabelInsideCV2Cell` helper method to walk the UIKit superview chain and detect CV2 cells, improving reliability and preventing crashes in CV1 layouts.
* Added a reference to `Microsoft.Maui.Controls.Handlers.Items2` to support the new CV2 cell detection logic.
<!-- Enter description of the fix in this section -->
### Why Tests were not added:
This bug occurs only during live scrolling of CollectionView cells on iOS when a Label with TextType="Html" is rendered. The issue depends on the precise timing of asynchronous HTML text application, which triggers a second layout pass while cells are visible, causing scroll jitter. Automated tests cannot reliably reproduce this because no framework can simulate real-time scrolling and layout timing at the native speed
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33065 

### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/1045cbe3-e869-4e08-9562-8032dd9cea88"> | <video src="https://github.com/user-attachments/assets/0c7b3bbb-4917-482f-ac7e-05e343de3ae0"> |


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
