### PR TITLE
Fix XamlC MSBuild target incrementality for Debug builds

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -224,6 +224,10 @@
 
 	<!-- XamlC -->
 	<PropertyGroup>
+		<_MauiXamlCValidateOnly>$(MauiXamlCValidateOnly)</_MauiXamlCValidateOnly>
+		<_MauiXamlCValidateOnly Condition="'$(Configuration)' == 'Debug' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>
+		<_MauiXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True'">True</_MauiXamlCValidateOnly>
+
 		<CompileDependsOn>
 			$(CompileDependsOn);
 			XamlC;
@@ -236,10 +240,6 @@
 		Outputs="$(IntermediateOutputPath)XamlC.stamp"
 		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != ''">
 		<PropertyGroup>
-			<_MauiXamlCValidateOnly>$(MauiXamlCValidateOnly)</_MauiXamlCValidateOnly>
-			<_MauiXamlCValidateOnly Condition="'$(Configuration)' == 'Debug' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>
-			<_MauiXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_MauiXamlCValidateOnly>
-
 			<MauiStrictXamlCompilation Condition="'$(MauiStrictXamlCompilation)' == '' and ('$(PublishAot)' == 'true' or '$(TrimMode)' == 'full')">true</MauiStrictXamlCompilation>
 			<_MauiXamlCWarningsNotAsErrors>$(WarningsNotAsErrors)</_MauiXamlCWarningsNotAsErrors>
 			<_MauiXamlCWarningsNotAsErrors Condition="'$(MauiStrictXamlCompilation)' != 'true'">$(_MauiXamlCWarningsNotAsErrors);XC0022;XC0023;XC0025</_MauiXamlCWarningsNotAsErrors>

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -231,14 +231,57 @@
 		<CompileDependsOn>
 			$(CompileDependsOn);
 			XamlC;
+			_XamlCValidateOnly;
 		</CompileDependsOn>
 	</PropertyGroup>
 
+	<!-- XamlC: Runs in non-validate-only mode (typically Release). KEEP BODY IN SYNC WITH _XamlCValidateOnly -->
 	<Target Name="XamlC"
 		AfterTargets="AfterCompile"
-		Inputs="$(IntermediateOutputPath)$(TargetFileName)"
+		Inputs="$(IntermediateOutputPath)$(TargetFileName);@(MauiXaml)"
 		Outputs="$(IntermediateOutputPath)XamlC.stamp"
-		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != ''">
+		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != '' AND '$(_MauiXamlCValidateOnly)' != 'True'">
+		<PropertyGroup>
+			<MauiStrictXamlCompilation Condition="'$(MauiStrictXamlCompilation)' == '' and ('$(PublishAot)' == 'true' or '$(TrimMode)' == 'full')">true</MauiStrictXamlCompilation>
+			<_MauiXamlCWarningsNotAsErrors>$(WarningsNotAsErrors)</_MauiXamlCWarningsNotAsErrors>
+			<_MauiXamlCWarningsNotAsErrors Condition="'$(MauiStrictXamlCompilation)' != 'true'">$(_MauiXamlCWarningsNotAsErrors);XC0022;XC0023;XC0025</_MauiXamlCWarningsNotAsErrors>
+
+      <_MauiXamlCGenerateFullPaths Condition="'$(_MauiXamlCGenerateFullPaths)' == '' and '$(GenerateFullPaths)' == 'true'">true</_MauiXamlCGenerateFullPaths>
+      <_MauiXamlCGenerateFullPaths Condition="'$(_MauiXamlCGenerateFullPaths)' == ''">false</_MauiXamlCGenerateFullPaths>
+      <_MauiXamlCFullPathPrefix Condition="'$(_MauiXamlCFullPathPrefix)' == '' and '$(_MauiXamlCGenerateFullPaths)' == 'true'">$(MSBuildProjectDirectory)</_MauiXamlCFullPathPrefix>
+		</PropertyGroup>
+		<XamlCTask
+			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
+			ReferencePath = "@(ReferencePath)"
+			OptimizeIL = "true"
+			DebugSymbols = "$(DebugSymbols)"
+			DebugType = "$(DebugType)"
+			DefaultCompile = "true"
+      CompileBindingsWithSource = "$(MauiEnableXamlCBindingWithSourceCompilation)"
+			ValidateOnly = "$(_MauiXamlCValidateOnly)"
+			TargetFramework = "$(TargetFramework)"
+			KeepXamlResources = "$(MauiKeepXamlResources)"
+
+      WarningLevel = "$(WarningLevel)"
+      TreatWarningsAsErrors = "$(TreatWarningsAsErrors)"
+      NoWarn = "$(NoWarn)"
+      WarningsAsErrors = "$(WarningsAsErrors)"
+      WarningsNotAsErrors = "$(_MauiXamlCWarningsNotAsErrors)"
+      GenerateFullPaths = "$(_MauiXamlCGenerateFullPaths)"
+      FullPathPrefix = "$(_MauiXamlCFullPathPrefix)" />
+      
+		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
+		<ItemGroup>
+			<FileWrites Include="$(IntermediateOutputPath)XamlC.stamp" />
+		</ItemGroup>
+	</Target>
+
+	<!-- _XamlCValidateOnly: Runs in validate-only mode (typically Debug). KEEP BODY IN SYNC WITH XamlC -->
+	<Target Name="_XamlCValidateOnly"
+		AfterTargets="AfterCompile"
+		Inputs="@(MauiXaml)"
+		Outputs="$(IntermediateOutputPath)XamlC.stamp"
+		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != '' AND '$(_MauiXamlCValidateOnly)' == 'True'">
 		<PropertyGroup>
 			<MauiStrictXamlCompilation Condition="'$(MauiStrictXamlCompilation)' == '' and ('$(PublishAot)' == 'true' or '$(TrimMode)' == 'full')">true</MauiStrictXamlCompilation>
 			<_MauiXamlCWarningsNotAsErrors>$(WarningsNotAsErrors)</_MauiXamlCWarningsNotAsErrors>
