### PR TITLE
[iOS] Fix tab bar unselected colors not rendering on iOS 26+

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/App.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/App.xaml.cs
@@ -1,24 +1,14 @@
-﻿namespace Maui.Controls.Sample;
+namespace Maui.Controls.Sample;
 
 public partial class App : Application
 {
-	public App()
-	{
-		InitializeComponent();
-	}
+public App()
+{
+InitializeComponent();
+}
 
-	protected override Window CreateWindow(IActivationState? activationState)
-	{
-		// To test shell scenarios, change this to true
-		bool useShell = false;
-
-		if (!useShell)
-		{
-			return new Window(new NavigationPage(new MainPage()));
-		}
-		else
-		{
-			return new Window(new SandboxShell());
-		}
-	}
+protected override Window CreateWindow(IActivationState? activationState)
+{
+return new Window(new SandboxShell());
+}
 }

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage2.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage2.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.MainPage2"
+             Title="Settings">
+    <Label Text="Settings Page" HorizontalOptions="Center" VerticalOptions="Center" />
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage2.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage2.xaml.cs
@@ -1,0 +1,9 @@
+namespace Maui.Controls.Sample;
+
+public partial class MainPage2 : ContentPage
+{
+	public MainPage2()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Sandbox/SandboxShell.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/SandboxShell.xaml
@@ -1,22 +1,12 @@
-﻿<Shell
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    x:Class="Maui.Controls.Sample.SandboxShell"
-    xmlns:local="clr-namespace:Maui.Controls.Sample"
-    x:Name="shell">
-    <TabBar Shell.TabBarForegroundColor="Green"
-        Shell.TabBarUnselectedColor="Red">
-        <Tab Title="MainPage1" Icon="groceries.png">
-            <ShellContent Icon="groceries.png"
-            Title="Home"
-            ContentTemplate="{DataTemplate local:MainPage}"
-            Route="MainPage" />
-        </Tab>
-        <Tab Title="MainPage2" Icon="dotnet_bot.png">
-            <ShellContent Icon="dotnet_bot.png"
-            Title="Home"
-            ContentTemplate="{DataTemplate local:MainPage}"
-            Route="MainPage2" />
-        </Tab>
+<?xml version="1.0" encoding="utf-8" ?>
+<Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       xmlns:local="clr-namespace:Maui.Controls.Sample"
+       x:Class="Maui.Controls.Sample.SandboxShell"
+       Shell.TabBarForegroundColor="Green"
+       Shell.TabBarUnselectedColor="Red">
+    <TabBar>
+        <ShellContent Title="Home" ContentTemplate="{DataTemplate local:MainPage}" Icon="{OnPlatform iOS='house.fill', Default='house.png'}" />
+        <ShellContent Title="Settings" ContentTemplate="{DataTemplate local:MainPage2}" Icon="{OnPlatform iOS='gear', Default='gear.png'}" />
     </TabBar>
 </Shell>

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -62,13 +62,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// The liquid glass tab bar resets subview properties during layout.
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 			{
-				Console.WriteLine("DEBUG: UpdateLayout iOS 26+ path");
 				var tabBar = controller.TabBar;
 				if (_pendingSelectedTintColor is not null)
 					tabBar.TintColor = _pendingSelectedTintColor;
 				if (_pendingUnselectedTintColor is not null)
 				{
-					Console.WriteLine("DEBUG: Calling ApplyPreColoredImagesForIOS26");
 					tabBar.UnselectedItemTintColor = _pendingUnselectedTintColor;
 					tabBar.ApplyPreColoredImagesForIOS26(_pendingUnselectedTintColor, _pendingSelectedTintColor);
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.ComponentModel;
+using Microsoft.Maui.Platform;
 using ObjCRuntime;
 using UIKit;
 
@@ -13,6 +14,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		UIColor _defaultTint;
 		UIColor _defaultUnselectedTint;
 		UITabBarAppearance _tabBarAppearance;
+
+		// iOS 26+ stores pending colors to re-apply during layout
+		UIColor _pendingUnselectedTintColor;
+		UIColor _pendingSelectedTintColor;
+
 		public virtual void ResetAppearance(UITabBarController controller)
 		{
 			if (_defaultTint == null)
@@ -22,6 +28,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			tabBar.BarTintColor = _defaultBarTint;
 			tabBar.TintColor = _defaultTint;
 			tabBar.UnselectedItemTintColor = _defaultUnselectedTint;
+			_pendingUnselectedTintColor = null;
+			_pendingSelectedTintColor = null;
 		}
 
 		public virtual void SetAppearance(UITabBarController controller, ShellAppearance appearance)
@@ -50,6 +58,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public virtual void UpdateLayout(UITabBarController controller)
 		{
+			// iOS 26+: Re-apply colors on every layout pass.
+			// The liquid glass tab bar resets subview properties during layout.
+			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			{
+				var tabBar = controller.TabBar;
+				if (_pendingSelectedTintColor is not null)
+					tabBar.TintColor = _pendingSelectedTintColor;
+				if (_pendingUnselectedTintColor is not null)
+				{
+					tabBar.UnselectedItemTintColor = _pendingUnselectedTintColor;
+					tabBar.ApplyPreColoredImagesForIOS26(_pendingUnselectedTintColor, _pendingSelectedTintColor);
+				}
+			}
 		}
 
 		#region IDisposable Support
@@ -75,6 +96,55 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var foregroundColor = appearanceElement.EffectiveTabBarForegroundColor;
 			var unselectedColor = appearanceElement.EffectiveTabBarUnselectedColor;
 			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
+
+			// iOS 26+: The UITabBarAppearance Normal state (TitleTextAttributes, IconColor) is
+			// ignored by the liquid glass tab bar. Skip the full appearance pipeline and use
+			// direct UITabBar properties plus subview coloring instead.
+			// See: https://github.com/dotnet/maui/issues/32125, https://github.com/dotnet/maui/issues/34605
+			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			{
+				var tabBar = controller.TabBar;
+
+				// Background color via appearance (this still works on iOS 26)
+				if (_tabBarAppearance == null)
+				{
+					_tabBarAppearance = new UITabBarAppearance();
+					_tabBarAppearance.ConfigureWithDefaultBackground();
+				}
+				if (backgroundColor is not null)
+					_tabBarAppearance.BackgroundColor = backgroundColor.ToPlatform();
+
+				tabBar.StandardAppearance = _tabBarAppearance;
+				tabBar.ScrollEdgeAppearance = _tabBarAppearance;
+
+				// Selected color via TintColor (works on iOS 26)
+				var selectedColor = foregroundColor ?? titleColor;
+				if (selectedColor is not null)
+				{
+					_pendingSelectedTintColor = selectedColor.ToPlatform();
+					tabBar.TintColor = _pendingSelectedTintColor;
+				}
+				else
+				{
+					_pendingSelectedTintColor = null;
+					tabBar.TintColor = _defaultTint;
+				}
+
+				// Unselected color: set property + pre-colored images for visual rendering
+				if (unselectedColor is not null)
+				{
+					_pendingUnselectedTintColor = unselectedColor.ToPlatform();
+					tabBar.UnselectedItemTintColor = _pendingUnselectedTintColor;
+					tabBar.ApplyPreColoredImagesForIOS26(_pendingUnselectedTintColor, _pendingSelectedTintColor);
+				}
+				else
+				{
+					_pendingUnselectedTintColor = null;
+					tabBar.UnselectedItemTintColor = _defaultUnselectedTint;
+				}
+
+				return;
+			}
 
 			controller.TabBar
 				.UpdateiOS15TabBarAppearance(

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SafeShellTabBarAppearanceTracker.cs
@@ -62,11 +62,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// The liquid glass tab bar resets subview properties during layout.
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 			{
+				Console.WriteLine("DEBUG: UpdateLayout iOS 26+ path");
 				var tabBar = controller.TabBar;
 				if (_pendingSelectedTintColor is not null)
 					tabBar.TintColor = _pendingSelectedTintColor;
 				if (_pendingUnselectedTintColor is not null)
 				{
+					Console.WriteLine("DEBUG: Calling ApplyPreColoredImagesForIOS26");
 					tabBar.UnselectedItemTintColor = _pendingUnselectedTintColor;
 					tabBar.ApplyPreColoredImagesForIOS26(_pendingUnselectedTintColor, _pendingSelectedTintColor);
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform;
 using UIKit;
 using static Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page;
 using PageUIStatusBarAnimation = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
@@ -28,6 +29,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		IMauiContext _mauiContext;
 		UITabBarAppearance _tabBarAppearance;
 		WeakReference<VisualElement> _element;
+
+		// iOS 26+: cached unselected tint color for re-application during layout
+		UIColor _pendingUnselectedTintColor;
+		UIColor _pendingSelectedTintColor;
 
 		Brush _currentBarBackground;
 
@@ -136,6 +141,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			// in narrow viewports (< 667 points) before Element is set. Guard against this.
 			if (Element is IView view)
 				view.Arrange(View.Bounds.ToRectangle());
+
+			// iOS 26+: Re-apply unselected item colors on every layout pass.
+			// The liquid glass tab bar resets subview tint colors during layout.
+			if ((OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				&& _pendingUnselectedTintColor is not null && TabBar is not null)
+			{
+				TabBar.UnselectedItemTintColor = _pendingUnselectedTintColor;
+				TabBar.ApplyPreColoredImagesForIOS26(_pendingUnselectedTintColor, _pendingSelectedTintColor);
+			}
 		}
 
 		protected override void Dispose(bool disposing)
@@ -190,7 +204,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateTabBarItem(page);
 			}
 		}
-		
+
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			if (previousTraitCollection.VerticalSizeClass == TraitCollection.VerticalSizeClass)
@@ -610,15 +624,32 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			if (Tabbed is not TabbedPage tabbed)
 				return;
+
+			var unselectedTabColor = tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? tabbed.UnselectedTabColor : null;
+			var barTextColor = tabbed.IsSet(TabbedPage.BarTextColorProperty) ? tabbed.BarTextColor : null;
+
 			TabBar.UpdateiOS15TabBarAppearance(
 				ref _tabBarAppearance,
 				_defaultBarColor,
 				_defaultBarTextColor,
 				tabbed.IsSet(TabbedPage.SelectedTabColorProperty) ? tabbed.SelectedTabColor : null,
-				tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) ? tabbed.UnselectedTabColor : null,
+				unselectedTabColor,
 				tabbed.IsSet(TabbedPage.BarBackgroundColorProperty) ? tabbed.BarBackgroundColor : null,
-				tabbed.IsSet(TabbedPage.BarTextColorProperty) ? tabbed.BarTextColor : null,
-				tabbed.IsSet(TabbedPage.BarTextColorProperty) ? tabbed.BarTextColor : null);
+				barTextColor,
+				barTextColor);
+
+			// Cache the effective colors for iOS 26 layout re-application
+			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			{
+				_pendingUnselectedTintColor = unselectedTabColor?.ToPlatform()
+					?? barTextColor?.ToPlatform()
+					?? _defaultBarTextColor;
+
+				var selectedTabColor2 = tabbed.IsSet(TabbedPage.SelectedTabColorProperty) ? tabbed.SelectedTabColor : null;
+				_pendingSelectedTintColor = selectedTabColor2?.ToPlatform()
+					?? barTextColor?.ToPlatform()
+					?? _defaultBarTextColor;
+			}
 		}
 
 		#region IPlatformViewHandler

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task ForegroundColorSetsIconAndTitleColorSetsTitle()
 		{
 #if IOS || MACCATALYST
-			// Skip on iOS 26+ due to UITabBar internal API changes
-			// See: https://github.com/dotnet/maui/issues/33004
+			// Pixel-based tab bar color verification doesn't work on iOS 26+ due to UITabBar rendering changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				return;
 #endif
@@ -54,8 +53,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task ShellTabBarTitleColorInitializesCorrectly(string colorHex)
 		{
 #if IOS || MACCATALYST
-			// Skip on iOS 26+ due to UITabBar internal API changes
-			// See: https://github.com/dotnet/maui/issues/33004
+			// Pixel-based tab bar color verification doesn't work on iOS 26+ due to UITabBar rendering changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				return;
 #endif
@@ -78,8 +76,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task ShellTabBarForegroundInitializesCorrectly(string colorHex)
 		{
 #if IOS || MACCATALYST
-			// Skip on iOS 26+ due to UITabBar internal API changes
-			// See: https://github.com/dotnet/maui/issues/33004
+			// Pixel-based tab bar color verification doesn't work on iOS 26+ due to UITabBar rendering changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				return;
 #endif
@@ -100,8 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task ShellTabBarUnselectedColorInitializesCorrectly(string colorHex)
 		{
 #if IOS || MACCATALYST
-			// Skip on iOS 26+ due to UITabBar internal API changes
-			// See: https://github.com/dotnet/maui/issues/33004
+			// Pixel-based tab bar color verification doesn't work on iOS 26+ due to UITabBar rendering changes
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				return;
 #endif
@@ -114,6 +110,39 @@ namespace Microsoft.Maui.DeviceTests
 					await ValidateTabBarTextColor(shell.Items[0].Items[1], expectedColor, true);
 					await ValidateTabBarIconColor(shell.Items[0].Items[1], expectedColor, true);
 				});
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/32125
+		// On iOS 26+, Shell.TabBarUnselectedColor was not applied to unselected tabs
+		[Fact(DisplayName = "Shell TabBar UnselectedColor and TitleColor work together")]
+		public async Task ShellTabBarUnselectedAndTitleColorWorkTogether()
+		{
+			var titleColor = Color.FromArgb("#FFFF0000");
+			var unselectedColor = Color.FromArgb("#FF808080");
+			await RunShellTabBarTests(shell =>
+			{
+				Shell.SetTabBarTitleColor(shell, titleColor);
+				Shell.SetTabBarUnselectedColor(shell, unselectedColor);
+			},
+			async (shell) =>
+			{
+#if IOS || MACCATALYST
+				if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				{
+					// On iOS 26+, verify the UnselectedItemTintColor property directly
+					// because pixel-based verification doesn't work with the new tab bar rendering
+					await ValidateTabBarUnselectedTintColorProperty(shell.CurrentSection, unselectedColor);
+				}
+				else
+#endif
+				{
+					// Selected tab should use title color
+					await ValidateTabBarTextColor(shell.CurrentSection, titleColor, true);
+					// Unselected tab should use unselected color
+					await ValidateTabBarTextColor(shell.Items[0].Items[1], unselectedColor, true);
+					await ValidateTabBarIconColor(shell.Items[0].Items[1], unselectedColor, true);
+				}
+			});
 		}
 
 		async Task RunShellTabBarTests(Action<Shell> setup, Func<Shell, Task> runTest)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTabBarTests.iOS.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform.Compatibility;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -15,12 +16,35 @@ namespace Microsoft.Maui.DeviceTests
 		UITabBar GetTabBar(ShellSection item)
 		{
 			var shellItem = item.Parent as ShellItem;
-			var shell = shellItem.Parent as Shell;
+			var shell = shellItem?.Parent as Shell;
 
-			var pagerParent = (shell.CurrentPage.Handler as IPlatformViewHandler)
-				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
+			if (shell?.Handler is IShellContext shellContext)
+			{
+				if (shellContext.CurrentShellItemRenderer is UITabBarController tabBarController)
+					return tabBarController.TabBar;
+			}
 
-			// In macOS 15 Sequoia, the UITabBar is nested within the second subview (index 1) of the pagerParent. 
+			// Fallback: walk the view hierarchy from the current page
+			var platformView = (shell?.CurrentPage?.Handler as IPlatformViewHandler)?.PlatformView;
+			if (platformView is null)
+				return null;
+
+			var pagerParent = platformView.FindParent(x => x.NextResponder is UITabBarController);
+
+			if (pagerParent is null)
+			{
+				// iOS 26+: walk the responder chain to find the UITabBarController directly
+				UIResponder responder = platformView;
+				while (responder != null)
+				{
+					if (responder is UITabBarController tbc)
+						return tbc.TabBar;
+					responder = responder.NextResponder;
+				}
+				return null;
+			}
+
+			// In macOS 15 Sequoia, the UITabBar is nested within the second subview (index 1) of the pagerParent.
 			if (OperatingSystem.IsMacCatalystVersionAtLeast(15, 0) || OperatingSystem.IsMacOSVersionAtLeast(15, 0))
 			{
 				var subview = pagerParent.Subviews.ElementAtOrDefault(1);
@@ -66,6 +90,17 @@ namespace Microsoft.Maui.DeviceTests
 				await AssertionExtensions.AssertTabItemTextDoesNotContainColor(GetTabBar(item),
 					item.Title, textColor, MauiContext);
 			}
+		}
+
+		Task ValidateTabBarUnselectedTintColorProperty(ShellSection item, Color expectedColor)
+		{
+			var tabBar = GetTabBar(item);
+			Assert.NotNull(tabBar);
+			Assert.NotNull(tabBar.UnselectedItemTintColor);
+			Assert.True(
+				ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, expectedColor.ToPlatform(), 0.1),
+				$"Expected UnselectedItemTintColor to be {expectedColor} but got {tabBar.UnselectedItemTintColor}");
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task BarTextColor()
 		{
 #if IOS || MACCATALYST
-			// Skip on iOS 26+ due to UITabBar internal API changes
-			// See: https://github.com/dotnet/maui/issues/33004
+			// Pixel-based text color verification doesn't work on iOS 26+ due to UITabBar rendering changes.
+			// Property-based tests (UnselectedItemTintColorSetFromBarTextColor) verify the fix instead.
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				return;
 #endif
@@ -96,20 +96,11 @@ namespace Microsoft.Maui.DeviceTests
 			tabbedPage.BarTextColor = Colors.Red;
 			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
 			{
-				// Pre iOS15 you couldn't set the text color of the unselected tab
-				// so only android/windows currently set the color of both
-
-#if IOS
-				bool unselectedMatchesSelected = false;
-#else
-				bool unselectedMatchesSelected = true;
-#endif
-
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, unselectedMatchesSelected);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
 				tabbedPage.BarTextColor = Colors.Blue;
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Blue, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, unselectedMatchesSelected);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Blue, true);
 			});
 		}
 
