### PR TITLE
[Android, Windows] Fix CollectionView handler cleanup when DataTemplateSelector switches templates

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -59,16 +59,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				visualElement.MeasureInvalidated -= ElementMeasureInvalidated;
 			}
 
-			// Disconnect handlers before releasing content to break the handler circular reference
-			// (View.Handler ↔ IPlatformViewHandler.VirtualView) that prevents GC.
-			View?.DisconnectHandlers();
-
 			var platformView = PlatformView;
 
 			if (platformView != null)
 			{
 				RemoveView(platformView);
 			}
+
+			// Capture the current platform view before disconnecting handlers, because
+			// DisconnectHandlers() may null out the handler's PlatformView/ContainerView.
+			View?.DisconnectHandlers();
 
 			Content = null;
 			_pixelSize = null;

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				visualElement.MeasureInvalidated -= ElementMeasureInvalidated;
 			}
 
+			// Disconnect handlers before releasing content to break the handler circular reference
+			// (View.Handler ↔ IPlatformViewHandler.VirtualView) that prevents GC.
+			View?.DisconnectHandlers();
+
 			var platformView = PlatformView;
 
 			if (platformView != null)

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -42,6 +42,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			itemsView.RemoveLogicalChild(View);
+
+			// Disconnect and clear the handler via ItemContentView.Recycle(), which calls
+			// DisconnectHandlers() before releasing Content. Reset _selectedTemplate so the
+			// next Bind() call always goes through the templateChanging path and recreates
+			// the handler (since we just disconnected it).
+			_itemContentView.Recycle();
+			View = null; // clear reference to the disconnected view
+			_selectedTemplate = null; // force templateChanging=true on next Bind() to recreate the view
 		}
 
 		public void Bind(object itemBindingContext, ItemsView itemsView,

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -184,7 +184,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				foreach (var item in platformView.GetChildren<ItemContentControl>())
 				{
 					var element = item.GetVisualElement();
-					VirtualView.RemoveLogicalChild(element);
+
+					if (element is not null)
+					{
+						element.DisconnectHandlers();
+						VirtualView.RemoveLogicalChild(element);
+					}
 				}
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue32243.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue32243.cs
@@ -1,0 +1,315 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 32243, "CollectionView does not disconnect handlers when DataTemplateSelector changes template", PlatformAffected.Android | PlatformAffected.UWP)]
+public class Issue32243 : NavigationPage
+{
+	public Issue32243() : base(new _Issue32243MainPage())
+	{
+		_Issue32243TrackingLabel.ResetAll();
+	}
+}
+
+class _Issue32243MainPage : ContentPage
+{
+	readonly Label _handlerCountLabel;
+	readonly Label _statusLabel;
+
+	public _Issue32243MainPage()
+	{
+		Title = "Issue 32243";
+
+		_statusLabel = new Label
+		{
+			Text = "Navigate to the CollectionView page, switch templates, go back, then check handlers.",
+			AutomationId = "StatusLabel"
+		};
+
+		_handlerCountLabel = new Label
+		{
+			Text = "Connected handlers will be shown here.",
+			AutomationId = "HandlerCountLabel"
+		};
+
+		var navigateButton = new Button
+		{
+			Text = "Navigate to template page",
+			AutomationId = "NavigateButton"
+		};
+
+		navigateButton.Clicked += async (sender, args) =>
+		{
+			await Navigation.PushAsync(new _Issue32243CollectionPage());
+		};
+
+		var checkHandlersButton = new Button
+		{
+			Text = "Show connected handlers",
+			AutomationId = "CheckHandlersButton"
+		};
+
+		checkHandlersButton.Clicked += (sender, args) =>
+		{
+			var labelsWithHandlers = _Issue32243TrackingLabel.GetLabelsWithConnectedHandlers();
+
+			if (labelsWithHandlers.Count == 0)
+			{
+				_handlerCountLabel.Text = "✓ No labels have connected handlers (all cleaned up!)";
+				_handlerCountLabel.TextColor = Colors.Green;
+				_statusLabel.Text = "Status: No connected handlers found.";
+			}
+			else
+			{
+				var details = string.Join("\n", labelsWithHandlers.Select(label =>
+					$"Label #{label.InstanceId} - Text: '{label.Text}'"));
+
+				_handlerCountLabel.Text = $"⚠️ {labelsWithHandlers.Count} labels still have connected handlers:\n{details}";
+				_handlerCountLabel.TextColor = Colors.Brown;
+				_statusLabel.Text = "Status: Connected handlers are still present.";
+			}
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children =
+			{
+				new Label
+				{
+					Text = "This test mirrors the sandbox flow: navigate, switch templates, navigate back, then verify disconnected handlers."
+				},
+				navigateButton,
+				checkHandlersButton,
+				_statusLabel,
+				_handlerCountLabel
+			}
+		};
+	}
+}
+
+class _Issue32243CollectionPage : ContentPage
+{
+	readonly List<_Issue32243Item> _items;
+	readonly CollectionView _collectionView;
+	readonly Label _statusLabel;
+
+	public _Issue32243CollectionPage()
+	{
+		Title = "Template Page";
+
+		_items = Enumerable.Range(1, 50).Select(i => new _Issue32243Item
+		{
+			Name = $"Item {i}",
+			UseTemplateA = i % 2 == 1
+		}).ToList();
+
+		var templateA = new DataTemplate(() =>
+		{
+			var label = new _Issue32243TrackingLabel();
+			label.SetBinding(Label.TextProperty, nameof(_Issue32243Item.Name));
+			return new VerticalStackLayout
+			{
+				BackgroundColor = Colors.LightBlue,
+				Padding = new Thickness(10),
+				Children =
+				{
+					label,
+					new Label { Text = "Template A", TextColor = Colors.Blue }
+				}
+			};
+		});
+
+		var templateB = new DataTemplate(() =>
+		{
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, nameof(_Issue32243Item.Name));
+			return new VerticalStackLayout
+			{
+				BackgroundColor = Colors.LightGray,
+				Padding = new Thickness(10),
+				Children =
+				{
+					label,
+					new Label { Text = "Template B", TextColor = Colors.Gray }
+				}
+			};
+		});
+
+		_statusLabel = new Label
+		{
+			Text = "Status: Mixed templates active",
+			AutomationId = "TemplatePageStatusLabel"
+		};
+
+		var switchTemplateButton = new Button
+		{
+			Text = "Switch to all Template B",
+			AutomationId = "SwitchTemplateButton"
+		};
+
+		switchTemplateButton.Clicked += (sender, args) =>
+		{
+			foreach (var item in _items)
+			{
+				item.UseTemplateA = false;
+			}
+
+			_collectionView.ItemsSource = _items.ToList();
+			_statusLabel.Text = "Status: All items using Template B";
+		};
+
+		var navigateBackButton = new Button
+		{
+			Text = "Navigate back",
+			AutomationId = "NavigateBackButton"
+		};
+
+		navigateBackButton.Clicked += async (sender, args) =>
+		{
+			await Navigation.PopAsync();
+		};
+
+		_collectionView = new CollectionView
+		{
+			AutomationId = "ItemsCollectionView",
+			SelectionMode = SelectionMode.None,
+			ItemTemplate = new _Issue32243TemplateSelector
+			{
+				TemplateA = templateA,
+				TemplateB = templateB
+			},
+			ItemsSource = _items
+		};
+
+		Content = new Grid
+		{
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			},
+			Children =
+			{
+				new VerticalStackLayout
+				{
+					Padding = new Thickness(20, 20, 20, 10),
+					Spacing = 8,
+					Children =
+					{
+						new Label { Text = "50 items — odd=Template A (blue), even=Template B (gray)" },
+						switchTemplateButton,
+						navigateBackButton,
+						_statusLabel
+					}
+				},
+				_collectionView
+			}
+		};
+
+		Grid.SetRow(_collectionView, 1);
+	}
+}
+
+class _Issue32243TrackingLabel : Label
+{
+	static int _instanceCounter;
+	static readonly List<WeakReference<_Issue32243TrackingLabel>> _allInstances = [];
+	readonly int _instanceId;
+
+	public _Issue32243TrackingLabel()
+	{
+		_instanceId = ++_instanceCounter;
+		_allInstances.Add(new WeakReference<_Issue32243TrackingLabel>(this));
+		DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
+	}
+
+	protected override void OnHandlerChanged()
+	{
+		base.OnHandlerChanged();
+
+		if (Handler is null)
+		{
+			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+		}
+	}
+
+	public int InstanceId => _instanceId;
+
+	public static List<_Issue32243TrackingLabel> GetLabelsWithConnectedHandlers()
+	{
+		var result = new List<_Issue32243TrackingLabel>();
+
+		_allInstances.RemoveAll(wr =>
+		{
+			if (wr.TryGetTarget(out var label))
+			{
+				if (label.Handler != null)
+				{
+					result.Add(label);
+				}
+
+				return false;
+			}
+
+			return true;
+		});
+
+		return result;
+	}
+
+	void OnMainDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)
+	{
+		_ = _instanceId;
+	}
+
+	public static void ResetAll()
+	{
+		_allInstances.Clear();
+		_instanceCounter = 0;
+	}
+}
+
+class _Issue32243TemplateSelector : DataTemplateSelector
+{
+	public DataTemplate TemplateA { get; set; }
+	public DataTemplate TemplateB { get; set; }
+
+	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+	{
+		return item is _Issue32243Item { UseTemplateA: true } ? TemplateA : TemplateB;
+	}
+}
+
+class _Issue32243Item : INotifyPropertyChanged
+{
+	string _name = string.Empty;
+	bool _useTemplateA;
+
+	public string Name
+	{
+		get => _name;
+		set
+		{
+			_name = value;
+			OnPropertyChanged();
+		}
+	}
+
+	public bool UseTemplateA
+	{
+		get => _useTemplateA;
+		set
+		{
+			_useTemplateA = value;
+			OnPropertyChanged();
+		}
+	}
+
+	public event PropertyChangedEventHandler PropertyChanged;
+
+	protected void OnPropertyChanged([CallerMemberName] string name = null)
+		=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32243.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue32243.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+[Category(UITestCategories.CollectionView)]
+public class Issue32243 : _IssuesUITest
+{
+	public Issue32243(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "CollectionView does not disconnect handlers when DataTemplateSelector changes template";
+
+	[Test]
+	public void CollectionViewDisconnectsHandlersAfterNavigationBack()
+	{
+		App.WaitForElement("NavigateButton");
+		App.Tap("NavigateButton");
+
+		App.WaitForElement("SwitchTemplateButton");
+		App.Tap("SwitchTemplateButton");
+
+		App.WaitForElement("NavigateBackButton");
+		App.Tap("NavigateBackButton");
+
+		App.WaitForElement("CheckHandlersButton");
+		App.Tap("CheckHandlersButton");
+
+		var result = App.WaitForElement("HandlerCountLabel").GetText();
+		Assert.That(result, Is.EqualTo("✓ No labels have connected handlers (all cleaned up!)"),
+			"CollectionView should disconnect handlers from views belonging to the old DataTemplate after navigating back.");
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
CollectionView retains stale item handlers when content is no longer active—both when a DataTemplateSelector switches templates and when items are removed from the backing collection.

###  Root Cause
**Android**

`TemplatedItemViewHolder` removed the logical child during recycle, but it did not disconnect handlers before releasing the old templated content.

**Windows**

Windows also showed stale templated item reuse around template changes, where old templated content and handlers can survive longer than expected across cleanup and reuse.

### Description of Change
**Android**

- Added `DisconnectHandlers()` to `ItemContentView.Recycle()`
- Updated `TemplatedItemViewHolder.Recycle()` to call `_itemContentView.Recycle()`
- Cleared `View` and `_selectedTemplate` so recycled items rebuild cleanly on the next bind

**Windows**

- Updated `ItemsViewHandler.Windows.CleanUpCollectionViewSource()` to disconnect handlers before removing the logical child
- Kept the Windows fix scoped to the cleanup path

**Scenario 1: DataTemplateSelector switching templates**
When a DataTemplateSelector switches an item from one template to another, the old templated content is properly disconnected before being released. This prevents stale handlers from remaining attached to controls from the previous template.

**Scenario 2: Removing items from CollectionView**
When items are removed from the CollectionView (e.g., using RemoveAt(), Remove(), or Clear()), the item content is properly cleaned up and its handlers are disconnected before the view is released. This prevents stale handlers and avoids the memory leak described in the issue.

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/32243

### Technical Details

On Android, the important part is using `DisconnectHandlers()` so the full templated hierarchy is disconnected during recycle, not just the root view.
On Windows, the selected fix is the cleanup-path handler-disconnect change in `ItemsViewHandler.Windows.cs`.

### Screenshots

**Android**
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/b4d4ce80-3630-4d27-8fd2-7527862eaed9"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/5a7652f5-3dda-41e0-a27f-ce4114236c98"> |

**Windows**
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/28586ab0-566b-4e2a-97a6-45f33200d51e"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/2df1c9fc-ab73-4765-99d3-2a76d500c3ed"> |