### PR TITLE
[Windows] Fix FlexLayoutCycleException test failure on candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -127,7 +127,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void OnItemsVectorChanged(global::Windows.Foundation.Collections.IObservableVector<object> sender, global::Windows.Foundation.Collections.IVectorChangedEventArgs @event)
 		{
-			if (VirtualView is null)
+			// Use the nullable IViewHandler.VirtualView (not the typed property) for the null
+			// check. The typed VirtualView throws InvalidOperationException if base.VirtualView
+			// is null, which can happen if the handler was disconnected before this event fires.
+			if (((IViewHandler)this).VirtualView is null)
 				return;
 
 			if (sender is not ItemCollection items)
@@ -135,7 +138,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			ListViewBase.DispatcherQueue.TryEnqueue(() =>
 			{
-				if (VirtualView is null || ListViewBase is null)
+				// The lambda is dispatched asynchronously. By the time it runs, the handler may
+				// have been disconnected (e.g. by element.DisconnectHandlers() in
+				// CleanUpCollectionViewSource), setting base.VirtualView to null. The typed
+				// VirtualView property throws in that case, so use the nullable interface accessor
+				// here to safely bail out instead of crashing (issue #9075).
+				if (((IViewHandler)this).VirtualView is null || ListViewBase is null)
 				{
 					return;
 				}


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
PR #24867 deferred the OnItemsVectorChanged logic into an async DispatcherQueue.TryEnqueue lambda. Later, PR #34534 introduced DisconnectHandlers() in CleanUpCollectionViewSource, which sets base.VirtualView to null before the queued lambda executes.

**Test name:** FlexLayoutCycleException

### Description of Change
This PR resolves the `FlexLayoutCycleException` test failure on the candidate branch. In ItemsViewHandler.Windows.cs, the guards inside the OnItemsVectorChanged lambda were updated from: if (VirtualView is null) return; to: if (((IViewHandler)this).VirtualView is null) return; No other changes were made.

**Cause PR:** https://github.com/dotnet/maui/pull/34534

### Test result
| Before Issue Fix | After Issue Fix |
|----------|----------|
| <img width="300" height="600"  src="https://github.com/user-attachments/assets/ac0d8e92-8c20-4647-8334-b3dcbaa96a64"> | <img width="300" height="600"  src="https://github.com/user-attachments/assets/77010f17-8db3-4ffe-9a51-ba19e4b5079c"> |