### PR TITLE
Fixed candidate test failures caused by PR #33428.

### DIFF
--- a/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
+++ b/src/Core/src/Platform/Android/MauiWindowInsetListener.cs
@@ -284,10 +284,26 @@ namespace Microsoft.Maui.Platform
 				contentView?.SetPadding(0, 0, 0, 0);
 			}
 
-			// Pass insets through unconsumed so child views receive them intact.
-			// Bottom: BottomNavigationView needs the nav bar inset to extend its background in Edge-to-Edge mode (Issue #33344).
-			// Top: SafeAreaExtensions handles per-view overlap, avoiding double-padding.
-			return insets;
+			// Consume top inset when AppBar is visible — it already pads itself, so downstream
+			// views must not receive a top inset or SafeAreaExtensions will double-apply it.
+			// Bottom inset is passed through unconsumed so BottomNavigationView can extend its
+			// background into the system navigation bar area (issue #33344).
+			var newSystemBars = Insets.Of(
+				systemBars?.Left ?? 0,
+				appBarHasContent ? 0 : systemBars?.Top ?? 0,
+				systemBars?.Right ?? 0,
+				systemBars?.Bottom ?? 0) ?? Insets.None;
+
+			var newDisplayCutout = Insets.Of(
+				displayCutout?.Left ?? 0,
+				appBarHasContent ? 0 : displayCutout?.Top ?? 0,
+				displayCutout?.Right ?? 0,
+				displayCutout?.Bottom ?? 0) ?? Insets.None;
+
+			return new WindowInsetsCompat.Builder(insets)
+				?.SetInsets(WindowInsetsCompat.Type.SystemBars(), newSystemBars)
+				?.SetInsets(WindowInsetsCompat.Type.DisplayCutout(), newDisplayCutout)
+				?.Build() ?? insets;
 		}
 
 		public void TrackView(AView view)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### RootCause of the issue

- In PR #33428, the WindowInsetsCompat.Builder block in MauiWindowInsetListener.ApplyDefaultWindowInsets was simplified to return insets; to standardize inset handling. This change was unrelated to the actual fix for #33344, which only required passing the bottom inset through as unconsumed.
As part of that refactor, top inset consumption was also removed, changing the prior contract where the top inset was consumed when appBarHasContent = true. While normal safe-area scenarios worked correctly, transient layout states (e.g., temporary Height = 0 during keyboard dismissal, rotation, animation, or dynamic item generation) triggered a second inset dispatch. In those moments, the top inset satisfied the overlap condition and was applied to content before SafeAreaExtensions could normalize it, causing test failures. Bottom insets did not regress because their overlap condition cannot be met in the same transient state.
 
### Description of Change
- Restored the original behavior by consuming the top inset when appBarHasContent = true, while continuing to pass the bottom inset through unconsumed (the only change required for #33344). This retains the Android edge-to-edge fix and restores deterministic safe-area handling.

### Test failures
- EntryScrollTest, HorizontalStackLayout_Spacing_WithLandscape, VerticalStackLayout_Spacing_WithLandscape, VerifyBindableLayoutWithGridItemTemplate - (EntryScrollTest)Test fails due to https://github.com/dotnet/maui/pull/33428 this PR



### Issues Fixed

Fixes #34509 


