### PR TITLE
 [MacCatalyst] Fix DatePicker Opened/Closed events not being raised

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34848.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34848.cs
@@ -1,0 +1,46 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34848, "DatePicker Opened and Closed events are not raised on MacCatalyst", PlatformAffected.macOS)]
+public class Issue34848 : TestContentPage
+{
+	DatePicker _datePicker;
+	Label _OpenstatusLabel;
+	Label _ClosestatusLabel;
+	protected override void Init()
+	{
+		_OpenstatusLabel = new Label
+		{
+			AutomationId = "Issue34848OpenStatusLabel",
+			Text = "Opened: Unknown",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		_ClosestatusLabel = new Label
+		{
+			AutomationId = "Issue34848CloseStatusLabel",
+			Text = "Closed: Unknown",
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		_datePicker = new DatePicker
+		{
+			AutomationId = "Issue34848TestDatePicker",
+			Date = DateTime.Today,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		_datePicker.Opened += (s, e) => _OpenstatusLabel.Text = "Opened";
+		_datePicker.Closed += (s, e) => _ClosestatusLabel.Text = "Closed";
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Children =
+			{
+				_OpenstatusLabel,
+				_ClosestatusLabel,
+				_datePicker
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34848.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34848.cs
@@ -4,18 +4,18 @@ namespace Maui.Controls.Sample.Issues;
 public class Issue34848 : TestContentPage
 {
 	DatePicker _datePicker;
-	Label _OpenstatusLabel;
-	Label _ClosestatusLabel;
+	Label _openStatusLabel;
+	Label _closeStatusLabel;
 	protected override void Init()
 	{
-		_OpenstatusLabel = new Label
+		_openStatusLabel = new Label
 		{
 			AutomationId = "Issue34848OpenStatusLabel",
 			Text = "Opened: Unknown",
 			HorizontalOptions = LayoutOptions.Center
 		};
 
-		_ClosestatusLabel = new Label
+		_closeStatusLabel = new Label
 		{
 			AutomationId = "Issue34848CloseStatusLabel",
 			Text = "Closed: Unknown",
@@ -29,16 +29,16 @@ public class Issue34848 : TestContentPage
 			HorizontalOptions = LayoutOptions.Center
 		};
 
-		_datePicker.Opened += (s, e) => _OpenstatusLabel.Text = "Opened";
-		_datePicker.Closed += (s, e) => _ClosestatusLabel.Text = "Closed";
+		_datePicker.Opened += (s, e) => _openStatusLabel.Text = "Opened";
+		_datePicker.Closed += (s, e) => _closeStatusLabel.Text = "Closed";
 
 		Content = new VerticalStackLayout
 		{
 			Spacing = 10,
 			Children =
 			{
-				_OpenstatusLabel,
-				_ClosestatusLabel,
+				_openStatusLabel,
+				_closeStatusLabel,
 				_datePicker
 			}
 		};

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34848.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34848 : _IssuesUITest
+{
+	public Issue34848(TestDevice testDevice) : base(testDevice) { }
+
+	public override string Issue => "DatePicker Opened and Closed events are not raised on MacCatalyst";
+
+	[Test]
+	[Category(UITestCategories.DatePicker)]
+	public void DatePickerOpenedAndClosedEventsAreRaised()
+	{
+		App.WaitForElement("Issue34848OpenStatusLabel");
+		App.WaitForElement("Issue34848CloseStatusLabel");
+		App.WaitForElement("Issue34848TestDatePicker");
+
+		// Open the DatePicker
+		App.Tap("Issue34848TestDatePicker");
+
+#if IOS
+		// iOS DatePicker uses a wheel picker, so we can just tap the "Done" button to close it
+		App.Tap("Done");
+#elif WINDOWS
+		// On Windows, we can tap a date to close the DatePicker
+		App.Tap("16");
+#elif ANDROID
+		// On Android, we can tap the "Cancel" button to close the DatePicker
+		App.Tap("Cancel");
+#else
+		// On MacCatalyst, we can tap outside the DatePicker to close it
+		App.TapCoordinates(30, 30);
+#endif
+
+		Assert.That(App.WaitForElement("Issue34848OpenStatusLabel").GetText(), Is.EqualTo("Opened"));
+		Assert.That(App.WaitForElement("Issue34848CloseStatusLabel").GetText(), Is.EqualTo("Closed"));
+	}
+}

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Maui.Handlers
 	public partial class DatePickerHandler : ViewHandler<IDatePicker, UIDatePicker>
 	{
 		readonly UIDatePickerProxy _proxy = new();
+		NSObject? _editingBeganObserver;
+		NSObject? _windowCloseObserver;
+		bool _isOpen;
+
+		static readonly NSString NSWindowDidCloseNotification = new("NSWindowDidCloseNotification");
 
 		protected override UIDatePicker CreatePlatformView()
 		{
@@ -26,6 +31,18 @@ namespace Microsoft.Maui.Handlers
 				platformView.Date = dt.ToNSDate();
 			}
 
+			// The compact UIDatePicker on MacCatalyst uses internal UITextField subviews
+			// for the date segments. Listen for any UITextField beginning editing — the
+			// IsDescendantOfView check ensures we only respond to our picker's fields.
+			_editingBeganObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+				UITextField.TextDidBeginEditingNotification, OnEditingBegan);
+
+			// On MacCatalyst the popover runs in an AppKit NSWindow. Tapping outside
+			// dismisses it at the AppKit level without firing UITextField EditingDidEnd,
+			// so NSWindowDidCloseNotification is needed for close.
+			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+				NSWindowDidCloseNotification, OnWindowClosed);
+
 			base.ConnectHandler(platformView);
 		}
 
@@ -33,7 +50,58 @@ namespace Microsoft.Maui.Handlers
 		{
 			_proxy.Disconnect(platformView);
 
+			if (_editingBeganObserver is not null)
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(_editingBeganObserver);
+				_editingBeganObserver = null;
+			}
+
+			if (_windowCloseObserver is not null)
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(_windowCloseObserver);
+				_windowCloseObserver = null;
+			}
+
+			_isOpen = false;
+
 			base.DisconnectHandler(platformView);
+		}
+
+		void OnEditingBegan(NSNotification notification)
+		{
+			if (_isOpen)
+			{
+				return;
+			}
+
+			if (notification.Object is UITextField textField && textField.IsDescendantOfView(PlatformView))
+			{
+				_isOpen = true;
+				if (VirtualView is IDatePicker virtualView)
+				{
+					virtualView.IsFocused = virtualView.IsOpen = true;
+				}
+			}
+		}
+
+		void OnWindowClosed(NSNotification notification)
+		{
+			if (!_isOpen)
+			{
+				return;
+			}
+
+			_isOpen = false;
+
+			if (UpdateImmediately)
+			{
+				SetVirtualViewDate();
+			}
+
+			if (VirtualView is IDatePicker virtualView)
+			{
+				virtualView.IsFocused = virtualView.IsOpen = false;
+			}
 		}
 
 		public static partial void MapFormat(IDatePickerHandler handler, IDatePicker datePicker)
@@ -102,15 +170,11 @@ namespace Microsoft.Maui.Handlers
 				_handler = new(handler);
 				_virtualView = new(virtualView);
 
-				platformView.EditingDidBegin += OnStarted;
-				platformView.EditingDidEnd += OnEnded;
 				platformView.ValueChanged += OnValueChanged;
 			}
 
 			public void Disconnect(UIDatePicker platformView)
 			{
-				platformView.EditingDidBegin -= OnStarted;
-				platformView.EditingDidEnd -= OnEnded;
 				platformView.ValueChanged -= OnValueChanged;
 			}
 
@@ -118,21 +182,6 @@ namespace Microsoft.Maui.Handlers
 			{
 				if (_handler is not null && _handler.TryGetTarget(out var handler) && handler.UpdateImmediately)
 					handler.SetVirtualViewDate();
-
-				if (VirtualView is IDatePicker virtualView)
-					virtualView.IsFocused = true;
-			}
-
-			void OnStarted(object? sender, EventArgs eventArgs)
-			{
-				if (VirtualView is IDatePicker virtualView)
-					virtualView.IsFocused = true;
-			}
-
-			void OnEnded(object? sender, EventArgs eventArgs)
-			{
-				if (VirtualView is IDatePicker virtualView)
-					virtualView.IsFocused = false;
 			}
 		}
 	}

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class DatePickerHandler : ViewHandler<IDatePicker, UIDatePicker>
 	{
+		static readonly NSString WindowDidCloseNotification = new("NSWindowDidCloseNotification");
+
 		readonly UIDatePickerProxy _proxy = new();
 		NSObject? _windowCloseObserver;
 		bool _isDatePickerOpen;
@@ -105,7 +107,7 @@ namespace Microsoft.Maui.Handlers
 			// dismisses it at the AppKit level without firing UITextField EditingDidEnd.
 			// Registering here (not in ConnectHandler) avoids spurious fires from
 			// unrelated window closes while the picker is not open.
-			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(new("NSWindowDidCloseNotification"), OnWindowClosed);
+			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(WindowDidCloseNotification, OnWindowClosed);
 
 			if (VirtualView is IDatePicker virtualView)
 			{

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
@@ -33,11 +33,6 @@ namespace Microsoft.Maui.Handlers
 			// for the date segments. Wire up EditingDidBegin directly on those fields.
 			WireTextFields(platformView);
 
-			// On MacCatalyst the popover runs in an AppKit NSWindow. Tapping outside
-			// dismisses it at the AppKit level without firing UITextField EditingDidEnd,
-			// so NSWindowDidCloseNotification is needed for close.
-			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(new("NSWindowDidCloseNotification"), OnWindowClosed);
-
 			base.ConnectHandler(platformView);
 		}
 
@@ -104,6 +99,14 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			_isDatePickerOpen = true;
+
+			// Register a one-shot observer scoped to this picker's open lifetime.
+			// On MacCatalyst the popover runs in an AppKit NSWindow; tapping outside
+			// dismisses it at the AppKit level without firing UITextField EditingDidEnd.
+			// Registering here (not in ConnectHandler) avoids spurious fires from
+			// unrelated window closes while the picker is not open.
+			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(new("NSWindowDidCloseNotification"), OnWindowClosed);
+
 			if (VirtualView is IDatePicker virtualView)
 			{
 				virtualView.IsFocused = virtualView.IsOpen = true;
@@ -112,17 +115,14 @@ namespace Microsoft.Maui.Handlers
 
 		void OnWindowClosed(NSNotification notification)
 		{
-			if (!_isDatePickerOpen)
+			// One-shot: remove the observer immediately so it won't fire again.
+			if (_windowCloseObserver is not null)
 			{
-				return;
+				NSNotificationCenter.DefaultCenter.RemoveObserver(_windowCloseObserver);
+				_windowCloseObserver = null;
 			}
 
 			_isDatePickerOpen = false;
-
-			if (UpdateImmediately)
-			{
-				SetVirtualViewDate();
-			}
 
 			if (VirtualView is IDatePicker virtualView)
 			{

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
@@ -10,10 +10,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		readonly UIDatePickerProxy _proxy = new();
 		NSObject? _windowCloseObserver;
-		readonly List<UITextField> _textFields = new();
-		bool _isOpen;
-
-		static readonly NSString NSWindowDidCloseNotification = new("NSWindowDidCloseNotification");
+		bool _isDatePickerOpen;
 
 		protected override UIDatePicker CreatePlatformView()
 		{
@@ -34,12 +31,12 @@ namespace Microsoft.Maui.Handlers
 
 			// The compact UIDatePicker on MacCatalyst uses internal UITextField subviews
 			// for the date segments. Wire up EditingDidBegin directly on those fields.
-			FindAndWireTextFields(platformView);
+			WireTextFields(platformView);
 
 			// On MacCatalyst the popover runs in an AppKit NSWindow. Tapping outside
 			// dismisses it at the AppKit level without firing UITextField EditingDidEnd,
 			// so NSWindowDidCloseNotification is needed for close.
-			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(NSWindowDidCloseNotification, OnWindowClosed);
+			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(new("NSWindowDidCloseNotification"), OnWindowClosed);
 
 			base.ConnectHandler(platformView);
 		}
@@ -48,7 +45,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			_proxy.Disconnect(platformView);
 
-			UnwireTextFields();
+			UnwireTextFields(platformView);
 
 			if (_windowCloseObserver is not null)
 			{
@@ -56,47 +53,57 @@ namespace Microsoft.Maui.Handlers
 				_windowCloseObserver = null;
 			}
 
-			_isOpen = false;
+			_isDatePickerOpen = false;
 
 			base.DisconnectHandler(platformView);
 		}
 
-		// Recursively searches the UIDatePicker's view hierarchy for internal
-		// UITextField subviews used by the compact date picker on MacCatalyst
-		// and subscribes to their editing events to track focus state.
-		void FindAndWireTextFields(UIView view)
+
+		// Recursively traverses the view hierarchy and yields all UITextField subviews.
+		// Used to find the internal text fields of the compact UIDatePicker on MacCatalyst.
+		static IEnumerable<UITextField> GetTextFields(UIView view)
 		{
 			foreach (var subview in view.Subviews)
 			{
+
 				if (subview is UITextField textField)
 				{
-					textField.EditingDidBegin += OnEditingDidBegin;
-					_textFields.Add(textField);
+					yield return textField;
 				}
 				else
 				{
-					FindAndWireTextFields(subview);
+					foreach (var nested in GetTextFields(subview))
+					{
+						yield return nested;
+					}
 				}
 			}
 		}
 
-		void UnwireTextFields()
+		void WireTextFields(UIView view)
 		{
-			foreach (var textField in _textFields)
+			foreach (var textField in GetTextFields(view))
+			{
+				textField.EditingDidBegin += OnEditingDidBegin;
+			}
+		}
+
+		void UnwireTextFields(UIView view)
+		{
+			foreach (var textField in GetTextFields(view))
 			{
 				textField.EditingDidBegin -= OnEditingDidBegin;
 			}
-			_textFields.Clear();
 		}
 
 		void OnEditingDidBegin(object? sender, EventArgs e)
 		{
-			if (_isOpen)
+			if (_isDatePickerOpen)
 			{
 				return;
 			}
 
-			_isOpen = true;
+			_isDatePickerOpen = true;
 			if (VirtualView is IDatePicker virtualView)
 			{
 				virtualView.IsFocused = virtualView.IsOpen = true;
@@ -105,12 +112,12 @@ namespace Microsoft.Maui.Handlers
 
 		void OnWindowClosed(NSNotification notification)
 		{
-			if (!_isOpen)
+			if (!_isDatePickerOpen)
 			{
 				return;
 			}
 
-			_isOpen = false;
+			_isDatePickerOpen = false;
 
 			if (UpdateImmediately)
 			{
@@ -132,9 +139,10 @@ namespace Microsoft.Maui.Handlers
 
 		void ResignTextFields()
 		{
+			var platformView = PlatformView;
 			CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
 			{
-				foreach (var textField in _textFields)
+				foreach (var textField in GetTextFields(platformView))
 				{
 					if (textField.IsFirstResponder)
 					{

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Foundation;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -8,8 +9,8 @@ namespace Microsoft.Maui.Handlers
 	public partial class DatePickerHandler : ViewHandler<IDatePicker, UIDatePicker>
 	{
 		readonly UIDatePickerProxy _proxy = new();
-		NSObject? _editingBeganObserver;
 		NSObject? _windowCloseObserver;
+		readonly List<UITextField> _textFields = new();
 		bool _isOpen;
 
 		static readonly NSString NSWindowDidCloseNotification = new("NSWindowDidCloseNotification");
@@ -32,16 +33,13 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			// The compact UIDatePicker on MacCatalyst uses internal UITextField subviews
-			// for the date segments. Listen for any UITextField beginning editing — the
-			// IsDescendantOfView check ensures we only respond to our picker's fields.
-			_editingBeganObserver = NSNotificationCenter.DefaultCenter.AddObserver(
-				UITextField.TextDidBeginEditingNotification, OnEditingBegan);
+			// for the date segments. Wire up EditingDidBegin directly on those fields.
+			FindAndWireTextFields(platformView);
 
 			// On MacCatalyst the popover runs in an AppKit NSWindow. Tapping outside
 			// dismisses it at the AppKit level without firing UITextField EditingDidEnd,
 			// so NSWindowDidCloseNotification is needed for close.
-			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(
-				NSWindowDidCloseNotification, OnWindowClosed);
+			_windowCloseObserver = NSNotificationCenter.DefaultCenter.AddObserver(NSWindowDidCloseNotification, OnWindowClosed);
 
 			base.ConnectHandler(platformView);
 		}
@@ -50,11 +48,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			_proxy.Disconnect(platformView);
 
-			if (_editingBeganObserver is not null)
-			{
-				NSNotificationCenter.DefaultCenter.RemoveObserver(_editingBeganObserver);
-				_editingBeganObserver = null;
-			}
+			UnwireTextFields();
 
 			if (_windowCloseObserver is not null)
 			{
@@ -67,20 +61,42 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
-		void OnEditingBegan(NSNotification notification)
+		void FindAndWireTextFields(UIView view)
+		{
+			foreach (var subview in view.Subviews)
+			{
+				if (subview is UITextField textField)
+				{
+					textField.EditingDidBegin += OnEditingDidBegin;
+					_textFields.Add(textField);
+				}
+				else
+				{
+					FindAndWireTextFields(subview);
+				}
+			}
+		}
+
+		void UnwireTextFields()
+		{
+			foreach (var textField in _textFields)
+			{
+				textField.EditingDidBegin -= OnEditingDidBegin;
+			}
+			_textFields.Clear();
+		}
+
+		void OnEditingDidBegin(object? sender, EventArgs e)
 		{
 			if (_isOpen)
 			{
 				return;
 			}
 
-			if (notification.Object is UITextField textField && textField.IsDescendantOfView(PlatformView))
+			_isOpen = true;
+			if (VirtualView is IDatePicker virtualView)
 			{
-				_isOpen = true;
-				if (VirtualView is IDatePicker virtualView)
-				{
-					virtualView.IsFocused = virtualView.IsOpen = true;
-				}
+				virtualView.IsFocused = virtualView.IsOpen = true;
 			}
 		}
 

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.MacCatalyst.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
+		// Recursively searches the UIDatePicker's view hierarchy for internal
+		// UITextField subviews used by the compact date picker on MacCatalyst
+		// and subscribes to their editing events to track focus state.
 		void FindAndWireTextFields(UIView view)
 		{
 			foreach (var subview in view.Subviews)
@@ -118,6 +121,27 @@ namespace Microsoft.Maui.Handlers
 			{
 				virtualView.IsFocused = virtualView.IsOpen = false;
 			}
+
+			// On MacCatalyst the internal UITextFields stay as first responder
+			// (visually highlighted) even after the popover window closes.
+			// EndEditing(true) on the parent view does not propagate to them,
+			// so we must directly resign each tracked text field on the next
+			// run-loop iteration (the notification fires before UIKit is ready).
+			ResignTextFields();
+		}
+
+		void ResignTextFields()
+		{
+			CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+			{
+				foreach (var textField in _textFields)
+				{
+					if (textField.IsFirstResponder)
+					{
+						textField.ResignFirstResponder();
+					}
+				}
+			});
 		}
 
 		public static partial void MapFormat(IDatePickerHandler handler, IDatePicker datePicker)
@@ -198,6 +222,9 @@ namespace Microsoft.Maui.Handlers
 			{
 				if (_handler is not null && _handler.TryGetTarget(out var handler) && handler.UpdateImmediately)
 					handler.SetVirtualViewDate();
+
+				if (VirtualView is IDatePicker virtualView)
+					virtualView.IsFocused = true;
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

This pull request addresses the issue where the `DatePicker` control on MacCatalyst did not correctly raise its `Opened` and `Closed` events. The changes implement a more robust mechanism for detecting when the DatePicker is opened and closed, specifically for MacCatalyst, and add new tests to verify this behavior.
### Description of Change :

**MacCatalyst DatePicker Event Handling Improvements:**

* Added logic to traverse the internal view hierarchy of the compact `UIDatePicker` to find and wire up `UITextField` subviews, allowing detection of when the DatePicker is opened via the `EditingDidBegin` event. A one-shot observer is registered to detect when the picker popover window closes, ensuring the `Closed` event is raised reliably. (`DatePickerHandler.MacCatalyst.cs`)
* Implemented cleanup logic to unwire event handlers and remove observers during disconnect, preventing memory leaks and spurious event firing. (`DatePickerHandler.MacCatalyst.cs`)
* Removed previous event handler attachments (`EditingDidBegin`/`EditingDidEnd`) from the proxy, as the new mechanism supersedes them. (`DatePickerHandler.MacCatalyst.cs`) [[1]](diffhunk://#diff-2107542f6f788907263db46eab6a80232ed765aa515806945e8f65681c8421d1L105-L113) [[2]](diffhunk://#diff-2107542f6f788907263db46eab6a80232ed765aa515806945e8f65681c8421d1L125-L136)

**Testing Enhancements:**

* Added a new test case page (`Issue34848`) and a corresponding UI test to verify that the `Opened` and `Closed` events are raised correctly on MacCatalyst and other platforms, using platform-specific logic to close the DatePicker. (`TestCases.HostApp/Issues/Issue34848.cs`, `TestCases.Shared.Tests/Tests/Issues/Issue34848.cs`) [[1]](diffhunk://#diff-652f2cd8a1e252cf8db29bf33034066d08ec5e3b43ec76a77d477824a08a1f44R1-R46) [[2]](diffhunk://#diff-a57ba10bf75c97b2a6f28c075585a1066df8c7c2c31751e3c799177fca6560b4R1-R42)

**General Codebase Improvements:**

* Minor code cleanup and improved organization in the DatePicker handler for MacCatalyst, including the addition of necessary using directives. (`DatePickerHandler.MacCatalyst.cs`)


<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34848 

### Tested the behavior in the following platforms

- [ ] Windows
- [ ] Android
- [ ] iOS
- [x] Mac

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/73c4686f-30d0-4a57-bb8d-be6b2d4b7cda">  | <video src="https://github.com/user-attachments/assets/65d6f44e-b145-48de-b41a-77b6abefabc4"> |
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
