### PR TITLE
Fix CollectionView Header is not visible when ItemsSource is not set and an EmptyView is set in iOS, Mac platform

### DIFF
--- a/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			// Only applies to non-grouped collections: grouped collections put group headers in
 			// per-section supplementary items, which would crash when accessing the empty group source.
 			if (count == 0
-				&& !(ItemsView is GroupableItemsView { IsGrouped: true })
+				&& ItemsSource is not null && !(ItemsView is GroupableItemsView { IsGrouped: true })
 				&& (ItemsView?.Header is not null || ItemsView?.HeaderTemplate is not null
 					|| ItemsView?.Footer is not null || ItemsView?.FooterTemplate is not null))
 			{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/StructuredItemsViewController2.cs
@@ -48,6 +48,26 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		protected override bool IsHorizontal => (ItemsView?.ItemsLayout as ItemsLayout)?.Orientation == ItemsLayoutOrientation.Horizontal;
 
+		public override nint NumberOfSections(UICollectionView collectionView)
+		{
+			var count = base.NumberOfSections(collectionView);
+
+			// UICollectionViewCompositionalLayout does not render global boundary supplementary items
+			// (header/footer set on NSCollectionLayoutConfiguration) when there are 0 sections.
+			// Return at least 1 section so the header/footer remains visible when ItemsSource is empty.
+			// Only applies to non-grouped collections: grouped collections put group headers in
+			// per-section supplementary items, which would crash when accessing the empty group source.
+			if (count == 0
+				&& !(ItemsView is GroupableItemsView { IsGrouped: true })
+				&& (ItemsView?.Header is not null || ItemsView?.HeaderTemplate is not null
+					|| ItemsView?.Footer is not null || ItemsView?.FooterTemplate is not null))
+			{
+				return 1;
+			}
+
+			return count;
+		}
+
 		internal void UpdateHeaderView()
 		{
 			// Clean up header view if no header content

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,8 +1,9 @@
-#nullable enable
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+﻿#nullable enable
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-﻿#nullable enable
+#nullable enable
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 ﻿#nullable enable
-~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
-~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,8 +1,9 @@
-#nullable enable
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
-~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+﻿#nullable enable
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
+~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-﻿#nullable enable
+#nullable enable
 override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
 *REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 ﻿#nullable enable
-~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
-~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
+override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
+override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.StructuredItemsViewController2<TItemsView>.NumberOfSections(UIKit.UICollectionView collectionView) -> nint
+*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
+~override Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2.DisconnectHandler(UIKit.UIView platformView) -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.ViewDidAppear(bool animated) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.DidMoveToParentViewController(UIKit.UIViewController parent) -> void
-*REMOVED*~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
-override Microsoft.Maui.Controls.Platform.Compatibility.ShellTableViewController.LoadView() -> void
-override Microsoft.Maui.Controls.Shapes.Shape.OnPropertyChanged(string? propertyName = null) -> void

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
@@ -24,18 +24,31 @@ public class Issue34897 : ContentPage
 				AutomationId = "Issue34897EmptyView",
 				BackgroundColor = Colors.LightYellow,
 			},
+			Footer = new Label
+			{
+				Text = "CollectionView Footer",
+				AutomationId = "Issue34897Footer",
+				BackgroundColor = Colors.LightGreen,
+			},
 		};
 
-		Content = new StackLayout
+		var grid = new Grid
 		{
-			Children =
+			RowDefinitions =
 			{
-				new Label
-				{
-					Text = "Header, Footer and EmptyView should all be visible below:",
-				},
-				collectionView,
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Star),
 			}
 		};
+
+		var label = new Label
+		{
+			Text = "Header, Footer and EmptyView should all be visible below:",
+		};
+
+		grid.Add(label, 0, 0);
+		grid.Add(collectionView, 0, 1);
+
+		Content = grid;
 	}
 }

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Controls;
+using System.Collections.ObjectModel;
 
 namespace Maui.Controls.Sample.Issues;
 
