### PR TITLE
Add Window.StatusBarTheme to control status bar icon appearance on mobile

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/StatusBarThemePage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/StatusBarThemePage.cs
@@ -1,0 +1,68 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public class StatusBarThemePage : ContentPage
+	{
+		readonly Label _statusLabel;
+
+		public StatusBarThemePage()
+		{
+			Title = "StatusBarTheme";
+
+			_statusLabel = new Label
+			{
+				Text = "Current: Default",
+				FontSize = 18,
+				HorizontalOptions = LayoutOptions.Center,
+				Margin = new Thickness(0, 20, 0, 0)
+			};
+
+			Content = new VerticalStackLayout
+			{
+				Spacing = 12,
+				Padding = new Thickness(20),
+				Children =
+				{
+					new Label
+					{
+						Text = "Window.StatusBarTheme",
+						Style = (Style)Application.Current.Resources["Headline"]
+					},
+					new Label
+					{
+						Text = "Controls whether OS-drawn status bar icons (clock, battery, signal) are light or dark. " +
+							"On mobile, set Dark for pages with dark headers so icons are white."
+					},
+					_statusLabel,
+					CreateButton("Default (follow theme)", StatusBarTheme.Default, Colors.Transparent),
+					CreateButton("Light (dark icons)", StatusBarTheme.Light, Color.FromArgb("#F0F0F0")),
+					CreateButton("Dark (light icons)", StatusBarTheme.Dark, Color.FromArgb("#1A1A2E")),
+				}
+			};
+		}
+
+		Button CreateButton(string text, StatusBarTheme theme, Color bgColor)
+		{
+			var button = new Button
+			{
+				Text = text,
+				BackgroundColor = bgColor,
+				TextColor = bgColor.GetLuminosity() > 0.5 ? Colors.Black : Colors.White
+			};
+
+			button.Clicked += (s, e) =>
+			{
+				if (this.Window is Window window)
+				{
+					window.StatusBarTheme = theme;
+					_statusLabel.Text = $"Current: {theme}";
+				}
+			};
+
+			return button;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/StatusBarThemePage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/StatusBarThemePage.cs
@@ -29,7 +29,8 @@ namespace Maui.Controls.Sample.Pages
 					new Label
 					{
 						Text = "Window.StatusBarTheme",
-						Style = (Style)Application.Current.Resources["Headline"]
+						FontSize = 24,
+						FontAttributes = FontAttributes.Bold
 					},
 					new Label
 					{

--- a/src/Controls/samples/Controls.Sample/ViewModels/CoreViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/CoreViewModel.cs
@@ -18,6 +18,9 @@ namespace Maui.Controls.Sample.ViewModels
 			new SectionModel(typeof(AppThemeBindingPage), "AppThemeBindings",
 				"Devices typically include light and dark themes, which each refer to a broad set of appearance preferences that can be set at the operating system level. Applications should respect these system themes, and respond immediately when the system theme changes."),
 
+			new SectionModel(typeof(StatusBarThemePage), "StatusBarTheme",
+				"Controls the appearance of OS-drawn status bar icons (clock, battery, signal) on mobile platforms independently of the app theme."),
+
 			new SectionModel(typeof(BrushesPage), "Brushes",
 				"A brush enables you to paint an area, such as the background of a control, using different approaches."),
 

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -669,6 +669,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return base.ChildViewControllerForStatusBarHidden();
 		}
 
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle() =>
+			ChildViewControllerForStatusBarHidden();
+#endif
+
 		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
 		{
 			get

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -2184,6 +2184,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return (Current.Handler as IPlatformViewHandler)?.ViewController;
 		}
 
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle() =>
+			(Current.Handler as IPlatformViewHandler)?.ViewController;
+#endif
+
 		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden =>
 			ChildViewControllerForStatusBarHidden();
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
@@ -48,6 +48,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override bool PrefersStatusBarHidden() => Detail.PrefersStatusBarHidden();
 
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle() => Detail;
+#endif
+
 		public override UIStatusBarAnimation PreferredStatusBarUpdateAnimation => Detail.PreferredStatusBarUpdateAnimation;
 
 		void IShellFlyoutRenderer.AttachFlyout(IShellContext context, UIViewController content)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class ShellItemRenderer : UITabBarController, IShellItemRenderer, IAppearanceObserver, IUINavigationControllerDelegate, IDisconnectable
 	{
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+			=> CurrentRenderer?.ViewController;
+#endif
+
 		readonly static UITableViewCell[] EmptyUITableViewCellArray = Array.Empty<UITableViewCell>();
 
 		#region IShellItemRenderer

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public override bool PrefersStatusBarHidden()
 			=> Shell?.CurrentPage?.OnThisPlatform()?.PrefersStatusBarHidden() == StatusBarHiddenMode.True;
 
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+			=> _currentShellItemRenderer?.ViewController;
+#endif
+
 		public override UIKit.UIStatusBarAnimation PreferredStatusBarUpdateAnimation
 		{
 			get

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellRenderer.cs
@@ -31,7 +31,24 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 #if !MACCATALYST
 		public override UIViewController ChildViewControllerForStatusBarStyle()
-			=> _currentShellItemRenderer?.ViewController;
+		{
+			if (Shell?.Window?.StatusBarTheme == StatusBarTheme.Default)
+				return base.ChildViewControllerForStatusBarStyle();
+
+			return null;
+		}
+
+		public override UIStatusBarStyle PreferredStatusBarStyle()
+		{
+			var theme = Shell?.Window?.StatusBarTheme ?? StatusBarTheme.Default;
+
+			return theme switch
+			{
+				StatusBarTheme.Light => UIStatusBarStyle.DarkContent,
+				StatusBarTheme.Dark => UIStatusBarStyle.LightContent,
+				_ => base.PreferredStatusBarStyle()
+			};
+		}
 #endif
 
 		public override UIKit.UIStatusBarAnimation PreferredStatusBarUpdateAnimation

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class ShellSectionRenderer : UINavigationController, IShellSectionRenderer, IAppearanceObserver, IDisconnectable
 	{
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+			=> TopViewController;
+#endif
+
 		#region IShellContentRenderer
 
 		public bool IsInMoreTab { get; set; }

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -286,6 +286,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return GetViewController(current);
 		}
 
+#if !MACCATALYST
+		public override UIViewController ChildViewControllerForStatusBarStyle() =>
+			ChildViewControllerForStatusBarHidden();
+#endif
+
 		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()
 		{
 			if (Page is Page page)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-#nullable enable
-*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor -> Microsoft.Maui.Graphics.Color
-*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor -> Microsoft.Maui.Graphics.Color
-~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor.get -> Microsoft.Maui.Graphics.Color
-~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor.get -> Microsoft.Maui.Graphics.Color
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
-~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnHiddenChanged(bool hidden) -> void
-~override Microsoft.Maui.Controls.Handlers.Items.RecyclerViewScrollListener<TItemsView, TItemsViewSource>.OnScrollStateChanged(AndroidX.RecyclerView.Widget.RecyclerView recyclerView, int newState) -> void
-~override Microsoft.Maui.Controls.Handlers.Items.SelectableItemsViewAdapter<TItemsView, TItemsSource>.IsSelectionEnabled(Android.Views.ViewGroup parent, int viewType) -> bool
+﻿#nullable enable
 Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
-Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
+~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnInterceptTouchEvent(Android.Views.MotionEvent e) -> bool
+~override Microsoft.Maui.Controls.Handlers.Items.MauiRecyclerView<TItemsView, TAdapter, TItemsViewSource>.OnTouchEvent(Android.Views.MotionEvent e) -> bool
+~override Microsoft.Maui.Controls.Handlers.Items.RecyclerViewScrollListener<TItemsView, TItemsViewSource>.OnScrollStateChanged(AndroidX.RecyclerView.Widget.RecyclerView recyclerView, int newState) -> void
+~override Microsoft.Maui.Controls.Handlers.Items.SelectableItemsViewAdapter<TItemsView, TItemsSource>.IsSelectionEnabled(Android.Views.ViewGroup parent, int viewType) -> bool
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnHiddenChanged(bool hidden) -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor.get -> Microsoft.Maui.Graphics.Color
+~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor.get -> Microsoft.Maui.Graphics.Color
+*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor -> Microsoft.Maui.Graphics.Color
+*REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor -> Microsoft.Maui.Graphics.Color
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 *REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor -> Microsoft.Maui.Graphics.Color
 *REMOVED*~static readonly Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultTitleColor -> Microsoft.Maui.Graphics.Color
 ~static Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.DefaultForegroundColor.get -> Microsoft.Maui.Graphics.Color
@@ -9,3 +9,6 @@ override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? property
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.OnHiddenChanged(bool hidden) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.RecyclerViewScrollListener<TItemsView, TItemsViewSource>.OnScrollStateChanged(AndroidX.RecyclerView.Widget.RecyclerView recyclerView, int newState) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items.SelectableItemsViewAdapter<TItemsView, TItemsSource>.IsSelectionEnabled(Android.Views.ViewGroup parent, int viewType) -> bool
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.set -> void
 ~Microsoft.Maui.Controls.MultiBinding.ConverterCulture.get -> System.Globalization.CultureInfo

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,3 +6,6 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,11 +1,11 @@
-#nullable enable
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
-~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+﻿#nullable enable
 Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
-Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
+~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microso
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.PreferredStatusBarStyle() -> UIKit.UIStatusBarStyle
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -2,6 +2,13 @@
 Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
 static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
+~override Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Handlers.Compatibility.TabbedRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ChildViewControllerForStatusBarStyle() -> UIKit.UIViewController
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,3 +6,6 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,11 +1,11 @@
-#nullable enable
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
-~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+﻿#nullable enable
 Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
-Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
+~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 *REMOVED*~static Microsoft.Maui.Controls.VisualStateManager.GetVisualStateGroups(Microsoft.Maui.Controls.VisualElement visualElement) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.VisualStateGroup>
 ~Microsoft.Maui.Controls.Binding.ConverterCulture.get -> System.Globalization.CultureInfo

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
-Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.HybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.Controls.HybridWebView.Invoker.set -> void
 Microsoft.Maui.Controls.HybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 Microsoft.Maui.Controls.AppThemeBinding
 Microsoft.Maui.Controls.AppThemeBinding.AppThemeBinding() -> void
 ~Microsoft.Maui.Controls.AppThemeBinding.Dark.get -> object

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-#nullable enable
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+﻿#nullable enable
 Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
-Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Window.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.Controls.Window.StatusBarTheme.set -> void
+static readonly Microsoft.Maui.Controls.Window.StatusBarThemeProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
 ~Microsoft.Maui.Controls.BaseShellItem.BadgeColor.get -> Microsoft.Maui.Graphics.Color

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Page))]
 	public partial class Window : NavigableElement, IWindow, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
 	{
-		static readonly BindablePropertyKey IsActivatedPropertyKey = 
+		static readonly BindablePropertyKey IsActivatedPropertyKey =
 			BindableProperty.CreateReadOnly(nameof(IsActivated), typeof(bool), typeof(Window), false, propertyChanged: OnIsActivatedPropertyChanged);
 
 		/// <summary>Bindable property for <see cref="IsActivated"/>.</summary>

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -80,6 +80,10 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty IsMaximizableProperty = BindableProperty.Create(nameof(IsMaximizable),
 			typeof(bool), typeof(Window), defaultValue: true);
 
+		/// <summary>Bindable property for <see cref="StatusBarTheme"/>.</summary>
+		public static readonly BindableProperty StatusBarThemeProperty = BindableProperty.Create(
+			nameof(StatusBarTheme), typeof(StatusBarTheme), typeof(Window), StatusBarTheme.Default);
+
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren;
 		Toolbar? _toolbar;
@@ -190,6 +194,17 @@ namespace Microsoft.Maui.Controls
 		{
 			get => (ITitleBar?)GetValue(TitleBarProperty);
 			set => SetValue(TitleBarProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets the theme for the status bar area on mobile platforms.
+		/// Controls whether OS-drawn icons (clock, battery, signal) are light or dark.
+		/// Default automatically follows the current app theme. No-op on desktop platforms.
+		/// </summary>
+		public StatusBarTheme StatusBarTheme
+		{
+			get => (StatusBarTheme)GetValue(StatusBarThemeProperty);
+			set => SetValue(StatusBarThemeProperty, value);
 		}
 
 		double IWindow.X => GetPositionCoordinate(XProperty);

--- a/src/Controls/src/Core/Window/Window.cs
+++ b/src/Controls/src/Core/Window/Window.cs
@@ -81,6 +81,10 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty IsMaximizableProperty = BindableProperty.Create(nameof(IsMaximizable),
 			typeof(bool), typeof(Window), defaultValue: true);
 
+		/// <summary>Bindable property for <see cref="StatusBarTheme"/>.</summary>
+		public static readonly BindableProperty StatusBarThemeProperty = BindableProperty.Create(
+			nameof(StatusBarTheme), typeof(StatusBarTheme), typeof(Window), StatusBarTheme.Default);
+
 		HashSet<IWindowOverlay> _overlays = new HashSet<IWindowOverlay>();
 		List<IVisualTreeElement> _visualChildren;
 		Toolbar? _toolbar;
@@ -191,6 +195,17 @@ namespace Microsoft.Maui.Controls
 		{
 			get => (ITitleBar?)GetValue(TitleBarProperty);
 			set => SetValue(TitleBarProperty, value);
+		}
+
+		/// <summary>
+		/// Gets or sets the theme for the status bar area on mobile platforms.
+		/// Controls whether OS-drawn icons (clock, battery, signal) are light or dark.
+		/// Default automatically follows the current app theme. No-op on desktop platforms.
+		/// </summary>
+		public StatusBarTheme StatusBarTheme
+		{
+			get => (StatusBarTheme)GetValue(StatusBarThemeProperty);
+			set => SetValue(StatusBarThemeProperty, value);
 		}
 
 		double IWindow.X => GetPositionCoordinate(XProperty);

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Graphics;
 using Xunit;
 
@@ -997,48 +998,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void StatusBarThemeInterfaceDefaultIsDefault()
+		public void StatusBarThemeChangesWithAppThemeBinding()
 		{
-			IWindow window = new Window();
-			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
-		}
+			AppInfo.SetCurrent(new MockAppInfo() { RequestedTheme = AppTheme.Light });
+			var app = new Application();
+			Application.Current = app;
 
-		[Fact]
-		public void StatusBarThemeCanBeChangedAtRuntime()
-		{
-			var window = new Window();
-			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
-
-			window.StatusBarTheme = StatusBarTheme.Dark;
-			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
-
-			window.StatusBarTheme = StatusBarTheme.Light;
-			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
-
-			window.StatusBarTheme = StatusBarTheme.Default;
-			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
-		}
-
-		[Fact]
-		public void StatusBarThemePropertyChangedFiresOnChange()
-		{
-			var window = new Window();
-			var changes = new List<StatusBarTheme>();
-
-			window.PropertyChanged += (s, e) =>
+			try
 			{
-				if (e.PropertyName == nameof(Window.StatusBarTheme))
-					changes.Add(window.StatusBarTheme);
-			};
+				var window = app.LoadPage(new ContentPage());
 
-			window.StatusBarTheme = StatusBarTheme.Dark;
-			window.StatusBarTheme = StatusBarTheme.Light;
-			window.StatusBarTheme = StatusBarTheme.Default;
+				window.SetBinding(Window.StatusBarThemeProperty, new AppThemeBinding
+				{
+					Light = StatusBarTheme.Light,
+					Dark = StatusBarTheme.Dark
+				});
 
-			Assert.Equal(3, changes.Count);
-			Assert.Equal(StatusBarTheme.Dark, changes[0]);
-			Assert.Equal(StatusBarTheme.Light, changes[1]);
-			Assert.Equal(StatusBarTheme.Default, changes[2]);
+				Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+
+				((MockAppInfo)AppInfo.Current).RequestedTheme = AppTheme.Dark;
+				((IApplication)app).ThemeChanged();
+
+				Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+			}
+			finally
+			{
+				Application.Current = null;
+			}
 		}
 
 		[Fact]
@@ -1053,28 +1039,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					changeCount++;
 			};
 
-			window.StatusBarTheme = StatusBarTheme.Dark; // same value
+			window.StatusBarTheme = StatusBarTheme.Dark;
 			Assert.Equal(0, changeCount);
-		}
-
-		[Fact]
-		public void StatusBarThemeWorksWithAppThemeBinding()
-		{
-			var window = new Window();
-			window.SetBinding(Window.StatusBarThemeProperty, new AppThemeBinding
-			{
-				Light = StatusBarTheme.Light,
-				Dark = StatusBarTheme.Dark,
-				Default = StatusBarTheme.Default
-			});
-
-			// AppThemeBinding evaluates based on current app theme;
-			// verify it doesn't crash and produces a valid value
-			var result = window.StatusBarTheme;
-			Assert.True(
-				result == StatusBarTheme.Light ||
-				result == StatusBarTheme.Dark ||
-				result == StatusBarTheme.Default);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -946,5 +946,55 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			public string TestProperty { get; set; } = "test";
 		}
+
+		[Fact]
+		public void StatusBarThemeDefaultValue()
+		{
+			var window = new Window();
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeCanBeSet()
+		{
+			var window = new Window
+			{
+				StatusBarTheme = StatusBarTheme.Dark
+			};
+			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeIsBindable()
+		{
+			var window = new Window();
+			window.SetValue(Window.StatusBarThemeProperty, StatusBarTheme.Light);
+			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeIsStyleable()
+		{
+			var style = new Style(typeof(Window))
+			{
+				Setters =
+				{
+					new Setter { Property = Window.StatusBarThemeProperty, Value = StatusBarTheme.Dark }
+				},
+			};
+
+			var app = new TestApp();
+			app.Resources.Add(style);
+
+			var window = app.CreateWindow();
+			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeInterfaceDefaultIsDefault()
+		{
+			IWindow window = new Window();
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -919,17 +919,17 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var rootServiceProvider = serviceCollection.BuildServiceProvider();
 
 			var appContext = new MauiContext(rootServiceProvider);
-			
+
 			// Simulate the window creation flow
 			var windowContext = appContext.MakeWindowScope(new object(), out var scope);
-			
+
 			// Verify we can get scoped services
 			var service1 = windowContext.Services.GetRequiredService<TestScopedService>();
 			var service2 = windowContext.Services.GetRequiredService<TestScopedService>();
-			
+
 			// Should be the same instance since it's scoped
 			Assert.Same(service1, service2);
-			
+
 			// Create window and set up handler
 			var window = new TestWindow(new ContentPage());
 			var handler = new WindowHandlerStub();

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -954,22 +954,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
 		}
 
-		[Fact]
-		public void StatusBarThemeCanBeSet()
+		[Theory]
+		[InlineData(StatusBarTheme.Default)]
+		[InlineData(StatusBarTheme.Light)]
+		[InlineData(StatusBarTheme.Dark)]
+		public void StatusBarThemeCanBeSetToAllValues(StatusBarTheme theme)
 		{
 			var window = new Window
 			{
-				StatusBarTheme = StatusBarTheme.Dark
+				StatusBarTheme = theme
 			};
-			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+			Assert.Equal(theme, window.StatusBarTheme);
 		}
 
-		[Fact]
-		public void StatusBarThemeIsBindable()
+		[Theory]
+		[InlineData(StatusBarTheme.Default)]
+		[InlineData(StatusBarTheme.Light)]
+		[InlineData(StatusBarTheme.Dark)]
+		public void StatusBarThemeIsBindableForAllValues(StatusBarTheme theme)
 		{
 			var window = new Window();
-			window.SetValue(Window.StatusBarThemeProperty, StatusBarTheme.Light);
-			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+			window.SetValue(Window.StatusBarThemeProperty, theme);
+			Assert.Equal(theme, window.StatusBarTheme);
 		}
 
 		[Fact]
@@ -995,6 +1001,80 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			IWindow window = new Window();
 			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeCanBeChangedAtRuntime()
+		{
+			var window = new Window();
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+
+			window.StatusBarTheme = StatusBarTheme.Dark;
+			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+
+			window.StatusBarTheme = StatusBarTheme.Light;
+			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+
+			window.StatusBarTheme = StatusBarTheme.Default;
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemePropertyChangedFiresOnChange()
+		{
+			var window = new Window();
+			var changes = new List<StatusBarTheme>();
+
+			window.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(Window.StatusBarTheme))
+					changes.Add(window.StatusBarTheme);
+			};
+
+			window.StatusBarTheme = StatusBarTheme.Dark;
+			window.StatusBarTheme = StatusBarTheme.Light;
+			window.StatusBarTheme = StatusBarTheme.Default;
+
+			Assert.Equal(3, changes.Count);
+			Assert.Equal(StatusBarTheme.Dark, changes[0]);
+			Assert.Equal(StatusBarTheme.Light, changes[1]);
+			Assert.Equal(StatusBarTheme.Default, changes[2]);
+		}
+
+		[Fact]
+		public void StatusBarThemePropertyChangedDoesNotFireForSameValue()
+		{
+			var window = new Window { StatusBarTheme = StatusBarTheme.Dark };
+			var changeCount = 0;
+
+			window.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(Window.StatusBarTheme))
+					changeCount++;
+			};
+
+			window.StatusBarTheme = StatusBarTheme.Dark; // same value
+			Assert.Equal(0, changeCount);
+		}
+
+		[Fact]
+		public void StatusBarThemeWorksWithAppThemeBinding()
+		{
+			var window = new Window();
+			window.SetBinding(Window.StatusBarThemeProperty, new AppThemeBinding
+			{
+				Light = StatusBarTheme.Light,
+				Dark = StatusBarTheme.Dark,
+				Default = StatusBarTheme.Default
+			});
+
+			// AppThemeBinding evaluates based on current app theme;
+			// verify it doesn't crash and produces a valid value
+			var result = window.StatusBarTheme;
+			Assert.True(
+				result == StatusBarTheme.Light ||
+				result == StatusBarTheme.Dark ||
+				result == StatusBarTheme.Default);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -954,22 +954,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
 		}
 
-		[Fact]
-		public void StatusBarThemeCanBeSet()
+		[Theory]
+		[InlineData(StatusBarTheme.Default)]
+		[InlineData(StatusBarTheme.Light)]
+		[InlineData(StatusBarTheme.Dark)]
+		public void StatusBarThemeCanBeSetToAllValues(StatusBarTheme theme)
 		{
 			var window = new Window
 			{
-				StatusBarTheme = StatusBarTheme.Dark
+				StatusBarTheme = theme
 			};
-			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+			Assert.Equal(theme, window.StatusBarTheme);
 		}
 
-		[Fact]
-		public void StatusBarThemeIsBindable()
+		[Theory]
+		[InlineData(StatusBarTheme.Default)]
+		[InlineData(StatusBarTheme.Light)]
+		[InlineData(StatusBarTheme.Dark)]
+		public void StatusBarThemeIsBindableForAllValues(StatusBarTheme theme)
 		{
 			var window = new Window();
-			window.SetValue(Window.StatusBarThemeProperty, StatusBarTheme.Light);
-			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+			window.SetValue(Window.StatusBarThemeProperty, theme);
+			Assert.Equal(theme, window.StatusBarTheme);
 		}
 
 		[Fact]
@@ -995,6 +1001,80 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			IWindow window = new Window();
 			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeCanBeChangedAtRuntime()
+		{
+			var window = new Window();
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+
+			window.StatusBarTheme = StatusBarTheme.Dark;
+			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+
+			window.StatusBarTheme = StatusBarTheme.Light;
+			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+
+			window.StatusBarTheme = StatusBarTheme.Default;
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemePropertyChangedFiresOnChange()
+		{
+			var window = new Window();
+			var changes = new List<StatusBarTheme>();
+
+			window.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(Window.StatusBarTheme))
+					changes.Add(window.StatusBarTheme);
+			};
+
+			window.StatusBarTheme = StatusBarTheme.Dark;
+			window.StatusBarTheme = StatusBarTheme.Light;
+			window.StatusBarTheme = StatusBarTheme.Default;
+
+			Assert.Equal(3, changes.Count);
+			Assert.Equal(StatusBarTheme.Dark, changes[0]);
+			Assert.Equal(StatusBarTheme.Light, changes[1]);
+			Assert.Equal(StatusBarTheme.Default, changes[2]);
+		}
+
+		[Fact]
+		public void StatusBarThemePropertyChangedDoesNotFireForSameValue()
+		{
+			var window = new Window { StatusBarTheme = StatusBarTheme.Dark };
+			var changeCount = 0;
+
+			window.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(Window.StatusBarTheme))
+					changeCount++;
+			};
+
+			window.StatusBarTheme = StatusBarTheme.Dark; // same value
+			Assert.Equal(0, changeCount);
+		}
+
+		[Fact]
+		public void StatusBarThemeWorksWithAppThemeBinding()
+		{
+			var window = new Window();
+			window.SetBinding(Window.StatusBarThemeProperty, new AppThemeBinding
+			{
+				Light = StatusBarTheme.Light,
+				Dark = StatusBarTheme.Dark,
+				Default = StatusBarTheme.Default
+			});
+
+			// AppThemeBinding evaluates based on current app theme;
+			// verify it doesn't crash and produces a valid value
+			var result = window.StatusBarTheme;
+			Assert.True(
+				result == StatusBarTheme.Light ||
+				result == StatusBarTheme.Dark ||
+				result == StatusBarTheme.Default);
 		}
 	}
 

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Graphics;
 using Xunit;
 
