### PR TITLE
Fix CI failures for Convert and ConvertIsCultureAware tests

### DIFF
--- a/src/Controls/src/Core/BindingExpressionHelper.cs
+++ b/src/Controls/src/Core/BindingExpressionHelper.cs
@@ -38,7 +38,11 @@ namespace Microsoft.Maui.Controls
 				}
 
 				// do not canonicalize "-0"; user will likely enter a period after "-0"
-				if ((stringValue.StartsWith("0") || stringValue.StartsWith("-0")) && DecimalTypes.Contains(convertTo))
+				// Only block when the string starts with "-0" and parses to exactly zero
+				// (e.g. "-0", "-0.0"), so that valid values like "0.5" or "-0.5" still convert.
+				if (stringValue.StartsWith("-0") && DecimalTypes.Contains(convertTo)
+				 && double.TryParse(stringValue, System.Globalization.NumberStyles.Any, CultureInfo.CurrentCulture, out var parsedNegZero)
+				 && parsedNegZero == 0.0)
 				{
 					value = original;
 					return false;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Detail
The fix for #30181 (PR #30540) introduced a regression where valid numeric strings starting with "0" — such as "0.5" (en-US) and "0,5" (pt-PT) — were incorrectly blocked from converting to double in BindingExpressionHelper.TryConvert. This caused Slider.Value to remain at its default 0.0 instead of the expected bound value.

### Root Cause
PR #30540 added StartsWith("0") to the conversion guard:
StartsWith("0") matched any string beginning with 0, including valid complete values like "0.5" and "0,5", blocking their conversion entirely.

### Description of Change
Narrowed the guard to only block "-0..." strings that parse to exactly 0.0 — the genuine negative-zero intermediate typing state (e.g., -0, -0.0):
This preserves the fix for #30181 while allowing valid complete values to convert normally.

### Test Fixed:

- ConvertIsCultureAware 
- Convert