### PR TITLE
Fix CI failure [WebView] FlowDirection is set correctly(flowDirection: RightToLeft) device tests

### DIFF
--- a/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/HybridWebView/HybridWebViewHandler.iOS.cs
@@ -79,6 +79,10 @@ namespace Microsoft.Maui.Handlers
 
 		internal static void MapFlowDirection(IHybridWebViewHandler handler, IHybridWebView hybridWebView)
 		{
+			// Update the WKWebView itself so SemanticContentAttribute is set correctly
+			handler.PlatformView?.UpdateFlowDirection(hybridWebView);
+
+			// Also update the internal ScrollView so the scrollbar aligns with the flow direction
 			var scrollView = handler.PlatformView?.ScrollView;
 			if (scrollView == null)
 				return;

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Maui.Handlers
 
 		internal static void MapFlowDirection(IWebViewHandler handler, IWebView webView)
 		{
+			// Update the WKWebView itself so SemanticContentAttribute is set correctly
+			handler.PlatformView?.UpdateFlowDirection(webView);
+
+			// Also update the internal ScrollView so the scrollbar aligns with the flow direction
 			var scrollView = handler.PlatformView?.ScrollView;
 			if (scrollView == null)
 				return;


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
This PR #30653 causes [WebView] FlowDirection is set correctly(flowDirection: RightToLeft) device tests was failed.


### Description of Change

<!-- Enter description of the fix in this section -->
The root cause is that MapFlowDirection only updated the internal UIScrollView of WKWebView, but not the WKWebView itself. Since the test reads SemanticContentAttribute directly from the WKWebView platform view, it always returned LeftToRight regardless of the set value. So updated the WebView FlowDirection as well.

### Test fixed
* [WebView] FlowDirection is set correctly(flowDirection: RightToLeft)