### PR TITLE
[Build] Skip XamlC when no XAML files need XamlC processing

### DIFF
--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -234,7 +234,7 @@
 		AfterTargets="AfterCompile"
 		Inputs="$(IntermediateOutputPath)$(TargetFileName)"
 		Outputs="$(IntermediateOutputPath)XamlC.stamp"
-		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != ''">
+		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(MauiXaml)' != '' AND ('@(_MauiXaml_XC)' != '' OR '@(_MauiXaml_RT)' != '') ">
 		<PropertyGroup>
 			<_MauiXamlCValidateOnly>$(MauiXamlCValidateOnly)</_MauiXamlCValidateOnly>
 			<_MauiXamlCValidateOnly Condition="'$(Configuration)' == 'Debug' AND '$(_MauiForceXamlCForDebug)' != 'True'">True</_MauiXamlCValidateOnly>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -25,6 +25,18 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			"Microsoft.Maui.dll",
 		};
 
+		/// <summary>
+		/// XamlC opt-in for tests where XamlC's behaviour is the subject. We use bare
+		/// <c>XamlC</c> (not <c>SourceGen,XamlC</c>) because (a) commas in <c>-p:</c> values
+		/// are interpreted as CLI switch separators by <c>dotnet build</c>, and (b) the combo
+		/// causes XamlGenerator to emit <c>.xsg.cs</c> while XamlC also emits
+		/// <c>InitializeComponent</c> from the embedded resource → CS0111 duplicate partial
+		/// method. <c>NoWarn=MAUI1001</c> silences the deprecation warning that fires
+		/// whenever <c>MauiXamlInflator</c> is set and not <c>SourceGen</c>
+		/// (Microsoft.Maui.Controls.targets ~line 137-140).
+		/// </summary>
+		private const string XamlCOptIn = "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001";
+
 		class Xaml
 		{
 			const string MicrosoftMauiControlsFormsDefaultNamespace = "http://schemas.microsoft.com/dotnet/2021/maui";
@@ -359,8 +371,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			// XamlC subject test — see XamlCOptIn doc
+			Build(projectFile, additionalArgs: XamlCOptIn);
 
 			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
 			AssertExists(xamlCStamp);
@@ -368,7 +380,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
 
 			//Build again
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			Build(projectFile, additionalArgs: XamlCOptIn);
 			AssertExists(xamlCStamp);
 
 			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
@@ -386,9 +398,9 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
+			// XamlC subject test — see XamlCOptIn doc.
 			// Clean keys off <FileWrites> recorded during this build, so the Clean invocation below does not need it.
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			Build(projectFile, additionalArgs: XamlCOptIn);
 
 			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
 			var fooCssG = IOPath.Combine(intermediateDirectory, "Foo.css.g.cs");
@@ -440,9 +452,9 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 
 			if (File.Exists(xamlCStamp))
 				System.IO.File.Delete(xamlCStamp);
-			AssertDoesNotExist(xamlCStamp); //XamlC should be skipped
+			AssertDoesNotExist(xamlCStamp); // precondition: stamp cleared before DTB build
 
-			Build(projectFile, "Compile", additionalArgs: "-p:DesignTimeBuild=True -p:BuildingInsideVisualStudio=True -p:SkipCompilerExecution=True -p:ProvideCommandLineArgs=True -p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			Build(projectFile, "Compile", additionalArgs: "-p:DesignTimeBuild=True -p:BuildingInsideVisualStudio=True -p:SkipCompilerExecution=True -p:ProvideCommandLineArgs=True " + XamlCOptIn);
 
 
 			//The assembly should not be compiled
@@ -450,8 +462,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			AssertDoesNotExist(xamlCStamp); //XamlC should be skipped
 
 			//Build again, a full build
-			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			// XamlC subject test — see XamlCOptIn doc
+			Build(projectFile, additionalArgs: XamlCOptIn);
 			AssertExists(assembly, nonEmpty: true);
 			AssertExists(xamlCStamp);
 
@@ -465,8 +477,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			// XamlC subject test — see XamlCOptIn doc
+			Build(projectFile, additionalArgs: XamlCOptIn);
 
 			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
 			AssertExists(xamlCStamp);
@@ -476,7 +488,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			//Build again, after adding a file, this triggers a full XamlG and XamlC -- *not* CssG
 			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
 			project.Save(projectFile);
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
+			Build(projectFile, additionalArgs: XamlCOptIn);
 			AssertExists(xamlCStamp);
 
 			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
@@ -492,7 +504,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			Build(projectFile);
+			// XamlC subject test — see XamlCOptIn doc. (Test currently skipped; opt-in kept for future-proofing.)
+			Build(projectFile, additionalArgs: XamlCOptIn);
 
 			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
 			var customViewXamlG = IOPath.Combine(intermediateDirectory, "CustomView.xaml.g.cs");
@@ -504,7 +517,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 
 			//Build again, after modifying the timestamp on a Xaml file, should trigger a partial XamlG and full XamlC
 			//https://github.com/xamarin/xamarin-android/blob/61851599fb1999964bd200ec1c373b6e395933f3/src/Microsoft.Maui.Controls.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs#L342
-			Build(projectFile);
+			Build(projectFile, additionalArgs: XamlCOptIn);
 			AssertExists(xamlCStamp);
 
 			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -25,18 +25,6 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			"Microsoft.Maui.dll",
 		};
 
-		/// <summary>
-		/// XamlC opt-in for tests where XamlC's behaviour is the subject. We use bare
-		/// <c>XamlC</c> (not <c>SourceGen,XamlC</c>) because (a) commas in <c>-p:</c> values
-		/// are interpreted as CLI switch separators by <c>dotnet build</c>, and (b) the combo
-		/// causes XamlGenerator to emit <c>.xsg.cs</c> while XamlC also emits
-		/// <c>InitializeComponent</c> from the embedded resource → CS0111 duplicate partial
-		/// method. <c>NoWarn=MAUI1001</c> silences the deprecation warning that fires
-		/// whenever <c>MauiXamlInflator</c> is set and not <c>SourceGen</c>
-		/// (Microsoft.Maui.Controls.targets ~line 137-140).
-		/// </summary>
-		private const string XamlCOptIn = "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001";
-
 		class Xaml
 		{
 			const string MicrosoftMauiControlsFormsDefaultNamespace = "http://schemas.microsoft.com/dotnet/2021/maui";
@@ -360,60 +348,6 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Assert.Contains("MainPage.xaml(7,6): XamlC error XC0000: Cannot resolve type \"http://schemas.microsoft.com/dotnet/2021/maui:NotARealThing\".", log, StringComparison.Ordinal);
 		}
 
-		/// <summary>
-		/// Tests that XamlG and XamlC targets skip, as well as checking IncrementalClean doesn't delete generated files
-		/// </summary>
-		[Fact]
-		public void TargetsShouldSkip()
-		{
-			SetUp();
-			var project = NewProject();
-			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
-			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
-			project.Save(projectFile);
-			// XamlC subject test — see XamlCOptIn doc
-			Build(projectFile, additionalArgs: XamlCOptIn);
-
-			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
-			AssertExists(xamlCStamp);
-
-			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
-
-			//Build again
-			Build(projectFile, additionalArgs: XamlCOptIn);
-			AssertExists(xamlCStamp);
-
-			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
-			Assert.Equal(expectedXamlC, actualXamlC);
-		}
-
-		/// <summary>
-		/// Checks that XamlG and XamlC files are cleaned
-		/// </summary>
-		[Fact]
-		public void Clean()
-		{
-			SetUp();
-			var project = NewProject();
-			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
-			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
-			project.Save(projectFile);
-			// XamlC subject test — see XamlCOptIn doc.
-			// Clean keys off <FileWrites> recorded during this build, so the Clean invocation below does not need it.
-			Build(projectFile, additionalArgs: XamlCOptIn);
-
-			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
-			var fooCssG = IOPath.Combine(intermediateDirectory, "Foo.css.g.cs");
-			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
-			AssertExists(xamlCStamp);
-
-			//Clean
-			Build(projectFile, "Clean");
-			AssertDoesNotExist(mainPageXamlG);
-			AssertDoesNotExist(fooCssG);
-			AssertDoesNotExist(xamlCStamp);
-		}
-
 		[Fact]
 		public void LinkedFile()
 		{
@@ -435,93 +369,6 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
 			// Default inflator is SourceGen, so the XamlC target is skipped and no stamp is produced.
 			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
-		}
-
-		//https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md
-		//https://daveaglick.com/posts/running-a-design-time-build-with-msbuild-apis
-		[Fact]
-		public void DesignTimeBuild()
-		{
-			SetUp();
-			var project = NewProject();
-			project.Add(AddFile(@"Pages\MainPage.xaml", "MauiXaml", Xaml.MainPage));
-			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
-			project.Save(projectFile);
-			var assembly = IOPath.Combine(intermediateDirectory, "test.dll");
-			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
-
-			if (File.Exists(xamlCStamp))
-				System.IO.File.Delete(xamlCStamp);
-			AssertDoesNotExist(xamlCStamp); // precondition: stamp cleared before DTB build
-
-			Build(projectFile, "Compile", additionalArgs: "-p:DesignTimeBuild=True -p:BuildingInsideVisualStudio=True -p:SkipCompilerExecution=True -p:ProvideCommandLineArgs=True " + XamlCOptIn);
-
-
-			//The assembly should not be compiled
-			//AssertDoesNotExist(assembly);
-			AssertDoesNotExist(xamlCStamp); //XamlC should be skipped
-
-			//Build again, a full build
-			// XamlC subject test — see XamlCOptIn doc
-			Build(projectFile, additionalArgs: XamlCOptIn);
-			AssertExists(assembly, nonEmpty: true);
-			AssertExists(xamlCStamp);
-
-		}
-
-		[Fact]
-		public void AddNewFile()
-		{
-			SetUp();
-			var project = NewProject();
-			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
-			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
-			project.Save(projectFile);
-			// XamlC subject test — see XamlCOptIn doc
-			Build(projectFile, additionalArgs: XamlCOptIn);
-
-			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
-			AssertExists(xamlCStamp);
-
-			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
-
-			//Build again, after adding a file, this triggers a full XamlG and XamlC -- *not* CssG
-			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
-			project.Save(projectFile);
-			Build(projectFile, additionalArgs: XamlCOptIn);
-			AssertExists(xamlCStamp);
-
-			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
-			Assert.NotEqual(expectedXamlC, actualXamlC);
-		}
-
-		[Fact(Skip = "source gen changes")]
-		public void TouchXamlFile()
-		{
-			SetUp();
-			var project = NewProject();
-			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
-			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
-			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
-			project.Save(projectFile);
-			// XamlC subject test — see XamlCOptIn doc. (Test currently skipped; opt-in kept for future-proofing.)
-			Build(projectFile, additionalArgs: XamlCOptIn);
-
-			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
-			var customViewXamlG = IOPath.Combine(intermediateDirectory, "CustomView.xaml.g.cs");
-			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
-			AssertExists(xamlCStamp);
-
-			var expectedCustomViewXamlG = new FileInfo(customViewXamlG).LastWriteTimeUtc;
-			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
-
-			//Build again, after modifying the timestamp on a Xaml file, should trigger a partial XamlG and full XamlC
-			//https://github.com/xamarin/xamarin-android/blob/61851599fb1999964bd200ec1c373b6e395933f3/src/Microsoft.Maui.Controls.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs#L342
-			Build(projectFile, additionalArgs: XamlCOptIn);
-			AssertExists(xamlCStamp);
-
-			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
-			Assert.NotEqual(expectedXamlC, actualXamlC);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -277,7 +277,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Build(projectFile);
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
-			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
+			// Default inflator is SourceGen, so the XamlC target is skipped and no stamp is produced.
+			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 
 		[Theory]
@@ -358,7 +359,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			Build(projectFile);
+			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 
 			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
 			AssertExists(xamlCStamp);
@@ -366,7 +368,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
 
 			//Build again
-			Build(projectFile);
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 			AssertExists(xamlCStamp);
 
 			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
@@ -384,7 +386,9 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			Build(projectFile);
+			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
+			// Clean keys off <FileWrites> recorded during this build, so the Clean invocation below does not need it.
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 
 			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
 			var fooCssG = IOPath.Combine(intermediateDirectory, "Foo.css.g.cs");
@@ -417,7 +421,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Build(projectFile);
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
-			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
+			// Default inflator is SourceGen, so the XamlC target is skipped and no stamp is produced.
+			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 
 		//https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md
@@ -437,7 +442,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 				System.IO.File.Delete(xamlCStamp);
 			AssertDoesNotExist(xamlCStamp); //XamlC should be skipped
 
-			Build(projectFile, "Compile", additionalArgs: "-p:DesignTimeBuild=True -p:BuildingInsideVisualStudio=True -p:SkipCompilerExecution=True -p:ProvideCommandLineArgs=True");
+			Build(projectFile, "Compile", additionalArgs: "-p:DesignTimeBuild=True -p:BuildingInsideVisualStudio=True -p:SkipCompilerExecution=True -p:ProvideCommandLineArgs=True -p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 
 
 			//The assembly should not be compiled
@@ -445,7 +450,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			AssertDoesNotExist(xamlCStamp); //XamlC should be skipped
 
 			//Build again, a full build
-			Build(projectFile);
+			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 			AssertExists(assembly, nonEmpty: true);
 			AssertExists(xamlCStamp);
 
@@ -459,7 +465,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			Build(projectFile);
+			// XamlC target is the subject under test — opt in via MauiXamlInflator=XamlC. NoWarn=MAUI1001 silences the deprecation warning (TWAE=true repo-wide would otherwise error). The SourceGen+XamlC combo would emit a duplicate InitializeComponent for these synthesised projects, so we use the bare form instead.
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 
 			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
 			AssertExists(xamlCStamp);
@@ -469,7 +476,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			//Build again, after adding a file, this triggers a full XamlG and XamlC -- *not* CssG
 			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
 			project.Save(projectFile);
-			Build(projectFile);
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:NoWarn=MAUI1001");
 			AssertExists(xamlCStamp);
 
 			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
@@ -515,7 +522,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Build(projectFile);
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
-			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
+			// Default inflator is SourceGen, so the XamlC target is skipped and no stamp is produced.
+			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 
 		// [Fact]
@@ -542,7 +550,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
 			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "MainPage.txt.g.cs"));
-			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
+			// Default inflator is SourceGen, so the XamlC target is skipped and no stamp is produced.
+			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 
 		[Fact]

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -15,7 +15,20 @@ using IOPath = System.IO.Path;
 
 namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 {
-	//This set of tests is for validating Microsoft.Maui.Controls.targets
+	// This set of tests is for validating Microsoft.Maui.Controls.targets.
+	//
+	// Contract under test: SourceGen is the net11.0 default XAML inflator, and the legacy
+	// `XamlC` MSBuild target must NOT run on a default, no-flag-passed build. Every
+	// surviving test here is a *negative* test that locks down that contract using one of
+	// two patterns:
+	//   1. AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"))
+	//      — proves the XamlC target was skipped (BuildAProject, LinkedFile, RandomXml,
+	//      RandomEmbeddedResource).
+	//   2. Diagnostic-verbosity log scrape asserting `Building target "XamlC"` is absent
+	//      — proves the target wasn't even scheduled (NoXamlFiles).
+	// Tests that forced `-p:MauiXamlInflator=XamlC` to exercise the legacy path were
+	// intentionally removed in dotnet/maui#34972 — do not reintroduce that opt-in.
+	// See ~/.copilot/lessons/dotnet/maui/xamlc-test-opt-in.md for rationale.
 	[Trait("Category", "LongRunning")]
 	public class MSBuildTests : IDisposable
 	{

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 	//   1. XamlC is SKIPPED when all XAML uses SourceGen (BuildAProject, LinkedFile,
 	//      RandomXml, RandomEmbeddedResource, NoXamlFiles).
 	//   2. XamlC DOES run when files use the XamlC or Runtime inflator
-	//      (XamlCRunsWhenXamlCInflatorUsed).
+	//      (XamlCRunsWhenDeprecatedInflatorUsed, covering both gate branches).
 	[Trait("Category", "LongRunning")]
 	public class MSBuildTests : IDisposable
 	{
@@ -174,7 +174,9 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			}
 			project.Add(itemGroup);
 
-			//Let's enable XamlC assembly-wide
+			// Legacy assembly-wide XamlC opt-in. Under the SourceGen-default model the inflator is
+			// driven by the MauiXamlInflator property / MauiXaml.Inflator metadata, so this attribute
+			// no longer forces the XamlC target — the skip tests rely on it being a no-op here.
 			project.Add(AddFile("AssemblyInfo.cs", "Compile", "#pragma warning disable CS0618\n[assembly: Microsoft.Maui.Controls.Xaml.XamlCompilation (Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Compile)]"));
 
 			//Add a single CSS file
@@ -433,25 +435,29 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		}
 
 		/// <summary>
-		/// Verifies that XamlC still runs when the deprecated XamlC inflator is explicitly requested.
-		/// This is the positive counterpart to BuildAProject — it proves the condition gate
-		/// correctly activates XamlC when _MauiXaml_XC is populated.
+		/// Verifies that the XamlC target still runs when a deprecated inflator is explicitly
+		/// requested. This is the positive counterpart to BuildAProject — it proves the condition
+		/// gate activates XamlC when either branch of the OR is populated: _MauiXaml_XC (XamlC) or
+		/// _MauiXaml_RT (Runtime). Both inflators are covered so a future edit cannot silently drop
+		/// build-time validation for one of them while the suite stays green.
 		/// </summary>
-		[Fact]
-		public void XamlCRunsWhenXamlCInflatorUsed()
+		[Theory]
+		[InlineData("XamlC")]
+		[InlineData("Runtime")]
+		public void XamlCRunsWhenDeprecatedInflatorUsed(string inflator)
 		{
 			SetUp();
 			var project = NewProject();
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			// MAUI1001 warns that the XamlC inflator is deprecated. WarningsNotAsErrors keeps
-			// the build green if a TreatWarningsAsErrors chain is ever introduced for these
+			// MAUI1001 warns that the XamlC and Runtime inflators are deprecated. WarningsNotAsErrors
+			// keeps the build green if a TreatWarningsAsErrors chain is ever introduced for these
 			// synthesized projects, without relying on the invalid `-warnaserror-:` switch syntax.
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:WarningsNotAsErrors=MAUI1001");
+			Build(projectFile, additionalArgs: $"-p:MauiXamlInflator={inflator} -p:WarningsNotAsErrors=MAUI1001");
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
-			// With XamlC inflator, _MauiXaml_XC is populated so the XamlC target runs.
+			// With the XamlC or Runtime inflator, _MauiXaml_XC / _MauiXaml_RT is populated so XamlC runs.
 			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -32,6 +32,19 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			"Microsoft.Maui.dll",
 		};
 
+		/// <summary>
+		/// XamlC opt-in for tests whose subject is the XamlC target itself. Under the SourceGen
+		/// default the XamlC target is gated off (see Microsoft.Maui.Controls.targets), so these
+		/// tests must explicitly select the XamlC inflator. We use the bare <c>XamlC</c> form
+		/// (not <c>SourceGen,XamlC</c>) because (a) commas in <c>-p:</c> values are interpreted as
+		/// CLI switch separators by <c>dotnet build</c>, and (b) the combo makes XamlGenerator emit
+		/// <c>.xsg.cs</c> while XamlC also emits <c>InitializeComponent</c> from the embedded
+		/// resource → CS0111 duplicate partial method. <c>WarningsNotAsErrors=MAUI1001</c> keeps the
+		/// deprecation warning (fired whenever <c>MauiXamlInflator</c> is set and not <c>SourceGen</c>)
+		/// from failing the build if a TreatWarningsAsErrors chain is ever introduced.
+		/// </summary>
+		private const string XamlCOptIn = "-p:MauiXamlInflator=XamlC -p:WarningsNotAsErrors=MAUI1001";
+
 		class Xaml
 		{
 			const string MicrosoftMauiControlsFormsDefaultNamespace = "http://schemas.microsoft.com/dotnet/2021/maui";
@@ -357,6 +370,60 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			Assert.Contains("MainPage.xaml(7,6): XamlC error XC0000: Cannot resolve type \"http://schemas.microsoft.com/dotnet/2021/maui:NotARealThing\".", log, StringComparison.Ordinal);
 		}
 
+		/// <summary>
+		/// Tests that XamlG and XamlC targets skip, as well as checking IncrementalClean doesn't delete generated files
+		/// </summary>
+		[Fact]
+		public void TargetsShouldSkip()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			// XamlC subject test — see XamlCOptIn doc
+			Build(projectFile, additionalArgs: XamlCOptIn);
+
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+			AssertExists(xamlCStamp);
+
+			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+
+			//Build again
+			Build(projectFile, additionalArgs: XamlCOptIn);
+			AssertExists(xamlCStamp);
+
+			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+			Assert.Equal(expectedXamlC, actualXamlC);
+		}
+
+		/// <summary>
+		/// Checks that XamlG and XamlC files are cleaned
+		/// </summary>
+		[Fact]
+		public void Clean()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			// XamlC subject test — see XamlCOptIn doc.
+			// Clean keys off <FileWrites> recorded during this build, so the Clean invocation below does not need it.
+			Build(projectFile, additionalArgs: XamlCOptIn);
+
+			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
+			var fooCssG = IOPath.Combine(intermediateDirectory, "Foo.css.g.cs");
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+			AssertExists(xamlCStamp);
+
+			//Clean
+			Build(projectFile, "Clean");
+			AssertDoesNotExist(mainPageXamlG);
+			AssertDoesNotExist(fooCssG);
+			AssertDoesNotExist(xamlCStamp);
+		}
+
 		[Fact]
 		public void LinkedFile()
 		{
@@ -378,6 +445,91 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
 			// Default inflator is SourceGen, so the XamlC target is skipped and no stamp is produced.
 			AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
+		}
+
+		//https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md
+		//https://daveaglick.com/posts/running-a-design-time-build-with-msbuild-apis
+		[Fact]
+		public void DesignTimeBuild()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile(@"Pages\MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			var assembly = IOPath.Combine(intermediateDirectory, "test.dll");
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+
+			if (File.Exists(xamlCStamp))
+				System.IO.File.Delete(xamlCStamp);
+			AssertDoesNotExist(xamlCStamp); // precondition: stamp cleared before DTB build
+
+			Build(projectFile, "Compile", additionalArgs: "-p:DesignTimeBuild=True -p:BuildingInsideVisualStudio=True -p:SkipCompilerExecution=True -p:ProvideCommandLineArgs=True " + XamlCOptIn);
+
+			//The assembly should not be compiled
+			//AssertDoesNotExist(assembly);
+			AssertDoesNotExist(xamlCStamp); //XamlC should be skipped
+
+			//Build again, a full build
+			// XamlC subject test — see XamlCOptIn doc
+			Build(projectFile, additionalArgs: XamlCOptIn);
+			AssertExists(assembly, nonEmpty: true);
+			AssertExists(xamlCStamp);
+		}
+
+		[Fact]
+		public void AddNewFile()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			// XamlC subject test — see XamlCOptIn doc
+			Build(projectFile, additionalArgs: XamlCOptIn);
+
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+			AssertExists(xamlCStamp);
+
+			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, after adding a file, this triggers a full XamlG and XamlC -- *not* CssG
+			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
+			project.Save(projectFile);
+			Build(projectFile, additionalArgs: XamlCOptIn);
+			AssertExists(xamlCStamp);
+
+			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+			Assert.NotEqual(expectedXamlC, actualXamlC);
+		}
+
+		[Fact(Skip = "source gen changes")]
+		public void TouchXamlFile()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			project.Add(AddFile("CustomView.xaml", "MauiXaml", Xaml.CustomView));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			// XamlC subject test — see XamlCOptIn doc. (Test currently skipped; opt-in kept for future-proofing.)
+			Build(projectFile, additionalArgs: XamlCOptIn);
+
+			var mainPageXamlG = IOPath.Combine(intermediateDirectory, "MainPage.xaml.g.cs");
+			var customViewXamlG = IOPath.Combine(intermediateDirectory, "CustomView.xaml.g.cs");
+			var xamlCStamp = IOPath.Combine(intermediateDirectory, "XamlC.stamp");
+			AssertExists(xamlCStamp);
+
+			var expectedCustomViewXamlG = new FileInfo(customViewXamlG).LastWriteTimeUtc;
+			var expectedXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+
+			//Build again, after modifying the timestamp on a Xaml file, should trigger a partial XamlG and full XamlC
+			//https://github.com/xamarin/xamarin-android/blob/61851599fb1999964bd200ec1c373b6e395933f3/src/Microsoft.Maui.Controls.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs#L342
+			Build(projectFile, additionalArgs: XamlCOptIn);
+			AssertExists(xamlCStamp);
+
+			var actualXamlC = new FileInfo(xamlCStamp).LastWriteTimeUtc;
+			Assert.NotEqual(expectedXamlC, actualXamlC);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -17,18 +17,12 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 {
 	// This set of tests is for validating Microsoft.Maui.Controls.targets.
 	//
-	// Contract under test: SourceGen is the net11.0 default XAML inflator, and the legacy
-	// `XamlC` MSBuild target must NOT run on a default, no-flag-passed build. Every
-	// surviving test here is a *negative* test that locks down that contract using one of
-	// two patterns:
-	//   1. AssertDoesNotExist(IOPath.Combine(intermediateDirectory, "XamlC.stamp"))
-	//      — proves the XamlC target was skipped (BuildAProject, LinkedFile, RandomXml,
-	//      RandomEmbeddedResource).
-	//   2. Diagnostic-verbosity log scrape asserting `Building target "XamlC"` is absent
-	//      — proves the target wasn't even scheduled (NoXamlFiles).
-	// Tests that forced `-p:MauiXamlInflator=XamlC` to exercise the legacy path were
-	// intentionally removed in dotnet/maui#34972 — do not reintroduce that opt-in.
-	// See ~/.copilot/lessons/dotnet/maui/xamlc-test-opt-in.md for rationale.
+	// Contract under test: SourceGen is the default XAML inflator, and the legacy
+	// `XamlC` MSBuild target must NOT run on a default build. Tests verify:
+	//   1. XamlC is SKIPPED when all XAML uses SourceGen (BuildAProject, LinkedFile,
+	//      RandomXml, RandomEmbeddedResource, NoXamlFiles).
+	//   2. XamlC DOES run when files use the XamlC or Runtime inflator
+	//      (XamlCRunsWhenXamlCInflatorUsed).
 	[Trait("Category", "LongRunning")]
 	public class MSBuildTests : IDisposable
 	{
@@ -436,6 +430,26 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Save(projectFile);
 			var log = Build(projectFile, verbosity: "diagnostic");
 			Assert.False(log.Contains("Building target \"XamlC\"", StringComparison.Ordinal), "XamlC should be skipped if there are no .xaml files.");
+		}
+
+		/// <summary>
+		/// Verifies that XamlC still runs when the deprecated XamlC inflator is explicitly requested.
+		/// This is the positive counterpart to BuildAProject — it proves the condition gate
+		/// correctly activates XamlC when _MauiXaml_XC is populated.
+		/// </summary>
+		[Fact]
+		public void XamlCRunsWhenXamlCInflatorUsed()
+		{
+			SetUp();
+			var project = NewProject();
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
+			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -warnaserror-:MAUI1001");
+
+			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
+			// With XamlC inflator, _MauiXaml_XC is populated so the XamlC target runs.
+			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 
 		/// <summary>

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -445,7 +445,10 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -warnaserror-:MAUI1001");
+			// MAUI1001 warns that the XamlC inflator is deprecated. WarningsNotAsErrors keeps
+			// the build green if a TreatWarningsAsErrors chain is ever introduced for these
+			// synthesized projects, without relying on the invalid `-warnaserror-:` switch syntax.
+			Build(projectFile, additionalArgs: "-p:MauiXamlInflator=XamlC -p:WarningsNotAsErrors=MAUI1001");
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
 			// With XamlC inflator, _MauiXaml_XC is populated so the XamlC target runs.

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -33,15 +33,11 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		};
 
 		/// <summary>
-		/// XamlC opt-in for tests whose subject is the XamlC target itself. Under the SourceGen
-		/// default the XamlC target is gated off (see Microsoft.Maui.Controls.targets), so these
-		/// tests must explicitly select the XamlC inflator. We use the bare <c>XamlC</c> form
-		/// (not <c>SourceGen,XamlC</c>) because (a) commas in <c>-p:</c> values are interpreted as
-		/// CLI switch separators by <c>dotnet build</c>, and (b) the combo makes XamlGenerator emit
-		/// <c>.xsg.cs</c> while XamlC also emits <c>InitializeComponent</c> from the embedded
-		/// resource → CS0111 duplicate partial method. <c>WarningsNotAsErrors=MAUI1001</c> keeps the
-		/// deprecation warning (fired whenever <c>MauiXamlInflator</c> is set and not <c>SourceGen</c>)
-		/// from failing the build if a TreatWarningsAsErrors chain is ever introduced.
+		/// Opts a test into the XamlC inflator — for tests whose subject is the XamlC build target,
+		/// which is gated off under the SourceGen default. Bare "XamlC" (not "SourceGen,XamlC")
+		/// avoids two traps: commas in -p: values split as CLI switches, and the combo produces a
+		/// duplicate InitializeComponent (CS0111). WarningsNotAsErrors=MAUI1001 silences the
+		/// inflator-deprecation warning.
 		/// </summary>
 		private const string XamlCOptIn = "-p:MauiXamlInflator=XamlC -p:WarningsNotAsErrors=MAUI1001";
 
@@ -187,9 +183,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			}
 			project.Add(itemGroup);
 
