### PR TITLE
Add InvalidateStyle() and VisualStateManager.InvalidateVisualStates() APIs

### DIFF
--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -27,8 +28,9 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>
 		/// Forces unapply and reapply of the current merged style.
-		/// Use when a <see cref="Style"/> has been mutated in-place and needs to be reflected on the element.
+		/// This method is intended for infrastructure use (e.g., Hot Reload) and should not be used in application code.
 		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void InvalidateStyle() => _mergedStyle.Reapply();
 
 		/// <summary>Gets a value indicating whether this image source is empty.</summary>

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Maui.Controls
 			_mergedStyle = new MergedStyle(GetType(), this);
 		}
 
+		/// <summary>
+		/// Forces unapply and reapply of the current merged style.
+		/// Use when a <see cref="Style"/> has been mutated in-place and needs to be reflected on the element.
+		/// </summary>
+		public void InvalidateStyle() => _mergedStyle.Reapply();
+
 		/// <summary>Gets a value indicating whether this image source is empty.</summary>
 		public virtual bool IsEmpty => false;
 

--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -127,6 +127,13 @@ namespace Microsoft.Maui.Controls
 			ImplicitStyle?.UnApply(bindable);
 		}
 
+		/// <summary>Unconditionally unapplies and reapplies all style layers on the target.</summary>
+		internal void Reapply()
+		{
+			UnApply(Target);
+			Apply(Target);
+		}
+
 		void OnClassStyleChanged()
 		{
 			ClassStyles = _classStyleProperties.Select(p => (Target.GetValue(p) as IList<Style>)?.FirstOrDefault(s => s.CanBeAppliedTo(TargetType))).ToList();

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -47,3 +47,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
 ~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -48,3 +48,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -48,3 +48,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -45,3 +45,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -45,3 +45,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -45,3 +45,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~const Microsoft.Maui.Controls.AppThemeBinding.AppThemeResource = "__MAUI_ApplicationTheme__" -> string
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -36,3 +36,7 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(System.Type targetType, System.Func<Microsoft.Maui.Controls.Style> factory, bool shared = true) -> void
 ~Microsoft.Maui.Controls.ResourceDictionary.AddFactory(string key, System.Func<object> factory, bool shared = true) -> void
 ~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> Microsoft.Maui.Controls.VisualStateGroupList
+Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void
+Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
+Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
+static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(Microsoft.Maui.Controls.VisualElement visualElement) -> void

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Maui.Controls
 			_mergedStyle = new MergedStyle(GetType(), this);
 		}
 
+		/// <summary>
+		/// Forces unapply and reapply of the current merged style.
+		/// Use when a <see cref="Style"/> has been mutated in-place and needs to be reflected on the element.
+		/// </summary>
+		public void InvalidateStyle() => _mergedStyle.Reapply();
+
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>
 		public static readonly BindableProperty StyleProperty = BindableProperty.Create(nameof(Style), typeof(Style), typeof(Span), default(Style),
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Span)bindable)._mergedStyle.Style = (Style)newvalue, defaultBindingMode: BindingMode.OneWay);

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.ComponentModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
@@ -19,8 +20,9 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>
 		/// Forces unapply and reapply of the current merged style.
-		/// Use when a <see cref="Style"/> has been mutated in-place and needs to be reflected on the element.
+		/// This method is intended for infrastructure use (e.g., Hot Reload) and should not be used in application code.
 		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void InvalidateStyle() => _mergedStyle.Reapply();
 
 		/// <summary>Bindable property for <see cref="Style"/>.</summary>

--- a/src/Controls/src/Core/StyleableElement/StyleableElement.cs
+++ b/src/Controls/src/Core/StyleableElement/StyleableElement.cs
@@ -53,5 +53,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 		IList<string> IStyleSelectable.Classes => StyleClass;
+
+		/// <summary>
+		/// Forces unapply and reapply of the current merged style.
+		/// Use when a <see cref="Style"/> has been mutated in-place and needs to be reflected on the element.
+		/// </summary>
+		public void InvalidateStyle() => _mergedStyle.Reapply();
 	}
 }

--- a/src/Controls/src/Core/StyleableElement/StyleableElement.cs
+++ b/src/Controls/src/Core/StyleableElement/StyleableElement.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.StyleSheets;
 
@@ -56,8 +57,9 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>
 		/// Forces unapply and reapply of the current merged style.
