### PR TITLE
[iOS, MacCatalyst] CollectionView: Fix grid spacing updates for first row and column

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -484,8 +484,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (_itemDecoration is SpacingItemDecoration spacingDecoration)
 			{
-				// Outer-edge spacing handled by SpacingItemDecoration.GetItemOffsets for all layout types.
-				SetPadding(0, 0, 0, 0);
+				var horizontalPadding = ItemsLayout is GridItemsLayout ? 0 : -spacingDecoration.HorizontalOffset;
+				var verticalPadding = ItemsLayout is GridItemsLayout ? 0 : -spacingDecoration.VerticalOffset;
+				SetPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -484,8 +484,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (_itemDecoration is SpacingItemDecoration spacingDecoration)
 			{
-				var horizontalPadding = ItemsLayout is GridItemsLayout ? 0 : -spacingDecoration.HorizontalOffset;
-				var verticalPadding = ItemsLayout is GridItemsLayout ? 0 : -spacingDecoration.VerticalOffset;
+				// SpacingItemDecoration applies spacing to all items & all 4 sides of the items.
+				// We need to adjust the padding on the RecyclerView so this spacing isn't visible around the outer edge of our control.
+				// Horizontal & vertical spacing should only exist between items. 
+				var horizontalPadding = -spacingDecoration.HorizontalOffset;
+				var verticalPadding = -spacingDecoration.VerticalOffset;
 				SetPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding);
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -484,12 +484,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (_itemDecoration is SpacingItemDecoration spacingDecoration)
 			{
-				// SpacingItemDecoration applies spacing to all items & all 4 sides of the items.
-				// We need to adjust the padding on the RecyclerView so this spacing isn't visible around the outer edge of our control.
-				// Horizontal & vertical spacing should only exist between items. 
-				var horizontalPadding = -spacingDecoration.HorizontalOffset;
-				var verticalPadding = -spacingDecoration.VerticalOffset;
-				SetPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding);
+				// Outer-edge spacing handled by SpacingItemDecoration.GetItemOffsets for all layout types.
+				SetPadding(0, 0, 0, 0);
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -164,11 +164,11 @@ internal static class LayoutFactory2
 			var halfHorizontalSpacing = new NFloat(horizontalItemSpacing / 2d);
 			var halfVerticalSpacing = new NFloat(verticalItemSpacing / 2d);
 
-			if (scrollDirection == UICollectionViewScrollDirection.Vertical && horizontalItemSpacing > 0)
+			if (scrollDirection == UICollectionViewScrollDirection.Vertical && horizontalItemSpacing > 0 && columns > 1)
 			{
 				item.ContentInsets = new NSDirectionalEdgeInsets(0, halfHorizontalSpacing, 0, halfHorizontalSpacing);
 			}
-			else if (scrollDirection == UICollectionViewScrollDirection.Horizontal && verticalItemSpacing > 0)
+			else if (scrollDirection == UICollectionViewScrollDirection.Horizontal && verticalItemSpacing > 0 && columns > 1)
 			{
 				item.ContentInsets = new NSDirectionalEdgeInsets(halfVerticalSpacing, 0, halfVerticalSpacing, 0);
 			}
@@ -192,18 +192,10 @@ internal static class LayoutFactory2
 			if (scrollDirection == UICollectionViewScrollDirection.Vertical)
 			{
 				section.InterGroupSpacing = new NFloat(verticalItemSpacing);
-				if (verticalItemSpacing > 0)
-				{
-					section.ContentInsets = new NSDirectionalEdgeInsets(halfVerticalSpacing, 0, halfVerticalSpacing, 0);
-				}
 			}
 			else
 			{
 				section.InterGroupSpacing = new NFloat(horizontalItemSpacing);
-				if (horizontalItemSpacing > 0)
-				{
-					section.ContentInsets = new NSDirectionalEdgeInsets(0, halfHorizontalSpacing, 0, halfHorizontalSpacing);
-				}
 			}
 
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -183,20 +183,28 @@ internal static class LayoutFactory2
 				? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, columns)
 				: NSCollectionLayoutGroup.CreateVertical(groupSize, item, columns);
 
-			if (scrollDirection == UICollectionViewScrollDirection.Vertical)
-				group.InterItemSpacing = NSCollectionLayoutSpacing.CreateFixed(new NFloat(horizontalItemSpacing));
-			else
-				group.InterItemSpacing = NSCollectionLayoutSpacing.CreateFixed(new NFloat(verticalItemSpacing));
-
+			group.InterItemSpacing = NSCollectionLayoutSpacing.CreateFixed(0);
 			// Create our section layout
 			var section = NSCollectionLayoutSection.Create(group: group);
 			if (OperatingSystem.IsIOSVersionAtLeast(26))
 				section.ContentInsetsReference = UIContentInsetsReference.None;
 
 			if (scrollDirection == UICollectionViewScrollDirection.Vertical)
+			{
 				section.InterGroupSpacing = new NFloat(verticalItemSpacing);
+				if (verticalItemSpacing > 0)
+				{
+					section.ContentInsets = new NSDirectionalEdgeInsets(halfVerticalSpacing, 0, halfVerticalSpacing, 0);
+				}
+			}
 			else
