### PR TITLE
[net11.0] Update dependencies to preview.3 build 26202.110

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,9 +6,11 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-e1d3646-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-e1d3646d-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-5797627" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-57976277/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-6542b70" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-6542b70a/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-6542b70-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-6542b70a-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--  Begin: Package sources from dotnet-dotnet -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,35 +1,35 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.3.26166.111">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.1.99-ci.main.217">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.99.0-preview.3.10">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>b63c601edfa528cb4ad9acbcb5c9d2e1702ae09d</Sha>
+      <Sha>00489087dbe2e91cfd1b4302530c0c528d32efbb</Sha>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
-    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-10.0.100" Version="36.1.43" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-10.0.100" Version="36.1.53" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/android</Uri>
-      <Sha>350a375fc202f0072ac4191624986d8c642b93fa</Sha>
+      <Sha>1aedd2b6964f4b238f72b19526ff2913997c14b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.2" Version="26.2.11547-net11-p3">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.2" Version="26.2.11588-net11-p3">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>2be35b76389335803cf44f4a3bc771312566fee0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.2" Version="26.2.11547-net11-p3">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.2" Version="26.2.11588-net11-p3">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>2be35b76389335803cf44f4a3bc771312566fee0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.2" Version="26.2.11547-net11-p3">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.2" Version="26.2.11588-net11-p3">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>2be35b76389335803cf44f4a3bc771312566fee0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.2" Version="26.2.11547-net11-p3">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.2" Version="26.2.11588-net11-p3">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>2be35b76389335803cf44f4a3bc771312566fee0</Sha>
     </Dependency>
@@ -53,109 +53,109 @@
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Authorization" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Facebook" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Google" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components.WebView" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.JSInterop" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.3.26166.111">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="11.0.0-preview.3.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -175,37 +175,37 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26166.111">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26203.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3ccdcc4cf9b93bf3504275d4506144cf68c15b2c</Sha>
+      <Sha>ca90a9c694e4f149f919285cc0d20454520f037c</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,11 +31,11 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>10.0.20</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.3.26166.111</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.3.26203.107</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
-    <MonoPackageVersion>11.0.100-preview.3.26166.111</MonoPackageVersion>
+    <MonoPackageVersion>11.0.100-preview.3.26203.107</MonoPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.3.26166.111</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.3.26203.107</MicrosoftNETCoreAppRefPackageVersion>
     <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
@@ -43,18 +43,18 @@
     <optimizationandroidx64MIBCRuntimePackageVersion>1.0.0-prerelease.26153.1</optimizationandroidx64MIBCRuntimePackageVersion>
     <!-- Microsoft/Extensions -->
     <SystemCodeDomPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemCodeDomPackageVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsFileProvidersAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsLoggingDebugVersion>
-    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.3.26166.111</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsFileProvidersAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingDebugVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsLoggingDebugVersion>
+    <MicrosoftExtensionsPrimitivesVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsAIVersion>10.3.0</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIAbstractionsVersion>10.3.0</MicrosoftExtensionsAIAbstractionsVersion>
     <MicrosoftExtensionsHttpVersion>11.0.0-preview.2.26103.111</MicrosoftExtensionsHttpVersion>
@@ -64,14 +64,14 @@
     <MicrosoftAgentsAIWorkflowsGeneratorsVersion>1.0.0-rc2</MicrosoftAgentsAIWorkflowsGeneratorsVersion>
     <MicrosoftAgentsAIHostingVersion>1.0.0-preview.260225.1</MicrosoftAgentsAIHostingVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>36.1.99-ci.main.217</MicrosoftAndroidSdkWindowsPackageVersion>
-    <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.43</MicrosoftNETSdkAndroidManifest100100PackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>36.99.0-preview.3.10</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftNETSdkAndroidManifest100100PackageVersion>36.1.53</MicrosoftNETSdkAndroidManifest100100PackageVersion>
     <AndroidNetPreviousVersion>$(MicrosoftNetSdkAndroidManifest100100PackageVersion)</AndroidNetPreviousVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftMacCatalystSdknet110_262PackageVersion>26.2.11547-net11-p3</MicrosoftMacCatalystSdknet110_262PackageVersion>
