### PR TITLE
Fix TalkBack not correctly narrating RadioButtons with Content

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -740,7 +740,7 @@ namespace Microsoft.Maui.Controls
 
 			if (ControlTemplate != null)
 			{
-				string contentAsString = ContentAsString();
+				string contentAsString = GetSemanticDescriptionFromContent();
 
 				if (!string.IsNullOrWhiteSpace(contentAsString) && string.IsNullOrWhiteSpace(semantics?.Description))
 				{
@@ -750,6 +750,56 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return semantics;
+		}
+
+		string GetSemanticDescriptionFromContent()
+		{
+			if (Content is string contentText)
+				return contentText;
+
+			if (Content is IView contentView && TryGetSemanticDescription(contentView, out var semanticDescription))
+				return semanticDescription;
+
+			if (Value is string valueText && !string.IsNullOrWhiteSpace(valueText))
+				return valueText;
+
+			return ContentAsString();
+		}
+
+		static bool TryGetSemanticDescription(IView view, out string semanticDescription)
+		{
+			semanticDescription = null;
+
+			if (view == null)
+				return false;
+
+			if (!string.IsNullOrWhiteSpace(view.Semantics?.Description))
+			{
+				semanticDescription = view.Semantics.Description;
+				return true;
+			}
+
+			if (view is IText text && !string.IsNullOrWhiteSpace(text.Text))
+			{
+				semanticDescription = text.Text;
+				return true;
+			}
+
+			if (view is IContentView contentView && contentView.PresentedContent is IView presentedContent && TryGetSemanticDescription(presentedContent, out semanticDescription))
+				return true;
+
+			if (view is Microsoft.Maui.ILayout layout)
+			{
+				for (int i = 0; i < layout.Count; i++)
+				{
+					var child = layout[i];
+
+					if (TryGetSemanticDescription(child, out semanticDescription))
+						return true;
+				}
+			}
+
+			return false;
 		}
 
 		class CornerRadiusToShape : IValueConverter

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -759,8 +759,11 @@ namespace Microsoft.Maui.Controls
 				return contentText;
 			}
 
-			if (Content is IView contentView && TryGetSemanticDescription(contentView, out var semanticDescription))
+			if (Content is IView contentView)
 			{
+				// Don't fall back to ContentAsString() for view-based content — it calls ToString()
+				// on the view and returns a type name rather than meaningful text.
+				TryGetSemanticDescription(contentView, out var semanticDescription);
 				return semanticDescription;
 			}
 

--- a/src/Controls/src/Core/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButton.cs
@@ -755,13 +755,19 @@ namespace Microsoft.Maui.Controls
 		string GetSemanticDescriptionFromContent()
 		{
 			if (Content is string contentText)
+			{
 				return contentText;
+			}
 
 			if (Content is IView contentView && TryGetSemanticDescription(contentView, out var semanticDescription))
+			{
 				return semanticDescription;
+			}
 
 			if (Value is string valueText && !string.IsNullOrWhiteSpace(valueText))
+			{
 				return valueText;
+			}
 
 			return ContentAsString();
 		}