@@ -997,48 +998,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public void StatusBarThemeInterfaceDefaultIsDefault()
+		public void StatusBarThemeChangesWithAppThemeBinding()
 		{
-			IWindow window = new Window();
-			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
-		}
+			AppInfo.SetCurrent(new MockAppInfo() { RequestedTheme = AppTheme.Light });
+			var app = new Application();
+			Application.Current = app;
 
-		[Fact]
-		public void StatusBarThemeCanBeChangedAtRuntime()
-		{
-			var window = new Window();
-			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
-
-			window.StatusBarTheme = StatusBarTheme.Dark;
-			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
-
-			window.StatusBarTheme = StatusBarTheme.Light;
-			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
-
-			window.StatusBarTheme = StatusBarTheme.Default;
-			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
-		}
-
-		[Fact]
-		public void StatusBarThemePropertyChangedFiresOnChange()
-		{
-			var window = new Window();
-			var changes = new List<StatusBarTheme>();
-
-			window.PropertyChanged += (s, e) =>
+			try
 			{
-				if (e.PropertyName == nameof(Window.StatusBarTheme))
-					changes.Add(window.StatusBarTheme);
-			};
+				var window = app.LoadPage(new ContentPage());
 
-			window.StatusBarTheme = StatusBarTheme.Dark;
-			window.StatusBarTheme = StatusBarTheme.Light;
-			window.StatusBarTheme = StatusBarTheme.Default;
+				window.SetBinding(Window.StatusBarThemeProperty, new AppThemeBinding
+				{
+					Light = StatusBarTheme.Light,
+					Dark = StatusBarTheme.Dark
+				});
 
-			Assert.Equal(3, changes.Count);
-			Assert.Equal(StatusBarTheme.Dark, changes[0]);
-			Assert.Equal(StatusBarTheme.Light, changes[1]);
-			Assert.Equal(StatusBarTheme.Default, changes[2]);
+				Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+
+				((MockAppInfo)AppInfo.Current).RequestedTheme = AppTheme.Dark;
+				((IApplication)app).ThemeChanged();
+
+				Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+			}
+			finally
+			{
+				Application.Current = null;
+			}
 		}
 
 		[Fact]