@@ -121,8 +112,8 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task SelectedAndUnselectedTabColor()
 		{
 #if IOS || MACCATALYST
-			// Skip on iOS 26+ due to UITabBar internal API changes
-			// See: https://github.com/dotnet/maui/issues/33004
+			// Pixel-based text color verification doesn't work on iOS 26+ due to UITabBar rendering changes.
+			// Property-based tests (UnselectedItemTintColorSetFromUnselectedTabColor) verify the fix instead.
 			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
 				return;
 #endif
@@ -135,15 +126,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
 			{
-				// Pre iOS15 you couldn't set the text color of the unselected tab
-				// so only android/windows currently set the color of both
-#if IOS
-				bool unselectedMatchesTabColor = false;
-#else
-				bool unselectedMatchesTabColor = true;
-#endif
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, unselectedMatchesTabColor);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Red, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Purple, true);
 
@@ -151,9 +135,50 @@ namespace Microsoft.Maui.DeviceTests
 				await OnNavigatedToAsync(tabbedPage.CurrentPage);
 
 				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Purple, true);
-				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, unselectedMatchesTabColor);
+				await ValidateTabBarTextColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[0].Title, Colors.Purple, true);
 				await ValidateTabBarIconColor(tabbedPage, tabbedPage.Children[1].Title, Colors.Red, true);
