### PR TITLE
[iOS] Fix PickContactAsync blocking subsequent dialog presentation

### DIFF
--- a/src/Essentials/src/Contacts/Contacts.ios.macos.cs
+++ b/src/Essentials/src/Contacts/Contacts.ios.macos.cs
@@ -22,25 +22,35 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 
 			var source = new TaskCompletionSource<Contact>();
 
+			var contactDelegate = new ContactPickerDelegate(phoneContact =>
+			{
+				try
+				{
+					source?.TrySetResult(ConvertContact(phoneContact));
+				}
+				catch (Exception ex)
+				{
+					source?.TrySetException(ex);
+				}
+			});
+
 			var picker = new CNContactPickerViewController
 			{
-				Delegate = new ContactPickerDelegate(phoneContact =>
-				{
-					try
-					{
-						source?.TrySetResult(ConvertContact(phoneContact));
-					}
-					catch (Exception ex)
-					{
-						source?.TrySetException(ex);
-					}
-				})
+				Delegate = contactDelegate
 			};
 
-			if (picker.PresentationController != null)
+			if (picker.PresentationController is not null)
 			{
+				// Only complete with null (swipe-to-dismiss) if the delegate hasn't already
+				// handled an explicit selection or cancellation via its completion callback.
 				picker.PresentationController.Delegate =
-					new UIPresentationControllerDelegate(() => source?.TrySetResult(null));
+					new UIPresentationControllerDelegate(() =>
+					{
+						if (!contactDelegate.IsResultDelivered)
+						{
+							source?.TrySetResult(null);
+						}
+					});
 			}
 
 			vc.PresentViewController(picker, true, null);
@@ -122,16 +132,20 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 
 			public Action<CNContact> DidSelectContactHandler { get; }
 
+			// Set to true when an explicit selection or cancellation is made, so that
+			// UIPresentationControllerDelegate.DidDismiss does not complete the TCS with null.
+			public bool IsResultDelivered { get; private set; }
+
 			public override void ContactPickerDidCancel(CNContactPickerViewController picker)
 			{
-				DidSelectContactHandler?.Invoke(default);
-				picker.DismissViewController(true, null);
+				IsResultDelivered = true;
+				picker.DismissViewController(true, () => DidSelectContactHandler?.Invoke(default));
 			}
 
 			public override void DidSelectContact(CNContactPickerViewController picker, CNContact contact)
 			{
-				DidSelectContactHandler?.Invoke(contact);
-				picker.DismissViewController(true, null);
+				IsResultDelivered = true;
+				picker.DismissViewController(true, () => DidSelectContactHandler?.Invoke(contact));
 			}
 
 			public override void DidSelectContactProperty(CNContactPickerViewController picker, CNContactProperty contactProperty) =>

--- a/src/Essentials/src/Contacts/Contacts.ios.macos.cs
+++ b/src/Essentials/src/Contacts/Contacts.ios.macos.cs
@@ -124,12 +124,14 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 
 			public override void ContactPickerDidCancel(CNContactPickerViewController picker)
 			{
-				picker.DismissViewController(true, () => DidSelectContactHandler?.Invoke(default));
+				DidSelectContactHandler?.Invoke(default);
+				picker.DismissViewController(true, null);
 			}
 
 			public override void DidSelectContact(CNContactPickerViewController picker, CNContact contact)
 			{
-				picker.DismissViewController(true, () => DidSelectContactHandler?.Invoke(contact));
+				DidSelectContactHandler?.Invoke(contact);
+				picker.DismissViewController(true, null);
 			}
 
 			public override void DidSelectContactProperty(CNContactPickerViewController picker, CNContactProperty contactProperty) =>

--- a/src/Essentials/src/Contacts/Contacts.ios.macos.cs
+++ b/src/Essentials/src/Contacts/Contacts.ios.macos.cs
@@ -121,25 +121,19 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			}
 
 			public Action<CNContact> DidSelectContactHandler { get; }
-#pragma warning disable CA1416 // picker.DismissModalViewController(bool) has UnsupportedOSPlatform("ios6.0")]. (Deprecated but still works)
-#pragma warning disable CA1422 // Validate platform compatibility
+
 			public override void ContactPickerDidCancel(CNContactPickerViewController picker)
 			{
-				DidSelectContactHandler?.Invoke(default);
-				picker.DismissModalViewController(true);
+				picker.DismissViewController(true, () => DidSelectContactHandler?.Invoke(default));
 			}
 
 			public override void DidSelectContact(CNContactPickerViewController picker, CNContact contact)
 			{
-				DidSelectContactHandler?.Invoke(contact);
-				picker.DismissModalViewController(true);
+				picker.DismissViewController(true, () => DidSelectContactHandler?.Invoke(contact));
 			}
 
 			public override void DidSelectContactProperty(CNContactPickerViewController picker, CNContactProperty contactProperty) =>
-				picker.DismissModalViewController(true);
-
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore CA1416
+				picker.DismissViewController(true, null);
 		}
 #endif
 	}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

###  Root Cause

In `ContactPickerDelegate`, the `TaskCompletionSource` was resolved **before** the picker's dismiss animation completed. iOS prevents presenting new view controllers during an ongoing dismissal animation, so any `PresentViewController` call (alert, action sheet) made after `await PickContactAsync()` would fail silently.

### Description of Change
* Extracted ContactPickerDelegate into a named variable (contactDelegate) to allow cross-referencing from the UIPresentationControllerDelegate closure.
* Added an IsResultDelivered flag to ContactPickerDelegate, set to true synchronously when an explicit selection or cancellation occurs.
* Moved DidSelectContactHandler?.Invoke(...) inside the DismissViewController(true, callback) completion callback. iOS invokes this callback only after the dismiss animation completes, ensuring await PickContactAsync() returns only when it is safe to present new view controllers.
* Updated UIPresentationControllerDelegate.DidDismiss to guard with !contactDelegate.IsResultDelivered before calling TrySetResult(null), preventing a swipe-to-dismiss from overwriting a valid contact result with null.

**Pattern**
This follows the existing pattern used in MediaPicker.ios.cs:
`picker.DismissViewController(true, () => CompletedHandler?.Invoke(info));`

### Issues Fixed
Fixes #20383

**Regarding testcase:** PickContactAsync() opens CNContactPickerViewController, which is a system-level iOS UI running outside the app process. Appium/XCUITest cannot interact with system-level view controllers, so automated tests cannot be added for this scenario.

#### Key Technical Details

- **`DismissViewController(animated:completion:)`** — The `completion` callback is fired by iOS only after the dismiss animation has fully completed and the view controller has been removed from the hierarchy. This is the correct hook to use when you need to guarantee the view hierarchy is clean before proceeding.

- **Why the old API was wrong** — `DismissModalViewController(animated:)` has no completion callback, so there was no way to know when the animation finished. The handler was called synchronously before the dismiss, racing the animation.

- **Pattern already in the codebase** — `MediaPicker.ios.cs` in the same Essentials project uses the identical correct pattern: "pickerController.DismissViewController(true, () => tcs.TrySetResult(result));". This fix makes `ContactPickerDelegate` consistent with `MediaPicker`.

#### Files Changed

| File | Lines | Change |
|------|-------|--------|
| `src/Essentials/src/Contacts/Contacts.ios.macos.cs` | +4 / -11 | Move TCS resolution into `DismissViewController` completion callback; remove deprecated `DismissModalViewController` and `#pragma warning` suppressions |

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/22e3a5f3-4445-4614-ad92-af35fb58f115"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/9d7894e2-cb9c-4552-914d-7d5a2bd336e2">) |