### PR TITLE
[iOS] Fix ArgumentOutOfRangeException in ObservableGroupedSource when removing a group from grouped CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableGroupedSource.cs
@@ -164,9 +164,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (!_collectionViewController.TryGetTarget(out var controller))
 				return;
 
-			// Force UICollectionView to get the internal accounting straight
 			var collectionView = controller.CollectionView;
-			UpdateSection(collectionView);
+
+			// Force UICollectionView to get the internal accounting straight.
+			// Skip for Remove: standard INotifyCollectionChanged semantics require the item to be
+			// already removed from the backing collection before CollectionChanged fires. This means
+			// _groupSource has N-1 items when we receive Remove, but UIKit still has N sections.
+			// Calling UpdateSection here triggers GetGroupCount with UIKit's stale section index
+			// (N-1), which is out of range on the already-mutated _groupSource → ArgumentOutOfRangeException.
+			// The post-processing UpdateSection call below handles reconciliation after DeleteSections.
+			if (args.Action != NotifyCollectionChangedAction.Remove)
+			{
+				UpdateSection(collectionView);
+			}
 
 			switch (args.Action)
 			{
@@ -360,6 +370,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		int GetGroupCount(int groupIndex)
 		{
+			// Defensive bounds check: UIKit can call back synchronously during DeleteSections,
+			// and other re-entrancy scenarios may present a stale groupIndex. Return 0 instead
+			// of throwing ArgumentOutOfRangeException.
+			if ((uint)groupIndex >= (uint)_groupSource.Count)
+				return 0;
+
 			switch (_groupSource[groupIndex])
 			{
 				case IList list:

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -49,11 +49,28 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		// Regression test for https://github.com/dotnet/maui/issues/34691
-		// ObservableGroupedSource.CollectionChanged called UpdateSection() before processing
-		// Remove, causing GetGroupCount(N-1) to be invoked when _groupSource already had N-1
-		// items → ArgumentOutOfRangeException.
-		[Fact(DisplayName = "Removing last section from grouped CollectionView does not crash")]
+		// Regression tests for https://github.com/dotnet/maui/issues/34691
+		//
+		// Root cause: ObservableGroupedSource.CollectionChanged() called UpdateSection() before
+		// processing Remove. INCC semantics require the item to be already removed from the
+		// backing collection before CollectionChanged fires, so _groupSource has N-1 items when
+		// MAUI receives Remove — but UIKit still has N sections. UpdateSection() then iterates
+		// UIKit's N sections and calls NumberOfItemsInSection(N-1), re-entering the data source:
+		//   GetGroupCount(N-1) → _groupSource[N-1] → ArgumentOutOfRangeException.
+		//
+		// These tests use CollectionViewHandler2 (the default iOS handler) because the production
+		// crash in issue #34691 goes through ItemsViewController2 (Items2/), which calls
+		// ItemsSourceFactory.CreateGrouped() → ObservableGroupedSource (Items/). Both handlers
+		// share the same ObservableGroupedSource, so fixing it covers both paths.
+		//
+		// Each test forces a synchronous UIKit layout pass after the removal via SetNeedsLayout()
+		// + LayoutIfNeeded(). Before the fix this deterministically triggers the crash:
+		//   CollectionChanged(Remove) → UpdateSection() → NumberOfItemsInSection(N-1)
+		//   → GetGroupCount(N-1) → ArgumentOutOfRangeException.
+		// After the fix the pre-Remove UpdateSection() is skipped and GetGroupCount() has a
+		// defensive bounds check, so both the synchronous and the deferred layout paths are safe.
+
+		[Fact(DisplayName = "Removing last section from grouped CollectionView does not crash (Handler2)")]
 		public async Task ItemsSourceGroupedRemoveLastSectionDoesNotCrash()
 		{
 			SetupBuilder();
@@ -73,24 +90,31 @@ namespace Microsoft.Maui.DeviceTests
 				ItemTemplate = new DataTemplate(() => new Label()),
 			};
 
-			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
-			{
-				await Task.Delay(1000);
+			// Capture the pre-layout frame so WaitForUIUpdate can detect the first layout pass.
+			var initialFrame = collectionView.Frame;
 
-				// Removing the last section was the classic crash: UIKit still had N sections
-				// when UpdateSection() was called before Remove(), so GetGroupCount(N-1) was
-				// invoked against a _groupSource that already had N-1 items → out of range.
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
+			{
+				// Wait for the initial layout rather than a fixed delay.
+				await WaitForUIUpdate(initialFrame, collectionView);
+
+				// Removing the last section was the classic crash: UIKit still has N sections
+				// when UpdateSection() is called before Remove(), so GetGroupCount(N-1) is
+				// invoked against a _groupSource that already has N-1 items → out of range.
 				groupData.RemoveAt(groupData.Count - 1);
 
-				await Task.Delay(500);
+				// Force a synchronous layout pass so UIKit queries the data source immediately.
+				// Without the fix this deterministically throws ArgumentOutOfRangeException.
+				handler.PlatformView.SetNeedsLayout();
+				handler.PlatformView.LayoutIfNeeded();
 
-				// Verify the CollectionView is still in a consistent state
 				Assert.Equal(2, groupData.Count);
+				// Verify UIKit's section count is consistent with the .NET collection.
+				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 
-		// Regression test for https://github.com/dotnet/maui/issues/34691
-		[Fact(DisplayName = "Removing first section from grouped CollectionView does not crash")]
+		[Fact(DisplayName = "Removing first section from grouped CollectionView does not crash (Handler2)")]
 		public async Task ItemsSourceGroupedRemoveFirstSectionDoesNotCrash()
 		{
 			SetupBuilder();
@@ -110,20 +134,26 @@ namespace Microsoft.Maui.DeviceTests
 				ItemTemplate = new DataTemplate(() => new Label()),
 			};
 
-			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			var initialFrame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
-				await Task.Delay(1000);
+				await WaitForUIUpdate(initialFrame, collectionView);
 
 				groupData.RemoveAt(0);
-				await Task.Delay(500);
+				handler.PlatformView.SetNeedsLayout();
+				handler.PlatformView.LayoutIfNeeded();
+
 				groupData.RemoveAt(0);
+				handler.PlatformView.SetNeedsLayout();
+				handler.PlatformView.LayoutIfNeeded();
 
 				Assert.Equal(1, groupData.Count);
+				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 
-		// Regression test for https://github.com/dotnet/maui/issues/34691
-		[Fact(DisplayName = "Removing sections one by one from grouped CollectionView does not crash")]
+		[Fact(DisplayName = "Removing all sections one by one from grouped CollectionView does not crash (Handler2)")]
 		public async Task ItemsSourceGroupedRemoveAllSectionsOneByOneDoesNotCrash()
 		{
 			SetupBuilder();
@@ -143,17 +173,23 @@ namespace Microsoft.Maui.DeviceTests
 				ItemTemplate = new DataTemplate(() => new Label()),
 			};
 
-			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			var initialFrame = collectionView.Frame;
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
-				await Task.Delay(1000);
+				await WaitForUIUpdate(initialFrame, collectionView);
 
 				while (groupData.Count > 0)
 				{
 					groupData.RemoveAt(groupData.Count - 1);
-					await Task.Delay(300);
+					// Force synchronous layout after each removal to exercise the full range
+					// of section indices and confirm no re-entrancy crash occurs.
+					handler.PlatformView.SetNeedsLayout();
+					handler.PlatformView.LayoutIfNeeded();
 				}
 
 				Assert.Empty(groupData);
+				Assert.Equal(0, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -109,8 +109,6 @@ namespace Microsoft.Maui.DeviceTests
 				handler.PlatformView.LayoutIfNeeded();
 
 				Assert.Equal(2, groupData.Count);
-				// Verify UIKit's section count is consistent with the .NET collection.
-				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 
@@ -148,8 +146,7 @@ namespace Microsoft.Maui.DeviceTests
 				handler.PlatformView.SetNeedsLayout();
 				handler.PlatformView.LayoutIfNeeded();
 
-				Assert.Equal(1, groupData.Count);
-				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
+				Assert.Single(groupData);
 			});
 		}
 
@@ -189,7 +186,6 @@ namespace Microsoft.Maui.DeviceTests
 				}
 
 				Assert.Empty(groupData);
-				Assert.Equal(0, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -49,6 +49,114 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		// Regression test for https://github.com/dotnet/maui/issues/34691
+		// ObservableGroupedSource.CollectionChanged called UpdateSection() before processing
+		// Remove, causing GetGroupCount(N-1) to be invoked when _groupSource already had N-1
+		// items → ArgumentOutOfRangeException.
+		[Fact(DisplayName = "Removing last section from grouped CollectionView does not crash")]
+		public async Task ItemsSourceGroupedRemoveLastSectionDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var data = new List<string> { "item 1", "item 2", "item 3" };
+			var groupData = new ObservableCollection<CollectionViewStringGroup>
+			{
+				new("Header 1", data),
+				new("Header 2", data),
+				new("Header 3", data),
+			};
+
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groupData,
+				ItemTemplate = new DataTemplate(() => new Label()),
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				await Task.Delay(1000);
+
+				// Removing the last section was the classic crash: UIKit still had N sections
+				// when UpdateSection() was called before Remove(), so GetGroupCount(N-1) was
+				// invoked against a _groupSource that already had N-1 items → out of range.
+				groupData.RemoveAt(groupData.Count - 1);
+
+				await Task.Delay(500);
+
+				// Verify the CollectionView is still in a consistent state
+				Assert.Equal(2, groupData.Count);
+			});
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/34691
+		[Fact(DisplayName = "Removing first section from grouped CollectionView does not crash")]
+		public async Task ItemsSourceGroupedRemoveFirstSectionDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var data = new List<string> { "item 1", "item 2" };
+			var groupData = new ObservableCollection<CollectionViewStringGroup>
+			{
+				new("Header 1", data),
+				new("Header 2", data),
+				new("Header 3", data),
+			};
+
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groupData,
+				ItemTemplate = new DataTemplate(() => new Label()),
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				await Task.Delay(1000);
+
+				groupData.RemoveAt(0);
+				await Task.Delay(500);
+				groupData.RemoveAt(0);
+
+				Assert.Equal(1, groupData.Count);
+			});
+		}
+
+		// Regression test for https://github.com/dotnet/maui/issues/34691
+		[Fact(DisplayName = "Removing sections one by one from grouped CollectionView does not crash")]
+		public async Task ItemsSourceGroupedRemoveAllSectionsOneByOneDoesNotCrash()
+		{
+			SetupBuilder();
+
+			var data = new List<string> { "item 1", "item 2" };
+			var groupData = new ObservableCollection<CollectionViewStringGroup>
+			{
+				new("Header 1", data),
+				new("Header 2", data),
+				new("Header 3", data),
+			};
+
+			var collectionView = new CollectionView
+			{
+				IsGrouped = true,
+				ItemsSource = groupData,
+				ItemTemplate = new DataTemplate(() => new Label()),
+			};
+
+			await CreateHandlerAndAddToWindow<CollectionViewHandler>(collectionView, async handler =>
+			{
+				await Task.Delay(1000);
+
+				while (groupData.Count > 0)
+				{
+					groupData.RemoveAt(groupData.Count - 1);
+					await Task.Delay(300);
+				}
+
+				Assert.Empty(groupData);
+			});
+		}
+
 		class CollectionViewStringGroup : List<string>
 		{
 			public string GroupHeader { get; private set; }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -50,25 +50,9 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		// Regression tests for https://github.com/dotnet/maui/issues/34691
-		//
-		// Root cause: ObservableGroupedSource.CollectionChanged() called UpdateSection() before
-		// processing Remove. INCC semantics require the item to be already removed from the
-		// backing collection before CollectionChanged fires, so _groupSource has N-1 items when
-		// MAUI receives Remove — but UIKit still has N sections. UpdateSection() then iterates
-		// UIKit's N sections and calls NumberOfItemsInSection(N-1), re-entering the data source:
-		//   GetGroupCount(N-1) → _groupSource[N-1] → ArgumentOutOfRangeException.
-		//
-		// These tests use CollectionViewHandler2 (the default iOS handler) because the production
-		// crash in issue #34691 goes through ItemsViewController2 (Items2/), which calls
-		// ItemsSourceFactory.CreateGrouped() → ObservableGroupedSource (Items/). Both handlers
-		// share the same ObservableGroupedSource, so fixing it covers both paths.
-		//
-		// Each test forces a synchronous UIKit layout pass after the removal via SetNeedsLayout()
-		// + LayoutIfNeeded(). Before the fix this deterministically triggers the crash:
-		//   CollectionChanged(Remove) → UpdateSection() → NumberOfItemsInSection(N-1)
-		//   → GetGroupCount(N-1) → ArgumentOutOfRangeException.
-		// After the fix the pre-Remove UpdateSection() is skipped and GetGroupCount() has a
-		// defensive bounds check, so both the synchronous and the deferred layout paths are safe.
+		// ObservableGroupedSource.CollectionChanged() called UpdateSection() before Remove,
+		// causing GetGroupCount to access a stale section index → ArgumentOutOfRangeException.
+		// Each test forces a synchronous UIKit layout pass after removal to exercise the fix.
 
 		[Fact(DisplayName = "Removing last section from grouped CollectionView does not crash (Handler2)")]
 		public async Task ItemsSourceGroupedRemoveLastSectionDoesNotCrash()
@@ -90,25 +74,18 @@ namespace Microsoft.Maui.DeviceTests
 				ItemTemplate = new DataTemplate(() => new Label()),
 			};
 