+			});
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/34605
+		// On iOS 26.2+, BarTextColor was only applied to the selected tab, not unselected tabs
+		[Fact(DisplayName = "BarTextColor applies to unselected tabs without UnselectedTabColor set"
+#if MACCATALYST
+			, Skip = "Fails on Mac Catalyst, fixme"
+#endif
+			)]
+		public async Task BarTextColorAppliesToUnselectedTabsWithoutExplicitUnselectedColor()
+		{
+#if IOS || MACCATALYST
+			// Pixel-based text color verification doesn't work on iOS 26+ due to UITabBar rendering changes.
+			// Property-based tests (UnselectedItemTintColorSetFromBarTextColor) verify the fix instead.
+			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				return;
+#endif
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage(true, pages: new[]
+			{
+				new ContentPage() { Title = "Tab A", IconImageSource = "white.png" },
+				new ContentPage() { Title = "Tab B", IconImageSource = "white.png" },
+				new ContentPage() { Title = "Tab C", IconImageSource = "white.png" }
+			});
+
+			// Set ONLY BarTextColor (no SelectedTabColor or UnselectedTabColor)
+			tabbedPage.BarTextColor = Colors.Orange;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, async handler =>
+			{
+				// All tabs (selected and unselected) should use the BarTextColor
+				await ValidateTabBarTextColor(tabbedPage, "Tab A", Colors.Orange, true);
+				await ValidateTabBarTextColor(tabbedPage, "Tab B", Colors.Orange, true);
+				await ValidateTabBarTextColor(tabbedPage, "Tab C", Colors.Orange, true);
+
+				// Switch selected tab and verify colors still correct
+				tabbedPage.CurrentPage = tabbedPage.Children[2];
+				await OnNavigatedToAsync(tabbedPage.CurrentPage);
+				await ValidateTabBarTextColor(tabbedPage, "Tab A", Colors.Orange, true);
+				await ValidateTabBarTextColor(tabbedPage, "Tab C", Colors.Orange, true);
 			});
 		}
 
