### PR TITLE
[Testing] Resolved build error in inflight/current branch

### DIFF
--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22060.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue22060.cs
@@ -14,7 +14,6 @@ public class Issue22060 : _IssuesUITest
 
 	[Test]
 	[Category(UITestCategories.Shell)]
-	[Category(UITestCategories.SearchBar)]
 	public void ShouldAppearFlyoutIconAndContentPageTitle()
 	{
 		App.EnterTextInShellSearchHandler("Hello");

--- a/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
+++ b/src/TestUtils/src/UITest.Appium/HelperExtensions.cs
@@ -2915,6 +2915,57 @@ namespace UITest.Appium
 			}
 		}
 
+		/// <summary>
+		/// Gets the display density for the current device using the appropriate platform-specific method.
+		/// For Android, uses the Appium getDisplayDensity command for accurate results.
+		/// For iOS and Catalyst, uses the deviceScreenInfo command.
+		/// For other platforms, falls back to driver capabilities.
+		/// </summary>
+		/// <param name="app">The IApp instance representing the application.</param>
+		/// <returns>The display density as a double value (e.g., 1.0 for mdpi, 2.0 for xhdpi/Retina, 3.0 for xxhdpi/Retina HD)</returns>
+		public static double GetDisplayDensity(this IApp app)
+		{
+			if (app is not AppiumApp appiumApp)
+			{
+				throw new InvalidOperationException($"GetDisplayDensity is only supported on AppiumApp");
+			}
+
+			// Use platform-specific methods for accurate results
+			return app switch
+			{
+				AppiumAndroidApp androidApp => GetAndroidDisplayDensity(androidApp),
+				AppiumIOSApp iOSApp => GetIOSDisplayDensity(iOSApp),
+				_ => 1.0 // Fallback for other platforms (Catalyst, Windows)
+			};
+		}
+
+		static double GetAndroidDisplayDensity(AppiumAndroidApp androidApp)
+		{
+			// Use the command executor to call the Android-specific action
+			float? response = (androidApp.Driver as AndroidDriver)?.GetDisplayDensity();
+			if (response is not null)
+			{
+				return (double)response.Value / 160f;
+			}
+
+			return 1.0;
+		}
+
+		static double GetIOSDisplayDensity(AppiumIOSApp iOSApp)
+		{
+			var response = (iOSApp.Driver as IOSDriver)?.ExecuteScript("mobile: deviceScreenInfo");
+			if (response is not null && response is IDictionary<string, object> screenInfo)
+			{
+				// Extract the scale factor from the deviceScreenInfo response
+				if (screenInfo.TryGetValue("scale", out var scaleValue))
+				{
+					return Convert.ToDouble(scaleValue);
+				}
+			}
+
+			return 1.0;
+		}
+
 		/// Enters text into the search handler element for the shell.
 		/// This method is used to enter the search handler element in the app.
 		/// It uses different queries based on the app type (Android, iOS, Catalyst, or Windows).


### PR DESCRIPTION
This PR addresses the build failures in the inflight/current branch by:
- Removing one UITestCategory from ShouldAppearFlyoutIconAndContentPageTitle test; previously, two UITestCategories were added.
- Added the GetDisplayDensity, GetAndroidDisplayDensity, and GetIOSDisplayDensity methods again, which were removed in this PR: https://github.com/dotnet/maui/pull/28474

### Test Case:
- ShouldAppearFlyoutIconAndContentPageTitle
- Issue28986_SafeAreaBorderOrientation