### PR TITLE
 [Android, Windows] Fix CarouselView PreviousPosition/PreviousItem incorrect during animated ScrollTo()

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -185,6 +185,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			// And at the same time the user is requesting we go to a particular item
 			if (position == -1)
 			{
+				_gotoPosition = -1;
 				if (Carousel.Loop)
 					_carouselViewLoopManager.AddPendingScrollTo(args);
 
@@ -193,7 +194,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (args.IsAnimated)
 			{
-				_gotoPosition = args.Index;
+				if (_gotoPosition == -1)
+					_gotoPosition = args.Index;
 				ScrollHelper.AnimateScrollToPosition(position, args.ScrollToPosition);
 			}
 			else

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -193,6 +193,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (args.IsAnimated)
 			{
+				_gotoPosition = position;
 				ScrollHelper.AnimateScrollToPosition(position, args.ScrollToPosition);
 			}
 			else
@@ -506,8 +507,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				_gotoPosition = currentItemPosition;
 				ItemsView.ScrollTo(currentItemPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
 			}
-
-			_gotoPosition = -1;
 		}
 
 		void IMauiCarouselRecyclerView.UpdateFromPosition()

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (args.IsAnimated)
 			{
-				_gotoPosition = position;
+				_gotoPosition = args.Index;
 				ScrollHelper.AnimateScrollToPosition(position, args.ScrollToPosition);
 			}
 			else

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -25,6 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		WScrollBarVisibility? _verticalScrollBarVisibilityWithoutLoop;
 		Size _currentSize;
 		bool _isCarouselViewReady;
+		int _gotoPosition = -1;
 		NotifyCollectionChangedEventHandler _collectionChanged;
 		readonly WeakNotifyCollectionChangedProxy _proxy = new();
 
@@ -188,6 +190,24 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public static void MapCurrentItem(CarouselViewHandler handler, CarouselView carouselView)
 		{
 			handler.UpdateCurrentItem();
+		}
+
+		protected override async Task ScrollTo(ScrollToRequestEventArgs args)
+		{
+			if (args.IsAnimated && args.Mode == ScrollToMode.Position)
+			{
+				_gotoPosition = args.Index;
+
+				// Commit Position immediately so PositionChanged fires with the correct
+				// PreviousPosition/PreviousItem before the animation starts. The visual scroll follows
+				// asynchronously. This mirrors the Android fix and ensures the label updates
+				// without waiting for the WinUI animation to settle (which can stall in test environments).
+				SetCarouselViewPosition(_gotoPosition);
+			}
+
+			await base.ScrollTo(args);
+
+			_gotoPosition = -1;
 		}
 
 		public static void MapPosition(CarouselViewHandler handler, CarouselView carouselView)
@@ -385,7 +405,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var currentItemPosition = GetItemPositionInCarousel(ItemsView.CurrentItem);
 
 			if (currentItemPosition < 0 || currentItemPosition >= ItemCount)
+			{
 				return;
+			}
+
+			if (_gotoPosition != -1)
+			{
+				return;
+			}
 
 			ItemsView.ScrollTo(currentItemPosition, position: ScrollToPosition.Center, animate: ItemsView.AnimateCurrentItemChanges);
 		}
@@ -491,6 +518,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void CarouselScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
+
+			// Ignore scroll events that fire before the initial position is established.
+			// On Windows, WinUI can fire ViewChanged during initial layout with an incorrect
+			// center index, which would incorrectly override the intended initial position.
+			if (!InitialPositionSet)
+			{
+				return;
+			}
+
 			var position = e.CenterItemIndex;
 
 			if (position == -1)
@@ -499,6 +535,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			if (position == Element.Position)
+			{
+				return;
+			}
+
+			// Suppress all events during a programmatic animated scroll.
+			// Position is committed immediately in ScrollTo before the animation starts.
+			if (_gotoPosition != -1)
 			{
 				return;
 			}

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -205,9 +205,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				SetCarouselViewPosition(_gotoPosition);
 			}
 
