### PR TITLE
Fix artifact upload collision in maui-pr-uitests pipeline

### DIFF
--- a/eng/pipelines/common/ui-tests-steps.yml
+++ b/eng/pipelines/common/ui-tests-steps.yml
@@ -186,6 +186,8 @@ steps:
 - task: PublishBuildArtifacts@1
   condition: always()
   displayName: publish artifacts
+  inputs:
+    artifactName: drop-$(System.StageName)-$(System.JobName)-$(System.JobAttempt)
 
 # Enable Notification Center re-enabled only for catalyst
 - ${{ if eq(parameters.platform, 'catalyst')}}:


### PR DESCRIPTION
## Problem

The `maui-pr-uitests` pipeline has 98+ test jobs that all publish artifacts using `PublishBuildArtifacts@1` with **no artifact name**, defaulting to `drop`. When multiple jobs upload the same file to the same container simultaneously, AzDO blob storage encounters write conflicts:

```
Blob is incomplete (missing block). Blob: 29adda685a1ff1119a49000d3a9183a5, Expected Offset: 0, Actual Offset: 8388608
##[error]File upload failed even after retry.
```

### Recent failures
- [Build 1334980](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1334980): 3 jobs failed (Controls CollectionView, Controls (vlatest), Controls (vlatest) CollectionView)
- [Build 1334245](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1334245): 1 job failed (Controls (vlatest))

The specific collision: both "Controls (vlatest)" and "Controls (vlatest) CollectionView" upload `drop/logs/appium_ios_Controls.TestCases.iOS.Tests-Release-ios-CollectionView.log` — same blob ID, concurrent writes.

## Fix

Add a unique artifact name per job using `$(System.StageName)-$(System.JobName)-$(System.JobAttempt)` in `eng/pipelines/common/ui-tests-steps.yml`. This matches the pattern already used by snapshot diff artifacts in `ui-tests-collect-snapshot-diffs.yml`.

Fixes #34477
Ref: dotnet/dnceng#1916