### PR TITLE
[iOS] Fix CollectionView ScrollOffset not resetting when ItemsSource changes

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/IScrollTrackingDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/IScrollTrackingDelegator.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.Maui.Controls.Handlers.Items;
+
+// Implemented by delegators to allow explicit scroll-tracking reset when ItemsSource changes.
+internal interface IScrollTrackingDelegator
+{
+	void ResetScrollTracking();
+}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -415,11 +415,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
 			// iOS/MacCatalyst: ReloadData does not reset ContentOffset (unlike Android/Windows).
-			// Explicitly reset it so the Scrolled event reports VerticalOffset = 0 after a source change.
-			// LayoutIfNeeded() forces a synchronous layout pass so visible cells are ready before Scrolled fires.
-			CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
-			CollectionView.LayoutIfNeeded();
-			Delegator?.Scrolled(CollectionView);
+			// Only reset when actually scrolled away from origin to avoid unnecessary layout passes
+			// during initial loading where UpdateItemsSource can be called multiple times.
+			if (CollectionView.ContentOffset != CoreGraphics.CGPoint.Empty)
+			{
+				CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
+				CollectionView.LayoutIfNeeded();
+				Delegator?.Scrolled(CollectionView);
+			}
 
 			(ItemsView as IView)?.InvalidateMeasure();
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -414,6 +414,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			CollectionView.ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
+			// iOS/MacCatalyst: ReloadData does not reset ContentOffset (unlike Android/Windows).
+			// Explicitly reset it so the Scrolled event reports VerticalOffset = 0 after a source change.
+			// LayoutIfNeeded() forces a synchronous layout pass so visible cells are ready before Scrolled fires.
+			CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
+			CollectionView.LayoutIfNeeded();
+			Delegator?.Scrolled(CollectionView);
+
 			(ItemsView as IView)?.InvalidateMeasure();
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -414,14 +414,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			CollectionView.ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
-			// iOS/MacCatalyst: ReloadData does not reset ContentOffset (unlike Android/Windows).
-			// Only reset when actually scrolled away from origin to avoid unnecessary layout passes
-			// during initial loading where UpdateItemsSource can be called multiple times.
+			// iOS/MacCatalyst: UIKit does not reset ContentOffset during ReloadData.
+			// ResetScrollTracking must run before the assignment so the UIKit-triggered
+			// scrollViewDidScroll callback computes delta from zero, not the stale previous offset.
 			if (CollectionView.ContentOffset != CoreGraphics.CGPoint.Empty)
 			{
+				(Delegator as IScrollTrackingDelegator)?.ResetScrollTracking();
 				CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
-				CollectionView.LayoutIfNeeded();
-				Delegator?.Scrolled(CollectionView);
 			}
 
 			(ItemsView as IView)?.InvalidateMeasure();

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewDelegator.cs
@@ -8,7 +8,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	public class ItemsViewDelegator<TItemsView, TViewController> : UICollectionViewDelegateFlowLayout
+	public class ItemsViewDelegator<TItemsView, TViewController> : UICollectionViewDelegateFlowLayout, IScrollTrackingDelegator
 		where TItemsView : ItemsView
 		where TViewController : ItemsViewController<TItemsView>
 	{
@@ -23,6 +23,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			ItemsViewLayout = itemsViewLayout;
 			_viewController = new(itemsViewController);
+		}
+
+		void IScrollTrackingDelegator.ResetScrollTracking()
+		{
+			PreviousHorizontalOffset = 0;
+			PreviousVerticalOffset = 0;
 		}
 
 		public override void Scrolled(UIScrollView scrollView)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -296,6 +296,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
+			// iOS/MacCatalyst: ReloadData does not reset ContentOffset (unlike Android/Windows).
+			// Explicitly reset it so the Scrolled event reports VerticalOffset = 0 after a source change.
+			// LayoutIfNeeded() forces a synchronous layout pass so visible cells are ready before Scrolled fires.
+			CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
+			CollectionView.LayoutIfNeeded();
+			Delegator?.Scrolled(CollectionView);
+
 			(ItemsView as IView)?.InvalidateMeasure();
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -297,11 +297,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
 			// iOS/MacCatalyst: ReloadData does not reset ContentOffset (unlike Android/Windows).