@@ -1053,28 +1039,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					changeCount++;
 			};
 
-			window.StatusBarTheme = StatusBarTheme.Dark; // same value
+			window.StatusBarTheme = StatusBarTheme.Dark;
 			Assert.Equal(0, changeCount);
-		}
-
-		[Fact]
-		public void StatusBarThemeWorksWithAppThemeBinding()
-		{
-			var window = new Window();
-			window.SetBinding(Window.StatusBarThemeProperty, new AppThemeBinding
-			{
-				Light = StatusBarTheme.Light,
-				Dark = StatusBarTheme.Dark,
-				Default = StatusBarTheme.Default
-			});
-
-			// AppThemeBinding evaluates based on current app theme;
-			// verify it doesn't crash and produces a valid value
-			var result = window.StatusBarTheme;
-			Assert.True(
-				result == StatusBarTheme.Light ||
-				result == StatusBarTheme.Dark ||
-				result == StatusBarTheme.Default);
 		}
 	}
 

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -946,6 +946,56 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			public string TestProperty { get; set; } = "test";
 		}
+
+		[Fact]
+		public void StatusBarThemeDefaultValue()
+		{
+			var window = new Window();
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeCanBeSet()
+		{
+			var window = new Window
+			{
+				StatusBarTheme = StatusBarTheme.Dark
+			};
+			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeIsBindable()
+		{
+			var window = new Window();
+			window.SetValue(Window.StatusBarThemeProperty, StatusBarTheme.Light);
+			Assert.Equal(StatusBarTheme.Light, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeIsStyleable()
+		{
+			var style = new Style(typeof(Window))
+			{
+				Setters =
+				{
+					new Setter { Property = Window.StatusBarThemeProperty, Value = StatusBarTheme.Dark }
+				},
+			};
+
+			var app = new TestApp();
+			app.Resources.Add(style);
+
+			var window = app.CreateWindow();
+			Assert.Equal(StatusBarTheme.Dark, window.StatusBarTheme);
+		}
+
+		[Fact]
+		public void StatusBarThemeInterfaceDefaultIsDefault()
+		{
+			IWindow window = new Window();
+			Assert.Equal(StatusBarTheme.Default, window.StatusBarTheme);
+		}
 	}
 
 	/// <summary>

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Android.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
+using AndroidX.Core.View;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
@@ -35,6 +36,47 @@ namespace Microsoft.Maui.DeviceTests
 				((IWindow)window).Destroying();
 
 				Assert.NotNull(windowScopeField.GetValue(mauiContext));
+			});
+		}
+
+		[Fact]
+		public async Task StatusBarThemeDoesNotChangeNavigationBarTheme()
+		{
+			SetupBuilder();
+
+			var window = new Window(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async handler =>
+			{
+				await OnLoadedAsync(window.Page);
+
+				var platformWindow = handler.PlatformView.Window;
+				Assert.NotNull(platformWindow);
+
+				var controller = WindowCompat.GetInsetsController(platformWindow, platformWindow.DecorView);
+				Assert.NotNull(controller);
+
+				var originalLightStatusBars = controller.AppearanceLightStatusBars;
+				var originalLightNavigationBars = controller.AppearanceLightNavigationBars;
+				try
+				{
+					controller.AppearanceLightNavigationBars = true;
+					window.StatusBarTheme = StatusBarTheme.Dark;
+
+					Assert.False(controller.AppearanceLightStatusBars);
+					Assert.True(controller.AppearanceLightNavigationBars);
+
+					controller.AppearanceLightNavigationBars = false;
+					window.StatusBarTheme = StatusBarTheme.Light;
+
+					Assert.True(controller.AppearanceLightStatusBars);
+					Assert.False(controller.AppearanceLightNavigationBars);
+				}
+				finally
+				{
+					controller.AppearanceLightStatusBars = originalLightStatusBars;
+					controller.AppearanceLightNavigationBars = originalLightNavigationBars;
+				}
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.iOS.cs
@@ -1,14 +1,68 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class WindowTests
 	{
+#if IOS
+		[Theory]
+		[InlineData(typeof(ContentPage))]
+		[InlineData(typeof(NavigationPage))]
+		[InlineData(typeof(TabbedPage))]
+		[InlineData(typeof(FlyoutPage))]
+		[InlineData(typeof(Shell))]
+		public async Task StatusBarThemeFlowsThroughRootController(Type rootPageType)
+		{
+			SetupBuilder();
+
+			var testCase = new WindowPageSwapTestCase(rootPageType);
+			var rootPage = testCase.GetNextPageType();
+			var window = new Window(rootPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async handler =>
+			{
+				await OnLoadedAsync(testCase.Page);
+
+				var rootController = ((IPlatformViewHandler)rootPage.Handler).ViewController;
+				var styleProvider = GetStatusBarStyleProvider(rootController);
+
+				Assert.Equal(UIStatusBarStyle.Default, styleProvider.PreferredStatusBarStyle());
+
+				window.StatusBarTheme = StatusBarTheme.Dark;
+				Assert.Equal(UIStatusBarStyle.LightContent, styleProvider.PreferredStatusBarStyle());
+
+				window.StatusBarTheme = StatusBarTheme.Light;
+				Assert.Equal(UIStatusBarStyle.DarkContent, styleProvider.PreferredStatusBarStyle());
+
+				window.StatusBarTheme = StatusBarTheme.Default;
+				Assert.Equal(UIStatusBarStyle.Default, styleProvider.PreferredStatusBarStyle());
+			});
+		}
+
+		static UIViewController GetStatusBarStyleProvider(UIViewController controller)
+		{
+			var visited = new HashSet<UIViewController>();
+
+			while (visited.Add(controller))
+			{
+				var child = controller.ChildViewControllerForStatusBarStyle();
+				if (child is null)
+					return controller;
+
+				controller = child;
+			}
+
+			throw new InvalidOperationException("The status bar style controller hierarchy contains a cycle.");
+		}
+#endif
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.iOS.cs
@@ -33,18 +33,21 @@ namespace Microsoft.Maui.DeviceTests
 				await OnLoadedAsync(testCase.Page);
 
 				var rootController = ((IPlatformViewHandler)rootPage.Handler).ViewController;
-				var styleProvider = GetStatusBarStyleProvider(rootController);
 
-				Assert.Equal(UIStatusBarStyle.Default, styleProvider.PreferredStatusBarStyle());
+				Assert.Same(window, rootPage.Window);
+				Assert.Equal(UIStatusBarStyle.Default, GetStatusBarStyleProvider(rootController).PreferredStatusBarStyle());
 
 				window.StatusBarTheme = StatusBarTheme.Dark;
+				var styleProvider = GetStatusBarStyleProvider(rootController);
+				if (rootPageType == typeof(Shell))
+					Assert.IsType<Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>(styleProvider);
 				Assert.Equal(UIStatusBarStyle.LightContent, styleProvider.PreferredStatusBarStyle());
 
 				window.StatusBarTheme = StatusBarTheme.Light;
-				Assert.Equal(UIStatusBarStyle.DarkContent, styleProvider.PreferredStatusBarStyle());
+				Assert.Equal(UIStatusBarStyle.DarkContent, GetStatusBarStyleProvider(rootController).PreferredStatusBarStyle());
 
 				window.StatusBarTheme = StatusBarTheme.Default;
-				Assert.Equal(UIStatusBarStyle.Default, styleProvider.PreferredStatusBarStyle());
+				Assert.Equal(UIStatusBarStyle.Default, GetStatusBarStyleProvider(rootController).PreferredStatusBarStyle());
 			});
 		}
 

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -130,6 +130,13 @@ namespace Microsoft.Maui
 
 		float RequestDisplayDensity();
 
+		/// <summary>
+		/// Gets the preferred theme for the status bar area on mobile platforms.
+		/// Controls whether OS-drawn icons (clock, battery, signal) are light or dark.
+		/// Default follows the current app theme. No-op on desktop platforms.
+		/// </summary>
+		StatusBarTheme StatusBarTheme => StatusBarTheme.Default;
+
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;
 		/// <summary>Gets a value indicating whether the window can be minimized.</summary>

--- a/src/Core/src/Core/IWindow.cs
+++ b/src/Core/src/Core/IWindow.cs
@@ -130,12 +130,14 @@ namespace Microsoft.Maui
 
 		float RequestDisplayDensity();
 
+#if !NETSTANDARD
 		/// <summary>
 		/// Gets the preferred theme for the status bar area on mobile platforms.
 		/// Controls whether OS-drawn icons (clock, battery, signal) are light or dark.
 		/// Default follows the current app theme. No-op on desktop platforms.
 		/// </summary>
 		StatusBarTheme StatusBarTheme => StatusBarTheme.Default;
+#endif
 
 #if WINDOWS || MACCATALYST
 		ITitleBar? TitleBar => null;

--- a/src/Core/src/Core/StatusBarTheme.cs
+++ b/src/Core/src/Core/StatusBarTheme.cs
@@ -1,0 +1,29 @@
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Controls the theme of OS-drawn status bar content (icons, text) on mobile platforms (Android, iOS).
+	/// Analogous to <see cref="ApplicationModel.AppTheme"/> — <see cref="Light"/> means light background
+	/// with dark icons, <see cref="Dark"/> means dark background with light icons.
+	/// On desktop platforms (Windows, macCatalyst) this is a no-op since there are no OS-drawn status bar icons.
+	/// </summary>
+	public enum StatusBarTheme
+	{
+		/// <summary>
+		/// Automatically follow the current app theme. This is the default
+		/// and preserves existing behavior.
+		/// </summary>
+		Default,
+
+		/// <summary>
+		/// The status bar area has a light background — use dark icons/text for contrast.
+		/// Maps to: Android <c>AppearanceLightStatusBars=true</c>, iOS <c>UIStatusBarStyle.DarkContent</c>.
+		/// </summary>
+		Light,
+
+		/// <summary>
+		/// The status bar area has a dark background — use light/white icons/text for contrast.
+		/// Maps to: Android <c>AppearanceLightStatusBars=false</c>, iOS <c>UIStatusBarStyle.LightContent</c>.
+		/// </summary>
+		Dark
+	}
+}

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Handlers
 			if (OperatingSystem.IsAndroidVersionAtLeast(30))
 			{
 				//Edge to Edge enabled for Android API 30+
-				PlatformView.Window.ConfigureTranslucentSystemBars(PlatformView);
+				PlatformView.Window.ConfigureTranslucentSystemBars(PlatformView, VirtualView.StatusBarTheme);
 			}
 			UpdateVirtualViewFrame(platformView);
 		}
