### PR TITLE
Move Mac UI tests to ACES Shared Infra

### DIFF
--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -143,8 +143,9 @@ parameters:
   - name: macosPoolPublic
     type: object
     default:
-      name: Azure Pipelines
-      vmImage: macOS-14
+      name: AcesShared
+      demands:
+        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
 stages:
 


### PR DESCRIPTION
## Description

Moves macOS UI test pools in \ci-uitests.yml\ to ACES Shared Infrastructure, aligning with the pattern already used by Android and iOS UI tests.

### Changes

| Pool | Before | After |
|------|--------|-------|
| **Public** (\macosPoolPublic\) | \Azure Pipelines\ / \macOS-14\ | \AcesShared\ / \ACES_VM_SharedPool_Tahoe\ |
| **Internal** (\macosPoolInternal\) | \Azure Pipelines\ / \macOS-14\ | \Azure Pipelines\ / \macOS-15-arm64\ |

This brings the macOS UI tests in line with the existing ACES pool configuration for Android and iOS UI tests in the same pipeline.