### PR TITLE
Fix CS8632: remove nullable annotations from #nullable disable context in Element.cs

### DIFF
--- a/src/Controls/src/Core/Element/Element.cs
+++ b/src/Controls/src/Core/Element/Element.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.Maui.Controls
 			OnDescendantAddedCore(child, null);
 		}
 
-		void OnDescendantAddedCore(Element child, ElementEventArgs? args)
+		void OnDescendantAddedCore(Element child, ElementEventArgs args)
 		{
 			if (DescendantAdded is not null)
 			{
@@ -1059,7 +1059,7 @@ namespace Microsoft.Maui.Controls
 			OnDescendantRemovedCore(child, null);
 		}
 
-		void OnDescendantRemovedCore(Element child, ElementEventArgs? args)
+		void OnDescendantRemovedCore(Element child, ElementEventArgs args)
 		{
 			if (DescendantRemoved is not null)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Removes `?` nullable annotations from `ElementEventArgs` parameters in `OnDescendantAddedCore` and `OnDescendantRemovedCore` in `Element.cs`.

The file starts with `#nullable disable`, so nullable reference type annotations are invalid and produce **CS8632** warnings. MAUI CI sets `TreatWarningsAsErrors=false` so these pass silently, but downstream consumers like **dotnet/android** build with `TreatWarningsAsErrors=true`, causing build failures.

Introduced in #34134.

## Fix

Simply remove the `?` from the `ElementEventArgs` parameter types. Under `#nullable disable`, reference types are already implicitly nullable, so the behavior is unchanged.