### PR TITLE
[iOS 26] Fix Issue20706.ChangeIncrementValue test failure regression

### DIFF
--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -204,6 +204,9 @@ namespace Microsoft.Maui.Handlers
 			{
 				if (VirtualView is IStepper virtualView && sender is UIStepper platformView)
 				{
+					var oldValue = virtualView.Value;
+					var newValue = platformView.Value;
+
 					// iOS 26+ fix: Adjust stepValue for boundary handling
 					if (OperatingSystem.IsIOSVersionAtLeast(26)
 						&& NeedsStepValueAdjustment(virtualView, platformView))
@@ -211,7 +214,30 @@ namespace Microsoft.Maui.Handlers
 						AdjustStepValueForBoundaries(virtualView, platformView);
 					}
 
-					virtualView.Value = platformView.Value;
+					// iOS 26+ fix: Correct partial steps caused by boundary adjustment.
+					// If the step was partial (stepValue was reduced for a boundary) but the
+					// full step still fits within [min, max], it was NOT an intentional
+					// boundary reach — correct to the full increment.
+					if (OperatingSystem.IsIOSVersionAtLeast(26))
+					{
+						const double epsilon = 1e-10;
+						var actualStep = newValue - oldValue;
+						var interval = virtualView.Interval;
+
+						if (Math.Abs(actualStep) > epsilon
+							&& Math.Abs(Math.Abs(actualStep) - interval) > epsilon)
+						{
+							var fullStep = oldValue + (actualStep > 0 ? interval : -interval);
+							if (fullStep >= virtualView.Minimum && fullStep <= virtualView.Maximum)
+							{
+								platformView.Value = fullStep;
+								platformView.StepValue = interval;
+								newValue = fullStep;
+							}
+						}
+					}
+
+					virtualView.Value = newValue;
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause
- PR #34081 correctly reduced stepValue to spaceToMin when near the minimum boundary so iOS 26 keeps the decrement button enabled — for example, with value=2 and interval=10, spaceToMin=2 is less than the interval so stepValue is set to 2 instead of 10. But this same reduced stepValue is also used by the increment button — causing it to step by 2 instead of the full interval 10, producing wrong values like 4 instead of the expected 12. This is why Issue20706.ChangeIncrementValue failed — the test changes the increment to 10 and taps the increment button expecting 12, but gets 4.

### Description of Change
- In OnValueChanged, after UIStepper applies a reduced stepValue, a check is performed to determine whether the step was partial (smaller than the defined interval). If the full step (oldValue + interval) falls within the valid range [min, max], the value is overridden to the expected result (e.g., ensuring “+” results in 12 instead of 4). If the full step exceeds the bounds (e.g., decrementing from value = 2 would result in -8), the value is left unchanged, preserving the intended boundary behavior.

### Issues Fixed

- Regression introduced by PR #34081
- **Resolved test case:** Issue20706.ChangeIncrementValue UI Test

### Output
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/52cd25f9-1d9e-4280-86c5-c731e551acb2"> | <img src="https://github.com/user-attachments/assets/83c130b9-d12b-426a-8558-f1987762b454"> |