-			// Capture the pre-layout frame so WaitForUIUpdate can detect the first layout pass.
 			var initialFrame = collectionView.Frame;
 
 			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
-				// Wait for the initial layout rather than a fixed delay.
 				await WaitForUIUpdate(initialFrame, collectionView);
 
-				// Removing the last section was the classic crash: UIKit still has N sections
-				// when UpdateSection() is called before Remove(), so GetGroupCount(N-1) is
-				// invoked against a _groupSource that already has N-1 items → out of range.
 				groupData.RemoveAt(groupData.Count - 1);
 
-				// Force a synchronous layout pass so UIKit queries the data source immediately.
-				// Without the fix this deterministically throws ArgumentOutOfRangeException.
 				handler.PlatformView.SetNeedsLayout();
 				handler.PlatformView.LayoutIfNeeded();
 
-				Assert.Equal(2, groupData.Count);
+				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 
@@ -141,12 +118,12 @@ namespace Microsoft.Maui.DeviceTests
 				groupData.RemoveAt(0);
 				handler.PlatformView.SetNeedsLayout();
 				handler.PlatformView.LayoutIfNeeded();
+				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 
 				groupData.RemoveAt(0);
 				handler.PlatformView.SetNeedsLayout();
 				handler.PlatformView.LayoutIfNeeded();
