### PR TITLE
[ci] Fix internal pipeline OfficialBuildId format

### DIFF
--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -55,7 +55,7 @@ variables:
     value: >-
       /p:DotNetPublishUsingPipelines=true
   - name: _OfficialBuildIdArgs
-    value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER) /p:_SkipUpdateBuildNumber=true
+    value: /p:OfficialBuildId=$(_BuildOfficialId) /p:_SkipUpdateBuildNumber=true # Use _BuildOfficialId because Arcade does MSBuild arithmetic on OfficialBuildId and BUILD.BUILDNUMBER may contain '+' which breaks parsing.
     # -runtimeSourceFeed https://ci.dot.net/internal -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
     # needed for signing
   - name: _SignType


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

The `dotnet-maui-build` internal pipeline (definition 1536) has been **failing on every single build since ~Jan 27** (~5+ weeks) because `BUILD.BUILDNUMBER` changed format to `10.0.50+azdo.XXXXX`.

Arcade's `Version.BeforeCommonTargets.targets` tries to do arithmetic on `OfficialBuildId` using `[MSBuild]::Add/Multiply/Subtract`, but the `+` character in the new format causes `MSB4186: Invalid static method invocation syntax`.

### Fix

Change the internal pipeline's `_OfficialBuildIdArgs` from `$(BUILD.BUILDNUMBER)` to `$(_BuildOfficialId)` (the `yyyyMMdd.counter` format already used by all other pipeline configurations).

### Impact

- **Internal (`dotnet-maui-build`)**: Fixed — uses `_BuildOfficialId` (`yyyyMMdd.counter`)
- **Public (`maui-pr`)**: Unchanged — already uses `_BuildOfficialId`  
- **PR builds**: Unchanged — already uses `_BuildOfficialId`
- Publishing and signing args are untouched