### PR TITLE
Cache Gradle downloads between CI runs to avoid transient failures

### DIFF
--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -1,0 +1,29 @@
+# Shared Gradle dependency cache template
+# Caches ~/.gradle/caches between pipeline runs to avoid transient network
+# failures when resolving Maven dependencies during Android binding builds.
+#
+# Adapted from dotnet/android: https://github.com/dotnet/android/commit/0a681023
+# See: https://learn.microsoft.com/azure/devops/pipelines/release/caching
+
+parameters:
+  checkoutDirectory: $(System.DefaultWorkingDirectory)
+
+steps:
+- script: |
+    echo "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$HOME/.gradle/caches"
+  displayName: prepare Gradle cache variables
+  condition: ne(variables['Agent.OS'], 'Windows_NT')
+
+- pwsh: |
+    $gradleCacheDir = Join-Path $env:USERPROFILE ".gradle\caches"
+    Write-Host "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$gradleCacheDir"
+  displayName: prepare Gradle cache variables
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- task: Cache@2
+  displayName: cache Gradle downloads
+  inputs:
+    key: '"gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/**/build.gradle'
+    restoreKeys: |
+      "gradle" | "v1" | "$(Agent.OS)"
+    path: $(GRADLE_CACHE_DIR)

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -1,29 +1,34 @@
 # Shared Gradle dependency cache template
-# Caches ~/.gradle/caches between pipeline runs to avoid transient network
-# failures when resolving Maven dependencies during Android binding builds.
+# Caches ~/.gradle (caches + wrapper distributions) between pipeline runs to
+# avoid transient network failures when resolving Maven dependencies and
+# downloading the Gradle distribution during Android binding builds.
 #
 # Adapted from dotnet/android: https://github.com/dotnet/android/commit/0a681023
 # See: https://learn.microsoft.com/azure/devops/pipelines/release/caching
+#
+# To manually bust the cache (e.g. poisoned or bloated), bump the version
+# segment below from "v1" to "v2".
 
 parameters:
   checkoutDirectory: $(System.DefaultWorkingDirectory)
 
 steps:
 - script: |
-    echo "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$HOME/.gradle/caches"
-  displayName: prepare Gradle cache variables
+    echo "##vso[task.setvariable variable=GRADLE_USER_HOME]$HOME/.gradle"
+  displayName: prepare Gradle cache variables (Linux/macOS)
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 
 - pwsh: |
-    $gradleCacheDir = Join-Path $env:USERPROFILE ".gradle\caches"
-    Write-Host "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$gradleCacheDir"
-  displayName: prepare Gradle cache variables
+    $gradleHome = Join-Path $env:USERPROFILE ".gradle"
+    Write-Host "##vso[task.setvariable variable=GRADLE_USER_HOME]$gradleHome"
+  displayName: prepare Gradle cache variables (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - task: Cache@2
   displayName: cache Gradle downloads
   inputs:
-    key: '"gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/**/build.gradle'
+    key: '"gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/settings.gradle | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle.properties | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/**/build.gradle'
     restoreKeys: |
+      "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"
-    path: $(GRADLE_CACHE_DIR)
+    path: $(GRADLE_USER_HOME)

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -29,7 +29,12 @@ steps:
 - task: Cache@2
   displayName: cache Gradle downloads
   inputs:
-    key: '"gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/settings.gradle | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle.properties | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/**/build.gradle'
+    key: >-
+      "gradle" | "v1" | "$(Agent.OS)"
+      | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
+      | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/settings.gradle
+      | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle.properties
+      | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/**/build.gradle
     restoreKeys: |
       "gradle" | "v1" | "$(Agent.OS)" | ${{ parameters.checkoutDirectory }}/src/Core/AndroidNative/gradle/wrapper/gradle-wrapper.properties
       "gradle" | "v1" | "$(Agent.OS)"

--- a/eng/pipelines/common/cache-gradle.yml
+++ b/eng/pipelines/common/cache-gradle.yml
@@ -14,12 +14,14 @@ parameters:
 
 steps:
 - script: |
+    mkdir -p "$HOME/.gradle"
     echo "##vso[task.setvariable variable=GRADLE_USER_HOME]$HOME/.gradle"
   displayName: prepare Gradle cache variables (Linux/macOS)
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 
 - pwsh: |
     $gradleHome = Join-Path $env:USERPROFILE ".gradle"
+    New-Item -ItemType Directory -Path $gradleHome -Force | Out-Null
     Write-Host "##vso[task.setvariable variable=GRADLE_USER_HOME]$gradleHome"
   displayName: prepare Gradle cache variables (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -331,3 +331,8 @@ steps:
     condition: succeeded()
     env:
       AndroidSdkProvisionApiLevel: ${{ parameters.androidEmulatorApiLevel }}
+
+# Cache Gradle downloads to avoid transient network failures during Android binding builds
+- template: /eng/pipelines/common/cache-gradle.yml@self
+  parameters:
+    checkoutDirectory: ${{ parameters.checkoutDirectory }}

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -333,6 +333,7 @@ steps:
       AndroidSdkProvisionApiLevel: ${{ parameters.androidEmulatorApiLevel }}
 
 # Cache Gradle downloads to avoid transient network failures during Android binding builds
-- template: /eng/pipelines/common/cache-gradle.yml@self
-  parameters:
-    checkoutDirectory: ${{ parameters.checkoutDirectory }}
+- ${{ if ne(parameters.skipAndroidCommonSdks, 'true') }}:
+  - template: /eng/pipelines/common/cache-gradle.yml@self
+    parameters:
+      checkoutDirectory: ${{ parameters.checkoutDirectory }}


### PR DESCRIPTION
## Problem

Android binding builds invoke Gradle to resolve Maven dependencies (e.g., `androidx` packages). When Gradle downloads fail due to transient DNS/network issues on CI agents, the build fails with:

```
gradlew exited with code 1
```

This is intermittent and often passes on retrigger, but wastes CI capacity and blocks PRs. See #34800 for recent examples.

## Fix

Add a shared `cache-gradle.yml` template using the AzDO [`Cache@2`](https://learn.microsoft.com/azure/devops/pipelines/release/caching) task to persist `~/.gradle/caches` between pipeline runs. When the cache is warm, Gradle resolves dependencies locally instead of downloading from Maven Central, eliminating transient network failures.

The cache key includes:
- `Agent.OS` — separate caches for macOS/Windows/Linux
- `gradle-wrapper.properties` — invalidates when Gradle version changes
- `build.gradle` files — invalidates when dependencies change

The template is called from `provision.yml` so it applies to all pipelines (build, pack, device tests, UI tests).

## Prior art

Adapted from the same approach in dotnet/android: https://github.com/dotnet/android/commit/0a681023be145d62d0d55a6e49bfc7f2b9aac86f (PR #10986)

Fixes #34800