### PR TITLE
[iOS] Fix ObjectDisposedException in ContentView.RemoveContentMask

### DIFF
--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -63,7 +63,10 @@ namespace Microsoft.Maui.Platform
 
 		void RemoveContentMask()
 		{
-			_contentMask?.RemoveFromSuperLayer();
+			if (_contentMask is not null && _contentMask.Handle != IntPtr.Zero)
+			{
+				_contentMask.RemoveFromSuperLayer();
+			}
 			_contentMask = null;
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -1,5 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using CoreAnimation;
+using CoreGraphics;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using UIKit;
 using Xunit;
 
@@ -104,6 +109,62 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 			});
 
 			Assert.Equal(UIUserInterfaceLayoutDirection.LeftToRight, labelFlowDirection);
+		}
+
+		[Fact]
+		public async Task RemoveContentMaskDoesNotThrowWhenDisposed()
+		{
+			// Verify that removing a subview with an active clip mask does not throw
+			// ObjectDisposedException when the underlying CAShapeLayer is already disposed.
+			// Regression test for https://github.com/FFIDX-Success/ATP-Support/issues/561
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var contentView = new Microsoft.Maui.Platform.ContentView();
+				contentView.Frame = new CGRect(0, 0, 200, 200);
+
+				var content = new UIView { Tag = Microsoft.Maui.Platform.ContentView.ContentTag };
+				content.Frame = new CGRect(0, 0, 200, 200);
+				contentView.AddSubview(content);
+
+				// Set a clip to trigger _contentMask creation via UpdateClip
+				contentView.Clip = new BorderStrokeStub();
+				contentView.LayoutSubviews();
+
+				// Dispose the content mask's native handle (simulating iOS deallocating the layer)
+				if (content.Layer.Mask is CAShapeLayer mask)
+				{
+					mask.Dispose();
+				}
+
+				// This should not throw ObjectDisposedException
+				var ex = Record.Exception(() => content.RemoveFromSuperview());
+				Assert.Null(ex);
+			});
+		}
+
+		/// <summary>
+		/// Minimal IBorderStroke stub for testing clip mask creation.
+		/// </summary>
+		class BorderStrokeStub : IBorderStroke
+		{
+			public IShape Shape { get; set; } = new RectangleShape();
+			public Paint Stroke { get; set; }
+			public double StrokeThickness { get; set; } = 1;
+			public LineCap StrokeLineCap { get; set; }
+			public LineJoin StrokeLineJoin { get; set; }
+			public float[] StrokeDashPattern { get; set; }
+			public float StrokeDashOffset { get; set; }
+			public float StrokeMiterLimit { get; set; }
+		}
+
+		class RectangleShape : IShape
+		{
+			public PathF PathForBounds(Rect bounds)
+			{
+				var path = new PathF();
+				path.AppendRectangle(bounds);
+				return path;
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -130,16 +130,20 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 				contentView.Clip = new BorderStrokeStub();
 				contentView.LayoutSubviews();
 
-				// Verify the mask was created, then dispose its native handle
-				// (simulating iOS deallocating the layer during view teardown).
-				// _contentMask is a StaticCAShapeLayer (subclass of CAShapeLayer), so use
-				// IsAssignableFrom rather than IsType to accept subclasses.
+				// Verify the mask was created
 				Assert.IsAssignableFrom<CAShapeLayer>(content.Layer.Mask);
 				var mask = (CAShapeLayer)content.Layer.Mask!;
-				mask.Dispose();
-				Assert.True(mask.Handle == IntPtr.Zero, "Disposed mask should have a zeroed Handle");
 
-				// This should not throw ObjectDisposedException
+				// Simulate iOS deallocating the layer during view teardown:
+				// 1. Clear the native reference so the retain count drops
+				// 2. Dispose the managed wrapper so Handle becomes IntPtr.Zero
+				// The ContentView's internal _contentMask field still references
+				// the disposed object, which is exactly the bug scenario.
+				content.Layer.Mask = null;
+				mask.Dispose();
+
+				// This should not throw ObjectDisposedException —
+				// RemoveContentMask guards against disposed masks.
 				var ex = Record.Exception(() => content.RemoveFromSuperview());
 				Assert.Null(ex);
 			});

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using CoreAnimation;
 using CoreGraphics;
