### PR TITLE
Improve try-fix skill: add eval.yaml and fix prompt issues

### DIFF
--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -14,7 +14,7 @@ Attempts ONE fix for a given problem. Receives all context upfront, tries a sing
 2. **Single-shot** - Each invocation = ONE fix idea, tested, reported
 3. **Alternative-focused** - Always propose something DIFFERENT from existing fixes (review PR changes first)
 4. **Empirical** - Actually implement and test, don't just theorize
-5. **Context-driven** - All information provided upfront; don't search for additional context
+5. **Context-driven** - Work with what's provided and git history; don't search external sources
 
 **Every invocation:** Review existing fixes → Think of DIFFERENT approach → Implement and test → Report results
 
@@ -23,7 +23,7 @@ Attempts ONE fix for a given problem. Receives all context upfront, tries a sing
 🚨 **Try-fix runs MUST be executed ONE AT A TIME - NEVER in parallel.**
 
 **Why:** Each try-fix run:
-- Modifies the same source files (SafeAreaExtensions.cs, etc.)
+- Modifies the same target source files
 - Uses the same device/emulator for testing
 - Runs EstablishBrokenBaseline.ps1 which reverts files to a known state
 
@@ -147,6 +147,8 @@ The skill is complete when:
 
 **Never stop due to:** Compile errors (fix them), infrastructure blame (debug your code), giving up too early.
 
+> **Session limits:** Each try-fix *invocation* allows up to 3 compile/test iterations. The *calling orchestrator* controls how many invocations (attempts) to run per session (typically 4-5 as part of pr-review Phase 3).
+
 ---
 
 ## Workflow
@@ -182,7 +184,7 @@ The skill is complete when:
 - What files should be investigated?
 - Are there hints about what to try or avoid?
 
-**Do NOT search for additional context.** Work with what's provided.
+**Do NOT search for external context.** Work with what's provided and the git history.
 
 ### Step 2: Establish Baseline (MANDATORY)
 
