### PR TITLE
[iOS] Fix Issue12574Test regression caused by early-exit guard in CollectionViewUpdating

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -354,14 +354,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			int carouselPosition = carousel.Position;
 			_positionAfterUpdate = carouselPosition;
-			var currentItemIndex = ItemsSource.GetIndexForItem(carousel.CurrentItem);
-			var currentItemPosition = currentItemIndex.Row;
+			var currentItemPosition = ItemsSource.GetIndexForItem(carousel.CurrentItem).Row;
 			var count = ItemsSource.ItemCount;
-
-			if (currentItemPosition < 0)
-			{
-				return;
-			}
 
 			if (e.Action == NotifyCollectionChangedAction.Remove)
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -297,13 +297,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			int carouselPosition = carousel.Position;
 			_positionAfterUpdate = carouselPosition;
-			var currentItemIndex = ItemsSource.GetIndexForItem(carousel.CurrentItem);
-			var currentItemPosition = currentItemIndex.Row;
-
-			if (currentItemPosition < 0)
-			{
-				return;
-			}
+			var currentItemPosition = ItemsSource.GetIndexForItem(carousel.CurrentItem).Row;
 
 			if (e.Action == NotifyCollectionChangedAction.Remove)
 			{


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Root Cause

- PR #32141 added an early-exit guard in CollectionViewUpdating that returned when currentItemPosition == -1, but -1 is the expected signal from GetIndexForItem indicating the current item was just removed — exiting early prevented GetPositionWhenRemovingItems from running, leaving _positionAfterUpdate stale.

### Description of Change
- Removed the early-exit guard on currentItemPosition < 0 in CollectionViewUpdating in both CarouselViewController.cs and CarouselViewController2.cs, allowing the -1 value to flow through to GetPositionWhenRemovingItems which correctly interprets it as "the current item was removed" and calculates the right position to navigate to.


### Issues Fixed

- Regression introduced by PR #32141 
- **Resolved test case** : Issue12574Test UI Test

### Output
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/3542d8f6-c525-4e76-994d-500a3af892f2"> | <img src="https://github.com/user-attachments/assets/292649b3-d71d-46c7-ad79-6d09070bba03"> |