### PR TITLE
Add default .gitignore to MAUI project templates

### DIFF
--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -56,14 +56,18 @@
       <PackageDestination>$([System.String]::Concat(%(RelativeDir), '%(Filename)%(Extension)'))</PackageDestination>
       <IntermediateLocation>$(IntermediateOutputPath)$([System.String]::Concat(%(RelativeDir), '%(Filename)%(Extension)'))</IntermediateLocation>
     </TemplateJsonInput>
-    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;@(TemplateJsonInput)" />
+    <TemplateDotFile Include="templates\**\.gitignore">
+      <PackageDestination>templates\%(RecursiveDir).gitignore</PackageDestination>
+      <IntermediateLocation>$(IntermediateOutputPath)dotfiles\templates\%(RecursiveDir)gitignore.gitignore</IntermediateLocation>
+    </TemplateDotFile>
+    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;@(TemplateJsonInput);@(TemplateDotFile)" />
     <!-- Only include cgmanifest.json when GenerateCgManifest is true (for CI builds) -->
     <Content Include="cgmanifest.json" Pack="true" PackagePath="content" Condition="'$(GenerateCgManifest)' == 'true'" />
     <Compile Remove="**\*" />
   </ItemGroup>
 
   <PropertyGroup>
-    <BeforePack>_UpdateTemplateVersions</BeforePack>
+    <BeforePack>_UpdateTemplateVersions;_UpdateTemplateDotFiles</BeforePack>
   </PropertyGroup>
 
   <Target Name="_UpdateTemplateVersions" DependsOnTargets="SetVersions;LocalizeTemplatesAfterBuild"
@@ -93,6 +97,19 @@
       <Content Include="%(TemplateJsonInput.IntermediateLocation)" PackagePath="$(ContentTargetFolders)\%(TemplateJsonInput.PackageDestination)" Pack="true" />
     </ItemGroup>
 
+  </Target>
+
+  <Target Name="_UpdateTemplateDotFiles"
+      Inputs="@(TemplateDotFile)"
+      Outputs="%(TemplateDotFile.IntermediateLocation)">
+    <Copy
+        SourceFiles="%(TemplateDotFile.Fullpath)"
+        DestinationFiles="%(TemplateDotFile.IntermediateLocation)" />
+
+    <ItemGroup>
+      <FileWrites Include="%(TemplateDotFile.IntermediateLocation)" />
+      <Content Include="%(TemplateDotFile.IntermediateLocation)" PackagePath="$(ContentTargetFolders)\%(TemplateDotFile.PackageDestination)" Pack="true" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_CopyToTemplatePacks" AfterTargets="Pack">

--- a/src/Templates/src/templates/maui-blazor-solution/.gitignore
+++ b/src/Templates/src/templates/maui-blazor-solution/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs
+bin/
+obj/
+
+# User-specific files
+.vs/
+*.user
+*.suo
+
+# OS-generated files
+.DS_Store

--- a/src/Templates/src/templates/maui-blazor/.gitignore
+++ b/src/Templates/src/templates/maui-blazor/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs
+bin/
+obj/
+
+# User-specific files
+.vs/
+*.user
+*.suo
+
+# OS-generated files
+.DS_Store

--- a/src/Templates/src/templates/maui-lib/.gitignore
+++ b/src/Templates/src/templates/maui-lib/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs
+bin/
+obj/
+
+# User-specific files
+.vs/
+*.user
+*.suo
+
+# OS-generated files
+.DS_Store

--- a/src/Templates/src/templates/maui-mobile/.gitignore
+++ b/src/Templates/src/templates/maui-mobile/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs
+bin/
+obj/
+
+# User-specific files
+.vs/
+*.user
+*.suo
+
+# OS-generated files
+.DS_Store

