### PR TITLE
[release/11.0.1xx-preview3] Install the iOS 26.2 simulator.

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -197,10 +197,6 @@ steps:
   - ${{ if ne(parameters.skipSimulatorSetup, 'true') }}:
     - script: |
         echo installing simulator runtimes...
-        # XCODE variable is in major.minor format (e.g., 26.1)
-        XCODE_MAJOR_MINOR=$(XCODE)
-        MAJOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f1)
-        MINOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f2)
 
         RC=0
         sudo xcodebuild -downloadPlatform iOS || RC=$?
@@ -217,11 +213,11 @@ steps:
             echo "    still $C simulators left..."
           done
           echo "Re-trying simulator runtime installation..."
-          sudo xcodebuild $DOWNLOAD_ARGS
+          sudo xcodebuild -downloadPlatform iOS
         fi
 
         echo "Installing the iOS 26.2 simulator as well"
-        sudo xcodebuild -downloadPlatform iOS -buildVersion 26.2
+        sudo xcodebuild -downloadPlatform iOS -buildVersion 26.2 -architectureVariant universal
 
         # Verify the simulator runtime was actually installed
         echo "Verifying simulator runtimes..."

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -202,16 +202,8 @@ steps:
         MAJOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f1)
         MINOR=$(echo "$XCODE_MAJOR_MINOR" | cut -d'.' -f2)
 
-        # if we're using Xcode 26.0[.?], then explicitly install the iOS 26.0 simulator (the iOS 26.0.1 simulator doesn't work for us)
-        # also install the universal simulator version, so that this bot can run x64 apps in the simulator.
-        if [[ "${MAJOR}" == "26" && "${MINOR}" == "0" ]]; then
-          DOWNLOAD_ARGS="-downloadPlatform iOS -architectureVariant universal -buildVersion 26.0"
-        else
-          DOWNLOAD_ARGS="-downloadPlatform iOS"
-        fi
-
         RC=0
-        sudo xcodebuild $DOWNLOAD_ARGS || RC=$?
+        sudo xcodebuild -downloadPlatform iOS || RC=$?
         if [[ "$RC" != "0" ]]; then
           echo "First attempt failed with exit code $RC, deleting all simulator runtimes and trying again..."
           sudo xcrun simctl runtime delete all
@@ -227,6 +219,9 @@ steps:
           echo "Re-trying simulator runtime installation..."
           sudo xcodebuild $DOWNLOAD_ARGS
         fi
+
+        echo "Installing the iOS 26.2 simulator as well"
+        sudo xcodebuild -downloadPlatform iOS -buildVersion 26.2
 
         # Verify the simulator runtime was actually installed
         echo "Verifying simulator runtimes..."


### PR DESCRIPTION
Just asking Xcode 26.2 to install the iOS simulator ends up installing the iOS 26.3 simulator, which causes build failures:

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
    { generic:1, platform:iOS }

Available destinations for the "MauiPlatformInterop" scheme:
    { platform:macOS, arch:x86_64, variant:Mac Catalyst, id:4203018E-580F-C1B5-9525-B745CECA79EB, name:My Mac }
    { platform:macOS, variant:Mac Catalyst, name:Any Mac }

Ineligible destinations for the "MauiPlatformInterop" scheme:
    { platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device, error:iOS 26.2 is not installed. Please download and install the platform from Xcode > Settings > Components. }
```

So just forcefully install the iOS 26.2 simulator for now.