-			// Legacy assembly-wide XamlC opt-in. Under the SourceGen-default model the inflator is
-			// driven by the MauiXamlInflator property / MauiXaml.Inflator metadata, so this attribute
-			// no longer forces the XamlC target — the skip tests rely on it being a no-op here.
+			// Legacy assembly-wide XamlC attribute. The inflator is now chosen by MauiXamlInflator,
+			// so this is a no-op — the skip tests rely on it NOT forcing the XamlC target.
 			project.Add(AddFile("AssemblyInfo.cs", "Compile", "#pragma warning disable CS0618\n[assembly: Microsoft.Maui.Controls.Xaml.XamlCompilation (Microsoft.Maui.Controls.Xaml.XamlCompilationOptions.Compile)]"));
 
 			//Add a single CSS file
@@ -587,11 +582,9 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		}
 
 		/// <summary>
-		/// Verifies that the XamlC target still runs when a deprecated inflator is explicitly
-		/// requested. This is the positive counterpart to BuildAProject — it proves the condition
-		/// gate activates XamlC when either branch of the OR is populated: _MauiXaml_XC (XamlC) or
-		/// _MauiXaml_RT (Runtime). Both inflators are covered so a future edit cannot silently drop
-		/// build-time validation for one of them while the suite stays green.
+		/// Positive counterpart to BuildAProject: XamlC runs when a deprecated inflator is selected.
+		/// Covers both gate branches — _MauiXaml_XC (XamlC) and _MauiXaml_RT (Runtime) — so neither
+		/// can be dropped without failing a test.
 		/// </summary>
 		[Theory]
 		[InlineData("XamlC")]
