### PR TITLE
[iOS] Fix Picker CharacterSpacing lost after item selection when Title is set

### DIFF
--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -255,6 +255,8 @@ namespace Microsoft.Maui.Handlers
 
 			PlatformView.Text = VirtualView.GetItem(pickerSource.SelectedIndex);
 			VirtualView.SelectedIndex = pickerSource.SelectedIndex;
+			// Re-apply kern: plain Text assignment above clears iOS kern attributes.
+			PlatformView.UpdateCharacterSpacing(VirtualView);
 		}
 
 		void UpdatePickerSelectedIndex(UIPickerView? pickerView, int formsIndex)

--- a/src/Core/src/Platform/iOS/PickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/PickerExtensions.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Maui.Platform
 				platformPicker.UpdatePickerTitle(picker);
 			}
 
+			platformPicker.UpdateCharacterSpacing(picker);
+
 			var pickerView = platformPicker.UIPickerView;
 			pickerView?.ReloadAllComponents();
 

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -5,7 +5,6 @@ using Microsoft.Maui.Handlers;
 using ObjCRuntime;
 using UIKit;
 using Xunit;
-using System.Collections.Generic;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -73,7 +72,7 @@ namespace Microsoft.Maui.DeviceTests
 			var picker = new PickerStub
 			{
 				Title = "Select an Item",
-				Items = new List<string> { "Apple", "Banana", "Cherry" },
+				Items = new[] { "Apple", "Banana", "Cherry" },
 				CharacterSpacing = 4,
 				SelectedIndex = initialIndex
 			};
@@ -92,6 +91,56 @@ namespace Microsoft.Maui.DeviceTests
 				var after = GetNativeCharacterSpacing(handler);
 				Assert.Equal(4.0, after);
 			});
+		}
+
+		[Theory(DisplayName = "Selecting An Item With Done Keeps CharacterSpacing")]
+		[InlineData(0, 1)]
+		[InlineData(1, 0)]
+		public async Task SelectingItemWithDoneDoesNotAffectCharacterSpacing(int initialIndex, int newIndex)
+		{
+			var picker = new PickerStub
+			{
+				Title = "Select an Item",
+				Items = new[] { "Apple", "Banana", "Cherry" },
+				CharacterSpacing = 4,
+				SelectedIndex = initialIndex
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(picker);
+				handler.UpdateValue(nameof(IPicker.CharacterSpacing));
+
+				var before = GetNativeCharacterSpacing(handler);
+				Assert.Equal(4.0, before);
+
+				var mauiPicker = GetNativePicker(handler);
+				mauiPicker.BecomeFirstResponder();
+
+				var pickerView = mauiPicker.UIPickerView;
+				var model = (PickerSource)pickerView.Model;
+				pickerView.Select(newIndex, 0, false);
+				model.Selected(pickerView, newIndex, 0);
+				TapDoneOnInputAccessoryView(mauiPicker);
+
+				Assert.Equal(picker.Items[newIndex], GetNativeText(handler));
+
+				var after = GetNativeCharacterSpacing(handler);
+				Assert.Equal(4.0, after);
+			});
+		}
+
+		void TapDoneOnInputAccessoryView(MauiPicker mauiPicker)
+		{
+			var toolbar = mauiPicker.InputAccessoryView as UIToolbar;
+			Assert.NotNull(toolbar);
+			Assert.NotNull(toolbar.Items);
+			Assert.NotEmpty(toolbar.Items);
+			var doneButton = toolbar.Items[toolbar.Items.Length - 1];
+			Assert.NotNull(doneButton);
+			Assert.NotNull(doneButton.Target);
+			Assert.NotNull(doneButton.Action);
+			UIApplication.SharedApplication.SendAction(doneButton.Action, doneButton.Target, doneButton, null);
 		}
 
 		double GetNativeCharacterSpacing(PickerHandler pickerHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Handlers;
 using ObjCRuntime;
 using UIKit;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -62,6 +63,41 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(xplatTitleColor, values.ViewValue);
 			Assert.Equal(expectedValue, values.PlatformViewValue);
+		}
+
+		[Theory(DisplayName = "Updating SelectedIndex Does Not Affect CharacterSpacing")]
+		[InlineData(0, 1)]
+		[InlineData(1, 0)]
+		public async Task SelectedIndexDoesNotAffectCharacterSpacing(int initialIndex, int newIndex)
+		{
+			var picker = new PickerStub
+			{
+				Title = "Select an Item",
+				Items = new List<string> { "Apple", "Banana", "Cherry" },
+				CharacterSpacing = 4,
+				SelectedIndex = initialIndex
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(picker);
+				handler.UpdateValue(nameof(IPicker.CharacterSpacing));
+
+				var before = GetNativeCharacterSpacing(handler);
+				Assert.Equal(4.0, before);
+
+				picker.SelectedIndex = newIndex;
+				handler.UpdateValue(nameof(IPicker.SelectedIndex));
+
+				var after = GetNativeCharacterSpacing(handler);
+				Assert.Equal(4.0, after);
+			});
+		}
+
+		double GetNativeCharacterSpacing(PickerHandler pickerHandler)
+		{
+			var mauiPicker = GetNativePicker(pickerHandler);
+			return mauiPicker.AttributedText.GetCharacterSpacing();
 		}
 
 		MauiPicker GetNativePicker(PickerHandler pickerHandler) =>


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

- When a Picker has both a Title and a non-zero CharacterSpacing, the character spacing is silently lost as soon as the user selects an item from the picker, or when SelectedIndex is changed programmatically. The spacing is visible before selection (applied to the placeholder/title text), but after any item is selected, the selected item renders without spacing.

### Root Cause
- **Regression**: Introduced by PR #20205 
- PR #20205 changed iOS Picker to apply CharacterSpacing via AttributedPlaceholder so the Title text respects kern. When the user selects an item, the code assigns a plain string to platformPicker.Text. iOS internally creates a zero-kern AttributedText from that plain string and simultaneously hides AttributedPlaceholder, since iOS never shows a placeholder when the text field has a value. This means the kern that was applied to the placeholder is gone, and no kern is applied to the selected item text — resulting in CharacterSpacing being silently lost after selection.

### Description of Change
- After platformPicker.Text is set to the selected item's string, UpdateCharacterSpacing is now explicitly called to re-apply kern to AttributedText. This is done in two places: in UpdatePickerFromPickerSource (the Done-button code path in PickerHandler.iOS.cs) and in UpdatePicker (the programmatic SelectedIndex change path in PickerExtensions.cs), ensuring CharacterSpacing survives item selection regardless of how the selection is triggered.


### Issues Fixed
Fixes #34971

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/df53cd2c-80f4-4661-b79d-f89cd36d3656"> | <video src="https://github.com/user-attachments/assets/40862e09-449b-4ba1-8b88-2e276291d3fe"> |