### PR TITLE
Fix XML doc build suggestions for enum remarks and unresolved inheritdoc

### DIFF
--- a/src/Controls/src/Core/GradientStop.cs
+++ b/src/Controls/src/Core/GradientStop.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Maui.Controls
 			Offset = offset;
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether the specified object is equal to the current <see cref="GradientStop"/>, using an approximate comparison for <see cref="Offset"/>.</summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns><see langword="true"/> if the specified object is a <see cref="GradientStop"/> with the same <see cref="Color"/> and an <see cref="Offset"/> value within a small tolerance of the current object; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object obj)
 		{
 			if (!(obj is GradientStop dest))
@@ -49,7 +51,8 @@ namespace Microsoft.Maui.Controls
 			return Color == dest.Color && global::System.Math.Abs(Offset - dest.Offset) < 0.00001;
 		}
 
-		/// <inheritdoc/>
-		public override int GetHashCode() => base.GetHashCode();
+		/// <summary>Serves as the default hash function.</summary>
+		/// <returns>A hash code for the current object.</returns>
+		public override int GetHashCode() => Color is null ? 0 : Color.GetHashCode();
 	}
 }

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
@@ -5,8 +5,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 	/// </summary>
 	public enum UIModalPresentationStyle
 	{
-		/// <summary>The content is displayed in a manner that covers the screen.</summary>
-		/// <remarks>The views belonging to the presenting view controller are removed after the presentation completes.</remarks>
+		/// <summary>The content is displayed in a manner that covers the screen. The views belonging to the presenting view controller are removed after the presentation completes.</summary>
 		FullScreen,
 
 		/// <summary>The content is displayed in the center of the screen.</summary>
@@ -15,8 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <summary>The system selects an appropriate presentation style for the view controller.</summary>
 		Automatic,
 
-		/// <summary>The content is displayed in a manner that covers the screen.</summary>
-		/// <remarks>The views belonging to the presenting view controller are not removed after the presentation completes.</remarks>
+		/// <summary>The content is displayed in a manner that covers the screen. The views belonging to the presenting view controller are not removed after the presentation completes.</summary>
 		OverFullScreen,
 
 		/// <summary>The content is displayed in a popover view.</summary>

--- a/src/Controls/src/Core/Shell/ShellAppearance.cs
+++ b/src/Controls/src/Core/Shell/ShellAppearance.cs
@@ -98,7 +98,9 @@ namespace Microsoft.Maui.Controls
 				_doubleArray[i] = -1;
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether the specified object is equal to the current <see cref="ShellAppearance"/>.</summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object obj)
 		{
 			if (!(obj is ShellAppearance appearance))
@@ -125,7 +127,8 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Serves as the default hash function.</summary>
+		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()
 		{
 			var hashCode = -1988429770;

--- a/src/Controls/src/Core/SolidColorBrush.cs
+++ b/src/Controls/src/Core/SolidColorBrush.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ColorProperty, value);
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether the specified object is equal to the current <see cref="SolidColorBrush"/>.</summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object obj)
 		{
 			if (!(obj is SolidColorBrush dest))
@@ -51,7 +53,8 @@ namespace Microsoft.Maui.Controls
 			return Equals(Color, dest.Color);
 		}
 
-		/// <inheritdoc/>
-		public override int GetHashCode() => base.GetHashCode();
+		/// <summary>Serves as the default hash function.</summary>
+		/// <returns>A hash code for the current object.</returns>
+		public override int GetHashCode() => Color?.GetHashCode() ?? 0;
 	}
 }

