### PR TITLE
Resolve UI test Build Sample failures - Candidate March 16

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33523.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33523.cs
@@ -2,7 +2,7 @@ using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues
 {
-	[Issue(IssueTracker.Github, 33523, "OnBackButtonPressed not firing for Shell Navigation Bar button in .NET 10 SR2", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.MacCatalyst)]
+	[Issue(IssueTracker.Github, 33523, "OnBackButtonPressed not firing for Shell Navigation Bar button in .NET 10 SR2", PlatformAffected.Android | PlatformAffected.iOS | PlatformAffected.macOS)]
 	public class Issue33523 : Shell
 	{
 		public Issue33523()


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

To resolve the UITest Build Sample failures , replaced the PlatformAffected.MacCatalyst with PlatformAffected.macOS — there is no MacCatalyst member in the enum. The correct value is macOS (lowercase 'm', uppercase 'OS'). - 


