### PR TITLE
[iOS] Fix GitHubIssue6184 regression on candidate — TabBarDisabledColor fix disabled More button when tabs > 5

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -158,7 +158,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (items is null)
 				return;
 
-			for (int i = 0; i < items.Count && i < TabBar.Items.Length; i++)
+			// When there are more tabs than iOS can display (> 5), iOS creates a "More" tab.
+			// Only iterate visible tab items, excluding the system "More" tab.
+			int visibleTabs = Math.Min(items.Count, TabBar.Items.Length);
+			if (items.Count > TabBar.Items.Length)
+				visibleTabs = TabBar.Items.Length - 1;
+
+			for (int i = 0; i < visibleTabs; i++)
 			{
 				if (!items[i].IsEnabled)
 					UpdateTabBarItemEnabled(TabBar.Items[i], false);


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause

PR #[33955](https://github.com/dotnet/maui/pull/33955) added `ApplyInitialDisabledState` to apply disabled tab styling on iOS. When a Shell has more than 5 tabs, iOS displays 4 visible tabs plus a system "More" button.
The loop iterated by index and mapped the 5th shell section to the "More" button, disabling it and blocking access to all overflow tabs.

### Description of Change

Calculate the number of visible tab items excluding the system "More" button before iterating. When a "More" tab exists, the loop now stops one item before the last TabBar entry, ensuring only actual shell section tabs are processed.

### Issues Fixed
`GitHubIssue6184` - iOS UI test case.
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [x] iOS
- [ ] Mac

### Screenshots
| Before Fix | After Fix |
|------------|-----------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/500ed712-09b3-46dc-8e6e-f79522508c58" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/11d823d7-48dc-474a-be50-03daeaced23f" /> |