### PR TITLE
[Android] Fix DatePicker dialog dismisses after the device is rotated

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/DatePicker/DatePickerTests.cs
@@ -124,7 +124,7 @@ public partial class DatePickerTests : ControlsHandlerTestBase
 			await InvokeOnMainThreadAsync(() =>
 			{
 #if ANDROID
-				// Note: handler.DatePickerDialog may be null if ResetDialog() was called
+				// Note: handler.DatePickerDialog may be null if DestroyDialog() was called
 				// during the initial mapper pass (PR #33687), but setting VirtualView.Date
 				// fires the DateSelected event regardless of dialog state.
 				handler.VirtualView.Date = newDate;

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -240,9 +240,12 @@ namespace Microsoft.Maui.Handlers
 
 			if (currentDialog is not null && currentDialog.IsShowing)
 			{
+				currentDialog.DismissEvent -= OnDialogDismiss;
 				currentDialog.Dismiss();
-
-				ShowPickerDialog(currentDialog.DatePicker.DateTime);
+				PlatformView?.Post(() =>
+				{
+					ShowPickerDialog(currentDialog.DatePicker.DateTime);
+				});
 			}
 		}
 	}

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(MauiDatePicker platformView)
 		{
-			ResetDialog();
+			DestroyDialog();
 
 			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
 			platformView.ViewDetachedFromWindow -= OnViewDetachedFromWindow;
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Handlers
 				// making it unreliable to update them after the dialog is created.
 				if (datePicker.MinimumDate is not null)
 				{
-					platformHandler.ResetDialog();
+					platformHandler.DestroyDialog();
 				}
 				else
 				{
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Handlers
 				// making it unreliable to update them after the dialog is created.
 				if (datePicker.MaximumDate is not null)
 				{
-					platformHandler.ResetDialog();
+					platformHandler.DestroyDialog();
 				}
 				else
 				{
@@ -134,7 +134,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		void ResetDialog()
+		void DestroyDialog()
 		{
 			if (_dialog is not null)
 			{
@@ -212,7 +212,6 @@ namespace Microsoft.Maui.Handlers
 				EventHandler? setDateLater = null;
 				setDateLater = (sender, e) => { _dialog!.UpdateDate(year, month, day); _dialog.ShowEvent -= setDateLater; };
 				_dialog.ShowEvent += setDateLater;
-				_dialog.DismissEvent += OnDialogDismiss;
 			}
 
 			_dialog.Show();
@@ -222,7 +221,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (_dialog != null)
 			{
-				_dialog.DismissEvent -= OnDialogDismiss;
 				_dialog.Hide();
 			}
 
@@ -236,16 +234,11 @@ namespace Microsoft.Maui.Handlers
 
 		void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)
 		{
-			DatePickerDialog? currentDialog = _dialog;
-
-			if (currentDialog is not null && currentDialog.IsShowing)
+			if (_dialog is not null && _dialog.IsShowing)
 			{
-				currentDialog.DismissEvent -= OnDialogDismiss;
-				currentDialog.Dismiss();
-				PlatformView?.Post(() =>
-				{
-					ShowPickerDialog(currentDialog.DatePicker.DateTime);
-				});
+				var currentDate = _dialog.DatePicker.DateTime;
+				DestroyDialog();
+				ShowPickerDialog(currentDate);
 			}
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Android.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		/// <summary>
 		/// The DatePickerDialog is lazily created after PR #33687 — setting MinimumDate or
-		/// MaximumDate calls ResetDialog() which nulls the dialog reference. The dialog is
+		/// MaximumDate calls DestroyDialog() which nulls the dialog reference. The dialog is
 		/// only recreated when ShowPickerDialog() runs. This helper opens and immediately
 		/// closes the picker to force dialog creation so that min/max values can be read
 		/// from the native DatePicker widget.


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details

- The DatePicker dialog is dismissed when the device is rotated while the dialog is open.

### Root Cause of the issue

- PR [29323](https://github.com/dotnet/maui/pull/29323) added DismissEvent subscription in CreateDatePickerDialog() and an OnDialogDismiss → HidePickerDialog() chain that sets IsOpen = false.
- On rotation, OnMainDisplayInfoChanged unsubscribes DismissEvent and calls Dismiss().
- ShowPickerDialog() runs synchronously after Dismiss(), enters the else branch, and re-subscribes DismissEvent on the same dialog.
- The DismissEvent from step 2 fires after re-subscription, triggering HidePickerDialog() which dismisses the newly-shown dialog.
- Before PR [29323](https://github.com/dotnet/maui/pull/29323): There was no DismissEvent subscription, no IsOpen property, and no OnDialogDismiss handler — so the dismiss-and-re-show flow in OnMainDisplayInfoChanged worked without interference.


### Description of Change

**Dialog lifecycle and event handling improvements:**

* Renamed `ResetDialog()` to `DestroyDialog()` and updated all references accordingly to clarify its purpose and ensure consistent dialog destruction and recreation.
* Removed unnecessary subscriptions and unsubscriptions to the dialog's `DismissEvent`, simplifying dialog event handling in both `ShowPickerDialog()` and `HidePickerDialog()`. 

**Display info change handling:**

* Improved the logic in `OnMainDisplayInfoChanged` to properly destroy and recreate the dialog with the current date, ensuring the dialog updates correctly when display information changes (such as orientation changes).

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34973 

### Tested the behaviour in the following platforms

- [ ] - Windows 
- [x] - Android
- [ ] - iOS
- [ ] - Mac

| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/c5de443c-371d-4b48-9623-9a17965ba5c3"> | <video src="https://github.com/user-attachments/assets/014ac4eb-7958-488b-bfad-4e3c6ef69796"> |







<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
