### PR TITLE
[iOS] Fix HEIC images picked via PickPhotosAsync not displayed

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -502,6 +502,14 @@ namespace Microsoft.Maui.Media
 
 		public override void DidFinishPicking(PHPickerViewController picker, PHPickerResult[] results)
 		{
+			// Null out the presentation delegate handler before dismiss to prevent a GC race condition.
+			// Without this, Dispose() on PhotoPickerPresentationControllerDelegate can fire tcs.TrySetResult([])
+			// while the async CompletedHandler is still processing (especially slow for HEIC transcoding).
+			if (picker.PresentationController?.Delegate is PhotoPickerPresentationControllerDelegate pd)
+			{
+				pd.Handler = null;
+			}
+
 			var captured = results?.Length > 0 ? results : [];
             picker.DismissViewController(true, () => CompletedHandler?.Invoke(captured));
 		}


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issue Details

- HEIC images picked via PickPhotosAsync are not displayed — the image appears blank, whereas other image formats (e.g., JPEG, PNG) display correctly.

### Root Cause of the issue

- PR [34250](https://github.com/dotnet/maui/pull/34250) moved CompletedHandler invocation into the DismissViewController completion callback. This introduced a GC race condition where PhotoPickerPresentationControllerDelegate.Dispose() fires tcs.TrySetResult([]) before the async CompletedHandler finishes HEIC transcoding. 
- HEIC is particularly affected because NSItemProvider.LoadDataRepresentationAsync transcoding is significantly slower than JPEG/PNG loading, widening the GC window.

### Description of Change
**Race condition prevention:**

* In `PhotoPickerDelegate.DidFinishPicking`, the `Handler` property of `PhotoPickerPresentationControllerDelegate` is set to `null` before dismissing the picker to avoid a garbage collection race condition that could interfere with the async completion handler, especially during slow operations like HEIC transcoding.
<!-- Enter description of the fix in this section -->

### Issues Fixed
Fixes #34953

### Tested the behaviour in the following platforms

- [ ] - Windows 
- [ ] - Android
- [x] - iOS
- [ ] - Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/368192e4-57ea-4732-82df-3e3ca386ab35"> | <video src="https://github.com/user-attachments/assets/0e3a5066-e092-4461-9199-1730475307d8"> |

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
