### PR TITLE
[Android/iOS] Fix CollectionView group size not updating when item properties change

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -2,6 +2,7 @@
 using System;
 using Android.Content;
 using Android.Views;
+using AndroidX.RecyclerView.Widget;
 using Microsoft.Maui.Graphics;
 using AView = Android.Views.View;
 
@@ -212,6 +213,18 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (this.IsAlive())
 			{
 				PlatformInterop.RequestLayoutIfNeeded(this);
+
+				if (Parent is RecyclerView recyclerView)
+				{
+					recyclerView.Post(() =>
+					{
+						var position = recyclerView.GetChildAdapterPosition(this);
+						if (position != RecyclerView.NoPosition)
+						{
+							recyclerView.GetAdapter()?.NotifyItemChanged(position);
+						}
+					});
+				}
 			}
 			else if (sender is VisualElement ve)
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemsSources/ObservableItemsSource.cs
@@ -1,245 +1,349 @@
-﻿#nullable disable
+#nullable disable
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
-	internal class ObservableItemsSource : IItemsViewSource, IObservableItemsViewSource
-	{
-		readonly IEnumerable _itemsSource;
-		readonly BindableObject _container;
-		readonly ICollectionChangedNotifier _notifier;
-		readonly WeakNotifyCollectionChangedProxy _proxy = new();
-		readonly NotifyCollectionChangedEventHandler _collectionChanged;
-		bool _disposed;
+internal class ObservableItemsSource : IItemsViewSource, IObservableItemsViewSource
+{
+readonly IEnumerable _itemsSource;
+readonly BindableObject _container;
+readonly ICollectionChangedNotifier _notifier;
+readonly WeakNotifyCollectionChangedProxy _proxy = new();
+readonly NotifyCollectionChangedEventHandler _collectionChanged;
+// Tracks INotifyPropertyChanged subscriptions on each item so we can properly
+// un/subscribe when items are added, removed, or replaced, and on Dispose.
+readonly Dictionary<INotifyPropertyChanged, PropertyChangedEventHandler> _itemPropertyChangedHandlers = new();
+bool _disposed;
 
-		~ObservableItemsSource() => _proxy.Unsubscribe();
+~ObservableItemsSource() => _proxy.Unsubscribe();
 
-		public ObservableItemsSource(IEnumerable itemSource, BindableObject container, ICollectionChangedNotifier notifier)
-		{
-			_itemsSource = itemSource;
-			_container = container;
-			_notifier = notifier;
-			_collectionChanged = CollectionChanged;
-			_proxy.Subscribe((INotifyCollectionChanged)itemSource, _collectionChanged);
-		}
+public ObservableItemsSource(IEnumerable itemSource, BindableObject container, ICollectionChangedNotifier notifier)
+{
+_itemsSource = itemSource;
+_container = container;
+_notifier = notifier;
+_collectionChanged = CollectionChanged;
+_proxy.Subscribe((INotifyCollectionChanged)itemSource, _collectionChanged);
+
+// Subscribe to property changes on existing items so that layout-affecting
+// changes (e.g. MaximumHeightRequest bound to a data property) cause
+// RecyclerView to re-measure and re-layout the affected item.  This is
+// essential for items in the last group whose RecyclerView ViewHolders may
+// be recycled after collapsing (Parent == null), making requestLayout() alone
+// insufficient to trigger a re-measure.
+SubscribeToItemsPropertyChanged(_itemsSource);
+}
 
 
-		internal event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
+internal event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
 
-		public int Count => ItemsCount() + (HasHeader ? 1 : 0) + (HasFooter ? 1 : 0);
+public int Count => ItemsCount() + (HasHeader ? 1 : 0) + (HasFooter ? 1 : 0);
 
-		public bool HasHeader { get; set; }
-		public bool HasFooter { get; set; }
+public bool HasHeader { get; set; }
+public bool HasFooter { get; set; }
 
-		public bool ObserveChanges { get; set; } = true;
+public bool ObserveChanges { get; set; } = true;
 
-		public void Dispose()
-		{
-			Dispose(true);
-		}
+public void Dispose()
+{
+Dispose(true);
+}
 
-		public bool IsFooter(int index)
-		{
-			return HasFooter && index == Count - 1;
-		}
+public bool IsFooter(int index)
+{
+return HasFooter && index == Count - 1;
+}
 
-		public bool IsHeader(int index)
-		{
-			return HasHeader && index == 0;
-		}
+public bool IsHeader(int index)
+{
+return HasHeader && index == 0;
+}
 
-		public int GetPosition(object item)
-		{
-			for (int n = 0; n < ItemsCount(); n++)
-			{
-				var elementByIndex = ElementAt(n);
-				var isEqual = elementByIndex == item || (elementByIndex != null && item != null && elementByIndex.Equals(item));
+public int GetPosition(object item)
+{
+for (int n = 0; n < ItemsCount(); n++)
+{
+var elementByIndex = ElementAt(n);
+var isEqual = elementByIndex == item || (elementByIndex != null && item != null && elementByIndex.Equals(item));
 
-				if (isEqual)
-				{
-					return AdjustPositionForHeader(n);
-				}
-			}
+if (isEqual)
+{
+return AdjustPositionForHeader(n);
+}
+}
 
-			return -1;
-		}
+return -1;
+}
 
-		public object GetItem(int position)
-		{
-			return ElementAt(AdjustIndexForHeader(position));
-		}
+public object GetItem(int position)
+{
+return ElementAt(AdjustIndexForHeader(position));
+}
 
-		protected virtual void Dispose(bool disposing)
-		{
-			if (_disposed)
-			{
-				return;
-			}
+protected virtual void Dispose(bool disposing)
+{
+if (_disposed)
+{
+return;
+}
 
-			_disposed = true;
+_disposed = true;
 
-			if (disposing)
-			{
-				_proxy.Unsubscribe();
-			}
-		}
+if (disposing)
+{
+_proxy.Unsubscribe();
+UnsubscribeFromAllItemsPropertyChanged();
+}
+}
 
-		int AdjustIndexForHeader(int index)
-		{
-			return index - (HasHeader ? 1 : 0);
-		}
+int AdjustIndexForHeader(int index)
+{
+return index - (HasHeader ? 1 : 0);
+}
 
-		int AdjustPositionForHeader(int position)
-		{
-			return position + (HasHeader ? 1 : 0);
-		}
+int AdjustPositionForHeader(int position)
+{
+return position + (HasHeader ? 1 : 0);
+}
 
-		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
-		{
-			if (!ObserveChanges)
-			{
-				return;
-			}
+void CollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+{
+if (!ObserveChanges)
+{
+return;
+}
 
-			_container.Dispatcher.DispatchIfRequired(() => CollectionChanged(args));
-		}
+_container.Dispatcher.DispatchIfRequired(() => CollectionChanged(args));
+}
 
-		void CollectionChanged(NotifyCollectionChangedEventArgs args)
-		{
-			switch (args.Action)
-			{
-				case NotifyCollectionChangedAction.Add:
-					Add(args);
-					break;
-				case NotifyCollectionChangedAction.Remove:
-					Remove(args);
-					break;
-				case NotifyCollectionChangedAction.Replace:
-					Replace(args);
-					break;
-				case NotifyCollectionChangedAction.Move:
-					Move(args);
-					break;
-				case NotifyCollectionChangedAction.Reset:
-					_notifier.NotifyDataSetChanged();
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
-			CollectionItemsSourceChanged?.Invoke(this, args);
-		}
+void CollectionChanged(NotifyCollectionChangedEventArgs args)
+{
+switch (args.Action)
+{
+case NotifyCollectionChangedAction.Add:
+Add(args);
+break;
+case NotifyCollectionChangedAction.Remove:
+Remove(args);
+break;
+case NotifyCollectionChangedAction.Replace:
+Replace(args);
+break;
+case NotifyCollectionChangedAction.Move:
+Move(args);
+break;
+case NotifyCollectionChangedAction.Reset:
+// The entire collection has changed; reset all property-change subscriptions
+UnsubscribeFromAllItemsPropertyChanged();
+SubscribeToItemsPropertyChanged(_itemsSource);
+_notifier.NotifyDataSetChanged();
+break;
+default:
+throw new ArgumentOutOfRangeException();
+}
+CollectionItemsSourceChanged?.Invoke(this, args);
+}
 
-		void Move(NotifyCollectionChangedEventArgs args)
-		{
-			var count = args.NewItems.Count;
+void Move(NotifyCollectionChangedEventArgs args)
+{
+var count = args.NewItems.Count;
 
-			if (count == 1)
-			{
-				// For a single item, we can use NotifyItemMoved and get the animation
-				_notifier.NotifyItemMoved(this, AdjustPositionForHeader(args.OldStartingIndex), AdjustPositionForHeader(args.NewStartingIndex));
-				return;
-			}
+if (count == 1)
+{
+// For a single item, we can use NotifyItemMoved and get the animation
+_notifier.NotifyItemMoved(this, AdjustPositionForHeader(args.OldStartingIndex), AdjustPositionForHeader(args.NewStartingIndex));
+return;
+}
 
-			var start = AdjustPositionForHeader(Math.Min(args.OldStartingIndex, args.NewStartingIndex));
-			var end = AdjustPositionForHeader(Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count);
-			_notifier.NotifyItemRangeChanged(this, start, end);
-		}
+var start = AdjustPositionForHeader(Math.Min(args.OldStartingIndex, args.NewStartingIndex));
+var end = AdjustPositionForHeader(Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count);
+_notifier.NotifyItemRangeChanged(this, start, end);
+}
 
-		void Add(NotifyCollectionChangedEventArgs args)
-		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
-			startIndex = AdjustPositionForHeader(startIndex);
-			var count = args.NewItems.Count;
+void Add(NotifyCollectionChangedEventArgs args)
+{
+var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
+startIndex = AdjustPositionForHeader(startIndex);
+var count = args.NewItems.Count;
 
-			if (count == 1)
-			{
-				_notifier.NotifyItemInserted(this, startIndex);
-				return;
-			}
+if (args.NewItems != null)
+{
+foreach (var item in args.NewItems)
+SubscribeToItemPropertyChanged(item);
+}
 
-			_notifier.NotifyItemRangeInserted(this, startIndex, count);
-		}
+if (count == 1)
+{
+_notifier.NotifyItemInserted(this, startIndex);
+return;
+}
 
-		void Remove(NotifyCollectionChangedEventArgs args)
-		{
-			var startIndex = args.OldStartingIndex;
+_notifier.NotifyItemRangeInserted(this, startIndex, count);
+}
 
-			if (startIndex < 0)
-			{
-				// INCC implementation isn't giving us enough information to know where the removed items were in the
-				// collection. So the best we can do is a NotifyDataSetChanged()
-				_notifier.NotifyDataSetChanged();
-				return;
-			}
+void Remove(NotifyCollectionChangedEventArgs args)
+{
+var startIndex = args.OldStartingIndex;
 
-			startIndex = AdjustPositionForHeader(startIndex);
+if (args.OldItems != null)
+{
+foreach (var item in args.OldItems)
+UnsubscribeFromItemPropertyChanged(item);
+}
 
-			// If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
-			var count = args.OldItems.Count;
+if (startIndex < 0)
+{
+// INCC implementation isn't giving us enough information to know where the removed items were in the
+// collection. So the best we can do is a NotifyDataSetChanged()
+_notifier.NotifyDataSetChanged();
+return;
+}
 
-			if (count == 1)
-			{
-				_notifier.NotifyItemRemoved(this, startIndex);
-				return;
-			}
+startIndex = AdjustPositionForHeader(startIndex);
 
-			_notifier.NotifyItemRangeRemoved(this, startIndex, count);
-		}
+// If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
+var count = args.OldItems.Count;
 
-		void Replace(NotifyCollectionChangedEventArgs args)
-		{
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
-			startIndex = AdjustPositionForHeader(startIndex);
-			var newCount = args.NewItems.Count;
+if (count == 1)
+{
+_notifier.NotifyItemRemoved(this, startIndex);
+return;
+}
 
-			if (newCount == args.OldItems.Count)
-			{
-				// We are replacing one set of items with a set of equal size; we can do a simple item or range 
-				// notification to the adapter
-				if (newCount == 1)
-				{
-					_notifier.NotifyItemChanged(this, startIndex);
-				}
-				else
-				{
-					_notifier.NotifyItemRangeChanged(this, startIndex, newCount);
-				}
+_notifier.NotifyItemRangeRemoved(this, startIndex, count);
+}
 
-				return;
-			}
+void Replace(NotifyCollectionChangedEventArgs args)
+{
+var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
+startIndex = AdjustPositionForHeader(startIndex);
+var newCount = args.NewItems.Count;
 
-			// The original and replacement sets are of unequal size; this means that everything currently in view will 
-			// have to be updated. So we just have to use NotifyDataSetChanged and let the RecyclerView update everything
-			_notifier.NotifyDataSetChanged();
-		}
+if (args.OldItems != null)
+{
+foreach (var item in args.OldItems)
+UnsubscribeFromItemPropertyChanged(item);
+}
 
-		internal int ItemsCount()
-		{
-			if (_itemsSource is IList list)
-				return list.Count;
+if (args.NewItems != null)
+{
+foreach (var item in args.NewItems)
+SubscribeToItemPropertyChanged(item);
+}
 
-			int count = 0;
-			foreach (var item in _itemsSource)
-				count++;
-			return count;
-		}
+if (newCount == args.OldItems.Count)
+{
+// We are replacing one set of items with a set of equal size; we can do a simple item or range 
+// notification to the adapter
+if (newCount == 1)
+{
+_notifier.NotifyItemChanged(this, startIndex);
+}
+else
+{
+_notifier.NotifyItemRangeChanged(this, startIndex, newCount);
+}
 
-		internal object ElementAt(int index)
-		{
-			if (_itemsSource is IList list)
-				return list[index];
+return;
+}
 
-			int count = 0;
-			foreach (var item in _itemsSource)
-			{
-				if (count == index)
-					return item;
-				count++;
-			}
+// The original and replacement sets are of unequal size; this means that everything currently in view will 
+// have to be updated. So we just have to use NotifyDataSetChanged and let the RecyclerView update everything
+_notifier.NotifyDataSetChanged();
+}
 
-			return -1;
-		}
-	}
+void SubscribeToItemsPropertyChanged(IEnumerable items)
+{
+if (items == null)
+return;
+
+foreach (var item in items)
+SubscribeToItemPropertyChanged(item);
+}
+
+void SubscribeToItemPropertyChanged(object item)
+{
+if (item is not INotifyPropertyChanged inpc)
+return;
+
+if (_itemPropertyChangedHandlers.ContainsKey(inpc))
+return;
+
+PropertyChangedEventHandler handler = ItemPropertyChanged;
+_itemPropertyChangedHandlers[inpc] = handler;
+inpc.PropertyChanged += handler;
+}
+
+void UnsubscribeFromItemPropertyChanged(object item)
+{
+if (item is not INotifyPropertyChanged inpc)
+return;
+
+if (_itemPropertyChangedHandlers.TryGetValue(inpc, out var handler))
+{
+inpc.PropertyChanged -= handler;
+_itemPropertyChangedHandlers.Remove(inpc);
+}
+}
+
+void UnsubscribeFromAllItemsPropertyChanged()
+{
+foreach (var kvp in _itemPropertyChangedHandlers)
+kvp.Key.PropertyChanged -= kvp.Value;
+
+_itemPropertyChangedHandlers.Clear();
+}
+
+void ItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+{
+if (!ObserveChanges || _disposed)
+return;
+
+// Find the adapter position of this item and call NotifyItemChanged so that
+// RecyclerView re-binds and re-measures it.  This is necessary when the item
+// is in the last group and its ViewHolder has been recycled (Parent == null)
+// after the group was collapsed to 0 height; in that scenario requestLayout()
+// alone cannot trigger a re-measure.
+var position = GetPosition(sender);
+if (position < 0)
+return;
+
+_container.Dispatcher.DispatchIfRequired(() =>
+{
+if (!_disposed)
+_notifier.NotifyItemChanged(this, position);
+});
+}
+
+internal int ItemsCount()
+{
+if (_itemsSource is IList list)
+return list.Count;
+
+int count = 0;
+foreach (var item in _itemsSource)
+count++;
+return count;
+}
+
+internal object ElementAt(int index)
+{
+if (_itemsSource is IList list)
+return list[index];
+
+int count = 0;
+foreach (var item in _itemsSource)
+{
+if (count == index)
+return item;
+count++;
+}
+
+return -1;
+}
+}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -284,6 +284,57 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					CollectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);
 				}
 			}
