### PR TITLE
Remove dead OnlyAndroid method from integration tests

### DIFF
--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AOTTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/AOTTemplateTest.cs
@@ -34,12 +34,6 @@ public class AOTTemplateTest : BaseTemplateTests
 		Assert.True(DotnetInternal.New(id, projectDir, DotNetCurrent, output: _output),
 			$"Unable to create template {id}. Check test output for errors.");
 
-		// For Android-only builds on Linux, modify the csproj to only target Android
-		// This avoids restore failures due to missing iOS/macCatalyst workloads
-		if (isAndroidPlatform && !TestEnvironment.IsMacOS && !TestEnvironment.IsWindows)
-		{
-			OnlyAndroid(projectFile);
-		}
 
 		var extendedBuildProps = isWindowsFramework
 			? PrepareNativeAotBuildPropsWindows(runtimeIdentifier)
@@ -95,12 +89,6 @@ public class AOTTemplateTest : BaseTemplateTests
 		Assert.True(DotnetInternal.New(id, projectDir, DotNetCurrent, output: _output),
 			$"Unable to create template {id}. Check test output for errors.");
 
-		// For Android-only builds on Linux, modify the csproj to only target Android
-		// This avoids restore failures due to missing iOS/macCatalyst workloads
-		if (isAndroidPlatform && !TestEnvironment.IsMacOS && !TestEnvironment.IsWindows)
-		{
-			OnlyAndroid(projectFile);
-		}
 
 		var extendedBuildProps = isWindowsFramework
 			? PrepareNativeAotBuildPropsWindows(runtimeIdentifier)

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseTemplateTests.cs
@@ -11,14 +11,6 @@ public abstract class BaseTemplateTests : BaseBuildTest
 			Path.Combine(TestDirectory, "Directory.Build.targets"), true);
 	}
 
-	protected void OnlyAndroid(string projectFile)
-	{
-		FileUtilities.ReplaceInFile(projectFile, new Dictionary<string, string>()
-		{
-			{ "<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>", "<TargetFrameworks>net10.0-android</TargetFrameworks>" },
-		});
-	}
-
 	protected void AssertContains(string expected, string actual)
 	{
 		Assert.True(

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -43,12 +43,6 @@ public class SimpleTemplateTest : BaseTemplateTests
 				"</Project>",
 				"<PropertyGroup><Version>1.0.0-preview.1</Version></PropertyGroup></Project>");
 
-		// We only have these packs for Android
-		if (additionalDotNetBuildParams.Contains("UseMonoRuntime=false", StringComparison.OrdinalIgnoreCase))
-		{
-			OnlyAndroid(projectFile);
-		}
-
 		var buildProps = BuildProps;
 
 		if (additionalDotNetBuildParams is not "" and not null)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Removes the dead `OnlyAndroid` method from `BaseTemplateTests` and its 3 call sites in `AOTTemplateTest` and `SimpleTemplateTest`.

### Why this is dead code

`OnlyAndroid` calls `ReplaceInFile` searching for:
```
<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
```

But MAUI templates now use MSBuild conditions with `DOTNET_TFM-android` placeholders — the static string above no longer exists in generated projects. The method is a silent no-op on every call.

### Why remove it now

On `net11.0`, this method was already removed by PR #33576. When merging `main → net11.0`, the call sites in `AOTTemplateTest.cs` (added by PR #33756) cause CS0103 build errors since the method does not exist on `net11.0`. Removing it from `main` prevents these merge conflicts going forward.

### Changes

- **`BaseTemplateTests.cs`**: Removed `OnlyAndroid` method definition
- **`AOTTemplateTest.cs`**: Removed 2 call sites (`PublishNativeAOT`, `PublishNativeAOTRootAllMauiAssemblies`)
- **`SimpleTemplateTest.cs`**: Removed 1 call site (`Build`)