@@ -378,7 +403,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
-#if IOS 
+#if IOS
 		[Theory(Skip = "Test doesn't work on iOS yet; probably because of https://github.com/dotnet/maui/issues/10591")]
 #elif WINDOWS
 		[Theory(Skip = "Test doesn't work on Windows")]

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.iOS.cs
@@ -7,6 +7,8 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using UIKit;
+using Xunit;
+using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -15,10 +17,27 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		UITabBar GetTabBar(TabbedPage tabbedPage)
 		{
-			var pagerParent = (tabbedPage.CurrentPage.Handler as IPlatformViewHandler)
-				.PlatformView.FindParent(x => x.NextResponder is UITabBarController);
+			// TabbedRenderer IS a UITabBarController — get TabBar from ViewController
+			var platformHandler = tabbedPage.Handler as IPlatformViewHandler;
+			if (platformHandler?.ViewController is UITabBarController tbc)
+				return tbc.TabBar;
 
-			return pagerParent.Subviews.FirstOrDefault(v => v.GetType() == typeof(UITabBar)) as UITabBar;
+			// Fallback: walk the responder chain
+			var handler = tabbedPage.CurrentPage.Handler as IPlatformViewHandler;
+			var platformView = handler?.PlatformView;
+
+			if (platformView is null)
+				throw new Exception("Unable to get platform view from handler");
+
+			UIResponder responder = platformView;
+			while (responder != null)
+			{
+				if (responder is UITabBarController controller)
+					return controller.TabBar;
+				responder = responder.NextResponder;
+			}
+
+			throw new Exception("Unable to find UITabBarController in view hierarchy");
 		}
 
 		async Task ValidateTabBarIconColor(
@@ -59,6 +78,129 @@ namespace Microsoft.Maui.DeviceTests
 					GetTabBar(tabbedPage),
 					tabText, iconColor, MauiContext);
 			}
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/34605
+		// Verifies UnselectedItemTintColor is correctly set on iOS 26+ when BarTextColor is set
+		[Fact(DisplayName = "iOS 26: UnselectedItemTintColor set when BarTextColor specified")]
+		public async Task UnselectedItemTintColorSetFromBarTextColor()
+		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(26) && !OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				return;
+
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage(true, pages: new[]
+			{
+				new ContentPage() { Title = "Tab 1" },
+				new ContentPage() { Title = "Tab 2" }
+			});
+
+			tabbedPage.BarTextColor = Colors.Red;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
+			{
+				var tabBar = GetTabBar(tabbedPage);
+
+				// On iOS 26+, our fix sets UnselectedItemTintColor as a workaround
+				Assert.NotNull(tabBar.UnselectedItemTintColor);
+				Assert.True(
+					ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Red.ToPlatform(), 0.1),
+					$"Expected UnselectedItemTintColor to be Red but got {tabBar.UnselectedItemTintColor}");
+
+				// Change the color and verify it updates
+				tabbedPage.BarTextColor = Colors.Blue;
+
+				Assert.NotNull(tabBar.UnselectedItemTintColor);
+				Assert.True(
+					ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Blue.ToPlatform(), 0.1),
+					$"Expected UnselectedItemTintColor to be Blue but got {tabBar.UnselectedItemTintColor}");
+
+				return Task.CompletedTask;
+			});
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/32125
+		// Verifies UnselectedItemTintColor is set from UnselectedTabColor on iOS 26+
+		[Fact(DisplayName = "iOS 26: UnselectedItemTintColor set from UnselectedTabColor")]
+		public async Task UnselectedItemTintColorSetFromUnselectedTabColor()
+		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(26) && !OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				return;
+
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage(true, pages: new[]
+			{
+				new ContentPage() { Title = "Tab 1" },
+				new ContentPage() { Title = "Tab 2" }
+			});
+
+			tabbedPage.SelectedTabColor = Colors.Green;
+			tabbedPage.UnselectedTabColor = Colors.Purple;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
+			{
+				var tabBar = GetTabBar(tabbedPage);
+
+				// UnselectedTabColor should take priority for UnselectedItemTintColor
+				Assert.NotNull(tabBar.UnselectedItemTintColor);
+				Assert.True(
+					ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Purple.ToPlatform(), 0.1),
+					$"Expected UnselectedItemTintColor to be Purple but got {tabBar.UnselectedItemTintColor}");
+
+				return Task.CompletedTask;
+			});
+		}
+
+		// Verifies changing BarTextColor updates UnselectedItemTintColor on iOS 26+
+		[Fact(DisplayName = "iOS 26: Changing BarTextColor updates UnselectedItemTintColor")]
+		public async Task ChangingBarTextColorUpdatesUnselectedItemTintColor()
+		{
+			if (!OperatingSystem.IsIOSVersionAtLeast(26) && !OperatingSystem.IsMacCatalystVersionAtLeast(26))
+				return;
+
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage(true, pages: new[]
+			{
+				new ContentPage() { Title = "Tab 1" },
+				new ContentPage() { Title = "Tab 2" }
+			});
+
+			tabbedPage.BarTextColor = Colors.Red;
+
+			await CreateHandlerAndAddToWindow<TabbedViewHandler>(tabbedPage, handler =>
+			{
+				var tabBar = GetTabBar(tabbedPage);
+
+				// Should be Red after BarTextColor is applied
+				Assert.NotNull(tabBar.UnselectedItemTintColor);
+				Assert.True(
+					ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Red.ToPlatform(), 0.1),
+					$"Expected Red but got {tabBar.UnselectedItemTintColor}");
+
+				// Change to Green
+				tabbedPage.BarTextColor = Colors.Green;
+
+				Assert.NotNull(tabBar.UnselectedItemTintColor);
+				Assert.True(
+					ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Green.ToPlatform(), 0.1),
+					$"Expected Green but got {tabBar.UnselectedItemTintColor}");
+
+				// Clear the color — should no longer be Red or Green
+				tabbedPage.BarTextColor = null;
+
+				// After clearing, the tint should not be Red or Green anymore
+				if (tabBar.UnselectedItemTintColor is not null)
+				{
+					Assert.False(
+						ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Red.ToPlatform(), 0.1),
+						"UnselectedItemTintColor should not still be Red after clearing");
+					Assert.False(
+						ColorComparison.ARGBEquivalent(tabBar.UnselectedItemTintColor, Colors.Green.ToPlatform(), 0.1),
+						"UnselectedItemTintColor should not still be Green after clearing");
+				}
+
+				return Task.CompletedTask;
+			});
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -201,13 +201,11 @@ namespace Microsoft.Maui.Platform
 					}
 				}
 
