### PR TITLE
Fix Shell flyout items scrolling behind FlyoutHeader on iOS (#34936)

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -221,8 +221,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					return;
 				}
 
-				// We take the measured header height without margin, since the margin is already accounted for in the positioning of the scroll view itself.
-				ScrollView.ContentInset = new UIEdgeInsets((nfloat)Math.Max(HeaderMinimumHeight, MeasuredHeaderViewHeightWithNoMargin), 0, 0, 0);
+				var headerBehavior = _context.Shell.FlyoutHeaderBehavior;
+				if (headerBehavior == FlyoutHeaderBehavior.Default || headerBehavior == FlyoutHeaderBehavior.Fixed)
+				{
+					// For Default/Fixed, the scroll view is positioned below the header,
+					// so no top content inset is needed.
+					ScrollView.ContentInset = new UIEdgeInsets(0, 0, 0, 0);
+				}
+				else
+				{
+					// For Scroll/CollapseOnScroll, the scroll view overlaps the header so the header
+					// can scroll away or shrink. We use content inset to push items below it initially.
+					ScrollView.ContentInset = new UIEdgeInsets((nfloat)Math.Max(HeaderMinimumHeight, MeasuredHeaderViewHeightWithNoMargin), 0, 0, 0);
+				}
 			}
 			else
 			{
@@ -328,9 +339,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				}
 				else
 				{
-					// For ScrollView, we need to consider the margin, but we should not consider the header height, since it should overlap with the scroll view. 
-					// The content inset is already managed by SetHeaderContentInset.
-					contentYOffset += HeaderView.View.Margin.VerticalThickness;
+					var headerBehavior = _context.Shell.FlyoutHeaderBehavior;
+					if (headerBehavior == FlyoutHeaderBehavior.Default || headerBehavior == FlyoutHeaderBehavior.Fixed)
+					{
+						// For Default/Fixed, position the scroll view below the header so items
+						// cannot scroll behind it. No content inset is needed in this case.
+						contentYOffset += HeaderView.Frame.Height;
+					}
+					else
+					{
+						// For Scroll/CollapseOnScroll, the scroll view overlaps the header so the header
+						// can scroll away or shrink. The content inset is managed by SetHeaderContentInset.
+						contentYOffset += HeaderView.View.Margin.VerticalThickness;
+					}
 				}
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellFlyoutTests.cs
@@ -233,18 +233,19 @@ namespace Microsoft.Maui.DeviceTests
                                 var expectedContentY = headerMargin.Top + headerMargin.Bottom + contentMargin.Top;
 
 #if IOS
-                                if (contentType != "ScrollView")
+                                if (contentType == "ScrollView" &&
+                                    (behavior == FlyoutHeaderBehavior.Scroll || behavior == FlyoutHeaderBehavior.CollapseOnScroll))
+                                {
+                                        // For Scroll/CollapseOnScroll, the scroll view overlaps the header so the header
+                                        // can scroll away or shrink. Content is offset via ContentInset, not frame position.
+                                        var scrollViewContentInsetTop = ((UIScrollView)((IView)shell.FlyoutContent).Handler.PlatformView).ContentInset.Top;
+                                        AssertionExtensions.CloseEnough(headerFrame.Height, scrollViewContentInsetTop, message: "Content ScrollView Inset Y");
+                                }
+                                else
 #endif
                                 {
                                         expectedContentY += headerFrame.Height;
                                 }
-#if IOS
-                                else
-                                {
-                                        var scrollViewContentInsetTop = ((UIScrollView)((IView)shell.FlyoutContent).Handler.PlatformView).ContentInset.Top;
-                                        AssertionExtensions.CloseEnough(headerFrame.Height, scrollViewContentInsetTop, message: "Content ScrollView Inset Y");
-                                }
-#endif
 
                                 AssertionExtensions.CloseEnough(0, contentFrame.X, message: "Content X");
                                 AssertionExtensions.CloseEnough(expectedContentY, contentFrame.Y, epsilon: 0.5, message: "Content Y");
@@ -260,6 +261,56 @@ namespace Microsoft.Maui.DeviceTests
                                 AssertionExtensions.CloseEnough(expectedFooterY + footerFrame.Height, flyoutFrame.Height, epsilon: 0.5, message: "Total Height");
                         });
                 }
+		// Regression test for https://github.com/dotnet/maui/issues/34925
+		// For Default/Fixed header behavior, the scroll view should be positioned below the header
+		// (ContentInset.Top = 0) so items cannot scroll behind the header.
+		[Theory]
+		[InlineData(FlyoutHeaderBehavior.Default)]
+		[InlineData(FlyoutHeaderBehavior.Fixed)]
+		public async Task FlyoutScrollViewDoesNotOverlapHeaderForDefaultAndFixed(FlyoutHeaderBehavior behavior)
+		{
+			var headerHeight = 150;
+
+			await RunShellTest(shell =>
+			{
+				shell.FlyoutHeaderBehavior = behavior;
+				shell.FlyoutHeader = new VerticalStackLayout
+				{
+					HeightRequest = headerHeight,
+					BackgroundColor = Colors.Blue,
+					Children = { new Label { Text = "Header" } }
+				};
+
+				// Add enough items to require scrolling
+				for (int i = 0; i < 20; i++)
+				{
+					shell.Items.Add(new FlyoutItem
+					{
+						Title = $"Page {i}",
+						Items = { new ShellContent { ContentTemplate = new DataTemplate(() => new ContentPage()) } }
+					});
+				}
+			},
+			async (shell, handler) =>
+			{
+				await OpenFlyout(handler);
+
+				var flyoutView = GetFlyoutPlatformView(handler);
+				var scrollView = flyoutView.FindDescendantView<UIScrollView>();
+				Assert.NotNull(scrollView);
+
+				var headerFrame = GetFrameRelativeToFlyout(handler, (IView)shell.FlyoutHeader);
+				var headerBottom = headerFrame.Y + headerFrame.Height;
+
+				// For Default/Fixed, the scroll view should be positioned below the header,
+				// not overlapping it with a content inset. When the scroll view overlaps the header,
+				// items become visible behind a semi-transparent header when scrolling.
+				Assert.True(
+					scrollView.Frame.Y >= headerBottom - 0.5,
+					$"ScrollView frame (Y={scrollView.Frame.Y}) should start at or below header bottom ({headerBottom}). " +
+					$"ContentInset.Top={scrollView.ContentInset.Top}. Items can scroll behind the header (issue #34925).");
+			});
+		}
 #endif
 #endif
 


### PR DESCRIPTION
### Description of Change

Ports PR #34936 to inflight/candidate.

For `Default` and `Fixed` `FlyoutHeaderBehavior`, the flyout scroll view is now positioned below the header instead of overlapping it with a content inset. This prevents items from rendering behind semi-transparent headers when scrolling.

`Scroll` and `CollapseOnScroll` behaviors are unchanged.

**Changes:**
- **ShellFlyoutLayoutManager.cs** (iOS): For Default/Fixed, sets `ContentInset.Top = 0` and positions scroll view below header
- **ShellFlyoutTests.cs**: New regression test + updated existing test expectations

### Issues Fixed

Fixes #34925