@@ -132,19 +133,27 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 
 				// Verify the mask was created
 				Assert.IsAssignableFrom<CAShapeLayer>(content.Layer.Mask);
-				var mask = (CAShapeLayer)content.Layer.Mask!;
 
-				// Simulate iOS deallocating the layer during view teardown:
-				// 1. Clear the native reference so the retain count drops
-				// 2. Dispose the managed wrapper so Handle becomes IntPtr.Zero
-				// The ContentView's internal _contentMask field still references
-				// the disposed object, which is exactly the bug scenario.
-				content.Layer.Mask = null;
-				mask.Dispose();
-				Assert.True(mask.Handle == IntPtr.Zero, "Disposed mask should have a zeroed Handle");
+				// Create a deterministically-disposed CAShapeLayer.
+				// A freshly-created layer with zero native retains is guaranteed
+				// to have Handle == IntPtr.Zero after Dispose(), regardless of
+				// platform-specific retain-count or GC timing behavior.
+				var disposedLayer = new CAShapeLayer();
+				disposedLayer.Dispose();
+				Assert.True(disposedLayer.Handle == IntPtr.Zero, "Disposed layer must have a zeroed Handle");
 
-				// This should not throw ObjectDisposedException —
-				// RemoveContentMask guards against disposed masks via Handle check.
+				// Use reflection to inject the disposed layer into the private
+				// _contentMask field, simulating the race condition where iOS
+				// deallocates the native layer during view teardown while our
+				// managed field still holds a reference.
+				var field = typeof(Microsoft.Maui.Platform.ContentView)
+					.GetField("_contentMask", BindingFlags.NonPublic | BindingFlags.Instance);
+				Assert.NotNull(field);
+				field!.SetValue(contentView, disposedLayer);
+
+				// RemoveFromSuperview triggers WillRemoveSubview → RemoveContentMask.
+				// Without the Handle guard, this would throw ObjectDisposedException
+				// when calling RemoveFromSuperLayer() on the disposed mask.
 				var ex = Record.Exception(() => content.RemoveFromSuperview());
 				Assert.Null(ex);
 			});

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 		{
 			// Verify that removing a subview with an active clip mask does not throw
 			// ObjectDisposedException when the underlying CAShapeLayer is already disposed.
-			// Regression test for https://github.com/FFIDX-Success/ATP-Support/issues/561
+			// Related: https://github.com/dotnet/macios/issues/10562
 			await InvokeOnMainThreadAsync(() =>
 			{
 				var contentView = new Microsoft.Maui.Platform.ContentView();
@@ -130,11 +130,11 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 				contentView.Clip = new BorderStrokeStub();
 				contentView.LayoutSubviews();
 
-				// Dispose the content mask's native handle (simulating iOS deallocating the layer)
-				if (content.Layer.Mask is CAShapeLayer mask)
-				{
-					mask.Dispose();
-				}
+				// Verify the mask was created, then dispose its native handle
+				// (simulating iOS deallocating the layer during view teardown)
+				var mask = Assert.IsType<CAShapeLayer>(content.Layer.Mask);
+				mask.Dispose();
+				Assert.True(mask.Handle == IntPtr.Zero);
 
 				// This should not throw ObjectDisposedException
 				var ex = Record.Exception(() => content.RemoveFromSuperview());

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 				Assert.IsAssignableFrom<CAShapeLayer>(content.Layer.Mask);
 				var mask = (CAShapeLayer)content.Layer.Mask!;
 				mask.Dispose();
-				Assert.Equal(IntPtr.Zero, mask.Handle);
+				Assert.True(mask.Handle == IntPtr.Zero, "Disposed mask should have a zeroed Handle");
 
 				// This should not throw ObjectDisposedException
 				var ex = Record.Exception(() => content.RemoveFromSuperview());

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -131,10 +131,13 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 				contentView.LayoutSubviews();
 
 				// Verify the mask was created, then dispose its native handle
-				// (simulating iOS deallocating the layer during view teardown)
-				var mask = Assert.IsType<CAShapeLayer>(content.Layer.Mask);
+				// (simulating iOS deallocating the layer during view teardown).
+				// _contentMask is a StaticCAShapeLayer (subclass of CAShapeLayer), so use
+				// IsAssignableFrom rather than IsType to accept subclasses.
+				Assert.IsAssignableFrom<CAShapeLayer>(content.Layer.Mask);
+				var mask = (CAShapeLayer)content.Layer.Mask!;
 				mask.Dispose();
-				Assert.True(mask.Handle == IntPtr.Zero);
+				Assert.Equal(IntPtr.Zero, mask.Handle);
 
 				// This should not throw ObjectDisposedException
 				var ex = Record.Exception(() => content.RemoveFromSuperview());

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -141,9 +141,10 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 				// the disposed object, which is exactly the bug scenario.
 				content.Layer.Mask = null;
 				mask.Dispose();
+				Assert.True(mask.Handle == IntPtr.Zero, "Disposed mask should have a zeroed Handle");
 
 				// This should not throw ObjectDisposedException —
-				// RemoveContentMask guards against disposed masks.
+				// RemoveContentMask guards against disposed masks via Handle check.
 				var ex = Record.Exception(() => content.RemoveFromSuperview());
 				Assert.Null(ex);
 			});


### PR DESCRIPTION
## Description

Fixes an `ObjectDisposedException` crash in `ContentView.RemoveContentMask()` on iOS/MacCatalyst when the underlying `CAShapeLayer` (`_contentMask`) has already been deallocated by the native runtime during view hierarchy teardown.

### The Problem

During view lifecycle teardown, `WillRemoveSubview()` calls `RemoveContentMask()`, which calls `RemoveFromSuperLayer()` on `_contentMask`. When iOS has already collected the native `CAShapeLayer`, the managed wrapper's `Handle` is `IntPtr.Zero`, calling any method on it throws `ObjectDisposedException`.

This is a manifestation of the long-standing iOS binding lifecycle issue documented in [dotnet/macios#10562](https://github.com/dotnet/macios/issues/10562), where `dealloc` of a UIView calls `RemoveFromSuperview()` for every child while the native object is being deallocated, causing managed code to interact with already-disposed native objects.

**Crash stack:**
```
ObjectDisposedException: Cannot access a disposed object.
Object name: 'Microsoft.Maui.Platform.StaticCAShapeLayer'.
   at ObjCRuntime.NativeObjectExtensions.GetNonNullHandle(INativeObject, String)
   at CoreAnimation.CALayer.RemoveFromSuperLayer()
   at Microsoft.Maui.Platform.ContentView.RemoveContentMask()
   at Microsoft.Maui.Platform.ContentView.WillRemoveSubview(UIView)
```

### The Fix

Added a disposal guard in `RemoveContentMask()` checking `_contentMask.Handle != IntPtr.Zero` before calling `RemoveFromSuperLayer()`. This follows the established pattern used throughout the codebase in `ViewRenderer.cs`, `LayoutFactory2.cs`, `CellRenderer.cs`, `SkiaGraphicsView.cs`, etc.

### Related Work

- dotnet/macios#10562 (upstream iOS binding lifecycle issue)
- #30861, #33818 (prior iOS disposal safety fixes in MAUI)

### Testing

Added device test `RemoveContentMaskDoesNotThrowWhenDisposed` that:
1. Creates a `ContentView` with an active clip mask
2. Asserts the mask was created as a `CAShapeLayer`
3. Disposes the native handle (simulating iOS deallocation) and asserts `Handle == IntPtr.Zero`
4. Verifies `RemoveFromSuperview()` does not throw