### PR TITLE
[Windows] Lifecycle: Add app activation event

### DIFF
--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages;
 using Maui.Controls.Sample.Services;
@@ -29,6 +30,8 @@ using Microsoft.Maui.Controls.Compatibility.Hosting;
 #if ANDROID
 using Android.Gms.Common;
 using Android.Gms.Maps;
+#elif WINDOWS
+using Microsoft.Windows.AppLifecycle;
 #endif
 
 namespace Maui.Controls.Sample
@@ -286,6 +289,7 @@ namespace Maui.Controls.Sample
 					events.AddWindows(windows => windows
 						// .OnPlatformMessage((a, b) => 
 						//	LogEvent(nameof(WindowsLifecycle.OnPlatformMessage)))
+						.OnAppActivation((application, args) => HandleWindowsAppActivation(application, args))
 						.OnActivated((a, b) => LogEvent(nameof(WindowsLifecycle.OnActivated)))
 						.OnClosed((a, b) => LogEvent(nameof(WindowsLifecycle.OnClosed)))
 						.OnLaunched((a, b) => LogEvent(nameof(WindowsLifecycle.OnLaunched)))
@@ -310,6 +314,34 @@ namespace Maui.Controls.Sample
 						Debug.WriteLine($"Lifecycle event: {eventName}{(type == null ? "" : $" ({type})")}");
 						return true;
 					}
