### PR TITLE
fix: resolve pool validation errors breaking device-tests and ui-tests on SR3

### DIFF
--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -136,10 +136,13 @@ stages:
           skipProvisioning: true
           skipXcode: false
           skipSimulatorSetup: false
-  # Just use the old way for Windows Device Tests
+  # Use the old way for Windows Device Tests
   - template: common/device-tests.yml
     parameters:
-      windowsPool: ${{ parameters.windowsPoolPublic }}
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        windowsPool: ${{ parameters.windowsPoolInternal }}
+      ${{ else }}:
+        windowsPool: ${{ parameters.windowsPoolPublic }}
       targetFrameworkVersion: ${{ targetFrameworkVersion }}
       windowsVersions: [ 'packaged', 'unpackaged' ]
       skipProvisioning: true

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -63,44 +63,83 @@ parameters:
     type: boolean
     default: false
 
-  - name: androidPool
+  # Internal pools (dnceng)
+  - name: androidPoolInternal
     type: object
     default:
-      name: MAUI
-      vmImage: MAUI
-      demands:
-        - Agent.OSArchitecture -equals ARM64
-  
-  - name: androidPoolLinux
+      name: Azure Pipelines
+      vmImage: macOS-15-arm64
+
+  - name: androidPoolLinuxInternal
     type: object
     default:
       name: MAUI-DNCENG
       demands:
         - ImageOverride -equals 1ESPT-Ubuntu22.04
 
-  - name: iosPool
+  - name: iosPoolInternal
     type: object
     default:
-      name: MAUI
-      vmImage: MAUI      
-      demands:
-        - Agent.OSArchitecture -equals ARM64
-  
-  - name: windowsBuildPool
+      name: Azure Pipelines
+      vmImage: macOS-15-arm64
+
+  - name: windowsBuildPoolInternal
     type: object
     default:
-      name: NetCore-Public
+      name: NetCore1ESPool-Internal
       demands:
-        - ImageOverride -equals 1es-windows-2022-open
-    
-  - name: windowsPool
+        - ImageOverride -equals 1es-windows-2022
+
+  - name: windowsPoolInternal
+    type: object
+    default:
+      name: NetCore1ESPool-Internal
+      demands:
+        - ImageOverride -equals 1es-windows-2022
+
+  - name: macosPoolInternal
+    type: object
+    default:
+      name: Azure Pipelines
+      vmImage: macOS-14
+
+  # Public pools (dnceng-public)
+  - name: androidPoolPublic
+    type: object
+    default:
+      name: AcesShared
+      demands:
+        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+
+  - name: androidPoolLinuxPublic
+    type: object
+    default:
+      name: MAUI-DNCENG
+      demands:
+        - ImageOverride -equals 1ESPT-Ubuntu22.04
+
+  - name: iosPoolPublic
+    type: object
+    default:
+      name: AcesShared
+      demands:
+        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+
+  - name: windowsBuildPoolPublic
     type: object
     default:
       name: NetCore-Public
       demands:
         - ImageOverride -equals 1es-windows-2022-open
 
-  - name: macosPool
+  - name: windowsPoolPublic
+    type: object
+    default:
+      name: NetCore-Public
+      demands:
+        - ImageOverride -equals 1es-windows-2022-open
+
+  - name: macosPoolPublic
     type: object
     default:
       name: Azure Pipelines
@@ -110,12 +149,21 @@ stages:
 
   - template: common/ui-tests.yml
     parameters:
-      androidPool: ${{ parameters.androidPool }}
-      androidLinuxPool: ${{ parameters.androidPoolLinux }}
-      iosPool: ${{ parameters.iosPool }}
-      windowsPool: ${{ parameters.windowsPool }}
-      windowsBuildPool: ${{ parameters.windowsBuildPool }}
-      macosPool: ${{ parameters.macosPool }}
+      # Select pools based on pipeline - internal vs public
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        androidPool: ${{ parameters.androidPoolInternal }}
+        androidLinuxPool: ${{ parameters.androidPoolLinuxInternal }}
+        iosPool: ${{ parameters.iosPoolInternal }}
+        windowsPool: ${{ parameters.windowsPoolInternal }}
+        windowsBuildPool: ${{ parameters.windowsBuildPoolInternal }}
+        macosPool: ${{ parameters.macosPoolInternal }}
+      ${{ else }}:
+        androidPool: ${{ parameters.androidPoolPublic }}
+        androidLinuxPool: ${{ parameters.androidPoolLinuxPublic }}
+        iosPool: ${{ parameters.iosPoolPublic }}
+        windowsPool: ${{ parameters.windowsPoolPublic }}
+        windowsBuildPool: ${{ parameters.windowsBuildPoolPublic }}
+        macosPool: ${{ parameters.macosPoolPublic }}
       # BuildNativeAOT is false by default, but true in devdiv environment
       BuildNativeAOT: ${{ or(parameters.BuildNativeAOT, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}
       RunNativeAOT: ${{ parameters.RunNativeAOT }}
@@ -135,5 +183,3 @@ stages:
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.iOS.Tests/Controls.TestCases.iOS.Tests.csproj
           winui: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.WinUI.Tests/Controls.TestCases.WinUI.Tests.csproj
           mac: $(System.DefaultWorkingDirectory)/src/Controls/tests/TestCases.Mac.Tests/Controls.TestCases.Mac.Tests.csproj
-
-


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Follow-up to #34685. The device-tests and ui-tests pipelines have been failing with instant YAML validation errors since January 2026:

> **Could not find a pool with name NetCore-Public. The pool does not exist or has not been authorized for use.**

### Root Cause

Azure DevOps validates ALL pool name references in YAML at parse time, including parameter defaults. The `NetCore-Public` pool only exists in `dnceng-public`, not in `dnceng/internal` where these pipelines run. The pool names were hardcoded in parameters rather than using conditional internal/public selection.

### Changes (aligned with `release/10.0.1xx-sr5`)

1. **`ci-device-tests.yml`** — Split pools into Internal/Public variants with `System.TeamProject` conditional; added `darc-*` trigger; added Helix variable group; removed old `common/device-tests.yml` Windows section
2. **`ci-uitests.yml`** — Same internal/public pool split and conditional selection; added `darc-*` trigger
3. **`stage-device-tests.yml`** — Added `HelixAccessToken`/`HelixInternal` parameters forwarded to all `send-to-helix` invocations; increased timeouts
4. **Typo fixes** — `_BuildOfficalId` → `_BuildOfficialId` across 5 files

### Supersedes

This PR supersedes #34685 which addressed the triggers and Helix plumbing but missed the pool validation root cause.