@@ -60,6 +60,16 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is DisplayDensityRequest request)
 				request.SetResult(handler.PlatformView.GetDisplayDensity());
+		}
+
+		public static void MapStatusBarTheme(IWindowHandler handler, IWindow window)
+		{
+			if (OperatingSystem.IsAndroidVersionAtLeast(23))
+			{
+				handler.PlatformView.Window?.ConfigureTranslucentSystemBars(
+					handler.PlatformView,
+					window.StatusBarTheme);
+			}
 		}
 
 		private protected override void OnConnectHandler(object platformView)

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -86,8 +86,7 @@ namespace Microsoft.Maui.Handlers
 
 			DisconnectHandler(_rootManager);
 
-			if (_rootManager != null)
-				_rootManager.RootViewChanged -= OnRootViewChanged;
+			_rootManager?.RootViewChanged -= OnRootViewChanged;
 
 			// The MauiCoordinatorLayout will automatically unregister from the static registry
 			// when it's detached from the window, but we can ensure cleanup here as well

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Maui.Handlers
 			if (OperatingSystem.IsAndroidVersionAtLeast(30))
 			{
 				//Edge to Edge enabled for Android API 30+
-				PlatformView.Window.ConfigureTranslucentSystemBars(PlatformView, VirtualView.StatusBarTheme);
+				PlatformView.Window.ConfigureTranslucentSystemBars(PlatformView);
+				PlatformView.Window.UpdateStatusBarTheme(PlatformView, VirtualView.StatusBarTheme);
 			}
 			UpdateVirtualViewFrame(platformView);
 		}
