### PR TITLE
[Android] Fix CollectionView sizing when wrapped in RefreshView

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12131.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12131.cs
@@ -44,7 +44,7 @@ namespace Maui.Controls.Sample.Issues
 				Padding = 10,
 				Children =
 				{
-					new Label { Text = "RefreshView inside VerticalStackLayout" },
+					new Label { Text = "CollectionView wrapped within RefreshView." },
 					sizeLabel,
 					refreshView
 				}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12131.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12131.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 12131, "RefreshView - CollectionView sizing not working correctly inside VerticalStackLayout", PlatformAffected.Android)]
+	public class Issue12131 : ContentPage
+	{
+		public Issue12131()
+		{
+			var items = Enumerable.Range(1, 20).Select(i => $"Item {i}").ToList();
+
+			var collectionView = new CollectionView
+			{
+				AutomationId = "CollectionView12131",
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, ".");
+					return label;
+				}),
+				ItemsSource = items
+			};
+
+			var refreshView = new RefreshView
+			{
+				AutomationId = "RefreshView12131",
+				Content = collectionView
+			};
+
+			var sizeLabel = new Label
+			{
+				AutomationId = "SizeLabel12131",
+				Text = "Waiting..."
+			};
+
+			refreshView.SizeChanged += (s, e) =>
+			{
+				sizeLabel.Text = $"Height={refreshView.Height:F0}";
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Padding = 10,
+				Children =
+				{
+					new Label { Text = "RefreshView inside VerticalStackLayout" },
+					sizeLabel,
+					refreshView
+				}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12131.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12131.cs
@@ -1,6 +1,3 @@
-using System.Reflection;
-using Microsoft.Maui.Controls;
-
 namespace Maui.Controls.Sample.Issues
 {
 	[Issue(IssueTracker.Github, 12131, "RefreshView - CollectionView sizing not working correctly inside VerticalStackLayout", PlatformAffected.Android)]

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12131.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12131.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue12131 : _IssuesUITest
+	{
+		public Issue12131(TestDevice testDevice) : base(testDevice) { }
+
+		public override string Issue => "RefreshView - CollectionView sizing not working correctly inside VerticalStackLayout";
+
+		[Test]
+		[Category(UITestCategories.RefreshView)]
+		public void RefreshViewHasNonZeroHeightInVerticalStackLayout()
+		{
+			App.WaitForElement("RefreshView12131");
+			var rect = App.FindElement("RefreshView12131").GetRect();
+			Assert.That(rect.Height, Is.GreaterThan(0), "RefreshView should have a non-zero height when placed inside a VerticalStackLayout");
+		}
+
+		[Test]
+		[Category(UITestCategories.RefreshView)]
+		public void CollectionViewDoesNotExceedAvailableWidth()
+		{
+			App.WaitForElement("CollectionView12131");
+			var refreshRect = App.FindElement("RefreshView12131").GetRect();
+			var collectionRect = App.FindElement("CollectionView12131").GetRect();
+			Assert.That(collectionRect.Width, Is.LessThanOrEqualTo(refreshRect.Width + 1), "CollectionView width should not exceed RefreshView width");
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/MauiSwipeRefreshLayout.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeRefreshLayout.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Maui.Platform
 
 		public override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
+			// Always call base.OnMeasure — unlike ContentViewGroup/LayoutViewGroup,
+			// SwipeRefreshLayout.onMeasure internally measures its spinner indicator
+			// (mCircleView). Skipping this leaves the spinner at 0x0, making it invisible.
 			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
 
 			if (CrossPlatformLayout is null)
@@ -49,11 +52,33 @@ namespace Microsoft.Maui.Platform
 			var deviceIndependentWidth = widthMeasureSpec.ToDouble(_context);
 			var deviceIndependentHeight = heightMeasureSpec.ToDouble(_context);
 
-			CrossPlatformLayout?.CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
+
+			var measure = CrossPlatformLayout.CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+
+			// Unlike ContentViewGroup/LayoutViewGroup, SwipeRefreshLayout internally positions
+			// its spinner at getMeasuredWidth()/2. We must use the full spec size for both
+			// Exactly and AtMost modes (matching View.getDefaultSize behavior) so the spinner
+			// is centered correctly. Only for Unspecified do we use the cross-platform measure.
+			var width = widthMode == MeasureSpecMode.Unspecified ? measure.Width : deviceIndependentWidth;
+			var height = heightMode == MeasureSpecMode.Unspecified ? measure.Height : deviceIndependentHeight;
+
+			var platformWidth = _context.ToPixels(width);
+			var platformHeight = _context.ToPixels(height);
+
+			// Minimum values win over everything
+			platformWidth = Math.Max(MinimumWidth, platformWidth);
+			platformHeight = Math.Max(MinimumHeight, platformHeight);
+
+			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
 		}
 
 		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
 		{
+			// Always call base.OnLayout — SwipeRefreshLayout.onLayout positions the
+			// spinner indicator (mCircleView) centered horizontally. Without this,
+			// the spinner won't appear or will be mispositioned.
 			base.OnLayout(changed, left, top, right, bottom);
 			if (CrossPlatformLayout is null)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
The sizing of the RefreshView no longer works when the content is wrapped inside a RefreshView. As a result, the RefreshView height is calculated as 0.

### Root Cause
MauiSwipeRefreshLayout.OnMeasure called CrossPlatformMeasure() but discarded the return value, never calling SetMeasuredDimension with the correct size. Android kept height=0 from base.OnMeasure().

### Description of Change
Updated MauiSwipeRefreshLayout.OnMeasure() to correctly use the result from CrossPlatformMeasure()
and call SetMeasuredDimension() with the resolved size. Previously, the return value was discarded
and Android retained height=0 from base.OnMeasure().

The implementation respects MeasureSpecMode as follows:

- EXACTLY — uses the size from the measure spec (parent dictates size).
- AT_MOST — uses the full spec constraint (not the cross-platform measure), matching Android's View.getDefaultSize() semantics. This is intentional: SwipeRefreshLayout internally centers its spinner indicator using getMeasuredWidth() / 2, so clamping to content size would misposition the spinner.
- UNSPECIFIED — uses the size returned from CrossPlatformMeasure() (content wraps naturally).

### Validated the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac


### Issues Fixed:
Fixes #12131

### Screenshots
| Before  | After |
|---------|--------|
| <img height=600 width=300 src="https://github.com/user-attachments/assets/6ffdfc04-fdc0-4c1a-b0fd-3f67c4744571"> |   <img  height=600 width=300 src="https://github.com/user-attachments/assets/7143297a-94f2-48a8-9eca-3516ddf70491">  |