-			await base.ScrollTo(args);
-
-			_gotoPosition = -1;
+			try
+			{
+				await base.ScrollTo(args);
+			}
+			finally
+			{
+				// Only reset if this call still owns _gotoPosition — a concurrent animated
+				// ScrollTo may have already replaced it with a different target.
+				if (_gotoPosition == args.Index)
+					_gotoPosition = -1;
+			}
 		}
 
 		public static void MapPosition(CarouselViewHandler handler, CarouselView carouselView)
@@ -518,7 +526,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void CarouselScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
-
 			// Ignore scroll events that fire before the initial position is established.
 			// On Windows, WinUI can fire ViewChanged during initial layout with an incorrect
 			// center index, which would incorrectly override the intended initial position.

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Windows.cs
@@ -198,10 +198,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				_gotoPosition = args.Index;
 
-				// Commit Position immediately so PositionChanged fires with the correct
-				// PreviousPosition/PreviousItem before the animation starts. The visual scroll follows
-				// asynchronously. This mirrors the Android fix and ensures the label updates
-				// without waiting for the WinUI animation to settle (which can stall in test environments).
+				// Commit position before animation so PreviousPosition/PreviousItem are correct immediately.
 				SetCarouselViewPosition(_gotoPosition);
 			}
 
@@ -211,8 +208,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 			finally
 			{
-				// Only reset if this call still owns _gotoPosition — a concurrent animated
-				// ScrollTo may have already replaced it with a different target.
+				// Conditional reset guards against a concurrent ScrollTo replacing the target.
 				if (_gotoPosition == args.Index)
 					_gotoPosition = -1;
 			}
