### PR TITLE
Fix TOOO typos in pragma warning comments

### DIFF
--- a/src/Compatibility/Core/src/iOS/Renderers/ImageButtonRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ImageButtonRenderer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (uiElement == null)
 				return;
 
-#pragma warning disable CA1416, CA1422 // TOOO:  UIButton.ContentEdgeInsets' is unsupported on: 'ios' 15.0 and later
+#pragma warning disable CA1416, CA1422 // TODO:  UIButton.ContentEdgeInsets' is unsupported on: 'ios' 15.0 and later
 			uiElement.ContentEdgeInsets = new UIEdgeInsets(
 				(float)(Element.Padding.Top),
 				(float)(Element.Padding.Left),

--- a/src/Core/src/Platform/iOS/MenuExtensions.cs
+++ b/src/Core/src/Platform/iOS/MenuExtensions.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-#pragma warning disable CA1416 // TOOO: UIMenuOptions.SingleSelection is only supported on: 'ios' 15.0 and later, 'tvos' 15.0 and later.
+#pragma warning disable CA1416 // TODO: UIMenuOptions.SingleSelection is only supported on: 'ios' 15.0 and later, 'tvos' 15.0 and later.
 				// This means we are creating our own new menu/submenu
 				platformMenu =
 					UIMenu.Create(title, uiImage, UIMenuIdentifier.None,


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Two files had `TOOO` instead of `TODO` in `#pragma warning disable` comments, making them invisible to TODO tooling.

### Changes

- `src/Compatibility/Core/src/iOS/Renderers/ImageButtonRenderer.cs` — `TOOO` → `TODO`
- `src/Core/src/Platform/iOS/MenuExtensions.cs` — `TOOO` → `TODO`

Comment-only change; no functional impact.