### PR TITLE
[Android] Fix Share.RequestAsync SecurityException on Android 10+ caused by missing ClipData

### DIFF
--- a/src/Essentials/src/Share/Share.android.cs
+++ b/src/Essentials/src/Share/Share.android.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.App;
@@ -85,25 +86,38 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 				// Set ClipData so the system grants URI read permission to the receiving app.
 				// Without this, Android 10+ logs a SecurityException when the share sheet
 				// or target app tries to read the FileProvider content URI.
-				intent.ClipData = ClipData.NewRawUri(request.Title ?? string.Empty, (AndroidUri)contentUris[0]);
+				if (OperatingSystem.IsAndroidVersionAtLeast(29))
+				{
+					intent.ClipData = ClipData.NewRawUri(request.Title ?? string.Empty, (AndroidUri)contentUris[0]);
+				}
 			}
 			else if (contentUris.Count > 1)
 			{
 				intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);
 
-				var clipData = new ClipData(
-					request.Title ?? string.Empty,
-					new[] { contentType },
-					new ClipData.Item((AndroidUri)contentUris[0]));
+				// Set ClipData so the system grants URI read permission to the receiving app.
+				// Without this, Android 10+ logs a SecurityException when the share sheet
+				// or target app tries to read the FileProvider content URI.
+				if (OperatingSystem.IsAndroidVersionAtLeast(29))
+				{
+					var clipData = new ClipData(
+						request.Title ?? string.Empty,
+						new[] { contentType },
+						new ClipData.Item((AndroidUri)contentUris[0]));
 
-				for (int i = 1; i < contentUris.Count; i++)
-					clipData.AddItem(new ClipData.Item((AndroidUri)contentUris[i]));
+					for (int i = 1; i < contentUris.Count; i++)
+					{
+						clipData.AddItem(new ClipData.Item((AndroidUri)contentUris[i]));
+					}
 
-				intent.ClipData = clipData;
+					intent.ClipData = clipData;
+				}
 			}
 
 			if (!string.IsNullOrEmpty(request.Title))
+			{
 				intent.PutExtra(Intent.ExtraTitle, request.Title);
+			}
 
 			return intent;
 		}

--- a/src/Essentials/src/Share/Share.android.cs
+++ b/src/Essentials/src/Share/Share.android.cs
@@ -79,19 +79,7 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 			intent.SetType(contentType);
 			intent.SetFlags(ActivityFlags.GrantReadUriPermission);
 
-			if (contentUris.Count == 1)
-			{
-				intent.PutExtra(Intent.ExtraStream, contentUris[0]);
-
-				// Set ClipData so the system grants URI read permission to the receiving app.
-				// Without this, Android 10+ logs a SecurityException when the share sheet
-				// or target app tries to read the FileProvider content URI.
-				if (OperatingSystem.IsAndroidVersionAtLeast(29))
-				{
-					intent.ClipData = ClipData.NewRawUri(request.Title ?? string.Empty, (AndroidUri)contentUris[0]);
-				}
-			}
-			else if (contentUris.Count > 1)
+			if (contentUris.Count > 1)
 			{
 				intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);
 
@@ -111,6 +99,18 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 					}
 
 					intent.ClipData = clipData;
+				}
+			}
+			else if (contentUris.Count == 1)
+			{
+				intent.PutExtra(Intent.ExtraStream, contentUris[0]);
+
+				// Set ClipData so the system grants URI read permission to the receiving app.
+				// Without this, Android 10+ logs a SecurityException when the share sheet
+				// or target app tries to read the FileProvider content URI.
+				if (OperatingSystem.IsAndroidVersionAtLeast(29))
+				{
+					intent.ClipData = ClipData.NewRawUri(request.Title ?? string.Empty, (AndroidUri)contentUris[0]);
 				}
 			}
 

