### PR TITLE
[Android] [Candidate branch] Fix VerifySelectedItemClearsOnNullAssignment, CollectionViewSelectionShouldClear, SelectedItemVisualIsCleared UI test failure on Android 

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
         		UpdateMauiSelection(adapterPosition);
         		// Unconditionally sync visual state for Single mode.
         		// Handles value-equal items where PropertyChanged is suppressed.
-        		if (ItemsView.SelectionMode == SelectionMode.Single && sender is SelectableViewHolder clickedHolder)
+        		if (ItemsView.SelectedItem is not null && ItemsView.SelectionMode == SelectionMode.Single && sender is SelectableViewHolder clickedHolder)
         		{
             		ClearPlatformSelection();
             		clickedHolder.IsSelected = true;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

The UI test case's VerifySelectedItemClearsOnNullAssignment, CollectionViewSelectionShouldClear, SelectedItemVisualIsCleared failed on android platform
       
### Root Cause:

The test case fails because the selection is still being applied when the collectionView.SelectedItem property is set to null during the SelectionChanged event.

### Description of Change:

Added a condition to prevent applying selection when SelectedItem is null.

**Tested the behavior in the following platforms:**

- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac    

### Screenshots
After
<img width="800" height="374" alt="image" src="https://github.com/user-attachments/assets/7b8b80bb-3813-4cac-9c3a-9fd59fa6a297" />
<img width="998" height="518" alt="image" src="https://github.com/user-attachments/assets/a46bc0c7-9608-4f1a-a329-830e5e3c124d" />
<img width="926" height="544" alt="image" src="https://github.com/user-attachments/assets/6fd1f053-9298-4457-8b6d-2a9ca2c47369" />

