### PR TITLE
[Testing] Fix Label CharacterSpacing/LineHeight/TextDecorations test for HTML labels (#34934)

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.iOS.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.DeviceTests
 				new object[] { label1, 5d, 1.5d, TextDecorations.Underline },
 				new object[] { label2, 5d, 1.5d, TextDecorations.Strikethrough },
 				new object[] { label3, 0d, 0d, TextDecorations.None },
-				new object[] { label4, 0d, 0d, TextDecorations.None }
+				new object[] { label4, 5d, 1.5d, TextDecorations.Underline }
 			};
 		}
 


### PR DESCRIPTION
### Description of Change

Ports the test fix from PR #34934 (inflight/current) to inflight/candidate.

PR #31202 changed the Label mapper conditions from `!IsPlainText(label)` to `label.HasFormattedTextSpans` for `MapLineHeight`, `MapTextDecorations`, and `MapCharacterSpacing`. This correctly enables these properties to be applied to HTML labels.

However, the test expectations for `label4` (an HTML label with `CharacterSpacing=5`, `LineHeight=1.5`, `TextDecorations=Underline`) were not updated.

**Fix:** Update expected values for label4 from `(0, 0, None)` to `(5, 1.5, Underline)`.

### Issues Fixed

Fixes CharacterSpacingWithLineHeightWithTextDecorationsWorksCorrectly device test regression from #31202