-    <MicrosoftmacOSSdknet110_262PackageVersion>26.2.11547-net11-p3</MicrosoftmacOSSdknet110_262PackageVersion>
-    <MicrosoftiOSSdknet110_262PackageVersion>26.2.11547-net11-p3</MicrosoftiOSSdknet110_262PackageVersion>
-    <MicrosofttvOSSdknet110_262PackageVersion>26.2.11547-net11-p3</MicrosofttvOSSdknet110_262PackageVersion>
+    <MicrosoftMacCatalystSdknet110_262PackageVersion>26.2.11588-net11-p3</MicrosoftMacCatalystSdknet110_262PackageVersion>
+    <MicrosoftmacOSSdknet110_262PackageVersion>26.2.11588-net11-p3</MicrosoftmacOSSdknet110_262PackageVersion>
+    <MicrosoftiOSSdknet110_262PackageVersion>26.2.11588-net11-p3</MicrosoftiOSSdknet110_262PackageVersion>
+    <MicrosofttvOSSdknet110_262PackageVersion>26.2.11588-net11-p3</MicrosofttvOSSdknet110_262PackageVersion>
     <!-- This is a subscription of the .NET 10 latest stable versions of our packages -->
     <MicrosoftMacCatalystSdknet100_262PackageVersion>26.2.10223</MicrosoftMacCatalystSdknet100_262PackageVersion>
     <MicrosoftmacOSSdknet100_262PackageVersion>26.2.10223</MicrosoftmacOSSdknet100_262PackageVersion>
@@ -85,19 +85,19 @@
     <MicrosoftGraphicsWin2DPackageVersion>1.3.2</MicrosoftGraphicsWin2DPackageVersion>
     <MicrosoftWindowsWebView2PackageVersion>1.0.3179.45</MicrosoftWindowsWebView2PackageVersion>
     <!-- Everything else -->
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
-    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsFormsPackageVersion>
-    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsWebPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.3.26166.111</MicrosoftAspNetCoreMetadataPackageVersion>
-    <MicrosoftJSInteropPackageVersion>11.0.0-preview.3.26166.111</MicrosoftJSInteropPackageVersion>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
+    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsWebAssemblyPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsWebAssemblyServerPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>11.0.0-preview.3.26203.107</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftJSInteropPackageVersion>11.0.0-preview.3.26203.107</MicrosoftJSInteropPackageVersion>
     <!-- Everything else (previous edition) -->
     <MicrosoftAspNetCorePackageVersion>10.0.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>$(MicrosoftAspNetCorePackageVersion)</MicrosoftAspNetCoreAuthorizationPreviousPackageVersion>
@@ -147,13 +147,13 @@
     <TizenUIExtensionsVersion>0.9.0</TizenUIExtensionsVersion>
     <ExCSSPackageVersion>4.2.3</ExCSSPackageVersion>
     <SystemDrawingCommonPackageVersion>9.0.0</SystemDrawingCommonPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26166.111</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26166.111</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26166.111</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26166.111</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>11.0.0-beta.26203.107</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26203.107</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26203.107</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26203.107</MicrosoftDotNetHelixSdkPackageVersion>
     <MicroBuildPluginsSwixBuildDotnetPackageVersion>1.1.87-gba258badda</MicroBuildPluginsSwixBuildDotnetPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26166.111</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26166.111</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26203.107</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26203.107</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftNETTestSdkPackageVersion>17.6.0</MicrosoftNETTestSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,9 @@
     <AndroidSdkApiLevels Include="33" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
     <AndroidSdkApiLevels Include="35" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
-    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+    <AndroidSdkApiLevels Include="36.1" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+    <AndroidSdkApiLevels Include="37" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- arcade -->

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -6,6 +6,7 @@ Param(
   [string][Alias('v')]$verbosity = "minimal",
   [string] $msbuildEngine = $null,
   [bool] $warnAsError = $true,
+  [string] $warnNotAsError = '',
   [bool] $nodeReuse = $true,
   [switch] $buildCheck = $false,
   [switch][Alias('r')]$restore,
@@ -70,6 +71,7 @@ function Print-Usage() {
   Write-Host "  -excludeCIBinarylog     Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
+  Write-Host "  -warnNotAsError <value> Sets a semi-colon delimited list of warning codes that should not be treated as errors"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
   Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -42,6 +42,7 @@ usage()
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
+  echo "  --warnNotAsError <value> Sets a semi-colon delimited list of warning codes that should not be treated as errors"
   echo "  --buildCheck <value>     Sets /check msbuild parameter"
   echo "  --fromVMR                Set when building from within the VMR"
   echo ""
@@ -78,6 +79,7 @@ ci=false
 clean=false
 
 warn_as_error=true
+warn_not_as_error=''
 node_reuse=true
 build_check=false
 binary_log=false
@@ -174,6 +176,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -warnaserror)
       warn_as_error=$2
+      shift
+      ;;
+    -warnnotaserror)
+      warn_not_as_error=$2
       shift
       ;;
     -nodereuse)