+			else
+			{
+				// No visible cells found with MeasureInvalidated, but NeedsCellLayout is true.
+				// This happens when cells are at 0-height (they aren't in VisibleCells because
+				// CGRectIntersectsRect returns false for zero-height frames). Their cached size
+				// is 0, so GetSizeForItem returns 0, and UIKit never tries to display them –
+				// PreferredLayoutAttributesFittingAttributes never gets called to pick up the
+				// new MaximumHeightRequest value. Fix: clear the 0-height cache entries so that
+				// GetSizeForItem returns EstimatedItemSize (non-zero) for those items, then do
+				// a targeted layout invalidation that lets UIKit dequeue the cells and re-measure.
+				List<NSIndexPath> zeroHeightIndexPaths = null;
+
+				var groupCount = ItemsSource.GroupCount;
+				for (nint section = 0; section < groupCount; section++)
+				{
+					var itemCount = ItemsSource.ItemCountInGroup(section);
+					for (nint row = 0; row < itemCount; row++)
+					{
+						var indexPath = NSIndexPath.FromRowSection(row, section);
+						if (!ItemsSource.IsIndexPathValid(indexPath))
+							continue;
+
+						var item = ItemsSource[indexPath];
+						if (item != null
+							&& ItemsViewLayout.TryGetCachedCellSize(item, out var cachedSize)
+							&& cachedSize.Height == 0)
+						{
+							ItemsViewLayout.RemoveCachedCellSize(item);
+							zeroHeightIndexPaths ??= [];
+							zeroHeightIndexPaths.Add(indexPath);
+						}
+					}
+				}
+
+				if (zeroHeightIndexPaths?.Count > 0)
+				{
+					// Partial invalidation for just the items that had 0-height cached sizes.
+					// UIKit will now query EstimatedItemSize for them, dequeue their cells,
+					// and call PreferredLayoutAttributesFittingAttributes to get the real size.
+					if (ItemsSource.ItemCount == 1)
+					{
+						CollectionView.CollectionViewLayout.InvalidateLayout();
+					}
+					else
+					{
+						var context = new UICollectionViewFlowLayoutInvalidationContext();
+						context.InvalidateItems(zeroHeightIndexPaths.ToArray());
+						CollectionView.CollectionViewLayout.InvalidateLayout(context);
+					}
+				}
+			}
 		}
 
 		bool IsRefreshing()

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewLayout.cs
@@ -623,6 +623,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			_cellSizeCache.Clear();
 		}
 
