### PR TITLE
Enable Controls CoreCLR device tests on iOS and Catalyst

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -196,7 +196,6 @@ stages:
           desc: Controls
           androidApiLevelsExclude: [ 27, 25 ] # Ignore for now API25 since the runs's are not stable
           androidApiLevelsCoreClrExclude: [ 27, 25, 23]
-          # Re-enabled CoreCLR tests for iOS and Catalyst (tracking issue: https://github.com/dotnet/runtime/issues/122219)
           androidConfiguration: 'Debug'
           iOSConfiguration: 'Debug'
           windowsConfiguration: 'Debug'

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -196,9 +196,7 @@ stages:
           desc: Controls
           androidApiLevelsExclude: [ 27, 25 ] # Ignore for now API25 since the runs's are not stable
           androidApiLevelsCoreClrExclude: [ 27, 25, 23]
-          # Tracking issue: https://github.com/dotnet/runtime/issues/122219
-          iosVersionsCoreClrExclude: [ 'simulator-18.4' ] # Disable Controls tests on CoreCLR for iOS as they are failing
-          catalystVersionsCoreClrExclude: [ 'latest' ] # Disable Controls tests on CoreCLR for Catalyst as they are failing
+          # Re-enabled CoreCLR tests for iOS and Catalyst (tracking issue: https://github.com/dotnet/runtime/issues/122219)
           androidConfiguration: 'Debug'
           iOSConfiguration: 'Debug'
           windowsConfiguration: 'Debug'


### PR DESCRIPTION
## Description

Re-enable Controls device tests on CoreCLR for Apple mobile

Fixes https://github.com/dotnet/runtime/issues/122219