--- a/eng/common/core-templates/job/renovate.yml
+++ b/eng/common/core-templates/job/renovate.yml
@@ -53,6 +53,30 @@ parameters:
   type: boolean
   default: false
 
+# Name of the arcade repository resource in the pipeline.
+# This allows repos which haven't been onboarded to Arcade to still use this 
+# template by checking out the repo as a resource with a custom name and pointing
+# this parameter to it.
+- name: arcadeRepoResource
+  type: string
+  default: self
+
+# Directory name for the self repo under $(Build.SourcesDirectory) in multi-checkout.
+# In multi-checkout (when arcadeRepoResource != 'self'), Azure DevOps checks out the
+# self repo to $(Build.SourcesDirectory)/<repoName>. Set this to match the auto-generated
+# directory name. Using the auto-generated name is necessary rather than explicitly
+# defining a checkout path because container jobs expect repos to live under the agent's
+# workspace ($(Pipeline.Workspace)). On some self-hosted setups the host path
+# (e.g., /mnt/vss/_work) differs from the container path (e.g., /__w), and a custom checkout
+# path can fail validation. Using the default checkout location keeps the paths consistent
+# and avoids this issue.
+- name: selfRepoName
+  type: string
+  default: ''
+- name: arcadeRepoName
+  type: string
+  default: ''
+
 # Pool configuration for the job.
 - name: pool
   type: object
@@ -71,16 +95,36 @@ jobs:
   # Changing the variable name here would require updating the name in https://github.com/dotnet/arcade/blob/main/eng/renovate.json as well.
   - name: renovateVersion
     value: '42'
+    readonly: true
+  - name: renovateLogFilePath
+    value: '$(Build.ArtifactStagingDirectory)/renovate.json'
+    readonly: true
   - name: dryRunArg
+    readonly: true
     ${{ if eq(parameters.dryRun, true) }}:
       value: 'full'
     ${{ else }}:
       value: ''
   - name: recreateWhenArg
+    readonly: true
     ${{ if eq(parameters.forceRecreatePR, true) }}:
       value: 'always'
     ${{ else }}:
       value: ''
+  # In multi-checkout (without custom paths), Azure DevOps places each repo under
+  # $(Build.SourcesDirectory)/<repoName>. selfRepoName must be provided in that case.
+  - name: selfRepoPath
+    readonly: true
+    ${{ if eq(parameters.arcadeRepoResource, 'self') }}:
+      value: '$(Build.SourcesDirectory)'
+    ${{ else }}:
+      value: '$(Build.SourcesDirectory)/${{ parameters.selfRepoName }}'
+  - name: arcadeRepoPath
+    readonly: true
+    ${{ if eq(parameters.arcadeRepoResource, 'self') }}:
+      value: '$(Build.SourcesDirectory)'
+    ${{ else }}:
+      value: '$(Build.SourcesDirectory)/${{ parameters.arcadeRepoName }}'
   pool: ${{ parameters.pool }}
   
   templateContext:
@@ -96,8 +140,19 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 1
+  
+  - ${{ if ne(parameters.arcadeRepoResource, 'self') }}:
+    - checkout: ${{ parameters.arcadeRepoResource }}
+      fetchDepth: 1
 
-  - script: renovate-config-validator $(Build.SourcesDirectory)/${{parameters.renovateConfigPath}}
+  - script: |
+      renovate-config-validator $(selfRepoPath)/${{parameters.renovateConfigPath}} 2>&1 | tee /tmp/renovate-config-validator.out
+      validatorExit=${PIPESTATUS[0]}
+      if grep -q '^ WARN:' /tmp/renovate-config-validator.out; then
+        echo "##vso[task.logissue type=warning]Renovate config validator produced warnings."
+        echo "##vso[task.complete result=SucceededWithIssues]"
+      fi
+      exit $validatorExit
     displayName: Validate Renovate config
     env:
       LOG_LEVEL: info
@@ -105,8 +160,14 @@ jobs:
       LOG_FILE: $(Build.ArtifactStagingDirectory)/renovate-config-validator.json
   
   - script: |
