### PR TITLE
Fixed CI failure : Restore BackButtonBehavior IsEnabled after CanExecute changes

### DIFF
--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -62,13 +62,22 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IconOverrideProperty, value); }
 		}
 
+		// Tracks the value explicitly set by the user (default matches IsEnabledProperty default of true).
+		bool _userDefinedIsEnabled = true;
+		// Tracks the enabled state derived from the command's CanExecute result.
+		bool _commandEnabled = true;
+
 		/// <summary>
 		/// Gets or sets a value indicating whether the back button is enabled. This is a bindable property.
 		/// </summary>
 		public bool IsEnabled
 		{
 			get { return (bool)GetValue(IsEnabledProperty); }
-			set { SetValue(IsEnabledProperty, value); }
+			set
+			{
+				_userDefinedIsEnabled = value;
+				SetValue(IsEnabledProperty, _userDefinedIsEnabled && _commandEnabled);
+			}
 		}
 
 		/// <summary>
@@ -89,7 +98,14 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(TextOverrideProperty, value); }
 		}
 
-		bool IsEnabledCore { set => SetValue(IsEnabledProperty, value && IsEnabled); }
+		bool IsEnabledCore
+		{
+			set
+			{
+				_commandEnabled = value;
+				SetValue(IsEnabledProperty, _userDefinedIsEnabled && value);
+			}
+		}
 
 		static void OnCommandChanged(BindableObject bindable, object oldValue, object newValue)
 		{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue details
This PR #28734 causes the unit test below

1. BackButtonUpdatesWhenSetToNewCommand
2. BackButtonDisabledWhenCommandDisabled

### Description of Change

The root cause is [IsEnabledCore { set => SetValue(IsEnabledProperty, value && IsEnabled); }](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — a circular read: once [IsEnabledProperty](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is false, reading [IsEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) always returns false, so the property is permanently stuck.

The fix introduces two backing fields to track the concerns independently:

- [_userDefinedIsEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — written only by the developer via [IsEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [_commandEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — written only by [CanExecute](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) via [IsEnabledCore](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [IsEnabledProperty](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is always [_userDefinedIsEnabled && _commandEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), eliminating the circular read.

- BackButtonDisabledWhenCommandDisabled — When [CanExecute](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) flips to true and [ChangeCanExecute()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is called, [_commandEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) updates correctly and the back button re-enables.

- BackButtonUpdatesWhenSetToNewCommand — Setting [Command = null](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) resets [_commandEnabled = true](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), so the back button re-enables as expected.


### Test fixed
Unit tests:
BackButtonUpdatesWhenSetToNewCommand
BackButtonDisabledWhenCommandDisabled