### PR TITLE
Add branch guard to merge-net11-to-release workflow

### DIFF
--- a/.github/workflows/merge-net11-to-release.yml
+++ b/.github/workflows/merge-net11-to-release.yml
@@ -1,5 +1,10 @@
 # Merge net11.0 → next release branch
 # Target branch is configured in /github-merge-flow-release-11.jsonc (MergeToBranch)
+#
+# This workflow must be triggered FROM the net11.0 branch because the arcade merge
+# script uses GITHUB_REF_NAME as the config lookup key. When triggered via
+# workflow_dispatch from the GitHub UI, select 'net11.0' from the branch dropdown.
+# The schedule trigger only works when this file exists on net11.0.
 
 name: Merge net11.0 to next release
 
@@ -17,6 +22,8 @@ permissions:
 
 jobs:
   Merge:
+    # Only run if triggered from net11.0 (push trigger or correct workflow_dispatch)
+    if: github.ref_name == 'net11.0'
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
       configuration_file_path: 'github-merge-flow-release-11.jsonc'


### PR DESCRIPTION
## Problem

The `Merge net11.0 to next release` workflow silently does nothing when triggered via `workflow_dispatch` or `schedule` because both run against `main` (the default branch). The arcade merge script uses `GITHUB_REF_NAME` as the config lookup key, finds no `"main"` entry in `github-merge-flow-release-11.jsonc`, and exits with "There was no configuration found for main" — but reports success.

## Fix

Add `if: github.ref_name == 'net11.0'` guard to the job so it skips immediately when triggered from the wrong branch, instead of silently succeeding.

**For `workflow_dispatch`**: Select `net11.0` from the branch dropdown in the GitHub UI before clicking Run.

**For `schedule`**: The cron trigger always runs on the default branch (`main`), so it will be skipped. The workflow on the `net11.0` branch (triggered by `push`) handles the actual merges.