-			// Explicitly reset it so the Scrolled event reports VerticalOffset = 0 after a source change.
-			// LayoutIfNeeded() forces a synchronous layout pass so visible cells are ready before Scrolled fires.
-			CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
-			CollectionView.LayoutIfNeeded();
-			Delegator?.Scrolled(CollectionView);
+			// Only reset when actually scrolled away from origin to avoid unnecessary layout passes
+			// during initial loading where UpdateItemsSource can be called multiple times.
+			if (CollectionView.ContentOffset != CoreGraphics.CGPoint.Empty)
+			{
+				CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
+				CollectionView.LayoutIfNeeded();
+				Delegator?.Scrolled(CollectionView);
+			}
 
 			(ItemsView as IView)?.InvalidateMeasure();
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using CoreGraphics;
 using Foundation;
+using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using PassKit;
@@ -296,14 +297,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 
-			// iOS/MacCatalyst: ReloadData does not reset ContentOffset (unlike Android/Windows).
-			// Only reset when actually scrolled away from origin to avoid unnecessary layout passes
-			// during initial loading where UpdateItemsSource can be called multiple times.
+			// iOS/MacCatalyst: UIKit does not reset ContentOffset during ReloadData.
+			// ResetScrollTracking must run before the assignment so the UIKit-triggered
+			// scrollViewDidScroll callback computes delta from zero, not the stale previous offset.
 			if (CollectionView.ContentOffset != CoreGraphics.CGPoint.Empty)
 			{
+				(Delegator as IScrollTrackingDelegator)?.ResetScrollTracking();
 				CollectionView.ContentOffset = CoreGraphics.CGPoint.Empty;
-				CollectionView.LayoutIfNeeded();
-				Delegator?.Scrolled(CollectionView);
 			}
 
 			(ItemsView as IView)?.InvalidateMeasure();

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewDelegator2.cs
@@ -9,7 +9,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Handlers.Items2
 {
-	public class ItemsViewDelegator2<TItemsView, TViewController> : UICollectionViewDelegateFlowLayout
+	public class ItemsViewDelegator2<TItemsView, TViewController> : UICollectionViewDelegateFlowLayout, IScrollTrackingDelegator
 		where TItemsView : ItemsView
 		where TViewController : ItemsViewController2<TItemsView>
 	{
@@ -24,6 +24,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 		{
 			ItemsViewLayout = itemsViewLayout;
 			_viewController = new(ItemsViewController2);
+		}
+
+		void IScrollTrackingDelegator.ResetScrollTracking()
+		{
+			PreviousHorizontalOffset = 0;
+			PreviousVerticalOffset = 0;
 		}
 
 		public override void Scrolled(UIScrollView scrollView)

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7993.xaml
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7993.xaml
@@ -12,12 +12,13 @@
         </Grid.RowDefinitions>
 
         <StackLayout Grid.Row="0" Orientation="Vertical" Spacing="5" BackgroundColor="Beige">
-            <Label LineBreakMode="WordWrap" Text="Scroll down into the list to increase vertical offset. Click NewItemsSource to reset items source. Verify that vertical offset becomes zero." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
-            <Label x:Name="Label1" Text="VerticalOffset: 0" HorizontalTextAlignment="Center"/>
-            <Button Text="NewItemsSource" Clicked="NewItemsSourceClicked" HorizontalOptions="Center"/>
+            <Label LineBreakMode="WordWrap" Text="Tap ScrollToEnd to scroll the list, then tap NewItemsSource. Verify that vertical offset becomes zero." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+            <Label x:Name="Label1" AutomationId="VerticalOffsetLabel" Text="VerticalOffset: 0" HorizontalTextAlignment="Center"/>
+            <Button Text="ScrollToEnd" AutomationId="ScrollToEnd" Clicked="ScrollToEndClicked" HorizontalOptions="Center"/>
+            <Button Text="NewItemsSource" AutomationId="NewItemsSource" Clicked="NewItemsSourceClicked" HorizontalOptions="Center"/>
         </StackLayout>
 
-        <CollectionView Grid.Row="1" AutomationId="CollectionView7993" ItemsSource="{Binding Items}" Scrolled="CollectionView_OnScrolled">
+        <CollectionView x:Name="CollectionView7993" Grid.Row="1" AutomationId="CollectionView7993" ItemsSource="{Binding Items}" Scrolled="CollectionView_OnScrolled">
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout Orientation="Vertical" ItemSpacing="5"/>
             </CollectionView.ItemsLayout>

--- a/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7993.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/XFIssue/Issue7993.xaml.cs
@@ -17,6 +17,15 @@ public partial class Issue7993 : TestContentPage
 		Label1.Text = "VerticalOffset: " + e.VerticalOffset;
 	}
 
+	void ScrollToEndClicked(object sender, EventArgs e)
+	{
+		var vm = BindingContext as ViewModel7993;
+		if (vm?.Items.Count > 0)
+		{
+			CollectionView7993.ScrollTo(vm.Items[vm.Items.Count - 1]);
+		}
+	}
+
 	void NewItemsSourceClicked(object sender, EventArgs e)
 	{
 		BindingContext = new ViewModel7993();

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7993.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7993.cs
@@ -1,4 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_IOS //In MacCatalyst, the DragCoordinates is not supported. On the iOS platform, scroll position is not reset while update the itemsource. Issue: https://github.com/dotnet/maui/issues/26366
+﻿#if TEST_FAILS_ON_CATALYST //In MacCatalyst, the DragCoordinates is not supported.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7993.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7993.cs
@@ -1,5 +1,4 @@
-﻿#if TEST_FAILS_ON_CATALYST //In MacCatalyst, the DragCoordinates is not supported.
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
 
@@ -17,16 +16,11 @@ public class Issue7993 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void CollectionViewVerticalOffset()
 	{
-		var colView = App.WaitForElement("CollectionView7993");
-
+		App.WaitForElement("CollectionView7993");
 		App.WaitForElement("VerticalOffset: 0");
-		App.DragCoordinates(colView.GetRect().Width - 10,
-			colView.GetRect().Y + colView.GetRect().Height - 50,
-			colView.GetRect().Width - 10,
-			colView.GetRect().Y + 5);
+		App.Tap("ScrollToEnd");
 		App.WaitForElement("19");
 		App.Tap("NewItemsSource");
 		App.WaitForElement("VerticalOffset: 0");
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7993.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/XFIssue/Issue7993.cs
@@ -20,6 +20,7 @@ public class Issue7993 : _IssuesUITest
 		App.WaitForElement("VerticalOffset: 0");
 		App.Tap("ScrollToEnd");
 		App.WaitForElement("19");
+		App.WaitForNoElement("VerticalOffset: 0");
 		App.Tap("NewItemsSource");
 		App.WaitForElement("VerticalOffset: 0");
 	}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- On iOS, when using CollectionView with the Scrolled event, the VerticalOffset value doesn't reset to 0 when changing the ItemsSource. While the collection view displays the new items correctly, the reported scroll position remains at the previous offset value instead of resetting to the top position.

### Root Cause
-  On iOS, UICollectionView.ReloadData() does not reset ContentOffset. ContentOffset retains its previous value, meaning any subsequent Scrolled callback—which derives VerticalOffset and delta values directly from ContentOffset—reports the stale, non-zero offset. As a result, MAUI's VerticalOffset never resets to 0 after the ItemsSource changes.

### Description of Change

- Added logic in ItemsViewController.cs and ItemsViewController2.cs to reset CollectionView.ContentOffset to zero only when it’s not already at the origin. This ensures the scroll position resets correctly when the ItemsSource changes on iOS/MacCatalyst.
- Before resetting the offset, ResetScrollTracking() is invoked via the internal IScrollTrackingDelegator interface so that the scrollViewDidScroll callback computes the delta from zero instead of using a stale offset.

**Test and UI improvements:**

- Updated the test page (Issue7993.xaml) to add a "ScrollToEnd" button for reliably scrolling the list, and updated label and button identifiers for improved test automation.
- Added the ScrollToEndClicked handler in Issue7993.xaml.cs to programmatically scroll to the end of the list, supporting the new test flow.
- Removed platform-specific test skips and refactored the test (Issue7993.cs) to use the new "ScrollToEnd" and "NewItemsSource" buttons, improving reliability and making the test applicable to iOS/MacCatalyst.


### Issues Fixed
Fixes #26366
Fixes #33500

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/a374859f-25ce-445f-a53f-6354c2d3f201"> | <video src="https://github.com/user-attachments/assets/2bdc2dd4-43be-41ef-810c-e4098cba791f"> |