### PR TITLE
[XAML] Fix type resolver incorrectly matching static Extension classes instead of Enum types

### DIFF
--- a/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
+++ b/src/Controls/src/Build.Tasks/XmlTypeExtensions.cs
@@ -111,7 +111,14 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				string typeName = typeInfo.typeName.Replace('+', '/'); //Nested types
 				var type = module.GetTypeDefinition(cache, (typeInfo.assemblyName, typeInfo.clrNamespace, typeName));
 				if (type is not null && type.IsPublicOrVisibleInternal(module))
+				{
+					// Skip static classes found via the "Extension" suffix expansion when they shadow
+					// the exact name (e.g. MyEnumExtension shadowing MyEnum). Static types cannot
+					// implement IMarkupExtension, so they are never valid markup extensions. (#34021)
+					if (typeInfo.typeName != xmlType.Name && type.IsAbstract && type.IsSealed)
+						return null;
 					return type;
+				}
 				return null;
 			}, expandToExtension: expandToExtension);
 

--- a/src/Controls/src/SourceGen/XmlTypeExtensions.cs
+++ b/src/Controls/src/SourceGen/XmlTypeExtensions.cs
@@ -67,6 +67,12 @@ static class XmlTypeExtensions
 			if (types.Length == 1)
 			{
 				symbol = types[0];
+				// If the match is via the "Extension" suffix but the type is static, it cannot be
+				// an IMarkupExtension (static types cannot implement interfaces). In that case, skip
+				// this match and continue to try the exact name. This prevents a static helper class
+				// like MyEnumExtension from being returned instead of the MyEnum enum type. (#34021)
+				if (suffix == "Extension" && symbol.IsStatic)
+					continue;
 				if (symbol.IsGenericType && xmlType.TypeArguments is not null)
 				{
 					var typeArgs = xmlType.TypeArguments.Select(typeArg => typeArg.GetTypeSymbol(reportDiagnostic, compilation, xmlnsCache, typeCache)!).ToArray();

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -108,6 +108,15 @@ namespace Microsoft.Maui.Controls.Xaml
 				if ((returnTypeName == null || returnTypeName == typeInfo.typeName) //only return multiple types if they share the same name. avoid returning both BindingExtension and Binding
 					&& (type = refFromTypeInfo(typeInfo)) != null)
 				{
+					// If this is an Extension-suffix match but the type is static (cannot implement
+					// IMarkupExtension), skip it and continue to try the exact name. This prevents
+					// a static helper class like MyEnumExtension from shadowing MyEnum. (#34021)
+					if (returnTypeName == null
+						&& typeInfo.typeName.EndsWith("Extension", StringComparison.Ordinal)
+						&& typeInfo.typeName != elementName
+						&& type is System.Type runtimeType
+						&& runtimeType.IsAbstract && runtimeType.IsSealed) // static in reflection: abstract+sealed
+						continue;
 					returnTypeName = typeInfo.typeName;
 					yield return type;
 				}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
-             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34021Rtxc">
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34021">
 
-     <local:Maui34021DataObject x:TypeArguments="local:Maui34021MyEnum"/>
+        <local:Maui34021DataObject x:TypeArguments="local:Maui34021MyEnum"/>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34021Rtxc">
+
+     <local:Maui34021DataObject x:TypeArguments="local:Maui34021MyEnum"/>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml.cs
@@ -1,0 +1,83 @@
+using System;
+using Xunit;
+
+using static Microsoft.Maui.Controls.Xaml.UnitTests.MockSourceGenerator;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public enum Maui34021MyEnum { Value1, Value2, Value3 }
+
+internal static class Maui34021MyEnumExtension
+{
+    public static string ToFriendlyString(this Maui34021MyEnum value) => value.ToString();
+}
+
+public class Maui34021DataObject<T> : View where T : Enum
+{
+}
+
+public partial class Maui34021Rtxc : ContentPage
+{
+    public Maui34021Rtxc() => InitializeComponent();
+
+    [Collection("Issue")]
+    public class Tests : IDisposable
+    {
+        public void Dispose() => Application.Current = null;
+
+        [Theory]
+        [InlineData(XamlInflator.Runtime)]
+        [InlineData(XamlInflator.XamlC)]
+        [InlineData(XamlInflator.SourceGen)]
+        internal void SourceGenResolvesEnumTypeNotExtensionClass(XamlInflator inflator)
+        {
+            if (inflator == XamlInflator.SourceGen)
+            {
+                const string xaml = """
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34021SourceGenRepro">
+    <local:Maui34021DataObject x:TypeArguments="local:Maui34021MyEnum" />
+</ContentPage>
+""";
+
+                const string csharp = """
+using System;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public enum Maui34021MyEnum { Value1, Value2, Value3 }
+
+internal static class Maui34021MyEnumExtension
+{
+    public static string ToFriendlyString(this Maui34021MyEnum value) => value.ToString();
+}
+
+public class Maui34021DataObject<T> : View where T : Enum
+{
+}
+
+public partial class Maui34021SourceGenRepro : ContentPage
+{
+    public Maui34021SourceGenRepro() => InitializeComponent();
+}
+""";
+
+                var result = CreateMauiCompilation()
+                .WithAdditionalSource(csharp)
+                .RunMauiSourceGenerator(new AdditionalXamlFile("Issues/Maui34021SourceGenRepro.xaml", xaml, TargetFramework: "net10.0"));
+                var generated = result.GeneratedInitializeComponent();
+                Assert.DoesNotContain("Maui34021MyEnumExtension", generated, StringComparison.Ordinal);
+                Assert.Contains("Maui34021MyEnum", generated, StringComparison.Ordinal);
+            }
+            else
+            {
+                var page = new Maui34021Rtxc(inflator);
+                Assert.IsType<Maui34021DataObject<Maui34021MyEnum>>(page.Content);
+            }
+        }
+    }
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34021.xaml.cs
@@ -16,9 +16,9 @@ public class Maui34021DataObject<T> : View where T : Enum
 {
 }
 
-public partial class Maui34021Rtxc : ContentPage
+public partial class Maui34021 : ContentPage
 {
-    public Maui34021Rtxc() => InitializeComponent();
+    public Maui34021() => InitializeComponent();
 
     [Collection("Issue")]
     public class Tests : IDisposable
@@ -75,7 +75,7 @@ public partial class Maui34021SourceGenRepro : ContentPage
             }
             else
             {
-                var page = new Maui34021Rtxc(inflator);
+                var page = new Maui34021(inflator);
                 Assert.IsType<Maui34021DataObject<Maui34021MyEnum>>(page.Content);
             }
         }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
The SourceGen XAML inflator incorrectly generated code referencing `MyEnumExtension` (the static class) instead of `MyEnum`, causing build errors:
- `MAUIG1001`: An error occurred while parsing Xaml: Member not found
- `CS0718`: `MyEnumExtension`: static types cannot be used as type arguments
- `CS0716`: Cannot convert to static type `MyEnumExtension`

### Root Cause
In `TryResolveTypeSymbol()` (`XmlTypeExtensions.cs`) and `GetTypeReferences()` (`XmlTypeXamlExtensions.cs`), the type resolver tries the `[Name]Extension` suffix **first** as a convenience for XAML markup extensions. When a static utility class named `MyEnumExtension` exists in the same namespace as `MyEnum`, it was returned before ever trying the exact name `MyEnum`.

### Description of Change
When the Extension-suffix lookup finds a **static type**, skip it and continue to the exact name. Static types cannot implement `IMarkupExtension` (static types can't implement interfaces in C#), so they can never be valid XAML markup extension classes. This is a minimal, targeted fix that does not affect existing markup extension resolution (e.g., `{Binding}` → `BindingExtension`, `{x:Type}` → `TypeExtension`).

Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
 
### Issues Fixed
  
Fixes #34021 

### Output  ScreenShot

Android

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/d98540c0-1921-4f47-985a-40d118b84469" >| <video src="https://github.com/user-attachments/assets/59718a20-506b-4605-8cae-d40427b4d265">|