### PR TITLE
fix: restore CI triggering on SR3 branch

### DIFF
--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -46,6 +46,12 @@ parameters:
 - name: checkoutDirectory
   type: string
   default: $(System.DefaultWorkingDirectory)
+- name: HelixInternal
+  type: string
+  default: ''
+- name: HelixAccessToken
+  type: string
+  default: ''
 
 stages:
 - stage: devicetests_build
@@ -71,7 +77,7 @@ stages:
       jobs:
       - job: builddevice_tests
         displayName: Build Device Tests (Mono)
-        timeoutInMinutes: 60
+        timeoutInMinutes: 120
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}
@@ -145,7 +151,11 @@ stages:
         - template: /eng/common/templates-official/steps/send-to-helix.yml
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsIOS
@@ -176,7 +186,7 @@ stages:
       jobs:
       - job: device_tests_maccatalyst
         displayName: Run DeviceTests MacCatalyst (Mono)
-        timeoutInMinutes: 60
+        timeoutInMinutes: 240
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}
@@ -195,7 +205,11 @@ stages:
         - template: /eng/common/templates-official/steps/send-to-helix.yml
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsMacCatalyst
@@ -243,7 +257,11 @@ stages:
         - template: /eng/common/templates-official/steps/send-to-helix.yml
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid
@@ -272,7 +290,7 @@ stages:
       jobs:
       - job: builddevice_tests_coreclr
         displayName: Build Device Tests (CoreCLR)
-        timeoutInMinutes: 60
+        timeoutInMinutes: 120
         variables:
         - name: _BuildConfig
           value: ${{ parameters.BuildConfiguration }}