-		/// Use when a <see cref="Style"/> has been mutated in-place and needs to be reflected on the element.
+		/// This method is intended for infrastructure use (e.g., Hot Reload) and should not be used in application code.
 		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void InvalidateStyle() => _mergedStyle.Reapply();
 	}
 }

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using Microsoft.Maui.Controls.Xaml;
 
@@ -154,9 +155,10 @@ namespace Microsoft.Maui.Controls
 
 		/// <summary>
 		/// Forces unapply and reapply of the current visual state setters for the specified <paramref name="visualElement"/>.
-		/// Use when visual state setters have been mutated in-place and the changes need to be reflected on the element.
+		/// This method is intended for infrastructure use (e.g., Hot Reload) and should not be used in application code.
 		/// </summary>
 		/// <param name="visualElement">The visual element whose visual states should be reapplied.</param>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void InvalidateVisualStates(VisualElement visualElement)
 		{
 			var context = visualElement.GetContext(VisualStateGroupsProperty);

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -175,7 +175,9 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var vsgSpecificity = vsgSpecificityValue.Key;
-			var specificity = vsgSpecificity.CopyStyle(1, 0, 0, 0);
+			// Build a VSM setter specificity that preserves the style origin so setters
+			// are unapplied/reapplied at the correct priority level.
+			var specificity = vsgSpecificity.CopyStyle(extras: 1, manual: 0, isDynamicResource: 0, isBinding: 0);
 
 			foreach (VisualStateGroup group in groups)
 			{

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -152,6 +152,48 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
+		/// <summary>
+		/// Forces unapply and reapply of the current visual state setters for the specified <paramref name="visualElement"/>.
+		/// Use when visual state setters have been mutated in-place and the changes need to be reflected on the element.
+		/// </summary>
+		/// <param name="visualElement">The visual element whose visual states should be reapplied.</param>
+		public static void InvalidateVisualStates(VisualElement visualElement)
+		{
+			var context = visualElement.GetContext(VisualStateGroupsProperty);
+			if (context is null)
+			{
+				return;
+			}
+
+			var vsgSpecificityValue = context.Values.GetSpecificityAndValue();
+			var groups = (VisualStateGroupList)vsgSpecificityValue.Value;
+			if (groups?.IsDefault != false)
+			{
+				return;
+			}
+
+			var vsgSpecificity = vsgSpecificityValue.Key;
+			var specificity = vsgSpecificity.CopyStyle(1, 0, 0, 0);
+
+			foreach (VisualStateGroup group in groups)
+			{
+				if (group.CurrentState is not { } state)
+				{
+					continue;
+				}
+
+				foreach (Setter setter in state.Setters)
+				{
+					setter.UnApply(visualElement, specificity);
+				}
+
+				foreach (Setter setter in state.Setters)
+				{
+					setter.Apply(visualElement, specificity);
+				}
+			}
+		}
+
 		internal static void UpdateStateTriggers(VisualElement visualElement)
 		{
 			var groups = (VisualStateGroupList)visualElement.GetValue(VisualStateGroupsProperty);
@@ -751,7 +793,7 @@ namespace Microsoft.Maui.Controls
 				group.VisualElement = clone.VisualElement;
 				clone.Add(group.Clone());
 			}
-			
+
 			// Preserve specificity when cloning (issue #27202)
 			if (groups is VisualStateGroupList sourceList)
 			{

--- a/src/Controls/tests/Core.UnitTests/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleTests.cs
@@ -1202,5 +1202,58 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(Label.TextProperty.DefaultValue, label.Text);
 
 		}
+
+		[Fact]
+		public void InvalidateStyleReappliesMutatedSetter()
+		{
+			var style = new Style(typeof(Label))
+			{
+				Setters = {
+					new Setter { Property = Label.TextProperty, Value = "original" },
+				}
+			};
+
+			var label = new Label { Style = style };
+			Assert.Equal("original", label.Text);
+
+			// Mutate the setter in-place — the label should NOT update yet
+			style.Setters[0].Value = "mutated";
+			Assert.Equal("original", label.Text);
+
+			// After InvalidateStyle, the new value should be applied
+			label.InvalidateStyle();
+			Assert.Equal("mutated", label.Text);
+		}
+
+		[Fact]
+		public void InvalidateStyleReappliesMultipleSetters()
+		{
+			var style = new Style(typeof(Label))
+			{
+				Setters = {
+					new Setter { Property = Label.TextProperty, Value = "text" },
+					new Setter { Property = VisualElement.BackgroundColorProperty, Value = Colors.Red },
+				}
+			};
+
+			var label = new Label { Style = style };
+			Assert.Equal("text", label.Text);
+			Assert.Equal(Colors.Red, label.BackgroundColor);
+
+			style.Setters[0].Value = "updated";
+			style.Setters[1].Value = Colors.Blue;
+
+			label.InvalidateStyle();
+			Assert.Equal("updated", label.Text);
+			Assert.Equal(Colors.Blue, label.BackgroundColor);
+		}
+
+		[Fact]
+		public void InvalidateStyleWithNoStyleDoesNotThrow()
+		{
+			var label = new Label();
+			var exception = Record.Exception(() => label.InvalidateStyle());
+			Assert.Null(exception);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -534,5 +534,50 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Debug.WriteLine($">>>>> VisualStateManagerTests ValidatePerformance: {watch.ElapsedMilliseconds}ms over {iterations} iterations; average of {average}ms");
 
 		}
+
+		[Fact]
+		public void InvalidateVisualStatesReappliesMutatedSetter()
+		{
+			var label = new Label();
+			var normalState = new VisualState { Name = NormalStateName };
+			normalState.Setters.Add(new Setter { Property = Label.TextProperty, Value = "original" });
+
+			var group = new VisualStateGroup { Name = CommonStatesGroupName };
+			group.States.Add(normalState);
+
+			var groups = new VisualStateGroupList { group };
+			VisualStateManager.SetVisualStateGroups(label, groups);
+
+			// Initial state should be applied
+			Assert.Equal("original", label.Text);
+
+			// Mutate the setter in-place — the label should NOT update yet
+			normalState.Setters[0].Value = "mutated";
+			Assert.Equal("original", label.Text);
+
+			// After InvalidateVisualStates, the new value should be applied
+			VisualStateManager.InvalidateVisualStates(label);
+			Assert.Equal("mutated", label.Text);
+		}
+
+		[Fact]
+		public void InvalidateVisualStatesWithNoGroupsDoesNotThrow()
+		{
+			var label = new Label();
+			var exception = Record.Exception(() => VisualStateManager.InvalidateVisualStates(label));
+			Assert.Null(exception);
+		}
+
+		[Fact]
+		public void InvalidateVisualStatesWithNoCurrentStateDoesNotThrow()
+		{
+			var label = new Label();
+			var groups = CreateStateGroupsWithoutNormalState();
+			VisualStateManager.SetVisualStateGroups(label, groups);
+
+			// No current state is set (no Normal state)
+			var exception = Record.Exception(() => VisualStateManager.InvalidateVisualStates(label));
+			Assert.Null(exception);
+		}
 	}
 }


