### PR TITLE
[Windows] Fix CollectionView ScrollTo related test cases failed in CI

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CollectionView/ScrollingFeature/CollectionViewScrollPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CollectionView/ScrollingFeature/CollectionViewScrollPage.xaml.cs
@@ -18,6 +18,10 @@ public partial class CollectionViewScrollPage : ContentPage
 		BindingContext = _viewModel = new CollectionViewViewModel(isScrollingFeatureTest: true);
 		_viewModel.ItemsSourceType = ItemsSourceType.ObservableCollectionT3;
 		_viewModel.ScrollToPosition = ScrollToPosition.MakeVisible;
+		// Wait for any deferred DispatcherQueue.TryEnqueue callbacks from OnItemsVectorChanged
+		// (introduced by the fix in ItemsViewHandler.Windows.cs) to fire before resetting the
+		// scroll event labels, so the reset isn't overwritten by the deferred scroll.
+		await Task.Delay(300);
 		ResetScrollEventLabels();
 		await Navigation.PushAsync(new ScrollBehaviorOptionsPage(_viewModel));
 	}

--- a/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CollectionView/ScrollingFeature/CollectionViewScrollPage.xaml.cs
+++ b/src/Controls/tests/TestCases.HostApp/FeatureMatrix/CollectionView/ScrollingFeature/CollectionViewScrollPage.xaml.cs
@@ -18,10 +18,12 @@ public partial class CollectionViewScrollPage : ContentPage
 		BindingContext = _viewModel = new CollectionViewViewModel(isScrollingFeatureTest: true);
 		_viewModel.ItemsSourceType = ItemsSourceType.ObservableCollectionT3;
 		_viewModel.ScrollToPosition = ScrollToPosition.MakeVisible;
+#if WINDOWS
 		// Wait for any deferred DispatcherQueue.TryEnqueue callbacks from OnItemsVectorChanged
 		// (introduced by the fix in ItemsViewHandler.Windows.cs) to fire before resetting the
 		// scroll event labels, so the reset isn't overwritten by the deferred scroll.
 		await Task.Delay(300);
+#endif
 		ResetScrollEventLabels();
 		await Navigation.PushAsync(new ScrollBehaviorOptionsPage(_viewModel));
 	}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue33614.cs
@@ -71,6 +71,11 @@ public class Issue33614 : ContentPage
 
     private void OnScrollToButtonClicked(object sender, EventArgs e)
     {
+#if WINDOWS
+        // Disable animation on Windows to avoid flaky test results 
+        _collectionView.ScrollTo(15, position: ScrollToPosition.Start, animate: false);
+#else
         _collectionView.ScrollTo(15, position: ScrollToPosition.Start, animate: true);
+#endif
     }
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/CollectionView_ScrollingFeatureTests.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/FeatureMatrix/CollectionView_ScrollingFeatureTests.cs
@@ -1223,7 +1223,7 @@ public class CollectionView_ScrollingFeatureTests : _GalleryUITest
 #endif
 #endif
 
-#if TEST_FAILS_ON_ANDROID && TEST_FAILS_ON_WINDOWS // In windows, related issue: https://github.com/dotnet/maui/issues/34772
+#if TEST_FAILS_ON_ANDROID
 	//[Android] KeepScrollOffset doesn't not works as expected when new items are added in CollectionView Issue Link:  https://github.com/dotnet/maui/issues/29131
 	[Test]
 	[Category(UITestCategories.CollectionView)]
@@ -1577,7 +1577,6 @@ public class CollectionView_ScrollingFeatureTests : _GalleryUITest
 	}
 
 	// ScrollTo By Index Tests
-#if TEST_FAILS_ON_WINDOWS // Related issue: https://github.com/dotnet/maui/issues/34772
 	[Test]
 	[Category(UITestCategories.CollectionView)]
 	public void VerifyScrollToByIndexWithMakeVisiblePositionAndVerticalList_Carrot()
@@ -1790,7 +1789,6 @@ public class CollectionView_ScrollingFeatureTests : _GalleryUITest
 		Assert.That(App.WaitForElement("ItemLabel").GetText(), Is.EqualTo("Carrot"));
 		VerifyScreenshot();
 	}
-#endif
 
 	// Grouped ScrollTo By Index Tests
 #if TEST_FAILS_ON_CATALYST && TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_IOS // Issue - https://github.com/dotnet/maui/issues/17664

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33614.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue33614.cs
@@ -1,4 +1,3 @@
-#if TEST_FAILS_ON_WINDOWS // Related issue: https://github.com/dotnet/maui/issues/34772
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -21,4 +20,3 @@ public class Issue33614 : _IssuesUITest
         Assert.That(firstIndexText, Is.EqualTo("FirstVisibleItemIndex: 15"));
     }
 }
-#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Root Cause

- PR [24867](https://github.com/dotnet/maui/pull/24867) fixed a COM exception on Windows by wrapping [ListViewBase.ScrollIntoView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) inside [DispatcherQueue.TryEnqueue()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [ItemsViewHandler.Windows.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [OnItemsVectorChanged](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This changed [ScrollIntoView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from synchronous to asynchronous execution, introducing a race condition in ScrollTo-related UI tests on Windows.

- Before [24867](https://github.com/dotnet/maui/pull/24867)
  - Items load → [OnItemsVectorChanged](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [ScrollIntoView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) fires (sync) → Scrolled event updates label → Test resets label → Label = "Not Fired" 

- After [24867](https://github.com/dotnet/maui/pull/24867) (async via TryEnqueue):
  - Items load → [OnItemsVectorChanged](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [ScrollIntoView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is queued (async) → Test resets label to "Not Fired" → Queued [ScrollIntoView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) fires → Scrolled event overwrites label = "Fired" 

- The deferred [ScrollIntoView](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) callback executes after the test has already reset the scroll event labels, causing stale scroll events to overwrite the expected state. Similarly, for [ScrollTo(animate: true)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) tests, the animated scroll produces intermediate [Scrolled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) events that haven't settled to the final index when the test reads the label value.

### Description of Change

<!-- Enter description of the fix in this section -->
**Test reliability improvements:**

* Added a delay in `CollectionViewScrollPage.xaml.cs` before resetting scroll event labels to ensure deferred callbacks complete, preventing test flakiness on Windows.
* Disabled animation for `ScrollTo` actions on Windows in `Issue33614.cs` to avoid flaky test results.

**Test coverage and platform-specific adjustments:**

* Removed Windows-specific test skip conditions in `Issue33614.cs` and `CollectionView_ScrollingFeatureTests.cs`, re-enabling these tests on Windows as the related issues have been resolved. [[1]](diffhunk://#diff-d98964fb2b3496a40f82c4700a38b02be920ba2dc4c500cd6f020d1f74b847d1L1) [[2]](diffhunk://#diff-d98964fb2b3496a40f82c4700a38b02be920ba2dc4c500cd6f020d1f74b847d1L24) [[3]](diffhunk://#diff-d0158d1415828d2b2a784462d5b03cadbc262b1cd822351d96b35b146976da66L1580) [[4]](diffhunk://#diff-d0158d1415828d2b2a784462d5b03cadbc262b1cd822351d96b35b146976da66L1793)
* Updated conditional compilation for a grouped list test to only skip on Android, as the Windows issue has been addressed.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34772

| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/7db67c75-c970-43b0-bcb8-3232af341fa4"> | <img src="https://github.com/user-attachments/assets/998d74ee-5d4b-48b2-8632-47dc89d2e3e7"> |


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
