### PR TITLE
[Android] Fix for TapGestureRecognizer doesn't fire

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Platform
 		bool _inputTransparent;
 		bool _isEnabled;
 		bool? _focusableDefaultValue;
-		RecyclerView.IOnItemTouchListener? _recyclerViewTouchListener;
+		GestureItemTouchListener? _recyclerViewTouchListener;
 		protected virtual VisualElement? Element => _handler?.VirtualView as VisualElement;
 
 		View? View => Element as View;
@@ -225,11 +225,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (shouldAddTouchEvent)
 			{
-				// For RecyclerView-based views (CollectionView, ListView), use AddOnItemTouchListener
+				// For RecyclerView-based views (e.g., CollectionView), use AddOnItemTouchListener
 				// instead of the Touch event. Child item views (made clickable by SelectableViewHolder's
 				// SetOnClickListener) consume touch events, preventing them from reaching the
 				// Touch event handler. OnItemTouchListener.OnInterceptTouchEvent fires BEFORE children
-				// get the event, ensuring TapGestureRecognizers on the CollectionView/ListView receive
+				// get the event, ensuring TapGestureRecognizers on the CollectionView receive
 				// all touch events regardless of child handling.
 				if (platformView is RecyclerView recyclerView)
 				{
@@ -429,7 +429,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_recyclerViewTouchListener is not null && platformView is RecyclerView recyclerView)
 			{
 				recyclerView.RemoveOnItemTouchListener(_recyclerViewTouchListener);
-				(_recyclerViewTouchListener as Java.Lang.Object)?.Dispose();
+				_recyclerViewTouchListener.Dispose();
 				_recyclerViewTouchListener = null;
 			}
 		}

--- a/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GesturePlatformManager.Android.cs
@@ -7,6 +7,7 @@ using Android.Content;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
 using AndroidX.Core.View;
+using AndroidX.RecyclerView.Widget;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using static Android.Views.View;
@@ -25,6 +26,7 @@ namespace Microsoft.Maui.Controls.Platform
 		bool _inputTransparent;
 		bool _isEnabled;
 		bool? _focusableDefaultValue;
+		RecyclerView.IOnItemTouchListener? _recyclerViewTouchListener;
 		protected virtual VisualElement? Element => _handler?.VirtualView as VisualElement;
 
 		View? View => Element as View;
@@ -216,14 +218,28 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			// Always unsubscribe first to avoid duplicates
-
+			ClearRecyclerViewTouchListener(platformView);
 			platformView.Touch -= OnPlatformViewTouched;
 			platformView.KeyPress -= OnKeyPress;
 
 
 			if (shouldAddTouchEvent)
 			{
-				platformView.Touch += OnPlatformViewTouched;
+				// For RecyclerView-based views (CollectionView, ListView), use AddOnItemTouchListener
+				// instead of the Touch event. Child item views (made clickable by SelectableViewHolder's
+				// SetOnClickListener) consume touch events, preventing them from reaching the
+				// Touch event handler. OnItemTouchListener.OnInterceptTouchEvent fires BEFORE children
+				// get the event, ensuring TapGestureRecognizers on the CollectionView/ListView receive
+				// all touch events regardless of child handling.
+				if (platformView is RecyclerView recyclerView)
+				{
+					_recyclerViewTouchListener = new GestureItemTouchListener(this);
+					recyclerView.AddOnItemTouchListener(_recyclerViewTouchListener);
+				}
+				else
+				{
+					platformView.Touch += OnPlatformViewTouched;
+				}
 
 				// If we have a TapGestureRecognizer, we need to handle key presses
 				if (View.HasAccessibleTapGesture())
@@ -292,6 +308,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				platformView.Focusable = _focusableDefaultValue ?? platformView.Focusable;
 				_focusableDefaultValue = null;
+				ClearRecyclerViewTouchListener(platformView);
 				platformView.Touch -= OnPlatformViewTouched;
 				platformView.KeyPress -= OnKeyPress;
 			}