+
+#if WINDOWS
+					static bool HandleWindowsAppActivation(Microsoft.UI.Xaml.Application application, AppActivationArguments args)
+					{
+						LogEvent(nameof(WindowsLifecycle.OnAppActivation), args.Kind.ToString());
+
+						// This sample opts into single-instancing from the MAUI lifecycle callback
+						// instead of a custom Program.cs entry point.
+						var keyInstance = AppInstance.FindOrRegisterForKey("Maui.Controls.Sample");
+
+						if (!keyInstance.IsCurrent)
+						{
+							// The WinAppSDK single-instance guidance redirects the activation and then
+							// terminates the losing instance immediately. Using Kill here avoids leaving
+							// a headless process around that can continue to hold build outputs open.
+							keyInstance.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
+							Process.GetCurrentProcess().Kill();
+							return true;
+						}
+
+						if (Application.Current?.Windows.FirstOrDefault() is Window window)
+							// Redirected activations can arrive off the UI thread, so hop through the
+							// MAUI window dispatcher before re-activating the existing window.
+							window.Dispatcher.Dispatch(() => Application.Current.ActivateWindow(window));
+
+						return false;
+					}
+#endif
 				});
 
 			// Adapt to dual-screen and foldable Android devices like Surface Duo, includes TwoPaneView layout control

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
@@ -1,7 +1,10 @@
-﻿namespace Microsoft.Maui.LifecycleEvents
+using Microsoft.Windows.AppLifecycle;
+
+namespace Microsoft.Maui.LifecycleEvents
 {
 	public static class WindowsLifecycle
 	{
+		public delegate bool OnAppActivation(UI.Xaml.Application application, AppActivationArguments args);
 		public delegate void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs args);
 		public delegate void OnClosed(UI.Xaml.Window window, UI.Xaml.WindowEventArgs args);
 		public delegate void OnLaunched(UI.Xaml.Application application, UI.Xaml.LaunchActivatedEventArgs args);

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
@@ -2,6 +2,7 @@
 {
 	public static class WindowsLifecycleBuilderExtensions
 	{
+		public static IWindowsLifecycleBuilder OnAppActivation(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnAppActivation del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnActivated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnActivated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnClosed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnClosed del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnLaunching(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnLaunching del) => lifecycle.OnEvent(del);

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
+using Microsoft.Windows.AppLifecycle;
 
 namespace Microsoft.Maui
 {
@@ -20,9 +21,17 @@ namespace Microsoft.Maui
 
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)
 		{
-			// Windows running on a different thread will "launch" the app again
+			LaunchActivatedEventArgs = args;
+
+			var launchActivation = AppInstance.GetCurrent().GetActivatedEventArgs();
+
+			// A running WinUI app can be activated again without rebuilding the MAUI application.
+			// Reuse the existing services and let activation handlers short-circuit the relaunch path.
 			if (_application != null && _services != null)
 			{
+				if (launchActivation is AppActivationArguments activatedEventArgs && OnAppActivation(activatedEventArgs))
+					return;
+
 				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 				_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 				return;
@@ -37,6 +46,14 @@ namespace Microsoft.Maui
 
 			_services = applicationContext.Services;
 
+			// Future AppInstance activation callbacks need the app-level services to exist first.
+			RegisterForAppActivation();
+
+			// Run the initial activation after services are available, but before OnLaunching/window creation,
+			// so handlers can redirect or suppress the default startup flow.
+			if (launchActivation is AppActivationArguments initialActivation && OnAppActivation(initialActivation))
+				return;
+
 			_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 
 			_application = _services.GetRequiredService<IApplication>();
@@ -48,9 +65,40 @@ namespace Microsoft.Maui
 			_services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 		}
 
+		protected virtual bool OnAppActivation(AppActivationArguments args)
+		{
+			var wasHandled = false;
+
+			_services?.InvokeLifecycleEvents<WindowsLifecycle.OnAppActivation>(del =>
+			{
+				// Preserve any earlier "handled" result so multiple listeners can participate safely.
+				wasHandled = del(this, args) || wasHandled;
+			});
+
+			return wasHandled;
+		}
+
+		void RegisterForAppActivation()
+		{
+			if (_isRegisteredForAppActivation)
+				return;
+
+			_isRegisteredForAppActivation = true;
+
+			// After startup, later file/protocol/redirected activations are delivered through AppInstance.
+			AppInstance.GetCurrent().Activated += OnAppInstanceActivated;
+
+			void OnAppInstanceActivated(object? sender, AppActivationArguments args)
+			{
+				OnAppActivation(args);
+			}
+		}
+
 		public static new MauiWinUIApplication Current => (MauiWinUIApplication)UI.Xaml.Application.Current;
 
 		public UI.Xaml.LaunchActivatedEventArgs LaunchActivatedEventArgs { get; protected set; } = null!;
+
+		bool _isRegisteredForAppActivation;
 
 		IServiceProvider? _services;
 

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,6 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppActivation
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
+static Microsoft.Maui.LifecycleEvents.WindowsLifecycleBuilderExtensions.OnAppActivation(this Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder! lifecycle, Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppActivation! del) -> Microsoft.Maui.LifecycleEvents.IWindowsLifecycleBuilder!
+virtual Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppActivation.Invoke(Microsoft.UI.Xaml.Application! application, Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool
+virtual Microsoft.Maui.MauiWinUIApplication.OnAppActivation(Microsoft.Windows.AppLifecycle.AppActivationArguments! args) -> bool

--- a/src/Core/tests/UnitTests/LifecycleEvents/LifecycleEventsTests.cs
+++ b/src/Core/tests/UnitTests/LifecycleEvents/LifecycleEventsTests.cs
@@ -161,6 +161,49 @@ namespace Microsoft.Maui.UnitTests.LifecycleEvents
 			Assert.Equal(1, event2Fired);
 		}
 
+#if WINDOWS
+		[Fact]
+		public void CanAddWindowsOnAppActivationLifecycleEvent()
+		{
+			var firstHandlerCalled = false;
+			var secondHandlerCalled = false;
+			var wasHandled = false;
+
+			var mauiApp = MauiApp.CreateBuilder()
+				.ConfigureLifecycleEvents(builder =>
+				{
+					builder.AddWindows(windows =>
+					{
+						windows.OnAppActivation((application, args) =>
+						{
+							firstHandlerCalled = true;
+							return false;
+						});
+
+						windows.OnAppActivation((application, args) =>
+						{
+							secondHandlerCalled = true;
+							return true;
+						});
+					});
+				})
+				.Build();
+
+			var service = mauiApp.Services.GetRequiredService<ILifecycleEventService>();
+
+			Assert.True(service.ContainsEvent(nameof(WindowsLifecycle.OnAppActivation)));
+
+			service.InvokeEvents<WindowsLifecycle.OnAppActivation>(nameof(WindowsLifecycle.OnAppActivation), del =>
+			{
+				wasHandled = del(null!, null!) || wasHandled;
+			});
+
+			Assert.True(firstHandlerCalled);
+			Assert.True(secondHandlerCalled);
+			Assert.True(wasHandled);
+		}
+#endif
+
 #if ANDROID
 		[Fact]
 		public void CanAddAndroidOnKeyDownLifecycleEvent()


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

On Windows, MAUI exposed launch and window lifecycle hooks but not the underlying `AppActivationArguments` payload. That made single-instance redirect, protocol or file activation, and follow-on Windows auth work harder to handle cleanly from `MauiProgram` without app-specific plumbing.

### Description of Change

This PR adds a new Windows lifecycle hook:

- `WindowsLifecycle.OnAppActivation(UI.Xaml.Application, AppActivationArguments) -> bool`
- `IWindowsLifecycleBuilder.OnAppActivation(...)`

`MauiWinUIApplication` now:

- captures the initial `AppInstance.GetActivatedEventArgs()` payload,
- registers once for `AppInstance.GetCurrent().Activated`,
- raises the new lifecycle event once MAUI services are available,
- respects the handler return value so apps can mark an activation as handled and suppress the default launch flow when appropriate.

The Controls sample demonstrates using this from `MauiProgram` to keep the app single-instanced, redirect later launches back into the running instance, and re-activate the existing MAUI window. The redirected losing instance follows the WinAppSDK single-instance pattern and terminates immediately after `RedirectActivationToAsync(...)`.

### Key Technical Details

- Initial activation is raised after `_services = applicationContext.Services` so lifecycle handlers can actually run.
- Redirected activations and later re-activations flow through the same `OnAppActivation` hook.
- Registration is guarded so `AppInstance.Activated` is only subscribed once.

### What NOT to Do (for future agents)

- ❌ **Don't call the activation lifecycle hook before `_services` exists** - it becomes a no-op because the lifecycle pipeline has not been built yet.
- ❌ **Don't bake WebAuthenticator-specific behavior into `MauiWinUIApplication`** - this PR intentionally keeps the API generic.
- ❌ **Don't require a custom Windows `Program.cs` just to observe app activation in a MAUI app** - the goal here is a reusable lifecycle event from `MauiProgram`.

### Issues Fixed

Related to #9973

### Testing

- `dotnet build src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj -f net10.0-windows10.0.20348.0 /p:RestoreIgnoreFailedSources=true /p:NuGetAudit=false /p:WarningsNotAsErrors=NU1301;NU1801 /p:TreatWarningsAsErrors=false`
- `dotnet test src\Core\tests\UnitTests\Core.UnitTests.csproj --filter LifecycleEventsTests /p:RestoreIgnoreFailedSources=true /p:NuGetAudit=false /p:WarningsNotAsErrors=NU1301;NU1801 /p:TreatWarningsAsErrors=false`