+			{
 				section.InterGroupSpacing = new NFloat(horizontalItemSpacing);
+				if (horizontalItemSpacing > 0)
+				{
+					section.ContentInsets = new NSDirectionalEdgeInsets(0, halfHorizontalSpacing, 0, halfHorizontalSpacing);
+				}
+			}
 
 
 			section.BoundarySupplementaryItems = CreateSupplementaryItems(

--- a/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/LayoutFactory2.cs
@@ -161,7 +161,17 @@ internal static class LayoutFactory2
 			var itemSize = NSCollectionLayoutSize.Create(itemWidth, itemHeight);
 			// Create the item itself from the size
 			var item = NSCollectionLayoutItem.Create(layoutSize: itemSize);
+			var halfHorizontalSpacing = new NFloat(horizontalItemSpacing / 2d);
+			var halfVerticalSpacing = new NFloat(verticalItemSpacing / 2d);
 
+			if (scrollDirection == UICollectionViewScrollDirection.Vertical && horizontalItemSpacing > 0)
+			{
+				item.ContentInsets = new NSDirectionalEdgeInsets(0, halfHorizontalSpacing, 0, halfHorizontalSpacing);
+			}
+			else if (scrollDirection == UICollectionViewScrollDirection.Horizontal && verticalItemSpacing > 0)
+			{
+				item.ContentInsets = new NSDirectionalEdgeInsets(halfVerticalSpacing, 0, halfVerticalSpacing, 0);
+			}
 			// Each group of items (for grouped collections) has a size
 			var groupSize = NSCollectionLayoutSize.Create(groupWidth, groupHeight);
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34257.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34257.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -36,4 +35,3 @@ public class Issue34257 : _IssuesUITest
 		Assert.That(firstColumnBefore.Y, Is.Not.EqualTo(firstColumnAfter.Y), $"Expected the first row to move");
 	}
 }
-#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34257.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34257.cs
@@ -28,10 +28,17 @@ public class Issue34257 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void UpdatingVerticalSpacingShouldResizeBothRows()
 	{
-		var firstColumnBefore = App.WaitForElement("FirstColumnTopItem").GetRect();
+		var firstColumnTopBefore = App.WaitForElement("FirstColumnTopItem").GetRect();
+		var firstColumnBottomBefore = App.WaitForElement("FirstColumnBottomItem").GetRect();
+		var rowGapBefore = firstColumnBottomBefore.Y - (firstColumnTopBefore.Y + firstColumnTopBefore.Height);
+
 		App.Tap("ApplyVerticalSpacingButton");
 		App.WaitForElement("StatusLabel", "Spacing=40,0");
-		var firstColumnAfter = App.WaitForElement("FirstColumnTopItem").GetRect();
-		Assert.That(firstColumnBefore.Y, Is.Not.EqualTo(firstColumnAfter.Y), $"Expected the first row to move");
+
+		var firstColumnTopAfter = App.WaitForElement("FirstColumnTopItem").GetRect();
+		var firstColumnBottomAfter = App.WaitForElement("FirstColumnBottomItem").GetRect();
+		var rowGapAfter = firstColumnBottomAfter.Y - (firstColumnTopAfter.Y + firstColumnTopAfter.Height);
+
+		Assert.That(rowGapAfter, Is.GreaterThan(rowGapBefore), $"Expected the gap between rows to increase");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34257.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34257.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS //In windows, related issue: https://github.com/dotnet/maui/issues/4715
+#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -29,11 +29,11 @@ public class Issue34257 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void UpdatingVerticalSpacingShouldResizeBothRows()
 	{
-		var firstColumnBefore = App.WaitForElement("FirstColumnBottomItem").GetRect();
+		var firstColumnBefore = App.WaitForElement("FirstColumnTopItem").GetRect();
 		App.Tap("ApplyVerticalSpacingButton");
 		App.WaitForElement("StatusLabel", "Spacing=40,0");
-		var firstColumnAfter = App.WaitForElement("FirstColumnBottomItem").GetRect();
-		Assert.That(firstColumnBefore.Y, Is.Not.EqualTo(firstColumnAfter.Y), $"Expected the second row to move");
+		var firstColumnAfter = App.WaitForElement("FirstColumnTopItem").GetRect();
+		Assert.That(firstColumnBefore.Y, Is.Not.EqualTo(firstColumnAfter.Y), $"Expected the first row to move");
 	}
 }
 #endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

Horizontalspacing / Verticalspacing is not not applied to the first column in GridItemLayout using CollectionView on iOS,Mac and Android platform.
        
### Root Cause:

The grid spacing was not being distributed symmetrically across the active layout implementations, so edge items did not fully participate when spacing changed at runtime. On iOS and MacCatalyst, the active Items2 compositional layout path handled spacing in a way that visually created gaps but did not cause the first column and first row to update consistently with the rest of the grid.

### Description of Change:

- On iOS/MacCatalyst, the fix in LayoutFactory2.cs keeps the existing compositional grid item sizing (FractionalWidth(1f / span) for vertical grids and FractionalHeight(1f / span) for horizontal grids), but changes how spacing is applied. Instead of relying on group.InterItemSpacing, the fix computes half of the requested horizontal and vertical spacing and applies that half-spacing through item.ContentInsets so each item contributes to the gap. It then sets group.InterItemSpacing to 0, keeps section.InterGroupSpacing for spacing between rows or columns, and adds matching half-spacing to section.ContentInsets. This makes the first row/column participate when spacing changes, which fixes the issue where only later rows or columns visually updated.

**Tested the behavior in the following platforms: **

- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #34257      

### Screenshots
| Before  | After  |
|---------|--------|
|   <Video src="https://github.com/user-attachments/assets/578dda69-1d60-474c-a6d8-23b3f9d29a50" Width="300" Height="600">   |    <Video src="https://github.com/user-attachments/assets/7f3826e6-5922-4b6f-a6b9-de581b7db6c3" Width="300" Height="600">  |
