### PR TITLE
[net11] Fix internal pipeline: remove deleted SDLValidationParameters

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -125,6 +125,3 @@ extends:
         - Pack
         publishDependsOn:
         - Validate
-        # This is to enable SDL runs part of Post-Build Validation Stage
-        SDLValidationParameters:
-          enable: false


### PR DESCRIPTION
## Problem

The Arcade SDK update to `11.0.0-beta.26166.111` (PR #34314) removed the `SDLValidationParameters` parameter from `eng/common/core-templates/post-build/post-build.yml`, but `ci-official.yml` still passed it.

Azure DevOps rejects undeclared template parameters during YAML expansion, causing **every `net11.0` internal build to fail instantly** (0s duration, no stages/timeline) since March 18.

**15+ consecutive builds affected**, including scheduled daily builds and CI-triggered builds.

## Fix

Remove the `SDLValidationParameters` block from `eng/pipelines/ci-official.yml` — it references a parameter that no longer exists in the post-build template.

## Verification

- Confirmed `main` branch still has the parameter in its Arcade SDK (`10.0.0-beta.25555.106`) — only `net11.0` is affected
- Confirmed the parameter was removed in the Arcade SDK diff (`11.0.0-beta.26166.111`)
- Validated on dnceng internal pipeline that the fix allows YAML expansion to succeed