### PR TITLE
[Controls] Fix EventTrigger in global implicit style firing twice

### DIFF
--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -34,15 +34,10 @@ namespace Microsoft.Maui.Controls
 		{
 			Target = target;
 			TargetType = targetType;
+			// RegisterImplicitStyles handles the initial apply via OnImplicitStyleChanged -> SetStyle.
+			// An explicit Apply(Target) call here would double-attach event handlers when
+			// Application.Current.Resources already contains the implicit style (#24152).
 			RegisterImplicitStyles();
-			// If RegisterImplicitStyles() resolved resources synchronously (e.g. via Application.Current.Resources),
-			// OnImplicitStyleChanged already called SetStyle which applied the implicit style.
-			// Calling Apply(Target) unconditionally would attach event handlers a second time,
-			// causing EventTrigger actions in global implicit styles to fire twice (#24152).
-			if (_implicitStyle == null)
-			{
-				Apply(Target);
-			}
 		}
 
 		public IStyle Style
@@ -180,24 +175,14 @@ namespace Microsoft.Maui.Controls
 				Target.RemoveDynamicResource(_implicitStyles[i]);
 			_implicitStyles.Clear();
 
-			// Reset _implicitStyle so RegisterImplicitStyles can re-apply from scratch.
-			// UnApply the current implicit style first so there is no leftover state.
-			ImplicitStyle?.UnApply(Target);
-			_implicitStyle = null;
-
 			//Register the fallback
 			BindableProperty implicitStyleProperty = BindableProperty.Create(nameof(ImplicitStyle), typeof(Style), typeof(NavigableElement), default(Style),
 						propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
 			_implicitStyles.Add(implicitStyleProperty);
 			Target.SetDynamicResource(implicitStyleProperty, fallbackTypeName);
 
-			//and proceed as usual
+			//and proceed as usual - RegisterImplicitStyles handles apply via OnImplicitStyleChanged
 			RegisterImplicitStyles();
-			// Only call Apply if RegisterImplicitStyles didn't already apply via synchronous resource resolution.
-			if (_implicitStyle == null)
-			{
-				Apply(Target);
-			}
 		}
 
 		void SetStyle(IStyle implicitStyle, IList<Style> classStyles, IStyle style)

--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -35,7 +35,14 @@ namespace Microsoft.Maui.Controls
 			Target = target;
 			TargetType = targetType;
 			RegisterImplicitStyles();
-			Apply(Target);
+			// If RegisterImplicitStyles() resolved resources synchronously (e.g. via Application.Current.Resources),
+			// OnImplicitStyleChanged already called SetStyle which applied the implicit style.
+			// Calling Apply(Target) unconditionally would attach event handlers a second time,
+			// causing EventTrigger actions in global implicit styles to fire twice (#24152).
+			if (_implicitStyle == null)
+			{
+				Apply(Target);
+			}
 		}
 
 		public IStyle Style
@@ -173,6 +180,11 @@ namespace Microsoft.Maui.Controls
 				Target.RemoveDynamicResource(_implicitStyles[i]);
 			_implicitStyles.Clear();
 
+			// Reset _implicitStyle so RegisterImplicitStyles can re-apply from scratch.
+			// UnApply the current implicit style first so there is no leftover state.
+			ImplicitStyle?.UnApply(Target);
+			_implicitStyle = null;
+
 			//Register the fallback
 			BindableProperty implicitStyleProperty = BindableProperty.Create(nameof(ImplicitStyle), typeof(Style), typeof(NavigableElement), default(Style),
 						propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
@@ -181,7 +193,11 @@ namespace Microsoft.Maui.Controls
 
 			//and proceed as usual
 			RegisterImplicitStyles();
-			Apply(Target);
+			// Only call Apply if RegisterImplicitStyles didn't already apply via synchronous resource resolution.
+			if (_implicitStyle == null)
+			{
+				Apply(Target);
+			}
 		}
 
 		void SetStyle(IStyle implicitStyle, IList<Style> classStyles, IStyle style)

--- a/src/Controls/tests/Core.UnitTests/EventTriggerTest.cs
+++ b/src/Controls/tests/Core.UnitTests/EventTriggerTest.cs
@@ -13,6 +13,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 	}
 
