### PR TITLE
Feature/blazorwebview wpf composition control opt in

### DIFF
--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
@@ -5,7 +5,7 @@ using Microsoft.Web.WebView2.Core;
 using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
 #elif WEBVIEW2_WPF
 using Microsoft.Web.WebView2.Core;
-using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.IWebView2;
 #elif WINDOWS && WEBVIEW2_MAUI
 using Microsoft.Web.WebView2.Core;
 using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -28,7 +28,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Components.WebView.Wpf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Web.WebView2.Core;
-using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.IWebView2;
 using System.Reflection;
 #elif WEBVIEW2_MAUI
 using Microsoft.AspNetCore.Components.WebView.Maui;

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 
 			// Default to the composition control; OnUseCompositionControlPropertyChanged will
 			// update this if UseCompositionControl is set to false before the control is initialized.
-			Template = CreateWebViewTemplate(useComposition: true);
+			Template = CreateWebViewTemplate(useComposition: UseCompositionControl);
 
 			ApplyTabNavigation(IsTabStop);
 		}

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -16,7 +16,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
+using IWebView2 = Microsoft.Web.WebView2.Wpf.IWebView2;
+using WebView2CompositionControl = Microsoft.Web.WebView2.Wpf.WebView2CompositionControl;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
 
 namespace Microsoft.AspNetCore.Components.WebView.Wpf
 {
@@ -85,10 +87,19 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			propertyType: typeof(EventHandler<BlazorWebViewInitializedEventArgs>),
 			ownerType: typeof(BlazorWebView));
 
+		/// <summary>
+		/// The backing store for the <see cref="UseCompositionControl"/> property.
+		/// </summary>
+		public static readonly DependencyProperty UseCompositionControlProperty = DependencyProperty.Register(
+			name: nameof(UseCompositionControl),
+			propertyType: typeof(bool),
+			ownerType: typeof(BlazorWebView),
+			typeMetadata: new PropertyMetadata(true, OnUseCompositionControlPropertyChanged));
+
 		#endregion
 
 		private const string WebViewTemplateChildName = "WebView";
-		private WebView2Control? _webview;
+		private IWebView2? _webview;
 		private WebView2WebViewManager? _webviewManager;
 		private bool _isDisposed;
 
@@ -113,23 +124,24 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			SetValue(RootComponentsProperty, new RootComponentsCollection());
 			RootComponents.CollectionChanged += HandleRootComponentsCollectionChanged;
 
-			Template = new ControlTemplate
-			{
-				VisualTree = new FrameworkElementFactory(typeof(WebView2Control), WebViewTemplateChildName)
-			};
+			// Default to the composition control; OnUseCompositionControlPropertyChanged will
+			// update this if UseCompositionControl is set to false before the control is initialized.
+			Template = CreateWebViewTemplate(useComposition: true);
 
 			ApplyTabNavigation(IsTabStop);
 		}
 
 		/// <summary>
-		/// Returns the inner <see cref="WebView2Control"/> used by this control.
+		/// Returns the inner <see cref="IWebView2"/> used by this control.
+		/// When <see cref="UseCompositionControl"/> is <see langword="true"/> (the default), this is a
+		/// <see cref="WebView2CompositionControl"/>; otherwise it is a <see cref="WebView2Control"/>.
 		/// </summary>
 		/// <remarks>
 		/// Directly using some functionality of the inner web view can cause unexpected results because its behavior
 		/// is controlled by the <see cref="BlazorWebView"/> that is hosting it.
 		/// </remarks>
 		[Browsable(false)]
-		public WebView2Control WebView => _webview!;
+		public IWebView2 WebView => _webview!;
 
 		/// <summary>
 		/// Path to the host page within the application's static files. For example, <code>wwwroot\index.html</code>.
@@ -195,6 +207,23 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			set => SetValue(ServicesProperty, value);
 		}
 
