### PR TITLE
[iOS] Fix ScrollView not expanding to full width in landscape when HorizontalOptions=FillAndExpand

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20042.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20042.cs
@@ -1,0 +1,58 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 20042, "[iOS] ScrollView HorizontalOptions=StartAndExpand does not expand to fill screen width in landscape", PlatformAffected.iOS)]
+public class Issue20042 : ContentPage
+{
+	public Issue20042()
+	{
+		var scrollView = new ScrollView
+		{
+			Orientation = ScrollOrientation.Vertical,
+			HorizontalOptions = LayoutOptions.StartAndExpand,
+			VerticalOptions = LayoutOptions.Fill,
+		};
+
+		var innerGrid = new Grid
+		{
+			BackgroundColor = Colors.LightBlue,
+			AutomationId = "InnerGrid",
+		};
+
+		var label = new Label
+		{
+			Text = "ScrollView with HorizontalOptions=StartAndExpand\nIn landscape, this blue area must fill the full screen width.",
+			HorizontalTextAlignment = TextAlignment.Center,
+			VerticalTextAlignment = TextAlignment.Center,
+			Margin = new Thickness(16),
+		};
+
+		innerGrid.Add(label);
+		scrollView.Content = innerGrid;
+
+		// A reference element that always fills the full page width — used to compare against InnerGrid.
+		var referenceBar = new BoxView
+		{
+			Color = Colors.Red,
+			HeightRequest = 4,
+			HorizontalOptions = LayoutOptions.Fill,
+			AutomationId = "ReferenceBar",
+		};
+
+		Content = new Grid
+		{
+			RowDefinitions = new RowDefinitionCollection
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star },
+			},
+			Children =
+			{
+				referenceBar,
+				scrollView,
+			}
+		};
+
+		Grid.SetRow(referenceBar, 0);
+		Grid.SetRow(scrollView, 1);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20042.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20042.cs
@@ -1,0 +1,49 @@
+#if IOS || ANDROID //SetOrientation is only supported on iOS and Android; orientation change is not available on Windows and MacCatalyst.
+
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue20042 : _IssuesUITest
+{
+	public Issue20042(TestDevice device) : base(device) { }
+
+	public override string Issue => "[iOS] ScrollView HorizontalOptions=StartAndExpand does not expand to fill screen width in landscape";
+
+	[Test]
+	[Category(UITestCategories.ScrollView)]
+	public void ScrollViewShouldFillScreenWidthInLandscape()
+	{
+		App.WaitForElement("InnerGrid");
+
+		var portraitGridRect = App.WaitForElement("InnerGrid").GetRect();
+		var portraitRefRect = App.WaitForElement("ReferenceBar").GetRect();
+
+		Assert.That(portraitGridRect.Width, Is.EqualTo(portraitRefRect.Width).Within(5),
+			$"Portrait: InnerGrid width ({portraitGridRect.Width}) should match full page width ({portraitRefRect.Width})");
+
+		try
+		{
+			App.SetOrientationLandscape();
+
+			Thread.Sleep(2000);
+
+			var landscapeGridRect = App.WaitForElement("InnerGrid").GetRect();
+			var landscapeRefRect = App.WaitForElement("ReferenceBar").GetRect();
+
+			Assert.That(landscapeGridRect.Width, Is.EqualTo(landscapeRefRect.Width).Within(5),
+				$"Landscape: InnerGrid width ({landscapeGridRect.Width}) should match full screen width ({landscapeRefRect.Width})");
+
+			Assert.That(landscapeGridRect.Width, Is.GreaterThan(portraitGridRect.Width),
+				"Landscape width should be greater than portrait width");
+		}
+		finally
+		{
+			App.SetOrientationPortrait();
+		}
+	}
+}
+
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20042.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20042.cs
@@ -27,8 +27,7 @@ public class Issue20042 : _IssuesUITest
 		try
 		{
 			App.SetOrientationLandscape();
-
-			Thread.Sleep(2000);
+			App.WaitForElement("InnerGrid");
 
 			var landscapeGridRect = App.WaitForElement("InnerGrid").GetRect();
 			var landscapeRefRect = App.WaitForElement("ReferenceBar").GetRect();

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -163,6 +163,17 @@ namespace Microsoft.Maui.Handlers
 			var width = contentSize.Width <= widthConstraint ? contentSize.Width : widthConstraint;
 			var height = contentSize.Height <= heightConstraint ? contentSize.Height : heightConstraint;
 
+			// Expand the ScrollView to fill the available constraint if the content requests it (e.g., Fill alignment).
+			if (scrollView.PresentedContent is { } presentedContent)
+			{
+				var fillWidth = double.IsInfinity(widthConstraint) ? width : widthConstraint;
+				var fillHeight = double.IsInfinity(heightConstraint) ? height : heightConstraint;
+				var adjustedSize = new Size(width, height).AdjustForFill(
+					new Rect(0, 0, fillWidth, fillHeight), presentedContent);
+				width = adjustedSize.Width;
+				height = adjustedSize.Height;
+			}
+
 			width = ViewHandlerExtensions.ResolveConstraints(width, scrollView.Width, scrollView.MinimumWidth, scrollView.MaximumWidth);
 			height = ViewHandlerExtensions.ResolveConstraints(height, scrollView.Height, scrollView.MinimumHeight, scrollView.MaximumHeight);
 


### PR DESCRIPTION
### Root Cause
During the measure pass on iOS, the `ScrollView` handler calculated its size as the minimum of the inner content size and the available screen constraint. In landscape, although the available width increased (for example, from portrait to a wider constraint), the inner content had already measured itself at the smaller width. As a result, the `ScrollView` retained that earlier measured width and did not re-evaluate whether the content intended to stretch and fill the additional space. Unlike Android, the iOS implementation did not check whether the inner content had `Fill` alignment (which is the default for `Grid` and most layouts) after measurement. Because of this missing alignment evaluation, the `ScrollView` would shrink to content size instead of expanding to fill the available width when requested.

### Description of Change
The iOS ScrollView handler’s measure logic was updated to align with Android behavior. After computing the initial size from content measurement, it now evaluates whether the inner content has Fill horizontal alignment. If so, and if the available width constraint is finite, the ScrollView expands to match the full available constraint. If the available constraint is infinite (such as when the ScrollView is placed inside a StackLayout or another unconstrained parent), the logic safely falls back to the measured content size to avoid invalid fill calculations. The adjustment is applied before explicit size overrides, ensuring that developer-defined Width, MinimumWidth, or MaximumWidth values continue to take precedence.

### Issues Fixed
Fixes #20042  
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [x] iOS
- [ ] Mac

### Note
Orientation change is not supported on Windows and MacCatalyst in this scenario, so the corresponding test case was not added for those platforms.

### Output Video
Before Issue Fix | After Issue Fix |
|----------|----------|
|<video width="40" height="60" alt="Before Fix" src="https://github.com/user-attachments/assets/8b786834-a08b-4d9e-891b-eb13a6600c24">|<video width="50" height="40" alt="After Fix" src="https://github.com/user-attachments/assets/ad4499ca-5ee7-40f0-84fd-1d85d64e760e">|