### PR TITLE
[iOS/Mac] Fix MediaPicker.CapturePhotoAsync() fails with UnauthorisedAccessException on iOS

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -98,11 +98,6 @@ namespace Microsoft.Maui.Media
 			}
 			else
 			{
-				if (!pickExisting)
-				{
-					await Permissions.EnsureGrantedAsync<Permissions.PhotosAddOnly>();
-				}
-
 				var sourceType = pickExisting
 					? UIImagePickerControllerSourceType.PhotoLibrary
 					: UIImagePickerControllerSourceType.Camera;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
In the latest .NET MAUI, calling CapturePhotoAsync() throws an UnauthorizedAccessException.

### Root Cause
In the CapturePhotoAsync method, EnsureGrantedAsync is called for the PhotosAddOnly permission.
PhotosAddOnly is used to write images to the photo library, which is not required for CapturePhotoAsync.

### Description of Change

<!-- Enter description of the fix in this section -->
Removed the PhotosAddOnly permission check from the CapturePhotoAsync method.

### Regarding test case
Capturing an image is not possible in a test.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34661 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac


| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/30ab4081-3db5-43a0-9da7-32aafd545be3" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/a7feac89-3f26-45f6-a951-f64a292f0b87" width="300" height="600"> |
