### PR TITLE
Publish snapshots-diff as separate lightweight artifact

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -187,6 +187,16 @@ steps:
   condition: always()
   displayName: publish artifacts
 
+# Publish only the snapshots-diff folder as a separate lightweight artifact
+# so it can be downloaded without pulling the full drop (~5GB)
+- task: PublishPipelineArtifact@1
+  condition: always()
+  displayName: Publish snapshots-diff
+  continueOnError: true
+  inputs:
+    targetPath: $(Build.ArtifactStagingDirectory)/Controls.TestCases.Shared.Tests/snapshots-diff
+    artifact: 'snapshots-diff-$(System.JobName)-$(System.JobAttempt)'
+
 # Enable Notification Center re-enabled only for catalyst
 - ${{ if eq(parameters.platform, 'catalyst')}}:
   - bash: |


### PR DESCRIPTION
## Description

Adds a new `PublishPipelineArtifact` step in `ui-tests-steps.yml` that publishes only the `snapshots-diff` folder as a standalone artifact named `snapshots-diff-{jobName}-{attempt}`.

This allows downloading just the screenshot diffs without pulling the full `drop` artifact (~5GB).

**No existing artifacts are modified** — `drop`, `uitest-snapshot-results-*`, and all other artifacts remain unchanged.

### Before
To see screenshot diffs, you had to download the full `drop` artifact (~5GB) which contains logs, test-results, and snapshots-diff.

### After
A new `snapshots-diff-*` artifact appears in the artifacts list containing only the diff images (a few MB).