-      . $(Build.SourcesDirectory)/eng/common/renovate.env
-      renovate
+      . $(arcadeRepoPath)/eng/common/renovate.env
+      renovate 2>&1 | tee /tmp/renovate.out
+      renovateExit=${PIPESTATUS[0]}
+      if grep -q '^ WARN:' /tmp/renovate.out; then
+        echo "##vso[task.logissue type=warning]Renovate produced warnings."
+        echo "##vso[task.complete result=SucceededWithIssues]"
+      fi
+      exit $renovateExit
     displayName: Run Renovate
     env:
       RENOVATE_FORK_TOKEN: $(BotAccount-dotnet-renovate-bot-PAT)
@@ -117,13 +178,13 @@ jobs:
       RENOVATE_RECREATE_WHEN: $(recreateWhenArg)
       LOG_LEVEL: info
       LOG_FILE_LEVEL: debug
-      LOG_FILE: $(Build.ArtifactStagingDirectory)/renovate.json
-      RENOVATE_CONFIG_FILE: $(Build.SourcesDirectory)/${{parameters.renovateConfigPath}}
+      LOG_FILE: $(renovateLogFilePath)
+      RENOVATE_CONFIG_FILE: $(selfRepoPath)/${{parameters.renovateConfigPath}}
   
   - script: |
       echo "PRs created by Renovate:"
-      if [ -s "$(Build.ArtifactStagingDirectory)/renovate-log.json" ]; then
-        if ! jq -r 'select(.msg == "PR created" and .pr != null) | "https://github.com/\(.repository)/pull/\(.pr)"' "$(Build.ArtifactStagingDirectory)/renovate-log.json" | sort -u; then
+      if [ -s "$(renovateLogFilePath)" ]; then
+        if ! jq -r 'select(.msg == "PR created" and .pr != null) | "https://github.com/\(.repository)/pull/\(.pr)"' "$(renovateLogFilePath)" | sort -u; then
           echo "##vso[task.logissue type=warning]Failed to parse Renovate log file with jq."
           echo "##vso[task.complete result=SucceededWithIssues]"
         fi

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -15,6 +15,8 @@ jobs:
   variables:
   - name: BinlogPath
     value: ${{ parameters.binlogPath }}
+  - name: skipComponentGovernanceDetection
+    value: true
   - template: /eng/common/core-templates/variables/pool-providers.yml
     parameters:
       is1ESPipeline: ${{ parameters.is1ESPipeline }}

--- a/eng/common/core-templates/stages/renovate.yml
+++ b/eng/common/core-templates/stages/renovate.yml
@@ -35,6 +35,21 @@ parameters:
   type: boolean
   default: false
 
+# Name of the arcade repository resource in the pipeline.
+# This allows repos which haven't been onboarded to Arcade to still use this 
+# template by checking out the repo as a resource with a custom name and pointing
+# this parameter to it.
+- name: arcadeRepoResource
+  type: string
+  default: 'self'
+
+- name: selfRepoName
+  type: string
+  default: ''
+- name: arcadeRepoName
+  type: string
+  default: ''
+
 # Pool configuration for the pipeline.
 - name: pool
   type: object
@@ -69,6 +84,13 @@ extends:
     pool: ${{ parameters.pool }}
     sdl:
       sourceAnalysisPool: ${{ parameters.sdlPool }}
+      # When repos that aren't onboarded to Arcade use this template, they set the
+      # arcadeRepoResource parameter to point to their Arcade repo resource. In that case,
+      # Aracde will be excluded from SDL analysis.
+      ${{ if ne(parameters.arcadeRepoResource, 'self') }}:
+        sourceRepositoriesToScan:
+          exclude:
+          - repository: ${{ parameters.arcadeRepoResource }}
     containers:
       RenovateContainer:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-renovate-${{ parameters.renovateVersion }}-amd64
@@ -76,7 +98,7 @@ extends:
     - stage: Renovate
       displayName: Run Renovate
       jobs:
-      - template: /eng/common/core-templates/job/renovate.yml
+      - template: /eng/common/core-templates/job/renovate.yml@${{ parameters.arcadeRepoResource }}
         parameters:
           renovateConfigPath: ${{ parameters.renovateConfigPath }}
           gitHubRepo: ${{ parameters.gitHubRepo }}
@@ -84,3 +106,6 @@ extends:
           dryRun: ${{ parameters.dryRun }}
           forceRecreatePR: ${{ parameters.forceRecreatePR }}
           pool: ${{ parameters.pool }}
+          arcadeRepoResource: ${{ parameters.arcadeRepoResource }}
+          selfRepoName: ${{ parameters.selfRepoName }}
+          arcadeRepoName: ${{ parameters.arcadeRepoName }}

