### PR TITLE
Fix style inheritance by unapplying base style before reapplying

### DIFF
--- a/src/Controls/src/Core/Style.cs
+++ b/src/Controls/src/Core/Style.cs
@@ -186,7 +186,10 @@ namespace Microsoft.Maui.Controls
 		void ApplyCore(BindableObject bindable, Style basedOn, SetterSpecificity specificity)
 		{
 			if (basedOn != null)
+			{
+				((IStyle)basedOn).UnApply(bindable);
 				((IStyle)basedOn).Apply(bindable, specificity.AsBaseStyle());
+			}
 
 #if NETSTANDARD2_0
 			specificities.Remove(bindable);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31280.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31280.xaml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui31280">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Style
+				x:Key="LabelBaseStyle"
+				TargetType="Label">
+				<Setter Property="TextColor"
+						Value="{AppThemeBinding Light=Green, Dark=Green}"/>
+			</Style>
+
+			<Style
+				x:Key="LabelBaseStyleRed"
+				BaseResourceKey="LabelBaseStyle"
+				TargetType="Label">
+				<Setter Property="TextColor"
+						Value="Red"/>
+			</Style>
+
+			<Style
+				x:Key="LabelBaseStyleFromRedWithPadding"
+				BaseResourceKey="LabelBaseStyleRed"
+				TargetType="Label">
+				<Setter Property="Padding"
+						Value="20"/>
+			</Style>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+
+	<StackLayout>
+		<Label Text="Base Style"
+			   x:Name="LabelBaseStyle"
+			   Style="{StaticResource LabelBaseStyle}"/>
+		<Label Text="Red Style"
+			   x:Name="LabelBaseStyleRed"
+			   Style="{StaticResource LabelBaseStyleRed}"/>
+		<Label Text="From Red With Padding"
+			   x:Name="LabelWithPadding"
+			   Style="{StaticResource LabelBaseStyleFromRedWithPadding}"/>
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui31280.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui31280.xaml.cs
@@ -1,0 +1,26 @@
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui31280 : ContentPage
+{
+	public Maui31280()
+	{
+		InitializeComponent();
+	}
+
+	[Collection("Issue")]
+	public class Tests
+	{
+		[Theory]
+		[XamlInflatorData]
+		internal void StyleInheritanceShouldWork(XamlInflator inflator)
+		{
+			var layout = new Maui31280(inflator);
+			Assert.Equal(Colors.Green, layout.LabelBaseStyle.TextColor);
+			Assert.Equal(Colors.Red, layout.LabelBaseStyleRed.TextColor);
+			Assert.Equal(Colors.Red, layout.LabelWithPadding.TextColor);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Cherry-pick of #31317 targeting `net11.0`. Corrects style inheritance in `Style.ApplyCore` by unapplying the base style before reapplying it.

Test updated from NUnit to xUnit patterns (`XamlInflator`, `[Theory]`, `Assert.Equal`) and renamed from `Issue31280` to `Maui31280` per conventions.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/31280