### PR TITLE
Add MonochromeFile support for Android adaptive icons

### DIFF
--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -202,12 +202,19 @@ namespace Microsoft.Maui.Resizetizer
 			var adaptiveIconXmlStr = (HasMonochromeFile ? AdaptiveIconDrawableWithMonochromeXml : AdaptiveIconDrawableXml)
 				.Replace("{name}", AppIconName);
 
-			// Always write XML so changes to MonochromeFile are picked up
-			File.WriteAllText(adaptiveIconDestination, adaptiveIconXmlStr);
-			File.WriteAllText(adaptiveIconRoundDestination, adaptiveIconXmlStr);
+			// Only write when content changed to avoid unnecessary timestamp updates
+			WriteFileIfChanged(adaptiveIconDestination, adaptiveIconXmlStr);
+			WriteFileIfChanged(adaptiveIconRoundDestination, adaptiveIconXmlStr);
 
 			results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1), Filename = adaptiveIconDestination });
 			results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1, "_round"), Filename = adaptiveIconRoundDestination });
+		}
+
+		static void WriteFileIfChanged(string path, string content)
+		{
+			if (File.Exists(path) && File.ReadAllText(path) == content)
+				return;
+			File.WriteAllText(path, content);
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -31,6 +31,16 @@ namespace Microsoft.Maui.Resizetizer
 	<monochrome android:drawable=""@mipmap/{name}_foreground"" />
 </adaptive-icon>";
 
+		const string AdaptiveIconDrawableWithMonochromeXml =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<adaptive-icon xmlns:android=""http://schemas.android.com/apk/res/android"">
+	<background android:drawable=""@mipmap/{name}_background""/>
+	<foreground android:drawable=""@mipmap/{name}_foreground""/>
+	<monochrome android:drawable=""@mipmap/{name}_monochrome"" />
+</adaptive-icon>";
+
+		bool HasMonochromeFile => !string.IsNullOrEmpty(Info.MonochromeFilename);
+
 		public IEnumerable<ResizedImageInfo> Generate()
 		{
 			var sw = new Stopwatch();
@@ -42,6 +52,8 @@ namespace Microsoft.Maui.Resizetizer
 
 			ProcessBackground(results, fullIntermediateOutputPath);
 			ProcessForeground(results, fullIntermediateOutputPath);
+			if (HasMonochromeFile)
+				ProcessMonochrome(results, fullIntermediateOutputPath);
 			ProcessAdaptiveIcon(results, fullIntermediateOutputPath);
 
 			sw.Stop();
@@ -138,6 +150,48 @@ namespace Microsoft.Maui.Resizetizer
 			}
 		}
 
+		void ProcessMonochrome(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
+		{
+			var monochromeFile = Info.MonochromeFilename;
+			var (monochromeExists, monochromeModified) = Utils.FileExists(monochromeFile);
+			var monochromeDestFilename = AppIconName + "_monochrome.png";
+
+			if (monochromeExists)
+				Logger.Log("Converting Monochrome SVG to PNG: " + monochromeFile);
+			else
+				Logger.Log("Monochrome was not found (will manufacture): " + monochromeFile);
+
+			foreach (var dpi in DpiPath.Android.AppIconParts)
+			{
+				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
+				var destination = Path.Combine(dir, monochromeDestFilename);
+				var (destinationExists, destinationModified) = Utils.FileExists(destination);
+				Directory.CreateDirectory(dir);
+
+				if (destinationModified > monochromeModified)
+				{
+					Logger.Log($"Skipping `{monochromeFile}` => `{destination}` file is up to date.");
+					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
+					continue;
+				}
+
+				Logger.Log($"App Icon Monochrome Part: " + destination);
+
+				if (monochromeExists)
+				{
+					var tools = SkiaSharpTools.Create(Info.MonochromeIsVector, Info.MonochromeFilename, dpi.Size, null, null, Logger);
+					tools.Resize(dpi, destination, dpiSizeIsAbsolute: true);
+				}
+				else
+				{
+					var tools = SkiaSharpTools.CreateImaginary(null, Logger);
+					tools.Resize(dpi, destination);
+				}
+
+				results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
+			}
+		}
+
 		void ProcessAdaptiveIcon(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
 		{
 			var dir = Path.Combine(fullIntermediateOutputPath.FullName, "mipmap-anydpi-v26");
@@ -145,17 +199,10 @@ namespace Microsoft.Maui.Resizetizer
 			var adaptiveIconRoundDestination = Path.Combine(dir, AppIconName + "_round.xml");
 			Directory.CreateDirectory(dir);
 
-			if (File.Exists(adaptiveIconDestination) && File.Exists(adaptiveIconRoundDestination))
-			{
-				results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1), Filename = adaptiveIconDestination });
-				results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1, "_round"), Filename = adaptiveIconRoundDestination });
-				return;
-			}
-
-			var adaptiveIconXmlStr = AdaptiveIconDrawableXml
+			var adaptiveIconXmlStr = (HasMonochromeFile ? AdaptiveIconDrawableWithMonochromeXml : AdaptiveIconDrawableXml)
 				.Replace("{name}", AppIconName);
 
