### PR TITLE
[Testing] Fixed Build error on inflight/ candidate PR 34885

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34310.cs
@@ -6,7 +6,7 @@ using AFrameLayout = Android.Widget.FrameLayout;
 using UIKit;
 #elif WINDOWS
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
+using WGrid = Microsoft.UI.Xaml.Controls.Grid;
 #endif
 #nullable enable
 using Microsoft.Maui.Handlers;
@@ -217,7 +217,7 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 	}
 }
 #elif WINDOWS
-public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, Grid>
+public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostView, WGrid>
 {
 	UIElement? _nativeChild;
 	View? _previousHostedView;
@@ -230,16 +230,16 @@ public class Issue34310NativeHostViewHandler : ViewHandler<Issue34310NativeHostV
 
 	public Issue34310NativeHostViewHandler() : base(Mapper) { }
 
-	protected override Grid CreatePlatformView()
-		=> new Grid();
+	protected override WGrid CreatePlatformView()
+		=> new WGrid();
 
-	protected override void ConnectHandler(Grid platformView)
+	protected override void ConnectHandler(WGrid platformView)
 	{
 		base.ConnectHandler(platformView);
 		UpdateHostedView();
 	}
 
-	protected override void DisconnectHandler(Grid platformView)
+	protected override void DisconnectHandler(WGrid platformView)
 	{
 		RemoveNativeChild();
 		base.DisconnectHandler(platformView);


### PR DESCRIPTION
 
This pull request updates the Windows-specific handler in `Issue34310.cs` to use an alias (`WGrid`) for `Microsoft.UI.Xaml.Controls.Grid`, improving code clarity and consistency across the file.

**Windows handler type aliasing and usage:**

* Introduced the `WGrid` alias for `Microsoft.UI.Xaml.Controls.Grid` to clarify platform-specific usage and replaced all direct references to `Grid` with `WGrid` in the Windows handler (`Issue34310NativeHostViewHandler`). [[1]](diffhunk://#diff-08c1725ba487aaecb24e2638d9a9767cfeaf27b0e1af0100a3ebdcfe876d2d18L9-R9) [[2]](diffhunk://#diff-08c1725ba487aaecb24e2638d9a9767cfeaf27b0e1af0100a3ebdcfe876d2d18L220-R220) [[3]](diffhunk://#diff-08c1725ba487aaecb24e2638d9a9767cfeaf27b0e1af0100a3ebdcfe876d2d18L233-R242)

Candidate PR:
https://github.com/dotnet/maui/pull/34885 