### PR TITLE
[iOS 26] Fix NavigationPage blank screen after rapidly pushing and popping pages

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -741,11 +741,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				// Also worth noting this task returns on the main thread
 				if (t.Result)
 					return;
-				// Only dispose if the controller was actually removed from the navigation stack.
-				// On iOS 26, interrupted transitions and subsequent navigations can complete
-				// this task with false even when the controller is still visible.
-				if (controller is not null && !ViewControllers.Contains(controller))
-					controller.Dispose();
+
+				if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				{
+					// Only dispose if the controller was actually removed from the navigation stack.
+					// On iOS 26, interrupted transitions and subsequent navigations can complete
+					// this task with false even when the controller is still visible.
+					if (controller is not null && !ViewControllers.Contains(controller))
+						controller.Dispose();
+				}
+				else
+				{
+					// because we skip the normal pop process we need to dispose ourselves
+					controller?.Dispose();
+				}
 			}, TaskScheduler.FromCurrentSynchronizationContext());
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -741,8 +741,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				// Also worth noting this task returns on the main thread
 				if (t.Result)
 					return;
-				// because we skip the normal pop process we need to dispose ourselves
-				controller?.Dispose();
+				// Only dispose if the controller was actually removed from the navigation stack.
+				// On iOS 26, interrupted transitions and subsequent navigations can complete
+				// this task with false even when the controller is still visible.
+				if (controller is not null && !ViewControllers.Contains(controller))
+					controller.Dispose();
 			}, TaskScheduler.FromCurrentSynchronizationContext());
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

On iOS 26, rapidly pushing and popping pages on a `NavigationPage` causes the previous page to become white/blank. The page content is destroyed during the push animation, so going back reveals an empty page.

My previous PR https://github.com/dotnet/maui/pull/34481 was supposed to fix this issue. However, after building locally my branch with the fix and testing it a lot, I've found out that the issue was still happening. So, even though my change/check made sense, it wasn't the root cause of the problem. After some investigations, here are my findings:

####  Root cause
The `RemoveViewControllers` method (called from the `PopViewController` override when the back button is tapped) captures `TopViewController` and sets up a fire-and-forget task. When the task completes with `false`, the captured controller is disposed via `Disconnect(true)`, which removes **all subviews** from its view.

The problem is that the task result `false` does not exclusively mean "the page was popped." It can also mean "a subsequent navigation started and cleared the pending task via `CompletePendingNavigation(false)`." On iOS 26 with fluid transitions, when a pop is interrupted by a new push, the pop may be cancelled -- leaving the controller still visible in the navigation stack. But the fire-and-forget task is completed with `false` by the new navigation, causing `Dispose()` to be called on a **still-visible** `ParentingViewController`. This strips all content from the page, leaving a blank white view.

### Issues Fixed

Fixes #34480 (NavigationPage path — not covered by the original Shell-only fix in #32456)