@@ -7,7 +8,7 @@ public class Issue34897 : ContentPage
 {
 	public Issue34897()
 	{
-		// This reproduces the bug: Header set statically with EmptyView active and no ItemsSource.
+		// This reproduces the bug: Header set statically with EmptyView active and ItemsSource=null.
 		// UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
 		// when NumberOfSections returns 0 — which happens when ItemsSource is null.
 		var collectionView = new CollectionView
@@ -34,7 +35,9 @@ public class Issue34897 : ContentPage
 				BackgroundColor = Colors.LightYellow,
 				Padding = new Thickness(8),
 			},
-			// ItemsSource intentionally NOT set (null) — this is the bug scenario
+			// ItemsSource intentionally set to null (not an empty collection)
+			// This is the key condition that triggers the bug
+			ItemsSource = null,
 		};
 
 		Content = new StackLayout

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
@@ -2,7 +2,7 @@ using Microsoft.Maui.Controls;
 
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 34897, "CollectionView Header is not visible when ItemsSource is not set and EmptyView is set", PlatformAffected.iOS | PlatformAffected.MacCatalyst)]
+[Issue(IssueTracker.Github, 34897, "CollectionView Header is not visible when ItemsSource is not set and EmptyView is set", PlatformAffected.iOS | PlatformAffected.macOS)]
 public class Issue34897 : ContentPage
 {
 	public Issue34897()
@@ -18,6 +18,13 @@ public class Issue34897 : ContentPage
 				Text = "CollectionView Header",
 				AutomationId = "Issue34897Header",
 				BackgroundColor = Colors.LightBlue,
+				Padding = new Thickness(8),
+			},
+			Footer = new Label
+			{
+				Text = "CollectionView Footer",
+				AutomationId = "Issue34897Footer",
+				BackgroundColor = Colors.LightGreen,
 				Padding = new Thickness(8),
 			},
 			EmptyView = new Label