-				// Set per-item title text attributes for unselected state
-				if (unselectedColor is not null)
-				{
-					item.SetTitleTextAttributes(
-						new UIStringAttributes { ForegroundColor = unselectedColor, ParagraphStyle = NSParagraphStyle.Default },
-						UIControlState.Normal);
-				}
+				// Note: SetTitleTextAttributes for Normal state is intentionally not called on iOS 26+.
+				// Apple's Liquid Glass design system ignores the Normal state appearance to ensure visual
+				// consistency with the glass material. Icon coloring via AlwaysOriginal rendering (above)
+				// is the supported workaround. Text color customization for unselected tabs is not available
+				// on iOS 26+. See: https://github.com/dotnet/maui/issues/32125
 
 				if (selectedColor is not null)
 				{
@@ -216,10 +214,6 @@ namespace Microsoft.Maui.Platform
 						UIControlState.Selected);
 				}
 			}
-
-			// On iOS 26, SetTitleTextAttributes for Normal state is ignored by the liquid glass compositing.
-			// Walk the tab bar subviews to find text labels and apply colors directly.
-			ApplyDirectTextColorsForIOS26(tabBar, unselectedColor, selectedColor);
 		}
 
 		// Stores original template images per tab bar item so we always tint from
@@ -267,71 +261,6 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return resizedImage;
-		}
-
-static void ApplyDirectTextColorsForIOS26(UITabBar tabBar, UIColor? unselectedColor, UIColor? selectedColor)
-	{
-		if (unselectedColor == null && selectedColor == null)
-			return;
-
-		Console.WriteLine($"=== TEXT COLOR DEBUG START ===");
-		Console.WriteLine($"  unselectedColor: {unselectedColor}");
-		Console.WriteLine($"  selectedColor: {selectedColor}");
-		Console.WriteLine($"  tabBar: {tabBar}");
-		Console.WriteLine($"  tabBar.Items.Length: {tabBar.Items?.Length ?? 0}");
-		
-		var items = tabBar.Items ?? [];
-		if (items.Length == 0)
-		{
-			Console.WriteLine("  No items in tabBar!");
-			return;
-		}
-
-		var selectedItem = tabBar.SelectedItem;
-		var queue = new Queue<UIView>();
-		queue.Enqueue(tabBar);
-		
-		int viewCount = 0;
-		int labelCount = 0;
-		while (queue.Count > 0)
-		{
-			var view = queue.Dequeue();
-			viewCount++;
-			
-			// Log every 10th view
-			if (viewCount % 10 == 0)
-				Console.WriteLine($"  Processed {viewCount} views, found {labelCount} labels...");
-			
-			// Color any UILabel we find
-			if (view is UILabel label)
-			{
-				var oldColor = label.TextColor;
-				label.TextColor = unselectedColor ?? UIColor.Black;
-				labelCount++;
-				Console.WriteLine($"  [LABEL #{labelCount}] Changed from {oldColor} to {label.TextColor}");
-			}
-			
-			// Enqueue all subviews for processing
-			foreach (var subview in view.Subviews)
-			{
-				queue.Enqueue(subview);
-			}
-		}
-		
-		Console.WriteLine($"  FINAL: Walked {viewCount} views total, colored {labelCount} labels");
-		Console.WriteLine($"=== TEXT COLOR DEBUG END ===");
-	}
-
-
-
-					buttonIndex++;
-				}
-
-				foreach (var subview in view.Subviews)
-				{
-					queue.Enqueue(subview);
-				}
-			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -216,6 +216,10 @@ namespace Microsoft.Maui.Platform
 						UIControlState.Selected);
 				}
 			}
