### PR TITLE
Fix CI failure for NavigatingAwayFromTabbedPageResizesContentPage device tests

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -222,10 +222,14 @@ public class TabbedPageManager
 
 	protected virtual void OnTabbedPageDisappearing(object sender, EventArgs e)
 	{
-		// Intentionally left empty. Previously this called RemoveTabs() which
-		// destroyed tab fragments, causing them to not restore properly after
-		// modal navigation. Tabs should remain visible and intact.
-		// TODO: This method can be removed in .NET 11.
+		// Don't remove tabs during modal navigation — tabs should remain visible so they
+		// restore properly when the modal is dismissed.
+		// For non-modal navigation (e.g. NavigationPage.PushAsync), tabs must be removed so that
+		// the newly pushed page can use the full available height.
+		if (Element?.Navigation?.ModalStack?.Count > 0)
+			return;
+
+		RemoveTabs();
 	}
 
 	protected virtual void OnTabbedPageAppearing(object sender, EventArgs e)


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details
This PR #32878  caused the NavigatingAwayFromTabbedPageResizesContentPage device tests to failed in Candidate branch.


### Description of Change

<!-- Enter description of the fix in this section -->

In the device test NavigatingAwayFromTabbedPageResizesContentPage, the height of the new ContentPage is validated. Due to the changes in PR #32878, an incorrect page height was returned, causing the test to fail.

In TabbedPageManager, reintroduced RemoveTabs(). For modal navigation, an early return is applied (similar to PR #32878).

With these changes, both issue https://github.com/CommunityToolkit/Maui/issues/2708 and the candidate test failures are resolved.