### PR TITLE
Remove disabled darc-pub-dotnet-android NuGet feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -38,8 +38,6 @@
     <add key="darc-pub-dotnet-runtime-2b2a06c8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-35c70a50/nuget/v3/index.json" />
     <!-- Added manually for dotnet/aspnet 9.0.13 -->
     <add key="darc-pub-dotnet-aspnetcore-553d4e88" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-4967d5a6/nuget/v3/index.json" />
-    <!-- Added manually for .NET 9 Android -->
-    <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 macios -->
     <add key="darc-pub-dotnet-macios-e6a0fb79" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-e6a0fb79/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
## Description

The `darc-pub-dotnet-android-1719a35b` NuGet feed has been disabled by dnceng infrastructure (HTTP 404, TF1600012: feed has been disabled). This causes every internal `dotnet-maui` build on the `net10.0` branch to fail at the `Provision JDK` step when `Provisioning.csproj` restore encounters the dead feed.

**Failing since**: At least April 4, 2026  
**Affected pipeline**: `dotnet-maui` (def 1095) on `net10.0` branch  
**Error**: `NU1301: Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json`

## Root Cause

The feed was added manually for .NET 9 Android SDK packages (`Microsoft.NET.Sdk.Android.Manifest-9.0.100` v35.0.105). Those packages have since been promoted to nuget.org and the `dotnet-public` feed, both of which are already configured as package sources in NuGet.config.

## Fix

Remove the disabled feed reference. No packages depend on it exclusively.

## Verification

Tested locally:
- **Before**: `dotnet restore src/Provisioning/Provisioning.csproj` → ❌ `NU1301` error
- **After**: `dotnet restore src/Provisioning/Provisioning.csproj` → ✅ Restored successfully

Also verified all other manually-added feeds in NuGet.config return HTTP 200 (only this one returns 404).