### PR TITLE
Fix FlexLayout items with dynamic WidthRequest not updating on Android

### DIFF
--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -523,10 +523,15 @@ namespace Microsoft.Maui.Controls
 					else
 					{
 						// Arrange pass, do not ever run a measure here!
+						// When WidthRequest/HeightRequest is explicitly set, the Flex.Item already
+						// has the correct value from EnsureFlexItemPropertiesUpdated(). Return NaN
+						// so layout_item preserves that value instead of overwriting it with a
+						// potentially stale DesiredSize from a previous measure pass. This fixes
+						// dynamic WidthRequest not updating on Android (see #31109).
 						request = child.DesiredSize;
 					}
-					w = (float)request.Width;
-					h = (float)request.Height;
+					w = (!inMeasureMode && !float.IsNaN(it.Width)) ? float.NaN : (float)request.Width;
+					h = (!inMeasureMode && !float.IsNaN(it.Height)) ? float.NaN : (float)request.Height;
 				};
 			}
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -315,5 +315,34 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			var afterFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
 			Assert.Equal(150, afterFrame.Width);
 		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/31109
+		// Verifies that clearing WidthRequest (setting to -1) falls back to DesiredSize during arrange.
+		[Fact]
+		public void ArrangeOnlyPassFallsBackToDesiredSizeWhenWidthRequestCleared()
+		{
+			var root = new Grid();
+			var flexLayout = new FlexLayout() { Direction = FlexDirection.Row };
+			var view = new FlexTestView { WidthRequest = 200 };
+
+			root.Add(flexLayout);
+			(flexLayout as IFlexLayout).Add(view as IView);
+
+			// Initial measure + arrange with explicit WidthRequest
+			var measure = flexLayout.CrossPlatformMeasure(1000, 1000);
+			flexLayout.CrossPlatformArrange(new Rect(Point.Zero, measure));
+
+			var initialFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(200, initialFrame.Width);
+
+			// Clear WidthRequest and re-measure so DesiredSize reflects auto-sizing
+			view.WidthRequest = -1;
+			flexLayout.CrossPlatformMeasure(1000, 1000);
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 1000, 1000));
+
+			// Should fall back to the auto-sized DesiredSize (100 from FlexTestView default)
+			var clearedFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(100, clearedFrame.Width);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -218,5 +218,102 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Equal(0, flexFrame.X);
 			Assert.Equal(0, flexFrame.Y);
 		}