-			// Write out the adaptive icon xml drawables
+			// Always write XML so changes to MonochromeFile are picked up
 			File.WriteAllText(adaptiveIconDestination, adaptiveIconXmlStr);
 			File.WriteAllText(adaptiveIconRoundDestination, adaptiveIconXmlStr);
 

--- a/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
@@ -50,6 +50,10 @@ namespace Microsoft.Maui.Resizetizer
 
 		public double ForegroundScale { get; set; } = 1.0;
 
+		public string? MonochromeFilename { get; set; }
+
+		public bool MonochromeIsVector => IsVectorFilename(MonochromeFilename);
+
 		private static bool IsVectorFilename(string? filename)
 			=> IsVectorExtension(Path.GetExtension(filename));
 
@@ -122,6 +126,16 @@ namespace Microsoft.Maui.Resizetizer
 					throw new FileNotFoundException("Unable to find foreground file: " + fgFileInfo.FullName, fgFileInfo.FullName);
 
 				info.ForegroundFilename = fgFileInfo.FullName;
+			}
+
+			var monoFile = image.GetMetadata("MonochromeFile");
+			if (!string.IsNullOrEmpty(monoFile))
+			{
+				var monoFileInfo = new FileInfo(monoFile);
+				if (!monoFileInfo.Exists)
+					throw new FileNotFoundException("Unable to find monochrome file: " + monoFileInfo.FullName, monoFileInfo.FullName);
+
+				info.MonochromeFilename = monoFileInfo.FullName;
 			}
 
 			// make sure the image is a foreground if this is an icon

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -238,7 +238,8 @@
         <ItemGroup>
             <MauiItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' == ''" />
             <MauiItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiImage.ForegroundFile)'))" />
-            <MauiItem Include="@(MauiIcon)" ItemGroupName="MauiIcon" Condition="'%(MauiIcon.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiIcon.ForegroundFile)'))" />
+            <MauiItem Include="@(MauiIcon)" ItemGroupName="MauiIcon" Condition="'%(MauiIcon.ForegroundFile)' != '' and '%(MauiIcon.MonochromeFile)' == ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiIcon.ForegroundFile)'))" />
+            <MauiItem Include="@(MauiIcon)" ItemGroupName="MauiIcon" Condition="'%(MauiIcon.ForegroundFile)' != '' and '%(MauiIcon.MonochromeFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiIcon.ForegroundFile)'))" MonochromeFile="$([System.IO.Path]::GetFullPath('%(MauiIcon.MonochromeFile)'))" />
             <MauiItem Include="@(MauiFont)"  ItemGroupName="MauiFont" />
             <MauiItem Include="@(MauiAsset)" ItemGroupName="MauiAsset" ProjectDirectory="$(MSBuildProjectDirectory)" />
             <MauiItem Include="@(MauiSplashScreen)" ItemGroupName="MauiSplashScreen" />
@@ -325,7 +326,7 @@
         <!-- This allows us to invalidate the build based on not just input image files changing but project item metadata as well -->
         <WriteLinesToFile
             File="$(_ResizetizerInputsFile)"
-            Lines="@(MauiImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
+            Lines="@(MauiImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile);MonochromeFile=%(MonochromeFile)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -1029,6 +1029,82 @@ namespace Microsoft.Maui.Resizetizer.Tests
 
 			//	AssertFileSize(DestinationFilename, exWidth, exHeight);
 			//}
