### PR TITLE
Add /review command to trigger AzDO review pipeline from PR comments

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,0 +1,159 @@
+name: "Trigger AzDO Review Pipeline"
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+      platform:
+        description: 'Platform to review (android, ios, or both)'
+        required: true
+        type: choice
+        options:
+          - android
+          - ios
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  trigger-review:
+    name: Queue Review Pipeline
+    runs-on: ubuntu-latest
+    if: |
+      github.repository_owner == 'dotnet' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.issue.pull_request != '' &&
+        startsWith(github.event.comment.body, '/review')))
+    steps:
+      - name: Check permissions
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login
+            });
+            const allowed = ['admin', 'write'];
+            if (!allowed.includes(data.permission)) {
+              core.setFailed(`User @${context.payload.comment.user.login} does not have write access. Permission: ${data.permission}`);
+            }
+
+      - name: Parse inputs
+        id: parse
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "pr_number=$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "platform=$INPUT_PLATFORM" >> "$GITHUB_OUTPUT"
+          else
+            PR_NUMBER="$ISSUE_NUMBER"
+            # Extract platform from comment: /review <platform>
+            PLATFORM=$(echo "$COMMENT_BODY" | sed 's|^/review[[:space:]]*||' | tr '[:upper:]' '[:lower:]' | xargs)
+            if [ -z "$PLATFORM" ]; then
+              PLATFORM="android"
+            fi
+            # Sanitize: only allow alphanumeric characters
+            PLATFORM=$(echo "$PLATFORM" | tr -cd 'a-z')
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate platform
+        shell: bash
+        env:
+          PLATFORM: ${{ steps.parse.outputs.platform }}
+        run: |
+          if [[ "$PLATFORM" != "android" && "$PLATFORM" != "ios" ]]; then
+            echo "::error::Invalid platform '$PLATFORM'. Must be 'android' or 'ios'."
+            exit 1
+          fi
+
+      - name: Queue Azure DevOps pipeline
+        shell: bash
+        env:
+          REVIEW_PR_AZDO_PAT: ${{ secrets.REVIEW_PR_AZDO_PAT }}
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          PLATFORM: ${{ steps.parse.outputs.platform }}
+        run: |
+          if [ "$PLATFORM" = "ios" ]; then
+            POOL_STR='{"name": "AcesShared"}'
+          else
+            POOL_STR='{"name": "Azure Pipelines", "vmImage": "ubuntu-22.04"}'
+          fi
+
+          AUTH=$(printf ':%s' "$REVIEW_PR_AZDO_PAT" | base64 -w0)
+
+          echo "Queuing review pipeline for PR #${PR_NUMBER} (platform: ${PLATFORM})"
+
+          jq -n \
+            --arg pr "$PR_NUMBER" \
+            --arg plat "$PLATFORM" \
+            --arg pool "$POOL_STR" \
+            '{
+              definition: {id: 27723},
+              sourceBranch: "refs/heads/main",
+              templateParameters: {
+                PRNumber: $pr,
+                Platform: $plat,
+                pool: $pool
+              }
+            }' > /tmp/request.json
+
+          echo "Request body:"
+          cat /tmp/request.json
+
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" -X POST \
+            "https://devdiv.visualstudio.com/DevDiv/_apis/build/builds?api-version=7.0" \
+            -H "Authorization: Basic ${AUTH}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/request.json)
+
+          RESP_BODY=$(cat /tmp/response.json)
+
+          echo "response_body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$RESP_BODY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            BUILD_ID=$(echo "$RESP_BODY" | jq -r '.id')
+            BUILD_URL=$(echo "$RESP_BODY" | jq -r '._links.web.href')
+            echo "✅ Pipeline queued successfully!"
+            echo "Build ID: $BUILD_ID"
+            echo "Build URL: $BUILD_URL"
+            echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+            echo "build_url=$BUILD_URL" >> "$GITHUB_OUTPUT"
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Failed to queue pipeline (HTTP $HTTP_CODE)"
+            echo "$RESP_BODY"
+            echo "success=false" >> "$GITHUB_OUTPUT"
+          fi
+        id: queue
+
+      - name: Add reaction to comment
+        if: github.event_name == 'issue_comment' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const success = '${{ steps.queue.outputs.success }}' === 'true';
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: success ? 'rocket' : 'confused'
+            });

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -10,12 +10,14 @@ on:
         required: true
         type: number
       platform:
-        description: 'Platform to review (android, ios, or both)'
+        description: 'Platform to review'
         required: true
         type: choice
         options:
           - android
           - ios
+          - catalyst
+          - windows
 
 permissions:
   contents: read
@@ -41,9 +43,9 @@ jobs:
               repo: context.repo.repo,
               username: context.payload.comment.user.login
             });
