### PR TITLE
Add merge flow: net11.0 → next release branch

### DIFF
--- a/.github/workflows/merge-net11-to-release.yml
+++ b/.github/workflows/merge-net11-to-release.yml
@@ -1,0 +1,22 @@
+# Merge net11.0 → next release branch
+# Target branch is configured in /github-merge-flow-release-11.jsonc (MergeToBranch)
+
+name: Merge net11.0 to next release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - net11.0
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  Merge:
+    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
+    with:
+      configuration_file_path: 'github-merge-flow-release-11.jsonc'

--- a/github-merge-flow-release-11.jsonc
+++ b/github-merge-flow-release-11.jsonc
@@ -1,0 +1,10 @@
+// Update MergeToBranch when cutting a new release.
+{
+    "merge-flow-configurations": {
+        "net11.0": {
+            "MergeToBranch": "release/11.0.1xx-preview3",
+            "ExtraSwitches": "-QuietComments",
+            "ResetToTargetPaths": "global.json;NuGet.config;eng/Version.Details.xml;eng/Versions.props;eng/common/*"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds arcade inter-branch merge workflow and configuration to automate merging `net11.0` into the `release/11.0.1xx-preview3` branch.

### Files added

| File | Purpose |
|------|---------|
| `github-merge-flow-release-11.jsonc` | Merge flow config — source `net11.0`, target `release/11.0.1xx-preview3` |
| `.github/workflows/merge-net11-to-release.yml` | GitHub Actions workflow — triggers on push to net11.0, daily cron, manual dispatch |

### How it works

Uses the shared [dotnet/arcade inter-branch merge infrastructure](https://github.com/dotnet/arcade/blob/main/.github/workflows/inter-branch-merge-base.yml):
- **Event-driven**: triggers on push to `net11.0`, with daily cron safety net
- **ResetToTargetPaths**: auto-resets `global.json`, `NuGet.config`, `eng/Version.Details.xml`, `eng/Versions.props`, `eng/common/*` to target branch versions
- **QuietComments**: reduces GitHub notification noise
- Skips PRs when only Maestro bot commits exist

### Incrementing for future releases

When cutting a new release (e.g., preview4), update:
1. `github-merge-flow-release-11.jsonc` → change `MergeToBranch` value
2. `.github/workflows/merge-net11-to-release.yml` → update workflow `name` field

Follows the same pattern as `merge-main-to-net11.yml` / `github-merge-flow-net11.jsonc`.