@@ -405,6 +422,52 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			_isEnabled = Element.IsEnabled;
+		}
+
+		void ClearRecyclerViewTouchListener(AView platformView)
+		{
+			if (_recyclerViewTouchListener is not null && platformView is RecyclerView recyclerView)
+			{
+				recyclerView.RemoveOnItemTouchListener(_recyclerViewTouchListener);
+				(_recyclerViewTouchListener as Java.Lang.Object)?.Dispose();
+				_recyclerViewTouchListener = null;
+			}
+		}
+
+		// Forwards touch events from RecyclerView to the gesture system before children get them.
+		// OnInterceptTouchEvent is called by RecyclerView BEFORE dispatching to child views,
+		// so we receive all touch events even when clickable child item views would otherwise
+		// consume them (due to SelectableViewHolder's SetOnClickListener).
+		sealed class GestureItemTouchListener : Java.Lang.Object, RecyclerView.IOnItemTouchListener
+		{
+			readonly GesturePlatformManager _manager;
+
+			public GestureItemTouchListener(GesturePlatformManager manager)
+			{
+				_manager = manager;
+			}
+
+			public bool OnInterceptTouchEvent(RecyclerView rv, MotionEvent e)
+			{
+				if (!_manager._disposed)
+				{
+					_manager.OnTouchEvent(e);
+				}
+
+				// Return false: don't intercept the event - let children handle it normally
+				// (item selection via OnClickListener continues to work)
+				return false;
+			}
+
+			public void OnTouchEvent(RecyclerView rv, MotionEvent e)
+			{
+				// Only called if OnInterceptTouchEvent previously returned true; no-op here.
+			}
+
+			public void OnRequestDisallowInterceptTouchEvent(bool disallowIntercept)
+			{
+				// No-op: we never intercept, so this callback has no effect.
+			}
 		}
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue5825.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue5825.cs
@@ -1,0 +1,61 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 5825, "[Android] TapGestureRecognizer doesn't fire inside CollectionView/ListView", PlatformAffected.Android)]
+public class Issue5825 : ContentPage
+{
+	public Issue5825()
+	{
+		var resultLabel = new Label
+		{
+			Text = "Waiting",
+			AutomationId = "ResultLabel",
+			FontSize = 24,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		var items = new List<string> { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
+
+		var collectionView = new CollectionView
+		{
+			ItemsSource = items,
+			HeightRequest = 300,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					FontSize = 18,
+					AutomationId = "CollectionViewItem"
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			})
+		};
+
+		var tapGesture = new TapGestureRecognizer
+		{
+			NumberOfTapsRequired = 2,
+			Command = new Command(() =>
+			{
+				resultLabel.Text = "Success";
+			})
+		};
+
+		collectionView.GestureRecognizers.Add(tapGesture);
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 20,
+			Children =
+			{
+				new Label
+				{
+					Text = "Double-tap on the CollectionView below. The label should change to 'Success'.",
+					FontSize = 16
+				},
+				collectionView,
+				resultLabel
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue5825.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue5825.cs
@@ -20,7 +20,6 @@ public class Issue5825 : _IssuesUITest
 		App.DoubleTap("CollectionViewItem");
 
 		// Verify the command fired
-		var resultText = App.FindElement("ResultLabel").GetText();
-		Assert.That(resultText, Is.EqualTo("Success"));
+		App.WaitForTextToBePresentInElement("ResultLabel", "Success");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue5825.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue5825.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+using Microsoft.Maui.TestCases.Tests;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue5825 : _IssuesUITest
+{
+	public override string Issue => "[Android] TapGestureRecognizer doesn't fire inside CollectionView/ListView";
+
+	public Issue5825(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.Gestures)]
+	public void DoubleTapInCollectionViewShouldFireCommand()
+	{
+		App.WaitForElement("CollectionViewItem");
+
+		// Double-tap on a CollectionView item label
+		App.DoubleTap("CollectionViewItem");
+
+		// Verify the command fired
+		var resultText = App.FindElement("ResultLabel").GetText();
+		Assert.That(resultText, Is.EqualTo("Success"));
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue5825.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue5825.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
-using Microsoft.Maui.TestCases.Tests;
 
 namespace Microsoft.Maui.TestCases.Tests.Issues;
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- TapGestureRecognizer on a CollectionView does not fire on Android, but works correctly on Windows and iOS.

### Root Cause of the issue

- On Android, SelectableViewHolder calls itemView.SetOnClickListener(this) on each CollectionView/ListView item view, which implicitly sets Clickable = true. During Android's touch dispatch, a clickable child view consumes the MotionEvent by returning true from OnTouchEvent(). This prevents the parent CollectionView's Touch event handler (platformView.Touch += OnPlatformViewTouched in GesturePlatformManager) from ever receiving the event. As a result, the gesture system never processes touches on CollectionView items, and TapGestureRecognizer (including double-tap) never fires.



### Description of Change

### Gesture handling improvements for RecyclerView-based views

* Added a specialized `GestureItemTouchListener` class that forwards touch events from `RecyclerView` to the gesture system before child views handle them, ensuring `TapGestureRecognizer` works reliably on `CollectionView` and `ListView`.
* Updated `SetupGestures()` to use `AddOnItemTouchListener` for `RecyclerView` views instead of the standard `Touch` event, preventing child item views from blocking gesture events.
* Implemented `ClearRecyclerViewTouchListener()` to properly remove and dispose of the touch listener when gestures are reset or the element changes, avoiding memory leaks and duplicate event handling. [[1]](diffhunk://#diff-2d78f02242798d0f2863f679e4dfdee230944be37db5e1a1446bfa4c6c43a5c6R311) [[2]](diffhunk://#diff-2d78f02242798d0f2863f679e4dfdee230944be37db5e1a1446bfa4c6c43a5c6R426-R471)

### Test coverage

* Added a new sample test page (`Issue5825.cs`) that demonstrates the fix by requiring a double-tap gesture on a `CollectionView` and updating a label if the gesture fires.
* Introduced a UI test (`Issue5825.cs`) that verifies the double-tap gesture command fires as expected in a `CollectionView` on Android.

### Dependency update

* Imported `AndroidX.RecyclerView.Widget` to support the new gesture handling logic for RecyclerView-based views.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #5825 

### Tested the behaviour in the following platforms

- [x] - Windows 
- [x] - Android
- [x] - iOS
- [x] - Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/2e975ecc-ed6d-4cb6-936e-8f421df07a21"> | <video src="https://github.com/user-attachments/assets/49b76d28-9e21-4194-a1cb-bf31fec2c209"> |



<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