+
+		// Test view that respects WidthRequest/HeightRequest in MeasureOverride,
+		// simulating real controls like Grid, StackLayout, etc.
+		class FlexTestView : View
+		{
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				var w = WidthRequest >= 0 ? Math.Min(WidthRequest, widthConstraint) : Math.Min(100, widthConstraint);
+				var h = HeightRequest >= 0 ? Math.Min(HeightRequest, heightConstraint) : Math.Min(50, heightConstraint);
+				return new Size(w, h);
+			}
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/31109
+		// Verifies that dynamically changing WidthRequest on a FlexLayout child
+		// is correctly reflected during an arrange-only pass (no preceding measure).
+		[Fact]
+		public void ArrangeOnlyPassUsesUpdatedWidthRequest()
+		{
+			var root = new Grid();
+			var flexLayout = new FlexLayout() { Direction = FlexDirection.Row };
+			var view = new FlexTestView { WidthRequest = 200 };
+
+			root.Add(flexLayout);
+			(flexLayout as IFlexLayout).Add(view as IView);
+
+			// Initial measure + arrange
+			var measure = flexLayout.CrossPlatformMeasure(1000, 1000);
+			flexLayout.CrossPlatformArrange(new Rect(Point.Zero, measure));
+
+			var initialFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(200, initialFrame.Width);
+
+			// Change WidthRequest without re-measuring
+			view.WidthRequest = 300;
+
+			// Arrange-only pass (simulates Android arrange without preceding measure)
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 1000, 1000));
+
+			var updatedFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(300, updatedFrame.Width);
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/31109
+		// Verifies that changing HeightRequest during arrange-only pass works correctly.
+		[Fact]
+		public void ArrangeOnlyPassUsesUpdatedHeightRequest()
+		{
+			var root = new Grid();
+			var flexLayout = new FlexLayout() { Direction = FlexDirection.Column };
+			var view = new FlexTestView { HeightRequest = 80 };
+
+			root.Add(flexLayout);
+			(flexLayout as IFlexLayout).Add(view as IView);
+
+			// Initial measure + arrange
+			var measure = flexLayout.CrossPlatformMeasure(1000, 1000);
+			flexLayout.CrossPlatformArrange(new Rect(Point.Zero, measure));
+
+			var initialFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(80, initialFrame.Height);
+
+			// Change HeightRequest without re-measuring
+			view.HeightRequest = 120;
+
+			// Arrange-only pass
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 1000, 1000));
+
+			var updatedFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(120, updatedFrame.Height);
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/31109
+		// Verifies that children without explicit WidthRequest still use DesiredSize during arrange.
+		[Fact]
+		public void ArrangeOnlyPassUsesDesiredSizeWhenNoWidthRequest()
+		{
+			var root = new Grid();
+			var flexLayout = new FlexLayout() { Direction = FlexDirection.Row };
+			var view = new TestLabel(); // No WidthRequest set, MeasureOverride returns (150, 100)
+
+			root.Add(flexLayout);
+			(flexLayout as IFlexLayout).Add(view as IView);
+
+			// Initial measure + arrange
+			var measure = flexLayout.CrossPlatformMeasure(1000, 1000);
+			flexLayout.CrossPlatformArrange(new Rect(Point.Zero, measure));
+
+			var initialFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(150, initialFrame.Width);
+
+			// Arrange-only pass (should still use DesiredSize since no WidthRequest)
+			flexLayout.CrossPlatformArrange(new Rect(0, 0, 1000, 1000));
+
+			var afterFrame = (flexLayout as IFlexLayout).GetFlexFrame(view as IView);
+			Assert.Equal(150, afterFrame.Width);
+		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue31109.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue31109.cs
@@ -1,0 +1,78 @@
+namespace Maui.Controls.Sample.Issues
+{
+	[Issue(IssueTracker.Github, 31109, "FlexLayout items with Dynamic Width are not updating correctly on orientation change or scroll in Android", PlatformAffected.Android)]
+	public class Issue31109 : TestContentPage
+	{
+		FlexLayout _flexLayout;
+		Label _statusLabel;
+		double _currentWidth = 100;
+
+		protected override void Init()
+		{
+			_flexLayout = new FlexLayout
+			{
+				Direction = Microsoft.Maui.Layouts.FlexDirection.Row,
+				Wrap = Microsoft.Maui.Layouts.FlexWrap.Wrap,
+				BackgroundColor = Colors.LightGray,
+			};
+
+			var item1 = CreateItem("Item1", 100);
+			var item2 = CreateItem("Item2", 150);
+			var item3 = CreateItem("Item3", 200);
+
+			_flexLayout.Add(item1);
+			_flexLayout.Add(item2);
+			_flexLayout.Add(item3);
+
+			_statusLabel = new Label
+			{
+				AutomationId = "StatusLabel",
+				Text = "Width: 100, 150, 200",
+			};
+
+			var changeButton = new Button
+			{
+				Text = "Change Widths",
+				AutomationId = "ChangeWidthsButton",
+			};
+			changeButton.Clicked += OnChangeWidths;
+
+			Content = new ScrollView
+			{
+				Content = new VerticalStackLayout
+				{
+					_statusLabel,
+					changeButton,
+					_flexLayout,
+				}
+			};
+		}
+
+		BoxView CreateItem(string automationId, double width)
+		{
+			return new BoxView
+			{
+				AutomationId = automationId,
+				WidthRequest = width,
+				HeightRequest = 50,
+				Color = Colors.CornflowerBlue,
+				Margin = 5,
+			};
+		}
+
+		void OnChangeWidths(object sender, EventArgs e)
+		{
+			_currentWidth += 50;
+
+			foreach (var child in _flexLayout.Children)
+			{
+				if (child is BoxView box)
+				{
+					box.WidthRequest = _currentWidth;
+				}
+			}
+
+			_statusLabel.Text = $"Width: {_currentWidth}";
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
@@ -33,9 +33,21 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 			App.WaitForElement("ChangeWidthsButton");
 			App.Tap("ChangeWidthsButton");
 
-			// Wait for status label to update confirming the click happened
-			App.WaitForElement("StatusLabel");
+			// Wait until Item1 width has actually changed to ensure the layout update completed
+			var timeout = System.TimeSpan.FromSeconds(5);
+			var pollDelay = System.TimeSpan.FromMilliseconds(100);
+			var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
+			while (stopwatch.Elapsed < timeout)
+			{
+				var currentRect = App.WaitForElement("Item1").GetRect();
+				if (System.Math.Abs(currentRect.Width - item1Before.Width) > 1)
+				{
+					break;
+				}
+
+				System.Threading.Tasks.Task.Delay(pollDelay).Wait();
+			}
 			// After changing widths, all items should have equal width
 			var item1After = App.WaitForElement("Item1").GetRect();
 			var item2After = App.WaitForElement("Item2").GetRect();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 					break;
 				}
 
-				System.Threading.Tasks.Task.Delay(pollDelay).Wait();
+				System.Threading.Thread.Sleep(pollDelay);
 			}
 			// After changing widths, all items should have equal width
 			var item1After = App.WaitForElement("Item1").GetRect();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	[Category(UITestCategories.Layout)]
+	public class Issue31109 : _IssuesUITest
+	{
+		public Issue31109(TestDevice device) : base(device)
+		{
+		}
+
+		public override string Issue => "FlexLayout items with Dynamic Width are not updating correctly on orientation change or scroll in Android";
+
+		[Test]
+		public void DynamicWidthRequestUpdatesFlexLayoutItems()
+		{
+			// Wait for the initial layout to render
+			App.WaitForElement("Item1");
+			App.WaitForElement("Item2");
+			App.WaitForElement("Item3");
+
+			// Get initial widths
+			var item1Before = App.WaitForElement("Item1").GetRect();
+			var item2Before = App.WaitForElement("Item2").GetRect();
+
+			// All items should have different initial widths
+			Assert.That(item1Before.Width, Is.LessThan(item2Before.Width),
+				"Item1 should be narrower than Item2 initially");
+
+			// Change all widths to the same value
+			App.WaitForElement("ChangeWidthsButton");
+			App.Tap("ChangeWidthsButton");
+
+			// Wait for status label to update confirming the click happened
+			App.WaitForElement("StatusLabel");
+
+			// After changing widths, all items should have equal width
+			var item1After = App.WaitForElement("Item1").GetRect();
+			var item2After = App.WaitForElement("Item2").GetRect();
+			var item3After = App.WaitForElement("Item3").GetRect();
+
+			// All items should now have the same width (within tolerance for density conversion)
+			Assert.That(item1After.Width, Is.EqualTo(item2After.Width).Within(2),
+				"After width change, Item1 and Item2 should have equal widths");
+			Assert.That(item2After.Width, Is.EqualTo(item3After.Width).Within(2),
+				"After width change, Item2 and Item3 should have equal widths");
+
+			// Widths should be larger than the initial smallest width
+			Assert.That(item1After.Width, Is.GreaterThan(item1Before.Width),
+				"Item1 should be wider after changing WidthRequest");
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue31109.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 			while (stopwatch.Elapsed < timeout)
 			{
-				var currentRect = App.WaitForElement("Item1").GetRect();
+				var currentRect = App.FindElement("Item1").GetRect();
 				if (System.Math.Abs(currentRect.Width - item1Before.Width) > 1)
 				{
 					break;
@@ -48,6 +48,12 @@ namespace Microsoft.Maui.TestCases.Tests.Issues
 
 				System.Threading.Thread.Sleep(pollDelay);
 			}
+
+			// Verify the width actually changed; fail here rather than in downstream assertions
+			var item1Check = App.FindElement("Item1").GetRect();
+			Assert.That(item1Check.Width, Is.Not.EqualTo(item1Before.Width).Within(1),
+				"Item1 width should have changed within timeout after tapping ChangeWidths");
+
 			// After changing widths, all items should have equal width
 			var item1After = App.WaitForElement("Item1").GetRect();
 			var item2After = App.WaitForElement("Item2").GetRect();


### PR DESCRIPTION
### Description of Change

The fix makes SelfSizing return `NaN` for explicitly-set dimensions during the arrange pass, so `layout_item` preserves the correct value from `WidthRequest`/`HeightRequest` instead of overwriting it. When no explicit size is set (`NaN`), the existing `DesiredSize` behavior is preserved.

### Issues Fixed

During the arrange pass, FlexLayout's SelfSizing callback unconditionally returned `child.DesiredSize`, which could be stale when `WidthRequest`/`HeightRequest` changed dynamically between measure and arrange passes. The Flex engine's `layout_item` function would then overwrite the correct explicit Width (from `EnsureFlexItemPropertiesUpdated`) with the stale `DesiredSize` value.

On Android, arrange-only passes can occur without a preceding measure (e.g., during scrolling or when `requestLayoutIfNeeded` defers the layout request), making this timing gap visible. iOS is unaffected because its layout system couples measure+arrange more tightly via `InvalidateAncestorsMeasures`.

Fixes #31109