### PR TITLE
[Android] Fix the CarouselView ScrollTo issue in the candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -297,10 +297,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 						{
 							SetCurrentItem(carouselPosition);
 							UpdatePosition(carouselPosition);
+							ScrollToPosition(carouselPosition);
 						}
-
-						ScrollToPosition(carouselPosition);
-
+						
 						//If we are adding or removing the last item we need to update
 						//the inset that we give to items so they are centered
 						if (e.NewStartingIndex == count - 1 || removingLastElement)


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!

### Root Cause of the issue



- The problem is on `MauiCarouselRecyclerView`.cs:302. PR #30106 added ScrollToPosition(carouselPosition) unconditionally — outside the _scrollToCounter guard. So even when the Issue22417 explicitly calls ScrollTo(5) (which increments _scrollToCounter), the dispatched callback still forces the carousel back to carouselPosition (position 0 for a new item added, since ItemsUpdatingScrollMode defaults to KeepScrollOffset).



### Description of Change



-  Moved ScrollToPosition(carouselPosition) inside the _scrollToCounter == savedScrollToCounter guard so it's also skipped when an explicit ScrollTo was called between dispatch and delivery.

This preserves the #29415 fix because when no explicit ScrollTo is called (the normal ItemsUpdatingScrollMode scenario), _scrollToCounter won't change and the ScrollToPosition will still execute as intended.



### Issues Fixed



Fixes #29415 

### Test details fails on Candidate

- AddItemsToCarouselViewWorks (22417)

After fix, ensured AddItemsToCarouselViewWorks test and original issue ItemsUpdatingScrollModeShouldWork (29415)

### Regression PR

- #30106

### Tested the behaviour in the following platforms



- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac



### Screenshot

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/d3d394be-8716-406f-8635-95035acee88a"> | <video src="https://github.com/user-attachments/assets/2d1fb0f7-4caf-4956-b625-56e04412bdec"> |