--- a/eng/common/renovate.env
+++ b/eng/common/renovate.env
@@ -37,3 +37,6 @@ export RENOVATE_PR_BODY_TEMPLATE='{{{header}}}{{{table}}}{{{warnings}}}{{{notes}
 # https://docs.renovatebot.com/self-hosted-configuration/#globalextends
 # Disable the Dependency Dashboard issue that tracks all updates
 export RENOVATE_GLOBAL_EXTENDS='[":disableDependencyDashboard"]'
+
+# Allow all commands for post-upgrade commands.
+export RENOVATE_ALLOWED_COMMANDS='[".*"]'

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -34,6 +34,9 @@
 # Configures warning treatment in msbuild.
 [bool]$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } else { $true }
 
+# Specifies semi-colon delimited list of warning codes that should not be treated as errors.
+[string]$warnNotAsError = if (Test-Path variable:warnNotAsError) { $warnNotAsError } else { '' }
+
 # Specifies which msbuild engine to use for build: 'vs', 'dotnet' or unspecified (determined based on presence of tools.vs in global.json).
 [string]$msbuildEngine = if (Test-Path variable:msbuildEngine) { $msbuildEngine } else { $null }
 
@@ -837,6 +840,10 @@ function MSBuild-Core() {
   }
   else {
     $cmdArgs += ' /p:TreatWarningsAsErrors=false'
+  }
+
+  if ($warnNotAsError) {
+    $cmdArgs += " /warnnotaserror:$warnNotAsError /p:AdditionalWarningsNotAsErrors=$warnNotAsError"
   }
 
   foreach ($arg in $args) {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -52,6 +52,9 @@ fi
 # Configures warning treatment in msbuild.
 warn_as_error=${warn_as_error:-true}
 
+# Specifies semi-colon delimited list of warning codes that should not be treated as errors.
+warn_not_as_error=${warn_not_as_error:-''}
+
 # True to attempt using .NET Core already that meets requirements specified in global.json
 # installed on the machine instead of downloading one.
 use_installed_dotnet_cli=${use_installed_dotnet_cli:-true}
@@ -530,7 +533,12 @@ function MSBuild-Core {
     mt_switch="-mt"
   fi
 
-  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
+  local warnnotaserror_switch=""
+  if [[ -n "$warn_not_as_error" ]]; then
+    warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=$warn_not_as_error"
+  fi
+
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch $warnnotaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 function GetDarc {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.3.26166.111"
+    "dotnet": "11.0.100-preview.3.26203.107"
   },
   "sdk": {
     "paths": [
@@ -11,7 +11,7 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26166.111",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26166.111"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26203.107",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26203.107"
   }
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -423,10 +423,13 @@ namespace Microsoft.Maui.Handlers
 						for (nuint i = 0; i < records.Count; i++)
 						{
 							var record = records.GetItem<WKWebsiteDataRecord>(i);
+							if (record is null)
+								continue;
 
 							foreach (var deleteme in cookies)
 							{
-								if (record.DisplayName.Contains(deleteme.Domain, StringComparison.Ordinal) || deleteme.Domain.Contains(record.DisplayName, StringComparison.Ordinal))
+								if (record.DisplayName is { } displayName &&
+									(displayName.Contains(deleteme.Domain, StringComparison.Ordinal) || deleteme.Domain.Contains(displayName, StringComparison.Ordinal)))
 								{
 									WKWebsiteDataStore.DefaultDataStore.RemoveDataOfTypes(record.DataTypes,
 										  new[] { record }, () => { });


### PR DESCRIPTION
Update all dotnet/dotnet, Android, and macios dependencies to match the `release/11.0.1xx-preview3` branch versions (build 26202.110).

### Changes
- **SDK**: `11.0.100-preview.3.26166.111` → `11.0.100-preview.3.26202.110`
- **Runtime**: `11.0.0-preview.3.26166.111` → `11.0.0-preview.3.26202.110`
- **Android SDK**: `36.1.99-ci.main.217` → `36.99.0-preview.3.10`
- **macios SDKs**: `26.2.11547-net11-p3` → `26.2.11587-net11-p3`
- **Arcade/Helix**: `11.0.0-beta.26166.111` → `11.0.0-beta.26202.110`

### Why
The existing Maestro bump PR (#34552) moves to preview.4, which has incompatible dependencies (`_SystemNative_IsATty` link error from runtime/macios mismatch). This PR stays on **preview.3** using the same proven versions as the `release/11.0.1xx-preview3` branch.

### Additional fix
- Fix CS8602 nullable dereference in `WebViewHandler.iOS.cs` (stricter analysis in newer SDK)