### PR TITLE
Fix Changing Content property of ShellContent doesn't change visual content

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -44,6 +44,26 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				_createdShellContent.Remove(remove);
 		}
 
+		/// <summary>
+		/// Invalidates the cached item ID for the given <paramref name="shellContent"/> so that
+		/// existing fragment and recreate it with the updated page content.
+		/// </summary>
+		public void InvalidateShellContent(ShellContent shellContent)
+		{
+			long removeKey = -1;
+			foreach (var item in _createdShellContent)
+			{
+				if (item.Value == shellContent)
+				{
+					removeKey = item.Key;
+					break;
+				}
+			}
+
+			if (removeKey >= 0)
+				_createdShellContent.Remove(removeKey);
+		}
+
 		public int CountOverride { get; set; }
 
 		public override int ItemCount => _items.Count;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -45,8 +45,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		}
 
 		/// <summary>
-		/// Invalidates the cached item ID for the given <paramref name="shellContent"/> so that
-		/// existing fragment and recreate it with the updated page content.
+		/// Invalidates the cached item ID for the given <paramref name="shellContent"/>.
+		/// This causes the existing fragment for that item to be destroyed and a new fragment
+		/// to be created with the updated page content.
 		/// </summary>
 		internal void InvalidateShellContent(ShellContent shellContent)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		/// Invalidates the cached item ID for the given <paramref name="shellContent"/> so that
 		/// existing fragment and recreate it with the updated page content.
 		/// </summary>
-		public void InvalidateShellContent(ShellContent shellContent)
+		internal void InvalidateShellContent(ShellContent shellContent)
 		{
 			long removeKey = -1;
 			foreach (var item in _createdShellContent)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -161,6 +161,16 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				UpdateTabTitle(shellContent);
 			}
+			else if (e.PropertyName == ShellContent.ContentProperty.PropertyName && sender is ShellContent changedContent)
+			{
+				// The page inside this ShellContent changed — force ViewPager2 to recreate the
+				// fragment so it picks up the new content.
+				if (_viewPager?.Adapter is ShellFragmentStateAdapter adapter)
+				{
+					adapter.InvalidateShellContent(changedContent);
+					SafeNotifyDataSetChanged();
+				}
+			}
 		}
 
 		void UpdateTabTitle(ShellContent shellContent)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -169,6 +169,16 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					adapter.InvalidateShellContent(changedContent);
 					SafeNotifyDataSetChanged();
