### PR TITLE
[Android] Fix CollectionView EmptyView not displayed correctly

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/GridLayoutSpanSizeLookup.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/GridLayoutSpanSizeLookup.cs
@@ -16,7 +16,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override int GetSpanSize(int position)
 		{
-			var itemViewType = _recyclerView.GetAdapter().GetItemViewType(position);
+			var adapter = _recyclerView.GetAdapter();
+
+			// EmptyViewAdapter uses private incrementing view type IDs that never match
+			// the static ItemViewType constants. All items it contains (header, empty view,
+			// footer) should span the full grid width.
+			if (adapter is EmptyViewAdapter)
+			{
+				return _gridItemsLayout.Span;
+			}
+
+			var itemViewType = adapter.GetItemViewType(position);
 
 			if (itemViewType == ItemViewType.Header || itemViewType == ItemViewType.Footer
 				|| itemViewType == ItemViewType.GroupHeader || itemViewType == ItemViewType.GroupFooter)

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34861.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34861.cs
@@ -1,0 +1,55 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34861, "[Android] CollectionView EmptyView not displayed correctly with GridItemsLayout span > 1", PlatformAffected.Android)]
+public class Issue34861 : ContentPage
+{
+	public Issue34861()
+	{
+		var collectionView = new CollectionView
+		{
+			AutomationId = "TestCollectionView",
+			ItemsLayout = new GridItemsLayout(2, ItemsLayoutOrientation.Vertical),
+			Header = new Label
+			{
+				Text = "Header",
+				AutomationId = "HeaderLabel",
+				FontSize = 20,
+				FontAttributes = FontAttributes.Bold,
+				BackgroundColor = Colors.LightBlue,
+				Padding = new Thickness(10)
+			},
+			EmptyView = new Label
+			{
+				Text = "No items available",
+				AutomationId = "EmptyViewLabel",
+				FontSize = 16,
+				HorizontalTextAlignment = TextAlignment.Center,
+				VerticalTextAlignment = TextAlignment.Center,
+				BackgroundColor = Colors.LightYellow,
+				Padding = new Thickness(10)
+			},
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, ".");
+				return label;
+			}),
+			// Empty source to trigger EmptyView
+			ItemsSource = new System.Collections.ObjectModel.ObservableCollection<string>()
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Children =
+			{
+				new Label
+				{
+					Text = "The EmptyView should appear below the Header, spanning the full width.",
+					AutomationId = "InstructionLabel",
+					Padding = new Thickness(10)
+				},
+				collectionView
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34861.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34861.cs
@@ -28,14 +28,6 @@ public class Issue34861 : ContentPage
 				BackgroundColor = Colors.LightYellow,
 				Padding = new Thickness(10)
 			},
-			ItemTemplate = new DataTemplate(() =>
-			{
-				var label = new Label();
-				label.SetBinding(Label.TextProperty, ".");
-				return label;
-			}),
-			// Empty source to trigger EmptyView
-			ItemsSource = new System.Collections.ObjectModel.ObservableCollection<string>()
 		};
 
 		Content = new VerticalStackLayout

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34861.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34861.cs
@@ -1,4 +1,4 @@
-#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST
+#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST // Test fails on iOS, Windows and Catalyst because of Header is not visible https://github.com/dotnet/maui/issues/34897
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34861.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34861.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34861 : _IssuesUITest
+{
+	public Issue34861(TestDevice testDevice) : base(testDevice)
+	{
+	}
+
+	public override string Issue => "[Android] CollectionView EmptyView not displayed correctly with GridItemsLayout span > 1";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void EmptyViewShouldAppearBelowHeaderInGridLayout()
+	{
+		App.WaitForElement("TestCollectionView");
+
+		var headerRect = App.WaitForElement("HeaderLabel").GetRect();
+		var emptyViewRect = App.WaitForElement("EmptyViewLabel").GetRect();
+
+		// EmptyView should be below the header (its Y should be >= header's bottom edge)
+		Assert.That(emptyViewRect.Y, Is.GreaterThanOrEqualTo(headerRect.Y + headerRect.Height),
+			"EmptyView should appear below the Header, not beside it");
+
+		// EmptyView should start at (or near) the left edge, not pushed to the right
+		Assert.That(emptyViewRect.X, Is.LessThanOrEqualTo(headerRect.X + 10),
+			"EmptyView should be aligned to the left, not pushed to the right of the Header");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34861.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34861.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_IOS && TEST_FAILS_ON_WINDOWS && TEST_FAILS_ON_CATALYST
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -30,3 +31,4 @@ public class Issue34861 : _IssuesUITest
 			"EmptyView should be aligned to the left, not pushed to the right of the Header");
 	}
 }
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

When a CollectionView with a GridItemsLayout (span > 1) has both a Header and an EmptyView, the EmptyView appeared beside the Header instead of below it.
       
### Root Cause:

The root cause is in GridLayoutSpanSizeLookup.GetSpanSize(), which determines how many grid columns each item should occupy. Normally it checks ItemViewType constants (like Header = 43, Footer = 44) to give those items full-width span. However, when the collection is empty, Android uses an EmptyViewAdapter that assigns its items private incrementing IDs (1, 2, 3…) which never match those constants — so everything falls through to return 1, giving each item only a single column.

### Description of Change:

The fix adds a simple early check: if the current adapter is an EmptyViewAdapter, immediately return the full _gridItemsLayout.Span for every position, skipping the view-type matching entirely. This ensures that when
the collection is empty, all items (header, empty view, footer) always span the full grid width and stack vertically as expected.

**Tested the behavior in the following platforms:**

- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #34861         

### Screenshots
| Before  | After  |
|---------|--------|
|  <img src="https://github.com/user-attachments/assets/d1cea6d7-157d-4230-a13e-dc06241176db" Width="300" Height="600">  |  <img alt="image" src="https://github.com/user-attachments/assets/653580a4-0c9c-4fc8-b0e2-2712261aa823" Width="300" Height="600">  |