### PR TITLE
Fix SwipeView.Open() crash on second call (iOS/MacCatalyst)

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34917.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34917.cs
@@ -1,0 +1,87 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34917, "SwipeView.Open crashes with ArgumentException on second call", PlatformAffected.iOS)]
+public class Issue34917 : TestContentPage
+{
+	const string OpenButtonId = "OpenButton";
+	const string CloseButtonId = "CloseButton";
+	const string StatusLabelId = "StatusLabel";
+
+	protected override void Init()
+	{
+		Title = "Issue 34917";
+
+		var statusLabel = new Label
+		{
+			AutomationId = StatusLabelId,
+			Text = "Ready"
+		};
+
+		var swipeItem = new SwipeItem
+		{
+			BackgroundColor = Colors.Red,
+			Text = "Action"
+		};
+
+		var swipeView = new SwipeView
+		{
+			HeightRequest = 60,
+			WidthRequest = 300,
+			LeftItems = new SwipeItems { swipeItem },
+			Content = new Grid
+			{
+				BackgroundColor = Colors.Gray,
+				Children =
+				{
+					new Label
+					{
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.Center,
+						Text = "Swipe content"
+					}
+				}
+			}
+		};
+
+		var openButton = new Button
+		{
+			AutomationId = OpenButtonId,
+			Text = "Open SwipeView"
+		};
+
+		var closeButton = new Button
+		{
+			AutomationId = CloseButtonId,
+			Text = "Close SwipeView"
+		};
+
+		int openCount = 0;
+
+		openButton.Clicked += (s, e) =>
+		{
+			try
+			{
+				openCount++;
+				swipeView.Open(OpenSwipeItem.LeftItems);
+				statusLabel.Text = $"Opened {openCount}";
+			}
+			catch (Exception ex)
+			{
+				statusLabel.Text = $"Error: {ex.GetType().Name}";
+			}
+		};
+
+		closeButton.Clicked += (s, e) =>
+		{
+			swipeView.Close();
+			statusLabel.Text = "Closed";
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Spacing = 10,
+			Padding = 20,
+			Children = { openButton, closeButton, swipeView, statusLabel }
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34917.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34917.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues
+{
+	public class Issue34917 : _IssuesUITest
+	{
+		public Issue34917(TestDevice testDevice) : base(testDevice)
+		{
+		}
+
+		public override string Issue => "SwipeView.Open crashes with ArgumentException on second call";
+
+		[Test]
+		[Category(UITestCategories.SwipeView)]
+		public void SwipeViewOpenDoesNotCrashOnSecondCall()
+		{
+			App.WaitForElement("OpenButton");
+
+			// First open
+			App.Tap("OpenButton");
+			App.WaitForElement("StatusLabel");
+			var status1 = App.FindElement("StatusLabel").GetText();
+			Assert.That(status1, Is.EqualTo("Opened 1"), "First Open should succeed");
+
+			// Close
+			App.Tap("CloseButton");
+
+			// Wait for close animation
+			Task.Delay(500).Wait();
+
+			// Second open - this used to crash with ArgumentException
+			App.Tap("OpenButton");
+			var status2 = App.FindElement("StatusLabel").GetText();
+			Assert.That(status2, Is.EqualTo("Opened 2"), "Second Open should succeed without crash");
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -294,6 +294,11 @@ namespace Microsoft.Maui.Platform
 			if (items == null || items.Count == 0)
 				return;
 
+			// Clean up any previous swipe items to prevent duplicate key exceptions
+			// when Open() is called again after _isOpen was reset without DisposeSwipeItems
+			_swipeItems.Clear();
+			_actionView?.RemoveFromSuperview();
+
 			_swipeItemsRect = new List<CGRect>();
 
 			double swipeItemsWidth;
@@ -802,7 +807,7 @@ namespace Microsoft.Maui.Platform
 					() =>
 					{
 						_swipeOffset = Math.Abs(GetSwipeThreshold());
-						
+
 						// If the user swiped left or up, we need a negative offset to move content in the correct direction on the screen.
 						if (_swipeDirection == SwipeDirection.Left || _swipeDirection == SwipeDirection.Up)
 							_swipeOffset = -_swipeOffset;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #34917

Calling `SwipeView.Open()` a second time on iOS/MacCatalyst crashes with `System.ArgumentException: An item with the same key has already been added`.

### Root Cause

In `MauiSwipeView.cs`, the `Swipe()` method (line 584) sets `_isOpen = offset != 0`, which can transition `_isOpen` to `false` without calling `DisposeSwipeItems()`. This leaves stale entries in the `_swipeItems` dictionary. When `Open()` is called again:

1. `_isOpen` is `false`, so the guard in `ProgrammaticallyOpenSwipeItem` is skipped
2. `UpdateSwipeItems()` is called
3. `_swipeItems.Add(item, swipeItem)` throws `ArgumentException` because the dictionary already contains keys from the previous open

### Fix

Clear the `_swipeItems` dictionary and remove the old `_actionView` from the superview at the start of `UpdateSwipeItems()`, before creating new swipe item views. This makes the method idempotent — safe to call regardless of prior state.

### Testing

Added UI test (`Issue34917`) that opens a SwipeView, closes it, then opens it again — verifying no crash occurs on the second open.