+
+			// On iOS 26, SetTitleTextAttributes for Normal state is ignored by the liquid glass compositing.
+			// Walk the tab bar subviews to find text labels and apply colors directly.
+			ApplyDirectTextColorsForIOS26(tabBar, unselectedColor, selectedColor);
 		}
 
 		// Stores original template images per tab bar item so we always tint from
@@ -263,6 +267,55 @@ namespace Microsoft.Maui.Platform
 			}
 
 			return resizedImage;
+		}
+
+static void ApplyDirectTextColorsForIOS26(UITabBar tabBar, UIColor? unselectedColor, UIColor? selectedColor)
+	{
+		if (unselectedColor == null && selectedColor == null)
+			return;
+
+		Console.WriteLine("DEBUG: ApplyDirectTextColorsForIOS26 START - walking tab bar hierarchy");
+		
+		var items = tabBar.Items ?? [];
+		if (items.Length == 0)
+			return;
+
+		var selectedItem = tabBar.SelectedItem;
+		var queue = new Queue<UIView>();
+		queue.Enqueue(tabBar);
+		
+		int labelCount = 0;
+		while (queue.Count > 0)
+		{
+			var view = queue.Dequeue();
+			
+			// Color any UILabel we find
+			if (view is UILabel label)
+			{
+				label.TextColor = unselectedColor ?? UIColor.Black;
+				labelCount++;
+				Console.WriteLine($"DEBUG: Colored label #{labelCount}");
+			}
+			
+			// Enqueue all subviews for processing
+			foreach (var subview in view.Subviews)
+			{
+				queue.Enqueue(subview);
+			}
+		}
+		
+		Console.WriteLine($"DEBUG: ApplyDirectTextColorsForIOS26 DONE - colored {labelCount} labels");
+	}
+
+
+					buttonIndex++;
+				}
+
+				foreach (var subview in view.Subviews)
+				{
+					queue.Enqueue(subview);
+				}
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using CoreGraphics;
 using Foundation;
@@ -90,36 +91,137 @@ namespace Microsoft.Maui.Platform
 			}
 
 			// Set UnselectedTabColor
