### PR TITLE
Fix MauiFont and MauiSplashScreen assets missing on first/incremental builds

### DIFF
--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -76,7 +76,6 @@
         <_ResizetizerStampFile>$(_ResizetizerIntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
         <_MauiFontInputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
         <_MauiSplashInputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.inputs</_MauiSplashInputsFile>
-        <_MauiSplashStampFile>$(_ResizetizerIntermediateOutputPath)mauisplash.stamp</_MauiSplashStampFile>
         <_MauiManifestStampFile>$(_ResizetizerIntermediateOutputPath)mauimanifest.stamp</_MauiManifestStampFile>
 
         <_ResizetizerIntermediateOutputRoot>$(_ResizetizerIntermediateOutputPath)resizetizer\</_ResizetizerIntermediateOutputRoot>
@@ -401,9 +400,7 @@
     </Target>
 
     <Target Name="ProcessMauiSplashScreens"
-        Condition="'$(EnableMauiSplashScreenProcessing)' == 'true'"
-        Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_MauiSplashInputsFile);@(MauiSplashScreen)"
-        Outputs="$(_MauiSplashStampFile)">
+        Condition="'$(EnableMauiSplashScreenProcessing)' == 'true'">
 
         <PropertyGroup>
             <_MauiHasSplashScreens>false</_MauiHasSplashScreens>
@@ -509,13 +506,9 @@
             <TizenTpkUserIncludeFiles Include="@(_MauiSplashScreens)" TizenTpkSubDir="shared\res\splash" />
         </ItemGroup>
 
-        <!-- Stamp file for Outputs -->
-        <MakeDir Directories="$(_ResizetizerIntermediateOutputPath)"/>
-        <Touch Files="$(_MauiSplashStampFile)" AlwaysCreate="True" />
-
+        <!-- Include splash assets as filewrites so they don't get rm'd -->
         <ItemGroup>
             <FileWrites Include="@(_MauiSplashAssets)" />
