### PR TITLE
doc: Add paragraph to README.md explaining how to fetch the `maui` project templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 Create a new app with `dotnet new maui -n NewApp` or a [sample app](https://github.com/dotnet/maui-samples/tree/main/10.0/Apps/DeveloperBalance#developer-balance) with `dotnet new maui -n NewApp -sc` that includes the [open-source Syncfusion Toolkit for .NET MAUI](https://www.syncfusion.com/net-maui-toolkit?utm_source=msftdotnet&utm_medium=banner&utm_campaign=mauipremium_sep25) with over 30 additional controls, the [.NET MAUI Community Toolkit](https://github.com/CommunityToolkit/Maui) with tons of helpers and views, and [MVVM Toolkit](https://github.com/CommunityToolkit/dotnet). 
 
+**Note:** To install the `maui` project templates, run `dotnet new install Microsoft.Maui.Templates.net10` (or the relevant template version).
+
 ## Overview
 
 .NET Multi-platform App UI (.NET MAUI) is the evolution of Xamarin.Forms that expand capabilities beyond mobile Android and iOS into desktop apps for Windows and macOS. With .NET MAUI, you can build apps that perform great on any device that runs Windows, macOS, Android, & iOS from a single codebase. Coupled with Visual Studio productivity tools and emulators, .NET and Visual Studio significantly speed up the development process for building apps that target the widest possible set of devices. Use a single development stack that supports the best-of-breed solutions for all modern workloads with a unified SDK, base class libraries, and a toolchain.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Create a new app with `dotnet new maui -n NewApp` or a [sample app](https://github.com/dotnet/maui-samples/tree/main/10.0/Apps/DeveloperBalance#developer-balance) with `dotnet new maui -n NewApp -sc` that includes the [open-source Syncfusion Toolkit for .NET MAUI](https://www.syncfusion.com/net-maui-toolkit?utm_source=msftdotnet&utm_medium=banner&utm_campaign=mauipremium_sep25) with over 30 additional controls, the [.NET MAUI Community Toolkit](https://github.com/CommunityToolkit/Maui) with tons of helpers and views, and [MVVM Toolkit](https://github.com/CommunityToolkit/dotnet). 
 
-**Note:** To install the `maui` project templates, run `dotnet new install Microsoft.Maui.Templates.net10` (or the relevant template version).
+**Note:** If the `maui` template is not available, first install the .NET MAUI workload with `dotnet workload install maui`.
 
 ## Overview
 


### PR DESCRIPTION
doc: Add paragraph to README.md explaining how to fetch the `maui` project templates

### Description of Change

README.md explains how to create a new MAUI app using `dotnet new maui` but the command will fail unless you have already installed the MAUI project templates. This commit adds a paragraph to README.md explaining how to fetch the `maui` project templates (which is not straightforward as the Microsoft.Maui.Templates point to an outdated .NET 6 version of the templates)

### Issues Fixed

Runing `dotnet new maui` will fail unless you have installed the MAUI templates:
```
$ dotnet new maui -n NewApp
No templates or subcommands found matching: 'maui'.
Did you mean one of the following templates?
   dotnet new mvc
   dotnet new enum
   dotnet new page

To list installed templates similar to 'maui', run:
   dotnet new list maui
To search for the templates on NuGet.org, run:
   dotnet new search maui


For details on the exit code, refer to https://aka.ms/templating-exit-codes#103
```

