### PR TITLE
[Android] Fix CarouselView Issue23291 and Issue29216 test regression on candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -548,7 +548,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling && centerPosition != carouselPosition)
 			{
 				if (_initialized)
+				{
 					_gotoPosition = carouselPosition;
+				}
 
 				ItemsView.ScrollTo(carouselPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
 			}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var centerPosition = GetCarouselViewCurrentIndex(carouselPosition);
-			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling && centerPosition != carouselPosition)
+			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling && centerPosition != carouselPosition && _initialized)
 			{
 				_gotoPosition = carouselPosition;
 

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -545,9 +545,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var centerPosition = GetCarouselViewCurrentIndex(carouselPosition);
-			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling && centerPosition != carouselPosition && _initialized)
+			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling && centerPosition != carouselPosition)
 			{
-				_gotoPosition = carouselPosition;
+				if (_initialized)
+					_gotoPosition = carouselPosition;
 
 				ItemsView.ScrollTo(carouselPosition, position: Microsoft.Maui.Controls.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
 			}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
During CarouselView startup on Android, `UpdateFromPosition` runs before the carousel is fully initialized (`_initialized = false`). It sets `_gotoPosition` during an initial scroll attempt, but since the layout is not ready, the scroll never completes. This leaves `_gotoPosition` stuck at a non-negative value.

Earlier, this was unintentionally handled by an unconditional `_gotoPosition = -1` in `UpdateFromCurrentItem`, which cleared the stale state. PR #34570 removed that line (to avoid breaking the guard during animations for #29544), exposing the issue.

As a result, `_gotoPosition` remains stuck, causing all subsequent `UpdateFromPosition` calls to fail the `_gotoPosition == -1` check and skip scrolling. This leads to timeouts in tests like `Issue23291` and `Issue29216`, as the carousel never moves to the requested position.
 
### Description of Change
Updated the guard condition in `UpdateFromPosition` by applying the `_initialized` check only to the `_gotoPosition` assignment, ensuring it is set only after initialization while leaving the rest of the logic unaffected.
This prevents premature or stale `_gotoPosition` values during startup and preserves the existing scroll behavior, keeping the change safe.

 
### Issues Fixed
Fixes regression introduced by #34570 : 
`Issue23291Test`
`Issue29216CarouselViewScrollingIssue  on Candidate branch`.
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac
