### PR TITLE
Add android-36.1 and android-37 to SDK provisioning API levels

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,9 @@
     <AndroidSdkApiLevels Include="33" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="35" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
-    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+    <AndroidSdkApiLevels Include="36.1" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="37" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- arcade -->


### PR DESCRIPTION
Backport of #34805 to preview3.

## Problem

CI macOS builds fail with:

```
XA5207: Could not find android.jar for API level 36.1
Expected: /Users/builder/Library/Developer/Xamarin/android-sdk-macosx/platforms/android-36.1/android.jar
```

`AndroidTargetFrameworkVersion` was bumped to `36.1` but the provisioning list only had `android-36`. When CI runs with `onlyAndroidPlatformDefaultApis: true`, only the `IsDefault` item gets installed via `dotnet android sdk install --package "platforms;android-36.1"`.

## Fix

- Keep `android-36` in the list (without `IsDefault`)
- Add `android-36.1` with `IsDefault=True` so CI installs it
- Add `android-37` for forward-compat (without `IsDefault`)

## Related

- #34805 — net11.0 target
- dotnet/android#11072 — same class of issue for API 37
- dotnet/android#10536 — non-integer API level support fixes