### PR TITLE
Fix CollectionView not scrolling to top on iOS status bar tap

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellTableViewController.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			public AccessibilityNeutralTableView()
 			{
 				this.SetAccessibilityContainerType(UIAccessibilityContainerType.None);
+				ScrollsToTop = false;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -181,6 +181,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				CollectionView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
 			}
 
+			CollectionView.ScrollsToTop = true;
+
 			RegisterViewTypes();
 
 			EnsureLayoutInitialized();

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -313,7 +313,14 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task CollectionViewScrollsToTopIsEnabled()
 		{
-			SetupBuilder();
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<CollectionView, CollectionViewHandler2>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
 
 			var collectionView = new CollectionView
 			{

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -310,6 +310,29 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
+		[Fact]
+		public async Task CollectionViewScrollsToTopIsEnabled()
+		{
+			SetupBuilder();
+
+			var collectionView = new CollectionView
+			{
+				ItemsSource = Enumerable.Range(0, 20).Select(i => $"Item {i}").ToList(),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, ".");
+					return label;
+				})
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, handler =>
+			{
+				var uiCollectionView = handler.Controller.CollectionView;
+				Assert.True(uiCollectionView.ScrollsToTop, "CollectionView's UICollectionView should have ScrollsToTop enabled");
+			});
+		}
+
 		Rect GetCollectionViewCellBounds(IView cellContent)
 		{
 			if (!cellContent.ToPlatform().IsLoaded())

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -619,6 +619,34 @@ namespace Microsoft.Maui.DeviceTests
 			await OnNavigatedToAsync(page);
 		}
 
+		[Fact(DisplayName = "Shell Flyout Table View Has ScrollsToTop Disabled")]
+		public async Task ShellFlyoutTableViewScrollsToTopIsDisabled()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new ContentPage() { Content = new Label() { Text = "Test Page" } });
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await OpenFlyout(handler);
+
+				var flyoutContent = handler.ViewController
+					.ChildViewControllers
+					.OfType<ShellFlyoutContentRenderer>()
+					.First();
+
+				var tableViewController = flyoutContent.ChildViewControllers
+					.OfType<ShellTableViewController>()
+					.FirstOrDefault();
+
+				Assert.NotNull(tableViewController);
+				Assert.False(tableViewController.TableView.ScrollsToTop,
+					"Shell flyout's table view should have ScrollsToTop disabled to avoid conflicting with content scroll views");
+			});
+		}
+
 		class ModalShellPage : ContentPage
 		{
 			public ModalShellPage()

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -628,10 +628,8 @@ namespace Microsoft.Maui.DeviceTests
 				shell.Items.Add(new ContentPage() { Content = new Label() { Text = "Test Page" } });
 			});
 
-			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, (handler) =>
 			{
-				await OpenFlyout(handler);
-
 				var flyoutContent = handler.ViewController
 					.ChildViewControllers
 					.OfType<ShellFlyoutContentRenderer>()
@@ -644,6 +642,8 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotNull(tableViewController);
 				Assert.False(tableViewController.TableView.ScrollsToTop,
 					"Shell flyout's table view should have ScrollsToTop disabled to avoid conflicting with content scroll views");
+
+				return Task.CompletedTask;
 			});
 		}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue19866.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue19866.cs
@@ -1,0 +1,33 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 19866, "CollectionView does not scroll to top on iOS status bar tap", PlatformAffected.iOS)]
+public class Issue19866 : TestShell
+{
+	protected override void Init()
+	{
+		var items = Enumerable.Range(0, 100).Select(i => $"Item {i}").ToList();
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "TestCollectionView",
+			ItemsSource = items,
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					Margin = new Thickness(10, 20),
+					FontSize = 16
+				};
+				label.SetBinding(Label.TextProperty, new Binding("."));
+				label.SetBinding(Label.AutomationIdProperty, new Binding("."));
+				return label;
+			})
+		};
+
+		AddContentPage(new ContentPage
+		{
+			Title = "Issue 19866",
+			Content = collectionView
+		});
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19866.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue19866.cs
@@ -1,0 +1,37 @@
+#if IOS
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue19866 : _IssuesUITest
+{
+	public Issue19866(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "CollectionView does not scroll to top on iOS status bar tap";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void StatusBarTapScrollsCollectionViewToTop()
+	{
+		// Verify first item is visible initially
+		App.WaitForElement("Item 0");
+
+		// Scroll down multiple times to move well past the first item
+		App.ScrollDown("TestCollectionView", ScrollStrategy.Gesture);
+		App.ScrollDown("TestCollectionView", ScrollStrategy.Gesture);
+		App.ScrollDown("TestCollectionView", ScrollStrategy.Gesture);
+
+		// First item should no longer be visible after scrolling
+		App.WaitForNoElement("Item 0");
+
+		// Tap the status bar area to trigger iOS scroll-to-top
+		var rect = App.WaitForElement("TestCollectionView").GetRect();
+		App.TapCoordinates(rect.X + (rect.Width / 2), 5);
+
+		// Verify first item is visible again after scroll-to-top
+		App.WaitForElement("Item 0", timeout: TimeSpan.FromSeconds(5));
+	}
+}
+#endif


### PR DESCRIPTION
## Description

Fixes #19866

On iOS, tapping the status bar should scroll the topmost `UIScrollView` to the top. This was not working for `CollectionView`, particularly when hosted inside a `Shell`.

## Root Cause

iOS disables its scroll-to-top behavior when **multiple** `UIScrollView` instances in the view hierarchy have `scrollsToTop = true`. The Shell flyout's internal `AccessibilityNeutralTableView` (a `UITableView` subclass) defaults `scrollsToTop` to `true`, conflicting with the `CollectionView`'s `UICollectionView`.

## Fix

Two changes:

1. **`ItemsViewController2.ViewDidLoad()`** — Explicitly set `CollectionView.ScrollsToTop = true` to opt in to scroll-to-top behavior
2. **`ShellTableViewController.AccessibilityNeutralTableView`** — Set `ScrollsToTop = false` on Shell's flyout table view to prevent the multi-scroll-view conflict

This follows the existing codebase pattern where `ScrollsToTop` is explicitly managed (e.g., `ShellSectionRootHeader` and `ContextActionCell` both set it to `false`).

## Validation

Verified with a Sandbox app using a grouped `CollectionView` inside a `Shell` with `TabBar`:
- **Without fix**: Diagnostic dump shows two scroll views with `scrollsToTop=True` → status bar tap does nothing  
- **With fix**: Only `MauiCollectionView` has `scrollsToTop=True` → status bar tap scrolls to top correctly