+	internal class CountingTriggerAction : TriggerAction<BindableObject>
+	{
+		public int InvokeCount { get; private set; }
+
+		protected override void Invoke(BindableObject sender)
+		{
+			InvokeCount++;
+		}
+	}
+
 	internal class MockBindableWithEvent : VisualElement
 	{
 		public void FireEvent()
@@ -31,9 +41,35 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public event EventHandler MockEvent2;
 	}
 
+	internal class MockViewWithEvent : View
+	{
+		public void FireEvent()
+		{
+			MockEvent?.Invoke(this, EventArgs.Empty);
+		}
+
+		public event EventHandler MockEvent;
+	}
+
 
 	public class EventTriggerTest : BaseTestFixture
 	{
+		public EventTriggerTest()
+		{
+			// Required so Application.Current.Resources is available — this is the
+			// condition under which the double-attachment bug manifests.
+			ApplicationExtensions.CreateAndSetMockApplication();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Application.ClearCurrent();
+			}
+
+			base.Dispose(disposing);
+		}
 		[Fact]
 		public void TestTriggerActionInvoked()
 		{
@@ -68,6 +104,31 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(triggeraction.Invoked);
 
 			Assert.Throws<InvalidOperationException>(() => eventtrigger.Event = "MockEvent2");
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/24152
+		// EventTrigger in a global (implicit) style should fire exactly once per event,
+		// not twice due to double-application in MergedStyle constructor.
+		[Fact]
+		public void EventTriggerInImplicitStyleFiresOnce()
+		{
+			var triggerAction = new CountingTriggerAction();
+			var implicitStyle = new Style(typeof(MockViewWithEvent))
+			{
+				Triggers = { new EventTrigger { Event = "MockEvent", Actions = { triggerAction } } }
+			};
+
+			// The bug only manifests when the implicit style is in Application.Current.Resources
+			// (e.g., defined in App.xaml / Styles.xaml). The TryGetResource fallback resolves
+			// the style synchronously during MergedStyle.RegisterImplicitStyles(), causing Apply()
+			// to be called once there AND again in the MergedStyle constructor — registering the
+			// event handler twice.
+			Application.Current.Resources.Add(implicitStyle);
+
+			var view = new MockViewWithEvent();
+			view.FireEvent();
+
+			Assert.Equal(1, triggerAction.InvokeCount);
 		}
 	}
 }


### PR DESCRIPTION

   <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
   
   Fixes #24152
   
   ## Description
   
   `EventTrigger` actions defined in a global implicit style (e.g. `App.xaml` or `Styles.xaml`) fired **twice** per event instead of once.
   
   ### Root Cause
   
   `MergedStyle` constructor called `RegisterImplicitStyles()` followed by an unconditional `Apply(Target)`. When `Application.Current.Resources` already contains an implicit style for the target type, `RegisterImplicitStyles()` resolves the style **synchronously** 
  via:
   
   `SetDynamicResource` → `OnSetDynamicResource` → `TryGetResource` (Application.Current fallback) → `OnImplicitStyleChanged` → `SetStyle` → `ImplicitStyle.Apply(Target)` ← **apply 1**
   
   Then the constructor called `Apply(Target)` again ← **apply 2**
   
   This caused `EventTrigger.OnAttachedTo` → `AddEventHandler` to be called twice, registering two delegates, so every event fired both.
   
   `ReRegisterImplicitStyles` had the same double-apply issue.
   
   ### Fix
   
   Removed the redundant `Apply(Target)` calls from the `MergedStyle` constructor and `ReRegisterImplicitStyles`. `SetStyle()` (called via `OnImplicitStyleChanged`) is the single authoritative apply path — the explicit `Apply(Target)` was either a duplicate or a no-op in all code paths.
   
   ## Testing
   
   Added unit test `EventTriggerInImplicitStyleFiresOnce` in `EventTriggerTest.cs` that:
   1. Adds an implicit style with an `EventTrigger` to `Application.Current.Resources`
   2. Creates a control that matches the implicit style
   3. Fires the event once
   4. Asserts the action was invoked **exactly once**
   
   The test fails without the fix (count = 2) and passes with it (count = 1). Full Controls unit test suite: 5509 passed, 0 failed.
 
