### PR TITLE
[iOS] Fix Issue23377ItemSpacing test failure on candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -67,6 +67,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 				ScrollDirection = compositionalLayout.Configuration.ScrollDirection;
 			}
 
+			// Preserve the content offset before updating the layout.
+			// SetCollectionViewLayout with animated:false can unexpectedly shift the content offset
+			// on UICollectionViewCompositionalLayout with estimated item sizes.
+			var savedOffset = CollectionView.ContentOffset;
+
 			ItemsViewLayout = newLayout;
 			_initialized = false;
 
@@ -74,6 +79,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (_initialized)
 			{
+				// Restore the content offset that may have been changed by SetCollectionViewLayout
+				CollectionView.ContentOffset = savedOffset;
 				// Reload the data so the currently visible cells get laid out according to the new layout
 				ReloadData();
 			}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
PR #34493 correctly reduced UpdateLayout() from N calls to a single call per layout-property change, but it exposed a UIKit behavior where SetCollectionViewLayout(layout, animated: false) can shift the contentOffset on a UICollectionViewCompositionalLayout with estimated item sizes. This causes the scroll position to jump after an ItemSpacing change.

**Test name:** Issue23377ItemSpacing
 
### Description of change
This PR resolves the `Issue23377ItemSpacing` test failure on the candidate branch. In ItemsViewController2.UpdateLayout(), the contentOffset is saved before calling SetCollectionViewLayout and explicitly restored afterward, ensuring the scroll position is preserved across layout updates on both iOS and MacCatalyst.

**Cause PR:** https://github.com/dotnet/maui/pull/34493

### Test result
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="300" height="600"  src="https://github.com/user-attachments/assets/d3e7d730-07ec-4987-bb4e-bd5b7c39897b"> | <img width="300" height="600"  src="https://github.com/user-attachments/assets/115e8518-3ae2-40f8-ae3b-e82f8079a5da"> |