@@ -66,7 +67,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (OperatingSystem.IsAndroidVersionAtLeast(23))
 			{
-				handler.PlatformView.Window?.ConfigureTranslucentSystemBars(
+				handler.PlatformView.Window?.UpdateStatusBarTheme(
 					handler.PlatformView,
 					window.StatusBarTheme);
 			}

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Maui.Handlers
 
 			DisconnectHandler(_rootManager);
 
-			_rootManager?.RootViewChanged -= OnRootViewChanged;
+			if (_rootManager is not null)
+				_rootManager.RootViewChanged -= OnRootViewChanged;
 
 			// The MauiCoordinatorLayout will automatically unregister from the static registry
 			// when it's detached from the window, but we can ensure cleanup here as well

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.Y)] = MapY,
 			[nameof(IWindow.Width)] = MapWidth,
 			[nameof(IWindow.Height)] = MapHeight,
+#if ANDROID || __IOS__
+			[nameof(IWindow.StatusBarTheme)] = MapStatusBarTheme,
+#endif
 #if WINDOWS || MACCATALYST
 			[nameof(IWindow.MaximumWidth)] = MapMaximumWidth,
 			[nameof(IWindow.MaximumHeight)] = MapMaximumHeight,

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -128,9 +128,9 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-#if !MACCATALYST
 		public static void MapStatusBarTheme(IWindowHandler handler, IWindow window)
 		{
+#if !MACCATALYST
 			var rootVc = handler.PlatformView.RootViewController;
 			if (rootVc is null)
 				return;
@@ -140,8 +140,8 @@ namespace Microsoft.Maui.Handlers
 				rootVc = rootVc.PresentedViewController;
 
 			rootVc.SetNeedsStatusBarAppearanceUpdate();
-		}
 #endif
+		}
 
 		void UpdateVirtualViewFrame(UIWindow window)
 		{

--- a/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.iOS.cs
@@ -128,6 +128,21 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+#if !MACCATALYST
+		public static void MapStatusBarTheme(IWindowHandler handler, IWindow window)
+		{
+			var rootVc = handler.PlatformView.RootViewController;
+			if (rootVc is null)
+				return;
+
+			// Walk to the topmost presented view controller
+			while (rootVc.PresentedViewController is not null)
+				rootVc = rootVc.PresentedViewController;
+
+			rootVc.SetNeedsStatusBarAppearanceUpdate();
+		}
+#endif
+
 		void UpdateVirtualViewFrame(UIWindow window)
 		{
 			VirtualView.FrameChanged(window.Bounds.ToRectangle());

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
@@ -80,6 +80,8 @@ namespace Microsoft.Maui.LifecycleEvents
 					var mauiWindow = activity.GetWindow();
 					if (mauiWindow is not null)
 					{
+						UpdateStatusBarThemeOnConfigurationChange(mauiWindow);
+
 						if (newConfig is not null)
 						{
 							var density = newConfig.DensityDpi / DeviceDisplay.BaseLogicalDpi;
@@ -90,6 +92,12 @@ namespace Microsoft.Maui.LifecycleEvents
 						mauiWindow.FrameChanged(frame);
 					}
 				});
+		}
+
+		internal static void UpdateStatusBarThemeOnConfigurationChange(IWindow window)
+		{
+			if (window.StatusBarTheme == StatusBarTheme.Default)
+				window.Handler?.UpdateValue(nameof(IWindow.StatusBarTheme));
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui
 		}
 
 		//TODO : Make it public in NET 11.
-		internal static void ConfigureTranslucentSystemBars(this Window? window, Activity activity)
+		internal static void ConfigureTranslucentSystemBars(this Window? window, Activity activity, StatusBarTheme statusBarTheme = StatusBarTheme.Default)
 		{
 			if (window is null)
 			{
@@ -54,13 +54,24 @@ namespace Microsoft.Maui
 			var windowInsetsController = WindowCompat.GetInsetsController(window, window.DecorView);
 			if (windowInsetsController is not null)
 			{
-				// Automatically adjust icon/text colors based on app theme
-				var configuration = activity.Resources?.Configuration;
-				var isLightTheme = configuration is null ||
-					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
+				bool isLightStatusBar;
+				switch (statusBarTheme)
+				{
+					case StatusBarTheme.Light:
+						isLightStatusBar = true;
+						break;
+					case StatusBarTheme.Dark:
+						isLightStatusBar = false;
+						break;
+					default:
+						var configuration = activity.Resources?.Configuration;
+						isLightStatusBar = configuration is null ||
+							(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
+						break;
+				}
 
-				windowInsetsController.AppearanceLightStatusBars = isLightTheme;
-				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
+				windowInsetsController.AppearanceLightStatusBars = isLightStatusBar;
+				windowInsetsController.AppearanceLightNavigationBars = isLightStatusBar;
 			}
 		}
 	}

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui
 		}
 
 		//TODO : Make it public in NET 11.
