### PR TITLE
[fix] ContentLabel Moved to a nested class to prevent CS0122 in external source generators

### DIFF
--- a/src/Controls/src/Core/ContentConverter.cs
+++ b/src/Controls/src/Core/ContentConverter.cs
@@ -129,21 +129,21 @@ namespace Microsoft.Maui.Controls
 
 			return false;
 		}
-	}
 
-	// Internal label type used by ContentPresenter to avoid interference from global Label styles.
-	// MAUI resolves implicit styles by looking up Type.FullName as the key in ResourceDictionary,
-	// starting from the element's own Resources and walking up the visual tree (see MergedStyle.RegisterImplicitStyles).
-	// By storing an empty Style keyed to typeof(ContentLabel).FullName in the element's own Resources,
-	// the lookup finds it locally and short-circuits — the global Label style (even with ApplyToDerivedTypes)
-	// is never reached. This keeps properties like TextColor unset, so ShouldSetBinding returns true
-	// and the binding to the templated parent (e.g. RadioButton.TextColor) can be established.
-	internal class ContentLabel : Label
-	{
-		static readonly Style s_style = new Style(typeof(ContentLabel));
-		public ContentLabel()
+		// Internal label type used by ContentPresenter to avoid interference from global Label styles.
+		// MAUI resolves implicit styles by looking up Type.FullName as the key in ResourceDictionary,
+		// starting from the element's own Resources and walking up the visual tree (see MergedStyle.RegisterImplicitStyles).
+		// By storing an empty Style keyed to typeof(ContentLabel).FullName in the element's own Resources,
+		// the lookup finds it locally and short-circuits — the global Label style (even with ApplyToDerivedTypes)
+		// is never reached. This keeps properties like TextColor unset, so ShouldSetBinding returns true
+		// and the binding to the templated parent (e.g. RadioButton.TextColor) can be established.
+		class ContentLabel : Label
 		{
-			Resources = new ResourceDictionary { { typeof(ContentLabel).FullName, s_style } };
+			static readonly Style s_style = new Style(typeof(ContentLabel));
+			public ContentLabel()
+			{
+				Resources = new ResourceDictionary { { typeof(ContentLabel).FullName, s_style } };
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
###  Root Cause :
-  [PR #31940 ](https://github.com/dotnet/maui/pull/31940) added `ContentLabel` as a top-level internal class in Microsoft.Maui.Controls. It inherits from `Label`, so it implements ITextStyle and IAnimatable.
- Source generators scan all namespace-level types in the assembly. Because `ContentLabel` is namespace-level, it was picked up and code was generated referencing it.
- Since the class is internal, the generated code cannot access it from another assembly, causing a compile-time accessibility error.

### Description of Change : 

- `ContentLabel` was moved from a top-level internal class in `Microsoft.Maui.Controls` to a nested class inside `ContentConverter`.
- Top-level internal classes are returned by namespace-level scans, but nested classes without an explicit modifier are private by default.
- Source generators scanning top-level types no longer see `ContentLabel`, so no code is generated referencing it.
- Functionally, nothing changed: `ContentLabel` is still used only inside `ContentConverter`, and style mechanisms continue to work correctly.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34512 

### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac
### ScreenShots
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="1158" height="276" alt="Screenshot 2026-03-17 at 19 42 54" src="https://github.com/user-attachments/assets/3021227c-b516-4403-98f3-569ec4266ee0" />| <img width="1073" height="833" alt="Screenshot 2026-03-17 at 19 37 06" src="https://github.com/user-attachments/assets/24dbc6ce-86b4-4748-9184-37a01f65005a" /> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
