### PR TITLE
[iOS,MacCatalyst] Fix for SwipeView.Open() throwing an ArgumentException on the second programmatic call

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34917.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34917.cs
@@ -1,0 +1,117 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34917, "[net 11.0][iOS,MacCatalyst] SwipeView.Open() throws ArgumentException on second programmatic call", PlatformAffected.iOS | PlatformAffected.macOS)]
+public class Issue34917 : ContentPage
+{
+	const string OpenRightButtonId = "OpenSwipeButton";
+	const string OpenBottomButtonId = "OpenBottomSwipeButton";
+	const string CloseButtonId = "CloseSwipeButton";
+	const string StatusLabelId = "StatusLabel";
+
+	readonly SwipeView _swipeView;
+
+	public Issue34917()
+	{
+		var openRightButton = new Button
+		{
+			Text = "Open RightItems",
+			AutomationId = OpenRightButtonId
+		};
+
+		var openBottomButton = new Button
+		{
+			Text = "Open BottomItems",
+			AutomationId = OpenBottomButtonId
+		};
+
+		var closeButton = new Button
+		{
+			Text = "Close SwipeView",
+			AutomationId = CloseButtonId
+		};
+
+		var statusLabel = new Label
+		{
+			Text = "Ready",
+			AutomationId = StatusLabelId,
+			HorizontalOptions = LayoutOptions.Center
+		};
+
+		var rightSwipeItem = new SwipeItem
+		{
+			Text = "Right Action",
+			BackgroundColor = Colors.LightBlue
+		};
+
+		var bottomSwipeItem = new SwipeItem
+		{
+			Text = "Bottom Action",
+			BackgroundColor = Colors.LightGreen
+		};
+
+		_swipeView = new SwipeView
+		{
+			HeightRequest = 60,
+			RightItems = new SwipeItems { rightSwipeItem },
+			BottomItems = new SwipeItems { bottomSwipeItem },
+			Content = new Grid
+			{
+				BackgroundColor = Colors.LightGray,
+				Children =
+				{
+					new Label
+					{
+						Text = "Swipe content",
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center
+					}
+				}
+			}
+		};
+
+		openRightButton.Clicked += (s, e) =>
+		{
+			try
+			{
+				_swipeView.Open(OpenSwipeItem.RightItems);
+				statusLabel.Text = "Success";
+			}
+			catch (Exception ex)
+			{
+				statusLabel.Text = $"Error: {ex.GetType().Name}";
+			}
+		};
+
+		openBottomButton.Clicked += (s, e) =>
+		{
+			try
+			{
+				_swipeView.Open(OpenSwipeItem.BottomItems);
+				statusLabel.Text = "Success";
+			}
+			catch (Exception ex)
+			{
+				statusLabel.Text = $"Error: {ex.GetType().Name}";
+			}
+		};
+
+		closeButton.Clicked += (s, e) =>
+		{
+			_swipeView.Close();
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 12,
+			Padding = new Thickness(20),
+			Children =
+			{
+				openRightButton,
+				openBottomButton,
+				closeButton,
+				_swipeView,
+				statusLabel
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34917.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34917.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34917 : _IssuesUITest
+{
+	public Issue34917(TestDevice device) : base(device) { }
+
+	public override string Issue => "[net 11.0][iOS,MacCatalyst] SwipeView.Open() throws ArgumentException on second programmatic call";
+
+	[Test]
+	[Category(UITestCategories.SwipeView)]
+	public void SwipeViewOpenRightDoesNotThrowOnSecondCall()
+	{
+		App.WaitForElement(OpenRightButtonId);
+
+		App.Tap(OpenRightButtonId);
+		App.WaitForElement(StatusLabelId);
+		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
+			"First Open(RightItems) call should succeed.");
+
+		App.Tap(OpenRightButtonId);
+		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
+			"Second consecutive Open(RightItems) call should not throw an exception.");
+	}
+
+	[Test]
+	[Category(UITestCategories.SwipeView)]
+	public void SwipeViewOpenBottomDoesNotThrowOnSecondCall()
+	{
+		App.WaitForElement(OpenBottomButtonId);
+
+		App.Tap(CloseButtonId);
+
+		App.Tap(OpenBottomButtonId);
+		App.WaitForElement(StatusLabelId);
+		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
+			"First Open(BottomItems) call should succeed.");
+
+		App.Tap(OpenBottomButtonId);
+		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
+			"Second consecutive Open(BottomItems) call should not throw an exception.");
+	}
+
+	const string OpenRightButtonId = "OpenSwipeButton";
+	const string OpenBottomButtonId = "OpenBottomSwipeButton";
+	const string CloseButtonId = "CloseSwipeButton";
+	const string StatusLabelId = "StatusLabel";
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34917.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34917.cs
@@ -18,10 +18,12 @@ public class Issue34917 : _IssuesUITest
 
 		App.Tap(OpenRightButtonId);
 		App.WaitForElement(StatusLabelId);
+		App.WaitForTextToBePresentInElement(StatusLabelId, "Success");
 		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
 			"First Open(RightItems) call should succeed.");
 
 		App.Tap(OpenRightButtonId);