-            const allowed = ['admin', 'write'];
+            const allowed = ['admin'];
             if (!allowed.includes(data.permission)) {
-              core.setFailed(`User @${context.payload.comment.user.login} does not have write access. Permission: ${data.permission}`);
+              core.setFailed(`User @${context.payload.comment.user.login} does not have admin access. Permission: ${data.permission}`);
             }
 
       - name: Parse inputs
@@ -77,8 +79,8 @@ jobs:
         env:
           PLATFORM: ${{ steps.parse.outputs.platform }}
         run: |
-          if [[ "$PLATFORM" != "android" && "$PLATFORM" != "ios" ]]; then
-            echo "::error::Invalid platform '$PLATFORM'. Must be 'android' or 'ios'."
+          if [[ "$PLATFORM" != "android" && "$PLATFORM" != "ios" && "$PLATFORM" != "catalyst" && "$PLATFORM" != "windows" ]]; then
+            echo "::error::Invalid platform '$PLATFORM'. Must be 'android', 'ios', 'catalyst', or 'windows'."
             exit 1
           fi
 
@@ -89,12 +91,6 @@ jobs:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           PLATFORM: ${{ steps.parse.outputs.platform }}
         run: |
-          if [ "$PLATFORM" = "ios" ]; then
-            POOL_STR='{"name": "AcesShared"}'
-          else
-            POOL_STR='{"name": "Azure Pipelines", "vmImage": "ubuntu-22.04"}'
-          fi
-
           AUTH=$(printf ':%s' "$REVIEW_PR_AZDO_PAT" | base64 -w0)
 
           echo "Queuing review pipeline for PR #${PR_NUMBER} (platform: ${PLATFORM})"
@@ -102,14 +98,12 @@ jobs:
           jq -n \
             --arg pr "$PR_NUMBER" \
             --arg plat "$PLATFORM" \
-            --arg pool "$POOL_STR" \
             '{
               definition: {id: 27723},
               sourceBranch: "refs/heads/main",
               templateParameters: {
                 PRNumber: $pr,
-                Platform: $plat,
-                pool: $pool
+                Platform: $plat
               }
             }' > /tmp/request.json
 

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   trigger-review:
@@ -84,14 +85,23 @@ jobs:
             exit 1
           fi
 
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
       - name: Queue Azure DevOps pipeline
+        id: queue
         shell: bash
         env:
-          REVIEW_PR_AZDO_PAT: ${{ secrets.REVIEW_PR_AZDO_PAT }}
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           PLATFORM: ${{ steps.parse.outputs.platform }}
         run: |
-          AUTH=$(printf ':%s' "$REVIEW_PR_AZDO_PAT" | base64 -w0)
+          TOKEN=$(az account get-access-token \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+            --query accessToken -o tsv)
 
           echo "Queuing review pipeline for PR #${PR_NUMBER} (platform: ${PLATFORM})"
 
@@ -112,16 +122,11 @@ jobs:
 
           HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" -X POST \
             "https://devdiv.visualstudio.com/DevDiv/_apis/build/builds?api-version=7.0" \
-            -H "Authorization: Basic ${AUTH}" \
+            -H "Authorization: Bearer ${TOKEN}" \
             -H "Content-Type: application/json" \
             -d @/tmp/request.json)
 
           RESP_BODY=$(cat /tmp/response.json)
-
-          echo "response_body<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$RESP_BODY" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
 
           if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             BUILD_ID=$(echo "$RESP_BODY" | jq -r '.id')
@@ -137,7 +142,6 @@ jobs:
             echo "$RESP_BODY"
             echo "success=false" >> "$GITHUB_OUTPUT"
           fi
-        id: queue
 
       - name: Add reaction to comment
         if: github.event_name == 'issue_comment' && always()


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds a GitHub Actions workflow that lets maintainers trigger the `maui-copilot` AzDO pipeline (definition 27723) by commenting `/review <platform>` on a PR.

### Usage

Comment on any PR:
```
/review android    # queue review for Android
/review ios        # queue review for iOS
```

### Features

- **Permission gated**: only users with write/admin access can trigger
- **Script injection safe**: all user input passed via env vars, platform sanitized
- **Platform-specific pools**: AcesShared (iOS), Azure Pipelines + ubuntu-22.04 (Android)
- **Reaction feedback**: 🚀 on success, 😕 on failure (no public comments)
- **workflow_dispatch support**: can also be triggered manually from Actions tab

### Requirements

Requires `REVIEW_PR_AZDO_PAT` repository secret with Azure DevOps Build Queue permission on the DevDiv project.

### Security

- All user input (`comment.body`) is passed through `env:` block, never inline `${{ }}` in shell scripts
- Platform input sanitized with `tr -cd a-z` before validation
- Permission check runs before any step that accesses secrets
- Minimal permissions: `contents: read`, `pull-requests: write`