+		internal void RemoveCachedCellSize(object item)
+		{
+			_cellSizeCache.Remove(item);
+		}
+
 		CGSize TryFindEstimatedSize(CGSize existingMeasurement)
 		{
 			if (CollectionView == null || GetPrototypeForIndexPath == null)

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -225,6 +225,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (invalidatedCells is not null)
 			{
+				if (ItemsView is GroupableItemsView { IsGrouped: true })
+				{
+					collectionView.CollectionViewLayout.InvalidateLayout();
+					return;
+				}
+
 				var layoutInvalidationContext = new UICollectionViewLayoutInvalidationContext();
 				layoutInvalidationContext.InvalidateItems(invalidatedCells.Select(CollectionView.IndexPathForCell).ToArray());
 				collectionView.CollectionViewLayout.InvalidateLayout(layoutInvalidationContext);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21913.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21913.cs
@@ -1,0 +1,130 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 21913, "Grouped CollectionView items leave stale space when MaximumHeightRequest changes", PlatformAffected.iOS | PlatformAffected.Android)]
+public class Issue21913 : ContentPage
+{
+	const double CollapsedSize = 0;
+	const double ExpandedSize = 30;
+
+	public ObservableCollection<Issue21913Group> Groups { get; } = new();
+
+	public Issue21913()
+	{
+		var group1 = new Issue21913Group
+		{
+			Name = "One",
+			AutomationId = "FirstGroupButton"
+		};
+		group1.Add(new Issue21913Item("A", "FirstGroupItemA", ExpandedSize));
+		group1.Add(new Issue21913Item("B", "FirstGroupItemB", ExpandedSize));
+		group1.Add(new Issue21913Item("C", "FirstGroupItemC", ExpandedSize));
+		Groups.Add(group1);
+
+		var group2 = new Issue21913Group
+		{
+			Name = "Two",
+			AutomationId = "SecondGroupButton"
+		};
+		group2.Add(new Issue21913Item("D", "SecondGroupItemD", ExpandedSize));
+		group2.Add(new Issue21913Item("E", "SecondGroupItemE", ExpandedSize));
+		group2.Add(new Issue21913Item("F", "SecondGroupItemF", ExpandedSize));
+		Groups.Add(group2);
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "Issue21913CollectionView",
+			IsGrouped = true,
+			ItemsSource = Groups,
+			GroupHeaderTemplate = new DataTemplate(() =>
+			{
+				var button = new Button();
+				button.SetBinding(Button.TextProperty, nameof(Issue21913Group.Name));
+				button.SetBinding(Button.AutomationIdProperty, nameof(Issue21913Group.AutomationId));
+				button.SetBinding(Button.CommandProperty, nameof(Issue21913Group.Toggle));
+				button.SetBinding(Button.CommandParameterProperty, ".");
+
+				return button;
+			}),
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, nameof(Issue21913Item.Name));
+				label.SetBinding(Label.AutomationIdProperty, nameof(Issue21913Item.AutomationId));
+				label.SetBinding(VisualElement.MaximumHeightRequestProperty, nameof(Issue21913Item.Size));
+
+				return label;
+			})
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 12,
+			Spacing = 8,
+			Children =
+			{
+				new Label
+				{
+					Text = "Click Group header to toggle"
+				},
+				collectionView
+			}
+		};
+
+		BindingContext = this;
+	}
+
+	public class Issue21913Group : ObservableCollection<Issue21913Item>
+	{
+		public string Name { get; set; }
+
+		public string AutomationId { get; set; }
+
+		public ICommand Toggle => new Command(parameter =>
+		{
+			if (parameter is Issue21913Group group)
+			{
+				foreach (var item in group)
+					item.Size = item.Size == CollapsedSize ? ExpandedSize : CollapsedSize;
+			}
+		});
+	}
+
+	public class Issue21913Item : INotifyPropertyChanged
+	{
+		double _size;
+
+		public Issue21913Item(string name, string automationId, double size)
+		{
+			Name = name;
+			AutomationId = automationId;
+			_size = size;
+		}
+
+		public string Name { get; }
+
+		public string AutomationId { get; }
+
+		public double Size
+		{
+			get => _size;
+			set => SetProperty(ref _size, value);
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+		{
+			if (Equals(storage, value))
+				return false;
+
+			storage = value;
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			return true;
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue21913.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue21913.cs
@@ -35,6 +35,16 @@ public class Issue21913 : ContentPage
 		group2.Add(new Issue21913Item("F", "SecondGroupItemF", ExpandedSize));
 		Groups.Add(group2);
 
+		var group3 = new Issue21913Group
+		{
+			Name = "Three",
+			AutomationId = "ThirdGroupButton"
+		};
+		group3.Add(new Issue21913Item("G", "ThirdGroupItemG", ExpandedSize));
+		group3.Add(new Issue21913Item("H", "ThirdGroupItemH", ExpandedSize));
+		group3.Add(new Issue21913Item("I", "ThirdGroupItemI", ExpandedSize));
+		Groups.Add(group3);
+
 		var collectionView = new CollectionView
 		{
 			AutomationId = "Issue21913CollectionView",

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21913.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21913.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue21913 : _IssuesUITest
+{
+	public Issue21913(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "Grouped CollectionView items leave stale space when MaximumHeightRequest changes";
+
+#if IOS
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void FirstGroupSecondToggleShouldMoveSecondHeaderBackDownOnIOS()
+	{
+	   App.WaitForElement("FirstGroupButton");
+	   App.WaitForElement("SecondGroupButton");
+		
+		App.Tap("FirstGroupButton");
+		Task.Delay(500).Wait(); // Allow time for the UI to update after collapsing the first group
+
+		App.Tap("FirstGroupButton");
+		VerifyScreenshot(retryTimeout: TimeSpan.FromSeconds(2));
+	}
+#endif
+
+#if ANDROID
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void SecondGroupSecondToggleShouldMoveThirdHeaderBackDownOnAndroid()
+	{
+		App.WaitForElement("SecondGroupButton");
+		var thirdGroupButton = App.WaitForElement("ThirdGroupButton");
+
+		App.Tap("SecondGroupButton");
+		Task.Delay(500).Wait(); // Allow time for the UI to update after collapsing the second group
+
+		App.Tap("SecondGroupButton");
+		Task.Delay(500).Wait(); // Allow time for the UI to update after expanding the second group
+		VerifyScreenshot();
+
+	}
+#endif
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21913.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21913.cs
@@ -33,13 +33,11 @@ public class Issue21913 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void SecondGroupSecondToggleShouldMoveThirdHeaderBackDownOnAndroid()
 	{
-		App.WaitForElement("SecondGroupButton");
-		var thirdGroupButton = App.WaitForElement("ThirdGroupButton");
-
-		App.Tap("SecondGroupButton");
+		App.WaitForElement("ThirdGroupButton");
+		App.Tap("ThirdGroupButton");
 		Task.Delay(500).Wait(); // Allow time for the UI to update after collapsing the second group
-
-		App.Tap("SecondGroupButton");
+        
+		App.Tap("ThirdGroupButton");
 		Task.Delay(500).Wait(); // Allow time for the UI to update after expanding the second group
 		VerifyScreenshot();
 


### PR DESCRIPTION
## Summary

Fixes a bug in grouped `CollectionView` where items that use `MaximumHeightRequest` (bound to a data property) to collapse/expand fail to update their layout after a second toggle.

### iOS behavior (before fix)
- First toggle (collapse): items go to 0 height ✅
- Second toggle (expand): items stay at 0 height, group appears "frozen" ❌

### Android behavior (before fix)
- Only affects the **last group**: after collapsing and trying to expand, the items remain at 0 height ❌
- Earlier groups work correctly because their ViewHolders are not recycled by RecyclerView

## Root Cause

### iOS
After items collapse to 0 height, their cells leave `UICollectionView.VisibleCells` (because `CGRectIntersectsRect` returns `false` for zero-height frames). `ItemsViewLayout._cellSizeCache` stores `size=0` for those items. When `MaximumHeightRequest` changes back to 30, `NeedsCellLayout` is set to `true` and `InvalidateLayoutIfItemsMeasureChanged()` runs, but finds **no visible cells** with `MeasureInvalidated` — so nothing happens. The stale 0-height cache entries mean `GetSizeForItem()` keeps returning 0, and UIKit never dequeues the cells to re-measure them.

### Android
After the **last group**'s items collapse to 0 height, their top coordinate equals `RecyclerView.height` exactly, so `LinearLayoutManager.recycleViewsFromEnd()` recycles those ViewHolders (`Parent` becomes `null`). When `MaximumHeightRequest` changes back to 30, `ItemContentView.ElementMeasureInvalidated` fires but the `if (Parent is RecyclerView)` guard fails — `notifyItemChanged()` is never called, and `requestLayout()` on a detached view has no effect.

## Fix

### iOS — `ItemsViewController.cs` + `ItemsViewLayout.cs`
Added an `else` branch to `InvalidateLayoutIfItemsMeasureChanged()` for when `NeedsCellLayout=true` but no visible cells have `MeasureInvalidated`:
1. Iterate all items; for each whose cached size has `Height==0`, remove that entry and collect its `NSIndexPath`.
2. Fire a targeted `UICollectionViewFlowLayoutInvalidationContext` for those index paths so UIKit queries `EstimatedItemSize` (now the only available size hint), dequeues the cells, and calls `PreferredLayoutAttributesFittingAttributes` — which measures them at the correct (non-zero) height.

Added `ItemsViewLayout.RemoveCachedCellSize(object item)` helper method.

### iOS CV2 — `ItemsViewController2.cs`
For grouped views: when visible invalidated cells are found, use a full `InvalidateLayout()` instead of a per-item context.

### Android — `ObservableItemsSource.cs`
Subscribe to `INotifyPropertyChanged` on each item in the collection (keeping subscriptions in sync via `Add`/`Remove`/`Replace`/`Reset` handlers and `Dispose`). When any item property changes, call `NotifyItemChanged(position)` on the adapter (via `Dispatcher`). This operates at the **data layer** — independent of whether the ViewHolder is currently attached — so it handles the recycled-ViewHolder scenario for the last group.

The existing `ItemContentView.ElementMeasureInvalidated` → `notifyItemChanged` path remains as a fast path for attached ViewHolders.

## Tests

- `src/Controls/tests/TestCases.HostApp/Issues/Issue21913.cs` — Host app page
- `src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue21913.cs` — UI tests
  - iOS: Collapse first group then expand → verify layout matches initial state
  - Android: Collapse third (last) group then expand → verify layout matches initial state