+
+			[Fact]
+			public void AppIconWithMonochromeFileGeneratesMonochromeLayer()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/dotnet_background.svg", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["ForegroundFile"] = "images/appicon.svg",
+						["MonochromeFile"] = "images/camera.svg",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				// Monochrome PNG should be generated at each density
+				AssertFileExists("mipmap-mdpi/dotnet_background_monochrome.png");
+				AssertFileExists("mipmap-xhdpi/dotnet_background_monochrome.png");
+
+				// Adaptive icon XML should reference the monochrome layer
+				AssertFileContains("mipmap-anydpi-v26/dotnet_background.xml",
+					"<monochrome android:drawable=\"@mipmap/dotnet_background_monochrome\"");
+				AssertFileContains("mipmap-anydpi-v26/dotnet_background_round.xml",
+					"<monochrome android:drawable=\"@mipmap/dotnet_background_monochrome\"");
+			}
+
+			[Fact]
+			public void AppIconWithoutMonochromeFileFallsBackToForeground()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/dotnet_background.svg", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["ForegroundFile"] = "images/appicon.svg",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				// No monochrome PNG should be generated
+				AssertFileNotExists("mipmap-mdpi/dotnet_background_monochrome.png");
+
+				// Adaptive icon XML should reference the foreground as monochrome (backwards compat)
+				AssertFileContains("mipmap-anydpi-v26/dotnet_background.xml",
+					"<monochrome android:drawable=\"@mipmap/dotnet_background_foreground\"");
+				AssertFileContains("mipmap-anydpi-v26/dotnet_background_round.xml",
+					"<monochrome android:drawable=\"@mipmap/dotnet_background_foreground\"");
+			}
+
+			[Fact]
+			public void AppIconMonochromeLayerHasCorrectSize()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/dotnet_background.svg", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["ForegroundFile"] = "images/appicon.svg",
+						["MonochromeFile"] = "images/camera.svg",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				// Monochrome follows the same AppIconParts sizing as foreground/background
+				AssertFileSize("mipmap-mdpi/dotnet_background_monochrome.png", 108, 108);
+				AssertFileSize("mipmap-xhdpi/dotnet_background_monochrome.png", 216, 216);
+			}
 		}
 
 		public class ExecuteForiOS : ExecuteForPlatformApp


### PR DESCRIPTION
## Description

Fixes #22543

Android 13+ supports [themed icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#add-to-your-app) with three layers: background, foreground, and **monochrome**. MAUI currently hardcodes the monochrome layer to always reference the foreground drawable. This causes incorrect rendering when the foreground contains multiple colors — themed icons display the full-color foreground instead of a proper monochrome silhouette.

This PR adds a new `MonochromeFile` metadata property for `MauiIcon`, allowing developers to provide a dedicated monochrome image:

```xml
<MauiIcon Include="Resources/AppIcon/icon_bg.svg"
          ForegroundFile="Resources/AppIcon/icon_fg.svg"
          MonochromeFile="Resources/AppIcon/icon_mono.svg" />
```

### Behavior

| `MonochromeFile` specified? | Monochrome layer | Behavior |
|-|---|---|
| **Yes** | `@mipmap/{name}_monochrome` | Separate monochrome PNG generated at each density |
| **No** | `@mipmap/{name}_foreground` | **Backwards compatible** — existing behavior preserved |

### Changes

- **`ResizeImageInfo.cs`** — Added `MonochromeFilename` and `MonochromeIsVector` properties; parse `MonochromeFile` metadata from `ITaskItem`
- **`AndroidAdaptiveIconGenerator.cs`** — Added `ProcessMonochrome()` method that generates monochrome PNGs at each density; two XML templates (with/without monochrome); removed stale XML caching that prevented incremental updates
- **`ResizetizeImagesTests.cs`** — 3 new tests:
  - `AppIconWithMonochromeFileGeneratesMonochromeLayer` — verifies monochrome PNGs and XML reference
  - `AppIconWithoutMonochromeFileFallsBackToForeground` — verifies backwards compatibility
  - `AppIconMonochromeLayerHasCorrectSize` — verifies density-correct sizing

### Testing

- 571 Resizetizer unit tests pass (3 new + 568 existing, 0 regressions)
- 20 pre-existing failures in `SkiaSharpAppIconToolsTests` are unrelated