### PR TITLE
Add local-android-packs skill

### DIFF
--- a/.github/skills/local-android-packs/SKILL.md
+++ b/.github/skills/local-android-packs/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: local-android-packs
+description: "Override provisioned Android workload packs with locally built versions from dotnet/android"
+metadata:
+  author: dotnet-maui
+  version: "1.0.0"
+compatibility: "macOS, Linux, Windows — requires local dotnet/android build"
+---
+
+# Local Android Packs Overlay
+
+Override the provisioned Android workload packs in `.dotnet/` with locally built packs from a [dotnet/android](https://github.com/dotnet/android) checkout. This lets you test android changes against MAUI without waiting for dependency flow through Maestro.
+
+## When to Use
+
+- **Testing local dotnet/android changes** — you've made a fix or feature in dotnet/android and want to verify it works with MAUI before submitting a PR
+- **Debugging Android workload issues** — you need to add diagnostics or logging to the Android SDK and test against MAUI
+- **Bisecting regressions in dotnet/android** — testing different dotnet/android commits against the same MAUI code
+
+## Prerequisites
+
+1. **Built dotnet/android repo** — clone and build locally:
+   ```bash
+   git clone https://github.com/dotnet/android ~/repos/android
+   cd ~/repos/android
+   dotnet build Xamarin.Android.sln -c Release
+   ```
+   The build output packs will be at `bin/Release/lib/packs/`.
+
+2. **Provisioned MAUI SDK** — the `.dotnet/` directory must exist. From the MAUI repo root:
+   ```bash
+   ./build.sh --restore
+   ```
+
+3. **PowerShell 7+** — installed on your platform (`pwsh`). The provisioned `.dotnet/` may include it, or install via your package manager.
+
+## Quick Start
+
+### Overlay Release packs
+
+```powershell
+.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
+    -AndroidSrcPath ~/repos/android
+```
+
+### Overlay Debug packs
+
+```powershell
+.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
+    -AndroidSrcPath ~/repos/android -Config Debug
+```
+
+### Restore original packs
+
+```powershell
+.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
+    -AndroidSrcPath ~/repos/android -Restore
+```
+
+## How It Works
+
+The script uses a **manifest patching + pack placement** approach:
+
+1. **Discovers SDK manifest path** — searches `.dotnet/sdk-manifests/*/microsoft.net.sdk.android/` for `WorkloadManifest.json`, picking the highest SDK band
+2. **Reads `WorkloadManifest.json`** to get the installed pack versions and the full list of net11 packs
+3. **Detects local build version** from the version subdirectory name under the local packs directory (e.g., `36.1.99-ci.main.157`)
+4. **Backs up the manifest** and records original version, local version, timestamp, and list of overlaid packs in a metadata file
+5. **Patches `WorkloadManifest.json`** — updates version fields for all net11 packs to the local build version. The net10 SDK entry and Templates pack are left untouched.
+6. **Places packs** — copies local pack directories into `.dotnet/packs/<PackName>/<local-version>/`. The SDK pack is mapped to the platform-specific alias (e.g., `Microsoft.Android.Sdk.Darwin` on macOS).
+7. **Verifies** key files exist in the overlaid packs
+
+Everything is reversible — run with `-Restore` to undo all changes.
+
+## What Gets Modified
+
+| Location | Change |
+|----------|--------|
+| `.dotnet/sdk-manifests/<band>/microsoft.net.sdk.android/WorkloadManifest.json` | Version fields patched to local build version |
+| `.dotnet/packs/<PackName>/<local-version>/` | Local pack directories placed alongside existing versions |
+| `.android-packs-backup/` (repo root) | Backup of original manifest + metadata (gitignored via `.dotnet/` parent) |
+
+## Pack Coverage
+
+The following packs are overlaid (all net11 packs from the manifest):
+
+| Pack ID (manifest entry) | Resolved Name | Kind |
+|--------------------------|---------------|------|
+| `Microsoft.Android.Sdk.net11` | `Microsoft.Android.Sdk.Darwin` / `.Linux` / `.Windows` (platform alias) | sdk |
+| `Microsoft.Android.Ref.36` | `Microsoft.Android.Ref.36` | framework |
+| `Microsoft.Android.Runtime.36.android` | `Microsoft.Android.Runtime.36.android` | framework |
+| `Microsoft.Android.Runtime.Mono.36.android-arm` | `Microsoft.Android.Runtime.Mono.36.android-arm` | framework |
+| `Microsoft.Android.Runtime.Mono.36.android-arm64` | `Microsoft.Android.Runtime.Mono.36.android-arm64` | framework |
+| `Microsoft.Android.Runtime.Mono.36.android-x86` | `Microsoft.Android.Runtime.Mono.36.android-x86` | framework |
+| `Microsoft.Android.Runtime.Mono.36.android-x64` | `Microsoft.Android.Runtime.Mono.36.android-x64` | framework |
+| `Microsoft.Android.Runtime.CoreCLR.36.android-arm64` | `Microsoft.Android.Runtime.CoreCLR.36.android-arm64` | framework |
+| `Microsoft.Android.Runtime.CoreCLR.36.android-x64` | `Microsoft.Android.Runtime.CoreCLR.36.android-x64` | framework |
+| `Microsoft.Android.Runtime.NativeAOT.36.android-arm64` | `Microsoft.Android.Runtime.NativeAOT.36.android-arm64` | framework |
+| `Microsoft.Android.Runtime.NativeAOT.36.android-x64` | `Microsoft.Android.Runtime.NativeAOT.36.android-x64` | framework |
+
+> **Skipped:** `Microsoft.Android.Sdk.net10` (different version for net10 compat) and `Microsoft.Android.Templates` (template pack, not needed for builds).
+
+## Restore / Undo
+
+Run with `-Restore` to revert all changes:
+
+```powershell
+.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
+    -AndroidSrcPath ~/repos/android -Restore
+```
+
+This will:
+1. Read the backup metadata to find all overlaid pack names and versions
+2. Remove the local version directories from `.dotnet/packs/`
+3. Restore the original `WorkloadManifest.json` from backup
+4. Delete the backup directory
+
+If an overlay fails partway through, the script automatically attempts to roll back from the backup.
+
+## Troubleshooting
+
+### "Local packs directory not found"
+
+The path `<AndroidSrcPath>/bin/<Config>/lib/packs` doesn't exist. Verify that:
+- Your `-AndroidSrcPath` points to the dotnet/android repo root
+- You built with the correct configuration (`-Config Release` vs `-Config Debug`)
+- The build completed successfully (`dotnet build Xamarin.Android.sln -c Release`)
+
+### "No manifest found"
+
+No `WorkloadManifest.json` was found under `.dotnet/sdk-manifests/*/microsoft.net.sdk.android/`. Run `./build.sh --restore` from the MAUI repo root to provision the SDK.
+
+### "Version mismatch" / unexpected behavior
+
+If the local dotnet/android build version doesn't match what MAUI expects, builds may fail with missing API errors. Check:
+- The dotnet/android branch matches the MAUI branch expectations
+- The local build is fresh (clean + rebuild if needed)
+
+### Pack not found in local build
+
+Some packs may not be present in the local build output (e.g., NativeAOT runtime packs if not built). These are skipped with a warning — the installed version remains for those packs.
+
+### Build errors after overlay
+
+If MAUI builds fail after overlaying, the local android version may be incompatible. Restore with `-Restore` to go back to the known-good state.
+
+## Notes
+
+- **Backups are gitignored** — the `.android-packs-backup/` directory lives under the repo root, and `.dotnet/` (where the packs live) is already in `.gitignore`
+- **Templates pack is skipped** — `Microsoft.Android.Templates` is not overlaid since it's only used for `dotnet new` project creation, not builds
+- **net10 SDK is untouched** — `Microsoft.Android.Sdk.net10` has a separate version for backward compatibility and is not modified
+- **Platform-specific SDK alias** — the script automatically detects whether you're on macOS (`Sdk.Darwin`), Linux (`Sdk.Linux`), or Windows (`Sdk.Windows`) and uses the correct pack name

--- a/.github/skills/local-android-packs/SKILL.md
+++ b/.github/skills/local-android-packs/SKILL.md
@@ -53,8 +53,7 @@ Override the provisioned Android workload packs in `.dotnet/` with locally built
 ### Restore original packs
 
 ```powershell
-.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
-    -AndroidSrcPath ~/repos/android -Restore
+.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 -Restore
 ```
 
 ## How It Works
@@ -67,7 +66,6 @@ The script uses a **manifest patching + pack placement** approach:
 4. **Backs up the manifest** and records original version, local version, timestamp, and list of overlaid packs in a metadata file
 5. **Patches `WorkloadManifest.json`** — updates version fields for all net11 packs to the local build version. The net10 SDK entry and Templates pack are left untouched.
 6. **Places packs** — copies local pack directories into `.dotnet/packs/<PackName>/<local-version>/`. The SDK pack is mapped to the platform-specific alias (e.g., `Microsoft.Android.Sdk.Darwin` on macOS).
-7. **Verifies** key files exist in the overlaid packs
 
 Everything is reversible — run with `-Restore` to undo all changes.
 
@@ -77,7 +75,7 @@ Everything is reversible — run with `-Restore` to undo all changes.
 |----------|--------|
 | `.dotnet/sdk-manifests/<band>/microsoft.net.sdk.android/WorkloadManifest.json` | Version fields patched to local build version |
 | `.dotnet/packs/<PackName>/<local-version>/` | Local pack directories placed alongside existing versions |
-| `.android-packs-backup/` (repo root) | Backup of original manifest + metadata (gitignored via `.dotnet/` parent) |
+| `.dotnet/.android-packs-backup/` | Backup of original manifest + metadata (gitignored via `.dotnet/` entry) |
 
 ## Pack Coverage
 
@@ -104,8 +102,7 @@ The following packs are overlaid (all net11 packs from the manifest):
 Run with `-Restore` to revert all changes:
 
 ```powershell
-.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
-    -AndroidSrcPath ~/repos/android -Restore
+.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 -Restore
 ```
 
 This will:
@@ -145,7 +142,7 @@ If MAUI builds fail after overlaying, the local android version may be incompati
 
 ## Notes
 
-- **Backups are gitignored** — the `.android-packs-backup/` directory lives under the repo root, and `.dotnet/` (where the packs live) is already in `.gitignore`
+- **Backups are gitignored** — the `.android-packs-backup/` directory lives under `.dotnet/`, which is already in `.gitignore`
 - **Templates pack is skipped** — `Microsoft.Android.Templates` is not overlaid since it's only used for `dotnet new` project creation, not builds
 - **net10 SDK is untouched** — `Microsoft.Android.Sdk.net10` has a separate version for backward compatibility and is not modified
 - **Platform-specific SDK alias** — the script automatically detects whether you're on macOS (`Sdk.Darwin`), Linux (`Sdk.Linux`), or Windows (`Sdk.Windows`) and uses the correct pack name

--- a/.github/skills/local-android-packs/SKILL.md
+++ b/.github/skills/local-android-packs/SKILL.md
@@ -47,7 +47,7 @@ Override the provisioned Android workload packs in `.dotnet/` with locally built
 
 ```powershell
 .github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1 `
-    -AndroidSrcPath ~/repos/android -Config Debug
+    -AndroidSrcPath ~/repos/android -Configuration Debug
 ```
 
 ### Restore original packs
@@ -80,6 +80,8 @@ Everything is reversible — run with `-Restore` to undo all changes.
 ## Pack Coverage
 
 The following packs are overlaid (all net11 packs from the manifest):
+
+> Pack names include the Android API level (currently 36). The script discovers these dynamically from the manifest, so the table below shows examples from the current version.
 
 | Pack ID (manifest entry) | Resolved Name | Kind |
 |--------------------------|---------------|------|
@@ -117,9 +119,9 @@ If an overlay fails partway through, the script automatically attempts to roll b
 
 ### "Local packs directory not found"
 
-The path `<AndroidSrcPath>/bin/<Config>/lib/packs` doesn't exist. Verify that:
+The path `<AndroidSrcPath>/bin/<Configuration>/lib/packs` doesn't exist. Verify that:
 - Your `-AndroidSrcPath` points to the dotnet/android repo root
-- You built with the correct configuration (`-Config Release` vs `-Config Debug`)
+- You built with the correct configuration (`-Configuration Release` vs `-Configuration Debug`)
 - The build completed successfully (`dotnet build Xamarin.Android.sln -c Release`)
 
 ### "No manifest found"

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -1,0 +1,472 @@
+<#
+.SYNOPSIS
+    Overlay locally built dotnet/android packs onto the provisioned .NET SDK.
+
+.DESCRIPTION
+    Replaces provisioned Android workload packs with locally built pack directories
+    from a dotnet/android build. This lets you test local android changes against a
+    MAUI build without waiting for dependency flow.
+
+    The script backs up everything it modifies and can fully restore via -Restore.
+
+.PARAMETER AndroidSrcPath
+    Path to the local dotnet/android repository root.
+
+.PARAMETER Config
+    Build configuration to use for locating packs. Default: Release.
+    The local packs are expected at: <AndroidSrcPath>/bin/<Config>/lib/packs/
+
+.PARAMETER Restore
+    Undo a previous overlay by restoring the original manifest and removing
+    overlaid pack directories.
+
+.EXAMPLE
+    # Overlay Release packs
+    ./Overlay-LocalAndroidPacks.ps1 -AndroidSrcPath ~/repos/android
+
+.EXAMPLE
+    # Overlay Debug packs
+    ./Overlay-LocalAndroidPacks.ps1 -AndroidSrcPath ~/repos/android -Config Debug
+
+.EXAMPLE
+    # Restore original packs
+    ./Overlay-LocalAndroidPacks.ps1 -AndroidSrcPath ~/repos/android -Restore
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'Overlay')]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AndroidSrcPath,
+
+    [Parameter(ParameterSetName = 'Overlay')]
+    [string]$Config = 'Release',
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Restore')]
+    [switch]$Restore
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Dot-source shared utilities for Write-Step, Write-Info, Write-Success, Write-Warn
+. "$PSScriptRoot/../../../scripts/shared/shared-utils.ps1"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Script is at .github/skills/local-android-packs/scripts/ — repo root is 4 levels up
+$RepoRoot = (Resolve-Path "$PSScriptRoot/../../../..").Path
+$DotnetRoot = Join-Path $RepoRoot '.dotnet'
+$BackupDir = Join-Path $RepoRoot '.android-packs-backup'
+$BackupMetadataFile = Join-Path $BackupDir 'backup-metadata.json'
+
+# Manifest entry names to skip during overlay
+$SkipPacks = @('Microsoft.Android.Sdk.net10', 'Microsoft.Android.Templates')
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function ConvertFrom-JsonSafe {
+    <#
+    .SYNOPSIS
+        Parse JSON that may contain trailing commas (common in workload manifests).
+        PowerShell's ConvertFrom-Json is strict about trailing commas, so we
+        strip them before parsing.
+    #>
+    param([string]$JsonText)
+    $cleaned = $JsonText -replace ',\s*([\]\}])', '$1'
+    return $cleaned | ConvertFrom-Json
+}
+
+function Find-AndroidManifest {
+    <#
+    .SYNOPSIS
+        Locate the Android WorkloadManifest.json under .dotnet/sdk-manifests/.
+        Returns the path to the manifest file. The manifest may be directly in
+        the manifest dir or inside a version subdirectory.
+    #>
+    param([string]$DotnetRoot)
+
+    $manifestsRoot = Join-Path $DotnetRoot 'sdk-manifests'
+    if (-not (Test-Path $manifestsRoot)) {
+        throw "No sdk-manifests directory found at: $manifestsRoot"
+    }
+
+    $candidates = Get-ChildItem -Path $manifestsRoot -Directory | Sort-Object Name -Descending
+    foreach ($band in $candidates) {
+        $androidDir = Join-Path $band.FullName 'microsoft.net.sdk.android'
+        if (-not (Test-Path $androidDir)) { continue }
+
+        # Manifest can be directly in the dir or in a version subdir
+        $directManifest = Join-Path $androidDir 'WorkloadManifest.json'
+        if (Test-Path $directManifest) {
+            return $directManifest
+        }
+
+        # Check version subdirectories (e.g., 36.1.2/)
+        $versionDirs = Get-ChildItem -Path $androidDir -Directory | Sort-Object Name -Descending
+        foreach ($vdir in $versionDirs) {
+            $versionedManifest = Join-Path $vdir.FullName 'WorkloadManifest.json'
+            if (Test-Path $versionedManifest) {
+                return $versionedManifest
+            }
+        }
+    }
+
+    throw "No Android WorkloadManifest.json found under: $manifestsRoot. Run './build.sh --restore' to provision the SDK."
+}
+
+function Get-PlatformSdkAlias {
+    <#
+    .SYNOPSIS
+        Return the platform-specific SDK pack name based on the current OS.
+    #>
+    if ($IsMacOS) { return 'Microsoft.Android.Sdk.Darwin' }
+    if ($IsLinux) { return 'Microsoft.Android.Sdk.Linux' }
+    if ($IsWindows) { return 'Microsoft.Android.Sdk.Windows' }
+    # Fallback: try to detect from runtime
+    throw "Cannot determine platform SDK alias — unsupported OS."
+}
+
+function Get-LocalPackVersion {
+    <#
+    .SYNOPSIS
+        Detect the local build version by examining the version subdirectory
+        inside any pack directory under the local packs path.
+    #>
+    param([string]$LocalPacksPath)
+
+    $packDirs = Get-ChildItem -Path $LocalPacksPath -Directory
+    foreach ($packDir in $packDirs) {
+        $versionDirs = Get-ChildItem -Path $packDir.FullName -Directory
+        if ($versionDirs.Count -gt 0) {
+            return $versionDirs[0].Name
+        }
+    }
+
+    throw "Could not detect local pack version — no version subdirectories found under: $LocalPacksPath"
+}
+
+function Get-ManifestNet11Packs {
+    <#
+    .SYNOPSIS
+        Return the list of pack entries in the manifest that should be overlaid
+        (net11 packs only, excluding skip list). Returns an array of pack names.
+    #>
+    param([PSCustomObject]$Manifest)
+
+    $result = @()
+    $installedVersion = $Manifest.version
+
+    $packMembers = $Manifest.packs | Get-Member -MemberType NoteProperty
+    foreach ($member in $packMembers) {
+        $packName = $member.Name
+
+        # Skip packs in the skip list
+        if ($packName -in $SkipPacks) { continue }
+
+        # Only overlay packs whose version matches the manifest's top-level version
+        # (this filters out net10 backcompat packs that have a different version)
+        $packInfo = $Manifest.packs.$packName
+        if ($packInfo.version -ne $installedVersion) { continue }
+
+        $result += $packName
+    }
+
+    return $result
+}
+
+# ---------------------------------------------------------------------------
+# Restore flow
+# ---------------------------------------------------------------------------
+
+function Invoke-Restore {
+    Write-Step "Restoring original Android packs..."
+
+    if (-not (Test-Path $BackupMetadataFile)) {
+        throw "No backup metadata found at: $BackupMetadataFile`nNothing to restore."
+    }
+
+    $metadata = Get-Content -Path $BackupMetadataFile -Raw | ConvertFrom-Json
+    Write-Info "Backup from: $($metadata.timestamp)"
+    Write-Info "Original version: $($metadata.originalVersion)"
+    Write-Info "Local version: $($metadata.localVersion)"
+
+    $errors = @()
+
+    # Step 1: Remove overlaid pack directories
+    foreach ($pack in $metadata.overlaidPacks) {
+        $localVersionDir = Join-Path $DotnetRoot "packs/$($pack.targetPackName)/$($metadata.localVersion)"
+        try {
+            if (Test-Path $localVersionDir) {
+                Write-Info "  Removing $($pack.targetPackName)/$($metadata.localVersion)"
+                Remove-Item -Path $localVersionDir -Recurse -Force
+            }
+            else {
+                Write-Warn "  Local version directory not found (already removed?): $localVersionDir"
+            }
+        }
+        catch {
+            $errors += "Failed to remove $($pack.targetPackName): $_"
+        }
+    }
+
+    # Step 2: Restore original manifest
+    $manifestBackup = Join-Path $BackupDir 'WorkloadManifest.json'
+    if (Test-Path $manifestBackup) {
+        $manifestPath = $metadata.manifestPath
+        Write-Info "  Restoring manifest: $manifestPath"
+        try {
+            Copy-Item -Path $manifestBackup -Destination $manifestPath -Force
+        }
+        catch {
+            $errors += "Failed to restore manifest: $_"
+        }
+    }
+    else {
+        $errors += "Manifest backup not found: $manifestBackup"
+    }
+
+    # Step 3: Clean up backup directory
+    try {
+        Remove-Item -Path $BackupDir -Recurse -Force
+    }
+    catch {
+        $errors += "Failed to remove backup directory: $_"
+    }
+
+    # Summary
+    if ($errors.Count -gt 0) {
+        Write-Warn "Restore completed with errors:"
+        foreach ($err in $errors) {
+            Write-Warn "  $err"
+        }
+    }
+    else {
+        Write-Success "Restore complete. All packs reverted to version $($metadata.originalVersion)."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Overlay flow
+# ---------------------------------------------------------------------------
+
+function Invoke-Overlay {
+    param(
+        [string]$AndroidSrcPath,
+        [string]$Config
+    )
+
+    $localPacksPath = Join-Path $AndroidSrcPath "bin/$Config/lib/packs"
+
+    # --- Step 1: Validate inputs ---
+    Write-Step "Validating inputs..."
+
+    if (-not (Test-Path $AndroidSrcPath)) {
+        throw "Android source path does not exist: $AndroidSrcPath"
+    }
+
+    if (-not (Test-Path $localPacksPath)) {
+        throw "Local packs directory not found: $localPacksPath`nVerify that dotnet/android was built with configuration '$Config'."
+    }
+
+    if (-not (Test-Path $DotnetRoot)) {
+        throw ".dotnet directory not found at: $DotnetRoot`nRun './build.sh --restore' to provision the SDK."
+    }
+
+    $manifestPath = Find-AndroidManifest -DotnetRoot $DotnetRoot
+    Write-Info "Manifest: $manifestPath"
+
+    # Check for existing overlay
+    if (Test-Path $BackupMetadataFile) {
+        throw "A previous overlay is still active (found $BackupMetadataFile).`nRun with -Restore first to revert, then re-run the overlay."
+    }
+
+    # --- Step 2: Read manifest and detect versions ---
+    Write-Step "Reading manifest and detecting versions..."
+
+    $manifestRaw = Get-Content -Path $manifestPath -Raw
+    $manifest = ConvertFrom-JsonSafe -JsonText $manifestRaw
+    $installedVersion = $manifest.version
+    Write-Info "Installed version: $installedVersion"
+
+    $platformSdkAlias = Get-PlatformSdkAlias
+    Write-Info "Platform SDK alias: $platformSdkAlias"
+
+    $localVersion = Get-LocalPackVersion -LocalPacksPath $localPacksPath
+    Write-Info "Local build version: $localVersion"
+
+    $net11Packs = Get-ManifestNet11Packs -Manifest $manifest
+    Write-Info "Net11 packs to overlay: $($net11Packs.Count)"
+
+    # --- Step 3: Create backup ---
+    Write-Step "Creating backup..."
+
+    if (-not (Test-Path $BackupDir)) {
+        New-Item -Path $BackupDir -ItemType Directory -Force | Out-Null
+    }
+    Copy-Item -Path $manifestPath -Destination (Join-Path $BackupDir 'WorkloadManifest.json') -Force
+
+    # --- Step 4: Patch manifest ---
+    Write-Step "Patching manifest..."
+
+    # Use text replacement to preserve formatting and trailing commas
+    # (ConvertFrom-Json → ConvertTo-Json would strip trailing commas and reformat)
+    $patchedContent = $manifestRaw.Replace("`"$installedVersion`"", "`"$localVersion`"")
+
+    # Restore the net10 pack version — it was incorrectly replaced above since we did
+    # a blanket string replacement. We need to put back the original net10 version.
+    # Read the original net10 version from the manifest object.
+    $net10PackInfo = $manifest.packs.'Microsoft.Android.Sdk.net10'
+    if ($net10PackInfo -and $net10PackInfo.version -ne $installedVersion) {
+        # The net10 version was different, so the blanket replace didn't touch it — good.
+        Write-Info "Net10 SDK version ($($net10PackInfo.version)) preserved (different from installed)."
+    }
+    elseif ($net10PackInfo -and $net10PackInfo.version -eq $installedVersion) {
+        # Edge case: net10 version matches net11 version. We need to restore it.
+        # This is unlikely in practice but handle it for correctness.
+        Write-Warn "Net10 SDK version matches net11 — it will also be updated. This is unusual."
+    }
+
+    Set-Content -Path $manifestPath -Value $patchedContent -NoNewline
+
+    # --- Step 5: Place packs ---
+    Write-Step "Placing packs..."
+
+    $overlaidPacks = @()
+    $skippedPacks = @()
+    $localPackDirs = Get-ChildItem -Path $localPacksPath -Directory
+
+    # Build a lookup: local pack dir name → local pack dir path
+    $localPackLookup = @{}
+    foreach ($dir in $localPackDirs) {
+        $localPackLookup[$dir.Name] = $dir.FullName
+    }
+
+    foreach ($manifestPackName in $net11Packs) {
+        # Determine which local directory corresponds to this manifest entry
+        $localDirName = $null
+        $targetPackName = $null
+
+        if ($manifestPackName -eq 'Microsoft.Android.Sdk.net11') {
+            # SDK pack uses platform alias both locally and in .dotnet/packs/
+            $localDirName = $platformSdkAlias
+            $targetPackName = $platformSdkAlias
+        }
+        else {
+            # All other packs: directory name matches manifest pack name
+            $localDirName = $manifestPackName
+            $targetPackName = $manifestPackName
+        }
+
+        # Check if the local pack exists
+        if (-not $localPackLookup.ContainsKey($localDirName)) {
+            $skippedPacks += @{ ManifestName = $manifestPackName; Reason = "Not found in local build" }
+            continue
+        }
+
+        $localPackDir = $localPackLookup[$localDirName]
+
+        # Find the version subdirectory in the local pack
+        $versionDirs = Get-ChildItem -Path $localPackDir -Directory
+        if ($versionDirs.Count -eq 0) {
+            $skippedPacks += @{ ManifestName = $manifestPackName; Reason = "No version subdirectory" }
+            continue
+        }
+        $localVersionDir = $versionDirs[0].FullName
+
+        # Target path in .dotnet/packs/
+        $targetDir = Join-Path $DotnetRoot "packs/$targetPackName/$localVersion"
+
+        # Copy the pack
+        if (Test-Path $targetDir) {
+            Write-Warn "  Target already exists, replacing: $targetPackName/$localVersion"
+            Remove-Item -Path $targetDir -Recurse -Force
+        }
+
+        New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+        Copy-Item -Path "$localVersionDir/*" -Destination $targetDir -Recurse -Force
+
+        $overlaidPacks += @{
+            manifestPackName = $manifestPackName
+            targetPackName   = $targetPackName
+            localDirName     = $localDirName
+        }
+
+        Write-Info "  $targetPackName : $installedVersion → $localVersion"
+    }
+
+    # --- Save backup metadata ---
+    $metadata = @{
+        originalVersion = $installedVersion
+        localVersion    = $localVersion
+        manifestPath    = $manifestPath
+        timestamp       = (Get-Date -Format 'o')
+        config          = $Config
+        overlaidPacks   = $overlaidPacks
+    }
+    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
+
+    # --- Step 6: Summary ---
+    Write-Host ""
+    Write-Success "=== Overlay Complete ==="
+    Write-Host ""
+    Write-Host "  Installed version : $installedVersion"
+    Write-Host "  Local version     : $localVersion"
+    Write-Host "  Packs overlaid    : $($overlaidPacks.Count)"
+    Write-Host ""
+
+    foreach ($p in $overlaidPacks) {
+        Write-Host "    ✅ $($p.targetPackName)" -ForegroundColor Green
+    }
+
+    if ($skippedPacks.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  Packs skipped     : $($skippedPacks.Count)" -ForegroundColor Yellow
+        foreach ($s in $skippedPacks) {
+            Write-Host "    ⏭️  $($s.ManifestName) — $($s.Reason)" -ForegroundColor Yellow
+        }
+    }
+
+    Write-Host ""
+    Write-Host "  To restore original packs:" -ForegroundColor Yellow
+    Write-Host "    $($MyInvocation.MyCommand.Name) -AndroidSrcPath '$AndroidSrcPath' -Restore" -ForegroundColor Yellow
+    Write-Host ""
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+try {
+    Write-Step "Android Packs Overlay"
+    Write-Info "Repo root: $RepoRoot"
+    Write-Info "DOTNET_ROOT: $DotnetRoot"
+
+    if ($Restore) {
+        Invoke-Restore
+    }
+    else {
+        $resolvedAndroidPath = (Resolve-Path $AndroidSrcPath).Path
+        Invoke-Overlay -AndroidSrcPath $resolvedAndroidPath -Config $Config
+    }
+}
+catch {
+    # On overlay failure, attempt automatic rollback if backup exists
+    if (-not $Restore -and (Test-Path $BackupMetadataFile)) {
+        Write-Warn "Overlay failed — attempting automatic rollback..."
+        try {
+            Invoke-Restore
+            Write-Info "Automatic rollback succeeded."
+        }
+        catch {
+            Write-Warn "Automatic rollback also failed: $_"
+            Write-Warn "Manual cleanup may be required. Check $BackupDir for backup files."
+        }
+    }
+
+    Write-Host ""
+    Write-Error "Fatal: $_"
+    exit 1
+}

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -30,12 +30,12 @@
 
 .EXAMPLE
     # Restore original packs
-    ./Overlay-LocalAndroidPacks.ps1 -AndroidSrcPath ~/repos/android -Restore
+    ./Overlay-LocalAndroidPacks.ps1 -Restore
 #>
 
 [CmdletBinding(DefaultParameterSetName = 'Overlay')]
 param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Overlay')]
     [string]$AndroidSrcPath,
 
     [Parameter(ParameterSetName = 'Overlay')]
@@ -57,7 +57,7 @@ $ErrorActionPreference = 'Stop'
 # Script is at .github/skills/local-android-packs/scripts/ — repo root is 4 levels up
 $RepoRoot = (Resolve-Path "$PSScriptRoot/../../../..").Path
 $DotnetRoot = Join-Path $RepoRoot '.dotnet'
-$BackupDir = Join-Path $RepoRoot '.android-packs-backup'
+$BackupDir = Join-Path $DotnetRoot '.android-packs-backup'
 $BackupMetadataFile = Join-Path $BackupDir 'backup-metadata.json'
 
 # Manifest entry names to skip during overlay
@@ -139,7 +139,7 @@ function Get-LocalPackVersion {
 
     $packDirs = Get-ChildItem -Path $LocalPacksPath -Directory
     foreach ($packDir in $packDirs) {
-        $versionDirs = Get-ChildItem -Path $packDir.FullName -Directory
+        $versionDirs = Get-ChildItem -Path $packDir.FullName -Directory | Sort-Object Name -Descending
         if ($versionDirs.Count -gt 0) {
             return $versionDirs[0].Name
         }
@@ -297,6 +297,12 @@ function Invoke-Overlay {
     $localVersion = Get-LocalPackVersion -LocalPacksPath $localPacksPath
     Write-Info "Local build version: $localVersion"
 
+    if ($localVersion -eq $installedVersion) {
+        throw "Local build version ($localVersion) matches the installed version." + `
+              " Overlay would delete the existing packs and leave the SDK broken on restore." + `
+              " Build dotnet/android at a different version, or modify the version suffix before overlaying."
+    }
+
     $net11Packs = Get-ManifestNet11Packs -Manifest $manifest
     Write-Info "Net11 packs to overlay: $($net11Packs.Count)"
 
@@ -308,28 +314,30 @@ function Invoke-Overlay {
     }
     Copy-Item -Path $manifestPath -Destination (Join-Path $BackupDir 'WorkloadManifest.json') -Force
 
+    # Write backup metadata immediately so auto-rollback works even if overlay fails partway through
+    $metadata = @{
+        originalVersion = $installedVersion
+        localVersion    = $localVersion
+        manifestPath    = $manifestPath
+        timestamp       = (Get-Date -Format 'o')
+        config          = $Config
+        overlaidPacks   = @()
+    }
+    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
+
     # --- Step 4: Patch manifest ---
     Write-Step "Patching manifest..."
 
-    # Use text replacement to preserve formatting and trailing commas
-    # (ConvertFrom-Json → ConvertTo-Json would strip trailing commas and reformat)
-    $patchedContent = $manifestRaw.Replace("`"$installedVersion`"", "`"$localVersion`"")
-
-    # Restore the net10 pack version — it was incorrectly replaced above since we did
-    # a blanket string replacement. We need to put back the original net10 version.
-    # Read the original net10 version from the manifest object.
-    $net10PackInfo = $manifest.packs.'Microsoft.Android.Sdk.net10'
-    if ($net10PackInfo -and $net10PackInfo.version -ne $installedVersion) {
-        # The net10 version was different, so the blanket replace didn't touch it — good.
-        Write-Info "Net10 SDK version ($($net10PackInfo.version)) preserved (different from installed)."
-    }
-    elseif ($net10PackInfo -and $net10PackInfo.version -eq $installedVersion) {
-        # Edge case: net10 version matches net11 version. We need to restore it.
-        # This is unlikely in practice but handle it for correctness.
-        Write-Warn "Net10 SDK version matches net11 — it will also be updated. This is unusual."
+    # Surgical per-pack JSON patching: only update version fields for packs we will overlay
+    $manifest.version = $localVersion
+    foreach ($packName in $net11Packs) {
+        $packInfo = $manifest.packs.$packName
+        if ($packInfo -and $packInfo.version -eq $installedVersion) {
+            $packInfo.version = $localVersion
+        }
     }
 
-    Set-Content -Path $manifestPath -Value $patchedContent -NoNewline
+    $manifest | ConvertTo-Json -Depth 10 | Set-Content -Path $manifestPath
 
     # --- Step 5: Place packs ---
     Write-Step "Placing packs..."
@@ -369,7 +377,7 @@ function Invoke-Overlay {
         $localPackDir = $localPackLookup[$localDirName]
 
         # Find the version subdirectory in the local pack
-        $versionDirs = Get-ChildItem -Path $localPackDir -Directory
+        $versionDirs = Get-ChildItem -Path $localPackDir -Directory | Sort-Object Name -Descending
         if ($versionDirs.Count -eq 0) {
             $skippedPacks += @{ ManifestName = $manifestPackName; Reason = "No version subdirectory" }
             continue
@@ -397,15 +405,8 @@ function Invoke-Overlay {
         Write-Info "  $targetPackName : $installedVersion → $localVersion"
     }
 
-    # --- Save backup metadata ---
-    $metadata = @{
-        originalVersion = $installedVersion
-        localVersion    = $localVersion
-        manifestPath    = $manifestPath
-        timestamp       = (Get-Date -Format 'o')
-        config          = $Config
-        overlaidPacks   = $overlaidPacks
-    }
+    # --- Update backup metadata with actual overlaid packs ---
+    $metadata.overlaidPacks = $overlaidPacks
     $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
 
     # --- Step 6: Summary ---
@@ -431,7 +432,7 @@ function Invoke-Overlay {
 
     Write-Host ""
     Write-Host "  To restore original packs:" -ForegroundColor Yellow
-    Write-Host "    $($MyInvocation.MyCommand.Name) -AndroidSrcPath '$AndroidSrcPath' -Restore" -ForegroundColor Yellow
+    Write-Host "    $($MyInvocation.MyCommand.Name) -Restore" -ForegroundColor Yellow
     Write-Host ""
 }
 

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -228,12 +228,12 @@ function Invoke-Restore {
         $errors += "Manifest backup not found: $manifestBackup"
     }
 
-    # Step 3: Clean up backup directory
-    try {
+    # Step 3: Clean up backup (only if no errors occurred)
+    if ($errors.Count -eq 0 -and (Test-Path $BackupDir)) {
         Remove-Item -Path $BackupDir -Recurse -Force
-    }
-    catch {
-        $errors += "Failed to remove backup directory: $_"
+        Write-Host "  Backup directory cleaned up" -ForegroundColor DarkGray
+    } elseif ($errors.Count -gt 0) {
+        Write-Host "  ⚠️  Backup preserved at $BackupDir due to errors above" -ForegroundColor Yellow
     }
 
     # Summary
@@ -297,10 +297,13 @@ function Invoke-Overlay {
     $localVersion = Get-LocalPackVersion -LocalPacksPath $localPacksPath
     Write-Info "Local build version: $localVersion"
 
-    if ($localVersion -eq $installedVersion) {
-        throw "Local build version ($localVersion) matches the installed version." + `
-              " Overlay would delete the existing packs and leave the SDK broken on restore." + `
-              " Build dotnet/android at a different version, or modify the version suffix before overlaying."
+    # Check for physical directory collision — would overlay overwrite existing pack dirs?
+    $sdkAlias = Get-PlatformSdkAlias
+    $collisionPath = Join-Path $DotnetRoot "packs/$sdkAlias/$localVersion"
+    if (Test-Path $collisionPath) {
+        throw "Local build version ($localVersion) already exists at $collisionPath." +
+              " Overlay would overwrite existing packs and leave the SDK broken on restore." +
+              " Build dotnet/android at a different version, or run with -Restore first."
     }
 
     $net11Packs = Get-ManifestNet11Packs -Manifest $manifest

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -438,7 +438,59 @@ function Invoke-Overlay {
         Write-Info "  $($pack.targetPackName) : $installedVersion → $localVersion"
     }
 
-    # --- Step 7: Summary ---
+    # --- Step 7: Backfill debugging support files ---
+    # The local build may not include debugging task DLLs. If missing, copy them
+    # from the provisioned (original) SDK pack so FastDev continues to work.
+    $overlaidSdkDir = Join-Path $DotnetRoot "packs/$platformSdkAlias/$localVersion"
+    $debuggingTasksDll = Join-Path $overlaidSdkDir 'tools/Xamarin.Android.Build.Debugging.Tasks.dll'
+
+    if (Test-Path $overlaidSdkDir) {
+        if (-not (Test-Path $debuggingTasksDll)) {
+            Write-Step "Backfilling debugging support files..."
+
+            $provisionedSdkDir = Join-Path $DotnetRoot "packs/$platformSdkAlias/$installedVersion"
+
+            if (Test-Path $provisionedSdkDir) {
+                try {
+                    # Find all debugging-related files in the provisioned pack's tools tree
+                    $provisionedToolsDir = Join-Path $provisionedSdkDir 'tools'
+                    $debuggingFiles = Get-ChildItem -Path $provisionedToolsDir -Filter '*Debugging*' -Recurse -File
+
+                    $copiedCount = 0
+                    foreach ($file in $debuggingFiles) {
+                        $relativePath = $file.FullName.Substring($provisionedToolsDir.Length).TrimStart([IO.Path]::DirectorySeparatorChar)
+                        $destPath = Join-Path $overlaidSdkDir "tools/$relativePath"
+                        $destDir = Split-Path $destPath -Parent
+
+                        if (-not (Test-Path $destDir)) {
+                            New-Item -Path $destDir -ItemType Directory -Force | Out-Null
+                        }
+
+                        Copy-Item -Path $file.FullName -Destination $destPath -Force
+                        $copiedCount++
+                    }
+
+                    Write-Info "Backfilled $copiedCount debugging support files from provisioned pack"
+                }
+                catch {
+                    Write-Warn "Failed to backfill debugging support files: $_"
+                    Write-Warn "FastDev may not work correctly."
+                }
+            }
+            else {
+                Write-Warn "Provisioned SDK pack not found at: $provisionedSdkDir"
+                Write-Warn "Could not backfill debugging support files — FastDev may not work."
+            }
+
+            # Verify the backfill actually landed the critical DLL
+            if (-not (Test-Path $debuggingTasksDll)) {
+                Write-Warn "Debugging support files could not be backfilled — FastDev may not work."
+                Write-Warn "You can manually copy debugging files from the provisioned pack at: $provisionedSdkDir"
+            }
+        }
+    }
+
+    # --- Step 8: Summary ---
     Write-Host ""
     Write-Success "=== Overlay Complete ==="
     Write-Host ""

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -407,15 +407,24 @@ function Invoke-Overlay {
         # Target path in .dotnet/packs/
         $targetDir = Join-Path $DotnetRoot "packs/$($pack.targetPackName)/$localVersion"
 
-        # Copy the pack
-        if (Test-Path $targetDir) {
-            Write-Warn "  Target already exists, replacing: $($pack.targetPackName)/$localVersion"
-            Remove-Item -Path $targetDir -Recurse -Force
+        try {
+            # Copy the pack
+            if (Test-Path $targetDir) {
+                Write-Warn "  Target already exists, replacing: $($pack.targetPackName)/$localVersion"
+                Remove-Item -Path $targetDir -Recurse -Force
+            }
+
+            New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+            Copy-Item -Path "$($pack.localVersionDir)/*" -Destination $targetDir -Recurse -Force
+        }
+        catch {
+            # Clean up partial directory immediately — metadata hasn't been updated
+            # for this pack yet, so auto-rollback wouldn't know to remove it.
+            Remove-Item -Path $targetDir -Recurse -Force -ErrorAction SilentlyContinue
+            throw  # re-throw to trigger outer catch for manifest rollback
         }
 
-        New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
-        Copy-Item -Path "$($pack.localVersionDir)/*" -Destination $targetDir -Recurse -Force
-
+        # Only reached on success — track this pack for rollback
         $overlaidPacks += @{
             manifestPackName = $pack.manifestPackName
             targetPackName   = $pack.targetPackName

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -12,9 +12,9 @@
 .PARAMETER AndroidSrcPath
     Path to the local dotnet/android repository root.
 
-.PARAMETER Config
+.PARAMETER Configuration
     Build configuration to use for locating packs. Default: Release.
-    The local packs are expected at: <AndroidSrcPath>/bin/<Config>/lib/packs/
+    The local packs are expected at: <AndroidSrcPath>/bin/<Configuration>/lib/packs/
 
 .PARAMETER Restore
     Undo a previous overlay by restoring the original manifest and removing
@@ -26,7 +26,7 @@
 
 .EXAMPLE
     # Overlay Debug packs
-    ./Overlay-LocalAndroidPacks.ps1 -AndroidSrcPath ~/repos/android -Config Debug
+    ./Overlay-LocalAndroidPacks.ps1 -AndroidSrcPath ~/repos/android -Configuration Debug
 
 .EXAMPLE
     # Restore original packs
@@ -39,7 +39,7 @@ param(
     [string]$AndroidSrcPath,
 
     [Parameter(ParameterSetName = 'Overlay')]
-    [string]$Config = 'Release',
+    [string]$Configuration = 'Release',
 
     [Parameter(Mandatory = $true, ParameterSetName = 'Restore')]
     [switch]$Restore
@@ -71,8 +71,8 @@ function ConvertFrom-JsonSafe {
     <#
     .SYNOPSIS
         Parse JSON that may contain trailing commas (common in workload manifests).
-        PowerShell's ConvertFrom-Json is strict about trailing commas, so we
-        strip them before parsing.
+        PowerShell versions before 7.5 are strict about trailing commas in JSON;
+        this provides backward compatibility by stripping them before parsing.
     #>
     param([string]$JsonText)
     $cleaned = $JsonText -replace ',\s*([\]\}])', '$1'
@@ -255,10 +255,10 @@ function Invoke-Restore {
 function Invoke-Overlay {
     param(
         [string]$AndroidSrcPath,
-        [string]$Config
+        [string]$Configuration
     )
 
-    $localPacksPath = Join-Path $AndroidSrcPath "bin/$Config/lib/packs"
+    $localPacksPath = Join-Path $AndroidSrcPath "bin/$Configuration/lib/packs"
 
     # --- Step 1: Validate inputs ---
     Write-Step "Validating inputs..."
@@ -268,7 +268,7 @@ function Invoke-Overlay {
     }
 
     if (-not (Test-Path $localPacksPath)) {
-        throw "Local packs directory not found: $localPacksPath`nVerify that dotnet/android was built with configuration '$Config'."
+        throw "Local packs directory not found: $localPacksPath`nVerify that dotnet/android was built with configuration '$Configuration'."
     }
 
     if (-not (Test-Path $DotnetRoot)) {
@@ -363,7 +363,7 @@ function Invoke-Overlay {
     }
 
     if ($overlayablePacks.Count -eq 0) {
-        throw "No local packs match manifest entries. Verify that dotnet/android was built with configuration '$Config'."
+        throw "No local packs match manifest entries. Verify that dotnet/android was built with configuration '$Configuration'."
     }
 
     # --- Step 4: Create backup ---
@@ -380,7 +380,7 @@ function Invoke-Overlay {
         localVersion    = $localVersion
         manifestPath    = $manifestPath
         timestamp       = (Get-Date -Format 'o')
-        config          = $Config
+        config          = $Configuration
         overlaidPacks   = @()
     }
     $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
@@ -479,7 +479,7 @@ try {
     }
     else {
         $resolvedAndroidPath = (Resolve-Path $AndroidSrcPath).Path
-        Invoke-Overlay -AndroidSrcPath $resolvedAndroidPath -Config $Config
+        Invoke-Overlay -AndroidSrcPath $resolvedAndroidPath -Configuration $Configuration
     }
 }
 catch {

--- a/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
+++ b/.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1
@@ -304,46 +304,11 @@ function Invoke-Overlay {
     }
 
     $net11Packs = Get-ManifestNet11Packs -Manifest $manifest
-    Write-Info "Net11 packs to overlay: $($net11Packs.Count)"
+    Write-Info "Net11 manifest packs found: $($net11Packs.Count)"
 
-    # --- Step 3: Create backup ---
-    Write-Step "Creating backup..."
+    # --- Step 3: Determine which packs are available locally ---
+    Write-Step "Scanning local packs..."
 
-    if (-not (Test-Path $BackupDir)) {
-        New-Item -Path $BackupDir -ItemType Directory -Force | Out-Null
-    }
-    Copy-Item -Path $manifestPath -Destination (Join-Path $BackupDir 'WorkloadManifest.json') -Force
-
-    # Write backup metadata immediately so auto-rollback works even if overlay fails partway through
-    $metadata = @{
-        originalVersion = $installedVersion
-        localVersion    = $localVersion
-        manifestPath    = $manifestPath
-        timestamp       = (Get-Date -Format 'o')
-        config          = $Config
-        overlaidPacks   = @()
-    }
-    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
-
-    # --- Step 4: Patch manifest ---
-    Write-Step "Patching manifest..."
-
-    # Surgical per-pack JSON patching: only update version fields for packs we will overlay
-    $manifest.version = $localVersion
-    foreach ($packName in $net11Packs) {
-        $packInfo = $manifest.packs.$packName
-        if ($packInfo -and $packInfo.version -eq $installedVersion) {
-            $packInfo.version = $localVersion
-        }
-    }
-
-    $manifest | ConvertTo-Json -Depth 10 | Set-Content -Path $manifestPath
-
-    # --- Step 5: Place packs ---
-    Write-Step "Placing packs..."
-
-    $overlaidPacks = @()
-    $skippedPacks = @()
     $localPackDirs = Get-ChildItem -Path $localPacksPath -Directory
 
     # Build a lookup: local pack dir name → local pack dir path
@@ -352,11 +317,12 @@ function Invoke-Overlay {
         $localPackLookup[$dir.Name] = $dir.FullName
     }
 
+    # Determine which manifest packs can actually be overlaid (exist locally)
+    $overlayablePacks = @()
+    $skippedPacks = @()
+
     foreach ($manifestPackName in $net11Packs) {
         # Determine which local directory corresponds to this manifest entry
-        $localDirName = $null
-        $targetPackName = $null
-
         if ($manifestPackName -eq 'Microsoft.Android.Sdk.net11') {
             # SDK pack uses platform alias both locally and in .dotnet/packs/
             $localDirName = $platformSdkAlias
@@ -376,40 +342,94 @@ function Invoke-Overlay {
 
         $localPackDir = $localPackLookup[$localDirName]
 
-        # Find the version subdirectory in the local pack
+        # Verify the local pack has a version subdirectory
         $versionDirs = Get-ChildItem -Path $localPackDir -Directory | Sort-Object Name -Descending
         if ($versionDirs.Count -eq 0) {
             $skippedPacks += @{ ManifestName = $manifestPackName; Reason = "No version subdirectory" }
             continue
         }
-        $localVersionDir = $versionDirs[0].FullName
 
+        $overlayablePacks += @{
+            manifestPackName = $manifestPackName
+            targetPackName   = $targetPackName
+            localDirName     = $localDirName
+            localVersionDir  = $versionDirs[0].FullName
+        }
+    }
+
+    Write-Info "Packs available to overlay: $($overlayablePacks.Count)"
+    if ($skippedPacks.Count -gt 0) {
+        Write-Info "Packs skipped (not in local build): $($skippedPacks.Count)"
+    }
+
+    if ($overlayablePacks.Count -eq 0) {
+        throw "No local packs match manifest entries. Verify that dotnet/android was built with configuration '$Config'."
+    }
+
+    # --- Step 4: Create backup ---
+    Write-Step "Creating backup..."
+
+    if (-not (Test-Path $BackupDir)) {
+        New-Item -Path $BackupDir -ItemType Directory -Force | Out-Null
+    }
+    Copy-Item -Path $manifestPath -Destination (Join-Path $BackupDir 'WorkloadManifest.json') -Force
+
+    # Write backup metadata immediately so auto-rollback works even if overlay fails partway through
+    $metadata = @{
+        originalVersion = $installedVersion
+        localVersion    = $localVersion
+        manifestPath    = $manifestPath
+        timestamp       = (Get-Date -Format 'o')
+        config          = $Config
+        overlaidPacks   = @()
+    }
+    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
+
+    # --- Step 5: Patch manifest (only for packs confirmed to exist locally) ---
+    Write-Step "Patching manifest..."
+
+    $manifest.version = $localVersion
+    foreach ($pack in $overlayablePacks) {
+        $packInfo = $manifest.packs.($pack.manifestPackName)
+        if ($packInfo -and $packInfo.version -eq $installedVersion) {
+            $packInfo.version = $localVersion
+        }
+    }
+
+    $manifest | ConvertTo-Json -Depth 10 | Set-Content -Path $manifestPath
+
+    # --- Step 6: Place packs ---
+    Write-Step "Placing packs..."
+
+    $overlaidPacks = @()
+
+    foreach ($pack in $overlayablePacks) {
         # Target path in .dotnet/packs/
-        $targetDir = Join-Path $DotnetRoot "packs/$targetPackName/$localVersion"
+        $targetDir = Join-Path $DotnetRoot "packs/$($pack.targetPackName)/$localVersion"
 
         # Copy the pack
         if (Test-Path $targetDir) {
-            Write-Warn "  Target already exists, replacing: $targetPackName/$localVersion"
+            Write-Warn "  Target already exists, replacing: $($pack.targetPackName)/$localVersion"
             Remove-Item -Path $targetDir -Recurse -Force
         }
 
         New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
-        Copy-Item -Path "$localVersionDir/*" -Destination $targetDir -Recurse -Force
+        Copy-Item -Path "$($pack.localVersionDir)/*" -Destination $targetDir -Recurse -Force
 
         $overlaidPacks += @{
-            manifestPackName = $manifestPackName
-            targetPackName   = $targetPackName
-            localDirName     = $localDirName
+            manifestPackName = $pack.manifestPackName
+            targetPackName   = $pack.targetPackName
+            localDirName     = $pack.localDirName
         }
 
-        Write-Info "  $targetPackName : $installedVersion → $localVersion"
+        # Update metadata incrementally so rollback can clean up partial overlays on failure
+        $metadata.overlaidPacks = $overlaidPacks
+        $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
+
+        Write-Info "  $($pack.targetPackName) : $installedVersion → $localVersion"
     }
 
-    # --- Update backup metadata with actual overlaid packs ---
-    $metadata.overlaidPacks = $overlaidPacks
-    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $BackupMetadataFile
-
-    # --- Step 6: Summary ---
+    # --- Step 7: Summary ---
     Write-Host ""
     Write-Success "=== Overlay Complete ==="
     Write-Host ""


### PR DESCRIPTION
## Summary

Adds a `local-android-packs` skill that overrides provisioned Android workload packs with locally built versions from dotnet/android.

### Deliverables
- `.github/skills/local-android-packs/SKILL.md` — Skill documentation
- `.github/skills/local-android-packs/scripts/Overlay-LocalAndroidPacks.ps1` — PowerShell overlay script

### How it works
Uses manifest patching + pack placement (Option B):
1. Scans local dotnet/android build output for available packs
2. Surgically patches matching entries in `WorkloadManifest.json`
3. Places packs in `.dotnet/packs/` with correct version directories
4. `-Restore` flag undoes everything atomically from backup metadata

### Key design decisions
- **Surgical per-pack JSON patching** — only patches manifest entries for packs confirmed locally
- **Incremental rollback metadata** — updated after each successful pack copy
- **Per-pack try/catch** — cleans up partial directories on copy failure
- **Version equality guard** — refuses overlay when local version equals installed version
- **`-Restore` standalone** — doesn't require `-AndroidSrcPath`

### Testing
- Script-level test: overlay + restore ✅
- Integration test on Android emulator: overlay → build Sandbox app → deploy → restore ✅
- 5-model consensus review (3 cycles, 4/5 approve)
- Production hardening review applied