### PR TITLE
Fix CI failure for NavBarIsVisibleUpdates unit test

### DIFF
--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Maui.Controls
 			if (property == Shell.NavBarIsVisibleProperty)
 			{
 				var shell = me.FindParentOfType<Shell>();
-				if (shell is not null && shell.IsSet(property) && !me.IsSet(property))
+				if (shell is not null && shell.IsSet(property))
 				{
 					// Get the value from the Shell directly
 					me.SetValue(property, shell.GetValue(property));

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -89,10 +89,42 @@ namespace Microsoft.Maui.Controls
 				// Notify about the property change
 				shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
 				
-				// Explicitly propagate the property change to all children
+				if (shell == null)
+				return;
+
+			shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
+
+			if (bindable.IsSet(NavBarIsVisibleProperty))
+			{
+				// Value explicitly set — propagate down so iOS/Mac compatibility renderers
+				// (which call Shell.GetNavBarIsVisible(page) directly) also see the change.
 				if (shell is IPropertyPropagationController controller)
-				{
 					controller.PropagatePropertyChanged(NavBarIsVisibleProperty.PropertyName);
+			}
+			else
+			{
+				// Value was cleared — also clear the propagated copies from visual children
+				// so GetEffectiveValue and platform handlers reflect the reverted state.
+				if (bindable is IVisualTreeElement element)
+					ClearPropagatedNavBarIsVisible(element, (bool)oldValue);
+			}
+		}
+
+		static void ClearPropagatedNavBarIsVisible(IVisualTreeElement element, bool propagatedValue)
+		{
+			foreach (var child in element.GetVisualChildren())
+			{
+				if (child is BindableObject bo
+					&& bo.IsSet(NavBarIsVisibleProperty)
+					&& (bool)bo.GetValue(NavBarIsVisibleProperty) == propagatedValue)
+				{
+					// ClearValue fires OnNavBarIsVisibleChanged on the child, which
+					// recursively clears further down the tree automatically.
+					bo.ClearValue(NavBarIsVisibleProperty);
+				}
+				else if (child is IVisualTreeElement childElement)
+				{
+					ClearPropagatedNavBarIsVisible(childElement, propagatedValue);
 				}
 			}
 		}

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -90,23 +90,30 @@ namespace Microsoft.Maui.Controls
 				shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
 				
 				if (shell == null)
-				return;
+				{
+					return;
+				}
 
-			shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
+				shell.OnPropertyChanged(NavBarIsVisibleProperty.PropertyName);
 
-			if (bindable.IsSet(NavBarIsVisibleProperty))
-			{
-				// Value explicitly set — propagate down so iOS/Mac compatibility renderers
-				// (which call Shell.GetNavBarIsVisible(page) directly) also see the change.
-				if (shell is IPropertyPropagationController controller)
-					controller.PropagatePropertyChanged(NavBarIsVisibleProperty.PropertyName);
-			}
-			else
-			{
-				// Value was cleared — also clear the propagated copies from visual children
-				// so GetEffectiveValue and platform handlers reflect the reverted state.
-				if (bindable is IVisualTreeElement element)
-					ClearPropagatedNavBarIsVisible(element, (bool)oldValue);
+				if (bindable.IsSet(NavBarIsVisibleProperty))
+				{
+					// Value explicitly set — propagate down so iOS/Mac compatibility renderers
+					// (which call Shell.GetNavBarIsVisible(page) directly) also see the change.
+					if (shell is IPropertyPropagationController controller)
+					{
+						controller.PropagatePropertyChanged(NavBarIsVisibleProperty.PropertyName);
+					}
+				}
+				else
+				{
+					// Value was cleared — also clear the propagated copies from visual children
+					// so GetEffectiveValue and platform handlers reflect the reverted state.
+					if (bindable is IVisualTreeElement element)
+					{
+						ClearPropagatedNavBarIsVisible(element, (bool)oldValue);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue Details:
This PR  #30339 caused the NavBarIsVisibleUpdates unit test to fail.

### Description of Changes:
In the test case, the NavBarIsVisible property value was cleared, but that scenario was not handled in the PR #30339 . I have updated the fix to address this case. With the current changes, both the test failure and the original issue are resolved.

### Test fixed 
* NavBarIsVisibleUpdates
