### PR TITLE
[Android]Fix TestDoesntCrashWithCachingDisable UI Test failure

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue2354.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue2354.cs
@@ -8,16 +8,16 @@
 		{
 			var presidents = new List<President>();
 
-			presidents.Add(new President($"Presidente 44", 1, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png?raw=true"));
-			presidents.Add(new President($"Presidente 43", 2, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/oasis.jpg?raw=true"));
-			presidents.Add(new President($"Presidente 42", 3, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/photo21314.jpg?raw=true"));
-			presidents.Add(new President($"Presidente 41", 4, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/groceries.png?raw=true"));
-			presidents.Add(new President($"Presidente 40", 5, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png?raw=true"));
-			presidents.Add(new President($"Presidente 39", 6, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/oasis.jpg?raw=true"));
-			presidents.Add(new President($"Presidente 38", 7, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/photo21314.jpg?raw=true"));
-			presidents.Add(new President($"Presidente 37", 8, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/groceries.png?raw=true"));
-			presidents.Add(new President($"Presidente 36", 9, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png?raw=true"));
-			presidents.Add(new President($"Presidente 35", 10, $"https://github.com/dotnet/maui/blob/main/src/Controls/tests/TestCases.HostApp/Resources/Images/oasis.jpg?raw=true"));
+			presidents.Add(new President($"Presidente 44", 1, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png"));
+			presidents.Add(new President($"Presidente 43", 2, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/oasis.jpg"));
+			presidents.Add(new President($"Presidente 42", 3, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/photo21314.jpg"));
+			presidents.Add(new President($"Presidente 41", 4, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/groceries.png"));
+			presidents.Add(new President($"Presidente 40", 5, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png"));
+			presidents.Add(new President($"Presidente 39", 6, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/oasis.jpg"));
+			presidents.Add(new President($"Presidente 38", 7, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/photo21314.jpg"));
+			presidents.Add(new President($"Presidente 37", 8, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/groceries.png"));
+			presidents.Add(new President($"Presidente 36", 9, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png"));
+			presidents.Add(new President($"Presidente 35", 10, $"https://raw.githubusercontent.com/dotnet/maui/main/src/Controls/tests/TestCases.HostApp/Resources/Images/oasis.jpg"));
 
 			var header = new Label
 			{


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

<!-- Enter description of the fix in this section -->

This pull request updates the image URLs used in the `President` objects within the `Init()` method of `Issue2354.cs` to ensure that they reference the correct raw image files directly from GitHub. This change improves reliability and consistency in how images are loaded for test cases.

Image URL updates:

* Changed all image URLs for `President` objects to use the `raw.githubusercontent.com` domain, removing the `?raw=true` query parameter and ensuring direct access to the image files.

**Instead of:**
https://github.com/.../avatar.png?raw=true

**use the resolved target:**
https://raw.githubusercontent.com/dotnet/maui/refs/heads/main/src/Controls/tests/TestCases.HostApp/Resources/Images/avatar.png

This removes the cross‑host redirect entirely and is the most robust option for in‑app fetching. The raw.githubusercontent.com which hosts the actual raw files. 

**References:** [Issue16032](https://github.com/dotnet/maui/blob/6c123d72970865ccb1312e118f5098ef6c44e892/src/Controls/tests/TestCases.HostApp/Issues/Issue16032.cs#L88), [Bugzilla35733](https://github.com/dotnet/maui/blob/6c123d72970865ccb1312e118f5098ef6c44e892/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla35733.cs#L30), [Bugzilla37625](https://github.com/dotnet/maui/blob/6c123d72970865ccb1312e118f5098ef6c44e892/src/Controls/tests/TestCases.HostApp/Issues/Bugzilla/Bugzilla37625.cs#L12) has a url that used form raw.githuusercontent. 