### PR TITLE
Skip simulator install in official pack pipeline

### DIFF
--- a/eng/pipelines/ci-official.yml
+++ b/eng/pipelines/ci-official.yml
@@ -104,6 +104,7 @@ extends:
             onlyAndroidPlatformDefaultApis: true
             skipAndroidEmulatorImages: true
             skipAndroidCreateAvds: true
+            skipSimulatorSetup: true
             skipProvisioning: true
             skipXcode: false
             base64Encode: true


### PR DESCRIPTION
The official `ci-official.yml` pack pipeline only builds and packs NuGet packages — no tests run, so simulator runtimes are not needed. The `Install Simulator Runtimes` step has been timing out on macOS agents, blocking official builds.

Adds `skipSimulatorSetup: true` to the provision parameters in the pack stage.

Backport of the same fix from `release/11.0.1xx-preview3` (#34801).