### PR TITLE
[Android] Fix Java.Lang.IllegalArgumentException crash in Entry with StringFormat binding

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+using System;
 using Android.Text;
 using Android.Widget;
 using AndroidX.Core.Widget;
@@ -56,9 +57,35 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (oldText != newText)
 			{
-				// This update is happening while inputting text into the EditText, so we want to avoid 
-				// resettting the cursor position and selection
-				editText.SetTextKeepState(newText);
+				// Use Editable.Replace() instead of SetTextKeepState() to avoid re-entering setText()
+				// inside afterTextChanged.
+				// SetTextKeepState() causes EmojiTextWatcher to crash with stale span positions
+				// when a StringFormat binding updates the text programmatically.
+				// https://github.com/dotnet/maui/issues/25728
+				var editable = editText.EditableText;
+
+				if (editable is not null)
+				{
+					// Preserve cursor position across the replace (matches SetTextKeepState behavior)
+					int selStart = editText.SelectionStart;
+					int selEnd = editText.SelectionEnd;
+
+					editable.Replace(0, editable.Length(), newText);
+
+					// Clamp selection to new text length before restoring
+					int len = editText.Text?.Length ?? 0;
+					selStart = Math.Min(selStart, len);
+					selEnd = Math.Min(selEnd, len);
+
+					if (selStart >= 0 && selEnd >= selStart)
+					{
+						editText.SetSelection(selStart, selEnd);
+					}
+				}
+				else
+				{
+					editText.SetTextKeepState(newText);
+				}
 			}
 		}
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue25728.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue25728.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 25728, "Java.Lang.IllegalArgumentException when clearing Entry text with StringFormat binding on Android", PlatformAffected.Android)]
+public class Issue25728 : ContentPage
+{
+	public Issue25728()
+	{
+		var vm = new Issue25728ViewModel();
+
+		var entry = new Entry
+		{
+			Keyboard = Keyboard.Numeric,
+			AutomationId = "FloatEntry"
+		};
+		entry.SetBinding(Entry.TextProperty, new Binding(nameof(Issue25728ViewModel.FloatValue), stringFormat: "{0:F2}"));
+
+		BindingContext = vm;
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(30, 0),
+			Spacing = 25,
+			Children = { entry }
+		};
+	}
+
+	public class Issue25728ViewModel : INotifyPropertyChanged
+	{
+		float _floatValue;
+
+		public float FloatValue
+		{
+			get => _floatValue;
+			set
+			{
+				if (!Equals(_floatValue, value))
+				{
+					_floatValue = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		void OnPropertyChanged([CallerMemberName] string propertyName = null) =>
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25728.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25728.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue25728 : _IssuesUITest
+{
+	public Issue25728(TestDevice device) : base(device) { }
+
+	public override string Issue => "Java.Lang.IllegalArgumentException when clearing Entry text with StringFormat binding on Android";
+
+	[Test]
+	[Category(UITestCategories.Entry)]
+	public void ClearingEntryWithStringFormatBindingShouldNotCrash()
+	{
+		// Wait for the Entry with StringFormat binding to appear (shows "0.00" initially)
+		App.WaitForElement("FloatEntry");
+
+		// Clear all characters from the Entry
+		App.ClearText("FloatEntry");
+
+		// Enter a number — this triggered Java.Lang.IllegalArgumentException on Android
+		App.EnterText("FloatEntry", "42");
+
+		// If we reach here without a crash, the issue is fixed
+		App.WaitForElement("FloatEntry");
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

When an Entry uses a StringFormat binding and the user clears the text then types a new number, the ViewModel's PropertyChanged fires synchronously inside Android's afterTextChanged callback. This triggers Entry.MapText → UpdateTextFromPlatform → SetTextKeepState.

SetTextKeepState internally calls TextView.setText(), which re-enters the afterTextChanged chain. At this point, EmojiTextWatcher still holds stale span indices (mStart / mEnd) from the previous text. These stale indices are passed to EmojiCompat.process(), where the end index becomes larger than the current text length, causing the crash:
java.lang.IllegalArgumentException: end should be < than charSequence length

### Description of Change

Instead of calling SetTextKeepState (which triggers a nested setText inside afterTextChanged), the fix updates the existing text buffer directly using editable.Replace(0, editable.Length(), newText).

SpannableStringBuilder.Replace is the recommended Android API for modifying text within a TextWatcher callback. It correctly adjusts all span positions internally, ensuring EmojiTextWatcher receives valid span indices during the subsequent afterTextChanged callback — no stale indices, no crash.

To preserve previous behavior, the cursor and selection position is saved before the replace and restored afterward, clamped to the new text length. A fallback to SetTextKeepState is retained for cases where the text source is not Editable.

### Issue Fixed

Fixes #25728

### Technical Details

| Item | Detail |
|------|--------|
| **Crash type** | `java.lang.IllegalArgumentException: end should be < than charSequence length` |
| **Crash stack** | `EmojiCompat.process` ← `EmojiTextWatcher.afterTextChanged` |
| **Trigger** | `SetTextKeepState()` called inside `afterTextChanged` re-enters `TextView.setText()`, causing `EmojiTextWatcher` to hold stale `mStart`/`mEnd` span positions |
| **Fix API** | `IEditable.Replace(int st, int en, ICharSequence text)` — Android's documented mutation API for use inside `TextWatcher` |
| **Why `Replace()` works** | `SpannableStringBuilder.replace()` internally adjusts all attached spans; EmojiTextWatcher receives valid indices on the next `afterTextChanged` |
| **Why toggle `EmojiCompatEnabled` doesn't work** | Runtime toggle reuses the same `EmojiTextWatcher` instance — stale `mStart`/`mEnd` are NOT reset |
| **Platforms affected** | Android only (`EmojiCompat` is Android-specific) |

### Files Changed

| File | Change | Description |
|------|--------|-------------|
| `src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs` | +28 / -3 | **The fix** — replace `SetTextKeepState` with `EditableText.Replace()` + selection restore in `UpdateTextFromPlatform` |
| `src/Controls/tests/TestCases.HostApp/Issues/Issue25728.cs` | +55 / 0 | New UI test host page — `Entry` with `StringFormat='{0:F2}'` binding, `AutomationId="FloatEntry"` |
| `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue25728.cs` | +28 / 0 | New NUnit UI test — wait → clear → enter "42" → verify no crash |

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/51e2b1e8-c57b-4358-a1b6-69acc14ceff7"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/26930d17-a4f2-4209-912e-5e8b56a731d7"> |