@@ -603,13 +596,12 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
-			// MAUI1001 warns that the XamlC and Runtime inflators are deprecated. WarningsNotAsErrors
-			// keeps the build green if a TreatWarningsAsErrors chain is ever introduced for these
-			// synthesized projects, without relying on the invalid `-warnaserror-:` switch syntax.
+			// WarningsNotAsErrors silences the MAUI1001 inflator-deprecation warning. The older
+			// "-warnaserror-:" syntax is rejected by newer MSBuild, so use the property form.
 			Build(projectFile, additionalArgs: $"-p:MauiXamlInflator={inflator} -p:WarningsNotAsErrors=MAUI1001");
 
 			AssertExists(IOPath.Combine(intermediateDirectory, "test.dll"), nonEmpty: true);
-			// With the XamlC or Runtime inflator, _MauiXaml_XC / _MauiXaml_RT is populated so XamlC runs.
+			// XamlC or Runtime populates _MauiXaml_XC/_RT, so the XamlC target runs.
 			AssertExists(IOPath.Combine(intermediateDirectory, "XamlC.stamp"));
 		}
 

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -591,7 +591,8 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		[InlineData("Runtime")]
 		public void XamlCRunsWhenDeprecatedInflatorUsed(string inflator)
 		{
-			SetUp();
+			// Per-inflator directory so the two Theory rows can't leak a stale XamlC.stamp between them.
+			SetUp($"{nameof(XamlCRunsWhenDeprecatedInflatorUsed)}_{inflator}");
 			var project = NewProject();
 			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");


### PR DESCRIPTION
## Summary

Skip the XamlC MSBuild target when no XAML files use the XamlC or Runtime inflator — i.e., when all XAML uses the default SourceGen inflator.

## Motivation

With SourceGen as the default inflator in .NET 11, the XamlC MSBuild target has nothing to do on a default build: there are no `_MauiXaml_XC` or `_MauiXaml_RT` items to process. Previously XamlC still ran (in `ValidateOnly=True` mode for Debug), loading the assembly via Cecil, parsing XAML, validating, and discarding results — all redundant because the Source Generator already validates XAML at compile time.

## Changes

- **`Microsoft.Maui.Controls.targets`** (1 line): Added `AND ('@(_MauiXaml_XC)' != '' OR '@(_MauiXaml_RT)' != '')`  to the XamlC target `Condition`, so it only runs when there are files that actually need XamlC processing.
- **`MSBuildTests.cs`**:
  - Skip tests (`BuildAProject`, `LinkedFile`, `RandomXml`, `RandomEmbeddedResource`, `NoXamlFiles`) assert `XamlC.stamp` does NOT exist under the default SourceGen inflator.
  - Added `XamlCRunsWhenDeprecatedInflatorUsed` — a `[Theory]` covering both `MauiXamlInflator=XamlC` and `=Runtime`, asserting XamlC still runs (covers both branches of the new `OR` condition).
  - Restored the XamlC-subject tests (`TargetsShouldSkip`, `Clean`, `DesignTimeBuild`, `AddNewFile`; `TouchXamlFile` kept `[Skip]`), adapted to explicitly opt into the XamlC inflator via the new `XamlCOptIn` constant.

## Target Ordering

`_MauiXamlComputeInflator` (which populates `_MauiXaml_XC`/`_MauiXaml_RT`) runs before Compile via `PrepareResourcesDependsOn`. XamlC runs `AfterTargets="AfterCompile"`, so the condition is evaluated after the item groups are fully populated.

## Impact

- Default builds (SourceGen inflator) skip the XamlC target entirely — saves the Cecil load + XAML parse overhead.
- Explicit `MauiXamlInflator=XamlC` or `MauiXamlInflator=Runtime` builds continue to work unchanged.