-		internal static void ConfigureTranslucentSystemBars(this Window? window, Activity activity, StatusBarTheme statusBarTheme = StatusBarTheme.Default)
+		internal static void ConfigureTranslucentSystemBars(this Window? window, Activity activity)
 		{
 			if (window is null)
 			{
@@ -54,25 +54,33 @@ namespace Microsoft.Maui
 			var windowInsetsController = WindowCompat.GetInsetsController(window, window.DecorView);
 			if (windowInsetsController is not null)
 			{
-				bool isLightStatusBar;
-				switch (statusBarTheme)
-				{
-					case StatusBarTheme.Light:
-						isLightStatusBar = true;
-						break;
-					case StatusBarTheme.Dark:
-						isLightStatusBar = false;
-						break;
-					default:
-						var configuration = activity.Resources?.Configuration;
-						isLightStatusBar = configuration is null ||
-							(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
-						break;
-				}
-
-				windowInsetsController.AppearanceLightStatusBars = isLightStatusBar;
-				windowInsetsController.AppearanceLightNavigationBars = isLightStatusBar;
+				var isLightTheme = IsLightTheme(activity);
+				windowInsetsController.AppearanceLightStatusBars = isLightTheme;
+				windowInsetsController.AppearanceLightNavigationBars = isLightTheme;
 			}
+		}
+
+		internal static void UpdateStatusBarTheme(this Window? window, Activity activity, StatusBarTheme statusBarTheme)
+		{
+			if (window is null)
+			{
+				return;
+			}
+
+			var windowInsetsController = WindowCompat.GetInsetsController(window, window.DecorView);
+			windowInsetsController?.AppearanceLightStatusBars = statusBarTheme switch
+				{
+					StatusBarTheme.Light => true,
+					StatusBarTheme.Dark => false,
+					_ => IsLightTheme(activity),
+				};
+		}
+
+		static bool IsLightTheme(Activity activity)
+		{
+			var configuration = activity.Resources?.Configuration;
+			return configuration is null ||
+				(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -68,12 +68,15 @@ namespace Microsoft.Maui
 			}
 
 			var windowInsetsController = WindowCompat.GetInsetsController(window, window.DecorView);
-			windowInsetsController?.AppearanceLightStatusBars = statusBarTheme switch
+			if (windowInsetsController is not null)
+			{
+				windowInsetsController.AppearanceLightStatusBars = statusBarTheme switch
 				{
 					StatusBarTheme.Light => true,
 					StatusBarTheme.Dark => false,
 					_ => IsLightTheme(activity),
 				};
+			}
 		}
 
 		static bool IsLightTheme(Activity activity)

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -56,20 +56,17 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public override UIStatusBarStyle PreferredStatusBarStyle
+		public override UIStatusBarStyle PreferredStatusBarStyle()
 		{
-			get
-			{
-				var window = CurrentView?.Handler?.MauiContext?.GetPlatformWindow()?.GetWindow();
-				var theme = window?.StatusBarTheme ?? StatusBarTheme.Default;
+			var window = CurrentView?.Handler?.MauiContext?.GetPlatformWindow()?.GetWindow();
+			var theme = window?.StatusBarTheme ?? StatusBarTheme.Default;
 
-				return theme switch
-				{
-					StatusBarTheme.Light => UIStatusBarStyle.DarkContent,
-					StatusBarTheme.Dark => UIStatusBarStyle.LightContent,
-					_ => base.PreferredStatusBarStyle
-				};
-			}
+			return theme switch
+			{
+				StatusBarTheme.Light => UIStatusBarStyle.DarkContent,
+				StatusBarTheme.Dark => UIStatusBarStyle.LightContent,
+				_ => base.PreferredStatusBarStyle()
+			};
 		}
 
 		public override void TraitCollectionDidChange(UITraitCollection? previousTraitCollection)

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -56,6 +56,22 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public override UIStatusBarStyle PreferredStatusBarStyle
+		{
+			get
+			{
+				var window = CurrentView?.Handler?.MauiContext?.GetPlatformWindow()?.GetWindow();
+				var theme = window?.StatusBarTheme ?? StatusBarTheme.Default;
+
+				return theme switch
+				{
+					StatusBarTheme.Light => UIStatusBarStyle.DarkContent,
+					StatusBarTheme.Dark => UIStatusBarStyle.LightContent,
+					_ => base.PreferredStatusBarStyle
+				};
+			}
+		}
+
 		public override void TraitCollectionDidChange(UITraitCollection? previousTraitCollection)
 		{
 			if (CurrentView?.Handler is ElementHandler handler)

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -59,7 +59,9 @@ namespace Microsoft.Maui.Platform
 #if !MACCATALYST
 		public override UIStatusBarStyle PreferredStatusBarStyle()
 		{
-			var window = CurrentView?.Handler?.MauiContext?.GetPlatformWindow()?.GetWindow();
+			var application = Context?.Services.GetService(typeof(IApplication)) as IApplication;
+			var window = CurrentView?.FindParentOfType<IWindow>() ??
+				Context?.GetOptionalPlatformWindow().GetWindow(application);
 			var theme = window?.StatusBarTheme ?? StatusBarTheme.Default;
 
 			return theme switch

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+#if !MACCATALYST
 		public override UIStatusBarStyle PreferredStatusBarStyle()
 		{
 			var window = CurrentView?.Handler?.MauiContext?.GetPlatformWindow()?.GetWindow();
@@ -68,6 +69,7 @@ namespace Microsoft.Maui.Platform
 				_ => base.PreferredStatusBarStyle()
 			};
 		}
+#endif
 
 		public override void TraitCollectionDidChange(UITraitCollection? previousTraitCollection)
 		{
@@ -102,4 +104,3 @@ namespace Microsoft.Maui.Platform
 		}
 	}
 }
-

--- a/src/Core/src/Platform/iOS/TabBarControllerManager/TabBarControllerManager.cs
+++ b/src/Core/src/Platform/iOS/TabBarControllerManager/TabBarControllerManager.cs
@@ -196,6 +196,11 @@ namespace Microsoft.Maui.Platform
                 return null;
             }
 