@@ -306,7 +349,7 @@
            Text="The %24(TargetFrameworkVersion) for $(ProjectName) ($(TargetFrameworkVersion)) is less than the minimum required %24(TargetFrameworkVersion) for Microsoft.Maui ($(MinTargetFrameworkVersionForMaui)). You need to increase the %24(TargetFrameworkVersion) for $(ProjectName)."   />
   </Target>
 
-  <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC">
+  <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink;_GenerateRuntimeConfigurationFilesInputCache;XamlC;_XamlCValidateOnly">
     <PropertyGroup>
       <MauiEnableIVisualAssemblyScanning Condition="'$(MauiEnableIVisualAssemblyScanning)' == ''">false</MauiEnableIVisualAssemblyScanning>
     </PropertyGroup>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -476,6 +476,57 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Assert.NotEqual(expectedXamlC, actualXamlC);
 		}
 
+		[Fact]
+		public void CSharpOnlyChange_DoesNotTriggerXamlCInDebug()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			Build(projectFile);
+
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+			AssertExists(xamlCStamp);
+
+			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, after adding a C# file (no XAML changes), XamlC should NOT re-run in Debug mode
+			project.Add(AddFile("NewClass.cs", "Compile", "namespace Test { public class NewClass { } }"));
+			project.Save(projectFile);
+			Build(projectFile);
+			AssertExists(xamlCStamp);
+
+			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+			Assert.Equal(expectedXamlC, actualXamlC);
+		}
+
+		[Fact]
+		public void CSharpOnlyChange_DoesTriggerXamlCInRelease()
+		{
+			SetUp();
+			intermediateDirectory = IOPath.Combine(tempDirectory, "obj", "Release", GetTfm());
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			Build(projectFile, additionalArgs: "-c Release");
+
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+			AssertExists(xamlCStamp);
+
+			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, after adding a C# file (no XAML changes), XamlC SHOULD re-run in Release mode
+			project.Add(AddFile("NewClass.cs", "Compile", "namespace Test { public class NewClass { } }"));
+			project.Save(projectFile);
+			Build(projectFile, additionalArgs: "-c Release");
+			AssertExists(xamlCStamp);
+
+			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+			Assert.NotEqual(expectedXamlC, actualXamlC);
+		}
+
 		[Fact(Skip = "source gen changes")]
 		public void TouchXamlFile()
 		{
@@ -554,6 +605,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Save(projectFile);
 			var log = Build(projectFile, verbosity: "diagnostic");
 			Assert.False(log.Contains("Building target \"XamlC\"", StringComparison.Ordinal), "XamlC should be skipped if there are no .xaml files.");
+			Assert.False(log.Contains("Building target \"_XamlCValidateOnly\"", StringComparison.Ordinal), "_XamlCValidateOnly should be skipped if there are no .xaml files.");
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes XamlC MSBuild target incrementality to avoid unnecessary re-runs on non-XAML C# changes, improving MAUI Android inner loop build performance.

### Problem

The XamlC target uses `Inputs="$(IntermediateOutputPath)$(TargetFileName)"` (the compiled assembly DLL). Since any C# change rebuilds the assembly, XamlC re-runs even when no XAML files changed. In Debug mode (ValidateOnly=True), this wastes ~0.56s scanning and validating all XAML on every incremental build.

### Solution

Split the XamlC target into two mutually exclusive targets based on `_MauiXamlCValidateOnly`:

| Target | Mode | Inputs | When it runs |
|--------|------|--------|-------------|
| `XamlC` | Release | Assembly + @(MauiXaml) | When assembly or XAML changes |
| `_XamlCValidateOnly` | Debug | @(MauiXaml) only | Only when XAML changes |

The key insight: in Debug/ValidateOnly mode, XamlC only reads the assembly for validation — it never writes to it. So the assembly does not need to be an Input. When only C# files change (no XAML changes), the validate-only target correctly reports up-to-date and skips.

In Release mode, XamlC compiles XAML into IL and writes it back into the assembly, so the assembly must remain an Input to ensure correctness.

### Tradeoff

In Debug mode, if a C# type referenced by XAML is removed/renamed without editing the XAML file, validation will not catch this until the XAML file is next modified or a clean build is done. This is an acceptable tradeoff because:
- The C# compiler catches many related errors independently
- Source generators provide additional compile-time checking
- A clean build or any XAML edit will trigger full validation

### Testing

- Added `CSharpOnlyChange_DoesNotTriggerXamlCInDebug` test verifying the core fix
- Added `CSharpOnlyChange_DoesTriggerXamlCInRelease` test verifying Release correctness
- Updated `NoXamlFiles` test to verify both targets are skipped when no XAML files exist
- All existing MSBuild incrementality tests continue to pass (20 tests: 18 passed, 2 pre-existing skips)