### PR TITLE
Add android-36.1 and android-37 to SDK provisioning API levels

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,9 @@
     <AndroidSdkApiLevels Include="33" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="35" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
-    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+    <AndroidSdkApiLevels Include="36.1" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="37" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- arcade -->


### PR DESCRIPTION
## Problem

CI macOS builds fail with:

```
XA5207: Could not find android.jar for API level 36.1
Expected: /Users/builder/Library/Developer/Xamarin/android-sdk-macosx/platforms/android-36.1/android.jar
```

`AndroidTargetFrameworkVersion` was bumped to `36.1` (via dotnet/android dependency updates in #34237), but the `AndroidSdkApiLevels` provisioning list in `eng/Versions.props` only went up to `36`.

When CI runs with `onlyAndroidPlatformDefaultApis: true` (the default), the `ProvisionAndroidSdkPlatformApiPackages` target only installs the item marked `IsDefault=True`. That was `android-36`, but the build now needs `android-36.1`.

The provisioning runs:
```
dotnet android sdk install --package "platforms;android-36.1"
```
which installs `platforms/android-36.1/android.jar` — the exact file the build expects. (`platforms;android-36.1` is a valid sdkmanager package; Google ships non-integer API levels as separate platform packages.)

## Fix

- Keep `android-36` in the list (without `IsDefault`)
- Add `android-36.1` with `IsDefault=True` so CI installs it
- Add `android-37` for forward-compat (without `IsDefault`)

## Affected builds

- [Build #2943247](https://dev.azure.com/dnceng/internal/_build/results?buildId=2943247) — `dotnet-maui-build`, Build macOS (Debug + Release)
- [Build #2943045](https://dev.azure.com/dnceng/internal/_build/results?buildId=2943045) — same failure on prior commit

## Related

- dotnet/android#11072 — same class of issue for API 37 (`android-37` vs `android-37.0`)
- dotnet/android#10536 — non-integer API level support fixes