### PR DESCRIPTION
## Description

Adds public APIs to force reapplication of in-place-mutated styles and visual states, primarily for Hot Reload scenarios (including XAML Incremental Hot Reload).

### Problem

When a `Style` or `VisualState` object is mutated in-place (e.g., a Setter's `Value` is changed), the framework does not reapply it:

- `MergedStyle` uses reference equality (`_style == value`) to skip reapplication
- `VisualStateManager.GoToState` short-circuits when `CurrentState.Name == name`

The only workaround was to create new object instances and reassign them.

### Solution

**`StyleableElement.InvalidateStyle()`** — unconditionally unapplies and reapplies the current merged style (implicit + class + explicit layers):
```csharp
element.InvalidateStyle();
```

Also added on `Span` and `ImageSource` which independently own their own `MergedStyle`.

**`VisualStateManager.InvalidateVisualStates(VisualElement)`** — unapplies and reapplies current state setters for all groups:
```csharp
VisualStateManager.InvalidateVisualStates(element);
```

Both APIs are caller-driven (no automatic change tracking) and have no effect on elements without styles/VSM groups.

### New Public API

```csharp
// Style reapplication
Microsoft.Maui.Controls.StyleableElement.InvalidateStyle() -> void
Microsoft.Maui.Controls.Span.InvalidateStyle() -> void
Microsoft.Maui.Controls.ImageSource.InvalidateStyle() -> void

// VSM reapplication
static Microsoft.Maui.Controls.VisualStateManager.InvalidateVisualStates(VisualElement) -> void
```

### Testing

6 new unit tests covering:
- Mutated setter values are reapplied after `InvalidateStyle()`
- Multiple setters are reapplied correctly
- No-op when no style is set
- Mutated VSM setter values are reapplied after `InvalidateVisualStates()`
- No-op when no VSM groups exist
- No-op when no current state is set

Fixes #34721
Fixes #34722
Fixes #618