### PR TITLE
[iOS, MacOS] [Candidate branch]Fix ShellFlyoutNavigationEventOrderShouldBeCorrect UI test failure on iOS 26.1+

### DIFF
--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1781,8 +1781,10 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			// On Windows, the Loaded event has already fired (IsLoaded=true), so SendNavigatedTo runs immediately without altering the flow.
-			if (CurrentPage.IsLoaded)
+			// Check if the Loaded event has actually been fired (not just IsLoaded which checks platform attachment).
+			// On iOS 26.1+, IsLoaded (view attached) can be true before the Loaded event is dispatched.
+			// On Windows, the Loaded event fires synchronously so IsLoadedFired is already true here.
+			if (CurrentPage.IsLoadedFired)
 			{
 				CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(_previousPage, _navigationType));
 			}
@@ -1820,7 +1822,7 @@ namespace Microsoft.Maui.Controls
 			}
       
       // Unsubscribe Loaded handler if navigating away before page loads to prevent memory leaks.
-			if (CurrentPage != null && !CurrentPage.IsLoaded)
+			if (CurrentPage != null && !CurrentPage.IsLoadedFired)
 			{
 				CurrentPage.Loaded -= OnCurrentPageLoaded;
 			}

--- a/src/Controls/src/Core/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement/VisualElement.cs
@@ -1861,6 +1861,7 @@ namespace Microsoft.Maui.Controls
 #nullable enable
 		Semantics? _semantics;
 		bool _isLoadedFired;
+		internal bool IsLoadedFired => _isLoadedFired;
 		EventHandler? _loaded;
 		EventHandler? _unloaded;
 		bool _watchingPlatformLoaded;


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause

PR #30757 defers the `NavigatedTo` event until the page’s `Loaded` event fires, using `CurrentPage.IsLoaded` to decide whether to defer. On iOS, `IsLoaded` checks if `UIView.Window` is set.

With iOS 26.1+, UIKit changed `AddSubview` to set `UIView.Window` synchronously instead of during the layout pass. As a result, `IsLoaded` returns true earlier—before the MAUI `Loaded` event is actually dispatched—causing `NavigatedTo` to fire immediately and before `Loaded`, reintroducing the original event-ordering issue only on iOS 26.1+.

### Description of Change

Replaced the `IsLoaded` check with `IsLoadedFired` in `PropagateSendNavigatedTo` and `SendNavigating`. `IsLoaded` relies on platform-level view attachment (`UIView.Window != null` on iOS), which became unreliable due to UIKit’s synchronous behavior change in iOS 26.1+. `IsLoadedFired`, on the other hand, tracks whether the MAUI `Loaded` event has actually been dispatched (`_isLoadedFired` set via `SendLoaded()`), ensuring correct lifecycle ordering independent of platform timing differences.

This change ensures consistent behavior across platforms — on Windows, `IsLoadedFired` is already true synchronously (no change), and on iOS 18.5/26.0 and Android, both values remain false at this stage, so existing behavior is preserved while fixing the regression on iOS 26.1+.

### Issues Fixed
`ShellFlyoutNavigationEventOrderShouldBeCorrect` - UI test case.
 
Tested the behaviour in the following platforms
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac