### PR TITLE
[iOS/Mac] Fix CI failure for label gradient background UI tests

### DIFF
--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -17,7 +17,15 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
-			handler.PlatformView?.UpdateBackground(label);
+			// Gradient sublayers cover UILabel text, so route them to WrapperView; solid colors stay on PlatformView for correct Clip masking.
+			if (label.Background is GradientPaint)
+			{
+				handler.ToPlatform()?.UpdateBackground(label);
+			}
+			else
+			{
+				handler.PlatformView?.UpdateBackground(label);
+			}
 		}
 
 		public static void MapText(ILabelHandler handler, ILabel label)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issues Details
PR #34276 caused the BackgroundGradientsShouldRenderCorrectly and GradientAndShadowShouldWork UI tests to fail on iOS and Mac. Label text is not visible when a gradient background is applied.


### Description of Change
In [MapBackground](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), added a condition to route [GradientPaint](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) backgrounds to [handler.ToPlatform()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (WrapperView) where the gradient layer sits behind the label text. Other backgrounds continue to use [handler.PlatformView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (MauiLabel) to preserve the #34114 clip fix.

With these changes, both the gradient background test failures and the original #34114 clip issue are resolved.


### Test Fixed 
UI Test
1. BackgroundGradientsShouldRenderCorrectly
2. GradientAndShadowShouldWork