### PR TITLE
[Android] Fix crash when shared swipe actions are used across multiple rows

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19331.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19331.cs
@@ -1,0 +1,80 @@
+﻿namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 19331, "SwipeItems referencing causes crash on Android", PlatformAffected.Android)]
+public class Issue19331 : ContentPage
+{
+	public const string StatusLabelId = "StatusLabel19331";
+	public const string SwipeRow1Id = "SwipeRow1_19331";
+	public const string SwipeRow2Id = "SwipeRow2_19331";
+	public const string SwipeRow3Id = "SwipeRow3_19331";
+
+	public Issue19331()
+	{
+		var sharedSwipeItems = new SwipeItems
+		{
+			new SwipeItem
+			{
+				Text = "Delete",
+				BackgroundColor = Colors.Red
+			}
+		};
+
+		var statusLabel = new Label
+		{
+			AutomationId = StatusLabelId,
+			Text = "Swipe rows to test",
+			HorizontalOptions = LayoutOptions.Center,
+			Margin = new Thickness(0, 10)
+		};
+
+		var row1Content = new Grid
+		{
+			BackgroundColor = Colors.LightGray,
+			HeightRequest = 60,
+			Padding = new Thickness(12, 0)
+		};
+		row1Content.Add(new Label
+		{
+			AutomationId = SwipeRow1Id,
+			Text = "Row 1 - Swipe left",
+			VerticalOptions = LayoutOptions.Center
+		});
+
+		var row2Content = new Grid
+		{
+			BackgroundColor = Colors.LightBlue,
+			HeightRequest = 60,
+			Padding = new Thickness(12, 0)
+		};
+		row2Content.Add(new Label
+		{
+			AutomationId = SwipeRow2Id,
+			Text = "Row 2 - Swipe left",
+			VerticalOptions = LayoutOptions.Center
+		});
+
+		var row3Content = new Grid
+		{
+			BackgroundColor = Colors.LightGreen,
+			HeightRequest = 60,
+			Padding = new Thickness(12, 0)
+		};
+		row3Content.Add(new Label
+		{
+			AutomationId = SwipeRow3Id,
+			Text = "Row 3 - Swipe left",
+			VerticalOptions = LayoutOptions.Center
+		});
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+			{
+				statusLabel,
+				new SwipeView { LeftItems = sharedSwipeItems, Content = row1Content },
+				new SwipeView { LeftItems = sharedSwipeItems, Content = row2Content },
+				new SwipeView { LeftItems = sharedSwipeItems, Content = row3Content },
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19331.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19331.cs
@@ -3,11 +3,6 @@
 [Issue(IssueTracker.Github, 19331, "SwipeItems referencing causes crash on Android", PlatformAffected.Android)]
 public class Issue19331 : ContentPage
 {
-	public const string StatusLabelId = "StatusLabel19331";
-	public const string SwipeRow1Id = "SwipeRow1_19331";
-	public const string SwipeRow2Id = "SwipeRow2_19331";
-	public const string SwipeRow3Id = "SwipeRow3_19331";
-
 	public Issue19331()
 	{
 		var sharedSwipeItems = new SwipeItems
@@ -21,7 +16,7 @@ public class Issue19331 : ContentPage
 
 		var statusLabel = new Label
 		{
-			AutomationId = StatusLabelId,
+			AutomationId = "StatusLabel19331",
 			Text = "Swipe rows to test",
 			HorizontalOptions = LayoutOptions.Center,
 			Margin = new Thickness(0, 10)
@@ -35,7 +30,7 @@ public class Issue19331 : ContentPage
 		};
 		row1Content.Add(new Label
 		{
-			AutomationId = SwipeRow1Id,
+			AutomationId = "SwipeRow1_19331",
 			Text = "Row 1 - Swipe left",
 			VerticalOptions = LayoutOptions.Center
 		});
@@ -48,7 +43,7 @@ public class Issue19331 : ContentPage
 		};
 		row2Content.Add(new Label
 		{
-			AutomationId = SwipeRow2Id,
+			AutomationId = "SwipeRow2_19331",
 			Text = "Row 2 - Swipe left",
 			VerticalOptions = LayoutOptions.Center
 		});
@@ -61,7 +56,7 @@ public class Issue19331 : ContentPage
 		};
 		row3Content.Add(new Label
 		{
-			AutomationId = SwipeRow3Id,
+			AutomationId = "SwipeRow3_19331",
 			Text = "Row 3 - Swipe left",
 			VerticalOptions = LayoutOptions.Center
 		});

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19331.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19331.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue19331 : _IssuesUITest
+{
+	public Issue19331(TestDevice device) : base(device) { }
+
+	public override string Issue => "SwipeItems referencing causes crash on Android";
+
+	[Test]
+	[Category(UITestCategories.SwipeView)]
+	public void SharedSwipeItemsShouldNotCrashWhenSwipingMultipleRows()
+	{
+		App.WaitForElement("StatusLabel19331");
+		App.SwipeLeftToRight("SwipeRow1_19331");
+		App.SwipeLeftToRight("SwipeRow2_19331");
+		App.WaitForElement("StatusLabel19331");
+	}
+}

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -561,6 +561,11 @@ namespace Microsoft.Maui.Platform
 			foreach (var item in items)
 			{
 				AView? swipeItem = item?.ToPlatform(MauiContext);
+				if (swipeItem?.Parent != null && item is IElement element)
+				{
+					element.Handler?.DisconnectHandler();
+					swipeItem = item?.ToPlatform(MauiContext);
+				}
 
 				if (swipeItem is not null)
 				{

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -561,6 +561,7 @@ namespace Microsoft.Maui.Platform
 			foreach (var item in items)
 			{
 				AView? swipeItem = item?.ToPlatform(MauiContext);
+				// Disconnect a shared SwipeItem's handler when its Android view is already parented, so ToPlatform() creates a fresh view for the new one.
 				if (swipeItem?.Parent != null && item is IElement element)
 				{
 					element.Handler?.DisconnectHandler();

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -728,7 +728,10 @@ namespace Microsoft.Maui.Platform
 
 			foreach (var item in _swipeItems.Keys)
 			{
-				item.Handler?.DisconnectHandler();
+				if (item.Handler is not null && ReferenceEquals(item.Handler.PlatformView, _swipeItems[item]))
+				{
+					item.Handler.DisconnectHandler();
+				}
 			}
 
 			_swipeItems.Clear();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
When the same swipe actions are shared across multiple rows, swiping a second row while the first is still open causes an Android crash.

### Root Cause
Each swipe action reuses a cached Android button view. When shared, the same button is already attached to the first row's view tree. Android does not allow adding an already-parented view to another parent.

### Description of Change
When a shared swipe action's Android button is already attached to another row, the handler is disconnected to force creation of a new button. The new button is then safely added to the current row without conflict.
 
Validated the behavior in the following platforms
 
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac
 
### Issues Fixed
  
Fixes #19331  

### Output  ScreenShot

|Before|After|
|--|--|
| <video src="https://github.com/user-attachments/assets/31ebd578-ce07-4d41-b067-c35a3a4a4d49" >| <video src="https://github.com/user-attachments/assets/382b3359-d318-43ef-bdab-590013e50165">|
