### PR TITLE
Fix Compiled Bindings with explicit sources inside DataTemplates

### DIFF
--- a/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/BindingExtension.cs
@@ -95,7 +95,17 @@ namespace Microsoft.Maui.Controls.Xaml
 					UpdateSourceEventName = UpdateSourceEventName,
 					FallbackValue = FallbackValue,
 					TargetNullValue = TargetNullValue,
-					DataType = bindingXDataType,
+					// When Source is set to a concrete element reference (e.g. x:Reference), the
+					// DataType from IXamlDataTypeProvider reflects the DataTemplate item type, not
+					// the explicit source type. Assigning that mismatched DataType causes
+					// BindingExpression.Apply to null-out the binding source when
+					// IsXamlCBindingWithSourceCompilationEnabled is true (.NET 10 default for
+					// AOT/trimmed builds). See https://github.com/dotnet/maui/issues/33291.
+					//
+					// RelativeBindingSource is excluded: the developer likely set x:DataType on
+					// the binding to describe the expected type of the resolved ancestor, and
+					// that validation should be preserved.
+					DataType = (Source is null || Source is RelativeBindingSource) ? bindingXDataType : null,
 				};
 			}
 		}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33291.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33291.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui33291"
+    x:DataType="local:Maui33291"
+    x:Name="thisPage">
+    <!-- Test: TapGestureRecognizer inside a CollectionView DataTemplate binds
+         its Command to the *page* BindingContext (via Source={x:Reference thisPage}),
+         while CommandParameter binds to the CollectionView item.
+         The DataTemplate has x:DataType="local:Maui33291Item" which must NOT be
+         used to compile the Command binding (the source is the page, not the item). -->
+    <CollectionView x:Name="TheCollectionView"
+        ItemsSource="{Binding Items}">
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="local:Maui33291Item">
+                <VerticalStackLayout>
+                    <VerticalStackLayout.GestureRecognizers>
+                        <TapGestureRecognizer x:Name="ItemTapGesture"
+                            Command="{Binding BindingContext.ItemTappedCommand, Source={x:Reference thisPage}}"
+                            CommandParameter="{Binding}" />
+                    </VerticalStackLayout.GestureRecognizers>
+                    <Label Text="{Binding Name}" />
+                </VerticalStackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui33291.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui33291.xaml.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+/// <summary>
+/// Regression test for https://github.com/dotnet/maui/issues/33291
+///
+/// Scenario:
+///   A TapGestureRecognizer inside a CollectionView DataTemplate binds its Command
+///   to the *page* BindingContext using Source={x:Reference thisPage}, while the
+///   CommandParameter binds to the current DataTemplate item.
+///
+///   The DataTemplate has x:DataType="local:Maui33291Item" (the item model type).
+///
+/// Bug (regressed in .NET 10 with MauiEnableXamlCBindingWithSourceCompilation):
+///   The source generator incorrectly compiled the Command binding using
+///   x:DataType="Maui33291Item" as the source type, producing a TypedBinding
+///   that could not find BindingContext.ItemTappedCommand on the item model.
+///   The Command was null at runtime, so tapping an item did nothing.
+///
+/// Fix:
+///   When a binding has Source={x:Reference ...}, skip the compiled binding path
+///   and use the fallback string-based binding instead, just as is done for
+///   Source={RelativeSource ...} (PR #33248 / #33247).
+/// </summary>
+public partial class Maui33291 : ContentPage
+{
+	public ObservableCollection<Maui33291Item> Items { get; } = new()
+	{
+		new Maui33291Item { Name = "Item A" },
+		new Maui33291Item { Name = "Item B" },
+	};
+
+	public ICommand ItemTappedCommand { get; } = new Command<Maui33291Item>(_ => { });
+
+	public Maui33291()
+	{
+		InitializeComponent();
+		BindingContext = this;
+	}
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests() => DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		public void Dispose() => DispatcherProvider.SetCurrent(null);
+
+		[Theory]
+		[XamlInflatorData]
+		internal void TapGestureCommandBindsToPageCommandViaXReference(XamlInflator inflator)
+		{
+			var page = new Maui33291(inflator);
+			// The inflator constructor bypasses the user-defined constructor which sets
+			// BindingContext = this, so we set it explicitly here to simulate the real
+			// app scenario where BindingContext is assigned to the page's view-model.
+			page.BindingContext = page;
+
+			// Create a DataTemplate item — this is what CollectionView does at scroll time.
+			var itemLayout = page.TheCollectionView.ItemTemplate.CreateContent() as VerticalStackLayout;
+			Assert.NotNull(itemLayout);
+
+			var tapGesture = itemLayout.GestureRecognizers[0] as TapGestureRecognizer;
+			Assert.NotNull(tapGesture);
+
+			// Command must NOT be null — this is the key assertion.
+			// When the bug is present, the SourceGen compiles the binding against the item
+			// model type (Maui33291Item), fails to find BindingContext.ItemTappedCommand on
+			// it, and the Command ends up null.
+			Assert.NotNull(tapGesture.Command);
+
+			// The resolved Command must be the same instance exposed by the page.
+			Assert.Same(page.ItemTappedCommand, tapGesture.Command);
+		}
+	}
+}
+
+public class Maui33291Item
+{
+	public string Name { get; set; } = string.Empty;
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause
The Compiled binding logic incorrectly applied the DataTemplate’s x:DataType to bindings that use an explicit source. Because of this, the binding engine tried to resolve the property on the DataTemplate item type instead of the referenced object, causing the binding (such as TapGestureRecognizer.Command) to resolve as null at runtime.
### Description of Change
**Binding engine fix:**

* Modified `BindingBase CreateBinding()` in `BindingExtension.cs` to assign `DataType` only when `Source` is null or a `RelativeBindingSource`, avoiding incorrect DataType assignment for explicit sources like `x:Reference`. This prevents the binding source from being null when source compilation is enabled.

**Test coverage for the fix:**

* Added `Maui33291.xaml` to test binding a `TapGestureRecognizer.Command` to the page's BindingContext via `Source={x:Reference}`, ensuring the DataTemplate's `x:DataType` is not incorrectly used.
* Added `Maui33291.xaml.cs` with a unit test that verifies the Command binding resolves correctly and is not null, confirming the fix for the regression.


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #33291 
### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/cbeb93de-f4d4-4e0e-b516-146badc22d40"> | <video src="https://github.com/user-attachments/assets/8ed1a0b1-8bdc-433a-89f8-400d1ccb6161"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
