### PR TITLE
Fix RadioButtonGroup not working with ContentView

### DIFF
--- a/src/Controls/src/Core/RadioButton/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButtonGroup.cs
@@ -79,7 +79,19 @@ namespace Microsoft.Maui.Controls
 		{
 			if (!string.IsNullOrEmpty(radioButton.GroupName))
 			{
-				var root = GetVisualRoot(radioButton) ?? radioButton.Parent;
+				var root = GetVisualRoot(radioButton);
+
+				// If no Page ancestor exists (e.g., during initial layout construction before the
+				// layout is attached to a Page), fall back to the controller's layout element.
+				// This ensures RadioButtons inside ContentView ControlTemplates are correctly found
+				// and unchecked even before the visual tree has a Page root (fixes issue #34759).
+				if (root == null)
+				{
+					root = RadioButtonGroupController.GetGroupController(radioButton)?.Layout;
+				}
+
+				root ??= (Element)radioButton.Parent;
+
 				if (root is not IElementController rootController)
 				{
 					return;

--- a/src/Controls/src/Core/RadioButton/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButtonGroup.cs
@@ -85,11 +85,7 @@ namespace Microsoft.Maui.Controls
 				// layout is attached to a Page), fall back to the controller's layout element.
 				// This ensures RadioButtons inside ContentView ControlTemplates are correctly found
 				// and unchecked even before the visual tree has a Page root (fixes issue #34759).
-				if (root == null)
-				{
-					root = RadioButtonGroupController.GetGroupController(radioButton)?.Layout;
-				}
-
+				root ??= RadioButtonGroupController.GetGroupController(radioButton)?.Layout;
 				root ??= (Element)radioButton.Parent;
 
 				if (root is not IElementController rootController)

--- a/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls
 		string _groupName;
 		private object _selectedValue;
 
+		internal Element Layout => _layout;
+
 		public string GroupName { get => _groupName; set => SetGroupName(value); }
 		public object SelectedValue { get => _selectedValue; set => SetSelectedValue(value); }
 

--- a/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButton/RadioButtonGroupController.cs
@@ -105,7 +105,10 @@ namespace Microsoft.Maui.Controls
 				_layout.SetValue(RadioButtonGroup.SelectedValueProperty, radioButton.Value);
 			}
 
-			if (object.Equals(radioButton.Value, this.SelectedValue))
+			// Only auto-check if SelectedValue is explicitly set (non-null).
+			// When SelectedValue is null (no selection), adding a RadioButton whose Value is also
+			// null must not cause it to be auto-checked (fixes issue #34759).
+			if (this.SelectedValue is not null && object.Equals(radioButton.Value, this.SelectedValue))
 			{
 				radioButton.SetValue(RadioButton.IsCheckedProperty, true, specificity: SetterSpecificity.FromHandler);
 			}

--- a/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
@@ -409,5 +409,46 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(radioButton2.IsChecked);
 			Assert.True(radioButton3.IsChecked);
 		}
+
+		[Fact]
+		public void RadioButtonGroupWorksWithContentViewControlTemplate_Issue34759()
+		{
+			// Simulates issue #34759: ContentView with ControlTemplate containing RadioButton
+			// The ControlTemplate is applied inline (before ContentView is added to parent layout)
+			var groupName = "Test1";
+			var layout = new VerticalStackLayout();
+			layout.SetValue(RadioButtonGroup.GroupNameProperty, groupName);
+
+			// Create ContentView with inline ControlTemplate (RadioButton inside Border)
+			// This mimics how XAML inline ControlTemplate works - template is applied
+			// before ContentView is added to the parent layout
+			var radioButton1 = new RadioButton { Content = "1", GroupName = groupName };
+			var radioButton2 = new RadioButton { Content = "2", GroupName = groupName };
+
+			var border1 = new Border { Content = radioButton1 };
+			var border2 = new Border { Content = radioButton2 };
+
+			var contentView1 = new ContentView();
+			var contentView2 = new ContentView();
+
+			// Apply ControlTemplate by simulating: template root added as logical child BEFORE parent is set
+			((IControlTemplated)contentView1).AddLogicalChild(border1);
+			((IControlTemplated)contentView2).AddLogicalChild(border2);
+
+			// Now add ContentViews to layout (parent set AFTER template already applied)
+			layout.Add(contentView1);
+			layout.Add(contentView2);
+
+			// Check radio button 1
+			radioButton1.IsChecked = true;
+			// Radio button 2 should NOT also be checked
+			Assert.True(radioButton1.IsChecked);
+			Assert.False(radioButton2.IsChecked);
+
+			// Check radio button 2 - radio button 1 should be unchecked
+			radioButton2.IsChecked = true;
+			Assert.False(radioButton1.IsChecked);
+			Assert.True(radioButton2.IsChecked);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(reference.IsAlive, "RadioButton should not be alive");
 
 		}
-		
+
 		[Fact]
 		public void GroupNullSelectionClearsAnySelection()
 		{
@@ -411,7 +411,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void RadioButtonGroupWorksWithContentViewControlTemplate_Issue34759()
+		public void RadioButtonGroupWorksWithContentViewControlTemplate()
 		{
 			// Simulates issue #34759: ContentView with ControlTemplate containing RadioButton
 			// The ControlTemplate is applied inline (before ContentView is added to parent layout)
@@ -438,6 +438,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Now add ContentViews to layout (parent set AFTER template already applied)
 			layout.Add(contentView1);
 			layout.Add(contentView2);
+
+			// Initially, neither button should be checked (no IsChecked="True" was set)
+			Assert.False(radioButton1.IsChecked);
+			Assert.False(radioButton2.IsChecked);
 
 			// Check radio button 1
 			radioButton1.IsChecked = true;

--- a/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Fact]
 		public void RadioButtonGroupWorksWithContentViewControlTemplate()
 		{
-			// Simulates issue #34759: ContentView with ControlTemplate containing RadioButton
+			// ContentView with ControlTemplate containing RadioButton
 			// The ControlTemplate is applied inline (before ContentView is added to parent layout)
 			var groupName = "Test1";
 			var layout = new VerticalStackLayout();
@@ -422,8 +422,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Create ContentView with inline ControlTemplate (RadioButton inside Border)
 			// This mimics how XAML inline ControlTemplate works - template is applied
 			// before ContentView is added to the parent layout
-			var radioButton1 = new RadioButton { Content = "1", GroupName = groupName };
-			var radioButton2 = new RadioButton { Content = "2", GroupName = groupName };
+			var radioButton1 = new RadioButton { Content = "Option 1", Value = "opt1", GroupName = groupName };
+			var radioButton2 = new RadioButton { Content = "Option 2", Value = "opt2", GroupName = groupName };
 
 			var border1 = new Border { Content = radioButton1 };
 			var border2 = new Border { Content = radioButton2 };
@@ -442,17 +442,54 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			// Initially, neither button should be checked (no IsChecked="True" was set)
 			Assert.False(radioButton1.IsChecked);
 			Assert.False(radioButton2.IsChecked);
+			Assert.Null(layout.GetValue(RadioButtonGroup.SelectedValueProperty));
 
-			// Check radio button 1
+			// Check radio button 1 - only rb1 should be checked and SelectedValue updated
 			radioButton1.IsChecked = true;
-			// Radio button 2 should NOT also be checked
 			Assert.True(radioButton1.IsChecked);
 			Assert.False(radioButton2.IsChecked);
+			Assert.Equal("opt1", layout.GetValue(RadioButtonGroup.SelectedValueProperty));
 
-			// Check radio button 2 - radio button 1 should be unchecked
+			// Check radio button 2 - radio button 1 should be unchecked and SelectedValue updated
 			radioButton2.IsChecked = true;
 			Assert.False(radioButton1.IsChecked);
 			Assert.True(radioButton2.IsChecked);
+			Assert.Equal("opt2", layout.GetValue(RadioButtonGroup.SelectedValueProperty));
+		}
+
+		[Fact]
+		public void RadioButtonGroupAutoChecksMatchingButtonInContentViewWhenSelectedValuePreset()
+		{
+			// Verifies the positive auto-check path for the ContentView/ControlTemplate scenario
+			// when SelectedValue IS explicitly set on the group, a RadioButton
+			// added through a ContentView ControlTemplate with a matching Value must be auto-checked.
+			var groupName = "Test2";
+			var layout = new VerticalStackLayout();
+			layout.SetValue(RadioButtonGroup.GroupNameProperty, groupName);
+
+			// Pre-set SelectedValue BEFORE adding buttons (simulates binding from ViewModel)
+			layout.SetValue(RadioButtonGroup.SelectedValueProperty, "opt2");
+
+			var radioButton1 = new RadioButton { Content = "Option 1", Value = "opt1", GroupName = groupName };
+			var radioButton2 = new RadioButton { Content = "Option 2", Value = "opt2", GroupName = groupName };
+
+			var border1 = new Border { Content = radioButton1 };
+			var border2 = new Border { Content = radioButton2 };
+
+			var contentView1 = new ContentView();
+			var contentView2 = new ContentView();
+
+			// Apply ControlTemplate before adding to layout
+			((IControlTemplated)contentView1).AddLogicalChild(border1);
+			((IControlTemplated)contentView2).AddLogicalChild(border2);
+
+			layout.Add(contentView1);
+			layout.Add(contentView2);
+
+			// RadioButton whose Value matches the pre-set SelectedValue must be auto-checked
+			Assert.False(radioButton1.IsChecked);
+			Assert.True(radioButton2.IsChecked);
+			Assert.Equal("opt2", layout.GetValue(RadioButtonGroup.SelectedValueProperty));
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Detail

RadioButtonGroup is not functioning correctly when RadioButton controls are placed inside a ContentView in .NET 10.

### Root Cause

PR [#32640](https://github.com/dotnet/maui/pull/32604) (fixing #32466) removed the coerceValue and Value = this initialiser from RadioButton, so RadioButton.Value now defaults to null. This introduced two distinct bugs in the ContentView+ControlTemplate scenario:

-  AddRadioButton guard object.Equals(radioButton.Value, this.SelectedValue) evaluates to object.Equals(null, null) == true, causing every button added via a ControlTemplate to be auto-checked immediately.
- When the layout is not yet attached to a Page (common during ControlTemplate inflation), GetVisualRoot() returns null. The original fallback radioButton.Parent resolves to the button's immediate parent (Border), which only contains that single button — so other RadioButtons in the same group are never found and never unchecked.

### Description of Change

- Updated the equality check in AddRadioButton to ensure comparison only happens when SelectedValue is not null. This avoids unintended selection during initialization.
- Improved the root resolution logic in UncheckOtherRadioButtonsInScope. If no visual root is found, fallback to the RadioButtonGroupController’s layout (group container).

### Issue Fixed
Fixes #34759 

### Screenshots

| Before  | After |
|---------|--------|
|  <video src="https://github.com/user-attachments/assets/39e1e45d-dd04-42b7-bb85-aea83124b0cb"> |   <video src="https://github.com/user-attachments/assets/252587b2-10ae-4eb9-968e-de114756aa0c">  |

