### PR TITLE
 [iOS] Fix span Tap gesture on wrapped Label lines in iOS 26+

### DIFF
--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using CoreFoundation;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using UIKit;
@@ -12,7 +13,21 @@ namespace Microsoft.Maui.Controls
 		{
 			var size = base.ArrangeOverride(bounds);
 
-			RecalculateSpanPositions(size);
+			// On iOS 26+ with NavigationPage, the UILabel's native Bounds may not be
+			// finalized during MAUI's ArrangeOverride due to the WrapperView layout
+			// timing. Detect this by checking if the UILabel Bounds are unset despite
+			// a valid MAUI-computed size, and defer span recalculation to the next main
+			// run loop iteration when iOS has propagated the frame correctly.
+			if (OperatingSystem.IsIOSVersionAtLeast(26) && HasFormattedTextSpans && Handler is LabelHandler labelHandler &&
+				labelHandler.PlatformView is UILabel platformLabel &&
+				platformLabel.Bounds.Width == 0 && size.Width > 0)
+			{
+				platformLabel.BeginInvokeOnMainThread(() => RecalculateSpanPositions(size));
+			}
+			else
+			{
+				RecalculateSpanPositions(size);
+			}
 
 			return size;
 		}

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -12,28 +12,7 @@ namespace Microsoft.Maui.Controls
 		{
 			var size = base.ArrangeOverride(bounds);
 
-			// On iOS 26+ with NavigationPage, the UILabel's native Bounds may not be
-			// finalized during MAUI's ArrangeOverride due to the WrapperView layout
-			// timing. Detect this by checking if the UILabel Bounds are unset despite
-			// a valid MAUI-computed size, and defer span recalculation to the next main
-			// run loop iteration when iOS has propagated the frame correctly.
-			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26)) && HasFormattedTextSpans && Handler is LabelHandler labelHandler &&
-				labelHandler.PlatformView is UILabel platformLabel &&
-				platformLabel.Bounds.Width == 0 && size.Width > 0)
-			{
-				platformLabel.BeginInvokeOnMainThread(() =>
-				{
-					var bounds = platformLabel.Bounds;
-					if (bounds.Width > 0 && bounds.Height > 0)
-					{
-						RecalculateSpanPositions(new Size(bounds.Width, bounds.Height));
-					}
-				});
-			}
-			else
-			{
-				RecalculateSpanPositions(size);
-			}
+			RecalculateSpanPositions(size);
 
 			return size;
 		}

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -1,6 +1,5 @@
 #nullable disable
 using System;