@@ -526,9 +522,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void CarouselScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
-			// Ignore scroll events that fire before the initial position is established.
-			// On Windows, WinUI can fire ViewChanged during initial layout with an incorrect
-			// center index, which would incorrectly override the intended initial position.
+			// Ignore ViewChanged events fired before the initial position is established.
 			if (!InitialPositionSet)
 			{
 				return;
@@ -546,8 +540,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			// Suppress all events during a programmatic animated scroll.
-			// Position is committed immediately in ScrollTo before the animation starts.
+			// Suppress intermediate scroll events during a programmatic animated scroll.
 			if (_gotoPosition != -1)
 			{
 				return;

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+~override Microsoft.Maui.Controls.Handlers.Items.CarouselViewHandler.ScrollTo(Microsoft.Maui.Controls.ScrollToRequestEventArgs args) -> System.Threading.Tasks.Task
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29544.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29544.cs
@@ -1,0 +1,152 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 29544,
+	"PreviousItem and PreviousPosition not updating correctly on ScrollTo or Position set",
+	PlatformAffected.Android)]
+public class Issue29544 : ContentPage
+{
+	readonly CarouselView _carouselView;
+	readonly ObservableCollection<string> _items;
+	readonly Label _previousItemLabel;
+	readonly Label _previousPositionLabel;
+	readonly Label _currentItemLabel;
+	readonly Label _currentPositionLabel;
+
+	public Issue29544()
+	{
+		_items = new ObservableCollection<string>
+		{
+			"Item 1",
+			"Item 2",
+			"Item 3",
+			"Item 4",
+			"Item 5"
+		};
+
+		_currentItemLabel = new Label
+		{
+			AutomationId = "CurrentItemLabel",
+			Text = "Current Item: Item 1"
+		};
+
+		_previousItemLabel = new Label
+		{
+			AutomationId = "PreviousItemLabel",
+			Text = "Previous Item: none"
+		};
+
+		_currentPositionLabel = new Label
+		{
+			AutomationId = "CurrentPositionLabel",
+			Text = "Current Position: 0"
+		};
+
+		_previousPositionLabel = new Label
+		{
+			AutomationId = "PreviousPositionLabel",
+			Text = "Previous Position: none"
+		};
+
+		_carouselView = new CarouselView
+		{
+			AutomationId = "CarouselView",
+			Loop = false,
+			ItemsSource = _items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					FontSize = 24,
+					BackgroundColor = Colors.LightGray,
+					HorizontalOptions = LayoutOptions.Fill,
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalTextAlignment = TextAlignment.Center
+				};
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			})
+		};
+
+		_carouselView.CurrentItemChanged += OnCurrentItemChanged;
+		_carouselView.PositionChanged += OnPositionChanged;
+
+		var scrollTo3Button = new Button
+		{
+			AutomationId = "ScrollTo3Button",
+			Text = "Scroll To 3"
+		};
+		scrollTo3Button.Clicked += (s, e) => _carouselView.ScrollTo(3);
+
+		var scrollTo1Button = new Button
+		{
+			AutomationId = "ScrollTo1Button",
+			Text = "Scroll To 1"
+		};
+		scrollTo1Button.Clicked += (s, e) => _carouselView.ScrollTo(1);
+
+		var setPosition3Button = new Button
+		{
+			AutomationId = "SetPosition3Button",
+			Text = "Set Position 3"
+		};
+		setPosition3Button.Clicked += (s, e) => _carouselView.Position = 3;
+
+		var setPosition0Button = new Button
+		{
+			AutomationId = "SetPosition0Button",
+			Text = "Set Position 0"
+		};
+		setPosition0Button.Clicked += (s, e) => _carouselView.Position = 0;
+
+		Content = new Grid
+		{
+			Padding = new Thickness(10),
+			RowDefinitions =
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			},
+			Children =
+			{
+				new VerticalStackLayout
+				{
+					Spacing = 6,
+					Children =
+					{
+						_currentItemLabel,
+						_previousItemLabel,
+						_currentPositionLabel,
+						_previousPositionLabel,
+						new HorizontalStackLayout
+						{
+							Spacing = 8,
+							Children = { scrollTo3Button, scrollTo1Button }
+						},
+						new HorizontalStackLayout
+						{
+							Spacing = 8,
+							Children = { setPosition3Button, setPosition0Button }
+						}
+					}
+				},
+				_carouselView
+			}
+		};
+
+		Grid.SetRow(_carouselView, 1);
+	}
+
+	void OnCurrentItemChanged(object sender, CurrentItemChangedEventArgs e)
+	{
+		_currentItemLabel.Text = $"Current Item: {e.CurrentItem}";
+		_previousItemLabel.Text = $"Previous Item: {e.PreviousItem ?? "none"}";
+	}
+
+	void OnPositionChanged(object sender, PositionChangedEventArgs e)
+	{
+		_currentPositionLabel.Text = $"Current Position: {e.CurrentPosition}";
+		_previousPositionLabel.Text = $"Previous Position: {e.PreviousPosition}";
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue29544.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue29544.cs
@@ -4,7 +4,7 @@ namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 29544,
 	"PreviousItem and PreviousPosition not updating correctly on ScrollTo or Position set",
-	PlatformAffected.Android)]
+	PlatformAffected.Android | PlatformAffected.UWP)]
 public class Issue29544 : ContentPage
 {
 	readonly CarouselView _carouselView;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29544.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue29544.cs
@@ -1,0 +1,84 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue29544 : _IssuesUITest
+{
+	public override string Issue =>
+		"PreviousItem and PreviousPosition not updating correctly on ScrollTo or Position set";
+
+	public Issue29544(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void PreviousPositionUpdatesCorrectlyOnScrollTo()
+	{
+		App.WaitForElement("ScrollTo3Button");
+		App.Tap("ScrollTo3Button");
+
+		App.RetryAssert(() =>
+		{
+			var currentPos = App.FindElement("CurrentPositionLabel").GetText();
+			Assert.That(currentPos, Does.Contain("3"),
+				"CarouselView should reach position 3 after ScrollTo");
+		});
+
+		var previousPositionText = App.FindElement("PreviousPositionLabel").GetText();
+		Assert.That(previousPositionText, Does.Contain("0"),
+			"After scrolling from position 0 to 3, PreviousPosition should be 0");
+
+		var previousItemText = App.FindElement("PreviousItemLabel").GetText();
+		Assert.That(previousItemText, Does.Contain("Item 1"),
+			"After scrolling from position 0 to 3, PreviousItem should be 'Item 1'");
+
+		App.Tap("ScrollTo1Button");
+
+		App.RetryAssert(() =>
+		{
+			var currentPos = App.FindElement("CurrentPositionLabel").GetText();
+			Assert.That(currentPos, Does.Contain("1"),
+				"CarouselView should reach position 1 after second ScrollTo");
+		});
+
+		var secondPreviousPosition = App.FindElement("PreviousPositionLabel").GetText();
+		Assert.That(secondPreviousPosition, Does.Contain("3"),
+			"After scrolling from position 3 to 1, PreviousPosition should be 3");
+
+		var secondPreviousItem = App.FindElement("PreviousItemLabel").GetText();
+		Assert.That(secondPreviousItem, Does.Contain("Item 4"),
+			"After scrolling from position 3 to 1, PreviousItem should be 'Item 4'");
+	}
+
+	[Test]
+	[Category(UITestCategories.CarouselView)]
+	public void PreviousPositionUpdatesCorrectlyOnSetPosition()
+	{
+		App.WaitForElement("SetPosition0Button");
+		App.Tap("SetPosition0Button");
+
+		App.RetryAssert(() =>
+		{
+			var pos = App.FindElement("CurrentPositionLabel").GetText();
+			Assert.That(pos, Does.Contain("0"), "CarouselView should be at position 0");
+		});
+
+		App.Tap("SetPosition3Button");
+
+		App.RetryAssert(() =>
+		{
+			var currentPos = App.FindElement("CurrentPositionLabel").GetText();
+			Assert.That(currentPos, Does.Contain("3"),
+				"CarouselView should reach position 3 after setting Position = 3");
+		});
+
+		var previousPositionText = App.FindElement("PreviousPositionLabel").GetText();
+		Assert.That(previousPositionText, Does.Contain("0"),
+			"After setting Position from 0 to 3, PreviousPosition should be 0");
+
+		var previousItemText = App.FindElement("PreviousItemLabel").GetText();
+		Assert.That(previousItemText, Does.Contain("Item 1"),
+			"After setting Position from 0 to 3, PreviousItem should be 'Item 1'");
+	}
+}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
**Android**: `CarouselView` is backed by `RecyclerView`, which emits intermediate position callbacks during animated programmatic navigation `(e.g., 0 → 1 → 2 → 3)`. These intermediate callbacks were incorrectly updating `PreviousPosition` and `PreviousItem`, causing the final values to reflect the last intermediate step instead of the true starting position.
 
**Windows**: `CarouselView.ScrollTo()` triggers an animated scroll via WinUI `ScrollViewer`, which raises `ViewChanged` events for each animation frame `(e.g., 1 → 2 → 3)`. These intermediate events committed transient `positions` as the current Position, resulting in incorrect `PreviousPosition` and `PreviousItem` values being captured.
 
### Description of Change
**Android**: Properly reused the existing `_gotoPosition` guard for animated programmatic navigation. The logical target index (`args.Index`) is now stored before animated `ScrollTo()` begins. Using the logical index instead of the looped adapter position ensures the guard works correctly in both Loop and non-Loop modes. The premature clearing of `_gotoPosition` in the position update path was also removed. This ensures intermediate callbacks are ignored and `PreviousPosition/PreviousItem` update only when the intended target is reached.
 
**Windows**: Implemented an early-commit approach aligned with the Android fix and adapted to WinUI’s async animation model. The target position is committed before the animation starts, ensuring `PositionChanged` fires with correct previous values while the visual animation proceeds. A guard flag suppresses intermediate `ViewChanged` updates and re-entrant scroll calls during animation and is cleared safely after completion, including error scenarios. An additional safeguard prevents initial layout events from overriding the configured starting position.
 
### Issues Fixed
Fixes #29544    
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

### Screenshots
**Android:**
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/38ae2b0f-4c8f-4452-a72f-73c849c061a6" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/fd31e15f-512b-40e9-8625-d6411d7e4967" /> |

**Windows:**
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <img width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/f287aae9-510a-4b1d-8e53-08cb1a52fb06" /> | <img width="350" alt="withfix" src="https://github.com/user-attachments/assets/aab19d5b-c807-4536-a093-9a31a28a02a0" /> |