@@ -770,8 +776,10 @@ namespace Microsoft.Maui.Controls
 		{
 			semanticDescription = null;
 
-			if (view == null)
+			if (view is null)
+			{
 				return false;
+			}
 
 			if (!string.IsNullOrWhiteSpace(view.Semantics?.Description))
 			{
@@ -786,16 +794,20 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (view is IContentView contentView && contentView.PresentedContent is IView presentedContent && TryGetSemanticDescription(presentedContent, out semanticDescription))
+			{
 				return true;
+			}
 
 			if (view is Microsoft.Maui.ILayout layout)
 			{
-				for (int i = 0; i < layout.Count; i++)
+				for (int index = 0; index < layout.Count; index++)
 				{
-					var child = layout[i];
+					var child = layout[index];
 
 					if (TryGetSemanticDescription(child, out semanticDescription))
+					{
 						return true;
+					}
 				}
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
@@ -101,5 +101,60 @@ namespace Microsoft.Maui.DeviceTests
 
 			await AssertionExtensions.WaitForGC(radioButtonHandlerRef, layoutHandlerRef, layoutPlatformRef, radioButtonPlatformRef);
 		}
+
+		[Fact(DisplayName = "Issue 34322 - Templated RadioButton uses content label for semantics")]
+		public async Task Issue34322_TemplatedRadioButtonUsesContentLabelForSemantics()
+		{
+			EnsureTemplatedRadioButtonHandlersCreated();
+
+			var radioButton = CreateIssue34322RadioButton("Dog", isChecked: false, useSemanticDescription: false);
+
+			await CreateHandlerAndAddToWindow<RadioButtonHandler>(radioButton, _ =>
+			{
+				Assert.Equal("Dog", (radioButton as IView).Semantics.Description);
+				return Task.CompletedTask;
+			});
+		}
+
+		void EnsureTemplatedRadioButtonHandlersCreated()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Border, BorderHandler>();
+					handlers.AddHandler<Shape, ShapeViewHandler>();
+					handlers.AddHandler<ContentPresenter, ContentViewHandler>();
+					handlers.AddHandler<RadioButton, RadioButtonHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+				});
+			});
+		}
+
+		static RadioButton CreateIssue34322RadioButton(string label, bool isChecked, bool useSemanticDescription)
+		{
+			var radioButton = new RadioButton
+			{
+				ControlTemplate = RadioButton.DefaultTemplate,
+				Content = new VerticalStackLayout
+				{
+					Children =
+					{
+						new Label
+						{
+							Text = label
+						}
+					}
+				},
+				IsChecked = isChecked,
+			};
+
+			if (useSemanticDescription)
+				SemanticProperties.SetDescription(radioButton, label);
+
+			return radioButton;
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/RadioButton/RadioButtonTests.cs
@@ -116,6 +116,35 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Issue 34322 - Explicit SemanticDescription is not overwritten by content-derived semantics")]
+		public async Task Issue34322_ExplicitSemanticDescriptionNotOverwrittenByContent()
+		{
+			EnsureTemplatedRadioButtonHandlersCreated();
+
+			var radioButton = new RadioButton
+			{
+				ControlTemplate = RadioButton.DefaultTemplate,
+				Content = new VerticalStackLayout
+				{
+					Children =
+					{
+						new Label
+						{
+							Text = "Dog"
+						}
+					}
+				},
+				IsChecked = false,
+			};
+			SemanticProperties.SetDescription(radioButton, "Custom Description");
+
+			await CreateHandlerAndAddToWindow<RadioButtonHandler>(radioButton, _ =>
+			{
+				Assert.Equal("Custom Description", (radioButton as IView).Semantics.Description);
+				return Task.CompletedTask;
+			});
+		}
+
 		void EnsureTemplatedRadioButtonHandlersCreated()
 		{
 			EnsureHandlerCreated(builder =>

--- a/src/Core/src/Platform/Android/SemanticExtensions.cs
+++ b/src/Core/src/Platform/Android/SemanticExtensions.cs
@@ -90,6 +90,13 @@ namespace Microsoft.Maui.Platform
 			if (!string.IsNullOrWhiteSpace(newText))
 				info.Text = newText;
 
+			if (virtualView is IRadioButton radioButton)
+			{
+				info.ClassName = Java.Lang.Class.FromType(typeof(global::Android.Widget.RadioButton)).Name;
+				info.Checkable = true;
+				info.Checked = radioButton.IsChecked;
+			}
+
 			if (!string.IsNullOrWhiteSpace(virtualView.AutomationId) &&
 				platformView?.Context != null)
 			{

--- a/src/Core/src/Platform/Android/SemanticExtensions.cs
+++ b/src/Core/src/Platform/Android/SemanticExtensions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Maui.Platform
 {
 	public static partial class SemanticExtensions
 	{
+		// Cached once to avoid repeated JNI/type lookups on every accessibility traversal.
+		static readonly string s_radioButtonClassName = Java.Lang.Class.FromType(typeof(global::Android.Widget.RadioButton)).Name;
 		public static void UpdateSemanticNodeInfo(this View platformView, IView virtualView, AccessibilityNodeInfoCompat? info)
 		{
 			if (info == null || virtualView == null)
@@ -92,7 +94,7 @@ namespace Microsoft.Maui.Platform
 
 			if (virtualView is IRadioButton radioButton)
 			{
-				info.ClassName = Java.Lang.Class.FromType(typeof(global::Android.Widget.RadioButton)).Name;
+				info.ClassName = s_radioButtonClassName;
 				info.Checkable = true;
 				info.Checked = radioButton.IsChecked;
 			}


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause:
When a `RadioButton` uses a `ControlTemplate` (i.e., `ControlTemplate != null`), `UpdateSemantics()` calls `ContentAsString()` to produce the accessibility label. For simple string content, this works fine, but for view-based content—such as a `Label` inside a `VerticalStackLayout`—`ContentAsString()` ultimately falls back to calling `ToString()` on the view object, returning a type name rather than the user-visible text.

Additionally, the Android accessibility node for `RadioButton` was never explicitly tagged as a radio button widget. Without the correct `ClassName`, `Checkable`, and `Checked` node properties, TalkBack cannot announce the checked/unchecked state of the control, even when a semantic description is otherwise available.

### Description of Changes

**Enhancements to semantic description logic:**

- Added `GetSemanticDescriptionFromContent()` and `TryGetSemanticDescription()` methods in `RadioButton.cs` to extract semantic descriptions from nested content views, labels, and value properties, improving accessibility for templated radio buttons.
- Updated `UpdateSemantics()` in `RadioButton.cs` to use the new semantic extraction logic instead of the previous `ContentAsString()` method.

**Platform-specific accessibility improvements:**

- Modified `SemanticExtensions.cs` for Android to set the correct class name, checkable, and checked properties for radio buttons, ensuring proper accessibility information is exposed.

**Testing and validation:**

- Added a new test (`Issue34322_TemplatedRadioButtonUsesContentLabelForSemantics`) and supporting helper methods in `RadioButtonTests.cs` to verify that templated radio buttons use their content label for semantics, addressing a specific accessibility issue.

### Issues Fixed

Fixes #34322

### Tested the behavior on the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|------------------|----------------|
| <img width="1180" height="984" alt="BeforeFixiOS" src="https://github.com/user-attachments/assets/ca0afb3d-6b3a-422d-975f-772205e0c4cc" /> | <img width="1225" height="986" alt="AfterFixiOS" src="https://github.com/user-attachments/assets/b34f7c37-d512-48ef-99de-a721039465eb" /> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->