### PR TITLE
[Testing] Fix Label CharacterSpacing/LineHeight/TextDecorations test for HTML labels

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.DeviceTests
 				new object[] { label1, 5d, 1.5d, TextDecorations.Underline },
 				new object[] { label2, 5d, 1.5d, TextDecorations.Strikethrough },
 				new object[] { label3, 0d, 0d, TextDecorations.None },
-				new object[] { label4, 0d, 0d, TextDecorations.None }
+				new object[] { label4, 5d, 1.5d, TextDecorations.Underline }
 			};
 		}
 


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Description of Change

Fixes the `CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly` device test regression introduced by PR #31202.

PR #31202 changed the Label mapper conditions from `!IsPlainText(label)` to `label.HasFormattedTextSpans` for `MapLineHeight`, `MapTextDecorations`, and `MapCharacterSpacing`. This correctly enables these properties to be applied to HTML labels (`TextType.Html`), since `HasFormattedTextSpans` only returns true for `FormattedText` with spans — not for HTML.

However, the test expectations for `label4` (an HTML label with `CharacterSpacing=5`, `LineHeight=1.5`, `TextDecorations=Underline`) were not updated and still expected `(0, 0, None)`.

**Fix:** Update expected values for label4 from `(0, 0, None)` to `(5, 1.5, Underline)` to match the new behavior.

### Issues Fixed

Fixes CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly device test regression from #31202