+		App.WaitForTextToBePresentInElement(StatusLabelId, "Success");
 		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
 			"Second consecutive Open(RightItems) call should not throw an exception.");
 	}
@@ -31,15 +33,18 @@ public class Issue34917 : _IssuesUITest
 	public void SwipeViewOpenBottomDoesNotThrowOnSecondCall()
 	{
 		App.WaitForElement(OpenBottomButtonId);
+		App.WaitForElement(CloseButtonId);
 
 		App.Tap(CloseButtonId);
 
 		App.Tap(OpenBottomButtonId);
 		App.WaitForElement(StatusLabelId);
+		App.WaitForTextToBePresentInElement(StatusLabelId, "Success");
 		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
 			"First Open(BottomItems) call should succeed.");
 
 		App.Tap(OpenBottomButtonId);
+		App.WaitForTextToBePresentInElement(StatusLabelId, "Success");
 		Assert.That(App.FindElement(StatusLabelId).GetText(), Is.EqualTo("Success"),
 			"Second consecutive Open(BottomItems) call should not throw an exception.");
 	}

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -295,6 +295,7 @@ namespace Microsoft.Maui.Platform
 				return;
 
 			_swipeItemsRect = new List<CGRect>();
+			_swipeItems.Clear();
 
 			double swipeItemsWidth;
 
@@ -1165,8 +1166,6 @@ namespace Microsoft.Maui.Platform
 			}
 
 			Swipe(animated);
-
-			_swipeOffset = Math.Abs(_swipeOffset);
 		}
 
 		void UpdateOffset(double swipeOffset)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details

The issue occurs when calling the SwipeView.Open() method programmatically multiple times on iOS and MacCatalyst platforms. The first call to open swipe items (such as RightItems or BottomItems) works as expected, but the second call throws a System.ArgumentException with the message “An item with the same key has already been added.”
 
This behavior is specific to certain swipe directions that rely on negative offsets (such as right and bottom swipe actions), where the swipe interaction briefly appears and then resets unexpectedly. As a result, internal state inconsistencies lead to a crash during subsequent calls.

### Root Cause

The issue occur because of an incorrect use of Math.Abs on the _swipeOffset value inside the ProgrammaticallyOpenSwipeItem()method. This operation removes the negative sign required for specific swipe directions (such as left or up), causing the offset to become invalid during layout validation.
 
Due to this invalid offset, the swipe view resets to a closed state while still retaining previously added entries in the _swipeItems dictionary. When Open() is called again, the same keys are added again to the dictionary, resulting in a duplicate key exception.

### Description of Change

The fix involves removing the Math.Abs operation on _swipeOffset to preserve the correct directional value required for swipe behavior, ensuring that the swipe state remains consistent after layout validation.
 
Additionally, a defensive improvement is introduced by clearing the _swipeItems dictionary before repopulating it in the UpdateSwipeItems() method. This prevents duplicate key insertion and ensures that the method behaves safely even if invoked multiple times under unexpected conditions.

### Issues Fixed
Fixes https://github.com/dotnet/maui/issues/34917

### Validated the behaviour in the following platforms

- [ ] Windows
- [ ] Android
- [x] iOS
- [x] Mac

### Output
| Before | After |
|----------|----------|
| <video src="https://github.com/user-attachments/assets/55a131cb-6ccc-4776-80d7-90655651565d"> | <video src="https://github.com/user-attachments/assets/5efc010e-04ec-4e4d-8729-d43f41d2d6bf"> |