### PR TITLE
Improve evaluate-pr-tests workflow: slash_command + workflow_dispatch, security hardening

### DIFF
--- a/.github/instructions/gh-aw-workflows.instructions.md
+++ b/.github/instructions/gh-aw-workflows.instructions.md
@@ -6,6 +6,34 @@ applyTo:
 
 # gh-aw (GitHub Agentic Workflows) Guidelines
 
+## 🚨 Before You Build: Prefer Built-in gh-aw Features
+
+**CRITICAL RULE:** Before implementing any trigger, output, scheduling, or interaction mechanism in a gh-aw workflow, check whether gh-aw has a built-in feature that does it. gh-aw extends GitHub Actions with many convenience features — manually reimplementing them is always worse (more code, more bugs, missing platform integration like emoji reactions, sanitized inputs, and noise reduction).
+
+### Step 1: Check the anti-patterns table below
+### Step 2: If not listed, check the [triggers reference](https://github.github.com/gh-aw/reference/triggers/), [frontmatter reference](https://github.github.com/gh-aw/reference/frontmatter/), and [safe-outputs reference](https://github.github.com/gh-aw/reference/safe-outputs/)
+### Step 3: If a built-in exists, use it. If not, proceed with manual implementation.
+
+### Anti-Patterns: Manual Reimplementations to Avoid
+
+| If you're about to implement... | Use this built-in instead | Docs |
+|---------------------------------|--------------------------|------|
+| `issue_comment` + `startsWith(comment.body, '/cmd')` | `slash_command:` trigger | [Command Triggers](https://github.github.com/gh-aw/reference/command-triggers/) |
+| Manual emoji reaction on triggering comment | `reaction:` field under `on:` | [Frontmatter](https://github.github.com/gh-aw/reference/frontmatter/) |
+| Posting "workflow started/completed" status comments | `status-comment: true` under `on:` | [Frontmatter](https://github.github.com/gh-aw/reference/frontmatter/) |
+| Fixed cron schedule (`0 9 * * 1`) for non-critical timing | `schedule: weekly on monday around 9:00` (fuzzy) | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+| Manual `if:` to skip bot-authored PRs | `skip-bots:` under `on:` | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+| Manual `if:` to skip by author role | `skip-roles:` under `on:` | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+| Manual label check + removal for one-shot commands | `label_command:` trigger | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+| Editing old comments to collapse them | `hide-older-comments: true` on `add-comment:` | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs/) |
+| Creating no-op report issues | `noop: report-as-issue: false` | [Safe Outputs / Monitoring](https://github.github.com/gh-aw/patterns/monitoring/) |
+| Auto-closing older issues from same workflow | `close-older-issues: true` on `create-issue:` | [Safe Outputs](https://github.github.com/gh-aw/reference/safe-outputs/) |
+| Disabling workflow after a date | `stop-after:` under `on:` | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+| Manual approval gating | `manual-approval:` under `on:` | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+| Search-based skip logic in `steps:` | `skip-if-match:` / `skip-if-no-match:` under `on:` | [Triggers](https://github.github.com/gh-aw/reference/triggers/) |
+
+**Note:** gh-aw is actively developed. If a capability feels like something a framework would provide natively, check the reference docs — it probably exists even if it's not in this table yet.
+
 ## Architecture
 
 gh-aw workflows are authored as `.md` files with YAML frontmatter, compiled to `.lock.yml` via `gh aw compile`. The lock file is auto-generated — **never edit it manually**.

--- a/.github/instructions/gh-aw-workflows.instructions.md
+++ b/.github/instructions/gh-aw-workflows.instructions.md
@@ -154,17 +154,15 @@ steps:
 ```
 
 The script:
-1. Captures the base branch SHA before checkout
-2. Checks out the PR branch via `gh pr checkout`
-3. Deletes `.github/skills/` and `.github/instructions/` (prevents fork-added files)
-4. Restores them from the base branch SHA (best-effort, non-fatal)
+1. Verifies the PR author has write access and rejects fork PRs
+2. Captures the base branch SHA before checkout
+3. Checks out the PR branch via `gh pr checkout`
+4. Restores `.github/skills/`, `.github/instructions/`, and `.github/copilot-instructions.md` from the base branch SHA (fatal on failure)
 
 **Behavior by trigger:**
 - **`workflow_dispatch`**: Platform checkout is skipped, so the restore IS the final workspace state (trusted files from base branch)
-- **`pull_request`** (same-repo): User step restores trusted infra. `checkout_pr_branch.cjs` runs after and re-checks out PR branch — for same-repo PRs, skill files typically match main unless the PR modified them.
-- **`pull_request`** (fork with `forks: ["*"]`): Same as above, but fork's skill files may differ. Same residual risk as `issue_comment` fork case — agent is sandboxed, pre-flight catches missing `SKILL.md`.
-- **`issue_comment`** (same-repo): Platform re-checks out PR branch — files already match, effectively a no-op
-- **`issue_comment`** (fork): Platform re-checks out fork branch after us, overwriting restored files. Agent is sandboxed; pre-flight in the prompt catches missing `SKILL.md`
+- **`slash_command`** (same-repo): Platform's `checkout_pr_branch.cjs` handles checkout. Skill files typically match main unless the PR modified them.
+- **`slash_command`** (fork): Platform re-checks out fork branch after user steps, overwriting restored files. Agent is sandboxed; pre-flight in the prompt catches missing `SKILL.md`
 
 ### Anti-Patterns
 

--- a/.github/instructions/gh-aw-workflows.instructions.md
+++ b/.github/instructions/gh-aw-workflows.instructions.md
@@ -130,6 +130,7 @@ Reference: https://securitylab.github.com/resources/github-actions-preventing-pw
 | `workflow_dispatch` | ❌ Skipped | ✅ Works — user steps handle checkout and restore is final |
 | `issue_comment` (same-repo) | ✅ Yes | ✅ Works — files already on PR branch |
 | `issue_comment` (fork) | ✅ Yes | ⚠️ Works — `checkout_pr_branch.cjs` re-checks out fork branch after user steps, potentially overwriting restored infra. Acceptable because agent is sandboxed (no credentials, max 1 comment via safe-outputs). Pre-flight check catches missing `SKILL.md` if fork isn't rebased. |
+| `slash_command` | ✅ Yes (compiles to `issue_comment` internally) | Same behavior as `issue_comment` above, but with platform-managed command matching, emoji reactions, and sanitized input. Prefer `slash_command:` over manual `issue_comment` + `startsWith()`. |
 
 ### The `issue_comment` + Fork Problem
 

--- a/.github/instructions/gh-aw-workflows.instructions.md
+++ b/.github/instructions/gh-aw-workflows.instructions.md
@@ -29,6 +29,8 @@ agent job:
 | Platform steps | ✅ Yes | ✅ Yes | ✅ Yes | Platform-controlled |
 | Agent container | ❌ Scrubbed | ❌ Scrubbed | ❌ Scrubbed | ✅ But sandboxed |
 
+**⚠️ Agent container credential nuance:** `GITHUB_TOKEN` and `gh` CLI credentials are scrubbed inside the agent container. However, `COPILOT_TOKEN` (used for LLM inference) is present in the environment via `--env-all`. Any subprocess (e.g., `dotnet build`, `npm install`) inherits this variable. The AWF network firewall, `redact_secrets.cjs` (post-agent log scrubbing), and the threat detection agent limit the blast radius. See [Security Boundaries](#security-boundaries) below.
+
 ### Step Ordering (Critical)
 
 User `steps:` **always run before** platform-generated steps. You cannot insert user steps after platform steps.
@@ -47,6 +49,41 @@ The prompt is built in the **activation job** via `{{#runtime-import .github/wor
 By default, `gh aw compile` automatically injects a fork guard into the activation job's `if:` condition: `head.repo.id == repository_id`. This blocks fork PRs on `pull_request` events.
 
 To **allow fork PRs**, add `forks: ["*"]` to the `pull_request` trigger in the `.md` frontmatter. The compiler removes the auto-injected guard from the compiled `if:` conditions. This is safe when the workflow uses the `Checkout-GhAwPr.ps1` pattern (checkout + trusted-infra restore) and the agent is sandboxed.
+
+## Security Boundaries
+
+### Key Principles (from [GitHub Security Lab](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/))
+
+1. **Never execute untrusted PR code with elevated credentials.** The classic "pwn-request" attack is `pull_request_target` + checkout PR + run build scripts with `GITHUB_TOKEN`. The attack surface includes build scripts (`make`, `build.ps1`), package manager hooks (`npm postinstall`, MSBuild targets), and test runners.
+
+2. **Treating PR contents as passive data is safe.** Reading, analyzing, or diffing PR code is fine — the danger is *executing* it. Our gh-aw workflows read code for evaluation; they never build or run it.
+
+3. **`pull_request_target` grants write permissions and secrets access.** This is by design — the workflow YAML comes from the base branch (trusted). But any step that checks out and runs fork code in this context creates a vulnerability.
+
+4. **`pull_request` from forks has no secrets access.** GitHub withholds secrets because the workflow YAML comes from the fork (untrusted). This is the safe default for CI builds on fork PRs.
+
+5. **The `workflow_run` pattern separates privilege from code execution.** Build in an unprivileged `pull_request` job → pass artifacts → process in a privileged `workflow_run` job. This is architecturally what gh-aw does: agent runs read-only, `safe_outputs` job has write permissions.
+
+### gh-aw Defense Layers
+
+| Layer | What it does | What it doesn't do |
+|-------|-------------|-------------------|
+| **AWF network firewall** | Restricts outbound to allowlisted domains | Doesn't prevent reading env vars inside the container |
+| **`redact_secrets.cjs`** | Scrubs known secret values from logs/artifacts post-agent | Doesn't catch encoded/obfuscated values |
+| **Threat detection agent** | Reviews agent outputs before safe-outputs publishes them | Can miss novel exfiltration techniques |
+| **Safe-outputs permission separation** | Write operations happen in separate job, not the agent | Agent can still request writes via safe-output tools |
+| **`max: 1` on `add-comment`** | Limits agent to one comment | That one comment could contain sensitive data (mitigated by redaction) |
+| **XPIA prompt** | Instructs LLM to resist prompt injection from untrusted content | LLM compliance is probabilistic, not guaranteed |
+| **`pre_activation` role check** | Gates on write-access collaborators | Does not apply if `roles: all` is set |
+
+### Rules for gh-aw Workflow Authors
+
+- ✅ **DO** treat PR contents as passive data (read, analyze, diff)
+- ✅ **DO** run data-gathering scripts in `steps:` (pre-agent, trusted context) not inside the agent
+- ✅ **DO** use `Checkout-GhAwPr.ps1` for `workflow_dispatch` to restore trusted `.github/` from base
+- ❌ **DO NOT** run `dotnet build`, `npm install`, or any build command on untrusted PR code inside the agent — build tool hooks (MSBuild targets, postinstall scripts) can read `COPILOT_TOKEN` from the environment
+- ❌ **DO NOT** execute workspace scripts (`.ps1`, `.sh`, `.py`) after checking out a fork PR in `steps:` — those run with `GITHUB_TOKEN`
+- ❌ **DO NOT** set `roles: all` on workflows that process PR content — this allows any user to trigger the workflow
 
 ## Fork PR Handling
 
@@ -70,7 +107,7 @@ Reference: https://securitylab.github.com/resources/github-actions-preventing-pw
 
 For `/slash-command` triggers on fork PRs, `checkout_pr_branch.cjs` runs AFTER all user steps and re-checks out the fork branch. This overwrites any files restored by user steps (e.g., `.github/skills/`). A fork could include a crafted `SKILL.md` that alters the agent's evaluation behavior.
 
-**Accepted residual risk:** The agent runs in a sandboxed container with all credentials scrubbed. The worst outcome is a manipulated evaluation comment (`safe-outputs: add-comment: max: 1`). The agent has no ability to push code, access secrets, or exfiltrate data. The pre-flight check in the agent prompt catches the case where `SKILL.md` is missing entirely (fork not rebased on `main`).
+**Accepted residual risk:** The agent runs in a sandboxed container with `GITHUB_TOKEN` and `gh` CLI credentials scrubbed. `COPILOT_TOKEN` (for LLM inference) remains in the environment but the AWF network firewall restricts outbound connections to an allowlist of domains, `redact_secrets.cjs` scrubs known secret values from logs/outputs post-agent, and the threat detection agent reviews outputs before they are published. The worst practical outcome is a manipulated evaluation comment (`safe-outputs: add-comment: max: 1`). The pre-flight check in the agent prompt catches the case where `SKILL.md` is missing entirely (fork not rebased on `main`).
 
 **Upstream issue:** [github/gh-aw#18481](https://github.com/github/gh-aw/issues/18481) — "Using gh-aw in forks of repositories"
 

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -3,9 +3,9 @@
     Shared PR checkout for gh-aw (GitHub Agentic Workflows).
 
 .DESCRIPTION
-    Checks out a PR branch and merges the base branch to produce the same
-    combined state as a pull_request merge commit. This gives the agent the
-    PR's code changes plus anything new on main (skills, instructions, etc.).
+    Checks out a PR branch and restores trusted agent infrastructure (skills,
+    instructions) from the base branch. This gives the agent the PR's code
+    changes with the latest skills and instructions from main.
 
     This script is only invoked for workflow_dispatch triggers. For
     pull_request_target and issue_comment, the gh-aw platform's
@@ -90,18 +90,17 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "✅ Checked out PR #$PrNumber"
 git log --oneline -1
 
-# ── Merge base branch into PR branch ────────────────────────────────────────
-# Produces the same combined state as a pull_request merge commit:
-# PR's changes + anything new on main. If the PR modifies a skill, the PR's
-# version wins. If it doesn't, main's version is used. This lets contributors
-# iterate on skills via workflow_dispatch while keeping everything else current.
+# ── Restore agent infrastructure from base branch ────────────────────────────
+# Replace skills and instructions with base branch versions to ensure the agent
+# always uses trusted infrastructure from main. Uses git checkout to read files
+# directly from the commit tree — works in shallow clones (no history traversal).
 
-Write-Host "Merging base branch ($BaseSha) into PR branch..."
-git merge $BaseSha --no-edit 2>&1
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "⚠️ Merge conflict — PR may have conflicts with the base branch."
-    Write-Host "   The agent will run with the PR branch as-is (without base branch updates)."
-    git merge --abort 2>&1
+if (Test-Path '.github/skills/') { Remove-Item -Recurse -Force '.github/skills/' }
+if (Test-Path '.github/instructions/') { Remove-Item -Recurse -Force '.github/instructions/' }
+
+git checkout $BaseSha -- .github/skills/ .github/instructions/ .github/copilot-instructions.md 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "✅ Restored agent infrastructure from base branch ($BaseSha)"
 } else {
-    Write-Host "✅ Merged base branch into PR — workspace has PR changes + latest main"
+    Write-Host "⚠️ Could not restore agent infrastructure from base branch — files may come from the PR branch"
 }

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -50,27 +50,32 @@ $PrNumber = $env:PR_NUMBER
 
 # ── Verify PR author has write access ────────────────────────────────────────
 # workflow_dispatch runs with GITHUB_TOKEN. Only check out code from trusted
-# authors to prevent untrusted fork code from landing in a privileged context.
+# authors of same-repo PRs. Fork PRs are handled by pull_request_target instead.
 
-$PrAuthor = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author --jq '.author.login'
+$PrInfo = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author,isCrossRepository --jq '{author: .author.login, isFork: .isCrossRepository}'  | ConvertFrom-Json
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "❌ Failed to fetch PR #$PrNumber author"
+    Write-Host "❌ Failed to fetch PR #$PrNumber metadata"
     exit 1
 }
 
-$Permission = gh api "repos/$($env:GITHUB_REPOSITORY)/collaborators/$PrAuthor/permission" --jq '.permission'
+if ($PrInfo.isFork) {
+    Write-Host "⏭️ PR #$PrNumber is from a fork. workflow_dispatch does not check out fork PRs."
+    Write-Host "   Fork PRs are evaluated automatically via pull_request_target."
+    exit 1
+}
+
+$Permission = gh api "repos/$($env:GITHUB_REPOSITORY)/collaborators/$($PrInfo.author)/permission" --jq '.permission'
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "❌ Failed to check permissions for '$PrAuthor'"
+    Write-Host "❌ Failed to check permissions for '$($PrInfo.author)'"
     exit 1
 }
 
 $AllowedRoles = @('admin', 'write', 'maintain')
 if ($Permission -notin $AllowedRoles) {
-    Write-Host "⏭️ PR author '$PrAuthor' has '$Permission' access. workflow_dispatch only processes PRs from authors with write access."
-    Write-Host "   Fork PRs from external contributors are evaluated automatically via pull_request_target."
+    Write-Host "⏭️ PR author '$($PrInfo.author)' has '$Permission' access. workflow_dispatch only processes PRs from authors with write access."
     exit 1
 }
-Write-Host "✅ PR author '$PrAuthor' has '$Permission' access"
+Write-Host "✅ PR #$PrNumber by '$($PrInfo.author)' ($Permission access, same-repo)"
 
 # ── Save base branch SHA ─────────────────────────────────────────────────────
 # Must be captured BEFORE checkout replaces HEAD.

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -50,6 +50,11 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
+if (-not $PrInfo -or -not $PrInfo.author) {
+    Write-Host "❌ PR #$PrNumber returned empty or malformed metadata"
+    exit 1
+}
+
 if ($PrInfo.isFork) {
     Write-Host "⏭️ PR #$PrNumber is from a fork. workflow_dispatch does not check out fork PRs."
     Write-Host "   Fork PRs are evaluated automatically via pull_request_target."

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -1,22 +1,21 @@
 <#
 .SYNOPSIS
-    Shared PR checkout for gh-aw (GitHub Agentic Workflows).
+    Shared PR checkout and trusted-infra restore for gh-aw workflows.
 
 .DESCRIPTION
     Checks out a PR branch and restores trusted agent infrastructure (skills,
     instructions) from the base branch. This gives the agent the PR's code
     changes with the latest skills and instructions from main.
 
-    This script is only invoked for workflow_dispatch triggers. For
-    pull_request_target and issue_comment, the gh-aw platform's
-    checkout_pr_branch.cjs handles PR checkout automatically.
-    workflow_dispatch skips the platform checkout entirely, so this script
-    is the only thing that gets the PR code onto disk.
+    Currently used for workflow_dispatch triggers. For slash_command and
+    issue_comment triggers, the gh-aw platform's checkout_pr_branch.cjs
+    handles PR checkout automatically — but may overwrite trusted infra
+    with fork-supplied files. Call this script after platform checkout to
+    restore trusted .github/ from the base branch.
 
-    SECURITY: Before checkout, the script verifies the PR is not from a
-    fork and that the author has write access (write, maintain, or admin).
-    Fork PRs are evaluated via pull_request_target instead (where the
-    platform handles checkout safely inside a sandboxed container).
+    SECURITY: Before checkout, the script verifies the PR author has
+    write access (write, maintain, or admin) and rejects fork PRs.
+    This prevents checkout of untrusted code in privileged contexts.
 
     DO NOT add steps after this that run scripts from the workspace
     (e.g., ./build.sh, pwsh ./script.ps1). That would create a code
@@ -44,14 +43,26 @@ $PrNumber = $env:PR_NUMBER
 
 # ── Verify PR is same-repo and author has write access ───────────────────────
 
-$PrInfo = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author,isCrossRepository --jq '{author: .author.login, isFork: .isCrossRepository}' | ConvertFrom-Json
+$RawJson = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author,isCrossRepository --jq '{author: .author.login, isFork: .isCrossRepository}'
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Failed to fetch PR #$PrNumber metadata"
     exit 1
 }
 
+try {
+    $PrInfo = $RawJson | ConvertFrom-Json
+} catch {
+    Write-Host "❌ PR #$PrNumber returned malformed JSON: $RawJson"
+    exit 1
+}
+
 if (-not $PrInfo -or -not $PrInfo.author) {
     Write-Host "❌ PR #$PrNumber returned empty or malformed metadata"
+    exit 1
+}
+
+if ($PrInfo.isFork) {
+    Write-Host "⏭️ PR #$PrNumber is from a fork — skipping. Fork PRs are evaluated in the sandboxed agent container via the platform's checkout_pr_branch.cjs."
     exit 1
 }
 
@@ -67,8 +78,7 @@ if ($Permission -notin $AllowedRoles) {
     exit 1
 }
 
-$IsFork = if ($PrInfo.isFork) { "fork" } else { "same-repo" }
-Write-Host "✅ PR #$PrNumber by '$($PrInfo.author)' ($Permission access, $IsFork)"
+Write-Host "✅ PR #$PrNumber by '$($PrInfo.author)' ($Permission access, same-repo)"
 
 # ── Save base branch SHA ─────────────────────────────────────────────────────
 
@@ -95,13 +105,12 @@ git log --oneline -1
 # Replace skills and instructions with base branch versions to ensure the agent
 # always uses trusted infrastructure from main. Uses git checkout to read files
 # directly from the commit tree — works in shallow clones (no history traversal).
-
-if (Test-Path '.github/skills/') { Remove-Item -Recurse -Force '.github/skills/' }
-if (Test-Path '.github/instructions/') { Remove-Item -Recurse -Force '.github/instructions/' }
+# Restore BEFORE deleting so a failure doesn't leave the workspace without infra.
 
 git checkout $BaseSha -- .github/skills/ .github/instructions/ .github/copilot-instructions.md 2>&1
 if ($LASTEXITCODE -eq 0) {
     Write-Host "✅ Restored agent infrastructure from base branch ($BaseSha)"
 } else {
-    Write-Host "⚠️ Could not restore agent infrastructure from base branch — files may come from the PR branch"
+    Write-Host "❌ Failed to restore agent infrastructure from base branch — aborting to prevent running with untrusted infra"
+    exit 1
 }

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -55,12 +55,6 @@ if (-not $PrInfo -or -not $PrInfo.author) {
     exit 1
 }
 
-if ($PrInfo.isFork) {
-    Write-Host "⏭️ PR #$PrNumber is from a fork. workflow_dispatch does not check out fork PRs."
-    Write-Host "   Fork PRs are evaluated automatically via pull_request_target."
-    exit 1
-}
-
 $Permission = gh api "repos/$($env:GITHUB_REPOSITORY)/collaborators/$($PrInfo.author)/permission" --jq '.permission'
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Failed to check permissions for '$($PrInfo.author)'"
@@ -70,9 +64,11 @@ if ($LASTEXITCODE -ne 0) {
 $AllowedRoles = @('admin', 'write', 'maintain')
 if ($Permission -notin $AllowedRoles) {
     Write-Host "⏭️ PR author '$($PrInfo.author)' has '$Permission' access. workflow_dispatch only processes PRs from authors with write access."
-    exit 1
+    exit 0
 }
-Write-Host "✅ PR #$PrNumber by '$($PrInfo.author)' ($Permission access, same-repo)"
+
+$IsFork = if ($PrInfo.isFork) { "fork" } else { "same-repo" }
+Write-Host "✅ PR #$PrNumber by '$($PrInfo.author)' ($Permission access, $IsFork)"
 
 # ── Save base branch SHA ─────────────────────────────────────────────────────
 

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -3,30 +3,24 @@
     Shared PR checkout for gh-aw (GitHub Agentic Workflows).
 
 .DESCRIPTION
-    Checks out a PR branch and restores trusted agent infrastructure (skills,
-    instructions) from the base branch. Works for both same-repo and fork PRs.
+    Checks out a PR branch and merges the base branch to produce the same
+    combined state as a pull_request merge commit. This gives the agent the
+    PR's code changes plus anything new on main (skills, instructions, etc.).
 
-    This script is only invoked for workflow_dispatch triggers. For pull_request
-    and issue_comment, the gh-aw platform's checkout_pr_branch.cjs handles PR
-    checkout automatically (it runs as a platform step after all user steps).
-    workflow_dispatch skips the platform checkout entirely, so this script is
-    the only thing that gets the PR code onto disk.
+    This script is only invoked for workflow_dispatch triggers. For
+    pull_request_target and issue_comment, the gh-aw platform's
+    checkout_pr_branch.cjs handles PR checkout automatically.
+    workflow_dispatch skips the platform checkout entirely, so this script
+    is the only thing that gets the PR code onto disk.
 
-    SECURITY: Before checkout, the script verifies the PR author has write
-    access (write, maintain, or admin) to the repository. This prevents
-    checking out untrusted fork code in a context that has GITHUB_TOKEN.
-    Fork PRs are evaluated via pull_request_target instead (where the platform
-    handles checkout safely inside a sandboxed container).
-
-    SECURITY NOTE: This script checks out PR code onto disk. This is safe
-    because NO subsequent user steps execute workspace code — the gh-aw
-    platform copies the workspace into a sandboxed container with scrubbed
-    credentials before starting the agent. The classic "pwn-request" attack
-    requires checkout + execution; we only do checkout.
+    SECURITY: Before checkout, the script verifies the PR is not from a
+    fork and that the author has write access (write, maintain, or admin).
+    Fork PRs are evaluated via pull_request_target instead (where the
+    platform handles checkout safely inside a sandboxed container).
 
     DO NOT add steps after this that run scripts from the workspace
-    (e.g., ./build.sh, pwsh ./script.ps1). That would create an actual
-    fork code execution vulnerability. See:
+    (e.g., ./build.sh, pwsh ./script.ps1). That would create a code
+    execution vulnerability. See:
     https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 
 .NOTES
@@ -48,11 +42,9 @@ if (-not $env:PR_NUMBER -or $env:PR_NUMBER -eq '0') {
 
 $PrNumber = $env:PR_NUMBER
 
-# ── Verify PR author has write access ────────────────────────────────────────
-# workflow_dispatch runs with GITHUB_TOKEN. Only check out code from trusted
-# authors of same-repo PRs. Fork PRs are handled by pull_request_target instead.
+# ── Verify PR is same-repo and author has write access ───────────────────────
 
-$PrInfo = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author,isCrossRepository --jq '{author: .author.login, isFork: .isCrossRepository}'  | ConvertFrom-Json
+$PrInfo = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author,isCrossRepository --jq '{author: .author.login, isFork: .isCrossRepository}' | ConvertFrom-Json
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Failed to fetch PR #$PrNumber metadata"
     exit 1
@@ -78,8 +70,6 @@ if ($Permission -notin $AllowedRoles) {
 Write-Host "✅ PR #$PrNumber by '$($PrInfo.author)' ($Permission access, same-repo)"
 
 # ── Save base branch SHA ─────────────────────────────────────────────────────
-# Must be captured BEFORE checkout replaces HEAD.
-# Exported for potential use by downstream platform steps (e.g., checkout_pr_branch.cjs)
 
 $BaseSha = git rev-parse HEAD
 if ($LASTEXITCODE -ne 0) {
@@ -87,6 +77,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 Add-Content -Path $env:GITHUB_ENV -Value "BASE_SHA=$BaseSha"
+Write-Host "Base branch SHA: $BaseSha"
 
 # ── Checkout PR branch ──────────────────────────────────────────────────────
 
@@ -99,17 +90,18 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "✅ Checked out PR #$PrNumber"
 git log --oneline -1
 
-# ── Restore .github/ from base branch ────────────────────────────────────────
-# This script only runs for workflow_dispatch (other triggers use the platform's
-# checkout_pr_branch.cjs instead). For workflow_dispatch the platform checkout is
-# skipped, so this restore IS the final workspace state.
-# rm -rf first to prevent fork-added files from surviving the restore.
+# ── Merge base branch into PR branch ────────────────────────────────────────
+# Produces the same combined state as a pull_request merge commit:
+# PR's changes + anything new on main. If the PR modifies a skill, the PR's
+# version wins. If it doesn't, main's version is used. This lets contributors
+# iterate on skills via workflow_dispatch while keeping everything else current.
 
-if (Test-Path '.github/') { Remove-Item -Recurse -Force '.github/' }
-
-git checkout $BaseSha -- .github/ 2>&1
-if ($LASTEXITCODE -eq 0) {
-    Write-Host "✅ Restored .github/ from base branch ($BaseSha)"
+Write-Host "Merging base branch ($BaseSha) into PR branch..."
+git merge $BaseSha --no-edit 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "⚠️ Merge conflict — PR may have conflicts with the base branch."
+    Write-Host "   The agent will run with the PR branch as-is (without base branch updates)."
+    git merge --abort 2>&1
 } else {
-    Write-Host "⚠️ Could not restore .github/ from base branch — files may come from the PR branch"
+    Write-Host "✅ Merged base branch into PR — workspace has PR changes + latest main"
 }

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -99,18 +99,17 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "✅ Checked out PR #$PrNumber"
 git log --oneline -1
 
-# ── Restore agent infrastructure from base branch ────────────────────────────
+# ── Restore .github/ from base branch ────────────────────────────────────────
 # This script only runs for workflow_dispatch (other triggers use the platform's
 # checkout_pr_branch.cjs instead). For workflow_dispatch the platform checkout is
 # skipped, so this restore IS the final workspace state.
 # rm -rf first to prevent fork-added files from surviving the restore.
 
-if (Test-Path '.github/skills/') { Remove-Item -Recurse -Force '.github/skills/' }
-if (Test-Path '.github/instructions/') { Remove-Item -Recurse -Force '.github/instructions/' }
+if (Test-Path '.github/') { Remove-Item -Recurse -Force '.github/' }
 
-git checkout $BaseSha -- .github/skills/ .github/instructions/ .github/copilot-instructions.md 2>&1
+git checkout $BaseSha -- .github/ 2>&1
 if ($LASTEXITCODE -eq 0) {
-    Write-Host "✅ Restored agent infrastructure from base branch ($BaseSha)"
+    Write-Host "✅ Restored .github/ from base branch ($BaseSha)"
 } else {
-    Write-Host "⚠️ Could not restore agent infrastructure from base branch — files may come from the PR branch"
+    Write-Host "⚠️ Could not restore .github/ from base branch — files may come from the PR branch"
 }

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -12,6 +12,12 @@
     workflow_dispatch skips the platform checkout entirely, so this script is
     the only thing that gets the PR code onto disk.
 
+    SECURITY: Before checkout, the script verifies the PR author has write
+    access (write, maintain, or admin) to the repository. This prevents
+    checking out untrusted fork code in a context that has GITHUB_TOKEN.
+    Fork PRs are evaluated via pull_request_target instead (where the platform
+    handles checkout safely inside a sandboxed container).
+
     SECURITY NOTE: This script checks out PR code onto disk. This is safe
     because NO subsequent user steps execute workspace code — the gh-aw
     platform copies the workspace into a sandboxed container with scrubbed
@@ -41,6 +47,30 @@ if (-not $env:PR_NUMBER -or $env:PR_NUMBER -eq '0') {
 }
 
 $PrNumber = $env:PR_NUMBER
+
+# ── Verify PR author has write access ────────────────────────────────────────
+# workflow_dispatch runs with GITHUB_TOKEN. Only check out code from trusted
+# authors to prevent untrusted fork code from landing in a privileged context.
+
+$PrAuthor = gh pr view $PrNumber --repo $env:GITHUB_REPOSITORY --json author --jq '.author.login'
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "❌ Failed to fetch PR #$PrNumber author"
+    exit 1
+}
+
+$Permission = gh api "repos/$($env:GITHUB_REPOSITORY)/collaborators/$PrAuthor/permission" --jq '.permission'
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "❌ Failed to check permissions for '$PrAuthor'"
+    exit 1
+}
+
+$AllowedRoles = @('admin', 'write', 'maintain')
+if ($Permission -notin $AllowedRoles) {
+    Write-Host "⏭️ PR author '$PrAuthor' has '$Permission' access. workflow_dispatch only processes PRs from authors with write access."
+    Write-Host "   Fork PRs from external contributors are evaluated automatically via pull_request_target."
+    exit 1
+}
+Write-Host "✅ PR author '$PrAuthor' has '$Permission' access"
 
 # ── Save base branch SHA ─────────────────────────────────────────────────────
 # Must be captured BEFORE checkout replaces HEAD.

--- a/.github/scripts/Checkout-GhAwPr.ps1
+++ b/.github/scripts/Checkout-GhAwPr.ps1
@@ -64,7 +64,7 @@ if ($LASTEXITCODE -ne 0) {
 $AllowedRoles = @('admin', 'write', 'maintain')
 if ($Permission -notin $AllowedRoles) {
     Write-Host "⏭️ PR author '$($PrInfo.author)' has '$Permission' access. workflow_dispatch only processes PRs from authors with write access."
-    exit 0
+    exit 1
 }
 
 $IsFork = if ($PrInfo.isFork) { "fork" } else { "same-repo" }

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"cabc5b0915b4add16085501d23269d5b5267807a442811973b6351cfbe8bc7be","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d983973d21a026cabac2f3fb0750961f00b90b25c3b2329f1735c6f42a877170","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -324,15 +324,7 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         if: github.event_name == 'workflow_dispatch'
         name: Checkout PR and restore agent infrastructure
-        run: |-
-          PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')
-          PERMISSION=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$PR_AUTHOR/permission" --jq '.permission')
-          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" && "$PERMISSION" != "maintain" ]]; then
-            echo "⏭️ PR author '$PR_AUTHOR' has '$PERMISSION' access. workflow_dispatch only processes PRs from authors with write access."
-            exit 1
-          fi
-          echo "✅ PR author '$PR_AUTHOR' has '$PERMISSION' access — proceeding with checkout."
-          pwsh .github/scripts/Checkout-GhAwPr.ps1
+        run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f433e59f7d91527b26a1c81c7dcd412aaedd51107340c2ebeda22b044bb532de","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"5e89be1390fc8a350db540c3696a0995b385eea4e6553806325678f807479fb7","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -368,7 +368,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
         name: Gate — skip if no test source files in diff
-        run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+        run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff.\"\n  echo \"HAS_TEST_FILES=false\" >> \"$GITHUB_ENV\"\n  exit 0\nfi\necho \"HAS_TEST_FILES=true\" >> \"$GITHUB_ENV\"\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
       - env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"09f68d05aba213f8074eac7c537cf1c959e56f8379b11b4dcc79af2a9369625c","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"796f3194cfdc08be55785e7e5bf7b6a7ea50b874a069f945d11da4b88570ec30","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -31,6 +31,7 @@ name: "Evaluate PR Tests"
   issue_comment:
     types:
     - created
+    - edited
   pull_request_target:
     paths:
     - src/**/tests/**
@@ -66,20 +67,23 @@ jobs:
       (needs.pre_activation.outputs.activated == 'true') && (((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') && (
       (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests'))
+      github.event_name == 'issue_comment'
       ))
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
     outputs:
       body: ${{ steps.sanitized.outputs.body }}
-      comment_id: ""
-      comment_repo: ""
+      comment_id: ${{ steps.add-comment.outputs.comment-id }}
+      comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
+      comment_url: ${{ steps.add-comment.outputs.comment-url }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
+      slash_command: ${{ needs.pre_activation.outputs.matched_command }}
       text: ${{ steps.sanitized.outputs.text }}
       title: ${{ steps.sanitized.outputs.title }}
     steps:
@@ -113,6 +117,19 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
+      - name: Add eyes reaction for immediate feedback
+        id: react
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.id == github.repository_id)
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_REACTION: "eyes"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_reaction.cjs');
+            await main();
       - name: Validate COPILOT_GITHUB_TOKEN secret
         id: validate-secret
         run: ${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
@@ -147,6 +164,19 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
+            await main();
+      - name: Add comment with workflow run link
+        id: add-comment
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.id == github.repository_id)
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_WORKFLOW_NAME: "Evaluate PR Tests"
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 🧪 *Test evaluation by [{workflow_name}]({run_url})*\",\"runStarted\":\"🔬 Evaluating tests on this PR… [{workflow_name}]({run_url})\",\"runSuccess\":\"✅ Test evaluation complete! [{workflow_name}]({run_url})\",\"runFailure\":\"❌ Test evaluation failed. [{workflow_name}]({run_url}) {status}\"}"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -246,6 +276,7 @@ jobs:
           GH_AW_INPUTS_SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_MATCHED_COMMAND: ${{ needs.pre_activation.outputs.matched_command }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -268,7 +299,8 @@ jobs:
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
                 GH_AW_INPUTS_SUPPRESS_OUTPUT: process.env.GH_AW_INPUTS_SUPPRESS_OUTPUT,
                 GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_MATCHED_COMMAND: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_MATCHED_COMMAND
               }
             });
       - name: Validate prompt placeholders
@@ -711,6 +743,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
+          GH_AW_COMMAND: evaluate-tests
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -1000,26 +1033,43 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_noop_message.cjs');
             await main();
+      - name: Update reaction comment with completion status
+        id: conclusion
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
+          GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
+          GH_AW_COMMENT_REPO: ${{ needs.activation.outputs.comment_repo }}
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_AW_WORKFLOW_NAME: "Evaluate PR Tests"
+          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
+          GH_AW_DETECTION_CONCLUSION: ${{ needs.agent.outputs.detection_conclusion }}
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 🧪 *Test evaluation by [{workflow_name}]({run_url})*\",\"runStarted\":\"🔬 Evaluating tests on this PR… [{workflow_name}]({run_url})\",\"runSuccess\":\"✅ Test evaluation complete! [{workflow_name}]({run_url})\",\"runFailure\":\"❌ Test evaluation failed. [{workflow_name}]({run_url}) {status}\"}"
+        with:
+          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/notify_comment_error.cjs');
+            await main();
 
   pre_activation:
     if: >
       ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') && (
       (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests'))
+      github.event_name == 'issue_comment'
       )
     runs-on: ubuntu-slim
     outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
+      activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_command_position.outputs.command_position_ok == 'true') }}
+      matched_command: ${{ steps.check_command_position.outputs.matched_command }}
     steps:
       - name: Setup Scripts
         uses: github/gh-aw-actions/setup@20045bbd5ad2632b9809856c389708eab1bd16ef # v0.62.2
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
-      - name: Check team membership for workflow
+      - name: Check team membership for command workflow
         id: check_membership
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
@@ -1031,6 +1081,17 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
+            await main();
+      - name: Check command position
+        id: check_command_position
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_COMMANDS: "[\"evaluate-tests\"]"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_command_position.cjs');
             await main();
 
   safe_outputs:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"230a1bc8346ff7d470433b8c4847233d31fc36b5e896076487ef4ecc9b0bb781","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2b2d6af9e369ce38bce64b975f84f095a6dd87ee1f5efb57e045a85f68970829","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -344,7 +344,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
         name: Gate — skip if no test source files in diff
-        run: "# Verify this is an open PR\nif ! STATE=$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --json state --jq .state 2>&1); then\n  echo \"❌ Failed to fetch PR #$PR_NUMBER state: $STATE\"\n  exit 1\nfi\nif [ \"$STATE\" != \"OPEN\" ]; then\n  echo \"⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation.\"\n  exit 1\nfi\n# Try gh pr diff first; fall back to REST API only on command failure\nif DIFF_OUTPUT=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null); then\n  TEST_FILES=$(echo \"$DIFF_OUTPUT\" \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nelse\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+        run: "# Verify this is an open PR\nif ! STATE=$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --json state --jq .state 2>&1); then\n  echo \"❌ Failed to fetch PR #$PR_NUMBER state: $STATE\"\n  exit 1\nfi\nif [ \"$STATE\" != \"OPEN\" ]; then\n  echo \"⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation.\"\n  exit 1\nfi\n# Try gh pr diff first; fall back to REST API only on command failure\nif DIFF_OUTPUT=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null); then\n  TEST_FILES=$(echo \"$DIFF_OUTPUT\" \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nelse\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  if ! API_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>&1); then\n    echo \"❌ gh pr diff failed and REST API fallback also failed: $API_FILES\"\n    exit 1\n  fi\n  TEST_FILES=$(echo \"$API_FILES\" \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4b6d0daf533af755e69a1c769871c511ee28df89f94422bd4b20ec1323ab4559","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6dce84b30064a2f881468240d22e3cc9deec065589e6f1c59aef9b8eb1451280","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d983973d21a026cabac2f3fb0750961f00b90b25c3b2329f1735c6f42a877170","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0a92e9e40d797284a9013f14f8f3074270993227a4841a7ffc3b3542d1d524ef","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -56,9 +56,13 @@ run-name: "Evaluate PR Tests"
 jobs:
   activation:
     if: >
-      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
+      (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests'))
+      startsWith(github.event.comment.body, '/evaluate-tests') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"6dce84b30064a2f881468240d22e3cc9deec065589e6f1c59aef9b8eb1451280","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"230a1bc8346ff7d470433b8c4847233d31fc36b5e896076487ef4ecc9b0bb781","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -44,7 +44,10 @@ run-name: "Evaluate PR Tests"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.outputs.activated == 'true') && (github.event_name == 'issue_comment')
+    if: >
+      (needs.pre_activation.outputs.activated == 'true') && (((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') &&
+      (((startsWith(github.event.comment.body, '/evaluate-tests ')) || (github.event.comment.body == '/evaluate-tests')) &&
+      (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment')))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -341,7 +344,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
         name: Gate — skip if no test source files in diff
-        run: "# Verify this is an open PR\nSTATE=$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --json state --jq .state 2>/dev/null || echo \"UNKNOWN\")\nif [ \"$STATE\" != \"OPEN\" ]; then\n  echo \"⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation.\"\n  exit 1\nfi\n# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+        run: "# Verify this is an open PR\nif ! STATE=$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --json state --jq .state 2>&1); then\n  echo \"❌ Failed to fetch PR #$PR_NUMBER state: $STATE\"\n  exit 1\nfi\nif [ \"$STATE\" != \"OPEN\" ]; then\n  echo \"⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation.\"\n  exit 1\nfi\n# Try gh pr diff first; fall back to REST API only on command failure\nif DIFF_OUTPUT=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null); then\n  TEST_FILES=$(echo \"$DIFF_OUTPUT\" \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nelse\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
 
       - name: Configure Git credentials
         env:
@@ -1020,7 +1023,9 @@ jobs:
             await main();
 
   pre_activation:
-    if: github.event_name == 'issue_comment'
+    if: >
+      ((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && (((startsWith(github.event.comment.body, '/evaluate-tests ')) ||
+      (github.event.comment.body == '/evaluate-tests')) && (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment'))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_command_position.outputs.command_position_ok == 'true') }}

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b93d66e9ef685f04f4a2d93d11d4537ff6be75abd61211e325db8fe42ef599d2","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4b6d0daf533af755e69a1c769871c511ee28df89f94422bd4b20ec1323ab4559","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -341,7 +341,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
         name: Gate — skip if no test source files in diff
-        run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+        run: "# Verify this is an open PR\nSTATE=$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --json state --jq .state 2>/dev/null || echo \"UNKNOWN\")\nif [ \"$STATE\" != \"OPEN\" ]; then\n  echo \"⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation.\"\n  exit 1\nfi\n# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2b2d6af9e369ce38bce64b975f84f095a6dd87ee1f5efb57e045a85f68970829","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"cbfd75d7a699f76155135d83866eda6476cef647c384243c8ee991065a2b44d7","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -32,12 +32,23 @@ name: "Evaluate PR Tests"
     types:
     - created
     - edited
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to evaluate
+        required: true
+        type: number
+      suppress_output:
+        default: false
+        description: Dry-run — evaluate but do not post output on the PR
+        required: false
+        type: boolean
 
 permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: evaluate-pr-tests-${{ github.event.issue.number || github.run_id }}
+  group: evaluate-pr-tests-${{ github.event.issue.number || inputs.pr_number || github.run_id }}
 
 run-name: "Evaluate PR Tests"
 
@@ -45,9 +56,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      (needs.pre_activation.outputs.activated == 'true') && (((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') &&
-      (((startsWith(github.event.comment.body, '/evaluate-tests ')) || (github.event.comment.body == '/evaluate-tests')) &&
-      (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment')))
+      (needs.pre_activation.outputs.activated == 'true') && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -161,6 +170,7 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ env.GH_AW_SAFE_OUTPUTS }}
+          GH_AW_EXPR_A77326CF: ${{ github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -229,7 +239,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_AW_EXPR_A77326CF: ${{ github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_INPUTS_SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
         with:
@@ -242,6 +252,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_EXPR_A77326CF: ${{ github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -265,6 +276,7 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
+                GH_AW_EXPR_A77326CF: process.env.GH_AW_EXPR_A77326CF,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -342,9 +354,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
         name: Gate — skip if no test source files in diff
         run: "# Verify this is an open PR\nif ! STATE=$(gh pr view \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --json state --jq .state 2>&1); then\n  echo \"❌ Failed to fetch PR #$PR_NUMBER state: $STATE\"\n  exit 1\nfi\nif [ \"$STATE\" != \"OPEN\" ]; then\n  echo \"⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation.\"\n  exit 1\nfi\n# Try gh pr diff first; fall back to REST API only on command failure\nif DIFF_OUTPUT=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null); then\n  TEST_FILES=$(echo \"$DIFF_OUTPUT\" \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nelse\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  if ! API_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>&1); then\n    echo \"❌ gh pr diff failed and REST API fallback also failed: $API_FILES\"\n    exit 1\n  fi\n  TEST_FILES=$(echo \"$API_FILES\" \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        if: github.event_name == 'workflow_dispatch'
+        name: Checkout PR and restore agent infrastructure
+        run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 
       - name: Configure Git credentials
         env:
@@ -1023,9 +1041,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: >
-      ((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && (((startsWith(github.event.comment.body, '/evaluate-tests ')) ||
-      (github.event.comment.body == '/evaluate-tests')) && (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment'))
+    if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_command_position.outputs.command_position_ok == 'true') }}

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1cead4a91eff14e2881035fceb96c10526d1265400b4b5d59c73951f208f9aa1","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"217d6a2ef047096333a7d61da2800b9a231fbe32125dede6d1c311c57bba2abf","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -45,9 +45,9 @@ name: "Evaluate PR Tests"
         description: PR number to evaluate
         required: true
         type: number
-      suppress_comment:
+      suppress_output:
         default: false
-        description: Dry-run — evaluate but do not post a comment on the PR
+        description: Dry-run — evaluate but do not post output on the PR
         required: false
         type: boolean
 
@@ -63,9 +63,13 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
+      (needs.pre_activation.outputs.activated == 'true') && (((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') && (
+      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests')))
+      startsWith(github.event.comment.body, '/evaluate-tests'))
+      ))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -157,7 +161,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_INPUTS_SUPPRESS_COMMENT: ${{ inputs.suppress_comment }}
+          GH_AW_INPUTS_SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
@@ -219,7 +223,7 @@ jobs:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
-          GH_AW_INPUTS_SUPPRESS_COMMENT: ${{ inputs.suppress_comment }}
+          GH_AW_INPUTS_SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -239,7 +243,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_INPUTS_SUPPRESS_COMMENT: ${{ inputs.suppress_comment }}
+          GH_AW_INPUTS_SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
@@ -262,7 +266,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_INPUTS_SUPPRESS_COMMENT: process.env.GH_AW_INPUTS_SUPPRESS_COMMENT,
+                GH_AW_INPUTS_SUPPRESS_OUTPUT: process.env.GH_AW_INPUTS_SUPPRESS_OUTPUT,
                 GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
@@ -988,7 +992,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: "true"
+          GH_AW_NOOP_REPORT_AS_ISSUE: "false"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -999,9 +1003,13 @@ jobs:
 
   pre_activation:
     if: >
-      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
+      ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') && (
+      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/evaluate-tests'))
+      )
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -1085,7 +1093,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1,\"target\":\"*\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1,\"target\":\"*\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8f1686e10a1aa945094b88478506817bd12164bc35d1582570ad8dca9e420b93","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"10204a6c8e2082405538d6953d80a166a21e0415f9de81d79562e5447d5c9cdd","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -43,6 +43,11 @@ name: "Evaluate PR Tests"
         description: PR number to evaluate
         required: true
         type: number
+      suppress_comment:
+        default: false
+        description: Dry-run — evaluate but do not post a comment on the PR
+        required: false
+        type: boolean
 
 permissions: {}
 
@@ -148,6 +153,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_INPUTS_SUPPRESS_COMMENT: ${{ inputs.suppress_comment }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
@@ -209,6 +215,7 @@ jobs:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_AW_INPUTS_SUPPRESS_COMMENT: ${{ inputs.suppress_comment }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -228,6 +235,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_INPUTS_SUPPRESS_COMMENT: ${{ inputs.suppress_comment }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
@@ -250,6 +258,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_INPUTS_SUPPRESS_COMMENT: process.env.GH_AW_INPUTS_SUPPRESS_COMMENT,
                 GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,10 +22,12 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"10204a6c8e2082405538d6953d80a166a21e0415f9de81d79562e5447d5c9cdd","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"1cead4a91eff14e2881035fceb96c10526d1265400b4b5d59c73951f208f9aa1","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
+  # bots: # Bots processed as bot check in pre-activation job
+  # - copilot[bot] # Bots processed as bot check in pre-activation job
   issue_comment:
     types:
     - created
@@ -134,6 +136,8 @@ jobs:
       - name: Compute current body text
         id: sanitized
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_ALLOWED_BOTS: copilot[bot]
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -1012,6 +1016,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_REQUIRED_ROLES: admin,maintainer,write
+          GH_AW_ALLOWED_BOTS: copilot[bot]
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"796f3194cfdc08be55785e7e5bf7b6a7ea50b874a069f945d11da4b88570ec30","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0e2fd785240c3ad98d232bd3281aca1e90802f6ba441fa20e57f8cc11e504748","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0a92e9e40d797284a9013f14f8f3074270993227a4841a7ffc3b3542d1d524ef","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8f1686e10a1aa945094b88478506817bd12164bc35d1582570ad8dca9e420b93","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -37,7 +37,6 @@ name: "Evaluate PR Tests"
     - opened
     - synchronize
     - reopened
-  # roles: all # Roles processed as role check in pre-activation job
   workflow_dispatch:
     inputs:
       pr_number:
@@ -55,14 +54,11 @@ run-name: "Evaluate PR Tests"
 
 jobs:
   activation:
+    needs: pre_activation
     if: >
-      (github.event_name == 'pull_request_target' &&
-      github.event.pull_request.draft == false &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
-      github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
+      (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      startsWith(github.event.comment.body, '/evaluate-tests')))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -233,6 +229,7 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -253,7 +250,8 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT
+                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
       - name: Validate prompt placeholders
@@ -984,6 +982,33 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_noop_message.cjs');
+            await main();
+
+  pre_activation:
+    if: >
+      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/evaluate-tests'))
+    runs-on: ubuntu-slim
+    outputs:
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      matched_command: ''
+    steps:
+      - name: Setup Scripts
+        uses: github/gh-aw-actions/setup@20045bbd5ad2632b9809856c389708eab1bd16ef # v0.62.2
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+      - name: Check team membership for workflow
+        id: check_membership
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_REQUIRED_ROLES: admin,maintainer,write
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
 
   safe_outputs:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3696e1009391ebf26f6ff0200253ee7cdb40480282a5dcc5ca67c3408ed8b406","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b93d66e9ef685f04f4a2d93d11d4537ff6be75abd61211e325db8fe42ef599d2","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -32,43 +32,19 @@ name: "Evaluate PR Tests"
     types:
     - created
     - edited
-  pull_request_target:
-    paths:
-    - src/**/tests/**
-    - src/**/test/**
-    types:
-    - opened
-    - synchronize
-    - reopened
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: PR number to evaluate
-        required: true
-        type: number
-      suppress_output:
-        default: false
-        description: Dry-run — evaluate but do not post output on the PR
-        required: false
-        type: boolean
 
 permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: evaluate-pr-tests-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
+  group: evaluate-pr-tests-${{ github.event.issue.number || github.run_id }}
 
 run-name: "Evaluate PR Tests"
 
 jobs:
   activation:
     needs: pre_activation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && (((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') && (
-      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'issue_comment'
-      ))
+    if: (needs.pre_activation.outputs.activated == 'true') && (github.event_name == 'issue_comment')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -182,7 +158,6 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ env.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -251,7 +226,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_INPUTS_SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
         with:
@@ -264,7 +239,6 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_93C755A4: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -288,7 +262,6 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_EXPR_93C755A4: process.env.GH_AW_EXPR_93C755A4,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -366,15 +339,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         name: Gate — skip if no test source files in diff
         run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
-      - env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-        if: github.event_name == 'workflow_dispatch'
-        name: Checkout PR and restore agent infrastructure
-        run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 
       - name: Configure Git credentials
         env:
@@ -1053,12 +1020,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: >
-      ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') && (
-      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'issue_comment'
-      )
+    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_command_position.outputs.command_position_ok == 'true') }}

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"698fe19ee67db9f4c5d7b49647270bb1a873f5dec6ef69a664e80303f43a773a","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"3696e1009391ebf26f6ff0200253ee7cdb40480282a5dcc5ca67c3408ed8b406","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -368,11 +368,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
         name: Gate — skip if no test source files in diff
-        run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff.\"\n  echo \"HAS_TEST_FILES=false\" >> \"$GITHUB_ENV\"\n  exit 0\nfi\necho \"HAS_TEST_FILES=true\" >> \"$GITHUB_ENV\"\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+        run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
       - env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
-        if: github.event_name == 'workflow_dispatch' && env.HAS_TEST_FILES != 'false'
+        if: github.event_name == 'workflow_dispatch'
         name: Checkout PR and restore agent infrastructure
         run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,16 +22,14 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d671028235c1b911c7a816a257b07b02793a6b57747b4358f792af183e26ca07","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7d2f69a1407ce62c7eec4db9f6fecdae1a6cb95524bf4af29ed58d1c069915d2","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
   issue_comment:
     types:
     - created
-  pull_request:
-    # forks: # Fork filtering applied via job conditions
-    # - "*" # Fork filtering applied via job conditions
+  pull_request_target:
     paths:
     - src/**/tests/**
     - src/**/test/**
@@ -39,7 +37,7 @@ name: "Evaluate PR Tests"
     - opened
     - synchronize
     - reopened
-    - ready_for_review
+  # roles: all # Roles processed as role check in pre-activation job
   workflow_dispatch:
     inputs:
       pr_number:
@@ -57,11 +55,10 @@ run-name: "Evaluate PR Tests"
 
 jobs:
   activation:
-    needs: pre_activation
     if: >
-      (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
+      (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests')))
+      startsWith(github.event.comment.body, '/evaluate-tests'))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -232,7 +229,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -253,8 +249,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT
               }
             });
       - name: Validate prompt placeholders
@@ -321,7 +316,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         name: Gate — skip if no test source files in diff
         run: "TEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
       - env:
@@ -985,33 +980,6 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_noop_message.cjs');
-            await main();
-
-  pre_activation:
-    if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/evaluate-tests'))
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-    steps:
-      - name: Setup Scripts
-        uses: github/gh-aw-actions/setup@20045bbd5ad2632b9809856c389708eab1bd16ef # v0.62.2
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_REQUIRED_ROLES: admin,maintainer,write
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
 
   safe_outputs:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"5e89be1390fc8a350db540c3696a0995b385eea4e6553806325678f807479fb7","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"698fe19ee67db9f4c5d7b49647270bb1a873f5dec6ef69a664e80303f43a773a","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -372,7 +372,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && env.HAS_TEST_FILES != 'false'
         name: Checkout PR and restore agent infrastructure
         run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,12 +22,12 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"217d6a2ef047096333a7d61da2800b9a231fbe32125dede6d1c311c57bba2abf","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a93bfc0e62ee433ef08616d717ab0f5ce66ccf930273a1214b1211d526c0b98e","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
   # bots: # Bots processed as bot check in pre-activation job
-  # - copilot[bot] # Bots processed as bot check in pre-activation job
+  # - copilot-swe-agent[bot] # Bots processed as bot check in pre-activation job
   issue_comment:
     types:
     - created
@@ -141,7 +141,7 @@ jobs:
         id: sanitized
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_ALLOWED_BOTS: copilot[bot]
+          GH_AW_ALLOWED_BOTS: copilot-swe-agent[bot]
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -1024,7 +1024,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_REQUIRED_ROLES: admin,maintainer,write
-          GH_AW_ALLOWED_BOTS: copilot[bot]
+          GH_AW_ALLOWED_BOTS: copilot-swe-agent[bot]
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0e2fd785240c3ad98d232bd3281aca1e90802f6ba441fa20e57f8cc11e504748","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f433e59f7d91527b26a1c81c7dcd412aaedd51107340c2ebeda22b044bb532de","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -366,8 +366,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        if: github.event_name == 'pull_request_target'
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
         name: Gate — skip if no test source files in diff
         run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
       - env:
@@ -639,7 +638,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -1008,7 +1007,7 @@ jobs:
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 🧪 *Test evaluation by [{workflow_name}]({run_url})*\",\"runStarted\":\"🔬 Evaluating tests on this PR… [{workflow_name}]({run_url})\",\"runSuccess\":\"✅ Test evaluation complete! [{workflow_name}]({run_url})\",\"runFailure\":\"❌ Test evaluation failed. [{workflow_name}]({run_url}) {status}\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
-          GH_AW_TIMEOUT_MINUTES: "15"
+          GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"7d2f69a1407ce62c7eec4db9f6fecdae1a6cb95524bf4af29ed58d1c069915d2","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"cabc5b0915b4add16085501d23269d5b5267807a442811973b6351cfbe8bc7be","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -324,7 +324,15 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         if: github.event_name == 'workflow_dispatch'
         name: Checkout PR and restore agent infrastructure
-        run: pwsh .github/scripts/Checkout-GhAwPr.ps1
+        run: |-
+          PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')
+          PERMISSION=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$PR_AUTHOR/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" && "$PERMISSION" != "maintain" ]]; then
+            echo "⏭️ PR author '$PR_AUTHOR' has '$PERMISSION' access. workflow_dispatch only processes PRs from authors with write access."
+            exit 1
+          fi
+          echo "✅ PR author '$PR_AUTHOR' has '$PERMISSION' access — proceeding with checkout."
+          pwsh .github/scripts/Checkout-GhAwPr.ps1
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a93bfc0e62ee433ef08616d717ab0f5ce66ccf930273a1214b1211d526c0b98e","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a50c4fa32a00cde10089c01615584e8c088eb523dae9fe7cd5828be145fd5055","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -337,7 +337,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         if: github.event_name == 'pull_request_target'
         name: Gate — skip if no test source files in diff
-        run: "TEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
+        run: "# Try gh pr diff first; fall back to REST API for large PRs (300+ files)\nTEST_FILES=$(gh pr diff \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\" --name-only 2>/dev/null \\\n  | grep -E '\\.(cs|xaml)$' \\\n  | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n  || true)\nif [ -z \"$TEST_FILES\" ]; then\n  # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API\n  TEST_FILES=$(gh api \"repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files\" --paginate --jq '.[].filename' 2>/dev/null \\\n    | grep -E '\\.(cs|xaml)$' \\\n    | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \\\n    || true)\nfi\nif [ -z \"$TEST_FILES\" ]; then\n  echo \"⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation.\"\n  exit 1\nfi\necho \"✅ Found test files to evaluate:\"\necho \"$TEST_FILES\" | head -20\n"
       - env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/copilot-evaluate-tests.lock.yml
+++ b/.github/workflows/copilot-evaluate-tests.lock.yml
@@ -22,7 +22,7 @@
 #
 # Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a50c4fa32a00cde10089c01615584e8c088eb523dae9fe7cd5828be145fd5055","compiler_version":"v0.62.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"09f68d05aba213f8074eac7c537cf1c959e56f8379b11b4dcc79af2a9369625c","compiler_version":"v0.62.2","strict":true}
 
 name: "Evaluate PR Tests"
 "on":
@@ -1093,7 +1093,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1,\"target\":\"*\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -65,14 +65,13 @@ concurrency:
   group: "evaluate-pr-tests-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}"
   cancel-in-progress: true
 
-timeout-minutes: 15
+timeout-minutes: 20
 
 steps:
   - name: Gate — skip if no test source files in diff
-    if: github.event_name == 'pull_request_target'
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
     run: |
       # Try gh pr diff first; fall back to REST API for large PRs (300+ files)
       TEST_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only 2>/dev/null \
@@ -155,7 +154,7 @@ Do not post a comment and do not silently exit — always use `noop` so the work
 ## Running the skill
 
 1. Use `gh pr view <number>` to fetch PR metadata (title, body, labels, base branch). If `gh` CLI is unavailable, use the GitHub MCP tools instead.
-2. Run `pwsh .github/skills/evaluate-pr-tests/scripts/Gather-TestContext.ps1` to gather automated context
+2. Run `pwsh .github/skills/evaluate-pr-tests/scripts/Gather-TestContext.ps1 -PrNumber <number>` to gather automated context (use the PR number from the Context section above)
 3. Read the context report and the actual changed files, then evaluate per SKILL.md criteria
 4. Post results using `add_comment` with `item_number` set to the PR number
 

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -6,8 +6,9 @@ on:
     paths:
       - 'src/**/tests/**'
       - 'src/**/test/**'
-  issue_comment:
-    types: [created]
+  slash_command:
+    name: evaluate-tests
+    events: [pull_request_comment, issue_comment]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -27,9 +28,7 @@ if: >-
   (
     (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
     github.event_name == 'workflow_dispatch' ||
-    (github.event_name == 'issue_comment' &&
-     github.event.issue.pull_request &&
-     startsWith(github.event.comment.body, '/evaluate-tests'))
+    github.event_name == 'issue_comment'
   )
 
 permissions:

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -86,9 +86,11 @@ steps:
           || true)
       fi
       if [ -z "$TEST_FILES" ]; then
-        echo "⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation."
-        exit 1
+        echo "⏭️ No test source files (.cs/.xaml) found in PR diff."
+        echo "HAS_TEST_FILES=false" >> "$GITHUB_ENV"
+        exit 0
       fi
+      echo "HAS_TEST_FILES=true" >> "$GITHUB_ENV"
       echo "✅ Found test files to evaluate:"
       echo "$TEST_FILES" | head -20
 

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -17,11 +17,14 @@ on:
   roles: all
 
 if: >-
-  (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
+  (github.event_name == 'pull_request_target' &&
+   github.event.pull_request.draft == false &&
+   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
   github.event_name == 'workflow_dispatch' ||
   (github.event_name == 'issue_comment' &&
    github.event.issue.pull_request &&
-   startsWith(github.event.comment.body, '/evaluate-tests'))
+   startsWith(github.event.comment.body, '/evaluate-tests') &&
+   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
 
 permissions:
   contents: read

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -1,6 +1,7 @@
 ---
 description: Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 on:
+  # pull_request_target is intentionally disabled — we don't want auto-runs on PR create/update.
   # pull_request_target:
   #   types: [opened, synchronize, reopened]
   #   paths:
@@ -9,24 +10,27 @@ on:
   slash_command:
     name: evaluate-tests
     events: [pull_request_comment]
-  # workflow_dispatch:
-  #   inputs:
-  #     pr_number:
-  #       description: 'PR number to evaluate'
-  #       required: true
-  #       type: number
-  #     suppress_output:
-  #       description: 'Dry-run — evaluate but do not post output on the PR'
-  #       required: false
-  #       type: boolean
-  #       default: false
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to evaluate'
+        required: true
+        type: number
+      suppress_output:
+        description: 'Dry-run — evaluate but do not post output on the PR'
+        required: false
+        type: boolean
+        default: false
   bots:
     - "copilot-swe-agent[bot]"
 
 labels: ["pr-review", "testing"]
 
-# The if: condition is omitted — slash_command compiles to issue_comment,
-# so the platform's pre_activation job handles trigger filtering.
+# Trigger filtering: slash_command compiles to issue_comment (platform handles
+# command matching). workflow_dispatch is always allowed.
+if: >-
+  github.event_name == 'issue_comment' ||
+  github.event_name == 'workflow_dispatch'
 
 permissions:
   contents: read
@@ -57,7 +61,7 @@ tools:
 network: defaults
 
 concurrency:
-  group: "evaluate-pr-tests-${{ github.event.issue.number || github.run_id }}"
+  group: "evaluate-pr-tests-${{ github.event.issue.number || inputs.pr_number || github.run_id }}"
   cancel-in-progress: true
 
 timeout-minutes: 20
@@ -66,7 +70,7 @@ steps:
   - name: Gate — skip if no test source files in diff
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ github.event.issue.number }}
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
     run: |
       # Verify this is an open PR
       if ! STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>&1); then
@@ -108,6 +112,15 @@ steps:
   # Mitigation: agent is sandboxed (no credentials), max 1 comment via safe-outputs,
   # and the agent prompt includes a pre-flight check that catches missing SKILL.md.
   # See: .github/instructions/gh-aw-workflows.instructions.md "The issue_comment + Fork Problem"
+
+  # For workflow_dispatch, the platform skips checkout entirely — this step is the
+  # only thing that gets the PR code onto disk and restores trusted infra from main.
+  - name: Checkout PR and restore agent infrastructure
+    if: github.event_name == 'workflow_dispatch'
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+    run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 ---
 
 # Evaluate PR Tests
@@ -117,7 +130,7 @@ Invoke the **evaluate-pr-tests** skill: read and follow `.github/skills/evaluate
 ## Context
 
 - **Repository**: ${{ github.repository }}
-- **PR Number**: ${{ github.event.issue.number }}
+- **PR Number**: ${{ github.event.issue.number || inputs.pr_number }}
 
 The PR branch has been checked out for you. All files from the PR are available locally.
 
@@ -141,13 +154,11 @@ If the file is **missing**, the fork PR branch is likely not rebased on the late
 
 Then stop — do not proceed with the evaluation.
 
-<!-- Dry-run mode is disabled while workflow_dispatch is commented out
 ## Dry-run mode
 
 When triggered via `workflow_dispatch`, the `suppress_output` input controls behavior.
 - If `${{ inputs.suppress_output }}` == **true**, perform the full evaluation but **do not** post output on the PR. Write the evaluation to the workflow log only. This is useful for testing the skill without spamming the PR.
 - If **false** (default), post the output as normal.
--->
 
 ## When no action is needed
 
@@ -168,7 +179,9 @@ Do not post a comment and do not silently exit — always use `noop` so the work
 
 ## Posting Results
 
-Call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
+If dry-run mode is active (`suppress_output` is true), log the evaluation report to stdout and stop — do **not** call `add_comment`.
+
+Otherwise, call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
 
 ```markdown
 ## 🧪 PR Test Evaluation

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -14,17 +14,13 @@ on:
         description: 'PR number to evaluate'
         required: true
         type: number
-  roles: all
 
 if: >-
-  (github.event_name == 'pull_request_target' &&
-   github.event.pull_request.draft == false &&
-   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+  (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
   github.event_name == 'workflow_dispatch' ||
   (github.event_name == 'issue_comment' &&
    github.event.issue.pull_request &&
-   startsWith(github.event.comment.body, '/evaluate-tests') &&
-   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+   startsWith(github.event.comment.body, '/evaluate-tests'))
 
 permissions:
   contents: read
@@ -114,7 +110,7 @@ If the file is **missing**, the fork PR branch is likely not rebased on the late
 
 ❌ **Cannot evaluate**: this PR's branch does not include the evaluate-pr-tests skill (`.github/skills/evaluate-pr-tests/SKILL.md` is missing).
 
-**Fix**: rebase your fork on the latest `main` branch, or use the **workflow_dispatch** trigger (Actions tab → "Evaluate PR Tests" → "Run workflow" → enter PR number) which handles this automatically.
+**Fix**: rebase your fork on the latest `main` branch and push again. The evaluation will trigger automatically once the skill file is available.
 ```
 
 Then stop — do not proceed with the evaluation.

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -25,8 +25,8 @@ on:
 
 labels: ["pr-review", "testing"]
 
-if: >-
-  github.event_name == 'issue_comment'
+# The if: condition is omitted — slash_command compiles to issue_comment,
+# so the platform's pre_activation job handles trigger filtering.
 
 permissions:
   contents: read
@@ -69,17 +69,21 @@ steps:
       PR_NUMBER: ${{ github.event.issue.number }}
     run: |
       # Verify this is an open PR
-      STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
+      if ! STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>&1); then
+        echo "❌ Failed to fetch PR #$PR_NUMBER state: $STATE"
+        exit 1
+      fi
       if [ "$STATE" != "OPEN" ]; then
         echo "⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation."
         exit 1
       fi
-      # Try gh pr diff first; fall back to REST API for large PRs (300+ files)
-      TEST_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only 2>/dev/null \
-        | grep -E '\.(cs|xaml)$' \
-        | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \
-        || true)
-      if [ -z "$TEST_FILES" ]; then
+      # Try gh pr diff first; fall back to REST API only on command failure
+      if DIFF_OUTPUT=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only 2>/dev/null); then
+        TEST_FILES=$(echo "$DIFF_OUTPUT" \
+          | grep -E '\.(cs|xaml)$' \
+          | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \
+          || true)
+      else
         # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API
         TEST_FILES=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null \
           | grep -E '\.(cs|xaml)$' \

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -20,7 +20,7 @@ on:
         type: boolean
         default: false
   bots:
-    - "copilot[bot]"
+    - "copilot-swe-agent[bot]"
 
 if: >-
   ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') &&

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -93,14 +93,13 @@ steps:
       echo "✅ Found test files to evaluate:"
       echo "$TEST_FILES" | head -20
 
-  # Checkout is handled automatically by the gh-aw platform's checkout_pr_branch.cjs
-  # for slash_command/issue_comment triggers. No manual checkout needed.
-  # - name: Checkout PR and restore agent infrastructure
-  #   if: github.event_name == 'workflow_dispatch'
-  #   env:
-  #     GH_TOKEN: ${{ github.token }}
-  #     PR_NUMBER: ${{ inputs.pr_number }}
-  #   run: pwsh .github/scripts/Checkout-GhAwPr.ps1
+  # For slash_command triggers, the gh-aw platform's checkout_pr_branch.cjs runs
+  # AFTER all user steps and overlays the PR branch onto the workspace. This means
+  # fork PRs can supply their own .github/skills/ and .github/instructions/.
+  # We cannot restore trusted infra here because the platform checkout runs later.
+  # Mitigation: agent is sandboxed (no credentials), max 1 comment via safe-outputs,
+  # and the agent prompt includes a pre-flight check that catches missing SKILL.md.
+  # See: .github/instructions/gh-aw-workflows.instructions.md "The issue_comment + Fork Problem"
 ---
 
 # Evaluate PR Tests

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -1,9 +1,8 @@
 ---
 description: Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    forks: ["*"]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     paths:
       - 'src/**/tests/**'
       - 'src/**/test/**'
@@ -15,9 +14,10 @@ on:
         description: 'PR number to evaluate'
         required: true
         type: number
+  roles: all
 
 if: >-
-  (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+  (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
   github.event_name == 'workflow_dispatch' ||
   (github.event_name == 'issue_comment' &&
    github.event.issue.pull_request &&
@@ -57,7 +57,7 @@ timeout-minutes: 15
 
 steps:
   - name: Gate — skip if no test source files in diff
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -73,7 +73,7 @@ steps:
       echo "✅ Found test files to evaluate:"
       echo "$TEST_FILES" | head -20
 
-  # Only needed for workflow_dispatch — for pull_request and issue_comment,
+  # Only needed for workflow_dispatch — for pull_request_target and issue_comment,
   # the gh-aw platform's checkout_pr_branch.cjs handles PR checkout automatically.
   # workflow_dispatch skips the platform checkout entirely, so we must do it here.
   - name: Checkout PR and restore agent infrastructure

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -72,10 +72,18 @@ steps:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     run: |
-      TEST_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only \
+      # Try gh pr diff first; fall back to REST API for large PRs (300+ files)
+      TEST_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only 2>/dev/null \
         | grep -E '\.(cs|xaml)$' \
         | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \
         || true)
+      if [ -z "$TEST_FILES" ]; then
+        # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API
+        TEST_FILES=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null \
+          | grep -E '\.(cs|xaml)$' \
+          | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \
+          || true)
+      fi
       if [ -z "$TEST_FILES" ]; then
         echo "⏭️ No test source files (.cs/.xaml) found in PR diff. Skipping evaluation."
         exit 1

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -76,22 +76,13 @@ steps:
   # Only needed for workflow_dispatch — for pull_request_target and issue_comment,
   # the gh-aw platform's checkout_pr_branch.cjs handles PR checkout automatically.
   # workflow_dispatch skips the platform checkout entirely, so we must do it here.
-  # Gate: only check out PRs from authors with write access (the checkout step
-  # runs with GITHUB_TOKEN, so we don't want to check out untrusted fork code).
+  # The script gates on PR author having write access before checkout.
   - name: Checkout PR and restore agent infrastructure
     if: github.event_name == 'workflow_dispatch'
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ inputs.pr_number }}
-    run: |
-      PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')
-      PERMISSION=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$PR_AUTHOR/permission" --jq '.permission')
-      if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" && "$PERMISSION" != "maintain" ]]; then
-        echo "⏭️ PR author '$PR_AUTHOR' has '$PERMISSION' access. workflow_dispatch only processes PRs from authors with write access."
-        exit 1
-      fi
-      echo "✅ PR author '$PR_AUTHOR' has '$PERMISSION' access — proceeding with checkout."
-      pwsh .github/scripts/Checkout-GhAwPr.ps1
+    run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 ---
 
 # Evaluate PR Tests

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -98,8 +98,9 @@ steps:
   # the gh-aw platform's checkout_pr_branch.cjs handles PR checkout automatically.
   # workflow_dispatch skips the platform checkout entirely, so we must do it here.
   # The script gates on PR author having write access before checkout.
+  # Skip if gate determined no test files (HAS_TEST_FILES set by gate step via GITHUB_ENV).
   - name: Checkout PR and restore agent infrastructure
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && env.HAS_TEST_FILES != 'false'
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -85,7 +85,11 @@ steps:
           || true)
       else
         # gh pr diff fails with HTTP 406 for PRs with 300+ files; use paginated files API
-        TEST_FILES=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null \
+        if ! API_FILES=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>&1); then
+          echo "❌ gh pr diff failed and REST API fallback also failed: $API_FILES"
+          exit 1
+        fi
+        TEST_FILES=$(echo "$API_FILES" \
           | grep -E '\.(cs|xaml)$' \
           | grep -iE '(tests?/|TestCases|UnitTests|DeviceTests)' \
           || true)

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -45,6 +45,7 @@ safe-outputs:
   add-comment:
     max: 1
     target: "*"
+    hide-older-comments: true
   noop:
     report-as-issue: false
   messages:

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -23,6 +23,8 @@ on:
   bots:
     - "copilot-swe-agent[bot]"
 
+labels: ["pr-review", "testing"]
+
 if: >-
   ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') &&
   (

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -14,8 +14,8 @@ on:
         description: 'PR number to evaluate'
         required: true
         type: number
-      suppress_comment:
-        description: 'Dry-run — evaluate but do not post a comment on the PR'
+      suppress_output:
+        description: 'Dry-run — evaluate but do not post output on the PR'
         required: false
         type: boolean
         default: false
@@ -23,11 +23,14 @@ on:
     - "copilot[bot]"
 
 if: >-
-  (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
-  github.event_name == 'workflow_dispatch' ||
-  (github.event_name == 'issue_comment' &&
-   github.event.issue.pull_request &&
-   startsWith(github.event.comment.body, '/evaluate-tests'))
+  ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') &&
+  (
+    (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
+    github.event_name == 'workflow_dispatch' ||
+    (github.event_name == 'issue_comment' &&
+     github.event.issue.pull_request &&
+     startsWith(github.event.comment.body, '/evaluate-tests'))
+  )
 
 permissions:
   contents: read
@@ -43,6 +46,7 @@ safe-outputs:
     max: 1
     target: "*"
   noop:
+    report-as-issue: false
   messages:
     footer: "> 🧪 *Test evaluation by [{workflow_name}]({run_url})*"
     run-started: "🔬 Evaluating tests on this PR… [{workflow_name}]({run_url})"
@@ -124,9 +128,9 @@ Then stop — do not proceed with the evaluation.
 
 ## Dry-run mode
 
-When triggered via `workflow_dispatch` with `suppress_comment` = `${{ inputs.suppress_comment }}`:
-- If **true**, perform the full evaluation but **do not** post a comment on the PR. Write the evaluation to the workflow log only. This is useful for testing the skill without spamming the PR.
-- If **false** (default), post the comment as normal.
+When triggered via `workflow_dispatch`, the `suppress_output` input controls behavior.
+- If `${{ inputs.suppress_output }}` == **true**, perform the full evaluation but **do not** post output on the PR. Write the evaluation to the workflow log only. This is useful for testing the skill without spamming the PR.
+- If **false** (default), post the output as normal.
 
 ## When no action is needed
 
@@ -147,7 +151,7 @@ Do not post a comment and do not silently exit — always use `noop` so the work
 
 ## Posting Results
 
-If dry-run mode is active (`suppress_comment` is true), log the evaluation report to stdout and stop — do **not** call `add_comment`.
+If dry-run mode is active (`suppress_output` is true), log the evaluation report to stdout and stop — do **not** call `add_comment`.
 
 Otherwise, call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
 

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -8,7 +8,7 @@ on:
   #     - 'src/**/test/**'
   slash_command:
     name: evaluate-tests
-    events: [pull_request_comment, issue_comment]
+    events: [pull_request_comment]
   # workflow_dispatch:
   #   inputs:
   #     pr_number:
@@ -68,6 +68,12 @@ steps:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.issue.number }}
     run: |
+      # Verify this is an open PR
+      STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
+      if [ "$STATE" != "OPEN" ]; then
+        echo "⏭️ PR #$PR_NUMBER is $STATE — skipping evaluation."
+        exit 1
+      fi
       # Try gh pr diff first; fall back to REST API for large PRs (300+ files)
       TEST_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only 2>/dev/null \
         | grep -E '\.(cs|xaml)$' \

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -76,12 +76,22 @@ steps:
   # Only needed for workflow_dispatch — for pull_request_target and issue_comment,
   # the gh-aw platform's checkout_pr_branch.cjs handles PR checkout automatically.
   # workflow_dispatch skips the platform checkout entirely, so we must do it here.
+  # Gate: only check out PRs from authors with write access (the checkout step
+  # runs with GITHUB_TOKEN, so we don't want to check out untrusted fork code).
   - name: Checkout PR and restore agent infrastructure
     if: github.event_name == 'workflow_dispatch'
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ inputs.pr_number }}
-    run: pwsh .github/scripts/Checkout-GhAwPr.ps1
+    run: |
+      PR_AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')
+      PERMISSION=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$PR_AUTHOR/permission" --jq '.permission')
+      if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" && "$PERMISSION" != "maintain" ]]; then
+        echo "⏭️ PR author '$PR_AUTHOR' has '$PERMISSION' access. workflow_dispatch only processes PRs from authors with write access."
+        exit 1
+      fi
+      echo "✅ PR author '$PR_AUTHOR' has '$PERMISSION' access — proceeding with checkout."
+      pwsh .github/scripts/Checkout-GhAwPr.ps1
 ---
 
 # Evaluate PR Tests

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -19,6 +19,8 @@ on:
         required: false
         type: boolean
         default: false
+  bots:
+    - "copilot[bot]"
 
 if: >-
   (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -86,11 +86,9 @@ steps:
           || true)
       fi
       if [ -z "$TEST_FILES" ]; then
-        echo "⏭️ No test source files (.cs/.xaml) found in PR diff."
-        echo "HAS_TEST_FILES=false" >> "$GITHUB_ENV"
-        exit 0
+        echo "⏭️ No test source files (.cs/.xaml) found in PR diff. Nothing to evaluate."
+        exit 1
       fi
-      echo "HAS_TEST_FILES=true" >> "$GITHUB_ENV"
       echo "✅ Found test files to evaluate:"
       echo "$TEST_FILES" | head -20
 
@@ -98,9 +96,8 @@ steps:
   # the gh-aw platform's checkout_pr_branch.cjs handles PR checkout automatically.
   # workflow_dispatch skips the platform checkout entirely, so we must do it here.
   # The script gates on PR author having write access before checkout.
-  # Skip if gate determined no test files (HAS_TEST_FILES set by gate step via GITHUB_ENV).
   - name: Checkout PR and restore agent infrastructure
-    if: github.event_name == 'workflow_dispatch' && env.HAS_TEST_FILES != 'false'
+    if: github.event_name == 'workflow_dispatch'
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -14,6 +14,11 @@ on:
         description: 'PR number to evaluate'
         required: true
         type: number
+      suppress_comment:
+        description: 'Dry-run — evaluate but do not post a comment on the PR'
+        required: false
+        type: boolean
+        default: false
 
 if: >-
   (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
@@ -115,6 +120,22 @@ If the file is **missing**, the fork PR branch is likely not rebased on the late
 
 Then stop — do not proceed with the evaluation.
 
+## Dry-run mode
+
+When triggered via `workflow_dispatch` with `suppress_comment` = `${{ inputs.suppress_comment }}`:
+- If **true**, perform the full evaluation but **do not** post a comment on the PR. Write the evaluation to the workflow log only. This is useful for testing the skill without spamming the PR.
+- If **false** (default), post the comment as normal.
+
+## When no action is needed
+
+If there is nothing to evaluate (PR has no test files, PR is a docs-only change, etc.), you **must** call the `noop` tool with a message explaining why:
+
+```json
+{"noop": {"message": "No action needed: [brief explanation, e.g. 'PR contains no test files']"}}
+```
+
+Do not post a comment and do not silently exit — always use `noop` so the workflow run shows a clear reason.
+
 ## Running the skill
 
 1. Use `gh pr view <number>` to fetch PR metadata (title, body, labels, base branch). If `gh` CLI is unavailable, use the GitHub MCP tools instead.
@@ -124,7 +145,9 @@ Then stop — do not proceed with the evaluation.
 
 ## Posting Results
 
-Call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
+If dry-run mode is active (`suppress_comment` is true), log the evaluation report to stdout and stop — do **not** call `add_comment`.
+
+Otherwise, call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
 
 ```markdown
 ## 🧪 PR Test Evaluation

--- a/.github/workflows/copilot-evaluate-tests.md
+++ b/.github/workflows/copilot-evaluate-tests.md
@@ -1,37 +1,32 @@
 ---
 description: Evaluates test quality, coverage, and appropriateness on PRs that add or modify tests
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'src/**/tests/**'
-      - 'src/**/test/**'
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened]
+  #   paths:
+  #     - 'src/**/tests/**'
+  #     - 'src/**/test/**'
   slash_command:
     name: evaluate-tests
     events: [pull_request_comment, issue_comment]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to evaluate'
-        required: true
-        type: number
-      suppress_output:
-        description: 'Dry-run — evaluate but do not post output on the PR'
-        required: false
-        type: boolean
-        default: false
+  # workflow_dispatch:
+  #   inputs:
+  #     pr_number:
+  #       description: 'PR number to evaluate'
+  #       required: true
+  #       type: number
+  #     suppress_output:
+  #       description: 'Dry-run — evaluate but do not post output on the PR'
+  #       required: false
+  #       type: boolean
+  #       default: false
   bots:
     - "copilot-swe-agent[bot]"
 
 labels: ["pr-review", "testing"]
 
 if: >-
-  ((!github.event.repository.fork) || github.event_name == 'workflow_dispatch') &&
-  (
-    (github.event_name == 'pull_request_target' && github.event.pull_request.draft == false) ||
-    github.event_name == 'workflow_dispatch' ||
-    github.event_name == 'issue_comment'
-  )
+  github.event_name == 'issue_comment'
 
 permissions:
   contents: read
@@ -62,7 +57,7 @@ tools:
 network: defaults
 
 concurrency:
-  group: "evaluate-pr-tests-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}"
+  group: "evaluate-pr-tests-${{ github.event.issue.number || github.run_id }}"
   cancel-in-progress: true
 
 timeout-minutes: 20
@@ -71,7 +66,7 @@ steps:
   - name: Gate — skip if no test source files in diff
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+      PR_NUMBER: ${{ github.event.issue.number }}
     run: |
       # Try gh pr diff first; fall back to REST API for large PRs (300+ files)
       TEST_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only 2>/dev/null \
@@ -92,16 +87,14 @@ steps:
       echo "✅ Found test files to evaluate:"
       echo "$TEST_FILES" | head -20
 
-  # Only needed for workflow_dispatch — for pull_request_target and issue_comment,
-  # the gh-aw platform's checkout_pr_branch.cjs handles PR checkout automatically.
-  # workflow_dispatch skips the platform checkout entirely, so we must do it here.
-  # The script gates on PR author having write access before checkout.
-  - name: Checkout PR and restore agent infrastructure
-    if: github.event_name == 'workflow_dispatch'
-    env:
-      GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ inputs.pr_number }}
-    run: pwsh .github/scripts/Checkout-GhAwPr.ps1
+  # Checkout is handled automatically by the gh-aw platform's checkout_pr_branch.cjs
+  # for slash_command/issue_comment triggers. No manual checkout needed.
+  # - name: Checkout PR and restore agent infrastructure
+  #   if: github.event_name == 'workflow_dispatch'
+  #   env:
+  #     GH_TOKEN: ${{ github.token }}
+  #     PR_NUMBER: ${{ inputs.pr_number }}
+  #   run: pwsh .github/scripts/Checkout-GhAwPr.ps1
 ---
 
 # Evaluate PR Tests
@@ -111,7 +104,7 @@ Invoke the **evaluate-pr-tests** skill: read and follow `.github/skills/evaluate
 ## Context
 
 - **Repository**: ${{ github.repository }}
-- **PR Number**: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+- **PR Number**: ${{ github.event.issue.number }}
 
 The PR branch has been checked out for you. All files from the PR are available locally.
 
@@ -135,11 +128,13 @@ If the file is **missing**, the fork PR branch is likely not rebased on the late
 
 Then stop — do not proceed with the evaluation.
 
+<!-- Dry-run mode is disabled while workflow_dispatch is commented out
 ## Dry-run mode
 
 When triggered via `workflow_dispatch`, the `suppress_output` input controls behavior.
 - If `${{ inputs.suppress_output }}` == **true**, perform the full evaluation but **do not** post output on the PR. Write the evaluation to the workflow log only. This is useful for testing the skill without spamming the PR.
 - If **false** (default), post the output as normal.
+-->
 
 ## When no action is needed
 
@@ -160,9 +155,7 @@ Do not post a comment and do not silently exit — always use `noop` so the work
 
 ## Posting Results
 
-If dry-run mode is active (`suppress_output` is true), log the evaluation report to stdout and stop — do **not** call `add_comment`.
-
-Otherwise, call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
+Call `add_comment` with `item_number` set to the PR number. Wrap the report in a collapsible `<details>` block:
 
 ```markdown
 ## 🧪 PR Test Evaluation


### PR DESCRIPTION
## Description

Overhauls the `copilot-evaluate-tests` gh-aw workflow — switches to on-demand triggers only (`/evaluate-tests` slash command + manual `workflow_dispatch`), adds security hardening, and improves error handling. No auto-runs on PR create/update.

### What Changed

**Triggers (on-demand only — no auto-runs)**
- Add `slash_command: evaluate-tests` — comment `/evaluate-tests` on a PR to trigger
- Keep `workflow_dispatch` — manual trigger from Actions tab with PR number input
- Disable `pull_request_target` — no auto-evaluation on PR create/update
- Add `bots: ["copilot-swe-agent[bot]"]` — Copilot-authored PRs can be evaluated
- Add `labels: ["pr-review", "testing"]` — workflow runs are labeled

**Gate step (fast-fail for invalid requests)**
- Check PR is OPEN before evaluating (rejects closed/merged PRs with clear message)
- Check for test source files in diff before spinning up agent
- Fall back to REST API for PRs with 300+ files (where `gh pr diff` returns HTTP 406)
- All API errors surfaced with clear messages — no silent masking
- `exit 1` stops the workflow immediately — no wasted agent compute

**Access gating (`Checkout-GhAwPr.ps1`)**
- Reject fork PRs (`isCrossRepository` check)
- Verify PR author has write access (admin/write/maintain roles)
- Fix `ConvertFrom-Json` ordering — check exit code before JSON parsing
- Make infrastructure restore fatal on failure (was soft warning)
- Remove pre-delete pattern — `git checkout` overwrites in-place

**Workflow improvements**
- `hide-older-comments: true` — previous evaluations auto-collapse
- `report-as-issue: false` for noop — no issue created when nothing to evaluate
- Timeout bumped 15 → 20 minutes
- Dry-run mode via `suppress_output` input (workflow_dispatch only)
- `Gather-TestContext.ps1` now receives `-PrNumber` parameter

**Security documentation (`gh-aw-workflows.instructions.md`)**
- Add "Before You Build" anti-patterns table — prefer built-in gh-aw features
- Add Security Boundaries section with defense layers table
- Add Rules for gh-aw Workflow Authors (DO/DON'T list)
- Document `COPILOT_TOKEN` exposure and mitigations
- Add `slash_command` to fork behavior table
- Update `Checkout-GhAwPr.ps1` description to match current behavior

### Trigger Behavior

| Trigger | When it fires | Who can trigger |
|---------|---------------|-----------------|
| `/evaluate-tests` comment | Comment on a PR | Write-access collaborators + copilot-swe-agent[bot] |
| `workflow_dispatch` | Actions tab → "Run workflow" → enter PR number | Write-access collaborators |
| ~~`pull_request_target`~~ | ~~Auto on PR create/update~~ | ~~Disabled~~ |

### Security Model

Based on [GitHub Security Lab guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/):

- PR contents treated as **passive data** (read/analyze, never built or executed)
- Agent runs in **sandboxed container** with `GITHUB_TOKEN` and `gh` CLI scrubbed
- Write operations in **separate `safe_outputs` job** (not the agent)
- Agent output limited to `max: 1` comment via safe-outputs
- `Checkout-GhAwPr.ps1` rejects fork PRs and verifies write access before checkout
- Infrastructure restore is fatal on failure — prevents running with untrusted infra

### Validation

| Test | PR | Result |
|------|-----|--------|
| Open PR with tests | #34983 | ✅ Full success (gate → checkout → agent → comment) |
| No-test PR | #34876 | ✅ Gate fast-fail ("no test source files") |
| Merged PR | #34932 | ✅ Gate fast-fail ("MERGED — skipping") |

### Known Limitations

- Fork PRs via `/evaluate-tests` can supply modified `.github/skills/` — accepted residual risk (agent sandboxed, output bounded). Tracked as [gh-aw#18481](https://github.com/github/gh-aw/issues/18481)
- `exit 1` in gate step shows ❌ in GitHub checks for no-test/closed PRs — intentional (no built-in "skip" mechanism in gh-aw steps)
- `pull_request_target` commented out — can be re-enabled later for auto-evaluation