@@ -36,7 +43,7 @@ public class Issue34897 : ContentPage
 			{
 				new Label
 				{
-					Text = "Header and EmptyView should both be visible below:",
+					Text = "Header, Footer and EmptyView should all be visible below:",
 					Margin = new Thickness(8),
 				},
 				collectionView,

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
@@ -8,36 +8,22 @@ public class Issue34897 : ContentPage
 {
 	public Issue34897()
 	{
-		// This reproduces the bug: Header set statically with EmptyView active and ItemsSource=null.
-		// UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
-		// when NumberOfSections returns 0 — which happens when ItemsSource is null.
 		var collectionView = new CollectionView
 		{
+			ItemsLayout = new GridItemsLayout(2, ItemsLayoutOrientation.Vertical),
 			AutomationId = "Issue34897CollectionView",
 			Header = new Label
 			{
 				Text = "CollectionView Header",
 				AutomationId = "Issue34897Header",
 				BackgroundColor = Colors.LightBlue,
-				Padding = new Thickness(8),
-			},
-			Footer = new Label
-			{
-				Text = "CollectionView Footer",
-				AutomationId = "Issue34897Footer",
-				BackgroundColor = Colors.LightGreen,
-				Padding = new Thickness(8),
 			},
 			EmptyView = new Label
 			{
 				Text = "No items available",
 				AutomationId = "Issue34897EmptyView",
 				BackgroundColor = Colors.LightYellow,
-				Padding = new Thickness(8),
 			},
-			// ItemsSource intentionally set to null (not an empty collection)
-			// This is the key condition that triggers the bug
-			ItemsSource = null,
 		};
 
 		Content = new StackLayout
@@ -47,7 +33,6 @@ public class Issue34897 : ContentPage
 				new Label
 				{
 					Text = "Header, Footer and EmptyView should all be visible below:",
-					Margin = new Thickness(8),
 				},
 				collectionView,
 			}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34897.cs
@@ -1,0 +1,46 @@
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34897, "CollectionView Header is not visible when ItemsSource is not set and EmptyView is set", PlatformAffected.iOS | PlatformAffected.MacCatalyst)]
+public class Issue34897 : ContentPage
+{
+	public Issue34897()
+	{
+		// This reproduces the bug: Header set statically with EmptyView active and no ItemsSource.
+		// UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
+		// when NumberOfSections returns 0 — which happens when ItemsSource is null.
+		var collectionView = new CollectionView
+		{
+			AutomationId = "Issue34897CollectionView",
+			Header = new Label
+			{
+				Text = "CollectionView Header",
+				AutomationId = "Issue34897Header",
+				BackgroundColor = Colors.LightBlue,
+				Padding = new Thickness(8),
+			},
+			EmptyView = new Label
+			{
+				Text = "No items available",
+				AutomationId = "Issue34897EmptyView",
+				BackgroundColor = Colors.LightYellow,
+				Padding = new Thickness(8),
+			},
+			// ItemsSource intentionally NOT set (null) — this is the bug scenario
+		};
+
+		Content = new StackLayout
+		{
+			Children =
+			{
+				new Label
+				{
+					Text = "Header and EmptyView should both be visible below:",
+					Margin = new Thickness(8),
+				},
+				collectionView,
+			}
+		};
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34897 : _IssuesUITest
+{
+	public Issue34897(TestDevice device) : base(device) { }
+
+	public override string Issue => "CollectionView Header is not visible when ItemsSource is not set and EmptyView is set";
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewHeaderVisibleWithEmptyViewAndNullItemsSource()
+	{
+		// Wait for the page to load — EmptyView should appear since ItemsSource is null
+		App.WaitForElement("Issue34897EmptyView");
+
+		// The Header must ALSO be visible even though ItemsSource is null and EmptyView is active.
+		// Bug: UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
+		// when NumberOfSections returns 0 (which happens when ItemsSource is null).
+		App.WaitForElement("Issue34897Header");
+	}
+
+	[Test]
+	[Category(UITestCategories.CollectionView)]
+	public void CollectionViewFooterVisibleWithEmptyViewAndNullItemsSource()
+	{
+		// Wait for page load
+		App.WaitForElement("Issue34897EmptyView");
+
+		// The Footer must also be visible — same root cause as the header bug.
+		// This test covers the footer scenario guarded by TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST.
+		App.WaitForElement("Issue34897Header");
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
@@ -14,25 +14,7 @@ public class Issue34897 : _IssuesUITest
 	[Category(UITestCategories.CollectionView)]
 	public void CollectionViewHeaderVisibleWithEmptyViewAndNullItemsSource()
 	{
-		// Wait for the page to load — EmptyView should appear since ItemsSource is null
 		App.WaitForElement("Issue34897EmptyView");
-
-		// The Header must ALSO be visible even though ItemsSource is null and EmptyView is active.
-		// Bug: UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
-		// when NumberOfSections returns 0 (which happens when ItemsSource is null).
 		App.WaitForElement("Issue34897Header");
-	}
-
-	[Test]
-	[Category(UITestCategories.CollectionView)]
-	public void CollectionViewFooterVisibleWithEmptyViewAndNullItemsSource()
-	{
-		// Wait for page load
-		App.WaitForElement("Issue34897EmptyView");
-
-		// The Footer must also be visible — same root cause as the header bug.
-		// Bug: UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
-		// when NumberOfSections returns 0 (which happens when ItemsSource is null).
-		App.WaitForElement("Issue34897Footer");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
@@ -17,6 +17,7 @@ public class Issue34897 : _IssuesUITest
 	{
 		App.WaitForElement("Issue34897EmptyView");
 		App.WaitForElement("Issue34897Header");
+		App.WaitForElement("Issue34897Footer");
 	}
 }
 #endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
@@ -31,7 +31,8 @@ public class Issue34897 : _IssuesUITest
 		App.WaitForElement("Issue34897EmptyView");
 
 		// The Footer must also be visible — same root cause as the header bug.
-		// This test covers the footer scenario guarded by TEST_FAILS_ON_IOS && TEST_FAILS_ON_CATALYST.
-		App.WaitForElement("Issue34897Header");
+		// Bug: UICollectionViewCompositionalLayout drops boundary supplementary items (header/footer)
+		// when NumberOfSections returns 0 (which happens when ItemsSource is null).
+		App.WaitForElement("Issue34897Footer");
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34897.cs
@@ -1,3 +1,4 @@
+#if TEST_FAILS_ON_WINDOWS // This test fails on Windows because we no longer works with CollectionView on Windows.
 using NUnit.Framework;
 using UITest.Appium;
 using UITest.Core;
@@ -18,3 +19,4 @@ public class Issue34897 : _IssuesUITest
 		App.WaitForElement("Issue34897Header");
 	}
 }
+#endif


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details:

On iOS and macCatalyst, the CollectionView Header/Footer is not visible when ItemsSource is not set (or empty) and an EmptyView is configured.
       
### Root Cause:

iOS/macCatalyst uses UICollectionViewCompositionalLayout, which renders the Header and Footer as global boundary supplementary items configured on NSCollectionLayoutConfiguration. The core problem is that UICollectionViewCompositionalLayout simply does not render these global boundary items when the collection reports 0 sections. When ItemsSource is null or empty, the data source returns 0 sections, causing the layout engine to skip rendering the Header/Footer entirely. Android is unaffected because its layout engine handles this case differently.

### Description of Change:

The fix overrides NumberOfSections in StructuredItemsViewController2.cs to return at least 1 section whenever the data source would return 0 sections but a Header or Footer is configured. This tricks the UICollectionViewCompositionalLayout into having one phantom empty section, which satisfies the layout engine and causes the Header/Footer to render correctly. A guard ensures this only applies to non-grouped collections — grouped collections use per-section supplementary items and would crash if given a phantom section that has no corresponding group data in the source.

**Tested the behavior in the following platforms:**

- [ ] Android
- [ ] Windows
- [x] iOS
- [x] Mac

### Reference:

N/A

### Issues Fixed:

Fixes  #34897          

### Screenshots
| Before  | After  |
|---------|--------|
| <img width="300" height="600" alt="Before_34897" src="https://github.com/user-attachments/assets/9e883564-d5cd-4f89-b238-f5b7c8bf434c" /> | <img width="300" height="600" alt="After_34897" src="https://github.com/user-attachments/assets/eb045764-1bee-4f52-b97f-65e39f0cdfc7" /> |