@@ -317,7 +319,7 @@ git diff | Set-Content "$OUTPUT_DIR/fix.diff"
 pwsh .github/scripts/EstablishBrokenBaseline.ps1 -Restore
 ```
 
-🚨 Do NOT use `git checkout HEAD -- .` or `git clean` to restore — use the script.
+🚨 Use `EstablishBrokenBaseline.ps1 -Restore` — not `git checkout`, `git restore`, or `git reset` (see Step 2 for why).
 
 ### Step 9: Report Results
 

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -220,6 +220,12 @@ Select-String -Path "$OUTPUT_DIR/baseline.log" -Pattern "Baseline established"
 
 Read the target files to understand the code.
 
+**Verify the platform code path before implementing.** Check which platform-specific file actually executes for the target scenario:
+- Files named `.iOS.cs` compile for both iOS AND MacCatalyst
+- Files named `.Android.cs` only compile for Android
+- Some platforms use Legacy implementations (e.g., iOS NavigationPage uses `NavigationPage.Legacy.cs`, not `MauiNavigationImpl`)
+If unsure which code path runs, check `AppHostBuilderExtensions` or handler registration to confirm.
+
 **Key questions:**
 - What is the root cause of this bug?
 - Where should the fix go?
@@ -232,6 +238,10 @@ Based on your analysis and any provided hints, design a single fix approach:
 - Which file(s) to change
 - What the change is
 - Why you think this will work
+
+**"Different" means different ROOT CAUSE hypothesis, not just different code location.**
+- ❌ Bad: PR checks `adapter == null` in OnMeasure; you check `adapter == null` in OnLayout (same root cause assumption — just a different call site)
+- ✅ Good: PR checks `adapter == null`; you prevent disposal from happening during measure (different root cause hypothesis)
 
 **If hints suggest specific approaches**, prioritize those.
 

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -359,9 +359,7 @@ Provide structured output to the invoker:
 [Why it worked, or why it failed and what was learned]
 
 **Diff:**
-```diff
-[The actual changes made]
-```
+(paste `git diff` output here)
 
 **This Attempt's Status:** Done/NeedsRetry
 **Reasoning:** [Why this specific approach succeeded or failed]

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -20,7 +20,7 @@ If the prompt does not include a **problem to fix** and a **test command to veri
 
 ## Core Principles
 
-1. **Always run** - Never question whether to run. The invoker decides WHEN, you decide WHAT alternative to try
+1. **Always run once activated** - Never question whether to run. The invoker decides WHEN, you decide WHAT alternative to try
 2. **Single-shot** - Each invocation = ONE fix idea, tested, reported
 3. **Alternative-focused** - Always propose something DIFFERENT from existing fixes (review PR changes first)
 4. **Empirical** - Actually implement and test, don't just theorize

--- a/.github/skills/try-fix/SKILL.md
+++ b/.github/skills/try-fix/SKILL.md
@@ -8,6 +8,16 @@ compatibility: Requires PowerShell, git, .NET MAUI build environment, Android/iO
 
 Attempts ONE fix for a given problem. Receives all context upfront, tries a single approach, tests it, and reports what happened.
 
+## Activation Guard
+
+🚨 **This skill is ONLY for proposing and testing code fixes.** Do NOT activate for:
+- Code review requests ("review this PR", "check code quality")
+- PR summaries or descriptions ("what does this PR do?")
+- Test-only requests ("run tests", "check CI status")
+- General questions about code or architecture
+
+If the prompt does not include a **problem to fix** and a **test command to verify**, this skill should not run.
+
 ## Core Principles
 
 1. **Always run** - Never question whether to run. The invoker decides WHEN, you decide WHAT alternative to try
@@ -357,7 +367,7 @@ Provide structured output to the invoker:
 | Test command fails to run | Report build/setup error with details |
 | Test times out | Report timeout, include partial output |
 | Can't determine fix approach | Report "no viable approach identified" with reasoning |
-| Git state unrecoverable | Run `git checkout HEAD -- .` and `git clean -fd` if needed |
+| Git state unrecoverable | Run `pwsh .github/scripts/EstablishBrokenBaseline.ps1 -Restore` (see Step 2/8) |
 
 ---
 

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -28,6 +28,7 @@ scenarios:
       Can you explain how handler architecture works in .NET MAUI? Specifically, what is the
       difference between ConnectHandler and DisconnectHandler, and when should each be used?
       I'm trying to understand the lifecycle so I can write my own custom handler.
+    expect_activation: false
     assertions:
       - type: output_not_contains
         value: "attempt-"

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -1,0 +1,142 @@
+scenarios:
+  - name: "Happy path: propose alternative fix with different approach"
+    prompt: |
+      Use the try-fix skill to attempt a fix for the following problem:
+
+      Problem: CollectionView throws ObjectDisposedException when navigating back from a page on Android.
+
+      The existing PR fix already adds a null check on the adapter in OnMeasure(). We need a DIFFERENT approach.
+
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue54321"
+
+      Target files:
+        - src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Android.cs
+
+      Platform: android
+
+      Hints: Focus on lifecycle/disposal timing rather than null checks.
+    assertions:
+      - type: output_contains
+        value: "Approach"
+      - type: output_contains
+        value: "Different from existing fix"
+      - type: output_not_contains
+        value: "null check on the adapter"
+      - type: output_contains
+        value: "result.txt"
+      - type: output_contains
+        value: "analysis"
+    rubric:
+      - "The agent proposes a fix approach that is clearly distinct from the null-check-on-adapter approach described as the existing fix"
+      - "The agent creates an approach.md document explaining the difference from the existing fix"
+      - "The agent saves artifacts (result.txt, fix.diff, analysis.md) to an output directory"
+      - "The agent reverts changes after testing using EstablishBrokenBaseline.ps1 rather than manual git commands"
+    timeout: 120
+
+  - name: "Negative trigger: code review request should not invoke try-fix workflow"
+    prompt: |
+      Please review the code changes in PR #34567 and tell me if the fix looks correct.
+      The PR modifies SafeAreaExtensions.cs to add padding adjustments.
+    assertions:
+      - type: output_not_contains
+        value: "EstablishBrokenBaseline"
+      - type: output_not_contains
+        value: "attempt-"
+      - type: output_not_contains
+        value: "OUTPUT_DIR"
+      - type: output_not_contains
+        value: "result.txt"
+    rubric:
+      - "The agent provides a code review rather than attempting to run a fix workflow"
+      - "The agent does not create output directories or artifact files associated with try-fix execution"
+    timeout: 60
+
+  - name: "Regression: agent must not claim Pass without running test command"
+    prompt: |
+      Use the try-fix skill for this problem:
+
+      Problem: Button tap does not fire Clicked event on iOS when inside a ScrollView.
+
+      Existing fix: Adds a gesture recognizer passthrough in ScrollViewHandler.
+
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "Issue99001"
+
+      Target files:
+        - src/Controls/src/Core/Handlers/Compatibility/ScrollViewRenderer.iOS.cs
+
+      Platform: ios
+
+      Note: No iOS simulator is currently available.
+    assertions:
+      - type: output_not_contains
+        value: "Pass"
+      - type: output_contains
+        value: "Blocked"
+      - type: output_not_contains
+        value: "code compiles successfully"
+      - type: output_not_contains
+        value: "logic looks correct"
+    rubric:
+      - "The agent reports 'Blocked' (not 'Pass') when no device/simulator is available to run the test command"
+      - "The agent does not claim success based on code review or compilation alone"
+      - "The agent explains why the result is Blocked rather than Pass or Fail"
+    timeout: 120
+
+  - name: "Edge case: second attempt reads and avoids prior failed approach"
+    prompt: |
+      Use the try-fix skill to attempt a fix. This is attempt #2 — attempt #1 already failed.
+
+      Problem: Shell navigation causes a NullReferenceException in ShellItemHandler on Android when popping to root.
+
+      Prior attempt (FAILED): Modified OnPageSelected to reset cached state after navigation.
+      Failure reason: OnPageSelected fires after layout measurement, so cached value was already consumed.
+
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue77123"
+
+      Target files:
+        - src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
+
+      Platform: android
+
+      Hints: Try intercepting at a different lifecycle point, before measurement occurs.
+    assertions:
+      - type: output_not_contains
+        value: "OnPageSelected"
+      - type: output_contains
+        value: "Different from existing fix"
+      - type: output_contains
+        value: "approach"
+    rubric:
+      - "The agent acknowledges the prior failed attempt and explicitly avoids repeating the OnPageSelected approach"
+      - "The agent proposes a lifecycle-based alternative that fires before layout measurement"
+      - "The approach.md clearly explains how this attempt differs from the prior failed attempt"
+    timeout: 120
+
+  - name: "Regression: agent must use EstablishBrokenBaseline script, not manual git commands"
+    prompt: |
+      Use the try-fix skill for this problem:
+
+      Problem: Entry text is not preserved on orientation change on Android.
+
+      Existing fix: Saves/restores text in OnSaveInstanceState override.
+
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue88200"
+
+      Target files:
+        - src/Core/src/Platform/Android/EntryHandler.Android.cs
+
+      Platform: android
+    assertions:
+      - type: output_contains
+        value: "EstablishBrokenBaseline"
+      - type: output_not_contains
+        value: "git checkout HEAD"
+      - type: output_not_contains
+        value: "git restore"
+      - type: output_not_contains
+        value: "git reset"
+    rubric:
+      - "The agent uses EstablishBrokenBaseline.ps1 to establish the baseline and restore working directory, not raw git commands"
+      - "The agent does not use 'git checkout HEAD', 'git restore', or 'git reset' to revert fix files"
+      - "The restore step is explicitly called after testing (whether pass or fail)"
+    timeout: 120

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -30,8 +30,6 @@ scenarios:
       I'm trying to understand the lifecycle so I can write my own custom handler.
     assertions:
       - type: output_not_contains
-        value: "EstablishBrokenBaseline"
-      - type: output_not_contains
         value: "attempt-"
       - type: output_not_contains
         value: "OUTPUT_DIR"
@@ -46,6 +44,8 @@ scenarios:
 
   - name: "Regression: agent must not claim success without running the test command"
     prompt: |
+      IMPORTANT: Before taking any other action, note that no iOS simulator or device is available for testing.
+
       try-fix invocation for Issue #99001:
       - Bug: Button inside a ScrollView doesn't fire its Clicked event on iOS
       - The existing fix adds a gesture recognizer passthrough in ScrollViewHandler
@@ -53,7 +53,6 @@ scenarios:
       - Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "Issue99001"
       - Target: src/Controls/src/Core/Handlers/Compatibility/ScrollViewRenderer.iOS.cs
       - Platform: ios
-      - IMPORTANT: No iOS simulator is currently available in this environment.
     assertions:
       - type: output_not_contains
         value: "✅ PASS"

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -140,3 +140,49 @@ scenarios:
       - "Agent does not continue proposing fixes indefinitely — stops at the iteration limit"
     timeout: 900
 
+  - name: "Regression: agent must not repeat the same root cause disguised as different approach"
+    prompt: |
+      This is attempt #3 at fixing a bug. The pr-review agent needs another alternative.
+
+      Prior attempts and their failures:
+      - Attempt 1 (FAIL): Returned 0 from GetHeight() when infinity detected, hoping parent fallback handles it. Failed because parent.MeasuredHeight returns 0 during initial layout.
+      - Attempt 2 (FAIL): Skipped setting RecyclerViewHeight when measurement was infinite, hoping parent fallback handles it. Failed for the same reason -- parent.MeasuredHeight returns 0 during initial layout.
+
+      Both attempts failed because they relied on PARENT MEASUREMENT FALLBACK which doesn't work during initial layout. Your approach must NOT depend on parent dimensions as a fallback.
+
+      Problem: Android RecyclerView inside ScrollView reports infinite height, causing items to overlap.
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "FullyQualifiedName~RecyclerViewHeightInScrollView"
+      Target files: src/Controls/src/Core/Handlers/Items/Android/RecyclerViewAdapter.cs
+      Platform: Android
+    assertions:
+      - type: output_not_contains
+        value: "parent.MeasuredHeight"
+      - type: output_not_contains
+        value: "parent measurement"
+      - type: output_not_contains
+        value: "fallback to parent"
+    rubric:
+      - "Agent identifies that parent measurement fallback is the common root cause of both prior failures, not just a surface-level detail"
+      - "Agent's proposed approach does NOT rely on parent dimensions or parent measurement as a fallback mechanism"
+      - "Agent explains WHY the new approach avoids the root cause, not just that it's different code"
+    timeout: 900
+
+  - name: "Regression: agent must verify correct platform-specific code path before implementing"
+    prompt: |
+      The pr-review agent needs an alternative fix attempt for a NavigationPage handler disconnection bug on iOS.
+
+      Problem: On iOS, pushing and popping pages rapidly causes the NavigationPage handler to disconnect while an animation is still running, resulting in a NullReferenceException.
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "FullyQualifiedName~NavigationPageHandlerDisconnect"
+      Target files: src/Controls/src/Core/Handlers/NavigationPage/
+      Platform: iOS
+
+      IMPORTANT: iOS navigation uses the Legacy implementation (NavigationPage.Legacy.cs and NavigationRenderer), NOT the newer MauiNavigationImpl. Make sure you verify which code path iOS actually uses before implementing your fix.
+    assertions:
+      - type: output_not_contains
+        value: "MauiNavigationImpl"
+    rubric:
+      - "Agent verifies or acknowledges which code path iOS actually uses before proposing a fix"
+      - "Agent targets the Legacy navigation implementation (NavigationPage.Legacy.cs or NavigationRenderer), not MauiNavigationImpl"
+      - "Agent's fix addresses the disconnection-during-animation scenario specifically"
+    timeout: 900
+

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -1,40 +1,33 @@
 scenarios:
   - name: "Happy path: propose alternative fix with different approach"
     prompt: |
-      Use the try-fix skill to attempt a fix for the following problem:
+      The pr-review agent needs an alternative fix attempt for issue #54321.
 
-      Problem: CollectionView throws ObjectDisposedException when navigating back from a page on Android.
+      The bug: CollectionView throws ObjectDisposedException on Android when the user navigates back
+      from a page that contains a CollectionView. The current PR already tried adding a null check on
+      the adapter inside OnMeasure() — that didn't fix it reliably.
 
-      The existing PR fix already adds a null check on the adapter in OnMeasure(). We need a DIFFERENT approach.
+      Please try a different approach focused on lifecycle/disposal timing.
 
-      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue54321"
-
-      Target files:
-        - src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Android.cs
-
-      Platform: android
-
-      Hints: Focus on lifecycle/disposal timing rather than null checks.
+      Test: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue54321"
+      Files to look at: src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Android.cs
     assertions:
-      - type: output_contains
-        value: "Approach"
-      - type: output_contains
-        value: "Different from existing fix"
       - type: output_not_contains
         value: "null check on the adapter"
-      - type: output_contains
-        value: "analysis"
+      - type: output_not_contains
+        value: "OnMeasure"
     rubric:
-      - "The agent proposes a fix approach that is clearly distinct from the null-check-on-adapter approach described as the existing fix"
-      - "The agent creates an approach.md document explaining the difference from the existing fix"
-      - "Agent creates result.txt in the output directory with Pass, Fail, or Blocked"
-      - "The agent reverts changes after testing using EstablishBrokenBaseline.ps1 rather than manual git commands"
+      - "The agent proposes a fix approach that is clearly distinct from the null-check-on-adapter approach in OnMeasure"
+      - "The agent documents why the chosen approach differs from the existing fix"
+      - "The agent saves output artifacts (approach, result, diff, analysis) to a structured output directory"
+      - "The agent restores the working directory to a clean state after testing, using the prescribed script"
     timeout: 900
 
-  - name: "Negative trigger: code review request should not invoke try-fix workflow"
+  - name: "Negative trigger: documentation question should not invoke fix workflow"
     prompt: |
-      Please review the code changes in PR #34567 and tell me if the fix looks correct.
-      The PR modifies SafeAreaExtensions.cs to add padding adjustments.
+      Can you explain how handler architecture works in .NET MAUI? Specifically, what is the
+      difference between ConnectHandler and DisconnectHandler, and when should each be used?
+      I'm trying to understand the lifecycle so I can write my own custom handler.
     assertions:
       - type: output_not_contains
         value: "EstablishBrokenBaseline"
@@ -44,113 +37,107 @@ scenarios:
         value: "OUTPUT_DIR"
       - type: output_not_contains
         value: "result.txt"
+      - type: output_not_contains
+        value: "fix.diff"
     rubric:
-      - "The agent provides a code review rather than attempting to run a fix workflow"
-      - "The agent does not create output directories or artifact files associated with try-fix execution"
+      - "The agent answers the handler lifecycle question directly without attempting to run any fix workflow"
+      - "The agent does not create output directories, diff files, or other try-fix artifacts"
     timeout: 60
 
-  - name: "Regression: agent must not claim Pass without running test command"
+  - name: "Regression: agent must not claim success without running the test command"
     prompt: |
-      Use the try-fix skill for this problem:
-
-      Problem: Button tap does not fire Clicked event on iOS when inside a ScrollView.
-
-      Existing fix: Adds a gesture recognizer passthrough in ScrollViewHandler.
-
-      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "Issue99001"
-
-      Target files:
-        - src/Controls/src/Core/Handlers/Compatibility/ScrollViewRenderer.iOS.cs
-
-      Platform: ios
-
-      Note: No iOS simulator is currently available.
+      try-fix invocation for Issue #99001:
+      - Bug: Button inside a ScrollView doesn't fire its Clicked event on iOS
+      - The existing fix adds a gesture recognizer passthrough in ScrollViewHandler
+      - Please try a different approach
+      - Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform ios -TestFilter "Issue99001"
+      - Target: src/Controls/src/Core/Handlers/Compatibility/ScrollViewRenderer.iOS.cs
+      - Platform: ios
+      - IMPORTANT: No iOS simulator is currently available in this environment.
     assertions:
       - type: output_not_contains
-        value: "Pass"
-      - type: output_contains
-        value: "Blocked"
+        value: "✅ PASS"
+      - type: output_not_contains
+        value: "Result: Pass"
       - type: output_not_contains
         value: "code compiles successfully"
       - type: output_not_contains
         value: "logic looks correct"
+      - type: output_not_contains
+        value: "the fix should work"
     rubric:
-      - "The agent reports 'Blocked' (not 'Pass') when no device/simulator is available to run the test command"
-      - "The agent does not claim success based on code review or compilation alone"
-      - "The agent explains why the result is Blocked rather than Pass or Fail"
+      - "The agent does NOT report the fix as passing when no device is available to run the test"
+      - "The agent explains that the result is blocked/unverified because no simulator is available"
+      - "The agent does not substitute code review or compilation success for actual test execution"
     timeout: 120
 
-  - name: "Edge case: second attempt reads and avoids prior failed approach"
+  - name: "Edge case: second attempt avoids repeating the prior failed approach"
     prompt: |
-      Use the try-fix skill to attempt a fix. This is attempt #2 — attempt #1 already failed.
+      Attempt #2 for Issue #77123. Attempt #1 already failed — do not repeat it.
 
-      Problem: Shell navigation causes a NullReferenceException in ShellItemHandler on Android when popping to root.
+      Bug: NullReferenceException in ShellItemHandler on Android when popping to root.
 
-      Prior attempt (FAILED): Modified OnPageSelected to reset cached state after navigation.
-      Failure reason: OnPageSelected fires after layout measurement, so cached value was already consumed.
+      Attempt #1 result: FAIL
+      What was tried: Modified OnPageSelected to reset cached navigation state after navigation completed.
+      Why it failed: OnPageSelected fires after layout measurement has already consumed the cached value,
+      so resetting it there has no effect on the crash.
 
-      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue77123"
-
-      Target files:
-        - src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
-
-      Platform: android
-
-      Hints: Try intercepting at a different lifecycle point, before measurement occurs.
+      Test: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue77123"
+      Files: src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Android.cs
+      Hint: The fix needs to happen before layout measurement, not after navigation completes.
     assertions:
       - type: output_not_contains
         value: "OnPageSelected"
-      - type: output_contains
-        value: "approach"
     rubric:
-      - "Agent explicitly states it is avoiding the OnPageSelected approach because of the prior failure"
-      - "The agent proposes a lifecycle-based alternative that fires before layout measurement"
-      - "The approach.md clearly explains how this attempt differs from the prior failed attempt"
+      - "Agent explicitly states it is avoiding the OnPageSelected approach because of the documented prior failure"
+      - "The agent proposes a fix that intercepts at an earlier lifecycle point, before layout measurement"
+      - "The agent's approach documentation explains why this attempt is different from attempt #1"
     timeout: 900
 
-  - name: "Regression: agent must use EstablishBrokenBaseline script, not manual git commands"
+  - name: "Regression: agent uses prescribed restore script, not raw git commands"
     prompt: |
-      Use the try-fix skill for this problem:
+      Please run a try-fix attempt on this Android issue:
 
-      Problem: Entry text is not preserved on orientation change on Android.
+      The bug is that Entry text is lost when the user rotates the device on Android. We already
+      tried saving/restoring text in an OnSaveInstanceState override — didn't work because the
+      override wasn't being called by the platform at the right time.
 
-      Existing fix: Saves/restores text in OnSaveInstanceState override.
+      Try a completely different mechanism for persisting the text across orientation changes.
 
       Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "Issue88200"
-
-      Target files:
-        - src/Core/src/Platform/Android/EntryHandler.Android.cs
-
-      Platform: android
+      Target file: src/Core/src/Platform/Android/EntryHandler.Android.cs
     assertions:
-      - type: output_contains
-        value: "EstablishBrokenBaseline"
       - type: output_not_contains
         value: "git checkout HEAD"
       - type: output_not_contains
         value: "git restore"
       - type: output_not_contains
-        value: "git reset"
+        value: "git reset --hard"
     rubric:
-      - "The agent uses EstablishBrokenBaseline.ps1 to establish the baseline and restore working directory, not raw git commands"
-      - "The agent does not use 'git checkout HEAD', 'git restore', or 'git reset' to revert fix files"
-      - "The restore step is explicitly called after testing (whether pass or fail)"
+      - "The agent uses the prescribed baseline/restore script to reset file state, not raw git commands"
+      - "The agent calls the restore step after testing completes (whether the fix passed or failed)"
+      - "The agent documents a fix approach that differs from the OnSaveInstanceState mechanism"
     timeout: 900
 
-  - name: "Edge case: exhausted iterations records Fail with analysis"
+  - name: "Edge case: exhausted iterations produces documented Fail, not silence or Pass"
     prompt: |
-      Use the try-fix skill to fix a bug. Problem: CollectionView items overlap on Android.
-      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "FullyQualifiedName~CollectionViewOverlap"
-      Target files: src/Controls/src/Core/Handlers/Items/Android/ItemsViewRenderer.cs
-      The test fails with: Assert.That(rect1.Bottom, Is.LessThanOrEqualTo(rect2.Top)) -- items visually overlap.
-      NOTE: The test environment is available but every approach will fail because the root cause is in the Android platform SDK, not in MAUI code. After 3 iterations you should report Fail.
+      try-fix for CollectionView item overlap on Android (Issue #CollectionViewOverlap).
+
+      The test assertion is: rect1.Bottom <= rect2.Top (items must not visually overlap).
+      Every approach has been failing because the root cause appears to be in the Android
+      RecyclerView layout manager, not in MAUI wrapper code. After trying up to 3 approaches
+      you should stop and report the result.
+
+      Test: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "FullyQualifiedName~CollectionViewOverlap"
+      Target: src/Controls/src/Core/Handlers/Items/Android/ItemsViewRenderer.cs
     assertions:
-      - type: output_contains
-        value: "Fail"
       - type: output_not_contains
-        value: "Pass"
+        value: "✅ PASS"
+      - type: output_not_contains
+        value: "Result: Pass"
     rubric:
-      - "Agent stops after exhausting 3 iterations and reports Fail"
-      - "Agent writes a failure analysis explaining why the approach did not work"
-      - "result.txt contains exactly Fail, not Blocked or Pass"
+      - "Agent stops after exhausting attempts and reports Fail rather than claiming success or going silent"
+      - "Agent produces a written analysis explaining why the attempted approaches did not resolve the issue"
+      - "Agent does not continue proposing fixes indefinitely — stops at the iteration limit"
     timeout: 900
+

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -69,7 +69,7 @@ scenarios:
       - "The agent does NOT report the fix as passing when no device is available to run the test"
       - "The agent explains that the result is blocked/unverified because no simulator is available"
       - "The agent does not substitute code review or compilation success for actual test execution"
-    timeout: 120
+    timeout: 300
 
   - name: "Edge case: second attempt avoids repeating the prior failed approach"
     prompt: |

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -93,7 +93,7 @@ scenarios:
       - type: output_not_contains
         value: "I will use OnPageSelected"
     rubric:
-      - "Agent explicitly states it is avoiding the OnPageSelected approach because of the documented prior failure"
+      - "Agent explicitly states it is avoiding the prior failed approach (page selection callback modification) and explains why"
       - "The agent proposes a fix that intercepts at an earlier lifecycle point, before layout measurement"
       - "The agent's approach documentation explains why this attempt is different from attempt #1"
     timeout: 900
@@ -165,7 +165,7 @@ scenarios:
       - type: output_not_contains
         value: "fallback to parent"
     rubric:
-      - "Agent identifies that parent measurement fallback is the common root cause of both prior failures, not just a surface-level detail"
+      - "Agent identifies that relying on parent dimensions as a fallback was the shared flaw in both prior attempts"
       - "Agent's proposed approach does NOT rely on parent dimensions or parent measurement as a fallback mechanism"
       - "Agent explains WHY the new approach avoids the root cause, not just that it's different code"
     timeout: 900

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -15,7 +15,9 @@ scenarios:
       - type: output_not_contains
         value: "null check on the adapter"
       - type: output_not_contains
-        value: "OnMeasure"
+        value: "I will modify the OnMeasure"
+      - type: output_contains
+        value: "approach"
     rubric:
       - "The agent proposes a fix approach that is clearly distinct from the null-check-on-adapter approach in OnMeasure"
       - "The agent documents why the chosen approach differs from the existing fix"
@@ -65,6 +67,8 @@ scenarios:
         value: "logic looks correct"
       - type: output_not_contains
         value: "the fix should work"
+      - type: output_contains
+        value: "Blocked"
     rubric:
       - "The agent does NOT report the fix as passing when no device is available to run the test"
       - "The agent explains that the result is blocked/unverified because no simulator is available"
@@ -87,7 +91,7 @@ scenarios:
       Hint: The fix needs to happen before layout measurement, not after navigation completes.
     assertions:
       - type: output_not_contains
-        value: "OnPageSelected"
+        value: "I will use OnPageSelected"
     rubric:
       - "Agent explicitly states it is avoiding the OnPageSelected approach because of the documented prior failure"
       - "The agent proposes a fix that intercepts at an earlier lifecycle point, before layout measurement"
@@ -135,6 +139,8 @@ scenarios:
         value: "✅ PASS"
       - type: output_not_contains
         value: "Result: Pass"
+      - type: output_contains
+        value: "Fail"
     rubric:
       - "Agent stops after exhausting attempts and reports Fail rather than claiming success or going silent"
       - "Agent produces a written analysis explaining why the attempted approaches did not resolve the issue"
@@ -157,10 +163,6 @@ scenarios:
       Platform: Android
     assertions:
       - type: output_not_contains
-        value: "parent.MeasuredHeight"
-      - type: output_not_contains
-        value: "parent measurement"
-      - type: output_not_contains
         value: "fallback to parent"
     rubric:
       - "Agent identifies that parent measurement fallback is the common root cause of both prior failures, not just a surface-level detail"
@@ -180,7 +182,7 @@ scenarios:
       IMPORTANT: iOS navigation uses the Legacy implementation (NavigationPage.Legacy.cs and NavigationRenderer), NOT the newer MauiNavigationImpl. Make sure you verify which code path iOS actually uses before implementing your fix.
     assertions:
       - type: output_not_contains
-        value: "MauiNavigationImpl"
+        value: "I will modify MauiNavigationImpl"
     rubric:
       - "Agent verifies or acknowledges which code path iOS actually uses before proposing a fix"
       - "Agent targets the Legacy navigation implementation (NavigationPage.Legacy.cs or NavigationRenderer), not MauiNavigationImpl"

--- a/.github/skills/try-fix/tests/eval.yaml
+++ b/.github/skills/try-fix/tests/eval.yaml
@@ -23,15 +23,13 @@ scenarios:
       - type: output_not_contains
         value: "null check on the adapter"
       - type: output_contains
-        value: "result.txt"
-      - type: output_contains
         value: "analysis"
     rubric:
       - "The agent proposes a fix approach that is clearly distinct from the null-check-on-adapter approach described as the existing fix"
       - "The agent creates an approach.md document explaining the difference from the existing fix"
-      - "The agent saves artifacts (result.txt, fix.diff, analysis.md) to an output directory"
+      - "Agent creates result.txt in the output directory with Pass, Fail, or Blocked"
       - "The agent reverts changes after testing using EstablishBrokenBaseline.ps1 rather than manual git commands"
-    timeout: 120
+    timeout: 900
 
   - name: "Negative trigger: code review request should not invoke try-fix workflow"
     prompt: |
@@ -103,14 +101,12 @@ scenarios:
       - type: output_not_contains
         value: "OnPageSelected"
       - type: output_contains
-        value: "Different from existing fix"
-      - type: output_contains
         value: "approach"
     rubric:
-      - "The agent acknowledges the prior failed attempt and explicitly avoids repeating the OnPageSelected approach"
+      - "Agent explicitly states it is avoiding the OnPageSelected approach because of the prior failure"
       - "The agent proposes a lifecycle-based alternative that fires before layout measurement"
       - "The approach.md clearly explains how this attempt differs from the prior failed attempt"
-    timeout: 120
+    timeout: 900
 
   - name: "Regression: agent must use EstablishBrokenBaseline script, not manual git commands"
     prompt: |
@@ -139,4 +135,22 @@ scenarios:
       - "The agent uses EstablishBrokenBaseline.ps1 to establish the baseline and restore working directory, not raw git commands"
       - "The agent does not use 'git checkout HEAD', 'git restore', or 'git reset' to revert fix files"
       - "The restore step is explicitly called after testing (whether pass or fail)"
-    timeout: 120
+    timeout: 900
+
+  - name: "Edge case: exhausted iterations records Fail with analysis"
+    prompt: |
+      Use the try-fix skill to fix a bug. Problem: CollectionView items overlap on Android.
+      Test command: pwsh .github/scripts/BuildAndRunHostApp.ps1 -Platform android -TestFilter "FullyQualifiedName~CollectionViewOverlap"
+      Target files: src/Controls/src/Core/Handlers/Items/Android/ItemsViewRenderer.cs
+      The test fails with: Assert.That(rect1.Bottom, Is.LessThanOrEqualTo(rect2.Top)) -- items visually overlap.
+      NOTE: The test environment is available but every approach will fail because the root cause is in the Android platform SDK, not in MAUI code. After 3 iterations you should report Fail.
+    assertions:
+      - type: output_contains
+        value: "Fail"
+      - type: output_not_contains
+        value: "Pass"
+    rubric:
+      - "Agent stops after exhausting 3 iterations and reports Fail"
+      - "Agent writes a failure analysis explaining why the approach did not work"
+      - "result.txt contains exactly Fail, not Blocked or Pass"
+    timeout: 900


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Improves the try-fix skill based on comprehensive evaluation (empirical + prompt analysis) and production data mining from 6 real agent-reviewed PRs.

### Changes
1. **Added tests/eval.yaml** -- 8 scenarios for empirical A/B validation (6 synthetic + 2 production-derived from PRs #33134, #32289)
2. **Fixed SKILL.md issues** -- context contradiction, hardcoded filename, iteration limits, error table, activation guard, root-cause warning, platform path warning, code fence rendering
3. **Used native spec features** -- expect_activation: false for negative trigger scenario

### Evaluation Results
- **Isolated improvement**: +51.7% (skill works when activated)
- **Dotnet Validator**: 7/10 KEEP
- **Anthropic Evaluator**: 9/10 KEEP
- **Consensus**: KEEP -- ready to merge