--- a/src/Essentials/src/Share/Share.android.cs
+++ b/src/Essentials/src/Share/Share.android.cs
@@ -4,6 +4,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using Microsoft.Maui.Storage;
+using AndroidUri = Android.Net.Uri;
 
 namespace Microsoft.Maui.ApplicationModel.DataTransfer
 {
@@ -44,7 +45,19 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 
 		Task PlatformRequestAsync(ShareMultipleFilesRequest request)
 		{
-			// load the data we need
+			var intent = CreateShareFileIntent(request);
+
+			var chooserIntent = Intent.CreateChooser(intent, request.Title ?? string.Empty);
+			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask | ActivityFlags.GrantReadUriPermission;
+			chooserIntent.SetFlags(flags);
+			Application.Context.StartActivity(chooserIntent);
+
+			return Task.CompletedTask;
+		}
+
+		// Extracted for testability — verifiable without launching an Activity.
+		internal static Intent CreateShareFileIntent(ShareMultipleFilesRequest request)
+		{
 			var contentUris = new List<IParcelable>(request.Files.Count);
 			var contentType = default(string);
 			foreach (var file in request.Files)
@@ -65,20 +78,34 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 			intent.SetType(contentType);
 			intent.SetFlags(ActivityFlags.GrantReadUriPermission);
 
-			if (contentUris.Count > 1)
-				intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);
-			else if (contentUris.Count == 1)
+			if (contentUris.Count == 1)
+			{
 				intent.PutExtra(Intent.ExtraStream, contentUris[0]);
+
+				// Set ClipData so the system grants URI read permission to the receiving app.
+				// Without this, Android 10+ logs a SecurityException when the share sheet
+				// or target app tries to read the FileProvider content URI.
+				intent.ClipData = ClipData.NewRawUri(request.Title ?? string.Empty, (AndroidUri)contentUris[0]);
+			}
+			else if (contentUris.Count > 1)
+			{
+				intent.PutParcelableArrayListExtra(Intent.ExtraStream, contentUris);
+
+				var clipData = new ClipData(
+					request.Title ?? string.Empty,
+					new[] { contentType },
+					new ClipData.Item((AndroidUri)contentUris[0]));
+
+				for (int i = 1; i < contentUris.Count; i++)
+					clipData.AddItem(new ClipData.Item((AndroidUri)contentUris[i]));
+
+				intent.ClipData = clipData;
+			}
 
 			if (!string.IsNullOrEmpty(request.Title))
 				intent.PutExtra(Intent.ExtraTitle, request.Title);
 
-			var chooserIntent = Intent.CreateChooser(intent, request.Title ?? string.Empty);
-			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-			chooserIntent.SetFlags(flags);
-			Application.Context.StartActivity(chooserIntent);
-
-			return Task.CompletedTask;
+			return intent;
 		}
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/Share_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Share_Tests.cs
@@ -98,9 +98,16 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 				var intent = ShareImplementation.CreateShareFileIntent((ShareMultipleFilesRequest)request);
 
-				Assert.NotNull(intent.ClipData);
-				Assert.Equal(1, intent.ClipData.ItemCount);
-				Assert.NotNull(intent.ClipData.GetItemAt(0)?.Uri);
+				if (OperatingSystem.IsAndroidVersionAtLeast(29))
+				{
+					Assert.NotNull(intent.ClipData);
+					Assert.Equal(1, intent.ClipData.ItemCount);
+					Assert.NotNull(intent.ClipData.GetItemAt(0)?.Uri);
+				}
+				else
+				{
+					Assert.Null(intent.ClipData);
+				}
 			}
 			finally
 			{
@@ -130,10 +137,17 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 				var intent = ShareImplementation.CreateShareFileIntent(request);
 
-				Assert.NotNull(intent.ClipData);
-				Assert.Equal(2, intent.ClipData.ItemCount);
-				Assert.NotNull(intent.ClipData.GetItemAt(0)?.Uri);
-				Assert.NotNull(intent.ClipData.GetItemAt(1)?.Uri);
+				if (OperatingSystem.IsAndroidVersionAtLeast(29))
+				{
+					Assert.NotNull(intent.ClipData);
+					Assert.Equal(2, intent.ClipData.ItemCount);
+					Assert.NotNull(intent.ClipData.GetItemAt(0)?.Uri);
+					Assert.NotNull(intent.ClipData.GetItemAt(1)?.Uri);
+				}
+				else
+				{
+					Assert.Null(intent.ClipData);
+				}
 			}
 			finally
 			{

--- a/src/Essentials/test/DeviceTests/Tests/Share_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Share_Tests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
+using Microsoft.Maui.Storage;
 using Xunit;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
@@ -78,5 +80,67 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Fact]
 		public void Share_FiletWithNullFilePath()
 			=> Assert.Throws<ArgumentNullException>(() => new ShareFile(fullPath: null));