+		/// <summary>
+		/// Gets or sets a value indicating whether to use the composition-based <see cref="WebView2CompositionControl"/>,
+		/// which resolves WPF airspace issues at the cost of additional rendering overhead, or the standard
+		/// <see cref="WebView2Control"/> for better performance in scenarios where airspace layering is not required.
+		/// Defaults to <see langword="true"/>.
+		/// </summary>
+		/// <remarks>
+		/// This property must be set before the control is initialized (e.g., in XAML or before adding the control to
+		/// the visual tree). Changing it after the underlying WebView2 has been created will throw an
+		/// <see cref="InvalidOperationException"/>.
+		/// </remarks>
+		public bool UseCompositionControl
+		{
+			get => (bool)GetValue(UseCompositionControlProperty);
+			set => SetValue(UseCompositionControlProperty, value);
+		}
+
 		private static void OnServicesPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((BlazorWebView)d).OnServicesPropertyChanged(e);
 
 		private void OnServicesPropertyChanged(DependencyPropertyChangedEventArgs e) => StartWebViewCoreIfPossible();
@@ -202,6 +231,28 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		private static void OnHostPagePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((BlazorWebView)d).OnHostPagePropertyChanged(e);
 
 		private void OnHostPagePropertyChanged(DependencyPropertyChangedEventArgs e) => StartWebViewCoreIfPossible();
+
+		private static void OnUseCompositionControlPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((BlazorWebView)d).OnUseCompositionControlPropertyChanged(e);
+
+		private void OnUseCompositionControlPropertyChanged(DependencyPropertyChangedEventArgs e)
+		{
+			if (_webview != null)
+			{
+				throw new InvalidOperationException(
+					$"The {nameof(UseCompositionControl)} property cannot be changed after the {nameof(BlazorWebView)} has been initialized.");
+			}
+
+			Template = CreateWebViewTemplate(useComposition: (bool)e.NewValue);
+		}
+
+		private static ControlTemplate CreateWebViewTemplate(bool useComposition)
+		{
+			var controlType = useComposition ? typeof(WebView2CompositionControl) : typeof(WebView2Control);
+			return new ControlTemplate
+			{
+				VisualTree = new FrameworkElementFactory(controlType, WebViewTemplateChildName)
+			};
+		}
 
 		private static void OnIsTabStopPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((BlazorWebView)d).OnIsTabStopPropertyChanged(e);
 
@@ -228,7 +279,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 
 			if (_webview == null)
 			{
-				_webview = (WebView2Control)GetTemplateChild(WebViewTemplateChildName);
+				_webview = (IWebView2)GetTemplateChild(WebViewTemplateChildName);
 				StartWebViewCoreIfPossible();
 			}
 		}
@@ -392,7 +443,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				_webviewManager = null;
 			}
 
-			_webview?.Dispose();
+			(_webview as IDisposable)?.Dispose();
 			_webview = null;
 		}
 

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -279,7 +279,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 
 			if (_webview == null)
 			{
-				_webview = (IWebView2)GetTemplateChild(WebViewTemplateChildName);
+				if (GetTemplateChild(WebViewTemplateChildName) is not IWebView2 webView)
+				{
+					throw new InvalidOperationException($"Template child '{WebViewTemplateChildName}' was not found or does not implement {nameof(IWebView2)}. Ensure the control template contains a WebView2 or WebView2CompositionControl element named '{WebViewTemplateChildName}'.");
+				}
+				_webview = webView;
 				StartWebViewCoreIfPossible();
 			}
 		}

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			if (_webview != null)
 			{
 				throw new InvalidOperationException(
-					$"The {nameof(UseCompositionControl)} property cannot be changed after the {nameof(BlazorWebView)} has been initialized.");
+					$"The {nameof(UseCompositionControl)} property cannot be changed after the underlying WebView has been created.");
 			}
 
 			Template = CreateWebViewTemplate(useComposition: (bool)e.NewValue);

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
@@ -34,10 +34,7 @@ Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.StartPath.get -> strin
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.StartPath.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.get -> bool
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2!
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControlProperty -> System.Windows.DependencyProperty!
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl!
 Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder
 Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
