### PR TITLE
[iOS] Fix Label with TailTruncation not rendering after empty-to-non-empty text transition

### DIFF
--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -376,7 +376,8 @@ namespace Microsoft.Maui.Controls
 			var wasEmpty = string.IsNullOrEmpty(oldvalue as string);
 			var isEmpty = string.IsNullOrEmpty(newvalue as string);
 
-			// Always invalidate when text transitions between empty and non-empty,
+			// Always invalidate when text transitions between empty and non-empty
+			// for labels that can grow in at least one direction (IsLabelSizeable),
 			// even for single-line horizontally-fixed labels (e.g. TailTruncation in
 			// a VerticalStackLayout), because the label height changes from 0 to line height.
 			if (TextChangedShouldInvalidateMeasure(label) || (wasEmpty != isEmpty && IsLabelSizeable(label)))

--- a/src/Controls/src/Core/Label/Label.cs
+++ b/src/Controls/src/Core/Label/Label.cs
@@ -373,11 +373,21 @@ namespace Microsoft.Maui.Controls
 		{
 			var label = (Label)bindable;
 
-			if (TextChangedShouldInvalidateMeasure(label))
+			var wasEmpty = string.IsNullOrEmpty(oldvalue as string);
+			var isEmpty = string.IsNullOrEmpty(newvalue as string);
+
+			// Always invalidate when text transitions between empty and non-empty,
+			// even for single-line horizontally-fixed labels (e.g. TailTruncation in
+			// a VerticalStackLayout), because the label height changes from 0 to line height.
+			if (TextChangedShouldInvalidateMeasure(label) || (wasEmpty != isEmpty && IsLabelSizeable(label)))
+			{
 				label.InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			}
 
 			if (newvalue != null)
+			{
 				label.FormattedText = null;
+			}
 		}
 
 		/// <inheritdoc/>

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34591.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34591.cs
@@ -1,0 +1,42 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34591, "Label with TailTruncation does not render text when initial text is null", PlatformAffected.iOS)]
+public class Issue34591 : TestContentPage
+{
+	protected override void Init()
+	{
+		Label resultLabel = new Label
+		{
+			AutomationId = "ResultLabel",
+			LineBreakMode = LineBreakMode.TailTruncation,
+		};
+
+		Button updateButton = new Button
+		{
+			AutomationId = "UpdateTextButton",
+			Text = "Update Text"
+		};
+
+		updateButton.Clicked += (s, e) =>
+		{
+			resultLabel.Text = "Test";
+		};
+
+		Label instructions = new Label
+		{
+			Text = "Tap the 'Update Text' button. If the text 'Test' is visible in the label above this description, the test has passed."
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 10,
+			Children =
+			{
+				updateButton,
+				resultLabel,
+				instructions
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34591.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34591.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34591 : _IssuesUITest
+{
+	public Issue34591(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "Label with TailTruncation does not render text when initial text is null";
+
+	[Test]
+	[Category(UITestCategories.Label)]
+	public void LabelWithTailTruncationRendersTextAfterUpdate()
+	{
+		App.WaitForElement("UpdateTextButton");
+		App.Tap("UpdateTextButton");
+
+		App.WaitForElement("Test");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34591.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34591.cs
@@ -17,6 +17,8 @@ public class Issue34591 : _IssuesUITest
 		App.WaitForElement("UpdateTextButton");
 		App.Tap("UpdateTextButton");
 
-		App.WaitForElement("Test");
+		var rect = App.WaitForElement("ResultLabel").GetRect();
+		Assert.That(rect.Height, Is.GreaterThan(0),
+			"Label should have non-zero height after setting text from null");
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
- When a Label is initialized with LineBreakMode="TailTruncation" and its Text is null or empty during the first
render, later updates to the Text property do not render any visible text on iOS. The label remains visually
empty even though the Text value changes successfully.

### Root Cause
- **Regression**: Introduced by PR #28931
- PR #28931 introduced ComputeConstraintForView on several layouts, which causes a Label with default HorizontalOptions = Fill (e.g., inside a VerticalStackLayout) to be marked as HorizontallyFixed. This activates an existing optimization in TextChangedShouldInvalidateMeasure that skips InvalidateMeasureInternal for labels that are both single-line and horizontally fixed.
- This optimization is valid for typical text changes (e.g., "Hello" → "World") where the height remains unchanged. However, it fails for the empty → non-empty transition. When a label initially has null/empty text, iOS measures it with a height of 0, and MAUI caches this value. When text is later assigned, the optimization prevents re-measurement, leaving the stale 0-height intact—resulting in the label being invisible despite having text.

### Description of Change
- Updated OnTextPropertyChanged in Label.cs to always invalidate measure when the label's text transitions between empty and non-empty, ensuring the label is properly rendered and sized in scenarios like TailTruncation.


### Issues Fixed
Fixes #34591

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/7d46bf6a-50f5-45ee-bc34-58071e4f17de"> | <video src="https://github.com/user-attachments/assets/7d600c48-2c94-4efe-ba98-81adf4976925"> |