### PR TITLE
Update Controls.ManualTest project: changes the android SupportedOSPlatformVersion from 21 to 24

### DIFF
--- a/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
+++ b/src/Controls/tests/ManualTests/Controls.ManualTests.csproj
@@ -32,7 +32,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>

--- a/src/Controls/tests/ManualTests/README.md
+++ b/src/Controls/tests/ManualTests/README.md
@@ -296,7 +296,7 @@ dotnet build
 ### Platform Requirements
 
 #### Android
-- Android SDK 21+ (as specified in `SupportedOSPlatformVersion`)
+- Android SDK 24+ (as specified in `SupportedOSPlatformVersion`)
 - Java 11 or higher
 
 #### iOS


### PR DESCRIPTION
### Description of Change

Update Controls.ManualTest project: changes the android SupportedOSPlatformVersion from 21 to 24

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fix Issue https://github.com/dotnet/maui/issues/34874: [.NET 11]With VS 18.6.0 Insiders + .NET11 Preview 3 installed: ManualMaui cannot be debugged on the Android platform with errors: XAAMM0000 & AMM0000 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
