### PR TITLE
Consolidate file path resolution for WebView controls

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/AndroidMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidMauiAssetFileProvider.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Android.Content.Res;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Maui.Storage;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
@@ -24,10 +25,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-			=> new AndroidMauiAssetDirectoryContents(_assets, Path.Combine(_contentRootDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_contentRootDir, subpath);
+			if (resolvedPath is null)
+				return NotFoundDirectoryContents.Singleton;
+			return new AndroidMauiAssetDirectoryContents(_assets, resolvedPath);
+		}
 
 		public IFileInfo GetFileInfo(string subpath)
-			=> new AndroidMauiAssetFileInfo(_assets, Path.Combine(_contentRootDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_contentRootDir, subpath);
+			if (resolvedPath is null)
+				return new NotFoundFileInfo(subpath);
+			return new AndroidMauiAssetFileInfo(_assets, resolvedPath);
+		}
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Maui.Storage;
 using Tizen.Applications;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -21,10 +22,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-			=> new TizenMauiAssetDirectoryContents(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return NotFoundDirectoryContents.Singleton;
+			return new TizenMauiAssetDirectoryContents(resolvedPath);
+		}
 
 		public IFileInfo GetFileInfo(string subpath)
-			=> new TizenMauiAssetFileInfo(Path.Combine(_resDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
+			if (resolvedPath is null)
+				return new NotFoundFileInfo(subpath);
+			return new TizenMauiAssetFileInfo(resolvedPath);
+		}
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/Tizen/TizenMauiAssetFileProvider.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
-using Microsoft.Maui.Storage;
 using Tizen.Applications;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -22,20 +21,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-		{
-			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
-			if (resolvedPath is null)
-				return NotFoundDirectoryContents.Singleton;
-			return new TizenMauiAssetDirectoryContents(resolvedPath);
-		}
+			=> new TizenMauiAssetDirectoryContents(Path.Combine(_resDir, subpath));
 
 		public IFileInfo GetFileInfo(string subpath)
-		{
-			var resolvedPath = FileSystemUtils.Combine(_resDir, subpath);
-			if (resolvedPath is null)
-				return new NotFoundFileInfo(subpath);
-			return new TizenMauiAssetFileInfo(resolvedPath);
-		}
+			=> new TizenMauiAssetFileInfo(Path.Combine(_resDir, subpath));
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.WebView.WebView2;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Platform;
+using Microsoft.Maui.Storage;
 using Microsoft.Web.WebView2.Core;
 using Windows.ApplicationModel;
 using Windows.Storage.Streams;
@@ -100,7 +101,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 				_logger.HandlingWebRequest(requestUri);
 
-				var relativePath = AppOriginUri.IsBaseOf(uri) ? AppOriginUri.MakeRelativeUri(uri).ToString() : null;
+				var relativePath = AppOriginUri.IsBaseOf(uri) ? Microsoft.Maui.WebUtils.ResolveRelativePath(AppOriginUri, uri) : null;
 
 				// Check if the uri is _framework/blazor.modules.json is a special case as the built-in file provider
 				// brings in a default implementation.
@@ -171,8 +172,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 			else
 			{
-				var path = Path.Combine(AppContext.BaseDirectory, relativePath);
-				if (File.Exists(path))
+				var path = FileSystemUtils.Combine(AppContext.BaseDirectory, relativePath);
+				if (path is not null && File.Exists(path))
 				{
 					using var contentStream = File.OpenRead(path);
 					stream = await CopyContentToRandomAccessStreamAsync(contentStream);

--- a/src/BlazorWebView/src/Maui/iOS/iOSMauiAssetFileProvider.cs
+++ b/src/BlazorWebView/src/Maui/iOS/iOSMauiAssetFileProvider.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Foundation;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Maui.Storage;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
@@ -21,10 +22,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)
-			=> new iOSMauiAssetDirectoryContents(Path.Combine(_bundleRootDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_bundleRootDir, subpath);
+			if (resolvedPath is null)
+				return NotFoundDirectoryContents.Singleton;
+			return new iOSMauiAssetDirectoryContents(resolvedPath);
+		}
 
 		public IFileInfo GetFileInfo(string subpath)
-			=> new iOSMauiAssetFileInfo(Path.Combine(_bundleRootDir, subpath));
+		{
+			var resolvedPath = FileSystemUtils.Combine(_bundleRootDir, subpath);
+			if (resolvedPath is null)
+				return new NotFoundFileInfo(subpath);
+			return new iOSMauiAssetFileInfo(resolvedPath);
+		}
 
 		public IChangeToken Watch(string filter)
 			=> NullChangeToken.Singleton;

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
@@ -81,6 +81,20 @@ public partial class BlazorWebViewTests
 	// for the Blazor component to render before running the test lambda.
 
 	// ============================================================
+	// Positive test — a known-good asset must still load after the
+	// path-hardening changes so we don't accidentally block legit
+	// requests
+	// ============================================================
+
+	[Fact]
+	public Task Blazor_KnownFrameworkAsset_LoadsSuccessfully() =>
+		RunUrlResolutionTest("_framework/blazor.webview.js", "relative", result =>
+		{
+			Assert.Equal(200, result.status);
+			Assert.True(result.bodyLength > 0, "Framework script should return content");
+		});
+
+	// ============================================================
 	// Rooted paths — Path.Combine drops the root when the second
 	// argument starts with a separator, so these should not resolve
 	// ============================================================

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
@@ -121,13 +121,13 @@ public partial class BlazorWebViewTests
 		});
 
 	// ============================================================
-	// Encoded separators — should not bypass path resolution
+	// Encoded separators — should not affect path resolution
 	// ============================================================
 
 	[Theory]
 	[InlineData("%2F%2Fimages%2Flogo.png")]
 	[InlineData("%2e%2e/readme.txt")]
