### PR TITLE
[Android] Fix SearchBar text bleeding between instances after navigation

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20348.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20348.cs
@@ -19,12 +19,14 @@ public class Issue20348 : NavigationPage
 			Label firstSearchBarTextLabel = new Label
 			{
 				AutomationId = "FirstSearchBarText",
-				Text = ""
+				Text = "Pass"
 			};
 
 			firstSearchBar.TextChanged += (s, e) =>
 			{
-				firstSearchBarTextLabel.Text = e.NewTextValue ?? "";
+				firstSearchBarTextLabel.Text = string.IsNullOrEmpty(e.NewTextValue)
+					? "Pass"
+					: "Fail";
 			};
 
 			SearchBar secondSearchBar = new SearchBar

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue20348.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue20348.cs
@@ -1,0 +1,77 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 20348, "SearchBar text incorrectly copied between multiple SearchBars on Android after back navigation", PlatformAffected.Android)]
+public class Issue20348 : NavigationPage
+{
+	public Issue20348() : base(new MainPage())
+	{
+	}
+
+	public class MainPage : ContentPage
+	{
+		public MainPage()
+		{
+			SearchBar firstSearchBar = new SearchBar
+			{
+				AutomationId = "FirstSearchBar"
+			};
+
+			Label firstSearchBarTextLabel = new Label
+			{
+				AutomationId = "FirstSearchBarText",
+				Text = ""
+			};
+
+			firstSearchBar.TextChanged += (s, e) =>
+			{
+				firstSearchBarTextLabel.Text = e.NewTextValue ?? "";
+			};
+
+			SearchBar secondSearchBar = new SearchBar
+			{
+				AutomationId = "SecondSearchBar"
+			};
+
+			Button navigateButton = new Button
+			{
+				Text = "Navigate",
+				AutomationId = "NavigateButton"
+			};
+
+			navigateButton.Clicked += async (s, e) =>
+			{
+				await Navigation.PushAsync(new SecondPage());
+			};
+
+			Label descriptionLabel = new Label
+			{
+				Text = "Test passes if SecondSearchBar text is NOT applied to FirstSearchBar after typing in SecondSearchBar, navigating to page 2, and pressing back.",
+				FontSize = 12,
+				TextColor = Colors.Gray,
+				HorizontalTextAlignment = TextAlignment.Center
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Padding = 20,
+				Spacing = 10,
+				Children = { descriptionLabel, firstSearchBar, firstSearchBarTextLabel, secondSearchBar, navigateButton }
+			};
+		}
+	}
+
+	public class SecondPage : ContentPage
+	{
+		public SecondPage()
+		{
+			Title = "Second Page";
+			Content = new Label
+			{
+				Text = "Second Page",
+				AutomationId = "SecondPageLabel",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20348.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20348.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue20348 : _IssuesUITest
+{
+	public override string Issue => "SearchBar text incorrectly copied between multiple SearchBars on Android after back navigation";
+
+	public Issue20348(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.SearchBar)]
+	public void SearchBarTextShouldNotBleedToOtherInstances()
+	{
+		App.WaitForElement("FirstSearchBar");
+		App.WaitForElement("SecondSearchBar");
+
+		App.EnterText("SecondSearchBar", "TestText");
+		App.Tap("NavigateButton");
+
+		App.WaitForElement("SecondPageLabel");
+		this.Back();
+		App.WaitForElement("FirstSearchBarText");
+
+		var firstSearchBarText = App.FindElement("FirstSearchBarText").GetText();
+		Assert.That(firstSearchBarText, Is.Null.Or.Empty,
+			"First SearchBar should be empty after back navigation — Android state save/restore should not bleed text from other SearchBar instances");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20348.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue20348.cs
@@ -24,8 +24,8 @@ public class Issue20348 : _IssuesUITest
 		this.Back();
 		App.WaitForElement("FirstSearchBarText");
 
-		var firstSearchBarText = App.FindElement("FirstSearchBarText").GetText();
-		Assert.That(firstSearchBarText, Is.Null.Or.Empty,
+		var result = App.FindElement("FirstSearchBarText").GetText();
+		Assert.That(result, Is.EqualTo("Pass"),
 			"First SearchBar should be empty after back navigation — Android state save/restore should not bleed text from other SearchBar instances");
 	}
 }

--- a/src/Core/src/Platform/Android/MauiSearchView.cs
+++ b/src/Core/src/Platform/Android/MauiSearchView.cs
@@ -22,6 +22,16 @@ namespace Microsoft.Maui.Platform
 
 			_queryEditor = this.GetFirstChildOfType<EditText>();
 
+			// Disable Android's built-in instance state saving on the internal EditText
+			// to prevent query text from being incorrectly restored across multiple
+			// SearchView instances during navigation. The EditText shares a fixed
+			// resource ID (search_src_text) across all SearchViews, causing state
+			// to bleed between instances. MAUI handles text via its own property mapping.
+			if (_queryEditor is not null)
+			{
+				_queryEditor.SaveEnabled = false;
+			}
+
 			if (_queryEditor?.LayoutParameters is LinearLayout.LayoutParams layoutParams)
 			{
 				layoutParams.Height = LinearLayout.LayoutParams.MatchParent;

--- a/src/Core/src/Platform/Android/MauiSearchView.cs
+++ b/src/Core/src/Platform/Android/MauiSearchView.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Platform
 			// to prevent query text from being incorrectly restored across multiple
 			// SearchView instances during navigation. The EditText shares a fixed
 			// resource ID (search_src_text) across all SearchViews, causing state
-			// to bleed between instances. MAUI handles text via its own property mapping.
+			// to bleed between instances.
 			if (_queryEditor is not null)
 			{
 				_queryEditor.SaveEnabled = false;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
### Issue Details
- On Android, when a page contains multiple SearchBar controls, navigating away (e.g., via NavigationPage.Push) and returning causes the text from one SearchBar to be incorrectly applied to the others.


### Root Cause
- Android saves and restores view state using the view’s resource ID as the key. The internal EditText inside every SearchView uses the same fixed ID (search_src_text).
- When multiple SearchBar instances are present on the same page, their state gets overwritten during the save process, leaving only the last SearchBar’s text preserved. During restore (e.g., after back navigation), this saved text is applied to all SearchBar instances sharing that ID, causing them to incorrectly display the same value.


### Description of Change
- Set SaveEnabled = false on the internal EditText of MauiSearchView to opt out of Android's instance state save/restore cycle, preventing stale text from being incorrectly applied across SearchBar instances during navigation. 


### Issues Fixed
Fixes #20348

### Validated the behaviour in the following platforms

- [ ] Windows
- [x] Android
- [ ] iOS
- [ ] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/48d70677-fa4f-4287-a55f-202e69da64c5"> | <video src="https://github.com/user-attachments/assets/cc42aa54-4450-46c6-864b-74266c780ddd"> |