### PR TITLE
[Android] Fix CollectionView dynamic item sizing reset after scroll

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -43,13 +43,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			itemsView.RemoveLogicalChild(View);
 
-			// Disconnect and clear the handler via ItemContentView.Recycle(), which calls
-			// DisconnectHandlers() before releasing Content. Reset _selectedTemplate so the
-			// next Bind() call always goes through the templateChanging path and recreates
-			// the handler (since we just disconnected it).
+			// Disconnect the current handler and release the platform content. We keep the
+			// existing View/_selectedTemplate references so the next Bind() can decide whether
+			// it needs to re-realize the same templated view or create a new one.
 			_itemContentView.Recycle();
-			View = null; // clear reference to the disconnected view
-			_selectedTemplate = null; // force templateChanging=true on next Bind() to recreate the view
 		}
 
 		public void Bind(object itemBindingContext, ItemsView itemsView,
@@ -90,8 +87,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (!templateChanging)
 			{
-				// Same template, new data
+				// Same template — update binding context. If the handler was disconnected
+				// during recycle, re-realize the existing view to reconnect platform content
+				// without losing any runtime property changes (e.g. dynamic HeightRequest).
 				View.BindingContext = itemBindingContext;
+
+				if (View?.Handler is null)
+				{
+					PropertyPropagationExtensions.PropagatePropertyChanged(null, View, itemsView);
+					_itemContentView.RealizeContent(View, itemsView);
+				}
 			}
 
 			itemsView.AddLogicalChild(View);

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34783.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34783.cs
@@ -1,0 +1,136 @@
+using System.Collections.ObjectModel;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34783, "CollectionView Dynamic item sizing - After dragging the scrollbar all images return to their original size", PlatformAffected.Android)]
+public class Issue34783 : ContentPage
+{
+	public Issue34783()
+	{
+		BindingContext = new Issue34783ViewModel();
+
+		var grid = new Grid
+		{
+			Margin = new Thickness(20),
+			RowDefinitions = new RowDefinitionCollection
+			{
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Auto },
+				new RowDefinition { Height = GridLength.Star }
+			}
+		};
+
+		var instructions = new StackLayout
+		{
+			Children =
+			{
+				new Label { Text = "1.Confirm that the CollectionView below is populated with monkeys and can be scrolled." },
+				new Label { Text = "2.The test passes if tapping each image dynamically changes its size." }
+			}
+		};
+
+		var tapLabel = new Label { Text = "Tap each image to dynamically change its size." };
+
+		var itemTemplate = new DataTemplate(() =>
+		{
+			var innerGrid = new Grid { Padding = new Thickness(10) };
+			innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			innerGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			innerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+			innerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
+
+			var image = new Image
+			{
+				Aspect = Aspect.AspectFill,
+				HeightRequest = 60,
+				WidthRequest = 60
+			};
+			image.SetBinding(Image.SourceProperty, new Binding("ImageUrl"));
+			image.SetBinding(Image.AutomationIdProperty, new Binding("Name"));
+
+			var tapGesture = new TapGestureRecognizer();
+			tapGesture.Tapped += OnImageTapped;
+			image.GestureRecognizers.Add(tapGesture);
+
+			Grid.SetRowSpan(image, 2);
+
+			var nameLabel = new Label { FontAttributes = FontAttributes.Bold };
+			nameLabel.SetBinding(Label.TextProperty, new Binding("Name"));
+			Grid.SetColumn(nameLabel, 1);
+
+			var locationLabel = new Label
+			{
+				FontAttributes = FontAttributes.Italic,
+				VerticalOptions = LayoutOptions.End
+			};
+			locationLabel.SetBinding(Label.TextProperty, new Binding("Location"));
+			Grid.SetRow(locationLabel, 1);
+			Grid.SetColumn(locationLabel, 1);
+
+			innerGrid.Children.Add(image);
+			innerGrid.Children.Add(nameLabel);
+			innerGrid.Children.Add(locationLabel);
+
+			return innerGrid;
+		});
+
+		var collectionView = new CollectionView
+		{
+			AutomationId = "Issue34783CollectionView",
+			ItemTemplate = itemTemplate
+		};
+		collectionView.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Monkeys"));
+
+		Grid.SetRow(tapLabel, 1);
+		Grid.SetRow(collectionView, 2);
+
+		grid.Children.Add(instructions);
+		grid.Children.Add(tapLabel);
+		grid.Children.Add(collectionView);
+
+		Content = grid;
+	}
+
+	void OnImageTapped(object sender, EventArgs e)
+	{
+		if (sender is Image image)
+			image.HeightRequest = image.WidthRequest = image.HeightRequest.Equals(60) ? 100 : 60;
+	}
+}
+
+public class Issue34783Monkey
+{
+	public string Name { get; set; }
+	public string Location { get; set; }
+	public string Details { get; set; }
+	public string ImageUrl { get; set; }
+}
+
+public class Issue34783ViewModel
+{
+	public ObservableCollection<Issue34783Monkey> Monkeys { get; set; }
+
+	public Issue34783ViewModel()
+	{
+		Monkeys = new ObservableCollection<Issue34783Monkey>
+		{
+			new Issue34783Monkey { Name = "Baboon",               Location = "Africa & Asia",               ImageUrl = "papio.jpg" },
+			new Issue34783Monkey { Name = "Capuchin Monkey",      Location = "Central & South America",     ImageUrl = "capuchin.jpg" },
+			new Issue34783Monkey { Name = "Blue Monkey",          Location = "Central and East Africa",     ImageUrl = "bluemonkey.jpg" },
+			new Issue34783Monkey { Name = "Squirrel Monkey",      Location = "Central & South America",     ImageUrl = "saimiri.jpg" },
+			new Issue34783Monkey { Name = "Golden Lion Tamarin",  Location = "Brazil",                      ImageUrl = "golden.jpg" },
+			new Issue34783Monkey { Name = "Howler Monkey",        Location = "South America",               ImageUrl = "alouatta.jpg" },
+			new Issue34783Monkey { Name = "Japanese Macaque",     Location = "Japan",                       ImageUrl = "papio.jpg" },
+			new Issue34783Monkey { Name = "Mandrill",             Location = "Central Africa",              ImageUrl = "capuchin.jpg" },
+			new Issue34783Monkey { Name = "Proboscis Monkey",     Location = "Borneo",                      ImageUrl = "bluemonkey.jpg" },
+			new Issue34783Monkey { Name = "Red-shanked Douc",     Location = "Vietnam, Laos",               ImageUrl = "saimiri.jpg" },
+			new Issue34783Monkey { Name = "Gray-shanked Douc",    Location = "Vietnam",                     ImageUrl = "golden.jpg" },
+			new Issue34783Monkey { Name = "Snub-nosed Monkey",    Location = "China",                       ImageUrl = "alouatta.jpg" },
+			new Issue34783Monkey { Name = "Black Snub-nosed",     Location = "China",                       ImageUrl = "papio.jpg" },
+			new Issue34783Monkey { Name = "Tonkin Monkey",        Location = "Vietnam",                     ImageUrl = "capuchin.jpg" },
+			new Issue34783Monkey { Name = "Thomas Langur",        Location = "Indonesia",                   ImageUrl = "bluemonkey.jpg" },
+			new Issue34783Monkey { Name = "Purple-faced Langur",  Location = "Sri Lanka",                   ImageUrl = "saimiri.jpg" },
+			new Issue34783Monkey { Name = "Gelada",               Location = "Ethiopia",                    ImageUrl = "golden.jpg" },
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34783.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34783.cs
@@ -24,8 +24,8 @@ public class Issue34783 : ContentPage
 		{
 			Children =
 			{
-				new Label { Text = "1.Confirm that the CollectionView below is populated with monkeys and can be scrolled." },
-				new Label { Text = "2.The test passes if tapping each image dynamically changes its size." }
+				new Label { Text = "1. Confirm that the CollectionView below is populated with monkeys and can be scrolled." },
+				new Label { Text = "2. Tap an image to dynamically change its size, then scroll it off-screen and back on-screen. The test passes if the resized image stays resized." }
 			}
 		};
 

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34783.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_CATALYST // Issue34783 is flaky on MacCatalyst due to non-deterministic scroll-recycle timing.
+#if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS // Android-only fix; exclude MacCatalyst (flaky) and Windows (scroll doesn't recycle items)
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34783.cs
@@ -1,0 +1,48 @@
+#if TEST_FAILS_ON_CATALYST // Issue34783 is flaky on MacCatalyst due to non-deterministic scroll-recycle timing.
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34783 : _IssuesUITest
+{
+	public override string Issue => "CollectionView Dynamic item sizing - After dragging the scrollbar all images return to their original size";
+
+	public Issue34783(TestDevice device) : base(device) { }
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void ImagesKeepSizeAfterScrolling()
+	{
+		// Wait for the CollectionView to load; first item "Baboon" image is used as the anchor
+		App.WaitForElement("Baboon");
+
+		// Record the initial rendered height of the first image (should be ~60)
+		var initialRect = App.WaitForElement("Baboon").GetRect();
+
+		// Tap the first image to enlarge it (60 → 100) using coordinates to reliably
+		// hit the Image element (which has a TapGestureRecognizer, not a Button click)
+		App.TapCoordinates(initialRect.X + initialRect.Width / 2, initialRect.Y + initialRect.Height / 2);
+
+		// Confirm the image has grown
+		var enlargedRect = App.WaitForElement("Baboon").GetRect();
+		Assert.That(enlargedRect.Height, Is.GreaterThan(initialRect.Height),
+			"Image should be enlarged after tap");
+
+		// Scroll down to push the first item off screen (simulates dragging the scrollbar,
+		// which triggers RecyclerView item recycling on Android)
+		App.ScrollDown("Issue34783CollectionView", ScrollStrategy.Gesture, 0.9);
+
+		// Scroll back up to bring Baboon back into view
+		App.ScrollUp("Issue34783CollectionView", ScrollStrategy.Gesture, 0.9);
+		App.ScrollUp("Issue34783CollectionView", ScrollStrategy.Gesture, 0.9);
+
+		// Verify the image is still at the enlarged size and was not reset to the original
+		App.WaitForElement("Baboon");
+		var afterScrollRect = App.WaitForElement("Baboon").GetRect();
+		Assert.That(afterScrollRect.Height, Is.GreaterThan(initialRect.Height),
+			"Image should keep its enlarged size after scrolling; resetting to original size is the bug");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34783.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34783.cs
@@ -25,14 +25,20 @@ public class Issue34783 : _IssuesUITest
 		// hit the Image element (which has a TapGestureRecognizer, not a Button click)
 		App.TapCoordinates(initialRect.X + initialRect.Width / 2, initialRect.Y + initialRect.Height / 2);
 
-		// Confirm the image has grown
-		var enlargedRect = App.WaitForElement("Baboon").GetRect();
-		Assert.That(enlargedRect.Height, Is.GreaterThan(initialRect.Height),
-			"Image should be enlarged after tap");
+		// Confirm the image has grown; layout/measure can complete asynchronously after the tap
+		App.RetryAssert(() =>
+		{
+			var enlargedRect = App.WaitForElement("Baboon").GetRect();
+			Assert.That(enlargedRect.Height, Is.GreaterThan(initialRect.Height),
+				"Image should be enlarged after tap");
+		});
 
 		// Scroll down to push the first item off screen (simulates dragging the scrollbar,
 		// which triggers RecyclerView item recycling on Android)
 		App.ScrollDown("Issue34783CollectionView", ScrollStrategy.Gesture, 0.9);
+
+		// Verify "Baboon" has left the viewport, confirming RecyclerView recycling will occur
+		App.WaitForNoElement("Baboon");
 
 		// Scroll back up to bring Baboon back into view
 		App.ScrollUp("Issue34783CollectionView", ScrollStrategy.Gesture, 0.9);


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

After tapping CollectionView images to dynamically resize them, scrolling items off-screen and back causes all images to reset to their original size. 

This is a **failure on the candidate branch**. A PR was previously created against inflight/candidate: https://github.com/dotnet/maui/pull/34828. It was closed when the inflight PR was merged into main. A new PR has now been created targeting main.

### Regression Details
The regression was introduced by PR #34534.

### Root Cause

In PR #34534, TemplatedItemViewHolder.Recycle() set View = null and _selectedTemplate = null, which forced Bind() to recreate the view from the DataTemplate on every scroll recycle. Since the template defines HeightRequest = 60, any runtime size changes made by the user were lost.

### Description of Change

- Recycle(): Removed View = null and _selectedTemplate = null. Now only _itemContentView.Recycle() is called, which disconnects the native handler while preserving the MAUI view reference.

- Bind(): Added a View?.Handler is null check within the existing if (!templateChanging) block. When the handler has been disconnected during recycle and the template has not changed, PropagatePropertyChanged and RealizeContent(View, itemsView) are invoked to reconnect the native handler to the existing MAUI view, preserving runtime property changes without recreating the view.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/34783

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/0befe25b-8467-4de7-a5da-926b61d783a3"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/6b3368a4-ea7c-4124-8a68-d8dc0bb3c2b9"> |