### PR TITLE
Fix incorrect SDK provisioning commands in integration-tests instructions

### DIFF
--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -179,8 +179,8 @@ If the skill reports missing prerequisites, provision the local SDK:
 1. **Provision the local SDK and workloads** - The `.dotnet/` folder must contain a fully provisioned .NET SDK with MAUI workloads. Run:
 
    ```bash
-   # Restore .NET SDK and workloads to .dotnet/ folder (recommended, uses Arcade infrastructure)
-   ./build.sh -restore
+   # Restore .NET SDK, build MAUI, and pack into .dotnet/ folder
+   ./build.sh -restore -pack
    ```
 
    **Verification**: After provisioning, verify the setup:

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -179,11 +179,8 @@ If the skill reports missing prerequisites, provision the local SDK:
 1. **Provision the local SDK and workloads** - The `.dotnet/` folder must contain a fully provisioned .NET SDK with MAUI workloads. Run:
 
    ```bash
-   # Step 1: Download the .NET SDK (creates .dotnet/dotnet binary)
-   ./build.sh --target=dotnet
-   
-   # Step 2: Install MAUI workloads into the local SDK (takes ~5 minutes)
-   ./build.sh --target=dotnet-local-workloads
+   # Restore .NET SDK and workloads to .dotnet/ folder (recommended, uses Arcade infrastructure)
+   ./build.sh -restore
    ```
 
    **Verification**: After provisioning, verify the setup:

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -179,9 +179,11 @@ If the skill reports missing prerequisites, provision the local SDK:
 1. **Provision the local SDK and workloads** - The `.dotnet/` folder must contain a fully provisioned .NET SDK with MAUI workloads. Run:
 
    ```bash
-   # Restore .NET SDK, build MAUI, and pack into .dotnet/ folder
-   ./build.sh -restore -pack
-   ```
+   # Step 1: Download the .NET SDK (creates .dotnet/dotnet binary)
+   dotnet cake --target=dotnet
+   
+   # Step 2: Install MAUI workloads into the local SDK (takes ~5 minutes)
+   dotnet cake --target=dotnet-local-workloads
 
    **Verification**: After provisioning, verify the setup:
    ```bash

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -179,11 +179,15 @@ If the skill reports missing prerequisites, provision the local SDK:
 1. **Provision the local SDK and workloads** - The `.dotnet/` folder must contain a fully provisioned .NET SDK with MAUI workloads. Run:
 
    ```bash
+   # Step 0: Restore repo-local tools (Cake, etc.) from .config/dotnet-tools.json
+   dotnet tool restore
+
    # Step 1: Download the .NET SDK (creates .dotnet/dotnet binary)
    dotnet cake --target=dotnet
-   
+
    # Step 2: Install MAUI workloads into the local SDK (takes ~5 minutes)
    dotnet cake --target=dotnet-local-workloads
+   ```
 
    **Verification**: After provisioning, verify the setup:
    ```bash


### PR DESCRIPTION
## Description

The `.github/instructions/integration-tests.instructions.md` file contained incorrect build commands:

```bash
./build.sh --target=dotnet
./build.sh --target=dotnet-local-workloads
```

These mix up Arcade build script syntax (`./build.sh`) with Cake target syntax (`--target=X`). Unrecognized arguments are silently passed through to MSBuild as properties via `eng/common/build.sh` (line 200-201) and do nothing useful.

## Fix

Replace with `dotnet cake`

```bash
dotnet cake --target=dotnet
dotnet cake --target=dotnet-local-workloads
```

## Impact

Documentation-only change. No functional code changes.

AI now uses the right commands.