@@ -34,7 +34,10 @@ Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.StartPath.get -> strin
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.StartPath.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl!
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.get -> bool
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControlProperty -> System.Windows.DependencyProperty!
 Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder
 Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+*REMOVED*~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl
+*REMOVED*Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2CompositionControl!
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.get -> bool
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.set -> void

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.get -> bool
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControl.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.IWebView2!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UseCompositionControlProperty -> System.Windows.DependencyProperty!


### PR DESCRIPTION
 ### Description of Change

  This change introduces an opt‑out mechanism for using `WebView2CompositionControl` in WPF BlazorWebView scenarios.
  While `WebView2CompositionControl` resolves the WPF airspace issue, it introduces measurable rendering overhead that
  negatively impacts Razor component performance.

  For apps that *do not* require XAML‑over‑WebView layering, developers can now disable the composition control and fall
   back to the standard `WebView2`, resulting in significantly improved performance on WPF.

  This feature also addresses feedback from the original `WebView2CompositionControl` introduction
  (PR #31777: https://github.com/dotnet/maui/pull/31777)
  and community requests asking for an opt‑in/opt‑out toggle
  (Issue #28063: https://github.com/dotnet/maui/issues/28063).

  ---

  ### Issues Fixed / Related

  - Original `WebView2CompositionControl` request and discussion:
    https://github.com/dotnet/maui/issues/28063
  - Original PR introducing the control:
    https://github.com/dotnet/maui/pull/31777

  This PR enables opting out of `WebView2CompositionControl` (added in .NET 10.0 to address WPF airspace issues) in
  favor of the standard `WebView2` when airspace layering is unnecessary and lower rendering overhead is preferred.

  ---

  ### Summary of Changes

  - Added `UseCompositionControl` dependency property (default: `true`) on `BlazorWebView`, preserving existing
  behavior.
  - Updated `_webview` and the `WebView` property to use `IWebView2`, implemented by both `WebView2` and
  `WebView2CompositionControl`.
  - `CreateWebViewTemplate()` now selects the correct control type at initialization; the property‑changed callback
  updates the template if changed before the control is added to the visual tree.
  - Added an `InvalidOperationException` if `UseCompositionControl` is modified after the underlying WebView has been
  created.
  - Updated `WebView2WebViewManager` and `BlazorWebViewInitializedEventArgs` shared source to use the WPF `IWebView2`
  alias.
  - Updated **PublicAPI.Unshipped.txt** with `*REMOVED*` entries for the old `WebView2CompositionControl` return types
  and the new `IWebView2` and `UseCompositionControl` public API surface.

  ---

  ### PR Review Feedback Addressed

  - **Missing `*REMOVED*` entries in `PublicAPI.Unshipped.txt`** — Added `*REMOVED*` entries for both
  `BlazorWebViewInitializedEventArgs.WebView` and `BlazorWebView.WebView` to satisfy the API analyzer.
  - **Unsafe cast in `OnApplyTemplate()`** — Replaced the direct `(IWebView2)` cast with an `is not` pattern match that
  throws a descriptive `InvalidOperationException` if the template child is missing or the wrong type.
  - **Unit tests** — No WPF-specific test project exists in this repository; the existing `DeviceTests` project targets
  the MAUI handler layer and is not appropriate for standalone WPF control tests. A dedicated WPF test project would be
  a disproportionate investment for this change and has been deferred.
  - **`WebView` return type / source compatibility** — The change from `WebView2CompositionControl!` to `IWebView2!` is
  intentional and documented. The proposed alternative (keeping `WebView` as `WebView2CompositionControl?` and adding a
  `WebViewBase` property) would itself be a breaking change (nullable return) and would produce a confusing two-property
   API. Callers relying on `WebView2CompositionControl`-specific members can cast explicitly.

  ---

  ### Notes

  This is **not** a bug fix; it is a feature/performance enhancement.