-
-				Assert.Single(groupData);
+				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 			});
 		}
 
@@ -179,10 +156,9 @@ namespace Microsoft.Maui.DeviceTests
 				while (groupData.Count > 0)
 				{
 					groupData.RemoveAt(groupData.Count - 1);
-					// Force synchronous layout after each removal to exercise the full range
-					// of section indices and confirm no re-entrancy crash occurs.
 					handler.PlatformView.SetNeedsLayout();
 					handler.PlatformView.LayoutIfNeeded();
+					Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
 				}
 
 				Assert.Empty(groupData);

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.iOS.cs
@@ -79,13 +79,14 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
 				await WaitForUIUpdate(initialFrame, collectionView);
+				var uiCollectionView = handler.Controller.CollectionView;
 
 				groupData.RemoveAt(groupData.Count - 1);
 
-				handler.PlatformView.SetNeedsLayout();
-				handler.PlatformView.LayoutIfNeeded();
+				uiCollectionView.SetNeedsLayout();
+				uiCollectionView.LayoutIfNeeded();
 
-				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
+				Assert.Equal(groupData.Count, (int)uiCollectionView.NumberOfSections());
 			});
 		}
 
@@ -114,16 +115,17 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
 				await WaitForUIUpdate(initialFrame, collectionView);
+				var uiCollectionView = handler.Controller.CollectionView;
 
 				groupData.RemoveAt(0);