+#if !MACCATALYST
+            public override UIViewController ChildViewControllerForStatusBarStyle()
+                => ChildViewControllerForStatusBarHidden();
+#endif
+
             public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
             {
                 get

--- a/src/Core/src/Platform/iOS/UIWindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/UIWindowExtensions.cs
@@ -8,11 +8,14 @@ namespace Microsoft.Maui.Platform
 	{
 		// TODO Add public docs
 		public static IWindow? GetWindow(this UIWindow? platformWindow)
+			=> platformWindow.GetWindow(IPlatformApplication.Current?.Application);
+
+		internal static IWindow? GetWindow(this UIWindow? platformWindow, IApplication? application)
 		{
 			if (platformWindow is null)
 				return null;
 
-			foreach (var window in IPlatformApplication.Current?.Application?.Windows ?? Array.Empty<IWindow>())
+			foreach (var window in application?.Windows ?? Array.Empty<IWindow>())
 			{
 				if (window?.Handler?.PlatformView == platformWindow)
 					return window;

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,16 +1,17 @@
-#nullable enable
+﻿#nullable enable
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.PlatformDrawable
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(Android.Content.Context? context) -> void
 Microsoft.Maui.PlatformDrawable.PlatformDrawable(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
-override Microsoft.Maui.PlatformDrawable.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
-override Microsoft.Maui.PlatformDrawable.ThresholdClass.get -> nint
-override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.Dispose(bool disposing) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnBoundsChange(Android.Graphics.Rect! bounds) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnDraw(Android.Graphics.Drawables.Shapes.Shape? shape, Android.Graphics.Canvas? canvas, Android.Graphics.Paint? paint) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+override Microsoft.Maui.PlatformDrawable.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override Microsoft.Maui.PlatformDrawable.ThresholdClass.get -> nint
+override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -9,3 +9,8 @@ override Microsoft.Maui.PlatformDrawable.ThresholdType.get -> System.Type!
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnBoundsChange(Android.Graphics.Rect! bounds) -> void
 *REMOVED*override Microsoft.Maui.Graphics.MauiDrawable.OnDraw(Android.Graphics.Drawables.Shapes.Shape? shape, Android.Graphics.Canvas? canvas, Android.Graphics.Paint? paint) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 #nullable enable
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
-﻿#nullable enable
+#nullable enable
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,8 +1,10 @@
-#nullable enable
-override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+﻿#nullable enable
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+override Microsoft.Maui.Platform.PageViewController.PreferredStatusBarStyle() -> UIKit.UIStatusBarStyle
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,41 +1,42 @@
-#nullable enable
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
-static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
+﻿#nullable enable
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ITab
+Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
+Microsoft.Maui.ITab.IsEnabled.get -> bool
+Microsoft.Maui.ITab.Title.get -> string!
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.TabBarPlacement
+Microsoft.Maui.TabBarPlacement.Bottom = 1 -> Microsoft.Maui.TabBarPlacement
+Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
 abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
+override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~override Microsoft.Maui.Handlers.TabbedViewHandler.ConnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Handlers.TabbedViewHandler.DisconnectHandler(UIKit.UIView platformView) -> void
+override Microsoft.Maui.MauiUIApplicationDelegate.ValidateCommand(UIKit.UICommand! command) -> void
+override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
+override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
+override Microsoft.Maui.Platform.PageViewController.PreferredStatusBarStyle() -> UIKit.UIStatusBarStyle
 static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(string! value) -> Microsoft.Maui.GridLength
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
 static Microsoft.Maui.Handlers.EditorHandler.MapBackground(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapBackground(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.RadioButtonHandler.MapBackground(Microsoft.Maui.Handlers.IRadioButtonHandler! handler, Microsoft.Maui.IRadioButton! radioButton) -> void
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
-Microsoft.Maui.ITab
-Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
-Microsoft.Maui.ITab.IsEnabled.get -> bool
-Microsoft.Maui.ITab.Title.get -> string!
-Microsoft.Maui.TabBarPlacement
-Microsoft.Maui.TabBarPlacement.Bottom = 1 -> Microsoft.Maui.TabBarPlacement
-Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
-override Microsoft.Maui.MauiUIApplicationDelegate.ValidateCommand(UIKit.UICommand! command) -> void
-override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
-override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
-override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
-override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
-override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
-override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 #nullable enable
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
-﻿#nullable enable
+#nullable enable
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,8 +1,10 @@
-#nullable enable
-override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+﻿#nullable enable
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+override Microsoft.Maui.Platform.PageViewController.PreferredStatusBarStyle() -> UIKit.UIStatusBarStyle
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -32,7 +32,6 @@ override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
 override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
 override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
-override Microsoft.Maui.Platform.PageViewController.PreferredStatusBarStyle() -> UIKit.UIStatusBarStyle
 static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(string! value) -> Microsoft.Maui.GridLength
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
 static Microsoft.Maui.Handlers.EditorHandler.MapBackground(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,41 +1,42 @@
-#nullable enable
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
-static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
+﻿#nullable enable
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!
 Microsoft.Maui.IHybridWebView.Invoker.set -> void
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
+Microsoft.Maui.ITab
+Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
+Microsoft.Maui.ITab.IsEnabled.get -> bool
+Microsoft.Maui.ITab.Title.get -> string!
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.TabBarPlacement
+Microsoft.Maui.TabBarPlacement.Bottom = 1 -> Microsoft.Maui.TabBarPlacement
+Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
 abstract Microsoft.Maui.HybridWebViewInvoker.InvokeMethodAsync(string! methodName, string![]? paramJsonValues) -> System.Threading.Tasks.Task<string?>!
+override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 override Microsoft.Maui.Handlers.LabelHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.StepperHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~override Microsoft.Maui.Handlers.TabbedViewHandler.ConnectHandler(UIKit.UIView platformView) -> void
 ~override Microsoft.Maui.Handlers.TabbedViewHandler.DisconnectHandler(UIKit.UIView platformView) -> void
+override Microsoft.Maui.MauiUIApplicationDelegate.ValidateCommand(UIKit.UICommand! command) -> void
+override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.get -> UIKit.UITextAlignment
 override Microsoft.Maui.Platform.MauiTextView.TextAlignment.set -> void
+override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
+override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
 override Microsoft.Maui.Platform.MauiView.DidUpdateFocus(UIKit.UIFocusUpdateContext! context, UIKit.UIFocusAnimationCoordinator! coordinator) -> void
+override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
+override Microsoft.Maui.Platform.PageViewController.PreferredStatusBarStyle() -> UIKit.UIStatusBarStyle
 static Microsoft.Maui.GridLength.implicit operator Microsoft.Maui.GridLength(string! value) -> Microsoft.Maui.GridLength
 static Microsoft.Maui.Handlers.DatePickerHandler.MapFlowDirection(Microsoft.Maui.Handlers.IDatePickerHandler! handler, Microsoft.Maui.IDatePicker! datePicker) -> void
 static Microsoft.Maui.Handlers.EditorHandler.MapBackground(Microsoft.Maui.Handlers.IEditorHandler! handler, Microsoft.Maui.IEditor! editor) -> void
 static Microsoft.Maui.Handlers.EntryHandler.MapBackground(Microsoft.Maui.Handlers.IEntryHandler! handler, Microsoft.Maui.IEntry! entry) -> void
 static Microsoft.Maui.Handlers.RadioButtonHandler.MapBackground(Microsoft.Maui.Handlers.IRadioButtonHandler! handler, Microsoft.Maui.IRadioButton! radioButton) -> void
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 static Microsoft.Maui.SafeAreaEdges.Container.get -> Microsoft.Maui.SafeAreaEdges
-Microsoft.Maui.ITab
-Microsoft.Maui.ITab.Icon.get -> Microsoft.Maui.IImageSource?
-Microsoft.Maui.ITab.IsEnabled.get -> bool
-Microsoft.Maui.ITab.Title.get -> string!
-Microsoft.Maui.TabBarPlacement
-Microsoft.Maui.TabBarPlacement.Bottom = 1 -> Microsoft.Maui.TabBarPlacement
-Microsoft.Maui.TabBarPlacement.Top = 0 -> Microsoft.Maui.TabBarPlacement
-override Microsoft.Maui.MauiUIApplicationDelegate.ValidateCommand(UIKit.UICommand! command) -> void
-override Microsoft.Maui.Platform.MauiTextField.LayoutSubviews() -> void
-override Microsoft.Maui.Platform.NoCaretField.LayoutSubviews() -> void
-override Microsoft.Maui.Platform.MauiView.AccessibilityActivate() -> bool
-override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.get -> string?
-override Microsoft.Maui.Platform.MauiView.AccessibilityLabel.set -> void
-override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 #nullable enable
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+static Microsoft.Maui.Handlers.WindowHandler.MapStatusBarTheme(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! window) -> void
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.IHybridWebView.SetInvokeJavaScriptTarget<T>(T! target, System.Text.Json.Serialization.JsonSerializerContext! jsonSerializerContext) -> void
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,7 @@
 #nullable enable
 override Microsoft.Maui.Platform.MauiPasswordTextBox.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer!
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.LifecycleEvents.WindowsLifecycle.OnAppInstanceActivated
 Microsoft.Maui.Platform.MauiLayoutAutomationPeer
 Microsoft.Maui.Platform.MauiLayoutAutomationPeer.MauiLayoutAutomationPeer(Microsoft.Maui.Platform.LayoutPanel! owner) -> void

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 ﻿#nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -3,4 +3,3 @@ Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 ﻿#nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,4 +3,3 @@ Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
-Microsoft.Maui.IWindow.StatusBarTheme.get -> Microsoft.Maui.StatusBarTheme

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 ﻿#nullable enable
+Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Default = 0 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Light = 1 -> Microsoft.Maui.StatusBarTheme
+Microsoft.Maui.StatusBarTheme.Dark = 2 -> Microsoft.Maui.StatusBarTheme
 Microsoft.Maui.HybridWebViewInvoker
 Microsoft.Maui.HybridWebViewInvoker.HybridWebViewInvoker(object? invokeJavaScriptTarget, System.Type? invokeJavaScriptType) -> void
 Microsoft.Maui.IHybridWebView.Invoker.get -> Microsoft.Maui.HybridWebViewInvoker!

--- a/src/Core/tests/DeviceTests.Shared/Stubs/WindowStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/WindowStub.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public bool IsResumed { get; set; }
 		public bool IsStopped { get; set; }
 		public FlowDirection FlowDirection { get; set; }
+		public StatusBarTheme StatusBarTheme { get; set; }
 
 		public void FrameChanged(Rect frame)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Android.App;
+using Android.Content.Res;
 using AndroidX.AppCompat.App;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
@@ -110,7 +111,7 @@ namespace Microsoft.Maui.DeviceTests
 				// Default should match the system theme
 				var configuration = activity.Resources?.Configuration;
 				var isLightTheme = configuration is null ||
-					(configuration.UiMode & Android.Content.Res.UiMode.NightMask) != Android.Content.Res.UiMode.NightYes;
+					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
 
 				Assert.Equal(isLightTheme, controller.AppearanceLightStatusBars);
 			});

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -68,5 +68,52 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(activity.Title, ApplicationModel.AppInfo.Current.Name);
 			});
 		}
+
+		[Theory]
+		[InlineData(StatusBarTheme.Light, true)]
+		[InlineData(StatusBarTheme.Dark, false)]
+		public async Task StatusBarThemeSetsAppearanceLightStatusBars(StatusBarTheme theme, bool expectedLightStatusBars)
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = (AppCompatActivity)MauiProgramDefaults.DefaultContext;
+				Assert.True(activity is not null, "Activity is Null");
+
+				var window = activity.Window;
+				Assert.True(window is not null, "Window is Null");
+
+				window.ConfigureTranslucentSystemBars(activity, theme);
+
+				var controller = AndroidX.Core.View.WindowCompat.GetInsetsController(window, window.DecorView);
+				Assert.True(controller is not null, "InsetsController is Null");
+
+				Assert.Equal(expectedLightStatusBars, controller.AppearanceLightStatusBars);
+			});
+		}
+
+		[Fact]
+		public async Task StatusBarThemeDefaultFollowsSystemTheme()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = (AppCompatActivity)MauiProgramDefaults.DefaultContext;
+				Assert.True(activity is not null, "Activity is Null");
+
+				var window = activity.Window;
+				Assert.True(window is not null, "Window is Null");
+
+				window.ConfigureTranslucentSystemBars(activity, StatusBarTheme.Default);
+
+				var controller = AndroidX.Core.View.WindowCompat.GetInsetsController(window, window.DecorView);
+				Assert.True(controller is not null, "InsetsController is Null");
+
+				// Default should match the system theme
+				var configuration = activity.Resources?.Configuration;
+				var isLightTheme = configuration is null ||
+					(configuration.UiMode & Android.Content.Res.UiMode.NightMask) != Android.Content.Res.UiMode.NightYes;
+
+				Assert.Equal(isLightTheme, controller.AppearanceLightStatusBars);
+			});
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -73,6 +73,43 @@ namespace Microsoft.Maui.DeviceTests
 		[Theory]
 		[InlineData(StatusBarTheme.Light, true)]
 		[InlineData(StatusBarTheme.Dark, false)]
+		public async Task StatusBarThemeAppliesWhenHandlerConnects(StatusBarTheme theme, bool expectedLightStatusBars)
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var activity = (AppCompatActivity)MauiProgramDefaults.DefaultContext;
+				Assert.NotNull(activity);
+
+				var platformWindow = activity.Window;
+				Assert.NotNull(platformWindow);
+
+				var controller = AndroidX.Core.View.WindowCompat.GetInsetsController(platformWindow, platformWindow.DecorView);
+				Assert.NotNull(controller);
+
+				var originalLightStatusBars = controller.AppearanceLightStatusBars;
+				var originalLightNavigationBars = controller.AppearanceLightNavigationBars;
+				var handler = new WindowHandler(new PropertyMapper<IWindow, IWindowHandler>
+				{
+					[nameof(IWindow.StatusBarTheme)] = WindowHandler.MapStatusBarTheme
+				});
+
+				try
+				{
+					InitializeViewHandler(new WindowStub { StatusBarTheme = theme }, handler);
+					Assert.Equal(expectedLightStatusBars, controller.AppearanceLightStatusBars);
+				}
+				finally
+				{
+					controller.AppearanceLightStatusBars = originalLightStatusBars;
+					controller.AppearanceLightNavigationBars = originalLightNavigationBars;
+					((IElementHandler)handler).DisconnectHandler();
+				}
+			});
+		}
+
+		[Theory]
+		[InlineData(StatusBarTheme.Light, true)]
+		[InlineData(StatusBarTheme.Dark, false)]
 		public async Task StatusBarThemeSetsAppearanceLightStatusBars(StatusBarTheme theme, bool expectedLightStatusBars)
 		{
 			await InvokeOnMainThreadAsync(() =>
@@ -83,12 +120,19 @@ namespace Microsoft.Maui.DeviceTests
 				var window = activity.Window;
 				Assert.True(window is not null, "Window is Null");
 
-				window.ConfigureTranslucentSystemBars(activity, theme);
-
 				var controller = AndroidX.Core.View.WindowCompat.GetInsetsController(window, window.DecorView);
 				Assert.True(controller is not null, "InsetsController is Null");
 
-				Assert.Equal(expectedLightStatusBars, controller.AppearanceLightStatusBars);
+				var originalLightStatusBars = controller.AppearanceLightStatusBars;
+				try
+				{
+					window.UpdateStatusBarTheme(activity, theme);
+					Assert.Equal(expectedLightStatusBars, controller.AppearanceLightStatusBars);
+				}
+				finally
+				{
+					controller.AppearanceLightStatusBars = originalLightStatusBars;
+				}
 			});
 		}
 