+
+					// Keep toolbar state in sync when the active tab's content page is replaced.
+					if (ShellSection?.CurrentItem == changedContent && _toolbarTracker is not null)
+					{
+						var page = ((IShellContentController)changedContent).GetOrCreateContent();
+						if (page is not null)
+						{
+							_toolbarTracker.Page = page;
+						}
+					}
 				}
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -554,8 +554,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (e.PropertyName == ShellContent.ContentProperty.PropertyName && sender is ShellContent shellContent)
 			{
-				// PropertyChanged fires BEFORE the BindableProperty's propertyChanged callback
-				// (OnContentChanged), so ContentCache may not be updated yet.
+				// INotifyPropertyChanged.PropertyChanged fires AFTER the BindableProperty's
+				// propertyChanged callback (OnContentChanged) in BindableObject.SetValueCore.
+				// For a Page, ContentCache is already updated by the time we get here.
 				if (shellContent.Content is Page newPage)
 				{
 					// Content is a Page — available immediately, no deferral needed.
@@ -564,8 +565,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				else if (shellContent.Content is DataTemplate)
 				{
 					// Content is a DataTemplate — ContentCache is populated by OnContentChanged,
-					// which runs after PropertyChanged completes. Defer to the next run-loop
-					// iteration so GetOrCreateContent() sees the updated ContentCache.
+					// which has already run before this PropertyChanged notification. However,
+					// defer to the next run-loop iteration to ensure any async post-processing
+					// in GetOrCreateContent() sees a fully settled ContentCache.
 					BeginInvokeOnMainThread(() =>
 					{
 						if (_isDisposed)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -101,6 +101,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			ShellSection.PropertyChanged += OnShellSectionPropertyChanged;
 			ShellSectionController.ItemsCollectionChanged += OnShellSectionItemsChanged;
 
+			foreach (var item in ShellSectionController.GetItems())
+				item.PropertyChanged += OnShellContentPropertyChanged;
+
 			_blurView = new UIView();
 			UIVisualEffect blurEffect = UIBlurEffect.FromStyle(UIBlurEffectStyle.ExtraLight);
 			_blurView = new UIVisualEffectView(blurEffect);
@@ -150,6 +153,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (ShellSectionController != null)
 				ShellSectionController.ItemsCollectionChanged -= OnShellSectionItemsChanged;
+
+			var shellContents = ShellSectionController?.GetItems();
+			if (shellContents != null)
+				foreach (var item in shellContents)
+					item.PropertyChanged -= OnShellContentPropertyChanged;
 
 			if (_shellContext?.Shell != null)
 				_shellContext.Shell.PropertyChanged -= HandleShellPropertyChanged;
@@ -500,6 +508,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				foreach (ShellContent oldItem in e.OldItems)
 				{
+					oldItem.PropertyChanged -= OnShellContentPropertyChanged;
+
 					// if current item is removed will be handled by the currentitem property changed event
 					// That way the render is swapped out cleanly once the new current item is set
 					if (_currentContent == oldItem)
@@ -524,6 +534,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				foreach (ShellContent newItem in e.NewItems)
 				{
+					newItem.PropertyChanged += OnShellContentPropertyChanged;
+
 					if (_renderers.ContainsKey(newItem))
 						continue;
 
@@ -532,6 +544,73 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 					AddChildViewController(renderer.ViewController);
 				}
+			}
+		}
+
+		void OnShellContentPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (_isDisposed)
+				return;
+
+			if (e.PropertyName == ShellContent.ContentProperty.PropertyName && sender is ShellContent shellContent)
+			{
+				// PropertyChanged fires BEFORE the BindableProperty's propertyChanged callback
+				// (OnContentChanged), so ContentCache may not be updated yet.
+				if (shellContent.Content is Page newPage)
+				{
+					// Content is a Page — available immediately, no deferral needed.
+					UpdateRendererForShellContent(shellContent, newPage);
+				}
+				else if (shellContent.Content is DataTemplate)
+				{
+					// Content is a DataTemplate — ContentCache is populated by OnContentChanged,
+					// which runs after PropertyChanged completes. Defer to the next run-loop
+					// iteration so GetOrCreateContent() sees the updated ContentCache.
+					BeginInvokeOnMainThread(() =>
+					{
+						if (_isDisposed)
+							return;
+						var page = ((IShellContentController)shellContent).GetOrCreateContent();
+						UpdateRendererForShellContent(shellContent, page);
+					});
+				}
+			}
+		}
+
+		void UpdateRendererForShellContent(ShellContent shellContent, Page newPage)
+		{
+			if (newPage == null)
+				return;
+
+			if (!_renderers.TryGetValue(shellContent, out var oldRenderer))
+				return;
+
+			// If the existing renderer is already showing the new page, nothing to do.
+			if (oldRenderer.VirtualView == newPage)
+				return;
+
+			bool isCurrentContent = shellContent == _currentContent;
+
+			// Remove the old renderer
+			if (isCurrentContent)
+				oldRenderer.ViewController?.ViewIfLoaded?.RemoveFromSuperview();
+
+			oldRenderer.ViewController?.RemoveFromParentViewController();
+			oldRenderer.DisconnectHandler();
+			_renderers.Remove(shellContent);
+
+			// Create a new renderer for the updated page
+			var renderer = SetPageRenderer(newPage, shellContent);
+			AddChildViewController(renderer.ViewController);
+
+			if (isCurrentContent)
+			{
+				_containerArea.AddSubview(renderer.ViewController.View);
+				renderer.ViewController.View.Frame = _containerArea.Bounds;
+				UpdateAdditionalSafeAreaInsets(renderer);
+
+				if (_tracker != null)
+					_tracker.Page = newPage;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -103,9 +103,9 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		// Called when ShellSection.DisplayedPage changes — covers both content changes and
 		// navigation pushes. We only act on content changes (stack depth == 1, no pending nav).
-		void OnDisplayedPageChanged(Page? page)
+		void OnDisplayedPageChanged(Page page)
 		{
-			if (page is null || VirtualView is null)
+			if (VirtualView is null)
 				return;
 
 			// Push/pop navigation is handled by OnNavigationRequested; skip those cases.

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Maui.Controls.Handlers
 		{
 			if (_shellSection != null)
 			{
+				((IShellSectionController)_shellSection).RemoveDisplayedPageObserver(this);
 				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
 
 				((IShellSectionController)_shellSection).ItemsCollectionChanged -= OnItemsCollectionChanged;
@@ -84,7 +85,6 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_shellSection != null)
 			{
 				((IShellSectionController)_shellSection).NavigationRequested += OnNavigationRequested;
-
 				((IShellSectionController)_shellSection).ItemsCollectionChanged += OnItemsCollectionChanged;
 
 				var shell = _shellSection.FindParentOfType<Shell>() as IShellController;
@@ -93,7 +93,34 @@ namespace Microsoft.Maui.Controls.Handlers
 					_lastShell = new WeakReference(shell);
 					shell.AddAppearanceObserver(this, _shellSection);
 				}
+
+				// AddDisplayedPageObserver immediately invokes the callback with the current page,
+				// but at that point PendingNavigationTask is already set from MapCurrentItem
+				// (which runs via base.SetVirtualView above), so it is safely skipped.
+				((IShellSectionController)_shellSection).AddDisplayedPageObserver(this, OnDisplayedPageChanged);
 			}
+		}
+
+		// Called when ShellSection.DisplayedPage changes — covers both content changes and
+		// navigation pushes. We only act on content changes (stack depth == 1, no pending nav).
+		void OnDisplayedPageChanged(Page? page)
+		{
+			if (page is null || VirtualView is null)
+				return;
+
+			// Push/pop navigation is handled by OnNavigationRequested; skip those cases.
+			if (VirtualView.Stack.Count > 1)
+				return;
+
+			// Tab switches are handled by MapCurrentItem which sets PendingNavigationTask first
+			// (because the property mapper fires before the propertyChanged callback that calls
+			// UpdateDisplayedPage). Skip when another navigation is already in flight.
+			if (VirtualView.PendingNavigationTask != null)
+				return;
+
+			// ContentCache has been updated by OnContentChanged at this point, so
+			// SyncNavigationStack will correctly pick up the new page via GetOrCreateContent().
+			SyncNavigationStack(false, null);
 		}
 
 		void OnNavigationRequested(object? sender, NavigationRequestedEventArgs e)
@@ -159,6 +186,9 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		protected override void DisconnectHandler(WFrame platformView)
 		{
+			if (_shellSection != null)
+				((IShellSectionController)_shellSection).RemoveDisplayedPageObserver(this);
+
 			_navigationManager?.Disconnect(VirtualView, platformView);
 			base.DisconnectHandler(platformView);
 		}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue12669.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue12669.cs
@@ -1,0 +1,61 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 12669, "Changing Content property of ShellContent doesn't change visual content", PlatformAffected.All)]
+public class Issue12669 : TestShell
+{
+	protected override void Init()
+	{
+		FlyoutBehavior = FlyoutBehavior.Disabled;
+
+		var shellContent = new ShellContent { Title = "Test" };
+
+		var changeButton = new Button
+		{
+			Text = "Change Content",
+			AutomationId = "ChangeContentButton"
+		};
+
+		shellContent.Content = new ContentPage
+		{
+			Content = new VerticalStackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Label
+					{
+						Text = "Original Content",
+						AutomationId = "OriginalContent"
+					},
+					changeButton
+				}
+			}
+		};
+
+		changeButton.Clicked += (s, e) =>
+		{
+			shellContent.ContentTemplate = null;
+			shellContent.Content = new ContentPage
+			{
+				Content = new VerticalStackLayout
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Children =
+					{
+						new Label
+						{
+							Text = "Content Changed",
+							AutomationId = "NewContent"
+						}
+					}
+				}
+			};
+		};
+
+		var tab = new Tab { Title = "Main" };
+		tab.Items.Add(shellContent);
+		Items.Add(tab);
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12669.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue12669.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+public class Issue12669 : _IssuesUITest
+{
+    public Issue12669(TestDevice device) : base(device) { }
+
+    public override string Issue => "Changing Content property of ShellContent doesn't change visual content";
+
+    [Test]
+    [Category(UITestCategories.Shell)]
+    public void ShellContentShouldUpdateWhenContentPropertyChanges()
+    {
+        App.WaitForElement("OriginalContent");
+        App.WaitForElement("ChangeContentButton");
+
+        App.Tap("ChangeContentButton");
+
+        // After clicking, the ShellContent.Content is changed to a new page.
+        // The visual should update to show the new content.
+        App.WaitForElement("NewContent");
+        var labelText = App.FindElement("NewContent").GetText();
+        Assert.That(labelText, Is.EqualTo("Content Changed"));
+    }
+}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
When dynamically change ShellContent.Content  at runtime, the Shell UI doesn't update — the old page stays visible on all three platforms.

### Description of Change

<!-- Enter description of the fix in this section -->
Android:
When ShellContent.Content changes, force ViewPager2 to destroy and recreate the fragment so the new page is displayed.
 
iOS:
Subscribe to each ShellContent.PropertyChanged. When Content changes, tear down the old page renderer and create a new one in its place.
 
Windows:
Watch ShellSection.DisplayedPage via AddDisplayedPageObserver. When it changes due to a content swap, call SyncNavigationStack to reload the frame with the new page.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #12669 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac

| Before  | After  |
|---------|--------|
| **Android**<br> <video src="https://github.com/user-attachments/assets/75769889-41e9-43c1-82b9-75228a8e89c6" width="300" height="600"> | **Android**<br> <video src="https://github.com/user-attachments/assets/5b7809ce-4eda-4d6e-99b6-0a994ca9ad88" width="300" height="600"> |


