### PR TITLE
Fix: Replace double.IsFinite to resolve compilation errors in SwipeGestureExtensions

### DIFF
--- a/src/Controls/src/Core/Internals/SwipeGestureExtensions.cs
+++ b/src/Controls/src/Core/Internals/SwipeGestureExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		internal static SwipeDirection TransformSwipeDirectionForRotation(SwipeDirection direction, double rotation)
 		{
-			if (!double.IsFinite(rotation))
+			if (double.IsNaN(rotation) || double.IsInfinity(rotation))
 			{
 				return direction;
 			}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
double.IsFinite() is a static method introduced in .NET Core 3.0 / .NET Standard 2.1 and is not available in .NET Standard 2.0. The Controls.Core.csproj project targets multiple frameworks, including netstandard2.0. When building for this TFM, the compiler cannot resolve double.IsFinite, resulting in a build error.  

Error: error CS0117: 'double' does not contain a definition for 'IsFinite'.

### Description of Change
Replaced the double.IsFinite check with:
`if (double.IsNaN(rotation) || double.IsInfinity(rotation))`
This is functionally equivalent to !double.IsFinite(rotation) and ensures compatibility across all target frameworks, since both methods are available in earlier .NET versions.

PR causing an error: [#30878](https://github.com/dotnet/maui/pull/30878)
### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1000" height="250"  src="https://github.com/user-attachments/assets/bb9a0c4f-6301-458c-bbe1-dd58590693a7"> | <img width="1000" height="250"  src="https://github.com/user-attachments/assets/c51d71f4-a6d8-4c65-8388-6fcd5ce681c6"> |