### PR TITLE
[ci] Update branding for MEAI Preview 1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,10 +5,9 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>50</PatchVersion>
     <SdkBandVersion>10.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>ci.main</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>meaipreview</PreReleaseVersionLabel>
     <PreReleaseVersionLabel Condition="'$(BUILD_SOURCEBRANCH)' == 'refs/heads/inflight/current'">ci.inflight</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>
-    </PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Essentials.AI preview versioning — bump this for new AI previews -->
     <EssentialsAIPreviewVersionIteration>1</EssentialsAIPreviewVersionIteration>
     <!-- Servicing builds have different characteristics for the way dependencies, baselines, and versions are handled. -->


### PR DESCRIPTION
This pull request updates the versioning configuration in the `eng/Versions.props` file to reflect a new preview release and ensures proper version iteration tracking.

Versioning updates:

* Changed the `PreReleaseVersionLabel` from `ci.main` to `meaipreview` to indicate a new AI preview release.
* Set the `PreReleaseVersionIteration` to `1` to start a new version iteration for the preview.