-            <FileWrites Include="$(_MauiSplashStampFile)" />
         </ItemGroup>
 
     </Target>

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -75,7 +75,6 @@
         <_ResizetizerOutputsFile>$(_ResizetizerIntermediateOutputPath)mauiimage.outputs</_ResizetizerOutputsFile>
         <_ResizetizerStampFile>$(_ResizetizerIntermediateOutputPath)mauiimage.stamp</_ResizetizerStampFile>
         <_MauiFontInputsFile>$(_ResizetizerIntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
-        <_MauiFontStampFile>$(_ResizetizerIntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
         <_MauiSplashInputsFile>$(_ResizetizerIntermediateOutputPath)mauisplash.inputs</_MauiSplashInputsFile>
         <_MauiSplashStampFile>$(_ResizetizerIntermediateOutputPath)mauisplash.stamp</_MauiSplashStampFile>
         <_MauiManifestStampFile>$(_ResizetizerIntermediateOutputPath)mauimanifest.stamp</_MauiManifestStampFile>
@@ -175,6 +174,11 @@
             $(ProcessMauiFontsAfterTargets);
             ResizetizeCollectItems;
         </ProcessMauiFontsAfterTargets>
+
+        <ProcessMauiFontsBeforeTargets>
+            $(ProcessMauiFontsBeforeTargets);
+            _ComputeAndroidAssetsPaths;
+        </ProcessMauiFontsBeforeTargets>
     </PropertyGroup>
 
     <!-- Windows App SDK -->
@@ -518,8 +522,6 @@
 
     <Target Name="ProcessMauiFonts"
         Condition="'$(EnableMauiFontProcessing)' == 'true'"
-        Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_MauiFontInputsFile);@(MauiFont)"
-        Outputs="$(_MauiFontStampFile)"
         AfterTargets="$(ProcessMauiFontsAfterTargets)"
         BeforeTargets="$(ProcessMauiFontsBeforeTargets)"
         DependsOnTargets="$(ProcessMauiFontsDependsOnTargets)">
@@ -595,12 +597,8 @@
             <TizenTpkUserIncludeFiles Include="@(_MauiFontCopied)"  Condition="'@(_MauiFontCopied)' != ''" TizenTpkSubDir="res\fonts\" />
         </ItemGroup>
 
-        <!-- Touch/create our stamp file for outputs -->
-        <Touch Files="$(_MauiFontStampFile)" AlwaysCreate="True" />
-
-        <!-- Include our fonts and stamp file as filewrites so they don't get rm'd -->
+        <!-- Include our fonts as filewrites so they don't get rm'd -->
         <ItemGroup>
-            <FileWrites Include="$(_MauiFontStampFile)" />
             <FileWrites Include="@(_MauiFontCopied)" />
         </ItemGroup>
     </Target>

--- a/src/SingleProject/Resizetizer/test/UnitTests/ProcessMauiFontsTargetTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ProcessMauiFontsTargetTests.cs
@@ -9,37 +9,37 @@ namespace Microsoft.Maui.Resizetizer.Tests
 {
 	/// <summary>
 	/// Verifies the MSBuild target structure in Microsoft.Maui.Resizetizer.After.targets
-	/// to prevent regression of the "fonts missing on first build" bug (#23268).
+	/// to prevent regression of the "fonts missing on first build" bug (#23268) and
+	/// the "splash screens randomly missing" bug (#33092).
 	///
-	/// Root cause: ProcessMauiFonts used Inputs/Outputs for incremental builds. When
-	/// the target was skipped (stamp file up-to-date), platform item groups
-	/// (AndroidAsset, BundleResource, etc.) were never populated — causing fonts
-	/// to silently disappear from build output.
+	/// Root cause: ProcessMauiFonts and ProcessMauiSplashScreens used Inputs/Outputs
+	/// for incremental builds. When the target was skipped (stamp file up-to-date),
+	/// platform item groups (AndroidAsset, BundleResource, etc.) were never populated
+	/// — causing fonts/splash screens to silently disappear from build output.
 	/// </summary>
-	public class ProcessMauiFontsTargetTests
+	public class ResizetizeTargetStructureTests
 	{
 		static readonly XNamespace MSBuildNs = "http://schemas.microsoft.com/developer/msbuild/2003";
 
 		readonly ITestOutputHelper _output;
 		readonly XDocument _targetsDoc;
-		readonly string _targetsFilePath;
 
-		public ProcessMauiFontsTargetTests(ITestOutputHelper output)
+		public ResizetizeTargetStructureTests(ITestOutputHelper output)
 		{
 			_output = output;
 
 			// Navigate from test output dir (artifacts/bin/.../net10.0/) to repo root
 			var repoRoot = Path.GetFullPath(Path.Combine(
 				Directory.GetCurrentDirectory(), "..", "..", "..", "..", ".."));
-			_targetsFilePath = Path.Combine(repoRoot,
+			var targetsFilePath = Path.Combine(repoRoot,
 				"src", "SingleProject", "Resizetizer", "src", "nuget",
 				"buildTransitive", "Microsoft.Maui.Resizetizer.After.targets");
 
-			Assert.True(File.Exists(_targetsFilePath),
-				$"Targets file not found at: {_targetsFilePath}");
-			_output.WriteLine($"Loading targets from: {_targetsFilePath}");
+			Assert.True(File.Exists(targetsFilePath),
+				$"Targets file not found at: {targetsFilePath}");
+			_output.WriteLine($"Loading targets from: {targetsFilePath}");
 
-			_targetsDoc = XDocument.Load(_targetsFilePath);
+			_targetsDoc = XDocument.Load(targetsFilePath);
 		}
 
 		XElement FindTarget(string name) =>
@@ -47,53 +47,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				.Elements(MSBuildNs + "Target")
 				.FirstOrDefault(t => t.Attribute("Name")?.Value == name);
 
-		/// <summary>
-		/// ProcessMauiFonts must NOT have an Inputs attribute. When Inputs/Outputs are
-		/// present, MSBuild skips the target body on incremental builds — meaning the
-		/// ItemGroups that register fonts with each platform (AndroidAsset,
-		/// BundleResource, ContentWithTargetPath) are never evaluated. The fonts then
-		/// silently disappear from the build output.
-		/// </summary>
-		[Fact]
-		public void ProcessMauiFonts_ShouldNotHaveInputsAttribute()
-		{
-			var target = FindTarget("ProcessMauiFonts");
-			Assert.NotNull(target);
-
-			var inputs = target.Attribute("Inputs");
-			Assert.True(inputs is null,
-				"ProcessMauiFonts must not use Inputs for incremental builds. " +
-				"When the target is skipped, platform item groups (AndroidAsset, " +
-				"BundleResource, etc.) are never populated, causing fonts to be " +
-				"missing from the build. See https://github.com/dotnet/maui/issues/23268");
-		}
-
-		/// <summary>
-		/// ProcessMauiFonts must NOT have an Outputs attribute (counterpart to Inputs).
-		/// </summary>
-		[Fact]
-		public void ProcessMauiFonts_ShouldNotHaveOutputsAttribute()
-		{
-			var target = FindTarget("ProcessMauiFonts");
-			Assert.NotNull(target);
-
-			var outputs = target.Attribute("Outputs");
-			Assert.True(outputs is null,
-				"ProcessMauiFonts must not use Outputs for incremental builds. " +
-				"See https://github.com/dotnet/maui/issues/23268");
-		}
-
-		/// <summary>
-		/// On Android, ProcessMauiFonts adds fonts to @(AndroidAsset). The Android SDK's
-		/// _ComputeAndroidAssetsPaths target consumes @(AndroidAsset). Without explicit
-		/// ordering, MSBuild may run _ComputeAndroidAssetsPaths before ProcessMauiFonts,
-		/// causing fonts to be missing from the APK even when the target body executes.
-		/// </summary>
-		[Fact]
-		public void Android_ProcessMauiFontsBeforeTargets_ShouldIncludeComputeAndroidAssetsPaths()
-		{
-			// Find the Android-only PropertyGroup (not the combined IsCompatibleApp one)
-			var androidPG = _targetsDoc.Root!
+		XElement FindAndroidPropertyGroup() =>
+			_targetsDoc.Root!
 				.Elements(MSBuildNs + "PropertyGroup")
 				.FirstOrDefault(pg =>
 				{
@@ -103,6 +58,34 @@ namespace Microsoft.Maui.Resizetizer.Tests
 						&& !cond.Contains("_ResizetizerIsiOSApp", StringComparison.Ordinal);
 				});
 
+		// ──────────────────────────────────────────────────────────
+		//  ProcessMauiFonts — #23268
+		// ──────────────────────────────────────────────────────────
+
+		[Fact]
+		public void ProcessMauiFonts_ShouldNotHaveInputsAttribute()
+		{
+			var target = FindTarget("ProcessMauiFonts");
+			Assert.NotNull(target);
+			Assert.True(target.Attribute("Inputs") is null,
+				"ProcessMauiFonts must not use Inputs for incremental builds. " +
+				"See https://github.com/dotnet/maui/issues/23268");
+		}
+
+		[Fact]
+		public void ProcessMauiFonts_ShouldNotHaveOutputsAttribute()
+		{
+			var target = FindTarget("ProcessMauiFonts");
+			Assert.NotNull(target);
+			Assert.True(target.Attribute("Outputs") is null,
+				"ProcessMauiFonts must not use Outputs for incremental builds. " +
+				"See https://github.com/dotnet/maui/issues/23268");
+		}
+
+		[Fact]
+		public void Android_ProcessMauiFontsBeforeTargets_ShouldIncludeComputeAndroidAssetsPaths()
+		{
+			var androidPG = FindAndroidPropertyGroup();
 			Assert.NotNull(androidPG);
 
 			var beforeTargets = androidPG.Element(MSBuildNs + "ProcessMauiFontsBeforeTargets");
@@ -110,26 +93,69 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			Assert.Contains("_ComputeAndroidAssetsPaths", beforeTargets.Value, StringComparison.Ordinal);
 		}
 
-		/// <summary>
-		/// Verifies consistency: ProcessMauiFonts should follow the same pattern as
-		/// ProcessMauiAssets (which has always worked). ProcessMauiAssets does NOT use
-		/// Inputs/Outputs — confirming this is the correct pattern for targets that
-		/// populate platform item groups.
-		/// </summary>
 		[Fact]
 		public void ProcessMauiFonts_MatchesWorkingProcessMauiAssetsPattern()
 		{
-			// ProcessMauiAssets works correctly and does NOT use Inputs/Outputs
 			var assetsTarget = FindTarget("ProcessMauiAssets");
 			Assert.NotNull(assetsTarget);
 			Assert.Null(assetsTarget.Attribute("Inputs"));
 			Assert.Null(assetsTarget.Attribute("Outputs"));
 
-			// ProcessMauiFonts should follow the same pattern
 			var fontsTarget = FindTarget("ProcessMauiFonts");
 			Assert.NotNull(fontsTarget);
 			Assert.Null(fontsTarget.Attribute("Inputs"));
 			Assert.Null(fontsTarget.Attribute("Outputs"));
+		}
+
+		// ──────────────────────────────────────────────────────────
+		//  ProcessMauiSplashScreens — #33092
+		// ──────────────────────────────────────────────────────────
+
+		/// <summary>
+		/// ProcessMauiSplashScreens must NOT have Inputs. Same root cause as fonts:
+		/// when skipped, platform item groups (LibraryResourceDirectories,
+		/// BundleResource, ContentWithTargetPath) may not be populated, causing
+		/// splash screens to randomly disappear from builds.
+		/// The custom tasks (GenerateSplashAndroidResources, etc.) have built-in
+		/// file-level incrementality via Resizer.IsUpToDate(), so removing
+		/// Inputs/Outputs does not cause expensive re-rendering.
+		/// </summary>
+		[Fact]
+		public void ProcessMauiSplashScreens_ShouldNotHaveInputsAttribute()
+		{
+			var target = FindTarget("ProcessMauiSplashScreens");
+			Assert.NotNull(target);
+			Assert.True(target.Attribute("Inputs") is null,
+				"ProcessMauiSplashScreens must not use Inputs for incremental builds. " +
+				"See https://github.com/dotnet/maui/issues/33092");
+		}
+
+		[Fact]
+		public void ProcessMauiSplashScreens_ShouldNotHaveOutputsAttribute()
+		{
+			var target = FindTarget("ProcessMauiSplashScreens");
+			Assert.NotNull(target);
+			Assert.True(target.Attribute("Outputs") is null,
+				"ProcessMauiSplashScreens must not use Outputs for incremental builds. " +
+				"See https://github.com/dotnet/maui/issues/33092");
+		}
+
+		/// <summary>
+		/// All three content-producing targets should follow the same pattern
+		/// as ProcessMauiAssets (no Inputs/Outputs).
+		/// </summary>
+		[Fact]
+		public void AllContentTargets_FollowProcessMauiAssetsPattern()
+		{
+			foreach (var targetName in new[] { "ProcessMauiAssets", "ProcessMauiFonts", "ProcessMauiSplashScreens" })
+			{
+				var target = FindTarget(targetName);
+				Assert.NotNull(target);
+				Assert.True(target.Attribute("Inputs") is null,
+					$"{targetName} must not use Inputs. See #23268 / #33092");
+				Assert.True(target.Attribute("Outputs") is null,
+					$"{targetName} must not use Outputs. See #23268 / #33092");
+			}
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/test/UnitTests/ProcessMauiFontsTargetTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ProcessMauiFontsTargetTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	/// <summary>
+	/// Verifies the MSBuild target structure in Microsoft.Maui.Resizetizer.After.targets
+	/// to prevent regression of the "fonts missing on first build" bug (#23268).
+	///
+	/// Root cause: ProcessMauiFonts used Inputs/Outputs for incremental builds. When
+	/// the target was skipped (stamp file up-to-date), platform item groups
+	/// (AndroidAsset, BundleResource, etc.) were never populated — causing fonts
+	/// to silently disappear from build output.
+	/// </summary>
+	public class ProcessMauiFontsTargetTests
+	{
+		static readonly XNamespace MSBuildNs = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+		readonly ITestOutputHelper _output;
+		readonly XDocument _targetsDoc;
+		readonly string _targetsFilePath;
+
+		public ProcessMauiFontsTargetTests(ITestOutputHelper output)
+		{
+			_output = output;
+
+			// Navigate from test output dir (artifacts/bin/.../net10.0/) to repo root
+			var repoRoot = Path.GetFullPath(Path.Combine(
+				Directory.GetCurrentDirectory(), "..", "..", "..", "..", ".."));
+			_targetsFilePath = Path.Combine(repoRoot,
+				"src", "SingleProject", "Resizetizer", "src", "nuget",
+				"buildTransitive", "Microsoft.Maui.Resizetizer.After.targets");
+
+			Assert.True(File.Exists(_targetsFilePath),
+				$"Targets file not found at: {_targetsFilePath}");
+			_output.WriteLine($"Loading targets from: {_targetsFilePath}");
+
+			_targetsDoc = XDocument.Load(_targetsFilePath);
+		}
+
+		XElement FindTarget(string name) =>
+			_targetsDoc.Root!
+				.Elements(MSBuildNs + "Target")
+				.FirstOrDefault(t => t.Attribute("Name")?.Value == name);
+
+		/// <summary>
+		/// ProcessMauiFonts must NOT have an Inputs attribute. When Inputs/Outputs are
+		/// present, MSBuild skips the target body on incremental builds — meaning the
+		/// ItemGroups that register fonts with each platform (AndroidAsset,
+		/// BundleResource, ContentWithTargetPath) are never evaluated. The fonts then
+		/// silently disappear from the build output.
+		/// </summary>
+		[Fact]
+		public void ProcessMauiFonts_ShouldNotHaveInputsAttribute()
+		{
+			var target = FindTarget("ProcessMauiFonts");
+			Assert.NotNull(target);
+
+			var inputs = target.Attribute("Inputs");
+			Assert.True(inputs is null,
+				"ProcessMauiFonts must not use Inputs for incremental builds. " +
+				"When the target is skipped, platform item groups (AndroidAsset, " +
+				"BundleResource, etc.) are never populated, causing fonts to be " +
+				"missing from the build. See https://github.com/dotnet/maui/issues/23268");
+		}
+
+		/// <summary>
+		/// ProcessMauiFonts must NOT have an Outputs attribute (counterpart to Inputs).
+		/// </summary>
+		[Fact]
+		public void ProcessMauiFonts_ShouldNotHaveOutputsAttribute()
+		{
+			var target = FindTarget("ProcessMauiFonts");
+			Assert.NotNull(target);
+
+			var outputs = target.Attribute("Outputs");
+			Assert.True(outputs is null,
+				"ProcessMauiFonts must not use Outputs for incremental builds. " +
+				"See https://github.com/dotnet/maui/issues/23268");
+		}
+
+		/// <summary>
+		/// On Android, ProcessMauiFonts adds fonts to @(AndroidAsset). The Android SDK's
+		/// _ComputeAndroidAssetsPaths target consumes @(AndroidAsset). Without explicit
+		/// ordering, MSBuild may run _ComputeAndroidAssetsPaths before ProcessMauiFonts,
+		/// causing fonts to be missing from the APK even when the target body executes.
+		/// </summary>
+		[Fact]
+		public void Android_ProcessMauiFontsBeforeTargets_ShouldIncludeComputeAndroidAssetsPaths()
+		{
+			// Find the Android-only PropertyGroup (not the combined IsCompatibleApp one)
+			var androidPG = _targetsDoc.Root!
+				.Elements(MSBuildNs + "PropertyGroup")
+				.FirstOrDefault(pg =>
+				{
+					var cond = pg.Attribute("Condition")?.Value;
+					return cond != null
+						&& cond.Contains("_ResizetizerIsAndroidApp", StringComparison.Ordinal)
+						&& !cond.Contains("_ResizetizerIsiOSApp", StringComparison.Ordinal);
+				});
+
+			Assert.NotNull(androidPG);
+
+			var beforeTargets = androidPG.Element(MSBuildNs + "ProcessMauiFontsBeforeTargets");
+			Assert.NotNull(beforeTargets);
+			Assert.Contains("_ComputeAndroidAssetsPaths", beforeTargets.Value, StringComparison.Ordinal);
+		}
+
+		/// <summary>
+		/// Verifies consistency: ProcessMauiFonts should follow the same pattern as
+		/// ProcessMauiAssets (which has always worked). ProcessMauiAssets does NOT use
+		/// Inputs/Outputs — confirming this is the correct pattern for targets that
+		/// populate platform item groups.
+		/// </summary>
+		[Fact]
+		public void ProcessMauiFonts_MatchesWorkingProcessMauiAssetsPattern()
+		{
+			// ProcessMauiAssets works correctly and does NOT use Inputs/Outputs
+			var assetsTarget = FindTarget("ProcessMauiAssets");
+			Assert.NotNull(assetsTarget);
+			Assert.Null(assetsTarget.Attribute("Inputs"));
+			Assert.Null(assetsTarget.Attribute("Outputs"));
+
+			// ProcessMauiFonts should follow the same pattern
+			var fontsTarget = FindTarget("ProcessMauiFonts");
+			Assert.NotNull(fontsTarget);
+			Assert.Null(fontsTarget.Attribute("Inputs"));
+			Assert.Null(fontsTarget.Attribute("Outputs"));
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #23268
Fixes #23659
Fixes #33092

Font assets (`MauiFont`) and splash screens (`MauiSplashScreen`) are intermittently missing from builds — particularly on the **first** build or when switching configurations. These are P/1 bugs affecting many users across multiple .NET versions and platforms (Android, iOS, Windows).

## Root Cause Analysis

Two issues in `ProcessMauiFonts` and `ProcessMauiSplashScreens` targets in `Microsoft.Maui.Resizetizer.After.targets`:

### 1. Missing Android target ordering (fonts only)
`ProcessMauiFonts` had no explicit ordering relative to `_ComputeAndroidAssetsPaths` (the Android SDK target that consumes `@(AndroidAsset)`). MSBuild `AfterTargets`/`BeforeTargets` are **not transitive** — the existing `AfterTargets="ResizetizeCollectItems"` did not guarantee execution before `_ComputeAndroidAssetsPaths`.

### 2. Incremental build skipping prevents item group population (fonts + splash)
Both `ProcessMauiFonts` and `ProcessMauiSplashScreens` used `Inputs`/`Outputs` with stamp files for incremental builds. When MSBuild skips the target body, the ItemGroups that register assets with each platform (AndroidAsset, BundleResource, ContentWithTargetPath, etc.) may not be populated — causing fonts/splash screens to silently disappear from the build output.

Compare with the working target in the same file:
| Target | Incremental | Works? |
|--------|------------|--------|
| `ProcessMauiAssets` | **No** (always runs) | ✅ |
| `ProcessMauiFonts` | Yes (stamp) | ❌ |
| `ProcessMauiSplashScreens` | Yes (stamp) | ❌ |

## Fix

### Fonts
1. **Add explicit ordering** — `_ComputeAndroidAssetsPaths` added to `ProcessMauiFontsBeforeTargets` on Android
2. **Remove `Inputs`/`Outputs`** from `ProcessMauiFonts` — matches the `ProcessMauiAssets` pattern
3. **Remove unused stamp file** — `_MauiFontStampFile` property, `Touch` task, and `FileWrites` entry removed

### Splash Screens
1. **Remove `Inputs`/`Outputs`** from `ProcessMauiSplashScreens` — same fix pattern as fonts
2. **Remove unused stamp file** — `_MauiSplashStampFile` property, `Touch` task, and `FileWrites` entry removed
3. **Safe to remove** because the custom tasks (`GenerateSplashAndroidResources`, `GenerateSplashAssets`, `GenerateSplashStoryboard`) have built-in file-level incrementality via `Resizer.IsUpToDate()`

## Changes

- `src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets`
  - Removed `_MauiFontStampFile` and `_MauiSplashStampFile` property definitions
  - Added `_ComputeAndroidAssetsPaths` to `ProcessMauiFontsBeforeTargets` (Android)
  - Removed `Inputs`/`Outputs` from both `ProcessMauiFonts` and `ProcessMauiSplashScreens` targets
  - Removed stamp file Touch and FileWrites from both targets

- `src/SingleProject/Resizetizer/test/UnitTests/ProcessMauiFontsTargetTests.cs` (**new**)
  - 7 regression tests verifying both font and splash screen fix structures
  - Tests fail when fixes are reverted, pass when applied

## Testing

- All 575 Resizetizer unit tests pass (7 new + 568 existing, 0 regressions)
- The 20 pre-existing failures in `SkiaSharpAppIconToolsTests` are unrelated
- Regression test cycle verified for both fixes:
  - Fonts: revert → 4/4 fail, restore → 4/4 pass
  - Splash: revert → 3/3 fail, restore → 3/3 pass