--- a/src/Templates/src/templates/maui-multiproject/.gitignore
+++ b/src/Templates/src/templates/maui-multiproject/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs
+bin/
+obj/
+
+# User-specific files
+.vs/
+*.user
+*.suo
+
+# OS-generated files
+.DS_Store

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseTemplateTests.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BaseTemplateTests.cs
@@ -24,4 +24,16 @@ public abstract class BaseTemplateTests : BaseBuildTest
 			actual.Contains(expected, StringComparison.Ordinal),
 			$"Expected string '{actual}' to not contain '{expected}'.");
 	}
+
+	protected void AssertIncludesRootGitIgnore(string projectDir)
+	{
+		var gitIgnorePath = Path.Combine(projectDir, ".gitignore");
+
+		Assert.True(File.Exists(gitIgnorePath),
+			$"Expected '{gitIgnorePath}' to exist.");
+
+		var gitIgnoreContents = File.ReadAllText(gitIgnorePath);
+		AssertContains("bin/", gitIgnoreContents);
+		AssertContains("obj/", gitIgnoreContents);
+	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/BlazorTemplateTest.cs
@@ -5,6 +5,19 @@ public class BlazorTemplateTest : BaseTemplateTests
 {
 	public BlazorTemplateTest(IntegrationTestFixture fixture, ITestOutputHelper output) : base(fixture, output) { }
 
+	[Fact]
+	public void NewMauiBlazorWebSolutionIncludesGitIgnore()
+	{
+		SetTestIdentifier();
+		const string templateShortName = "maui-blazor-web";
+		var solutionProjectDir = TestDirectory;
+
+		Assert.True(DotnetInternal.New(templateShortName, outputDirectory: solutionProjectDir, framework: DotNetCurrent, output: _output),
+			$"Unable to create template {templateShortName}. Check test output for errors.");
+
+		AssertIncludesRootGitIgnore(solutionProjectDir);
+	}
+
 	[Theory]
 	// Parameters:  target framework, build config, dotnet new additional parameters, use tricky project name, additional dotnet build parameters
 

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/MultiProjectTemplateTest.cs
@@ -5,6 +5,18 @@ public class MultiProjectTemplateTest : BaseTemplateTests
 {
 	public MultiProjectTemplateTest(IntegrationTestFixture fixture, ITestOutputHelper output) : base(fixture, output) { }
 
+	[Fact]
+	public void NewSolutionIncludesGitIgnore()
+	{
+		SetTestIdentifier();
+		var projectDir = TestDirectory;
+
+		Assert.True(DotnetInternal.New("maui-multiproject", projectDir, DotNetCurrent, output: _output),
+			$"Unable to create template maui-multiproject. Check test output for errors.");
+
+		AssertIncludesRootGitIgnore(projectDir);
+	}
+
 	[Theory]
 	[InlineData("Debug", "simplemulti")]
 	[InlineData("Release", "simplemulti")]

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/SimpleTemplateTest.cs
@@ -56,6 +56,21 @@ public class SimpleTemplateTest : BaseTemplateTests
 	}
 
 	[Theory]
+	[InlineData("maui")]
+	[InlineData("maui-blazor")]
+	[InlineData("mauilib")]
+	public void NewProjectIncludesGitIgnore(string id)
+	{
+		SetTestIdentifier(id);
+		var projectDir = TestDirectory;
+
+		Assert.True(DotnetInternal.New(id, projectDir, DotNetCurrent, output: _output),
+			$"Unable to create template {id}. Check test output for errors.");
+
+		AssertIncludesRootGitIgnore(projectDir);
+	}
+
+	[Theory]
 	[InlineData("maui", DotNetPrevious, "Debug")]
 	public void InstallPackagesIntoUnsupportedTfmFails(string id, string framework, string config)
 	{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description of Change

Adds a default root `.gitignore` to the main MAUI project and solution templates so newly created apps start with sensible ignored build and IDE artifacts.

### What changed
- adds a minimal `.gitignore` to the `maui`, `maui-blazor`, `maui-blazor-web`, `maui-multiproject`, and `mauilib` templates
- updates template packing so leading-dot files are preserved in the packed template nupkg
- adds integration coverage to verify the generated outputs include `.gitignore`

### Issues Fixed
- Fixes #4131
