### PR TITLE
Skip simulator install in official pack pipeline

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -102,6 +102,7 @@ extends:
             onlyAndroidPlatformDefaultApis: true
             skipAndroidEmulatorImages: true
             skipAndroidCreateAvds: true
+            skipSimulatorSetup: true
             skipProvisioning: true
             skipXcode: false
             base64Encode: true


### PR DESCRIPTION
Backport of #34801 to main.

The official pack pipeline doesn't need iOS simulators — it only builds and packs NuGet packages. The simulator install step is timing out on macOS agents, blocking BAR build production.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>