@@ -103,17 +147,25 @@ namespace Microsoft.Maui.DeviceTests
 				var window = activity.Window;
 				Assert.True(window is not null, "Window is Null");
 
-				window.ConfigureTranslucentSystemBars(activity, StatusBarTheme.Default);
-
 				var controller = AndroidX.Core.View.WindowCompat.GetInsetsController(window, window.DecorView);
 				Assert.True(controller is not null, "InsetsController is Null");
 
-				// Default should match the system theme
-				var configuration = activity.Resources?.Configuration;
-				var isLightTheme = configuration is null ||
-					(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
+				var originalLightStatusBars = controller.AppearanceLightStatusBars;
+				try
+				{
+					window.UpdateStatusBarTheme(activity, StatusBarTheme.Default);
 
-				Assert.Equal(isLightTheme, controller.AppearanceLightStatusBars);
+					// Default should match the system theme
+					var configuration = activity.Resources?.Configuration;
+					var isLightTheme = configuration is null ||
+						(configuration.UiMode & UiMode.NightMask) != UiMode.NightYes;
+
+					Assert.Equal(isLightTheme, controller.AppearanceLightStatusBars);
+				}
+				finally
+				{
+					controller.AppearanceLightStatusBars = originalLightStatusBars;
+				}
 			});
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Android.cs
@@ -107,6 +107,31 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task StatusBarThemeDefaultUpdatesOnConfigurationChange()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var updateCount = 0;
+				var mapper = new PropertyMapper<IWindow, IWindowHandler>
+				{
+					[nameof(IWindow.StatusBarTheme)] = (handler, window) => updateCount++
+				};
+				var handler = new WindowHandlerProxyStub(mapper);
+				var window = new WindowStub { StatusBarTheme = StatusBarTheme.Default };
+
+				InitializeViewHandler(window, handler);
+				updateCount = 0;
+
+				LifecycleEvents.AppHostBuilderExtensions.UpdateStatusBarThemeOnConfigurationChange(window);
+				Assert.Equal(1, updateCount);
+
+				window.StatusBarTheme = StatusBarTheme.Dark;
+				LifecycleEvents.AppHostBuilderExtensions.UpdateStatusBarThemeOnConfigurationChange(window);
+				Assert.Equal(1, updateCount);
+			});
+		}
+
 		[Theory]
 		[InlineData(StatusBarTheme.Light, true)]
 		[InlineData(StatusBarTheme.Dark, false)]

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -11,16 +11,16 @@ namespace Microsoft.Maui.DeviceTests
 	{
 #if !MACCATALYST
 		[Fact]
-		public async Task StatusBarThemeDefaultReturnsBaseStyle()
+		public async Task PageViewControllerReturnsDefaultStatusBarStyleWithoutWindow()
 		{
 			await InvokeOnMainThreadAsync(() =>
 			{
-				var page = new ContentPage { Content = new Label { Text = "Test" } };
-				var pageVc = page.ToUIViewController(MauiContext);
-				var pvc = Assert.IsType<PageViewController>(pageVc);
+				// PageViewController without a window should return UIStatusBarStyle.Default
+				// because the StatusBarTheme resolves to Default when no IWindow is available
+				var pvc = new Microsoft.Maui.Platform.PageViewController(
+					new DeviceTests.Stubs.StubBase(),
+					MauiContext);
 
-				// Without a window attached, StatusBarTheme resolves to Default,
-				// which falls back to base.PreferredStatusBarStyle()
 				Assert.Equal(UIStatusBarStyle.Default, pvc.PreferredStatusBarStyle());
 			});
 		}

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -9,6 +9,23 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class WindowHandlerTests : CoreHandlerTestBase
 	{
+#if !MACCATALYST
+		[Fact]
+		public async Task StatusBarThemeDefaultReturnsBaseStyle()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var page = new ContentPage { Content = new Label { Text = "Test" } };
+				var pageVc = page.ToUIViewController(MauiContext);
+				var pvc = Assert.IsType<PageViewController>(pageVc);
+
+				// Without a window attached, StatusBarTheme resolves to Default,
+				// which falls back to base.PreferredStatusBarStyle
+				Assert.Equal(UIStatusBarStyle.Default, pvc.PreferredStatusBarStyle);
+			});
+		}
+#endif
+
 #if MACCATALYST
 
 		[Fact(

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Maui.DeviceTests
 				var pvc = Assert.IsType<PageViewController>(pageVc);
 
 				// Without a window attached, StatusBarTheme resolves to Default,
-				// which falls back to base.PreferredStatusBarStyle
-				Assert.Equal(UIStatusBarStyle.Default, pvc.PreferredStatusBarStyle);
+				// which falls back to base.PreferredStatusBarStyle()
+				Assert.Equal(UIStatusBarStyle.Default, pvc.PreferredStatusBarStyle());
 			});
 		}
 #endif

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				// PageViewController without a window should return UIStatusBarStyle.Default
 				// because the StatusBarTheme resolves to Default when no IWindow is available
-				var pvc = new Microsoft.Maui.Platform.PageViewController(
-					new DeviceTests.Stubs.StubBase(),
+				using var pvc = new Microsoft.Maui.Platform.PageViewController(
+					new DeviceTests.Stubs.ContentViewStub(),
 					MauiContext);
 
 				Assert.Equal(UIStatusBarStyle.Default, pvc.PreferredStatusBarStyle());

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.iOS.cs
@@ -24,6 +24,41 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(UIStatusBarStyle.Default, pvc.PreferredStatusBarStyle());
 			});
 		}
+
+		[Fact]
+		public async Task TabBarControllerDelegatesStatusBarStyle()
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				using var controller = new UIViewController();
+				using var preferredController = new UIViewController();
+				using var manager = new Microsoft.Maui.Platform.TabBarControllerManager(
+					new TabBarManagerDelegateStub(controller));
+
+				Assert.Same(controller, manager.TabBarController.ChildViewControllerForStatusBarStyle());
+
+				manager.GetCurrentPageViewControllerFunc = () => preferredController;
+				Assert.Same(preferredController, manager.TabBarController.ChildViewControllerForStatusBarStyle());
+			});
+		}
+
+		sealed class TabBarManagerDelegateStub : Microsoft.Maui.Platform.ITabBarManagerDelegate
+		{
+			readonly UIViewController _controller;
+
+			public TabBarManagerDelegateStub(UIViewController controller)
+			{
+				_controller = controller;
+			}
+
+			public UIViewController GetCurrentPageViewController() => _controller;
+			public void OnTabSelected(int index) { }
+			public void OnTabsReordered(UIViewController[] viewControllers) { }
+			public void OnTraitCollectionDidChange(UITraitCollection previousTraitCollection) { }
+			public void OnViewDidAppear() { }
+			public void OnViewDidDisappear() { }
+			public void OnViewDidLayoutSubviews() { }
+		}
 #endif
 
 #if MACCATALYST


### PR DESCRIPTION
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could <a href="https://github.com/dotnet/maui/wiki/Testing-PR-Builds">test the resulting artifacts</a> from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Adds a new `Window.StatusBarTheme` property to control the appearance of OS-drawn status bar icons (clock, battery, signal) on Android and iOS, independently of the app theme.

### The Problem

With edge-to-edge rendering (enforced on Android 15+), the status bar is always transparent and app content renders behind it. MAUI automatically sets status bar icon color based on the app theme — but there's no API to override this. If an app has a dark header behind the status bar while using a light theme, the icons become unreadable (dark-on-dark).

### The Solution

A new `StatusBarTheme` enum (`Default`/`Light`/`Dark`) on `Window` that parallels `AppTheme`:

```csharp
// Force light icons over dark sidebar
window.StatusBarTheme = StatusBarTheme.Dark;
```

```xml
<!-- Theme-reactive via AppThemeBinding -->
<Window StatusBarTheme="{AppThemeBinding Light=Light, Dark=Dark}" />
```

## API

### New Enum

```csharp
public enum StatusBarTheme { Default, Light, Dark }
```

### IWindow Interface Addition

```csharp
StatusBarTheme StatusBarTheme => StatusBarTheme.Default;
```

### Window BindableProperty

```csharp
public StatusBarTheme StatusBarTheme { get; set; }
```

## Platform Mapping

| `StatusBarTheme` | Android | iOS | Desktop |
|---|---|---|---|
| `Default` | Follows system theme | `UIStatusBarStyle.Default` | No-op |
| `Light` | `AppearanceLightStatusBars=true` | `UIStatusBarStyle.DarkContent` | No-op |
| `Dark` | `AppearanceLightStatusBars=false` | `UIStatusBarStyle.LightContent` | No-op |

## Changes

- Added `StatusBarTheme` in `Microsoft.Maui` and `IWindow.StatusBarTheme` with a default implementation.
- Added the `Window.StatusBarThemeProperty` bindable property, including styling and `AppThemeBinding` support.
- Android applies the override only to status bar icons; navigation bar appearance remains independent.
- iOS resolves the style through ContentPage, NavigationPage, TabbedPage, FlyoutPage, Shell, and handler-based tab controller hierarchies.
- Mac Catalyst and other desktop platforms remain no-ops.
- Added unit tests plus Android and iOS device coverage for initial/runtime mapping, native flag preservation, and controller delegation.
- Added a Controls.Sample page for interactive validation.

## Issues

Fixes #34902
Related: #34462 (Problem 2), #998, #6159
