### PR TITLE
Update Magick.NET-Q8-AnyCPU to 14.10.4

### DIFF
--- a/src/TestUtils/src/VisualTestUtils.MagickNet/VisualTestUtils.MagickNet.csproj
+++ b/src/TestUtils/src/VisualTestUtils.MagickNet/VisualTestUtils.MagickNet.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.10.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the Magick.NET-Q8-AnyCPU dependency in `VisualTestUtils.MagickNet` from 13.5.0 to the latest stable (14.10.4).

This is a test utility dependency only — no shipping product impact.