### PR TITLE
[iOS] Preserve ScrollView offsets when Orientation changes to Neither

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34583.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Maui.Controls.Sample.Issues;
 
 [Issue(IssueTracker.Github, 34583, "ScrollView orientation change resets scroll position on iOS", PlatformAffected.iOS)]
@@ -255,7 +257,7 @@ public class Issue34583 : ContentPage
 	{
 		_lastAction = action ?? string.Empty;
 		_orientationLabel.Text = $"Orientation: {_bugScrollView.Orientation}";
-		_offsetLabel.Text = $"ScrollX: {_bugScrollView.ScrollX:0.##} | ScrollY: {_bugScrollView.ScrollY:0.##}";
+		_offsetLabel.Text = $"ScrollX: {_bugScrollView.ScrollX.ToString("0.##", CultureInfo.InvariantCulture)} | ScrollY: {_bugScrollView.ScrollY.ToString("0.##", CultureInfo.InvariantCulture)}";
 		_lastActionLabel.Text = $"Action: {_lastAction}";
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34583.cs
@@ -1,0 +1,285 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34583, "ScrollView orientation change resets scroll position on iOS", PlatformAffected.iOS)]
+public class Issue34583 : ContentPage
+{
+	private const double ReproScrollX = 700;
+	private const double ReproScrollY = 480;
+	private readonly Label _orientationLabel;
+	private readonly Label _offsetLabel;
+	private readonly Label _lastActionLabel;
+	private readonly ScrollView _bugScrollView;
+	private string _lastAction = string.Empty;
+
+	public Issue34583()
+	{
+		Title = "ScrollView Orientation Repro";
+
+		_orientationLabel = new Label
+		{
+			AutomationId = "OrientationLabel",
+			Text = "Orientation: Both"
+		};
+
+		_offsetLabel = new Label
+		{
+			AutomationId = "OffsetLabel",
+			Text = "ScrollX: 0 | ScrollY: 0"
+		};
+
+		_lastActionLabel = new Label
+		{
+			AutomationId = "LastActionLabel",
+			Text = "Action: launch the app and tap 'Scroll To Repro Offset'."
+		};
+
+		_bugScrollView = new ScrollView
+		{
+			AutomationId = "BugScrollView",
+			Orientation = ScrollOrientation.Both,
+			Content = CreateScrollContent()
+		};
+		_bugScrollView.Scrolled += OnScrollViewScrolled;
+
+		Content = new Grid
+		{
+			Padding = 16,
+			RowSpacing = 12,
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star)
+			},
+			Children =
+			{
+				new Label
+				{
+					Text = "Repro for dotnet/maui#34583: scroll away from the origin, then set Orientation to Neither. On iOS, ScrollX and ScrollY reset to 0 instead of being preserved.",
+					LineBreakMode = LineBreakMode.WordWrap
+				}.Row(0),
+				new VerticalStackLayout
+				{
+					Spacing = 6,
+					Children =
+					{
+						new HorizontalStackLayout
+						{
+							Spacing = 8,
+							Children =
+							{
+								new Button
+								{
+									Text = "Scroll To Repro Offset",
+									AutomationId = "ScrollToReproOffsetButton"
+								}.Assign(out var scrollToReproOffsetButton),
+								new Button
+								{
+									Text = "Set Both",
+									AutomationId = "SetBothButton"
+								}.Assign(out var setBothButton),
+								new Button
+								{
+									Text = "Set Neither",
+									AutomationId = "SetNeitherButton"
+								}.Assign(out var setNeitherButton),
+								new Button
+								{
+									Text = "Reset",
+									AutomationId = "ResetButton"
+								}.Assign(out var resetButton),
+							}
+						},
+						_orientationLabel,
+						_offsetLabel,
+						_lastActionLabel
+					}
+				}.Row(1),
+				new Border
+				{
+					StrokeThickness = 1,
+					Stroke = Color.FromArgb("#A0A0A0"),
+					Padding = 10,
+					Background = Color.FromArgb("#F7F7F7"),
+					Content = new Label
+					{
+						Text = "Expected: changing to Neither should preserve the current scroll position. Actual bug: the offset snaps back to the origin."
+					}
+				}.Row(2),
+				new Border
+				{
+					StrokeThickness = 1,
+					Stroke = Color.FromArgb("#202020"),
+					Background = Color.FromArgb("#FFFFFF"),
+					HeightRequest = 360,
+					Content = _bugScrollView
+				}.Row(3)
+			}
+		};
+
+		scrollToReproOffsetButton.Clicked += OnScrollToSampleClicked;
+		setBothButton.Clicked += OnSetBothClicked;
+		setNeitherButton.Clicked += OnSetNeitherClicked;
+		resetButton.Clicked += OnResetClicked;
+
+		RefreshState("Launch the app, tap 'Scroll To Repro Offset', then tap 'Set Neither'.");
+	}
+
+	private Grid CreateScrollContent()
+	{
+		return new Grid
+		{
+			WidthRequest = 1400,
+			HeightRequest = 1100,
+			Background = Color.FromArgb("#FFF8E7"),
+			RowDefinitions =
+			{
+				new RowDefinition(220),
+				new RowDefinition(220),
+				new RowDefinition(220),
+				new RowDefinition(220),
+				new RowDefinition(220)
+			},
+			ColumnDefinitions =
+			{
+				new ColumnDefinition(280),
+				new ColumnDefinition(280),
+				new ColumnDefinition(280),
+				new ColumnDefinition(280),
+				new ColumnDefinition(280)
+			},
+			Children =
+			{
+				new BoxView { Margin = 16, Color = Color.FromArgb("#F94144"), Opacity = 0.35 }.Row(0).Column(0),
+				new BoxView { Margin = 16, Color = Color.FromArgb("#F3722C"), Opacity = 0.35 }.Row(0).Column(4),
+				new BoxView { Margin = 16, Color = Color.FromArgb("#90BE6D"), Opacity = 0.45 }.Row(2).Column(2),
+				new BoxView { Margin = 16, Color = Color.FromArgb("#577590"), Opacity = 0.35 }.Row(4).Column(0),
+				new BoxView { Margin = 16, Color = Color.FromArgb("#277DA1"), Opacity = 0.35 }.Row(4).Column(4),
+				new Border
+				{
+					Margin = 20,
+					Padding = 12,
+					Background = Color.FromArgb("#FFFFFF"),
+					Stroke = Color.FromArgb("#222222"),
+					Content = new Label
+					{
+						Text = "Origin (0,0)",
+						FontAttributes = FontAttributes.Bold
+					}
+				}.Row(0).Column(0),
+				new Border
+				{
+					Margin = 20,
+					Padding = 12,
+					Background = Color.FromArgb("#FFFFFF"),
+					Stroke = Color.FromArgb("#222222"),
+					Content = new VerticalStackLayout
+					{
+						Spacing = 6,
+						Children =
+						{
+							new Label
+							{
+								Text = "Target zone",
+								FontAttributes = FontAttributes.Bold
+							},
+							new Label
+							{
+								Text = "Tap 'Scroll To Repro Offset', then 'Set Neither'."
+							}
+						}
+					}
+				}.Row(2).Column(2),
+				new Border
+				{
+					Margin = 20,
+					Padding = 12,
+					Background = Color.FromArgb("#FFFFFF"),
+					Stroke = Color.FromArgb("#222222"),
+					Content = new Label
+					{
+						Text = "Bottom-right marker",
+						FontAttributes = FontAttributes.Bold
+					}
+				}.Row(4).Column(4)
+			}
+		};
+	}
+
+	private async void OnScrollToSampleClicked(object sender, EventArgs e)
+	{
+		var orientationChanged = _bugScrollView.Orientation != ScrollOrientation.Both;
+		_bugScrollView.Orientation = ScrollOrientation.Both;
+
+		if (orientationChanged)
+		{
+			await Task.Delay(100);
+		}
+
+		await _bugScrollView.ScrollToAsync(ReproScrollX, ReproScrollY, false);
+		await Task.Delay(50);
+		RefreshState($"Scrolled to approx. X={ReproScrollX:0}, Y={ReproScrollY:0}.");
+	}
+
+	private void OnSetBothClicked(object sender, EventArgs e)
+	{
+		_bugScrollView.Orientation = ScrollOrientation.Both;
+		RefreshState("Orientation set to Both.");
+	}
+
+	private async void OnSetNeitherClicked(object sender, EventArgs e)
+	{
+		var beforeX = _bugScrollView.ScrollX;
+		var beforeY = _bugScrollView.ScrollY;
+
+		_bugScrollView.Orientation = ScrollOrientation.Neither;
+
+		await Task.Delay(100);
+		RefreshState($"Set Orientation to Neither. Before: X={beforeX:0.##}, Y={beforeY:0.##}. After: X={_bugScrollView.ScrollX:0.##}, Y={_bugScrollView.ScrollY:0.##}.");
+	}
+
+	private async void OnResetClicked(object sender, EventArgs e)
+	{
+		_bugScrollView.Orientation = ScrollOrientation.Both;
+		await _bugScrollView.ScrollToAsync(0, 0, false);
+		RefreshState("Reset orientation to Both and scrolled back to the origin.");
+	}
+
+	private void OnScrollViewScrolled(object sender, ScrolledEventArgs e)
+	{
+		RefreshState(_lastAction);
+	}
+
+	private void RefreshState(string action)
+	{
+		_lastAction = action ?? string.Empty;
+		_orientationLabel.Text = $"Orientation: {_bugScrollView.Orientation}";
+		_offsetLabel.Text = $"ScrollX: {_bugScrollView.ScrollX:0.##} | ScrollY: {_bugScrollView.ScrollY:0.##}";
+		_lastActionLabel.Text = $"Action: {_lastAction}";
+	}
+}
+
+static class Issue34583ViewExtensions
+{
+	public static TView Row<TView>(this TView view, int row)
+		where TView : View
+	{
+		Grid.SetRow(view, row);
+		return view;
+	}
+
+	public static TView Column<TView>(this TView view, int column)
+		where TView : View
+	{
+		Grid.SetColumn(view, column);
+		return view;
+	}
+
+	public static TView Assign<TView>(this TView view, out TView assigned)
+		where TView : View
+	{
+		assigned = view;
+		return view;
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34583.cs
@@ -3,13 +3,13 @@ namespace Maui.Controls.Sample.Issues;
 [Issue(IssueTracker.Github, 34583, "ScrollView orientation change resets scroll position on iOS", PlatformAffected.iOS)]
 public class Issue34583 : ContentPage
 {
-	private const double ReproScrollX = 700;
-	private const double ReproScrollY = 480;
-	private readonly Label _orientationLabel;
-	private readonly Label _offsetLabel;
-	private readonly Label _lastActionLabel;
-	private readonly ScrollView _bugScrollView;
-	private string _lastAction = string.Empty;
+	const double ReproScrollX = 700;
+	const double ReproScrollY = 480;
+	readonly Label _orientationLabel;
+	readonly Label _offsetLabel;
+	readonly Label _lastActionLabel;
+	readonly ScrollView _bugScrollView;
+	string _lastAction = string.Empty;
 
 	public Issue34583()
 	{
@@ -126,7 +126,7 @@ public class Issue34583 : ContentPage
 		RefreshState("Launch the app, tap 'Scroll To Repro Offset', then tap 'Set Neither'.");
 	}
 
-	private Grid CreateScrollContent()
+	Grid CreateScrollContent()
 	{
 		return new Grid
 		{
@@ -207,7 +207,7 @@ public class Issue34583 : ContentPage
 		};
 	}
 
-	private async void OnScrollToSampleClicked(object sender, EventArgs e)
+	async void OnScrollToSampleClicked(object sender, EventArgs e)
 	{
 		var orientationChanged = _bugScrollView.Orientation != ScrollOrientation.Both;
 		_bugScrollView.Orientation = ScrollOrientation.Both;
@@ -222,13 +222,13 @@ public class Issue34583 : ContentPage
 		RefreshState($"Scrolled to approx. X={ReproScrollX:0}, Y={ReproScrollY:0}.");
 	}
 
-	private void OnSetBothClicked(object sender, EventArgs e)
+	void OnSetBothClicked(object sender, EventArgs e)
 	{
 		_bugScrollView.Orientation = ScrollOrientation.Both;
 		RefreshState("Orientation set to Both.");
 	}
 
-	private async void OnSetNeitherClicked(object sender, EventArgs e)
+	async void OnSetNeitherClicked(object sender, EventArgs e)
 	{
 		var beforeX = _bugScrollView.ScrollX;
 		var beforeY = _bugScrollView.ScrollY;
@@ -239,19 +239,19 @@ public class Issue34583 : ContentPage
 		RefreshState($"Set Orientation to Neither. Before: X={beforeX:0.##}, Y={beforeY:0.##}. After: X={_bugScrollView.ScrollX:0.##}, Y={_bugScrollView.ScrollY:0.##}.");
 	}
 
-	private async void OnResetClicked(object sender, EventArgs e)
+	async void OnResetClicked(object sender, EventArgs e)
 	{
 		_bugScrollView.Orientation = ScrollOrientation.Both;
 		await _bugScrollView.ScrollToAsync(0, 0, false);
 		RefreshState("Reset orientation to Both and scrolled back to the origin.");
 	}
 
-	private void OnScrollViewScrolled(object sender, ScrolledEventArgs e)
+	void OnScrollViewScrolled(object sender, ScrolledEventArgs e)
 	{
 		RefreshState(_lastAction);
 	}
 
-	private void RefreshState(string action)
+	void RefreshState(string action)
 	{
 		_lastAction = action ?? string.Empty;
 		_orientationLabel.Text = $"Orientation: {_bugScrollView.Orientation}";

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_WINDOWS // Issue link: https://github.com/dotnet/maui/issues/34671
 using System.Globalization;
 using NUnit.Framework;
 using UITest.Appium;
@@ -39,3 +40,4 @@ public class Issue34583 : _IssuesUITest
 		Assert.That(scrollY, Is.GreaterThan(0d), "ScrollY should remain non-zero after setting orientation to Neither.");
 	}
 }
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
@@ -21,6 +21,7 @@ public class Issue34583 : _IssuesUITest
 	{
 		App.WaitForElement("ScrollToReproOffsetButton");
 		App.Tap("ScrollToReproOffsetButton");
+		App.WaitForTextToBePresentInElement("LastActionLabel", "Scrolled to approx");
 		App.WaitForElement("SetNeitherButton");
 		App.Tap("SetNeitherButton");
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34583.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34583 : _IssuesUITest
+{
+	public override string Issue => "ScrollView orientation change resets scroll position on iOS";
+
+	public Issue34583(TestDevice device)
+		: base(device)
+	{
+	}
+
+	[Test]
+	[Category(UITestCategories.ScrollView)]
+	public void ScrollPositionIsPreservedWhenOrientationChangesToNeither()
+	{
+		App.WaitForElement("ScrollToReproOffsetButton");
+		App.Tap("ScrollToReproOffsetButton");
+		App.WaitForElement("SetNeitherButton");
+		App.Tap("SetNeitherButton");
+
+		var offsetText = App.WaitForElement("OffsetLabel").GetText()
+			?? throw new InvalidOperationException("OffsetLabel text was null.");
+		var offsetParts = offsetText.Split('|', StringSplitOptions.TrimEntries);
+		var scrollXText = offsetParts[0]
+			.Replace("ScrollX:", string.Empty, StringComparison.Ordinal)
+			.Trim();
+		var scrollYText = offsetParts[1]
+			.Replace("ScrollY:", string.Empty, StringComparison.Ordinal)
+			.Trim();
+		var scrollX = double.Parse(scrollXText, CultureInfo.InvariantCulture);
+		var scrollY = double.Parse(scrollYText, CultureInfo.InvariantCulture);
+
+		Assert.That(scrollX, Is.GreaterThan(0d), "ScrollX should remain non-zero after setting orientation to Neither.");
+		Assert.That(scrollY, Is.GreaterThan(0d), "ScrollY should remain non-zero after setting orientation to Neither.");
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -323,7 +323,8 @@ namespace Microsoft.Maui.Platform
 						contentSize = new CGSize(frameSize.Width, contentSize.Height);
 					}
 
-					// Clamp height if vertical scrolling is disabled and content is larger than frame
+					// Clamp height when vertical scrolling is disabled but horizontal scrolling is enabled (Horizontal only)
+					// and the content is larger than the frame
 					if (orientation is ScrollOrientation.Horizontal && contentSize.Height > frameSize.Height)
 					{
 						contentSize = new CGSize(contentSize.Width, frameSize.Height);

--- a/src/Core/src/Platform/iOS/MauiScrollView.cs
+++ b/src/Core/src/Platform/iOS/MauiScrollView.cs
@@ -318,13 +318,13 @@ namespace Microsoft.Maui.Platform
 					var orientation = scrollView.Orientation;
 
 					// Clamp width if horizontal scrolling is disabled and content is larger than frame
-					if (orientation is ScrollOrientation.Vertical or ScrollOrientation.Neither && contentSize.Width > frameSize.Width)
+					if (orientation is ScrollOrientation.Vertical && contentSize.Width > frameSize.Width)
 					{
 						contentSize = new CGSize(frameSize.Width, contentSize.Height);
 					}
 
 					// Clamp height if vertical scrolling is disabled and content is larger than frame
-					if (orientation is ScrollOrientation.Horizontal or ScrollOrientation.Neither && contentSize.Height > frameSize.Height)
+					if (orientation is ScrollOrientation.Horizontal && contentSize.Height > frameSize.Height)
 					{
 						contentSize = new CGSize(contentSize.Width, frameSize.Height);
 					}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue details
On iOS, changing ScrollView.Orientation to Neither resets ScrollX and ScrollY to 0 instead of preserving the current scroll position.
 
### Regression Details
PR: https://github.com/dotnet/maui/pull/30991
The change came from PR #30991 (commit 2b13a90c74). The PR description indicates the goal was to align iOS ScrollView behavior with Android by preventing scrolling on disallowed axes, so clamping logic was introduced to enforce orientation behavior. No review comment or PR note explains why ScrollOrientation.Neither was included in both clamp conditions.
The clamping logic appears intentional, but the inclusion of Neither was likely an overextension or unintended side effect of that fix.
 
### Root Cause
MauiScrollView.LayoutSubviews treated ScrollOrientation.Neither as a resize-to-viewport scenario by clamping both width and height to the frame size. As a result, ContentSize shrank to the viewport, causing UIKit to clamp ContentOffset to (0, 0), which led to the issue.
 
### Description of change
The content-size clamping logic has been updated to skip Neither:

- Width is clamped only for Vertical
- Height is clamped only for Horizontal
- Neither preserves the existing ContentSize, ensuring the current ContentOffset is retained

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/34583

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/c61b76e1-fabc-47f1-a1b9-afe4352a37ce"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/b636601b-f0ec-4efe-841a-eaadf5d7d1d6"> |