-			if (unselectedTabColor is not null)
+			// On iOS 26+, UITabBarAppearance.Normal state (TitleTextAttributes, IconColor) is ignored
+			// by the liquid glass tab bar for unselected items. Skip setting Normal state and use
+			// UnselectedItemTintColor directly instead.
+			// See: https://github.com/dotnet/maui/issues/32125, https://github.com/dotnet/maui/issues/34605
+			bool isiOS26OrNewer = OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26);
+
+			if (!isiOS26OrNewer)
 			{
-				var foregroundColor = unselectedTabColor.ToPlatform();
-				var titleColor = effectiveUnselectedBarTextColor ?? foregroundColor;
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
-				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foregroundColor;
+				if (unselectedTabColor is not null)
+				{
+					var foregroundColor = unselectedTabColor.ToPlatform();
+					var titleColor = effectiveUnselectedBarTextColor ?? foregroundColor;
+					_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
+					_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foregroundColor;
 
-				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
-				_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foregroundColor;
+					_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
+					_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foregroundColor;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foregroundColor;
-			}
-			else
-			{
-				var foreground = UITabBar.Appearance.TintColor;
-				var titleColor = effectiveUnselectedBarTextColor ?? foreground;
-				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
-				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foreground;
+					_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
+					_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foregroundColor;
+				}
+				else
+				{
+					var foreground = UITabBar.Appearance.TintColor;
+					var titleColor = effectiveUnselectedBarTextColor ?? foreground;
+					_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
+					_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foreground;
 
-				_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
-				_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foreground;
+					_tabBarAppearance.InlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
+					_tabBarAppearance.InlineLayoutAppearance.Normal.IconColor = foreground;
 
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
-				_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foreground;
+					_tabBarAppearance.CompactInlineLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = titleColor, ParagraphStyle = NSParagraphStyle.Default };
+					_tabBarAppearance.CompactInlineLayoutAppearance.Normal.IconColor = foreground;
+				}
 			}
 
 			// Set the TabBarAppearance
+			// On iOS 26+, setting StandardAppearance may cause UIKit to ignore
+			// UnselectedItemTintColor. Only set appearance for background color and
+			// selected state; use direct properties for unselected state.
 			tabBar.StandardAppearance = tabBar.ScrollEdgeAppearance = _tabBarAppearance;
+
+			if (isiOS26OrNewer)
+			{
+				UIColor? effectiveUnselectedTint = null;
+
+				if (unselectedTabColor is not null)
+					effectiveUnselectedTint = unselectedTabColor.ToPlatform();
+				else if (effectiveUnselectedBarTextColor is not null)
+					effectiveUnselectedTint = effectiveUnselectedBarTextColor;
+
+				tabBar.UnselectedItemTintColor = effectiveUnselectedTint;
+
+				// Also ensure TintColor is set for selected items
+				var effectiveSelectedTint = selectedTabColor?.ToPlatform() ?? effectiveSelectedBarTextColor;
+				if (effectiveSelectedTint is not null)
+					tabBar.TintColor = effectiveSelectedTint;
+
+				// iOS 26 liquid glass strips tint colors during compositing.
+				// Use pre-colored images with AlwaysOriginal to bypass the tint pipeline.
+				tabBar.ApplyPreColoredImagesForIOS26(effectiveUnselectedTint, effectiveSelectedTint);
+			}
 		}
+
+		/// <summary>
+		/// On iOS 26+, the liquid glass tab bar's compositing pipeline strips TintColor from
+		/// unselected tab icons and labels. This method bypasses the tint system by creating
+		/// pre-colored copies of tab icons using AlwaysOriginal rendering mode, which bakes the
+		/// color into the image pixel data. Also sets per-item title text attributes.
+		/// Must be called on every layout pass because UIKit may reset these during layout.
+		/// See: https://github.com/dotnet/maui/issues/32125, https://github.com/dotnet/maui/issues/34605
+		/// </summary>
+		[System.Runtime.Versioning.SupportedOSPlatform("ios26.0")]
+		[System.Runtime.Versioning.SupportedOSPlatform("maccatalyst26.0")]
+		internal static void ApplyPreColoredImagesForIOS26(this UITabBar tabBar, UIColor? unselectedColor, UIColor? selectedColor)
+		{
+			if (tabBar.Items is null)
+				return;
+
+			foreach (var item in tabBar.Items)
+			{
+				if (item.Image is UIImage img && unselectedColor is not null)
+				{
+					// Retrieve or store the original template image so we always tint
+					// from a clean alpha mask, avoiding quality degradation from
+					// repeated AlwaysOriginal→Template round-trips.
+					if (!s_originalTemplateImages.TryGetValue(item, out var template))
+					{
+						template = img.RenderingMode == UIImageRenderingMode.AlwaysOriginal
+							? img.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+							: img;
+						s_originalTemplateImages.AddOrUpdate(item, template);
+					}
+
+					// Only re-tint if UIKit has reset the image (rendering mode won't
+					// be AlwaysOriginal) or if this is the first application. This avoids
+					// creating new UIImage instances on every layout pass.
+					if (img.RenderingMode != UIImageRenderingMode.AlwaysOriginal)
+					{
+						item.Image = template.ApplyTintColor(unselectedColor)
+							?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+
+						if (selectedColor is not null)
+						{
+							item.SelectedImage = template.ApplyTintColor(selectedColor)
+								?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+						}
+					}
+				}
+
+				// Set per-item title text attributes for unselected state
+				if (unselectedColor is not null)
+				{
+					item.SetTitleTextAttributes(
+						new UIStringAttributes { ForegroundColor = unselectedColor, ParagraphStyle = NSParagraphStyle.Default },
+						UIControlState.Normal);
+				}
+
+				if (selectedColor is not null)
+				{
+					item.SetTitleTextAttributes(
+						new UIStringAttributes { ForegroundColor = selectedColor, ParagraphStyle = NSParagraphStyle.Default },
+						UIControlState.Selected);
+				}
+			}
+		}
+
+		// Stores original template images per tab bar item so we always tint from
+		// a clean alpha mask. Uses ConditionalWeakTable so entries are collected
+		// when the UITabBarItem is garbage-collected.
+		static readonly ConditionalWeakTable<UITabBarItem, UIImage> s_originalTemplateImages = new();
 
 		internal static UIImage? AutoResizeTabBarImage(UITraitCollection traitCollection, UIImage image)
 		{
@@ -152,8 +254,15 @@ namespace Microsoft.Maui.Platform
 				newSize.Width = isRegularTabBar ? regularSquareSize : compactSquareSize;
 				newSize.Height = newSize.Width;
 			}