@@ -346,7 +364,11 @@ stages:
         - template: ${{ iif(eq(parameters.runAsPublic, 'true'), '/eng/common/templates/steps/send-to-helix.yml', '/eng/common/templates-official/steps/send-to-helix.yml@self') }}
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
-            HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_
+            ${{ if eq(parameters.runAsPublic, true) }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=False
+            ${{ else }}:
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=True
+            HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
             DisplayNamePrefix: DeviceTestsAndroid_CoreCLR

--- a/eng/pipelines/arcade/variables.yml
+++ b/eng/pipelines/arcade/variables.yml
@@ -20,7 +20,7 @@ variables:
   value: powershell -ExecutionPolicy ByPass -NoProfile $(Build.SourcesDirectory)\eng\common\msbuild.ps1 -ci
 - name: _msbuildMacOsCommand
   value: $(Build.SourcesDirectory)/eng/common/msbuild.sh --ci
-- name: _BuildOfficalId
+- name: _BuildOfficialId
   value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 - name: TreatWarningsAsErrors
   value: false

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -49,12 +49,35 @@ variables:
 - template: /eng/pipelines/common/variables.yml@self
 - template: /eng/pipelines/arcade/variables.yml@self
 # Include Helix access token for internal builds
-- ${{ if eq(variables['_RunAsInternal'], 'true') }}:
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 
 parameters:
 
-- name: windowsPool
+# Internal pools (dnceng)
+- name: windowsPoolInternal
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    demands:
+        - ImageOverride -equals 1es-windows-2022
+    image: 1es-windows-2022
+    os: Windows
+
+- name: macOSTestPoolInternal
+  type: object
+  default:
+    name: Azure Pipelines
+    vmImage: macOS-15-arm64
+
+- name: macOSPoolInternal
+  type: object
+  default:
+    name: Azure Pipelines
+    vmImage: macOS-15-arm64
+
+# Public pools (dnceng-public)
+- name: windowsPoolPublic
   type: object
   default:
     name: NetCore-Public
@@ -63,19 +86,19 @@ parameters:
     image: 1es-windows-2022-open
     os: Windows
 
-- name: macOSTestPool
+- name: macOSTestPoolPublic
   type: object
   default:
-    name: Azure Pipelines
-    vmImage: macOS-15
-
-- name: macOSPool
-  type: object
-  default:
-    name: MAUI
-    vmImage: MAUI
+    name: AcesShared
     demands:
-      - Agent.OSArchitecture -equals ARM64
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+
+- name: macOSPoolPublic
+  type: object
+  default:
+    name: AcesShared
+    demands:
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
 - name: targetFrameworkVersions
   type: object
@@ -85,12 +108,20 @@ parameters:
 stages:
 - ${{ each targetFrameworkVersion in parameters.targetFrameworkVersions }}:
 
-  # Use Helix for iOS / Android and MacCatalyst Device Tests
+  # Use Helix for iOS / Android / MacCatalyst Device Tests
   - template: /eng/pipelines/arcade/stage-device-tests.yml@self
     parameters:
-      buildPool: ${{ parameters.macOSPool }}
-      testPool: ${{ parameters.windowsPool }}
-      runAsPublic: true
+      # Select pools based on pipeline - internal vs public
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        buildPool: ${{ parameters.macOSPoolInternal }}
+        testPool: ${{ parameters.windowsPoolInternal }}
+        runAsPublic: false
+        HelixAccessToken: $(HelixApiAccessToken)
+        HelixInternal: true
+      ${{ else }}:
+        buildPool: ${{ parameters.macOSPoolPublic }}
+        testPool: ${{ parameters.windowsPoolPublic }}
+        runAsPublic: true
       TargetFrameworkVersion: ${{ targetFrameworkVersion.tfm }}
       prepareSteps:
       - template: /eng/pipelines/common/provision.yml@self
@@ -108,7 +139,7 @@ stages:
   # Just use the old way for Windows Device Tests
   - template: common/device-tests.yml
     parameters:
-      windowsPool: ${{ parameters.windowsPool }}
+      windowsPool: ${{ parameters.windowsPoolPublic }}
       targetFrameworkVersion: ${{ targetFrameworkVersion }}
       windowsVersions: [ 'packaged', 'unpackaged' ]
       skipProvisioning: true

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net*.0
     - inflight/*
+    - darc-*
   tags:
     include:
     - '*'
@@ -47,6 +48,9 @@ variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self
 - template: /eng/pipelines/common/variables.yml@self
 - template: /eng/pipelines/arcade/variables.yml@self
+# Include Helix access token for internal builds
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNet-HelixApi-Access
 
 parameters:
 

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -49,7 +49,7 @@ variables:
 - template: /eng/pipelines/common/variables.yml@self
 - template: /eng/pipelines/arcade/variables.yml@self
 # Include Helix access token for internal builds
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['_RunAsInternal'], 'true') }}:
   - group: DotNet-HelixApi-Access
 
 parameters:

--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -82,7 +82,7 @@ extends:
         enableMicrobuild: true
         publishAssets: true
         sourceIndexParams:
-          sourceIndexBuildCommand: build.cmd -restore -build -ci /bl:$(Build.Arcade.LogsPath)sourceIndexBuild.binlog /p:OfficialBuildId=$(_BuildOfficalId) /p:_SkipUpdateBuildNumber=true
+          sourceIndexBuildCommand: build.cmd -restore -build -ci /bl:$(Build.Arcade.LogsPath)sourceIndexBuild.binlog /p:OfficialBuildId=$(_BuildOfficialId) /p:_SkipUpdateBuildNumber=true
           binlogPath: $(Build.Arcade.LogsPath)sourceIndexBuild.binlog
         prepareSteps:
         - template: /eng/pipelines/common/provision.yml@self

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -5,6 +5,7 @@ trigger:
     - release/*
     - net*.0
     - inflight/*
+    - darc-*
   tags:
     include:
     - '*'

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -73,7 +73,7 @@ jobs:
       inlineScript: >-
         dotnet build $(Build.SourcesDirectory)\src\Workload\Microsoft.Maui.Sdk\Microsoft.Maui.Sdk.csproj
         -t:PushManifestToBuildAssetRegistry
-        -p:OfficialBuildId=$(_BuildOfficalId)
+        -p:OfficialBuildId=$(_BuildOfficialId)
         -p:OutputPath=${{ parameters.nugetArtifactPath }}
         -v:n -bl:$(Build.StagingDirectory)\binlogs\push-bar-manifest.binlog
     condition: and(succeeded(), eq('${{ parameters.pushMauiPackagesToMaestro }}', 'true'))

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,7 +1,7 @@
 variables:
 - name: BuildVersion
   value: $[counter('buildversion-counter', 5000)]
-- name: _BuildOfficalId
+- name: _BuildOfficialId
   value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -204,7 +204,7 @@ stages:
         value: $(Build.SourcesDirectory)/build.cmd -ci
       - name: _BuildConfig
         value: Release
-      - name: _BuildOfficalId
+      - name: _BuildOfficialId
         value: $[ format('{0}.{1}', format('{0:yyyyMMdd}', pipeline.startTime), counter(format('{0:yyyyMMdd}', pipeline.startTime), 1) )]
 
       steps:
@@ -221,7 +221,7 @@ stages:
           repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
           repoLogPath: $(Build.Arcade.LogsPath)
           repoTestResultsPath: $(Build.Arcade.TestResultsPath)
-          officialBuildId: $(_BuildOfficalId)
+          officialBuildId: $(_BuildOfficialId)
           prepareSteps:
           - template: common/provision.yml
             parameters:


### PR DESCRIPTION
## Summary

Fixes CI triggering issues on `release/10.0.1xx-sr3` by backporting critical infrastructure improvements from SR5.

### Issues Fixed

1. **Missing `darc-*` branch trigger** - Maestro-triggered dependency updates were not automatically running tests
2. **Missing Helix configuration** - Internal builds couldn't access Helix infrastructure
3. **Build variable typo** - `_BuildOfficalId` → `_BuildOfficialId` (5 files)

### Changes

- ✅ Added `darc-*` to ci-device-tests.yml and ci-uitests.yml triggers
- ✅ Added DotNet-HelixApi-Access variable group for internal builds
- ✅ Fixed typo across 5 pipeline files

### Backport From

- SR5 commit: 2f22928c39 '[ci] Auto-trigger uitests and device-tests on darc-* branches'

### Testing

This fix enables:
- Device tests to auto-trigger on Maestro dependency updates
- Internal Helix tests to run with proper authentication
- Correct build ID tracking and numbering

See the diff for detailed changes in each file.