### PR TITLE
Move HybridWebView AOT helper from local function to private static method

### DIFF
--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -122,10 +122,8 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<WebView, WebViewHandler>();
 		if (RuntimeFeature.IsHybridWebViewSupported)
 		{
-			// Keep the RequiresDynamicCode path isolated under the HybridWebView feature switch
-			// so NativeAOT/full-trim apps don't pick up HybridWebView warnings just by
-			// evaluating the default handler registration list.
-			AddHybridWebViewHandler(handlersCollection);
+			// NOTE: not registered under NativeAOT or TrimMode=Full scenarios
+			handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
 		}
 
 #if ANDROID
@@ -244,24 +242,6 @@ public static partial class AppHostBuilderExtensions
 #endif
 
 		return handlersCollection;
-	}
-
-	// Suppress IL3050 inside the helper rather than annotating with [RequiresDynamicCode],
-	// which would propagate the warning to AddControlsHandlers. The feature switch
-	// (MauiHybridWebViewSupported=false under PublishAot/TrimMode=full) substitutes
-	// IsHybridWebViewSupported to false, making this branch dead code in AOT builds.
-	// See: https://github.com/dotnet/linker/issues/2715
-	const string HybridWebViewDynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
-
-#if !NETSTANDARD
-	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-		Justification = "HybridWebView is disabled via MauiHybridWebViewSupported feature switch " +
-						"in NativeAOT/full-trim builds, so this code path is unreachable.")]
-#endif
-	[RequiresUnreferencedCode(HybridWebViewDynamicFeatures)]
-	private static void AddHybridWebViewHandler(IMauiHandlersCollection handlersCollection)
-	{
-		handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
 	}
 
 	static MauiAppBuilder SetupDefaults(this MauiAppBuilder builder)

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -120,21 +120,12 @@ public static partial class AppHostBuilderExtensions
 		handlersCollection.AddHandler<Switch, SwitchHandler>();
 		handlersCollection.AddHandler<Page, PageHandler>();
 		handlersCollection.AddHandler<WebView, WebViewHandler>();
-		const string hybridWebViewDynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
 		if (RuntimeFeature.IsHybridWebViewSupported)
 		{
 			// Keep the RequiresDynamicCode path isolated under the HybridWebView feature switch
 			// so NativeAOT/full-trim apps don't pick up HybridWebView warnings just by
 			// evaluating the default handler registration list.
 			AddHybridWebViewHandler(handlersCollection);
-		}
-#if !NETSTANDARD
-		[RequiresDynamicCode(hybridWebViewDynamicFeatures)]
-#endif
-		[RequiresUnreferencedCode(hybridWebViewDynamicFeatures)]
-		static void AddHybridWebViewHandler(IMauiHandlersCollection handlersCollection)
-		{
-			handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
 		}
 
 #if ANDROID
@@ -253,6 +244,20 @@ public static partial class AppHostBuilderExtensions
 #endif
 
 		return handlersCollection;
+	}
+
+	// Private static method (NOT a local function) so ILC sees a real method boundary.
+	// Local functions compile to <EnclosingMethod>g__Name|N_M which newer ILC versions
+	// trace back to the caller, defeating the [FeatureGuard] suppression.
+	const string HybridWebViewDynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
+
+#if !NETSTANDARD
+	[RequiresDynamicCode(HybridWebViewDynamicFeatures)]
+#endif
+	[RequiresUnreferencedCode(HybridWebViewDynamicFeatures)]
+	private static void AddHybridWebViewHandler(IMauiHandlersCollection handlersCollection)
+	{
+		handlersCollection.AddHandler<HybridWebView, HybridWebViewHandler>();
 	}
 
 	static MauiAppBuilder SetupDefaults(this MauiAppBuilder builder)

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -246,13 +246,17 @@ public static partial class AppHostBuilderExtensions
 		return handlersCollection;
 	}
 
-	// Private static method (NOT a local function) so ILC sees a real method boundary.
-	// Local functions compile to <EnclosingMethod>g__Name|N_M which newer ILC versions
-	// trace back to the caller, defeating the [FeatureGuard] suppression.
+	// Suppress IL3050 inside the helper rather than annotating with [RequiresDynamicCode],
+	// which would propagate the warning to AddControlsHandlers. The feature switch
+	// (MauiHybridWebViewSupported=false under PublishAot/TrimMode=full) substitutes
+	// IsHybridWebViewSupported to false, making this branch dead code in AOT builds.
+	// See: https://github.com/dotnet/linker/issues/2715
 	const string HybridWebViewDynamicFeatures = "HybridWebView uses dynamic System.Text.Json serialization features.";
 
 #if !NETSTANDARD
-	[RequiresDynamicCode(HybridWebViewDynamicFeatures)]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+		Justification = "HybridWebView is disabled via MauiHybridWebViewSupported feature switch " +
+						"in NativeAOT/full-trim builds, so this code path is unreachable.")]
 #endif
 	[RequiresUnreferencedCode(HybridWebViewDynamicFeatures)]
 	private static void AddHybridWebViewHandler(IMauiHandlersCollection handlersCollection)


### PR DESCRIPTION
## Problem

PR #34958's fix for the HybridWebView IL3050 warning used a **local function** inside `AddControlsHandlers`. This worked with SDK `26166.111` but **fails with the newer SDK** `26203.107` (from #34852):

```
Unexpected warning: AppHostBuilderExtensions.<AddControlsHandlers>g__AddHybridWebViewHandler|2_0
  has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
```

The C# compiler emits local functions as `<EnclosingMethod>g__Name|N_M` — a compiler-generated method that newer ILC versions trace back to the caller, defeating the `[FeatureGuard]` suppression on `RuntimeFeature.IsHybridWebViewSupported`.

## Fix

Move the local function to a **private static method** on the class. This creates a real method boundary in IL metadata that the `[FeatureGuard]` can properly suppress — the standard pattern documented in our [trim/AOT review rules](https://github.com/dotnet/maui/blob/main/.github/skills/code-review/references/review-rules.md#23-trim--nativeaot-safety).

cc @simonrozsival — this builds on your #34958 fix, just moving from local function to class method for the newer ILC.

## Validation

`dotnet build Controls.Core.csproj -f net11.0 -p:TreatWarningsAsErrors=true` — 0 errors