-			
-			return image.ResizeImageSource(newSize.Width, newSize.Height, new CGSize(image.Size.Width, image.Size.Height));
+
+			var resizedImage = image.ResizeImageSource(newSize.Width, newSize.Height, new CGSize(image.Size.Width, image.Size.Height));
+
+			if (OperatingSystem.IsIOSVersionAtLeast(26) || OperatingSystem.IsMacCatalystVersionAtLeast(26))
+			{
+				return resizedImage?.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+			}
+
+			return resizedImage;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TabbedViewExtensions.cs
@@ -274,27 +274,41 @@ static void ApplyDirectTextColorsForIOS26(UITabBar tabBar, UIColor? unselectedCo
 		if (unselectedColor == null && selectedColor == null)
 			return;
 
-		Console.WriteLine("DEBUG: ApplyDirectTextColorsForIOS26 START - walking tab bar hierarchy");
+		Console.WriteLine($"=== TEXT COLOR DEBUG START ===");
+		Console.WriteLine($"  unselectedColor: {unselectedColor}");
+		Console.WriteLine($"  selectedColor: {selectedColor}");
+		Console.WriteLine($"  tabBar: {tabBar}");
+		Console.WriteLine($"  tabBar.Items.Length: {tabBar.Items?.Length ?? 0}");
 		
 		var items = tabBar.Items ?? [];
 		if (items.Length == 0)
+		{
+			Console.WriteLine("  No items in tabBar!");
 			return;
+		}
 
 		var selectedItem = tabBar.SelectedItem;
 		var queue = new Queue<UIView>();
 		queue.Enqueue(tabBar);
 		
+		int viewCount = 0;
 		int labelCount = 0;
 		while (queue.Count > 0)
 		{
 			var view = queue.Dequeue();
+			viewCount++;
+			
+			// Log every 10th view
+			if (viewCount % 10 == 0)
+				Console.WriteLine($"  Processed {viewCount} views, found {labelCount} labels...");
 			
 			// Color any UILabel we find
 			if (view is UILabel label)
 			{
+				var oldColor = label.TextColor;
 				label.TextColor = unselectedColor ?? UIColor.Black;
 				labelCount++;
-				Console.WriteLine($"DEBUG: Colored label #{labelCount}");
+				Console.WriteLine($"  [LABEL #{labelCount}] Changed from {oldColor} to {label.TextColor}");
 			}
 			
 			// Enqueue all subviews for processing
@@ -304,8 +318,10 @@ static void ApplyDirectTextColorsForIOS26(UITabBar tabBar, UIColor? unselectedCo
 			}
 		}
 		
-		Console.WriteLine($"DEBUG: ApplyDirectTextColorsForIOS26 DONE - colored {labelCount} labels");
+		Console.WriteLine($"  FINAL: Walked {viewCount} views total, colored {labelCount} labels");
+		Console.WriteLine($"=== TEXT COLOR DEBUG END ===");
 	}
+
 
 
 					buttonIndex++;


### PR DESCRIPTION
## Description

On iOS 26+, Apple's liquid glass tab bar compositing pipeline ignores `UITabBarAppearance` Normal state (`TitleTextAttributes`, `IconColor`) **AND** `UITabBar.UnselectedItemTintColor` for visual rendering, even though the properties are stored correctly. This caused:

- **`TabbedPage.BarTextColor`** to have no visual effect on unselected tabs (#34605)
- **`Shell.TabBarUnselectedColor`** to have no visual effect (#32125)

## Root Cause

The iOS 26 liquid glass tab bar uses a dual-layer compositing architecture:
- **SelectedContentView** — renders all tabs with the selected tint (visible layer)
- **ContentView** — renders all tabs with unselected style (composited behind)
- **DestOutView** — uses `destOut` CALayer compositing filter to cut out the selected tab

The compositing pipeline strips all `TintColor`/`UnselectedItemTintColor` from the rendering path, regardless of whether they're set via appearance or direct properties.

## Fix

Bypass the tint pipeline entirely on iOS 26+ by using **pre-colored images with `AlwaysOriginal` rendering mode** via `UIImage.ApplyTintColor()`, which bakes the color into image pixel data. This is the same proven approach used for the iOS 26 back button color fix (PR #34326).

### What changed:

**`TabbedViewExtensions.cs`** (shared):
- New `ApplyPreColoredImagesForIOS26()` method that creates pre-colored tab icon copies using `AlwaysOriginal` rendering
- Caches original template images in a `ConditionalWeakTable` to avoid quality degradation
- Sets per-item `SetTitleTextAttributes` for text color
- On iOS 26+: skips Normal appearance state, sets direct properties + pre-colored images

**`SafeShellTabBarAppearanceTracker.cs`** (Shell):
- iOS 26+ early-return path that skips the full appearance pipeline
- Caches pending colors for re-application in `UpdateLayout()` (liquid glass resets properties during layout)

**`TabbedRenderer.cs`** (TabbedPage):
- Caches effective colors and re-applies pre-colored images in `ViewDidLayoutSubviews()`

Pre-iOS 26 behavior is completely unchanged.

### Why not `AlwaysTemplate` + `UnselectedItemTintColor`?

This was attempted in the previously closed PR #32153, but `AlwaysTemplate` relies on the tint pipeline — which is exactly what iOS 26 liquid glass ignores. `AlwaysOriginal` bakes color into pixel data, which survives the compositing.

## Test Results

| Category | iOS 26.2 | iOS 18.5 |
|----------|---------|---------|
| TabbedPage | ✅ 12 passed, 0 failed | ✅ 12 passed, 0 failed |
| Shell | ✅ 202 passed, 0 failed | ✅ 201 passed, 1 failed (pre-existing) |

## Issues Fixed

Fixes #32125
Fixes #34605