### PR TITLE
Fix incorrect access modifier in Slider extension

### DIFF
--- a/src/Core/src/Platform/Android/SliderExtensions.cs
+++ b/src/Core/src/Platform/Android/SliderExtensions.cs
@@ -107,8 +107,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: Make this public in NET 11.
-		internal static async Task UpdateThumbImageSourceAsync(this SeekBar seekBar, ISlider slider, IImageSourceServiceProvider provider)
+		public static async Task UpdateThumbImageSourceAsync(this SeekBar seekBar, ISlider slider, IImageSourceServiceProvider provider)
 		{
 			var context = seekBar.Context;
 			if (context is null)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

This pull request makes a minor accessibility change to the `SliderExtensions.cs` file. The method for updating the thumb image source on a slider is now public, allowing external code to call it directly.

* Changed the `UpdateThumbImageSourceAsync` method from `internal` to `public` in `SliderExtensions.cs`, making it accessible outside the assembly.

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->