### PR TITLE
Fix VisualStateGroups duplicate name crash with implicit styles (#34716)

### DIFF
--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -272,6 +272,21 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException(nameof(item));
 			}
 
+			// If a group with the same name already exists (e.g., set by an implicit style),
+			// remove it so the explicitly-added group takes precedence.
+			if (!string.IsNullOrEmpty(item.Name))
+			{
+				for (int i = _internalList.Count - 1; i >= 0; i--)
+				{
+					if (string.Equals(_internalList[i].Name, item.Name, StringComparison.Ordinal))
+					{
+						_internalList[i].StatesChanged -= ValidateAndNotify;
+						_internalList.Remove(_internalList[i]);
+						break;
+					}
+				}
+			}
+
 			_internalList.Add(item);
 
 			item.StatesChanged += ValidateAndNotify;
@@ -751,7 +766,7 @@ namespace Microsoft.Maui.Controls
 				group.VisualElement = clone.VisualElement;
 				clone.Add(group.Clone());
 			}
-			
+
 			// Preserve specificity when cloning (issue #27202)
 			if (groups is VisualStateGroupList sourceList)
 			{

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -141,12 +141,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void GroupNamesMustBeUniqueWithinGroupList()
+		public void GroupWithDuplicateNameReplacesExisting()
 		{
 			IList<VisualStateGroup> vsgs = CreateTestStateGroups();
 			var secondGroup = new VisualStateGroup { Name = CommonStatesGroupName };
+			secondGroup.States.Add(new VisualState { Name = NormalStateName });
 
-			Assert.Throws<InvalidOperationException>(() => vsgs.Add(secondGroup));
+			// Adding a group with the same name should replace the existing one, not throw
+			vsgs.Add(secondGroup);
+			Assert.Single(vsgs);
+			Assert.Same(secondGroup, vsgs[0]);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34716.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34716.xaml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui34716">
+    <ContentPage.Resources>
+        <Style x:Key="VsgStyle" TargetType="Button">
+            <Setter Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup Name="CommonStates">
+                        <VisualState Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="White" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState Name="Pressed">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="LightGray" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
+    <StackLayout>
+        <!-- Direct VisualStateGroups on element -->
+        <Button x:Name="button" Text="Press me">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup Name="CommonStates">
+                    <VisualState Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="White" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState Name="Pressed">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="LightGray" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Button>
+
+        <!-- Style-based VisualStateGroups -->
+        <Button x:Name="button2" Text="Styled" Style="{StaticResource VsgStyle}" />
+
+        <!-- Two groups on same element -->
+        <Button x:Name="button3" Text="Two groups">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup Name="CommonStates">
+                    <VisualState Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="White" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup Name="FocusStates">
+                    <VisualState Name="Focused">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="Yellow" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Button>
+
+        <!-- Explicit VisualStateGroupList -->
+        <Button x:Name="button4" Text="Explicit list">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroupList>
+                    <VisualStateGroup Name="CommonStates">
+                        <VisualState Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="White" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </VisualStateManager.VisualStateGroups>
+        </Button>
+    </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui34716.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui34716.xaml.cs
@@ -1,0 +1,121 @@
+using System;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui34716 : ContentPage
+{
+	public Maui34716() => InitializeComponent();
+
+	[Collection("Issue")]
+	public class Tests : IDisposable
+	{
+		public Tests()
+		{
+			Application.SetCurrentApplication(new MockApplication());
+		}
+
+		public void Dispose()
+		{
+			Application.Current = null;
+		}
+
+		// Registers an implicit Button style with VisualStateGroups (like the default MAUI template Styles.xaml)
+		void SetupImplicitButtonStyle()
+		{
+			Application.Current.Resources.Add(new Style(typeof(Button))
+			{
+				Setters =
+				{
+					new Setter
+					{
+						Property = VisualStateManager.VisualStateGroupsProperty,
+						Value = new VisualStateGroupList
+						{
+							new VisualStateGroup
+							{
+								Name = "CommonStates",
+								States =
+								{
+									new VisualState { Name = "Normal" },
+									new VisualState { Name = "Pressed" },
+									new VisualState { Name = "Disabled" }
+								}
+							}
+						}
+					}
+				}
+			});
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void VisualStateGroupsOnElementShouldNotThrowDuplicateNames(XamlInflator inflator)
+		{
+			var page = new Maui34716(inflator);
+			Assert.NotNull(page);
+
+			var groups = VisualStateManager.GetVisualStateGroups(page.button);
+			Assert.Single(groups);
+			Assert.Equal("CommonStates", groups[0].Name);
+			Assert.Equal(2, groups[0].States.Count);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void VisualStateGroupsWithImplicitStyleShouldNotThrowDuplicateNames(XamlInflator inflator)
+		{
+			// This is the real bug scenario: an implicit style already sets VisualStateGroups
+			// with "CommonStates", then the XAML also sets VisualStateGroups with "CommonStates".
+			// The SG calls GetValue() (returning the style's list) then Add() → duplicate name → crash.
+			SetupImplicitButtonStyle();
+
+			var page = new Maui34716(inflator);
+			Assert.NotNull(page);
+
+			// The explicit XAML VisualStateGroups should replace the implicit style's groups
+			var groups = VisualStateManager.GetVisualStateGroups(page.button);
+			Assert.Single(groups);
+			Assert.Equal("CommonStates", groups[0].Name);
+			Assert.Equal(2, groups[0].States.Count);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void VisualStateGroupsViaStyleShouldNotThrow(XamlInflator inflator)
+		{
+			var page = new Maui34716(inflator);
+			Assert.NotNull(page);
+
+			var groups = VisualStateManager.GetVisualStateGroups(page.button2);
+			Assert.Single(groups);
+			Assert.Equal("CommonStates", groups[0].Name);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void MultipleVisualStateGroupsShouldNotThrow(XamlInflator inflator)
+		{
+			var page = new Maui34716(inflator);
+			Assert.NotNull(page);
+
+			var groups = VisualStateManager.GetVisualStateGroups(page.button3);
+			Assert.Equal(2, groups.Count);
+			Assert.Equal("CommonStates", groups[0].Name);
+			Assert.Equal("FocusStates", groups[1].Name);
+		}
+
+		[Theory]
+		[XamlInflatorData]
+		internal void ExplicitVisualStateGroupListShouldNotThrow(XamlInflator inflator)
+		{
+			var page = new Maui34716(inflator);
+			Assert.NotNull(page);
+
+			var groups = VisualStateManager.GetVisualStateGroups(page.button4);
+			Assert.Single(groups);
+			Assert.Equal("CommonStates", groups[0].Name);
+		}
+	}
+}


### PR DESCRIPTION
## Description

Closes #34716

Fixes `InvalidOperationException: VisualStateGroup Names must be unique` that occurs when a Button (or any element) has explicit `VisualStateManager.VisualStateGroups` in XAML **and** an implicit style also sets `VisualStateGroups` with the same group name (e.g., "CommonStates").

## Root Cause

All three XAML inflators (Runtime, XamlC, SourceGen) use `GetValue(VisualStateGroupsProperty)` + `Add(group)` when processing implicit collection items. When an implicit style (like the default Button style in `Styles.xaml`) already populated the `VisualStateGroupList` with a "CommonStates" group, the inflator's `Add()` call introduces a duplicate name, triggering the validation exception.

## Fix

`VisualStateGroupList.Add()` now removes any existing group with the same name before adding the new one. This ensures explicit XAML groups replace style-set groups, and is backward-compatible since duplicate group names were never valid (the old behavior threw).

**Changed files:**
- `src/Controls/src/Core/VisualStateManager.cs` — Replace-on-duplicate in `Add()`
- `src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs` — Updated test to verify replace behavior
- `src/Controls/tests/Xaml.UnitTests/Issues/Maui34716.xaml[.cs]` — Regression tests

## Tests

15 XAML unit tests + 32 Core unit tests pass:

| Test | Scenario |
|------|----------|
| `VisualStateGroupsOnElementShouldNotThrowDuplicateNames` | Direct VSG on Button (exact issue repro) |
| `VisualStateGroupsWithImplicitStyleShouldNotThrowDuplicateNames` | **The bug** — implicit style + explicit XAML |
| `VisualStateGroupsViaStyleShouldNotThrow` | VSG via Style Setter |
| `MultipleVisualStateGroupsShouldNotThrow` | Two groups on same element |
| `ExplicitVisualStateGroupListShouldNotThrow` | Explicit `<VisualStateGroupList>` |
| `GroupWithDuplicateNameReplacesExisting` | Core test: Add() replaces duplicate |