-	public Task Blazor_EncodedSeparators_DoNotBypassResolution(string path) =>
+	public Task Blazor_EncodedSeparators_DoNotAffectResolution(string path) =>
 		RunUrlResolutionTest(path, "relative", result =>
 		{
 			Assert.True(

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
@@ -75,17 +75,10 @@ public partial class BlazorWebViewTests
 		result.bodyPreview.Contains("testhtmlloaded", StringComparison.Ordinal) ||
 		result.bodyPreview.Contains("There is no content at", StringComparison.Ordinal);
 
-	// ============================================================
-	// Host page — should load correctly
-	// ============================================================
-
-	[Fact]
-	public Task HostPage_LoadsSuccessfully() =>
-		RunUrlResolutionTest("", "relative", result =>
-		{
-			Assert.Equal(200, result.status);
-			Assert.True(result.bodyLength > 0, "Host page should return content");
-		});
+	// NOTE: No HostPage_LoadsSuccessfully test here because the Blazor host page
+	// is only served for navigation requests (ResourceContext.Document), not for
+	// fetch() requests. RunTest already verifies the host page loads by waiting
+	// for the Blazor component to render before running the test lambda.
 
 	// ============================================================
 	// Rooted paths — Path.Combine drops the root when the second

--- a/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
+++ b/src/BlazorWebView/tests/DeviceTests/Elements/BlazorWebViewTests.ContentRootResolution.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.MauiBlazorWebView.DeviceTests.Components;
+using Xunit;
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements;
+
+/// <summary>
+/// Tests for URL-to-file path resolution in BlazorWebView.
+/// Path.Combine ignores the first argument when the second starts with a path
+/// separator, which can cause incorrect file resolution. These tests verify that
+/// file resolution correctly handles various URL path formats.
+/// </summary>
+public partial class BlazorWebViewTests
+{
+	public class UrlResolutionResult
+	{
+		public int status { get; set; }
+		public int bodyLength { get; set; }
+		public string bodyPreview { get; set; } = "";
+		public string url { get; set; } = "";
+	}
+
+	[JsonSerializable(typeof(UrlResolutionResult))]
+	internal partial class UrlResolutionJsonContext : JsonSerializerContext
+	{
+	}
+
+	private async Task RunUrlResolutionTest(string path, string mode, Action<UrlResolutionResult> assertion)
+	{
+		await RunTest(async (blazorWebView, handler) =>
+		{
+			var jsPath = path.Replace("'", "\\'", StringComparison.Ordinal);
+			var result = await WebViewHelpers.ExecuteAsyncScriptAndWaitForResult<UrlResolutionResult>(
+				handler.PlatformView,
+				"try {" +
+				"  let url;" +
+				"  if ('" + mode + "' === 'origin') {" +
+				"    url = window.location.origin + '" + jsPath + "';" +
+				"  } else {" +
+				"    url = '" + jsPath + "';" +
+				"  }" +
+				"  const response = await fetch(url);" +
+				"  const body = await response.text();" +
+				"  return {" +
+				"    status: response.status," +
+				"    bodyLength: body.length," +
+				"    bodyPreview: body.substring(0, 200)," +
+				"    url: url" +
+				"  };" +
+				"} catch (e) {" +
+				"  let url = ('" + mode + "' === 'origin') ? window.location.origin + '" + jsPath + "' : '" + jsPath + "';" +
+				"  return {" +
+				"    status: -1," +
+				"    bodyLength: 0," +
+				"    bodyPreview: e.toString()," +
+				"    url: url" +
+				"  };" +
+				"}");
+
+			Assert.NotNull(result);
+			assertion(result);
+		});
+	}
+
+	/// <summary>
+	/// Checks if the response is the host page (SPA fallback) rather than actual file content.
+	/// BlazorWebView returns the host page for extensionless paths as part of SPA routing.
+	/// </summary>
+	static bool IsSpaFallback(UrlResolutionResult result) =>
+		result.bodyPreview.Contains("blazor.webview.js", StringComparison.Ordinal) ||
+		result.bodyPreview.Contains("testhtmlloaded", StringComparison.Ordinal) ||
+		result.bodyPreview.Contains("There is no content at", StringComparison.Ordinal);
+
+	// ============================================================
+	// Host page — should load correctly
+	// ============================================================
+
+	[Fact]
+	public Task HostPage_LoadsSuccessfully() =>
+		RunUrlResolutionTest("", "relative", result =>
+		{
+			Assert.Equal(200, result.status);
+			Assert.True(result.bodyLength > 0, "Host page should return content");
+		});
+
+	// ============================================================
+	// Rooted paths — Path.Combine drops the root when the second
+	// argument starts with a separator, so these should not resolve
+	// ============================================================
+
+	[Theory]
+	[InlineData("//images/logo.png")]
+	[InlineData("//data/readme.txt")]
+	[InlineData("//content/page.html")]
+	public Task Blazor_RootedPath_DoesNotResolve(string path) =>
+		RunUrlResolutionTest(path, "origin", result =>
+		{
+			Assert.True(
+				result.status != 200 || IsSpaFallback(result),
+				$"Path '{path}' unexpectedly returned content (status={result.status}, length={result.bodyLength})");
+		});
+
+	// ============================================================
+	// Dot-dot segments — should not resolve above content root
+	// ============================================================
+
+	[Theory]
+	[InlineData("../readme.txt")]
+	[InlineData("../../data/config.txt")]
+	[InlineData("subfolder/../../readme.txt")]
+	public Task Blazor_DotDotSegments_DoNotResolveAboveRoot(string path) =>
+		RunUrlResolutionTest(path, "relative", result =>
+		{
+			Assert.True(
+				result.status != 200 || IsSpaFallback(result),
+				$"Path '{path}' unexpectedly returned content (status={result.status}, length={result.bodyLength})");
+		});
+
+	// ============================================================
+	// Encoded separators — should not bypass path resolution
+	// ============================================================
+
+	[Theory]
+	[InlineData("%2F%2Fimages%2Flogo.png")]
+	[InlineData("%2e%2e/readme.txt")]
+	public Task Blazor_EncodedSeparators_DoNotBypassResolution(string path) =>
+		RunUrlResolutionTest(path, "relative", result =>
+		{
+			Assert.True(
+				result.status != 200 || IsSpaFallback(result),
+				$"Path '{path}' unexpectedly returned content (status={result.status}, length={result.bodyLength})");
+		});
+}

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\Essentials\src\Types\Shared\WebUtils.shared.cs" />
+    <Compile Include="..\..\..\Essentials\src\FileSystem\FileSystemUtils.shared.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(_MauiDesignDllBuild)' == 'True' and '$(TargetFramework)' == '$(_MauiDotNetTfm)'">

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ContentRootResolution.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ContentRootResolution.cs
@@ -1,0 +1,114 @@
+#nullable enable
+using System;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+/// <summary>
+/// Tests for URL-to-file path resolution in HybridWebView.
+/// Path.Combine ignores the first argument when the second starts with a path
+/// separator, which can cause incorrect file resolution. These tests verify that
+/// file resolution correctly handles various URL path formats.
+/// </summary>
+[Category(TestCategory.HybridWebView)]
+#if WINDOWS
+[Collection(WebViewsCollection)]
+#endif
+public partial class HybridWebViewTests_ContentRootResolution : HybridWebViewTestsBase
+{
+	public class UrlResolutionResult
+	{
+		public int status { get; set; }
+		public int bodyLength { get; set; }
+		public string bodyPreview { get; set; } = "";
+		public string url { get; set; } = "";
+	}
+
+	[JsonSourceGenerationOptions(WriteIndented = true)]
+	[JsonSerializable(typeof(UrlResolutionResult))]
+	[JsonSerializable(typeof(string))]
+	internal partial class UrlResolutionJsonContext : JsonSerializerContext
+	{
+	}
+
+	private Task RunUrlResolutionTest(string path, string mode, Action<UrlResolutionResult> assertion) =>
+		RunTest("urlresolution.html", async (hybridWebView) =>
+		{
+			var result = await hybridWebView.InvokeJavaScriptAsync<UrlResolutionResult>(
+				"TestUrlResolution",
+				UrlResolutionJsonContext.Default.UrlResolutionResult,
+				[path, mode],
+				[UrlResolutionJsonContext.Default.String, UrlResolutionJsonContext.Default.String]);
+
+			Assert.NotNull(result);
+			assertion(result);
+		});
+
+	// ============================================================
+	// Relative paths — files inside content root resolve correctly
+	// ============================================================
+
+	[Theory]
+	[InlineData("index.html")]
+	[InlineData("urlresolution.html")]
+	[InlineData("safe-file.txt")]
+	public Task RelativePaths_ResolveToContent(string path) =>
+		RunUrlResolutionTest(path, "relative", result =>
+		{
+			Assert.Equal(200, result.status);
+			Assert.True(result.bodyLength > 0, $"Expected content for '{path}' but got empty response.");
+		});
+
+	[Fact]
+	public Task KnownFile_ReturnsExpectedContent() =>
+		RunUrlResolutionTest("safe-file.txt", "relative", result =>
+		{
+			Assert.Equal(200, result.status);
+			Assert.Contains("content directory", result.bodyPreview, StringComparison.Ordinal);
+		});
+
+	// ============================================================
+	// Rooted paths — Path.Combine drops the root when the second
+	// argument starts with a separator, so these should not resolve
+	// ============================================================
+
+	[Theory]
+	[InlineData("//images/logo.png")]
+	[InlineData("//data/readme.txt")]
+	[InlineData("//content/page.html")]
+	public Task RootedPath_DoesNotResolve(string path) =>
+		RunUrlResolutionTest(path, "origin", result =>
+		{
+			Assert.NotEqual(200, result.status);
+		});
+
+	// ============================================================
+	// Dot-dot segments — should not resolve above content root
+	// ============================================================
+
+	[Theory]
+	[InlineData("../readme.txt")]
+	[InlineData("../../data/config.txt")]
+	[InlineData("subfolder/../../readme.txt")]
+	public Task DotDotSegments_DoNotResolveAboveRoot(string path) =>
+		RunUrlResolutionTest(path, "relative", result =>
+		{
+			Assert.NotEqual(200, result.status);
+		});
+
+	// ============================================================
+	// Encoded separators — should not bypass path resolution
+	// ============================================================
+
+	[Theory]
+	[InlineData("%2F%2Fimages%2Flogo.png")]
+	[InlineData("%2e%2e/readme.txt")]
+	public Task EncodedSeparators_DoNotBypassResolution(string path) =>
+		RunUrlResolutionTest(path, "relative", result =>
+		{
+			Assert.NotEqual(200, result.status);
+		});
+}

--- a/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ContentRootResolution.cs
+++ b/src/Controls/tests/DeviceTests/Elements/HybridWebView/HybridWebViewTests_ContentRootResolution.cs
@@ -100,13 +100,13 @@ public partial class HybridWebViewTests_ContentRootResolution : HybridWebViewTes
 		});
 
 	// ============================================================
-	// Encoded separators — should not bypass path resolution
+	// Encoded separators — should not affect path resolution
 	// ============================================================
 
 	[Theory]
 	[InlineData("%2F%2Fimages%2Flogo.png")]
 	[InlineData("%2e%2e/readme.txt")]
-	public Task EncodedSeparators_DoNotBypassResolution(string path) =>
+	public Task EncodedSeparators_DoNotAffectResolution(string path) =>
 		RunUrlResolutionTest(path, "relative", result =>
 		{
 			Assert.NotEqual(200, result.status);

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/safe-file.txt
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/safe-file.txt
@@ -1,0 +1,1 @@
+This file is inside the HybridRoot content directory.

--- a/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/urlresolution.html
+++ b/src/Controls/tests/DeviceTests/Resources/Raw/HybridTestRoot/urlresolution.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta charset="utf-8" />
+	<title>URL Resolution Tests</title>
+	<link rel="icon" href="data:,">
+	<script src="_framework/hybridwebview.js"></script>
+
+	<script>
+
+		// Tests URL-to-resource resolution by fetching a URL and returning the result.
+		// path: the path or URL fragment to fetch
+		// mode: "relative" to use the path as-is, "origin" to prefix with window.location.origin
+		async function TestUrlResolution(path, mode) {
+			let url;
+			if (mode === "origin") {
+				url = window.location.origin + path;
+			} else {
+				url = path;
+			}
+
+			try {
+				const response = await fetch(url);
+				const body = await response.text();
+				return {
+					status: response.status,
+					bodyLength: body.length,
+					bodyPreview: body.substring(0, 200),
+					url: url
+				};
+			} catch (e) {
+				return {
+					status: -1,
+					bodyLength: 0,
+					bodyPreview: e.toString(),
+					url: url
+				};
+			}
+		}
+
+	</script>
+</head>
+<body>
+	<h1>URL Resolution Test Page</h1>
+	<div id="htmlLoaded"></div>
+</body>
+</html>

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.Windows.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using System.Web;
 using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Storage;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
@@ -167,7 +168,12 @@ namespace Microsoft.Maui.Handlers
 
 			if (new Uri(requestUri) is Uri uri && AppOriginUri.IsBaseOf(uri))
 			{
-				var relativePath = AppOriginUri.MakeRelativeUri(uri).ToString();
+				var relativePath = WebUtils.ResolveRelativePath(AppOriginUri, uri);
+				if (relativePath is null)
+				{
+					logger?.LogDebug("Request for {Url} resolved to an invalid path.", url);
+					return (Stream: null, ContentType: null, StatusCode: 404, Reason: "Not Found");
+				}
 
 				// 1.a. Try the special "_framework/hybridwebview.js" path
 				if (relativePath == HybridWebViewDotJsPath)
@@ -238,8 +244,8 @@ namespace Microsoft.Maui.Handlers
 					}
 				}
 
-				var assetPath = Path.Combine(VirtualView.HybridRoot!, relativePath!);
-				using var contentStream = await GetAssetStreamAsync(assetPath);
+				var assetPath = FileSystemUtils.Combine(VirtualView.HybridRoot!, relativePath!);
+				using var contentStream = assetPath is not null ? await GetAssetStreamAsync(assetPath) : null;
 
 				if (contentStream is not null)
 				{

--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -227,7 +227,12 @@ namespace Microsoft.Maui.Handlers
 
 				if (new Uri(url) is Uri uri && AppOriginUri.IsBaseOf(uri))
 				{
-					var relativePath = AppOriginUri.MakeRelativeUri(uri).ToString();
+					var relativePath = WebUtils.ResolveRelativePath(AppOriginUri, uri);
+					if (relativePath is null)
+					{
+						logger?.LogDebug("Request for {Url} resolved to an invalid path.", url);
+						return (null, ContentType: null, StatusCode: 404);
+					}
 
 					var bundleRootDir = Path.Combine(NSBundle.MainBundle.ResourcePath, Handler.VirtualView.HybridRoot!);
 
@@ -298,10 +303,13 @@ namespace Microsoft.Maui.Handlers
 						}
 					}
 
-					var assetPath = Path.Combine(bundleRootDir, relativePath!);
-					assetPath = FileSystemUtils.NormalizePath(assetPath);
+					var assetPath = FileSystemUtils.Combine(bundleRootDir, relativePath!);
+					if (assetPath is not null)
+					{
+						assetPath = FileSystemUtils.NormalizePath(assetPath);
+					}
 
-					if (File.Exists(assetPath))
+					if (assetPath is not null && File.Exists(assetPath))
 					{
 						// 2.a. If something was found, return the content
 						logger?.LogDebug("Request for {Url} will return an app package file.", url);

--- a/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebViewClient.cs
@@ -76,7 +76,12 @@ namespace Microsoft.Maui.Platform
 
 			logger?.LogDebug("Request for {Url} will be handled by .NET MAUI.", fullUrl);
 
-			var relativePath = HybridWebViewHandler.AppOriginUri.MakeRelativeUri(uri).ToString();
+			var relativePath = WebUtils.ResolveRelativePath(HybridWebViewHandler.AppOriginUri, uri);
+			if (relativePath is null)
+			{
+				logger?.LogDebug("Request for {Url} resolved to an invalid path.", fullUrl);
+				return new WebResourceResponse("text/plain", "UTF-8", 404, "Not Found", GetHeaders("text/plain"), new MemoryStream());
+			}
 
 			// 1.a. Try the special "_framework/hybridwebview.js" path
 			if (relativePath == HybridWebViewHandler.HybridWebViewDotJsPath)
@@ -138,8 +143,8 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 
-			var assetPath = Path.Combine(Handler.VirtualView.HybridRoot!, relativePath!);
-			var contentStream = PlatformOpenAppPackageFile(assetPath);
+			var assetPath = FileSystemUtils.Combine(Handler.VirtualView.HybridRoot!, relativePath!);
+			var contentStream = assetPath is not null ? PlatformOpenAppPackageFile(assetPath) : null;
 
 			if (contentStream is not null)
 			{

--- a/src/Essentials/src/Email/Email.windows.cs
+++ b/src/Essentials/src/Email/Email.windows.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Maui.Storage;
 
 namespace Microsoft.Maui.ApplicationModel.Communication
 {
@@ -30,7 +31,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			{
 				foreach (var attachment in message.Attachments)
 				{
-					var path = NormalizePath(attachment.FullPath);
+					var path = FileSystemUtils.NormalizePath(attachment.FullPath);
 
 					platformEmailMessage.Attachments.Add(path);
 				}
@@ -38,9 +39,6 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 
 			await EmailHelper.ShowComposeNewEmailAsync(platformEmailMessage);
 		}
-
-		static string NormalizePath(string path)
-			=> path.Replace('/', Path.DirectorySeparatorChar);
 
 		void Sync(List<string> recipients, IList<PlatformEmailRecipient> nativeRecipients)
 		{

--- a/src/Essentials/src/FileSystem/FileSystemUtils.shared.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.shared.cs
@@ -32,8 +32,14 @@ namespace Microsoft.Maui.Storage
 			if (Path.IsPathRooted(relativePath))
 				return false;
 
-			if (relativePath.Contains("..", StringComparison.Ordinal))
-				return false;
+			// Check for ".." as a path segment, not as a substring,
+			// so that filenames like "foo..bar.js" are not rejected.
+			var segments = relativePath.Split(new[] { '\\', '/' }, StringSplitOptions.None);
+			foreach (var segment in segments)
+			{
+				if (string.Equals(segment, "..", StringComparison.Ordinal))
+					return false;
+			}
 
 			return true;
 		}
@@ -50,16 +56,36 @@ namespace Microsoft.Maui.Storage
 				return null;
 
 			var combined = Path.Combine(rootDirectory, relativePath);
-			var fullPath = Path.GetFullPath(combined);
 
-			var normalizedRoot = Path.GetFullPath(rootDirectory);
-			if (!normalizedRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
-				normalizedRoot += Path.DirectorySeparatorChar;
+			// When the root directory is absolute, resolve and verify the full path
+			// stays within the root using the file system's canonical paths.
+			if (Path.IsPathRooted(rootDirectory))
+			{
+				var fullPath = Path.GetFullPath(combined);
 
-			if (!fullPath.StartsWith(normalizedRoot, StringComparison.Ordinal))
-				return null;
+				var normalizedRoot = Path.GetFullPath(rootDirectory);
+				if (!normalizedRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+					normalizedRoot += Path.DirectorySeparatorChar;
 
-			return fullPath;
+				// Use case-insensitive comparison on Windows where the file system is case-insensitive.
+				var comparison = OperatingSystem.IsWindows()
+					? StringComparison.OrdinalIgnoreCase
+					: StringComparison.Ordinal;
+
+				// The full path must either be exactly the root (for empty relative paths)
+				// or start with the root + separator (for paths within the root).
+				if (!fullPath.StartsWith(normalizedRoot, comparison) &&
+					!string.Equals(fullPath + Path.DirectorySeparatorChar, normalizedRoot, comparison))
+					return null;
+
+				return fullPath;
+			}
+
+			// For relative roots (e.g., app-package or asset-relative paths like
+			// Android's "HybridTestRoot" or "wwwroot"), preserve the relative semantics.
+			// IsValidRelativePath has already ensured the relativePath is not rooted
+			// and does not contain "..", so the combined path stays within the root.
+			return NormalizePath(combined);
 		}
 	}
 }

--- a/src/Essentials/src/FileSystem/FileSystemUtils.shared.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.shared.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Maui.Storage
 			if (string.IsNullOrEmpty(relativePath))
 				return true;
 
-			if (Path.IsPathRooted(relativePath))
+			if (Path.IsPathRooted(relativePath!))
 				return false;
 
 			// Check for ".." as a path segment, not as a substring,
 			// so that filenames like "foo..bar.js" are not rejected.
-			var segments = relativePath.Split(new[] { '\\', '/' }, StringSplitOptions.None);
+			var segments = relativePath!.Split(new[] { '\\', '/' }, StringSplitOptions.None);
 			foreach (var segment in segments)
 			{
 				if (string.Equals(segment, "..", StringComparison.Ordinal))
@@ -67,15 +67,10 @@ namespace Microsoft.Maui.Storage
 				if (!normalizedRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
 					normalizedRoot += Path.DirectorySeparatorChar;
 
-				// Use case-insensitive comparison on Windows where the file system is case-insensitive.
-				var comparison = OperatingSystem.IsWindows()
-					? StringComparison.OrdinalIgnoreCase
-					: StringComparison.Ordinal;
-
-				// The full path must either be exactly the root (for empty relative paths)
-				// or start with the root + separator (for paths within the root).
-				if (!fullPath.StartsWith(normalizedRoot, comparison) &&
-					!string.Equals(fullPath + Path.DirectorySeparatorChar, normalizedRoot, comparison))
+				// Use case-insensitive comparison to handle platforms with case-insensitive
+				// file systems (e.g., Windows, macOS) without requiring platform detection.
+				if (!fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase) &&
+					!string.Equals(fullPath + Path.DirectorySeparatorChar, normalizedRoot, StringComparison.OrdinalIgnoreCase))
 					return null;
 
 				return fullPath;

--- a/src/Essentials/src/FileSystem/FileSystemUtils.shared.cs
+++ b/src/Essentials/src/FileSystem/FileSystemUtils.shared.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using System.IO;
 
 namespace Microsoft.Maui.Storage
@@ -18,5 +19,47 @@ namespace Microsoft.Maui.Storage
 			filename
 				.Replace('\\', Path.DirectorySeparatorChar)
 				.Replace('/', Path.DirectorySeparatorChar);
+
+		/// <summary>
+		/// Validates that a relative path does not resolve to an absolute or rooted
+		/// location and does not contain relative parent (..) segments.
+		/// </summary>
+		internal static bool IsValidRelativePath(string? relativePath)
+		{
+			if (string.IsNullOrEmpty(relativePath))
+				return true;
+
+			if (Path.IsPathRooted(relativePath))
+				return false;
+
+			if (relativePath.Contains("..", StringComparison.Ordinal))
+				return false;
+
+			return true;
+		}
+
+		/// <summary>
+		/// Combines a root directory with a relative path, validates the relative path,
+		/// and verifies the resolved full path is still within the root directory.
+		/// Returns <c>null</c> if the relative path is invalid or the combined path
+		/// falls outside the root.
+		/// </summary>
+		internal static string? Combine(string rootDirectory, string relativePath)
+		{
+			if (!IsValidRelativePath(relativePath))
+				return null;
+
+			var combined = Path.Combine(rootDirectory, relativePath);
+			var fullPath = Path.GetFullPath(combined);
+
+			var normalizedRoot = Path.GetFullPath(rootDirectory);
+			if (!normalizedRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+				normalizedRoot += Path.DirectorySeparatorChar;
+
+			if (!fullPath.StartsWith(normalizedRoot, StringComparison.Ordinal))
+				return null;
+
+			return fullPath;
+		}
 	}
 }

--- a/src/Essentials/src/Types/Shared/WebUtils.shared.cs
+++ b/src/Essentials/src/Types/Shared/WebUtils.shared.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 
 namespace Microsoft.Maui
 {

--- a/src/Essentials/src/Types/Shared/WebUtils.shared.cs
+++ b/src/Essentials/src/Types/Shared/WebUtils.shared.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.Maui
 {
@@ -19,6 +20,22 @@ namespace Microsoft.Maui
 			return (indexOfQueryString == -1)
 				? url
 				: url.Substring(0, indexOfQueryString);
+		}
+
+		/// <summary>
+		/// Resolves a request URI against an app origin to produce a validated relative path.
+		/// </summary>
+		internal static string? ResolveRelativePath(Uri appOriginUri, Uri requestUri)
+		{
+			if (!appOriginUri.IsBaseOf(requestUri))
+				return null;
+
+			var relativePath = appOriginUri.MakeRelativeUri(requestUri).ToString();
+
+			if (!Storage.FileSystemUtils.IsValidRelativePath(relativePath))
+				return null;
+
+			return relativePath ?? string.Empty;
 		}
 #endif
 

--- a/src/Essentials/test/UnitTests/FileSystemUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/FileSystemUtils_Tests.cs
@@ -1,0 +1,275 @@
+#nullable enable
+using System;
+using System.IO;
+using Microsoft.Maui.Storage;
+using Xunit;
+
+namespace Tests
+{
+	public class FileSystemUtils_Tests
+	{
+		// ============================================================
+		// IsValidRelativePath
+		// ============================================================
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		public void IsValidRelativePath_NullOrEmpty_ReturnsTrue(string? path)
+		{
+			Assert.True(FileSystemUtils.IsValidRelativePath(path));
+		}
+
+		[Theory]
+		[InlineData("file.txt")]
+		[InlineData("sub/file.txt")]
+		[InlineData("sub/deep/file.txt")]
+		[InlineData("./file.txt")]
+		[InlineData("sub/./file.txt")]
+		public void IsValidRelativePath_ValidRelative_ReturnsTrue(string path)
+		{
+			Assert.True(FileSystemUtils.IsValidRelativePath(path));
+		}
+
+		[Theory]
+		[InlineData("foo..bar.js")]
+		[InlineData("image..png")]
+		[InlineData("name...ext")]
+		[InlineData("a..b/c..d")]
+		public void IsValidRelativePath_DoubleDotInFilename_ReturnsTrue(string path)
+		{
+			// ".." inside a filename is not a path segment — should be allowed
+			Assert.True(FileSystemUtils.IsValidRelativePath(path));
+		}
+
+		[Theory]
+		[InlineData("../file.txt")]
+		[InlineData("../../file.txt")]
+		[InlineData("sub/../file.txt")]
+		[InlineData("sub/../../file.txt")]
+		[InlineData("..\\file.txt")]
+		[InlineData("sub\\..\\file.txt")]
+		public void IsValidRelativePath_DotDotSegment_ReturnsFalse(string path)
+		{
+			Assert.False(FileSystemUtils.IsValidRelativePath(path));
+		}
+
+		[Theory]
+		[InlineData("/file.txt")]
+		[InlineData("//file.txt")]
+		[InlineData("///file.txt")]
+		public void IsValidRelativePath_RootedPath_ReturnsFalse(string path)
+		{
+			Assert.False(FileSystemUtils.IsValidRelativePath(path));
+		}
+
+		[Fact]
+		public void IsValidRelativePath_WindowsDriveLetter_ReturnsFalse()
+		{
+			if (!OperatingSystem.IsWindows())
+				return; // Path.IsPathRooted behaves differently on non-Windows
+
+			Assert.False(FileSystemUtils.IsValidRelativePath("C:\\file.txt"));
+			Assert.False(FileSystemUtils.IsValidRelativePath("D:/file.txt"));
+		}
+
+		// ============================================================
+		// Combine — with absolute root directory
+		// ============================================================
+
+		[Fact]
+		public void Combine_AbsoluteRoot_ValidRelative_ReturnsFullPath()
+		{
+			var root = Path.GetTempPath();
+			var result = FileSystemUtils.Combine(root, "sub/file.txt");
+
+			Assert.NotNull(result);
+			Assert.True(Path.IsPathRooted(result));
+			Assert.StartsWith(root, result, StringComparison.Ordinal);
+			Assert.EndsWith("file.txt", result, StringComparison.Ordinal);
+		}
+
+		[Theory]
+		[InlineData("../file.txt")]
+		[InlineData("../../file.txt")]
+		[InlineData("sub/../../file.txt")]
+		public void Combine_AbsoluteRoot_DotDotAboveRoot_ReturnsNull(string relativePath)
+		{
+			var root = Path.Combine(Path.GetTempPath(), "testroot", "content");
+			var result = FileSystemUtils.Combine(root, relativePath);
+
+			Assert.Null(result);
+		}
+
+		[Theory]
+		[InlineData("/etc/config.txt")]
+		[InlineData("//images/logo.png")]
+		[InlineData("///data/readme.txt")]
+		public void Combine_AbsoluteRoot_RootedRelative_ReturnsNull(string relativePath)
+		{
+			var root = Path.Combine(Path.GetTempPath(), "testroot");
+			var result = FileSystemUtils.Combine(root, relativePath);
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void Combine_AbsoluteRoot_EmptyRelative_ReturnsRoot()
+		{
+			var root = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+			var result = FileSystemUtils.Combine(root, "");
+
+			// Empty relative path combined with root should return a path within root
+			Assert.NotNull(result);
+		}
+
+		[Fact]
+		public void Combine_AbsoluteRoot_SingleDot_ReturnsPathWithinRoot()
+		{
+			var root = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+			var result = FileSystemUtils.Combine(root, "./file.txt");
+
+			Assert.NotNull(result);
+			Assert.EndsWith("file.txt", result, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public void Combine_AbsoluteRoot_WindowsCaseSensitivity()
+		{
+			if (!OperatingSystem.IsWindows())
+				return;
+
+			// On Windows, paths are case-insensitive, so even if GetFullPath returns
+			// a different case, the boundary check should still pass.
+			var root = Path.Combine(Path.GetTempPath(), "TestRoot");
+			var result = FileSystemUtils.Combine(root, "sub/file.txt");
+
+			Assert.NotNull(result);
+		}
+
+		// ============================================================
+		// Combine — with relative root directory (Android/package paths)
+		// ============================================================
+
+		[Fact]
+		public void Combine_RelativeRoot_ValidRelative_ReturnsRelativePath()
+		{
+			var result = FileSystemUtils.Combine("wwwroot", "index.html");
+
+			Assert.NotNull(result);
+			// Should NOT be absolute — should stay relative for package/asset APIs
+			Assert.False(Path.IsPathRooted(result));
+			Assert.Contains("wwwroot", result, StringComparison.Ordinal);
+			Assert.Contains("index.html", result, StringComparison.Ordinal);
+		}
+
+		[Fact]
+		public void Combine_RelativeRoot_SubPath_PreservesRelativeStructure()
+		{
+			var result = FileSystemUtils.Combine("HybridTestRoot", "sub/file.txt");
+
+			Assert.NotNull(result);
+			Assert.False(Path.IsPathRooted(result));
+		}
+
+		[Theory]
+		[InlineData("../file.txt")]
+		[InlineData("../../file.txt")]
+		[InlineData("sub/../../file.txt")]
+		public void Combine_RelativeRoot_DotDotAboveRoot_ReturnsNull(string relativePath)
+		{
+			var result = FileSystemUtils.Combine("wwwroot", relativePath);
+
+			Assert.Null(result);
+		}
+
+		[Theory]
+		[InlineData("/etc/config.txt")]
+		[InlineData("//images/logo.png")]
+		public void Combine_RelativeRoot_RootedRelative_ReturnsNull(string relativePath)
+		{
+			var result = FileSystemUtils.Combine("wwwroot", relativePath);
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void Combine_RelativeRoot_NormalizesSlashes()
+		{
+			var result = FileSystemUtils.Combine("wwwroot", "sub/file.txt");
+
+			Assert.NotNull(result);
+			// Verify slashes are normalized for current platform
+			if (Path.DirectorySeparatorChar == '/')
+				Assert.DoesNotContain("\\", result, StringComparison.Ordinal);
+			else
+				Assert.DoesNotContain("/", result, StringComparison.Ordinal);
+		}
+
+		// ============================================================
+		// Combine — additional edge cases
+		// ============================================================
+
+		[Theory]
+		[InlineData("..\\readme.txt")]
+		[InlineData("..\\..\\data\\config.txt")]
+		[InlineData("subfolder\\..\\..\\readme.txt")]
+		public void Combine_BackslashDotDot_ReturnsNull(string relativePath)
+		{
+			var root = Path.Combine(Path.GetTempPath(), "testroot");
+			var result = FileSystemUtils.Combine(root, relativePath);
+
+			Assert.Null(result);
+		}
+
+		[Theory]
+		[InlineData("///127.0.0.1/share/data.txt")]
+		[InlineData("///localhost/C$/data.txt")]
+		public void Combine_NetworkStylePath_ReturnsNull(string relativePath)
+		{
+			var root = Path.Combine(Path.GetTempPath(), "testroot");
+			var result = FileSystemUtils.Combine(root, relativePath);
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void Combine_WindowsDriveLetter_ReturnsNull()
+		{
+			if (!OperatingSystem.IsWindows())
+				return;
+
+			var root = Path.Combine(Path.GetTempPath(), "testroot");
+			Assert.Null(FileSystemUtils.Combine(root, "C:\\Windows\\notepad.exe"));
+			Assert.Null(FileSystemUtils.Combine(root, "D:/projects/readme.md"));
+		}
+
+		// ============================================================
+		// Combine — filenames containing ".." that are NOT path segments
+		// ============================================================
+
+		[Theory]
+		[InlineData("foo..bar.js")]
+		[InlineData("image..png")]
+		[InlineData("a..b/c..d.txt")]
+		public void Combine_DoubleDotInFilename_Succeeds(string relativePath)
+		{
+			var root = Path.Combine(Path.GetTempPath(), "testroot");
+			var result = FileSystemUtils.Combine(root, relativePath);
+
+			Assert.NotNull(result);
+		}
+
+		// ============================================================
+		// NormalizePath
+		// ============================================================
+
+		[Fact]
+		public void NormalizePath_ReplacesForwardAndBackSlashes()
+		{
+			var result = FileSystemUtils.NormalizePath("a/b\\c");
+			var expected = $"a{Path.DirectorySeparatorChar}b{Path.DirectorySeparatorChar}c";
+			Assert.Equal(expected, result);
+		}
+	}
+}

--- a/src/Essentials/test/UnitTests/WebUtils_Tests.cs
+++ b/src/Essentials/test/UnitTests/WebUtils_Tests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using Xunit;
+
+namespace Tests
+{
+	public class WebUtils_Tests
+	{
+		// ============================================================
+		// ResolveRelativePath — valid cases
+		// ============================================================
+
+		[Fact]
+		public void ResolveRelativePath_ValidRelative_ReturnsPath()
+		{
+			var origin = new Uri("https://0.0.0.0/");
+			var request = new Uri("https://0.0.0.0/index.html");
+
+			var result = Microsoft.Maui.WebUtils.ResolveRelativePath(origin, request);
+
+			Assert.NotNull(result);
+			Assert.Equal("index.html", result);
+		}
+
+		[Fact]
+		public void ResolveRelativePath_SubPath_ReturnsPath()
+		{
+			var origin = new Uri("https://0.0.0.0/");
+			var request = new Uri("https://0.0.0.0/sub/file.txt");
+
+			var result = Microsoft.Maui.WebUtils.ResolveRelativePath(origin, request);
+
+			Assert.NotNull(result);
+			Assert.Equal("sub/file.txt", result);
+		}
+
+		[Fact]
+		public void ResolveRelativePath_RootRequest_ReturnsEmpty()
+		{
+			var origin = new Uri("https://0.0.0.0/");
+			var request = new Uri("https://0.0.0.0/");
+
+			var result = Microsoft.Maui.WebUtils.ResolveRelativePath(origin, request);
+
+			Assert.NotNull(result);
+			Assert.Equal(string.Empty, result);
+		}
+
+		// ============================================================
+		// ResolveRelativePath — invalid cases
+		// ============================================================
+
+		[Fact]
+		public void ResolveRelativePath_DifferentOrigin_ReturnsNull()
+		{
+			var origin = new Uri("https://0.0.0.0/");
+			var request = new Uri("https://other.example.com/file.txt");
+
+			var result = Microsoft.Maui.WebUtils.ResolveRelativePath(origin, request);
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void ResolveRelativePath_DoubleSlash_MakeRelativeUri_ProducesRooted_ReturnsNull()
+		{
+			// When the request has a double-slash path like //images/logo.png,
+			// MakeRelativeUri can produce a path that starts with a separator,
+			// which should be rejected as rooted.
+			var origin = new Uri("https://0.0.0.0/");
+			var request = new Uri("https://0.0.0.0//images/logo.png");
+
+			var result = Microsoft.Maui.WebUtils.ResolveRelativePath(origin, request);
+
+			// Either null (rejected) or a valid non-rooted path — never a rooted path
+			if (result is not null)
+			{
+				Assert.False(System.IO.Path.IsPathRooted(result),
+					$"ResolveRelativePath should not return a rooted path, got: '{result}'");
+			}
+		}
+
+		// ============================================================
+		// ResolveRelativePath — encoded paths
+		// ============================================================
+
+		[Fact]
+		public void ResolveRelativePath_EncodedDotDot_HandledCorrectly()
+		{
+			var origin = new Uri("https://0.0.0.0/");
+			// %2e%2e is URL-encoded ".." — Uri class may decode this
+			var request = new Uri("https://0.0.0.0/%2e%2e/secret.txt");
+
+			var result = Microsoft.Maui.WebUtils.ResolveRelativePath(origin, request);
+
+			// Should be null (invalid) or if Uri decoded it, the result should be valid
+			if (result is not null)
+			{
+				Assert.DoesNotContain("..", result, StringComparison.Ordinal);
+			}
+		}
+
+		// ============================================================
+		// RemovePossibleQueryString
+		// ============================================================
+
+		[Theory]
+		[InlineData(null, "")]
+		[InlineData("", "")]
+		[InlineData("https://example.com", "https://example.com")]
+		[InlineData("https://example.com?foo=bar", "https://example.com")]
+		[InlineData("https://example.com/path?query=1&other=2", "https://example.com/path")]
+		public void RemovePossibleQueryString_ReturnsExpected(string? input, string expected)
+		{
+			var result = Microsoft.Maui.WebUtils.RemovePossibleQueryString(input);
+			Assert.Equal(expected, result);
+		}
+	}
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Refactored scattered file-path resolution logic in HybridWebView and BlazorWebView into shared utilities (`FileSystemUtils.Combine`, `WebUtils.ResolveRelativePath`) to fix edge cases where `Path.Combine` drops the root directory when a relative path starts with a separator.

### Changes

- **`FileSystemUtils.shared.cs`** — Added `IsValidRelativePath()` and `Combine()` methods that validate relative paths and ensure the resolved path stays within the expected root directory
- **`WebUtils.shared.cs`** — Added `ResolveRelativePath()` to resolve request URIs against an app origin into validated relative paths
- **HybridWebView handlers** (iOS, Windows, Android) — Use the new shared utilities for file path resolution
- **BlazorWebView file providers** (iOS, Android, Windows, Tizen) — Use `FileSystemUtils.Combine()` for path resolution
- **`Email.windows.cs`** — Consolidated duplicate `NormalizePath` into `FileSystemUtils.NormalizePath`
- **Device tests** — Added path resolution tests for both HybridWebView and BlazorWebView covering relative paths, rooted paths, dot-dot segments, and encoded separators