-using CoreFoundation;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using UIKit;
@@ -22,7 +21,14 @@ namespace Microsoft.Maui.Controls
 				labelHandler.PlatformView is UILabel platformLabel &&
 				platformLabel.Bounds.Width == 0 && size.Width > 0)
 			{
-				platformLabel.BeginInvokeOnMainThread(() => RecalculateSpanPositions(size));
+				platformLabel.BeginInvokeOnMainThread(() =>
+				{
+					var bounds = platformLabel.Bounds;
+					if (bounds.Width > 0 && bounds.Height > 0)
+					{
+						RecalculateSpanPositions(new Size(bounds.Width, bounds.Height));
+					}
+				});
 			}
 			else
 			{

--- a/src/Controls/src/Core/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/Label/Label.iOS.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 			// timing. Detect this by checking if the UILabel Bounds are unset despite
 			// a valid MAUI-computed size, and defer span recalculation to the next main
 			// run loop iteration when iOS has propagated the frame correctly.
-			if (OperatingSystem.IsIOSVersionAtLeast(26) && HasFormattedTextSpans && Handler is LabelHandler labelHandler &&
+			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26)) && HasFormattedTextSpans && Handler is LabelHandler labelHandler &&
 				labelHandler.PlatformView is UILabel platformLabel &&
 				platformLabel.Bounds.Width == 0 && size.Width > 0)
 			{

--- a/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/FormattedStringExtensions.cs
@@ -177,8 +177,11 @@ namespace Microsoft.Maui.Controls.Platform
 			textStorage.AddLayoutManager(layoutManager);
 			layoutManager.AddTextContainer(textContainer);
 
-			textContainer.Size = new(control.Bounds.Width,
-				control.Lines == 0 ? nfloat.MaxValue : control.Bounds.Height);
+			// On iOS 26+ with NavigationPage, UILabel.Bounds may still be {0,0,0,0}
+			// during ArrangeOverride. Use finalSize (MAUI's computed size) as fallback.
+			var containerWidth = control.Bounds.Width > 0 ? control.Bounds.Width : (nfloat)finalSize.Width;
+			var containerHeight = control.Bounds.Height > 0 ? control.Bounds.Height : (nfloat)finalSize.Height;
+			textContainer.Size = new(containerWidth, control.Lines == 0 ? nfloat.MaxValue : containerHeight);
 
 			textStorage.SetString(attributedText);
 			layoutManager.EnsureLayoutForTextContainer(textContainer);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34504.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34504.cs
@@ -1,0 +1,140 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34504, "[iOS] Span TapGestureRecognizer does not work on the second line of the span, if the span is wrapped to the next line", PlatformAffected.iOS)]
+public class Issue34504 : NavigationPage
+{
+	public Issue34504() : base(new FirstPage()) { }
+
+	// First page mirrors the sandbox MainPage — has the same span content so
+	// the layout system is exercised before navigating to the second page.
+	class FirstPage : ContentPage
+	{
+		public FirstPage()
+		{
+			void OnSpanTapped(object sender, TappedEventArgs e)
+			{
+				// no-op — first page just needs spans to exist
+			}
+
+			var label = BuildSpanLabel(OnSpanTapped);
+
+			var navigateButton = new Button
+			{
+				Text = "Navigate to Test Page",
+				AutomationId = "NavigateButton",
+				HorizontalOptions = LayoutOptions.Fill,
+			};
+			navigateButton.Clicked += async (s, e) =>
+				await Navigation.PushAsync(new SecondPage());
+
+			Content = new VerticalStackLayout
+			{
+				Padding = new Thickness(30, 0),
+				Spacing = 25,
+				Children =
+				{
+					new Label
+					{
+						Text = "Click the button below to navigate to the test page with wrapped span gestures.",
+						FontSize = 14,
+						TextColor = Colors.Gray,
+					},
+					navigateButton,
+					new Border
+					{
+						StrokeThickness = 2,
+						Stroke = Colors.Black,
+						Padding = new Thickness(10),
+						Content = label,
+					},
+				}
+			};
+		}
+	}
+
+	// Second page mirrors the sandbox TestPage — this is where the bug manifests on iOS 26+.
+	public class SecondPage : ContentPage
+	{
+		public SecondPage()
+		{
+			var statusLabel = new Label
+			{
+				AutomationId = "StatusLabel",
+				Text = "Tap status will appear here",
+				FontSize = 14,
+				TextColor = Colors.Black,
+			};
+
+			void OnSpanTapped(object sender, TappedEventArgs e)
+			{
+				statusLabel.Text = "Success";
+			}
+
+			var spanLabel = BuildSpanLabel(OnSpanTapped);
+			spanLabel.AutomationId = "SpanLabel";
+
+			Content = new ScrollView
+			{
+				Content = new VerticalStackLayout
+				{
+					Padding = new Thickness(30, 0),
+					Spacing = 25,
+					Children =
+					{
+						new Label
+						{
+							Text = "iOS TapGesture Issue Demonstration",
+							FontSize = 18,
+							FontAttributes = FontAttributes.Bold,
+						},
+						new Label
+						{
+							Text = "Tap on the colored text below. On iOS, gestures on wrapped lines may not work.",
+							FontSize = 12,
+							TextColor = Colors.Gray,
+						},
+						new Border
+						{
+							StrokeThickness = 2,
+							Stroke = Colors.Black,
+							Padding = new Thickness(10),
+							Content = spanLabel,
+						},
+						statusLabel,
+					}
+				}
+			};
+		}
+	}
+
+	static Label BuildSpanLabel(EventHandler<TappedEventArgs> onTapped)
+	{
+		Span MakeSpan(string text, Color color)
+		{
+			var span = new Span
+			{
+				Text = text,
+				TextColor = color,
+				TextDecorations = TextDecorations.Underline,
+			};
+			var tap = new TapGestureRecognizer();
+			tap.Tapped += onTapped;
+			span.GestureRecognizers.Add(tap);
+			return span;
+		}
+
+		var fs = new FormattedString();
+		fs.Spans.Add(MakeSpan("Hello,This is a test. Hello,This is a test. Hello,This is a test.", Colors.Blue));
+		fs.Spans.Add(MakeSpan("Hello,This is a test1. Hello,This is a test1. Hello,This is a test1.", Colors.Red));
+		fs.Spans.Add(MakeSpan("Hello,This is a test2. Hello,This is a test2. Hello,This is a test2.", Colors.Green));
+		fs.Spans.Add(MakeSpan("Hello,This is a test4. Hello,This is a test4. Hello,This is a test4.", Colors.Orange));
+		fs.Spans.Add(MakeSpan("Hello,This is a test3. Hello,This is a test3. Hello,This is a test3.", Colors.Purple));
+		fs.Spans.Add(new Span { Text = " World!", FontAttributes = FontAttributes.Bold });
+
+		return new Label
+		{
+			FormattedText = fs,
+			BackgroundColor = Colors.Transparent,
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34504.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34504.cs
@@ -135,6 +135,8 @@ public class Issue34504 : NavigationPage
 		{
 			FormattedText = fs,
 			BackgroundColor = Colors.Transparent,
+			LineBreakMode = LineBreakMode.WordWrap,
+			MaximumWidthRequest = 300,
 		};
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34504.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34504.cs
@@ -29,6 +29,6 @@ public class Issue34504 : _IssuesUITest
 		// Tap near the bottom of the label to hit the second wrapped line of a span.
 		App.TapCoordinates(labelRect.X + labelRect.Width / 2, labelRect.Y + labelRect.Height * 0.75f);
 
-		App.WaitForElement("Success");
+		Assert.That(App.WaitForElement("StatusLabel").GetText(), Is.EqualTo("Success"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34504.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34504.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34504 : _IssuesUITest
+{
+	public Issue34504(TestDevice device) : base(device) { }
+
+	public override string Issue => "[iOS] Span TapGestureRecognizer does not work on the second line of the span, if the span is wrapped to the next line";
+
+	[Test]
+	[Category(UITestCategories.Label)]
+	// The bug only manifests on iOS 26+ (not Android / Windows / MacCatalyst),
+	// but the test is safe to run on all platforms — it will simply pass on unaffected ones.
+	public void SpanTapGestureOnSecondLineShouldWork()
+	{
+		// Navigate to the second page — the bug only reproduces on a pushed page.
+		App.WaitForElement("NavigateButton");
+		App.Tap("NavigateButton");
+
+		var labelRect = App.WaitForElement("SpanLabel").GetRect();
+
+		// Tap near the bottom of the label to hit the second wrapped line of a span.
+		App.TapCoordinates(labelRect.X + labelRect.Width / 2, labelRect.Y + labelRect.Height * 0.75f);
+
+		App.WaitForElement("Success");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34504.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34504.cs
@@ -22,6 +22,10 @@ public class Issue34504 : _IssuesUITest
 
 		var labelRect = App.WaitForElement("SpanLabel").GetRect();
 
+		// Ensure the label wrapped to multiple lines; if it's single-line the tap
+		// cannot exercise the second-line bug and the test would be a false-positive.
+		Assert.That(labelRect.Height, Is.GreaterThan(40), "SpanLabel must be tall enough to indicate multi-line text before tapping the second line.");
+
 		// Tap near the bottom of the label to hit the second wrapped line of a span.
 		App.TapCoordinates(labelRect.X + labelRect.Width / 2, labelRect.Y + labelRect.Height * 0.75f);
 


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause : 
On iOS 26+, UILabel layout isn’t finalized when span positions are calculated, so gesture hit areas are computed too early—leading to incorrect tap detection, especially for wrapped lines after navigation.
### Description of Change :

* Updated `Label.iOS.cs` to detect when the native `UILabel` bounds are not yet finalized during `ArrangeOverride` (on iOS/MacCatalyst 26+), and defer span position recalculation to the next main run loop iteration to ensure correct gesture hit-testing. [[1]](diffhunk://#diff-e20a5ee07fd9f73c1fb4fdc9c4f204ecbc3a5ec8ed654ed1f32c4f0f5265fcbdR3) [[2]](diffhunk://#diff-e20a5ee07fd9f73c1fb4fdc9c4f204ecbc3a5ec8ed654ed1f32c4f0f5265fcbdR16-R30)

**Testing and Reproduction:**

* Added a new issue reproduction page (`Issue34504`) to the test cases app, which sets up navigation and span labels to exercise the layout and gesture recognition scenario.
* Introduced an automated UI test (`Issue34504.cs` in shared tests) that navigates to the test page and verifies that tapping on a wrapped span line successfully triggers the gesture.



<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34504 

### Tested the behavior in the following platforms

- [x] Windows
- [x] Android
- [x] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/890f0df0-9d5d-4f94-98ec-eab209388368">  | <video src="https://github.com/user-attachments/assets/2f88bb03-bd48-422d-862b-ab30d79d7ec4"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