-				handler.PlatformView.SetNeedsLayout();
-				handler.PlatformView.LayoutIfNeeded();
-				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
+				uiCollectionView.SetNeedsLayout();
+				uiCollectionView.LayoutIfNeeded();
+				Assert.Equal(groupData.Count, (int)uiCollectionView.NumberOfSections());
 
 				groupData.RemoveAt(0);
-				handler.PlatformView.SetNeedsLayout();
-				handler.PlatformView.LayoutIfNeeded();
-				Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
+				uiCollectionView.SetNeedsLayout();
+				uiCollectionView.LayoutIfNeeded();
+				Assert.Equal(groupData.Count, (int)uiCollectionView.NumberOfSections());
 			});
 		}
 
@@ -152,13 +154,14 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<CollectionViewHandler2>(collectionView, async handler =>
 			{
 				await WaitForUIUpdate(initialFrame, collectionView);
+				var uiCollectionView = handler.Controller.CollectionView;
 
 				while (groupData.Count > 0)
 				{
 					groupData.RemoveAt(groupData.Count - 1);
-					handler.PlatformView.SetNeedsLayout();
-					handler.PlatformView.LayoutIfNeeded();
-					Assert.Equal(groupData.Count, (int)handler.PlatformView.NumberOfSections());
+					uiCollectionView.SetNeedsLayout();
+					uiCollectionView.LayoutIfNeeded();
+					Assert.Equal(groupData.Count, (int)uiCollectionView.NumberOfSections());
 				}
 
 				Assert.Empty(groupData);


### PR DESCRIPTION
## Summary

Fixes #34691 — `ArgumentOutOfRangeException` in `ObservableGroupedSource.GetGroupCount` when removing a group from a grouped `CollectionView` on iOS.

## Root Cause

`CollectionChanged(NotifyCollectionChangedEventArgs)` called `UpdateSection()` **before** processing the `Remove` action:

```csharp
var collectionView = controller.CollectionView;
UpdateSection(collectionView);  // ← called here, before Remove()

switch (args.Action) {
    case NotifyCollectionChangedAction.Remove:
        Remove(args);  // ← _groupSource already has N-1 items
```

Standard `INotifyCollectionChanged` semantics require the item to be **already removed** from the backing collection before `CollectionChanged` fires. So when MAUI receives `CollectionChanged(Remove)`, `_groupSource` has N-1 items — but UIKit still has N sections.

`UpdateSection` iterates UIKit's N sections and calls `NumberOfItemsInSection(N-1)`, which re-enters the data source:

```
UpdateSection  →  NumberOfItemsInSection(N-1)
  →  ItemCountInGroup(N-1)  →  GetGroupCount(N-1)
    →  _groupSource[N-1]    ← out of range → 💥
```

The `Compatibility` layer (`Microsoft.Maui.Controls.Compatibility.Platform.iOS.ObservableGroupedSource`) does **not** call `UpdateSection` before `Remove` and is unaffected.

## Fix

1. **Skip `UpdateSection` before `Remove`** — the post-processing call (after `DeleteSections` completes) already handles UIKit reconciliation.

2. **Defensive bounds check in `GetGroupCount`** — guards against other re-entrancy scenarios where UIKit calls back synchronously with a stale section index during `DeleteSections`.

## Testing

- Verified the fix prevents the crash in a grouped `CollectionView` with dynamic section removal on iOS
- `UpdateSection` is still called for `Add`, `Replace`, `Move`, and `Reset` — no regression expected for those actions
- The post-processing `UpdateSection` still runs for `Remove` after `DeleteSections` completes