### PR TITLE
Fix HybridWebView NativeAOT warning path

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -122,7 +122,17 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<WebView, WebViewHandler>();
 		if (RuntimeFeature.IsHybridWebViewSupported)
 		{
-			// NOTE: not registered under NativeAOT or TrimMode=Full scenarios
+			// Keep the RequiresDynamicCode path isolated under the HybridWebView feature switch
+			// so NativeAOT/full-trim apps don't pick up HybridWebView warnings just by
+			// evaluating the default handler registration list.
+			AddHybridWebViewHandler(handlersCollection);
+		}
+#if !NETSTANDARD
+		[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
+#endif
+		[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
+		static void AddHybridWebViewHandler(IMauiHandlersCollection handlersCollection)
+		{
 			handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
 		}
 

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -120,6 +120,7 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<Switch, SwitchHandler>();
 		handlersCollection.AddHandler<Page, PageHandler>();
 		handlersCollection.AddHandler<WebView, WebViewHandler>();
+		const string hybridWebViewDynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
 		if (RuntimeFeature.IsHybridWebViewSupported)
 		{
 			// Keep the RequiresDynamicCode path isolated under the HybridWebView feature switch
@@ -128,9 +129,9 @@ public static partial class AppHostBuilderExtensions
 			AddHybridWebViewHandler(handlersCollection);
 		}
 #if !NETSTANDARD
-		[RequiresDynamicCode(HybridWebViewHandler.DynamicFeatures)]
+		[RequiresDynamicCode(hybridWebViewDynamicFeatures)]
 #endif
-		[RequiresUnreferencedCode(HybridWebViewHandler.DynamicFeatures)]
+		[RequiresUnreferencedCode(hybridWebViewDynamicFeatures)]
 		static void AddHybridWebViewHandler(IMauiHandlersCollection handlersCollection)
 		{
 			handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

Fixes #34867

## Summary

Prevent NativeAOT/full-trim analysis from surfacing `HybridWebViewHandler` warnings when `HybridWebView` is feature-switched off.

## Root cause

`HybridWebView` was already being disabled for `PublishAot=true` / `TrimMode=full` via `MauiHybridWebViewSupported=false`. The warning still leaked because the default controls handler registration path directly referenced `HybridWebViewHandler`, which carries `RequiresDynamicCode` / `RequiresUnreferencedCode` annotations.

## What changed

- keep the existing `RuntimeFeature.IsHybridWebViewSupported` gate
- move the `HybridWebView` registration into a guarded local helper
- attach the AOT/trimming annotations to that guarded path instead of the default registration flow

## Why this approach

This fixes the actual reachability/analysis shape instead of suppressing the warning or expanding the expected-warning baseline.

## Validation

- `dotnet build src/Controls/src/Core/Controls.Core.csproj -f net11.0`
- local NativeAOT integration flow no longer emitted the previous unexpected `HybridWebViewHandler` warning; remaining local failures were unrelated environment/feed restore issues