### PR TITLE
Fix duplicate issue number crash breaking all Windows UI tests

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue8305_Toolbar.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue8305_Toolbar.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Maui.Controls.Sample.Issues;
 
-[Issue(IssueTracker.Github, 8305, "ToolbarItem Badge Support", PlatformAffected.All)]
+[Issue(IssueTracker.Github, 8305, "ToolbarItem Badge Support", PlatformAffected.All, issueTestNumber: 1)]
 public class Issue8305_Toolbar : ContentPage
 {
 	readonly ToolbarItem _badgeTextItem;
@@ -19,7 +19,7 @@ public class Issue8305_Toolbar : ContentPage
 		_badgeTextItem = new ToolbarItem
 		{
 			Text = "Mail",
-			IconImageSource = "envelope.png",
+			IconImageSource = "bank.png",
 			BadgeText = "New",
 			AutomationId = "BadgeTextItem"
 		};
@@ -28,7 +28,7 @@ public class Issue8305_Toolbar : ContentPage
 		_badgeCountItem = new ToolbarItem
 		{
 			Text = "Alerts",
-			IconImageSource = "bell.png",
+			IconImageSource = "calculator.png",
 			BadgeText = "3",
 			AutomationId = "BadgeCountItem"
 		};
@@ -37,7 +37,7 @@ public class Issue8305_Toolbar : ContentPage
 		_badgeColorItem = new ToolbarItem
 		{
 			Text = "Cart",
-			IconImageSource = "cart.png",
+			IconImageSource = "shopping_cart.png",
 			BadgeText = "1",
 			BadgeColor = Colors.Green,
 			AutomationId = "BadgeColorItem"


### PR DESCRIPTION
## Problem

PR #34669 (ToolbarItem Badge Support) added Issue8305_Toolbar.cs with `[Issue(IssueTracker.Github, 8305, ...)]`, but Issue8305.cs (Shell Badge, from PR #34659) already uses issue number 8305. Both generated the same `DisplayName = "G8305"`, causing `VerifyNoDuplicates()` in `TestCases.cs` to throw `NotSupportedException` at app startup, crashing the **entire HostApp** and failing **ALL** Windows UI tests (not just toolbar tests).

This crash has been present since build [1371858](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1371858) (PR #34669 merge). The follow-up PR #34963 fixed nullable warnings but did not address this crash.

## Root Cause

`TestCases.cs:VerifyNoDuplicates()` (line 161-175) uses a HashSet to check for duplicate `DisplayName` values. When two `[Issue]` attributes share the same tracker and number with default `issueTestNumber=0`, they produce identical display names, triggering the crash.

## Fix

1. **Add `issueTestNumber: 1`** to `Issue8305_Toolbar`'s `[Issue]` attribute, producing unique `DisplayName = "G8305 (1)"` instead of duplicate `"G8305"`
2. **Replace non-existent icon images** (`envelope.png`, `bell.png`, `cart.png`) with images that exist in HostApp resources (`bank.png`, `calculator.png`, `shopping_cart.png`)

## Verification

- Both `Controls.TestCases.HostApp` (Windows TFM) and `Controls.TestCases.Shared.Tests` build successfully
- The `issueTestNumber` pattern is well-established (used by Issue11769, Issue13126_2, Issue1583_1, Issue28986_Border, and others)