+
+#if ANDROID
+		[Fact]
+		public void Share_SingleFileIntent_HasClipData()
+		{
+			var file = Path.Combine(FileSystem.CacheDirectory, "share_clipdata_test.txt");
+			File.WriteAllText(file, "ClipData test content");
+
+			try
+			{
+				var request = new ShareFileRequest
+				{
+					Title = "Test Share",
+					File = new ShareFile(file)
+				};
+
+				var intent = ShareImplementation.CreateShareFileIntent((ShareMultipleFilesRequest)request);
+
+				Assert.NotNull(intent.ClipData);
+				Assert.Equal(1, intent.ClipData.ItemCount);
+				Assert.NotNull(intent.ClipData.GetItemAt(0)?.Uri);
+			}
+			finally
+			{
+				File.Delete(file);
+			}
+		}
+
+		[Fact]
+		public void Share_MultipleFilesIntent_HasClipData()
+		{
+			var file1 = Path.Combine(FileSystem.CacheDirectory, "share_clipdata_test1.txt");
+			var file2 = Path.Combine(FileSystem.CacheDirectory, "share_clipdata_test2.txt");
+			File.WriteAllText(file1, "ClipData test content 1");
+			File.WriteAllText(file2, "ClipData test content 2");
+
+			try
+			{
+				var request = new ShareMultipleFilesRequest
+				{
+					Title = "Test Share Multiple",
+					Files = new List<ShareFile>
+					{
+						new ShareFile(file1),
+						new ShareFile(file2)
+					}
+				};
+
+				var intent = ShareImplementation.CreateShareFileIntent(request);
+
+				Assert.NotNull(intent.ClipData);
+				Assert.Equal(2, intent.ClipData.ItemCount);
+				Assert.NotNull(intent.ClipData.GetItemAt(0)?.Uri);
+				Assert.NotNull(intent.ClipData.GetItemAt(1)?.Uri);
+			}
+			finally
+			{
+				File.Delete(file1);
+				File.Delete(file2);
+			}
+		}
+#endif
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- `Share.RequestAsync` logs `SecurityException` on Android 10+

### Root Cause of the issue

- Missing `ClipData` on the file share intent — Android 10+ uses `ClipData` (not `EXTRA_STREAM`) to propagate URI permission grants through the chooser
- `chooserIntent.SetFlags(ClearTop | NewTask)` was missing `GrantReadUriPermission`, so the chooser process (share sheet UI, uid=1000) couldn't read the FileProvider URI to show preview thumbnails

### Description of Change

<!-- Enter description of the fix in this section -->
Enhancements to Android file sharing:

* Ensured that `ClipData` is set on share intents for both single and multiple files, granting URI read permissions to receiving apps and preventing `SecurityException` on Android 10+ when accessing shared files.
* Extracted the intent creation logic into a new `CreateShareFileIntent` method, making it easier to test without launching an activity.

Test improvements:

* Added unit tests for Android to verify that `ClipData` is correctly set for both single and multiple file share intents, ensuring shared URIs are accessible.

Codebase maintenance:

* Added missing `using System;` directive and aliased `AndroidUri` for clarity in `Share.android.cs`.
* Updated test file imports to include necessary namespaces for file operations and storage.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34370 

### Tested the behaviour in the following platforms

- [ ] - Windows 
- [x] - Android
- [ ] - iOS
- [ ] - Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/dc1583d6-ba7a-4089-a289-acfb44828934"> | <video src="https://github.com/user-attachments/assets/bd678a0b-d62e-4253-9b46-03f7a6751e65"> |


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
