### PR TITLE
Skip simulator install in official pack pipeline

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -102,6 +102,7 @@ extends:
             onlyAndroidPlatformDefaultApis: true
             skipAndroidEmulatorImages: true
             skipAndroidCreateAvds: true
+            skipSimulatorSetup: true
             skipProvisioning: true
             skipXcode: false
             base64Encode: true


### PR DESCRIPTION
## Problem

The official `dotnet-maui` pack pipeline (`ci-official.yml`) installs iOS simulator runtimes even though it only builds and packs NuGet packages. The `Install Simulator Runtimes` step is consistently timing out on macOS agents, blocking BAR build production on `release/11.0.1xx-preview3`.

The last two official builds both failed with the same timeout:
- [Build #2943103](https://dev.azure.com/dnceng/internal/_build/results?buildId=2943103)
- [Build #2943044](https://dev.azure.com/dnceng/internal/_build/results?buildId=2943044)

The simulator actually downloads and installs successfully, but the task timeout fires ~3 seconds after completion.

## Fix

Add `skipSimulatorSetup: true` to the `provision.yml` parameters in `ci-official.yml`. The pack stage already skips emulators and AVDs — simulators should be skipped too since no tests run in this pipeline.

## Impact

Unblocks official builds on preview3, enabling BAR build production for the `.NET 11 Workload Release` channel.