--- a/src/Core/maps/src/Converters/MapSpanTypeConverter.cs
+++ b/src/Core/maps/src/Converters/MapSpanTypeConverter.cs
@@ -17,15 +17,25 @@ namespace Microsoft.Maui.Maps
 	/// </remarks>
 	public class MapSpanTypeConverter : TypeConverter
 	{
-		/// <inheritdoc/>
+		/// <summary>Determines whether conversion is possible from the specified type to <see cref="MapSpan"/>.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="sourceType">The source type to check.</param>
+		/// <returns><see langword="true"/> if the source type is <see cref="string"/>; otherwise, <see langword="false"/>.</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
 			=> sourceType == typeof(string);
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether conversion is possible from <see cref="MapSpan"/> to the specified type.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="destinationType">The destination type to check.</param>
+		/// <returns><see langword="true"/> if the destination type is <see cref="string"/>; otherwise, <see langword="false"/>.</returns>
 		public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
 			=> destinationType == typeof(string);
 
-		/// <inheritdoc/>
+		/// <summary>Converts a string representation to a <see cref="MapSpan"/> object.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="culture">The culture info.</param>
+		/// <param name="value">The value to convert, expected in the format <c>"latitude,longitude,latitudeDegrees,longitudeDegrees"</c>.</param>
+		/// <returns>A <see cref="MapSpan"/> object parsed from the string value.</returns>
 		public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
 		{
 			var strValue = value?.ToString()?.Trim();
@@ -47,7 +57,12 @@ namespace Microsoft.Maui.Maps
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(MapSpan)}");
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Converts a <see cref="MapSpan"/> object to a string representation.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="culture">The culture info.</param>
+		/// <param name="value">The <see cref="MapSpan"/> value to convert.</param>
+		/// <param name="destinationType">The destination type (must be <see cref="string"/>).</param>
+		/// <returns>A string in the format <c>"latitude,longitude,latitudeDegrees,longitudeDegrees"</c>.</returns>
 		public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
 		{
 			if (value is not MapSpan span)

--- a/src/Core/maps/src/Primitives/Distance.cs
+++ b/src/Core/maps/src/Primitives/Distance.cs
@@ -119,7 +119,9 @@ namespace Microsoft.Maui.Maps
 			return Meters.Equals(other.Meters);
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether the specified object is equal to the current <see cref="Distance"/>.</summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object? obj)
 		{
 			if (obj is null)
@@ -127,7 +129,8 @@ namespace Microsoft.Maui.Maps
 			return obj is Distance && Equals((Distance)obj);
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Serves as the default hash function.</summary>
+		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()
 		{
 			return Meters.GetHashCode();

--- a/src/Core/maps/src/Primitives/MapSpan.cs
+++ b/src/Core/maps/src/Primitives/MapSpan.cs
@@ -71,7 +71,9 @@ namespace Microsoft.Maui.Maps
 			return new MapSpan(new Location(lat, Center.Longitude), Math.Min(LatitudeDegrees, maxDLat), LongitudeDegrees);
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether the specified object is equal to the current <see cref="MapSpan"/>.</summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns><see langword="true"/> if the specified object is equal to the current object; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object? obj)
 		{
 			if (obj is null)
@@ -152,7 +154,8 @@ namespace Microsoft.Maui.Maps
 			return new MapSpan(new Location(centerLat, centerLon), latDegrees, lonDegrees);
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Serves as the default hash function.</summary>
+		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()
 		{
 			unchecked
@@ -229,7 +232,8 @@ namespace Microsoft.Maui.Maps
 			return latCircumference * longitudeDegrees / 360;
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Returns a string representation of the <see cref="MapSpan"/>.</summary>
+		/// <returns>A string that represents the current <see cref="MapSpan"/>.</returns>
 		public override string ToString()
 		{
 			return $"{Center}, {LatitudeDegrees}, {LongitudeDegrees}";

--- a/src/Core/src/Primitives/GridUnitType.cs
+++ b/src/Core/src/Primitives/GridUnitType.cs
@@ -12,10 +12,8 @@ public enum GridUnitType
 
 	/// <summary>
 	/// Interpret the <see cref="GridLength.Value"/> property value as a proportional weight, to be arranged after rows and columns with <see cref="GridUnitType.Absolute"/> or <see cref="GridUnitType.Auto"/>.
-	/// </summary>
-	/// <remarks>
 	/// After all Absolute and Auto rows/columns are arranged, remaining Star rows/columns receive a fraction of the leftover space determined by dividing each <see cref="GridLength.Value"/> by the sum of all star values.
-	/// </remarks>
+	/// </summary>
 	Star,
 
 	/// <summary>

--- a/src/Core/src/Primitives/TextType.cs
+++ b/src/Core/src/Primitives/TextType.cs
@@ -12,10 +12,8 @@ public enum TextType
 
 	/// <summary>
 	/// HTML-formatted text content that may include markup.
-	/// </summary>
-	/// <remarks>
 	/// The subset of supported HTML tags varies by platform. Each platform's native text rendering engine
 	/// determines which HTML tags and attributes are supported.
-	/// </remarks>
+	/// </summary>
 	Html
 }

--- a/src/Essentials/src/Geolocation/GeolocationError.shared.cs
+++ b/src/Essentials/src/Geolocation/GeolocationError.shared.cs
@@ -9,22 +9,18 @@ namespace Microsoft.Maui.Devices.Sensors
 	{
 		/// <summary>
 		/// The provider was unable to retrieve any position data.
+		/// On Android this is sent when no location provider is available that satisfies the requested geolocation accuracy.
+		/// On iOS this means getting location data has failed.
+		/// On Windows this means no location data is available from any source.
 		/// </summary>
-		/// <remarks>
-		/// Android: Sent when no location provider is available that satisfies the requested geolocation accuracy.
-		/// iOS: Getting location data has failed.
-		/// Windows: No location data is available from any source.
-		/// </remarks>
 		PositionUnavailable,
 
 		/// <summary>
 		/// The app is not, or no longer, authorized to receive location data.
+		/// On Android this is not used.
+		/// On iOS this means authorization for getting locations has changed.
+		/// On Windows this means location sources are turned off.
 		/// </summary>
-		/// <remarks>
-		/// Android: Not used.
-		/// iOS: Authorization for getting locations has changed.
-		/// Windows: Location sources are turned off.
-		/// </remarks>
 		Unauthorized,
 	}
 }

--- a/src/Essentials/src/Types/LocationTypeConverter.shared.cs
+++ b/src/Essentials/src/Types/LocationTypeConverter.shared.cs
@@ -16,15 +16,25 @@ namespace Microsoft.Maui.Devices.Sensors
 	/// </remarks>
 	public class LocationTypeConverter : TypeConverter
 	{
-		/// <inheritdoc/>
+		/// <summary>Determines whether conversion is possible from the specified type to <see cref="Location"/>.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="sourceType">The source type to check.</param>
+		/// <returns><see langword="true"/> if the source type is <see cref="string"/>; otherwise, <see langword="false"/>.</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
 			=> sourceType == typeof(string);
 
-		/// <inheritdoc/>
+		/// <summary>Determines whether conversion is possible from <see cref="Location"/> to the specified type.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="destinationType">The destination type to check.</param>
+		/// <returns><see langword="true"/> if the destination type is <see cref="string"/>; otherwise, <see langword="false"/>.</returns>
 		public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
 			=> destinationType == typeof(string);
 
-		/// <inheritdoc/>
+		/// <summary>Converts a string representation of latitude and longitude to a <see cref="Location"/> object.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="culture">The culture info.</param>
+		/// <param name="value">The value to convert, expected in the format <c>"latitude,longitude"</c>.</param>
+		/// <returns>A <see cref="Location"/> object parsed from the string value.</returns>
 		public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
 		{
 			var strValue = value?.ToString()?.Trim();
@@ -44,7 +54,12 @@ namespace Microsoft.Maui.Devices.Sensors
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(Location)}");
 		}
 
-		/// <inheritdoc/>
+		/// <summary>Converts a <see cref="Location"/> object to a string representation.</summary>
+		/// <param name="context">The format context.</param>
+		/// <param name="culture">The culture info.</param>
+		/// <param name="value">The <see cref="Location"/> value to convert.</param>
+		/// <param name="destinationType">The destination type (must be <see cref="string"/>).</param>
+		/// <returns>A string in the format <c>"latitude,longitude"</c>.</returns>
 		public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
 		{
 			if (value is not Location location)

--- a/src/Graphics/src/Graphics/PathF.cs
+++ b/src/Graphics/src/Graphics/PathF.cs
@@ -1671,7 +1671,9 @@ namespace Microsoft.Maui.Graphics
 			Invalidate();
 		}
 
-		/// <inheritdoc />
+		/// <summary>Determines whether the specified object is equal to the current <see cref="PathF"/> using tolerance-based comparison for geometric values.</summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns><see langword="true"/> if the specified object represents the same path as the current object, with point and arc values compared within <see cref="GeometryUtil.Epsilon"/>; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object obj)
 		{
 			if (obj is PathF compareTo)
@@ -1717,7 +1719,8 @@ namespace Microsoft.Maui.Graphics
 			return true;
 		}
 
-		/// <inheritdoc />
+		/// <summary>Serves as the default hash function.</summary>
+		/// <returns>A hash code for the current object.</returns>
 		public override int GetHashCode()
 		{
 			unchecked


### PR DESCRIPTION
## Description

Fixes 25 of the 26 suggestions reported by the [docs build pipeline](https://buildapi.docs.microsoft.com/Output/Commit/2e041bd6-b3f5-1301-8bcf-98e47a1d084d/202604080754207212-maui-net11/BuildReport?accessString=bbadcaf4322be4782ba8b5c8514060a6831140d2fba7ce8952a2dddfc57b6b13). The remaining suggestion (`HybridWebView.InvokeJavaScriptAsync`) already has explicit XML docs in  that one appears to be a docs-pipeline ingestion issue.source 

### Changes

**Enum field remarks merged into summary (4 suggestions)**

The doc pipeline ignores `remarks` on enum fields (`_Enum_NoRemarks`). Moved the remarks content into the `summary` tag:
- `UIModalPresentationStyle` (FullScreen, OverFullScreen)
- `GeolocationError` (PositionUnavailable, Unauthorized)
- `GridUnitType` (Star)
- `TextType` (Html)

**Replace inheritdoc with explicit XML docs (21 suggestions)**

The doc pipeline cannot resolve `inheritdoc` for `Equals(object)`, `GetHashCode()`, `ToString()`, and `TypeConverter` overrides (`_Inheritdoc_NoFoundParent`). Replaced with explicit `summary`, `param`, and `returns` tags:
- `GradientStop` (Equals, GetHashCode)
- `ShellAppearance` (Equals, GetHashCode)
- `SolidColorBrush` (Equals, GetHashCode)
- `PathF` (Equals, GetHashCode)
- `Distance` (Equals, GetHashCode)
- `MapSpan` (Equals, GetHashCode, ToString)
- `LocationTypeConverter` (CanConvertFrom, CanConvertTo, ConvertFrom, ConvertTo)
- `MapSpanTypeConverter` (CanConvertFrom, CanConvertTo, ConvertFrom, ConvertTo)

**Additional fixes**

- Fixed `Equals`/`GetHashCode` contract violations in `GradientStop` and `SolidColorBrush`, where `Equals` was value-based but `GetHashCode` used `base.GetHashCode()` (reference-based).
- Documented tolerance-based equality in `PathF.Equals` and `GradientStop.Equals` to accurately reflect the implementation behavior.
