### PR TITLE
[Testing][Windows] Fix SearchBar device test failure in candidate branch

### DIFF
--- a/src/Core/src/Platform/Windows/MauiAutoSuggestBox.cs
+++ b/src/Core/src/Platform/Windows/MauiAutoSuggestBox.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -16,13 +17,8 @@ namespace Microsoft.Maui.Platform
 		public static bool GetIsReadOnly(DependencyObject obj) =>
 			(bool)obj.GetValue(IsReadOnlyProperty);
 
-		public static void SetIsReadOnly(DependencyObject obj, bool value)
-		{
-			if (obj is FrameworkElement element && element.IsLoaded)
-			{
-				obj.SetValue(IsReadOnlyProperty, value);
-			}
-		}
+		public static void SetIsReadOnly(DependencyObject obj, bool value) =>
+			obj.SetValue(IsReadOnlyProperty, value);
 
 		public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.RegisterAttached(
 			"IsReadOnly", typeof(bool), typeof(MauiTextBox),
@@ -31,10 +27,31 @@ namespace Microsoft.Maui.Platform
 		static void OnIsReadOnlyPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs? e = null)
 		{
 			var element = d as FrameworkElement;
-			var textBox = element?.GetDescendantByName<TextBox>("TextBox");
-			if (textBox is not null && e?.NewValue is bool isReadOnly)
+
+			if (element is null)
 			{
-				textBox.IsReadOnly = isReadOnly;
+				return;
+			}
+
+			bool isReadOnly = e?.NewValue is bool val ? val : GetIsReadOnly(d);
+
+			Action applyIsReadOnly = () =>
+			{
+				var textBox = element.GetDescendantByName<TextBox>("TextBox");
+
+				if (textBox is not null)
+				{
+					textBox.IsReadOnly = isReadOnly;
+				}
+			};
+
+			if (element.IsLoaded)
+			{
+				applyIsReadOnly();
+			}
+			else
+			{
+				element.OnLoaded(applyIsReadOnly);
 			}
 		}
 	}

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIsReadOnly(this AutoSuggestBox platformControl, ISearchBar searchBar)
 		{
-			MauiAutoSuggestBox.SetIsReadOnly(platformControl, searchBar.IsReadOnly);
+			MauiAutoSuggestBox.SetIsReadOnly(platformControl, searchBar.MaxLength == 0 || searchBar.IsReadOnly);
 		}
 
 		public static void UpdateIsTextPredictionEnabled(this AutoSuggestBox platformControl, ISearchBar searchBar)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!


<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Root Cause of the issue:

- On Windows SearchBar, the read-only behavior is applied through an attached property on AutoSuggestBox, but the internal TextBox is created only after template/load.
- Initial IsReadOnly values could be set before the internal TextBox existed, so the value was not reliably reflected in the actual input control during first render.
- MaxLength == 0 is intended to force read-only (to block all typing), but IsReadOnly updates could later override that state if the mapper logic did not consistently re-apply the MaxLength rule.
- **Result**: behavior was inconsistent across initialization and subsequent property changes, and the SearchBar clear/deletion scenario in issue 29547 was not reliable on Windows.

### Description of Change
- Updated the Windows SearchBar read-only pipeline to reliably apply the attached IsReadOnly value both:
- Immediately when the platform control is already loaded.
- Deferred via OnLoaded when the internal TextBox is not yet available.
- Kept the attached property value as the source of truth so deferred application can read and apply the latest state.
- Updated SearchBar UpdateIsReadOnly mapping to enforce the intended rule in one expression:
- MaxLength == 0 || IsReadOnly.
- This guarantees MaxLength == 0 always has priority, while still honoring normal IsReadOnly behavior when max length is not zero.


