### PR TITLE
Fix Android layout jump when navigating with IME open and NavBarIsVisible=false

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -6,6 +6,7 @@ using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Views;
 using Android.Widget;
+using AndroidX.Core.View;
 using AndroidX.DrawerLayout.Widget;
 using AndroidX.Fragment.App;
 using Microsoft.Maui.ApplicationModel;
@@ -218,6 +219,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected virtual void SwitchFragment(FragmentManager manager, AView targetView, ShellItem newItem, bool animate = true)
 		{
+			var rootView = _flyoutView?.AndroidView;
+
+			if (rootView != null && rootView.IsSoftInputShowing())
+			{
+				rootView.HideSoftInput();
+			}
+
 			var previousView = _currentView;
 			_currentView = CreateShellItemRenderer(newItem);
 			_currentView.ShellItem = newItem;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -6,7 +6,7 @@ using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Views;
 using Android.Widget;
-using AndroidX.Core.View;
+using Microsoft.Maui.Platform;
 using AndroidX.DrawerLayout.Widget;
 using AndroidX.Fragment.App;
 using Microsoft.Maui.ApplicationModel;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -219,11 +219,20 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected virtual void SwitchFragment(FragmentManager manager, AView targetView, ShellItem newItem, bool animate = true)
 		{
-			var rootView = _flyoutView?.AndroidView;
-
-			if (rootView != null && rootView.IsSoftInputShowing())
+			if (animate)
 			{
-				rootView.HideSoftInput();
+				var shellContent = newItem?.CurrentItem?.CurrentItem as IShellContentController;
+				var destinationPage = shellContent?.GetOrCreateContent();
+
+				if (destinationPage != null && !Shell.GetNavBarIsVisible(destinationPage))
+				{
+					var rootView = _flyoutView?.AndroidView;
+
+					if (rootView != null && rootView.IsSoftInputShowing())
+					{
+						rootView.HideSoftInput();
+					}
+				}
 			}
 
 			var previousView = _currentView;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -219,12 +219,25 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected virtual void SwitchFragment(FragmentManager manager, AView targetView, ShellItem newItem, bool animate = true)
 		{
-			if (animate)
+			if (animate && newItem?.CurrentItem?.CurrentItem is IShellContentController shellContent)
 			{
-				var shellContent = newItem?.CurrentItem?.CurrentItem as IShellContentController;
-				var destinationPage = shellContent?.GetOrCreateContent();
+				bool? isNavBarVisible = null;
 
-				if (destinationPage != null && !Shell.GetNavBarIsVisible(destinationPage))
+				if (shellContent is BindableObject bindable &&
+					bindable.IsSet(Shell.NavBarIsVisibleProperty))
+				{
+					isNavBarVisible = Shell.GetNavBarIsVisible(bindable);
+				}
+
+				if (isNavBarVisible == null)
+				{
+					var destinationPage = shellContent.GetOrCreateContent();
+
+					if (destinationPage != null)
+						isNavBarVisible = Shell.GetNavBarIsVisible(destinationPage);
+				}
+
+				if (isNavBarVisible == false)
 				{
 					var rootView = _flyoutView?.AndroidView;
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34584.cs
@@ -8,22 +8,8 @@ public class Issue34584 : TestShell
 		var mainPage = new Issue34584_MainPage();
 		var destinationPage = new Issue34584_DestinationPage();
 
-		var shellContent1 = new ShellContent
-		{
-			Title = "Main",
-			Route = "MainPage",
-			Content = mainPage
-		};
-
-		var shellContent2 = new ShellContent
-		{
-			Title = "Destination",
-			Route = "DestinationPage",
-			Content = destinationPage
-		};
-
-		Items.Add(shellContent1);
-		Items.Add(shellContent2);
+		AddContentPage(mainPage, "MainPage");
+		AddContentPage(destinationPage, "DestinationPage");
 	}
 }
 
@@ -43,7 +29,7 @@ public class Issue34584_MainPage : ContentPage
 			AutomationId = "NavigateButton"
 		};
 
-		navigateButton.Clicked += async (s, e) =>
+		entry.Completed += async (s, e) =>
 		{
 			await Shell.Current.GoToAsync("//DestinationPage", false);
 		};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34584.cs
@@ -1,0 +1,88 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34584, "Content renders under status bar when navigating with keyboard open to a page with NavBarIsVisible=False", PlatformAffected.Android)]
+public class Issue34584 : TestShell
+{
+	protected override void Init()
+	{
+		var mainPage = new Issue34584_MainPage();
+		var destinationPage = new Issue34584_DestinationPage();
+
+		var shellContent1 = new ShellContent
+		{
+			Title = "Main",
+			Route = "MainPage",
+			Content = mainPage
+		};
+
+		var shellContent2 = new ShellContent
+		{
+			Title = "Destination",
+			Route = "DestinationPage",
+			Content = destinationPage
+		};
+
+		Items.Add(shellContent1);
+		Items.Add(shellContent2);
+	}
+}
+
+public class Issue34584_MainPage : ContentPage
+{
+	public Issue34584_MainPage()
+	{
+		var entry = new Entry
+		{
+			Placeholder = "Tap here to open keyboard",
+			AutomationId = "Entry"
+		};
+
+		var navigateButton = new Button
+		{
+			Text = "Navigate",
+			AutomationId = "NavigateButton"
+		};
+
+		navigateButton.Clicked += async (s, e) =>
+		{
+			await Shell.Current.GoToAsync("//DestinationPage", false);
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 20,
+			Padding = new Thickness(0),
+			Children =
+			{
+				new Label
+				{
+					Text = "Main Page - Tap entry, type text, then navigate",
+					FontSize = 18
+				},
+				entry,
+				navigateButton
+			}
+		};
+	}
+}
+
+public class Issue34584_DestinationPage : ContentPage
+{
+	public Issue34584_DestinationPage()
+	{
+		Shell.SetNavBarIsVisible(this, false);
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+			{
+				new Label
+				{
+					Text = "Destination Page",
+					FontSize = 24,
+					AutomationId = "TargetLabel"
+				}
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34584.cs
@@ -29,6 +29,11 @@ public class Issue34584_MainPage : ContentPage
 			AutomationId = "NavigateButton"
 		};
 
+		navigateButton.Clicked += async (s, e) =>
+		{
+			await Shell.Current.GoToAsync("//DestinationPage", false);
+		};
+
 		entry.Completed += async (s, e) =>
 		{
 			await Shell.Current.GoToAsync("//DestinationPage", false);

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
@@ -1,0 +1,44 @@
+#if ANDROID // This test validates Android-specific layout behavior with soft keyboard and navigation
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34584 : _IssuesUITest
+{
+	public Issue34584(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "Content renders under status bar when navigating with keyboard open to a page with NavBarIsVisible=False";
+
+	[Test]
+	[Category(UITestCategories.Shell)]
+	public void ContentShouldNotRenderUnderStatusBarAfterNavigatingWithKeyboardOpen()
+	{
+		// Wait for the main page to load
+		App.WaitForElement("Entry");
+
+		// Tap the Entry to open the soft keyboard
+		App.Tap("Entry");
+
+		// Enter text to ensure the IME is fully visible
+		App.EnterText("Entry", "test");
+
+		// Tap the navigate button to go to the destination page
+		App.Tap("NavigateButton");
+
+		// Wait for the destination page to load
+		App.WaitForElement("TargetLabel");
+
+		// Get the rect of the label on the destination page
+		var labelRect = App.FindElement("TargetLabel").GetRect();
+
+		// The label should be positioned below the status bar (Y > 0)
+		// If Y == 0, the content is rendering under the status bar which is the bug
+		Assert.That(labelRect.Y, Is.GreaterThan(0),
+			"TargetLabel should not be at Y=0 (would be under the status bar)");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
@@ -1,4 +1,4 @@
-#if ANDROID // This test validates Android-specific layout behavior with soft keyboard and navigation
+#if ANDROID
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -20,23 +20,23 @@ public class Issue34584 : _IssuesUITest
 		// Wait for the main page to load
 		App.WaitForElement("Entry");
 
-		// Tap the Entry to open the soft keyboard
+		// Focus Entry and open keyboard
 		App.Tap("Entry");
 
-		// Enter text to ensure the IME is fully visible
+		// Enter text to ensure IME is active
 		App.EnterText("Entry", "test");
 
-		// Tap the navigate button to go to the destination page
-		App.Tap("NavigateButton");
+		//  Trigger navigation while IME is still open
+		App.PressEnter();
 
-		// Wait for the destination page to load
+		// Wait for destination page
 		App.WaitForElement("TargetLabel");
 
-		// Get the rect of the label on the destination page
-		var labelRect = App.FindElement("TargetLabel").GetRect();
+		var label = App.FindElement("TargetLabel");
+		Assert.That(label, Is.Not.Null);
 
-		// The label should be positioned below the status bar (Y > 0)
-		// If Y == 0, the content is rendering under the status bar which is the bug
+		var labelRect = label.GetRect();
+
 		Assert.That(labelRect.Y, Is.GreaterThan(0),
 			"TargetLabel should not be at Y=0 (would be under the status bar)");
 	}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
@@ -17,28 +17,41 @@ public class Issue34584 : _IssuesUITest
 	[Category(UITestCategories.Shell)]
 	public void ContentShouldNotRenderUnderStatusBarAfterNavigatingWithKeyboardOpen()
 	{
-		// Wait for the main page to load
+		// Wait for the main page
 		App.WaitForElement("Entry");
 
-		// Focus Entry and open keyboard
+		// Open keyboard
 		App.Tap("Entry");
-
-		// Enter text to ensure IME is active
 		App.EnterText("Entry", "test");
 
-		//  Trigger navigation while IME is still open
+		// Navigate while keyboard is open
 		App.PressEnter();
 
 		// Wait for destination page
 		App.WaitForElement("TargetLabel");
 
-		var label = App.FindElement("TargetLabel");
-		Assert.That(label, Is.Not.Null);
+		// Poll for a short period to detect transient layout issues during navigation
+		bool foundInvalidPosition = false;
 
-		var labelRect = label.GetRect();
+		var start = DateTime.UtcNow;
+		var timeout = TimeSpan.FromSeconds(1);
 
-		Assert.That(labelRect.Y, Is.GreaterThan(0),
-			"TargetLabel should not be at Y=0 (would be under the status bar)");
+		while (DateTime.UtcNow - start < timeout)
+		{
+			var rect = App.FindElement("TargetLabel").GetRect();
+
+			// Small threshold to account for device differences
+			if (rect.Y < 5)
+			{
+				foundInvalidPosition = true;
+				break;
+			}
+
+			System.Threading.Thread.Sleep(50);
+		}
+
+		Assert.That(foundInvalidPosition, Is.False,
+			"TargetLabel was temporarily rendered under the status bar");
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
@@ -22,13 +22,13 @@ public class Issue34584 : _IssuesUITest
 		App.Tap("Entry");
 		App.EnterText("Entry", "test");
 
-		App.PressEnter();
+		App.Tap("NavigateButton");
 
 		App.WaitForElement("TargetLabel");
 
 		var rect = App.FindElement("TargetLabel").GetRect();
 
-		Assert.That(rect.Y, Is.GreaterThan(5),
+		Assert.That(rect.Y, Is.GreaterThan(50),
 			"TargetLabel should not render under the status bar");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34584.cs
@@ -17,41 +17,19 @@ public class Issue34584 : _IssuesUITest
 	[Category(UITestCategories.Shell)]
 	public void ContentShouldNotRenderUnderStatusBarAfterNavigatingWithKeyboardOpen()
 	{
-		// Wait for the main page
 		App.WaitForElement("Entry");
 
-		// Open keyboard
 		App.Tap("Entry");
 		App.EnterText("Entry", "test");
 
-		// Navigate while keyboard is open
 		App.PressEnter();
 
-		// Wait for destination page
 		App.WaitForElement("TargetLabel");
 
-		// Poll for a short period to detect transient layout issues during navigation
-		bool foundInvalidPosition = false;
+		var rect = App.FindElement("TargetLabel").GetRect();
 
-		var start = DateTime.UtcNow;
-		var timeout = TimeSpan.FromSeconds(1);
-
-		while (DateTime.UtcNow - start < timeout)
-		{
-			var rect = App.FindElement("TargetLabel").GetRect();
-
-			// Small threshold to account for device differences
-			if (rect.Y < 5)
-			{
-				foundInvalidPosition = true;
-				break;
-			}
-
-			System.Threading.Thread.Sleep(50);
-		}
-
-		Assert.That(foundInvalidPosition, Is.False,
-			"TargetLabel was temporarily rendered under the status bar");
+		Assert.That(rect.Y, Is.GreaterThan(5),
+			"TargetLabel should not render under the status bar");
 	}
 }
 #endif


### PR DESCRIPTION
### Description

On Android, navigating from a page with the soft keyboard (IME) open to a page with `Shell.NavBarIsVisible="False"` causes the destination page to initially render under the status bar and then jump into the correct position.

This behavior is more noticeable when the destination page performs heavier UI work, and in some cases the layout may remain incorrectly positioned.

### Root Cause

During `ShellRenderer.SwitchFragment`, the fragment transaction is committed while the IME is still visible. Android continues to report IME-related `WindowInsets`, causing the new layout to be measured with incorrect top insets.

Once the IME state stabilizes, the layout is corrected, resulting in a visible jump.

### Fix

Dismiss the soft keyboard before performing the fragment transaction:

- Detect IME visibility using `IsSoftInputShowing`
- Call `HideSoftInput()` prior to `FragmentTransaction`

This ensures that `WindowInsets` are stable before the new layout is measured.

### Result

- Eliminates layout jump when navigating with keyboard open
- Ensures correct layout positioning from initial render
- Improves Shell navigation consistency on Android

### Testing

Added a UI test (`Issue34584`) that:

- Opens the keyboard by focusing an `Entry`
- Navigates to a page with `Shell.NavBarIsVisible="False"`
- Verifies that content is laid out below the status bar (`Y > 0`)

Note: The test validates final layout correctness, not visual animation.

### Related Issues

- Fixes #34584
- Related to #34060