### PR TITLE
Add preview/RC milestone support with release branch detection

### DIFF
--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -172,11 +172,12 @@ Describe 'Find-PreviousTag' {
             '10.0.0', '10.0.1', '10.0.10', '10.0.11',
             '10.0.20', '10.0.30', '10.0.31',
             '10.0.40', '10.0.41', '10.0.50',
-            '9.0.82', '9.0.90'
+            '9.0.82', '9.0.90',
+            '11.0.0-preview.1.26107', '11.0.0-preview.2.26152.10', '11.0.0-preview.3.26203.7'
         )
     }
 
-    It '"<Tag>" → "<Expected>"' -ForEach @(
+    It 'stable: "<Tag>" → "<Expected>"' -ForEach @(
         @{ Tag = '10.0.50';  Expected = '10.0.41' }
         @{ Tag = '10.0.41';  Expected = '10.0.40' }
         @{ Tag = '10.0.40';  Expected = '10.0.31' }
@@ -188,8 +189,16 @@ Describe 'Find-PreviousTag' {
         Find-PreviousTag $Tag $tags | Should -Be $Expected
     }
 
+    It 'preview: "<Tag>" → "<Expected>"' -ForEach @(
+        @{ Tag = '11.0.0-preview.3.26203.7';  Expected = '11.0.0-preview.2.26152.10' }
+        @{ Tag = '11.0.0-preview.2.26152.10'; Expected = '11.0.0-preview.1.26107' }
+    ) {
+        Find-PreviousTag $Tag $tags | Should -Be $Expected
+    }
+
     It 'returns $null when no previous exists' {
         Find-PreviousTag '10.0.0' $tags | Should -BeNullOrEmpty
+        Find-PreviousTag '11.0.0-preview.1.26107' $tags | Should -BeNullOrEmpty
     }
 
     It 'only considers same major version' {
@@ -301,17 +310,22 @@ Describe 'Get-PatchVersion' {
 }
 
 Describe 'Test-IsReleaseTag' {
-    It 'accepts valid .NET 10 SR tags' {
+    It 'accepts valid .NET 10 stable tags' {
         Test-IsReleaseTag '10.0.50' 10 | Should -BeTrue
         Test-IsReleaseTag '10.0.0' 10  | Should -BeTrue
     }
 
-    It 'rejects wrong major version' {
-        Test-IsReleaseTag '9.0.82' 10  | Should -BeFalse
+    It 'accepts preview/RC tags for same major' {
+        Test-IsReleaseTag '11.0.0-preview.3.26203.7' 11 | Should -BeTrue
+        Test-IsReleaseTag '10.0.0-rc.1.25424.2' 10 | Should -BeTrue
     }
 
-    It 'rejects non-SR tags' {
-        Test-IsReleaseTag '10.0.0-preview.7.25406.3' 10 | Should -BeFalse
+    It 'rejects wrong major version' {
+        Test-IsReleaseTag '9.0.82' 10  | Should -BeFalse
+        Test-IsReleaseTag '11.0.0-preview.3.26203.7' 10 | Should -BeFalse
+    }
+
+    It 'rejects non-release tags' {
         Test-IsReleaseTag 'not-a-tag' 10 | Should -BeFalse
     }
 }

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -260,6 +260,35 @@ Describe 'Get-LinkedIssues' {
     }
 }
 
+Describe 'ConvertBranchToMilestone' {
+    It 'maps GA branch' {
+        ConvertBranchToMilestone 'release/10.0.1xx' | Should -Be '.NET 10.0 GA'
+    }
+
+    It 'maps SR branches' {
+        ConvertBranchToMilestone 'release/10.0.1xx-sr1' | Should -Be '.NET 10 SR1'
+        ConvertBranchToMilestone 'release/10.0.1xx-sr5' | Should -Be '.NET 10 SR5'
+        ConvertBranchToMilestone 'release/10.0.1xx-sr10' | Should -Be '.NET 10 SR10'
+    }
+
+    It 'maps preview branches' {
+        ConvertBranchToMilestone 'release/11.0.1xx-preview1' | Should -Be '.NET 11.0-preview1'
+        ConvertBranchToMilestone 'release/11.0.1xx-preview3' | Should -Be '.NET 11.0-preview3'
+        ConvertBranchToMilestone 'release/11.0.1xx-preview7' | Should -Be '.NET 11.0-preview7'
+    }
+
+    It 'maps RC branches' {
+        ConvertBranchToMilestone 'release/12.0.1xx-rc1' | Should -Be '.NET 12.0-rc1'
+        ConvertBranchToMilestone 'release/12.0.1xx-rc2' | Should -Be '.NET 12.0-rc2'
+    }
+
+    It 'returns $null for non-release branches' {
+        ConvertBranchToMilestone 'main' | Should -BeNullOrEmpty
+        ConvertBranchToMilestone 'net11.0' | Should -BeNullOrEmpty
+        ConvertBranchToMilestone 'feature/something' | Should -BeNullOrEmpty
+    }
+}
+
 Describe 'Get-PatchVersion' {
     It '"<Tag>" → <Expected>' -ForEach @(
         @{ Tag = '10.0.50';  Expected = 50 }

--- a/.github/scripts/Fix-MilestoneDrift.Tests.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.Tests.ps1
@@ -54,6 +54,21 @@ Describe 'ConvertTo-Milestone' {
     ) {
         ConvertTo-Milestone $Tag | Should -BeNullOrEmpty
     }
+
+    It 'maps preview "<Tag>" with label "<Label>" iter <Iter> to "<Expected>"' -ForEach @(
+        @{ Tag = '11.0.0'; Label = 'preview'; Iter = 1; Expected = '.NET 11.0-preview1' }
+        @{ Tag = '11.0.0'; Label = 'preview'; Iter = 3; Expected = '.NET 11.0-preview3' }
+        @{ Tag = '11.0.0'; Label = 'preview'; Iter = 7; Expected = '.NET 11.0-preview7' }
+        @{ Tag = '12.0.0'; Label = 'rc';      Iter = 1; Expected = '.NET 12.0-rc1' }
+        @{ Tag = '12.0.0'; Label = 'rc';      Iter = 2; Expected = '.NET 12.0-rc2' }
+    ) {
+        ConvertTo-Milestone $Tag $Label $Iter | Should -Be $Expected
+    }
+
+    It 'maps to GA when no pre-release label' {
+        ConvertTo-Milestone '11.0.0' $null 0 | Should -Be '.NET 11.0 GA'
+        ConvertTo-Milestone '11.0.0' | Should -Be '.NET 11.0 GA'
+    }
 }
 
 Describe 'Test-MilestoneMatch' {

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -98,9 +98,10 @@ function Get-MainBranchForVersion([int]$Major, [string]$Repo) {
 }
 
 function Get-VersionFromGitRef([string]$GitRef, [string]$Repo) {
-    <# Reads MajorVersion and PatchVersion from eng/Versions.props at a specific
-       git ref (commit SHA, branch, tag). Returns a synthetic release tag string
-       like "10.0.60" that can be passed to ConvertTo-Milestone.
+    <# Reads version info from eng/Versions.props at a specific git ref.
+       Returns a hashtable with Tag (synthetic release tag like "10.0.60"),
+       PreReleaseLabel (e.g. "preview", "rc", or $null for stable),
+       and PreReleaseIteration (e.g. 3).
        Fetches the commit if not available locally (e.g. PRs merged to inflight). #>
     $versionXml = git -C $Repo --no-pager show "${GitRef}:eng/Versions.props" 2>&1
     if ($LASTEXITCODE -ne 0) {
@@ -126,13 +127,43 @@ function Get-VersionFromGitRef([string]$GitRef, [string]$Repo) {
         Write-Warning "Could not parse PatchVersion from Versions.props at $GitRef"
         return $null
     }
-    return "$major.0.$patch"
+
+    # Detect pre-release label (preview, rc) and iteration
+    $preLabel = $null
+    $preIter = $null
+    if ($joined -match '<PreReleaseVersionLabel[^>]*>([^<]+)</PreReleaseVersionLabel>') {
+        $rawLabel = $Matches[1]
+        # Only treat "preview" and "rc" as pre-release; "ci.main", "ci.inflight", "servicing" are stable builds
+        if ($rawLabel -match '^(preview|rc)$') {
+            $preLabel = $rawLabel
+            if ($joined -match '<PreReleaseVersionIteration>(\d+)</PreReleaseVersionIteration>') {
+                $preIter = [int]$Matches[1]
+            }
+        }
+    }
+
+    return @{
+        Tag       = "$major.0.$patch"
+        PreLabel  = $preLabel
+        PreIter   = $preIter
+    }
 }
 
-function ConvertTo-Milestone([string]$ReleaseTag) {
-    <# Converts "10.0.50" → ".NET 10 SR5", "10.0.41" → ".NET 10 SR4.1", "10.0.0" → ".NET 10.0 GA" #>
+function ConvertTo-Milestone([string]$ReleaseTag, [string]$PreLabel, [int]$PreIter) {
+    <# Converts version info to a milestone name:
+       "10.0.50"                    → ".NET 10 SR5"
+       "10.0.41"                    → ".NET 10 SR4.1"
+       "10.0.0"                     → ".NET 10.0 GA"
+       "11.0.0" + preview + 3       → ".NET 11.0-preview3"
+       "11.0.0" + rc + 1            → ".NET 11.0-rc1" #>
     if ($ReleaseTag -notmatch '^(\d+)\.0\.(\d+)$') { return $null }
     $major = [int]$Matches[1]; $patch = [int]$Matches[2]
+
+    # Pre-release: preview/rc milestones
+    if ($PreLabel -and $PreIter -gt 0) {
+        return ".NET $major.0-$PreLabel$PreIter"
+    }
+
     if ($patch -eq 0)  { return ".NET $major.0 GA" }
     if ($patch -lt 10) { return ".NET $major.0 SR1" }
     $sr = [math]::Floor($patch / 10)
@@ -460,10 +491,13 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
     } elseif ($pr.MergeCommitSha) {
         # No tag — read Versions.props at the merge commit to determine
         # the version the branch was building when this PR merged.
-        $versionAtMerge = Get-VersionFromGitRef $pr.MergeCommitSha $Repo
-        if ($versionAtMerge) {
-            $ReleaseTag = $versionAtMerge
-            Write-Host "  Version from Versions.props at merge commit: $ReleaseTag"
+        $versionInfo = Get-VersionFromGitRef $pr.MergeCommitSha $Repo
+        if ($versionInfo) {
+            $ReleaseTag = $versionInfo.Tag
+            $script:_preLabel = $versionInfo.PreLabel
+            $script:_preIter = $versionInfo.PreIter
+            $preDisplay = if ($versionInfo.PreLabel) { " ($($versionInfo.PreLabel)$($versionInfo.PreIter))" } else { "" }
+            Write-Host "  Version from Versions.props at merge commit: $ReleaseTag$preDisplay"
         }
     }
 
@@ -478,7 +512,9 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         Write-Host "  Found in: $prevDisplay..$ReleaseTag"
     }
 
-    $expectedMs = ConvertTo-Milestone $ReleaseTag
+    $preLabel = if ($script:_preLabel) { $script:_preLabel } else { $null }
+    $preIter = if ($script:_preIter) { $script:_preIter } else { 0 }
+    $expectedMs = ConvertTo-Milestone $ReleaseTag $preLabel $preIter
     if (-not $expectedMs) { throw "Cannot determine milestone for tag $ReleaseTag" }
 
     # Derive MajorVersion from the tag

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -312,7 +312,7 @@ function Find-TagContainingPr([int]$PrNum, [string]$Repo, [int]$Major) {
        Handles GA (first tag) by searching all reachable commits. #>
     $allTags = Get-AllTags $Repo
     $srTags = $allTags | Where-Object { Test-IsReleaseTag $_ $Major } |
-              Sort-Object { Get-PatchVersion $_ }
+              Sort-Object { Get-TagSortKey $_ }
 
     for ($i = 0; $i -lt $srTags.Count; $i++) {
         $current = $srTags[$i]
@@ -563,6 +563,12 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
             Write-Warning "PR #$PrNum is not in the commit range for tag $ReleaseTag. The milestone may be set incorrectly."
         }
         Write-Host "  Using explicit tag: $ReleaseTag"
+        # For preview/RC tags, read Versions.props at the tag to get pre-release info
+        $versionInfo = Get-VersionFromGitRef $ReleaseTag $Repo
+        if ($versionInfo) {
+            $preLabel = $versionInfo.PreLabel
+            $preIter = if ($versionInfo.PreIter) { $versionInfo.PreIter } else { 0 }
+        }
     } elseif ($pr.MergeCommitSha) {
         # Step 1: Check release branches first — find the earliest release containing this commit.
         # This is the most accurate signal for which release the PR actually ships in.
@@ -572,7 +578,7 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         $releaseBranch = Find-ReleaseBranchForCommit $pr.MergeCommitSha $Repo $detectedMajor
         if ($releaseBranch) {
             $expectedMs = $releaseBranch.Milestone
-            $ReleaseTag = $versionInfo.Tag
+            if ($versionInfo) { $ReleaseTag = $versionInfo.Tag }
             Write-Host "  Found in release branch: $($releaseBranch.Branch) → $expectedMs"
         } else {
             # Step 2: Fall back to Versions.props at the merge commit
@@ -599,7 +605,9 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
             Write-Host "  Found in: $prevDisplay..$ReleaseTag"
         }
 
-        $expectedMs = ConvertTo-Milestone $ReleaseTag $preLabel $preIter
+        # Use the clean version tag (e.g. "11.0.0") for milestone mapping, not the full tag
+        $cleanTag = if ($versionInfo) { $versionInfo.Tag } else { $ReleaseTag }
+        $expectedMs = ConvertTo-Milestone $cleanTag $preLabel $preIter
     }
     if (-not $expectedMs) { throw "Cannot determine milestone for PR #$PrNum" }
 

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -348,15 +348,16 @@ function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Ma
         if ($_ -match 'refs/heads/(.+)$') { $Matches[1] }
     } | Where-Object { $_ }
 
-    # Sort: GA first, then by type and number
+    # Sort: GA first, then SRs, then RCs, then previews.
+    # If a commit is reachable from both GA and a preview, GA wins.
     # GA: release/10.0.1xx (no suffix)
     # SR: release/10.0.1xx-sr1, sr2, ...
+    # RC: release/10.0.1xx-rc1, rc2, ...
     # Preview: release/11.0.1xx-preview1, preview2, ...
-    # RC: release/11.0.1xx-rc1, rc2, ...
     $sorted = $branches | Sort-Object {
-        if ($_ -match '-sr(\d+)$')      { return 1000 + [int]$Matches[1] }
-        if ($_ -match '-preview(\d+)$') { return 100  + [int]$Matches[1] }
-        if ($_ -match '-rc(\d+)$')      { return 2000 + [int]$Matches[1] }
+        if ($_ -match '-sr(\d+)$')      { return 100  + [int]$Matches[1] }
+        if ($_ -match '-rc(\d+)$')      { return 200  + [int]$Matches[1] }
+        if ($_ -match '-preview(\d+)$') { return 1000 + [int]$Matches[1] }
         return 0  # GA (no suffix) comes first
     }
 

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -348,16 +348,17 @@ function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Ma
         if ($_ -match 'refs/heads/(.+)$') { $Matches[1] }
     } | Where-Object { $_ }
 
-    # Sort: GA first, then SRs, then RCs, then previews.
+    # Sort: GA first, then SRs, then previews, then RCs.
     # If a commit is reachable from both GA and a preview, GA wins.
+    # Previews come before RCs because RCs are cut later in the cycle.
     # GA: release/10.0.1xx (no suffix)
     # SR: release/10.0.1xx-sr1, sr2, ...
-    # RC: release/10.0.1xx-rc1, rc2, ...
     # Preview: release/11.0.1xx-preview1, preview2, ...
+    # RC: release/11.0.1xx-rc1, rc2, ...
     $sorted = $branches | Sort-Object {
         if ($_ -match '-sr(\d+)$')      { return 100  + [int]$Matches[1] }
-        if ($_ -match '-rc(\d+)$')      { return 200  + [int]$Matches[1] }
-        if ($_ -match '-preview(\d+)$') { return 1000 + [int]$Matches[1] }
+        if ($_ -match '-preview(\d+)$') { return 200  + [int]$Matches[1] }
+        if ($_ -match '-rc(\d+)$')      { return 1000 + [int]$Matches[1] }
         return 0  # GA (no suffix) comes first
     }
 

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -178,7 +178,17 @@ function Get-PatchVersion([string]$ReleaseTag) {
 }
 
 function Test-IsReleaseTag([string]$ReleaseTag, [int]$Major) {
-    return ($ReleaseTag -match "^$Major\.0\.\d+$")
+    # Matches stable tags (10.0.50) and preview/RC tags (11.0.0-preview.3.26203.7)
+    return ($ReleaseTag -match "^$Major\.0\.")
+}
+
+function Get-TagSortKey([string]$ReleaseTag) {
+    <# Returns a numeric sort key for ordering tags chronologically.
+       preview1 (100) < preview7 (107) < rc1 (200) < rc2 (201) < GA/stable (500+patch) #>
+    if ($ReleaseTag -match '-preview\.(\d+)') { return 100 + [int]$Matches[1] }
+    if ($ReleaseTag -match '-rc\.(\d+)')      { return 200 + [int]$Matches[1] }
+    if ($ReleaseTag -match '^(\d+)\.0\.(\d+)$') { return 500 + [int]$Matches[2] }
+    return 0
 }
 
 function Test-MilestoneMatch([string]$Actual, [string]$Expected) {
@@ -212,11 +222,17 @@ function Find-MatchingMilestone([string]$Expected, [hashtable]$AllMilestones) {
 }
 
 function Find-PreviousTag([string]$ReleaseTag, [string[]]$AllTags) {
-    if ($ReleaseTag -notmatch '^(\d+)\.0\.(\d+)$') { return $null }
-    $major = [int]$Matches[1]; $patch = [int]$Matches[2]
+    <# Finds the immediately preceding tag for the same major version.
+       Works for both stable tags (10.0.50 → 10.0.41) and preview/RC tags
+       (11.0.0-preview.3.x → 11.0.0-preview.2.x). #>
+    if ($ReleaseTag -notmatch '^(\d+)\.') { return $null }
+    $major = [int]$Matches[1]
+    $thisKey = Get-TagSortKey $ReleaseTag
+
+    # Find all tags for this major version with a lower sort key
     $candidates = $AllTags | Where-Object {
-        $_ -match "^$major\.0\.(\d+)$" -and [int]$Matches[1] -lt $patch
-    } | Sort-Object { Get-PatchVersion $_ }
+        ($_ -match "^$major\.0\.") -and (Get-TagSortKey $_) -lt $thisKey
+    } | Sort-Object { Get-TagSortKey $_ }
     return ($candidates | Select-Object -Last 1)
 }
 
@@ -655,7 +671,18 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
 }
 
 function Invoke-AnalyzeRelease([string]$ReleaseTag, [string]$PrevTag, [string]$Repo) {
+    # Try direct tag-to-milestone mapping first (works for stable tags like 10.0.50)
     $expectedMs = ConvertTo-Milestone $ReleaseTag
+
+    # If that fails, read Versions.props at the tag (works for preview/RC tags like 11.0.0-preview.3.26203.7)
+    if (-not $expectedMs) {
+        $versionInfo = Get-VersionFromGitRef $ReleaseTag $Repo
+        if ($versionInfo) {
+            $preLabel = $versionInfo.PreLabel
+            $preIter = if ($versionInfo.PreIter) { $versionInfo.PreIter } else { 0 }
+            $expectedMs = ConvertTo-Milestone $versionInfo.Tag $preLabel $preIter
+        }
+    }
     if (-not $expectedMs) { throw "Cannot determine milestone for tag $ReleaseTag" }
 
     # Derive MajorVersion from the tag

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -523,6 +523,10 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
     Write-Host "  Single-PR mode: #$PrNum"
     Write-Host "$('═' * 70)`n"
 
+    $expectedMs = $null
+    $script:_preLabel = $null
+    $script:_preIter = $null
+
     # Fetch PR info first — we need merge_commit_sha for version detection
     $pr = Get-PrInfo $PrNum
     if (-not $pr) { throw "Could not fetch PR #$PrNum" }
@@ -582,10 +586,16 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         $preIter = if ($script:_preIter) { $script:_preIter } else { 0 }
         $expectedMs = ConvertTo-Milestone $ReleaseTag $preLabel $preIter
     }
-    if (-not $expectedMs) { throw "Cannot determine milestone for tag $ReleaseTag" }
+    if (-not $expectedMs) { throw "Cannot determine milestone for PR #$PrNum" }
 
-    # Derive MajorVersion from the tag
-    $Major = if ($ReleaseTag -match '^(\d+)\.') { [int]$Matches[1] } else { Get-CurrentMajorVersion $Repo }
+    # Derive MajorVersion from the milestone name, tag, or Versions.props
+    $Major = if ($expectedMs -match '\.NET (\d+)') {
+        [int]$Matches[1]
+    } elseif ($ReleaseTag -and $ReleaseTag -match '^(\d+)\.') {
+        [int]$Matches[1]
+    } else {
+        Get-CurrentMajorVersion $Repo
+    }
 
     # Detect which branch owns this version's tags
     $Branch = Get-MainBranchForVersion $Major $Repo

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -163,6 +163,9 @@ function ConvertTo-Milestone([string]$ReleaseTag, [string]$PreLabel, [int]$PreIt
     if ($PreLabel -and $PreIter -gt 0) {
         return ".NET $major.0-$PreLabel$PreIter"
     }
+    if ($PreLabel -and $PreIter -le 0) {
+        Write-Warning "PreReleaseVersionLabel is '$PreLabel' but PreReleaseVersionIteration is missing or 0 — falling back to GA/SR mapping"
+    }
 
     if ($patch -eq 0)  { return ".NET $major.0 GA" }
     if ($patch -lt 10) { return ".NET $major.0 SR1" }
@@ -542,6 +545,7 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
     $expectedMs = $null
     $preLabel = $null
     $preIter = 0
+    $versionInfo = $null
 
     # Fetch PR info first — we need merge_commit_sha for version detection
     $pr = Get-PrInfo $PrNum
@@ -608,6 +612,17 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         # Use the clean version tag (e.g. "11.0.0") for milestone mapping, not the full tag
         $cleanTag = if ($versionInfo) { $versionInfo.Tag } else { $ReleaseTag }
         $expectedMs = ConvertTo-Milestone $cleanTag $preLabel $preIter
+
+        # If ConvertTo-Milestone failed (e.g. $cleanTag is a preview tag string),
+        # read Versions.props at the tag to get clean version + pre-release info
+        if (-not $expectedMs -and $ReleaseTag) {
+            $tagVersionInfo = Get-VersionFromGitRef $ReleaseTag $Repo
+            if ($tagVersionInfo) {
+                $preLabel = $tagVersionInfo.PreLabel
+                $preIter = if ($tagVersionInfo.PreIter) { $tagVersionInfo.PreIter } else { 0 }
+                $expectedMs = ConvertTo-Milestone $tagVersionInfo.Tag $preLabel $preIter
+            }
+        }
     }
     if (-not $expectedMs) { throw "Cannot determine milestone for PR #$PrNum" }
 

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -100,8 +100,8 @@ function Get-MainBranchForVersion([int]$Major, [string]$Repo) {
 function Get-VersionFromGitRef([string]$GitRef, [string]$Repo) {
     <# Reads version info from eng/Versions.props at a specific git ref.
        Returns a hashtable with Tag (synthetic release tag like "10.0.60"),
-       PreReleaseLabel (e.g. "preview", "rc", or $null for stable),
-       and PreReleaseIteration (e.g. 3).
+       PreLabel (e.g. "preview", "rc", or $null for stable),
+       and PreIter (e.g. 3).
        Fetches the commit if not available locally (e.g. PRs merged to inflight). #>
     $versionXml = git -C $Repo --no-pager show "${GitRef}:eng/Versions.props" 2>&1
     if ($LASTEXITCODE -ne 0) {
@@ -337,7 +337,7 @@ function ConvertBranchToMilestone([string]$BranchName) {
 
 function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Major) {
     <# Finds the earliest release branch containing a commit.
-       Checks GA branch first, then SR/preview/RC branches in order.
+       Checks in chronological order: previews → RCs → GA → SRs.
        Returns @{ Branch; Milestone } or $null. #>
 
     # Fetch all release branches for this major version
@@ -363,7 +363,7 @@ function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Ma
     foreach ($branch in $sorted) {
         # Make sure we have the branch ref locally
         $null = git -C $Repo fetch origin $branch --quiet 2>&1
-        $isAncestor = git -C $Repo merge-base --is-ancestor $CommitSha "origin/$branch" 2>&1
+        $null = git -C $Repo merge-base --is-ancestor $CommitSha "origin/$branch" 2>&1
         if ($LASTEXITCODE -eq 0) {
             $milestone = ConvertBranchToMilestone $branch
             if ($milestone) {
@@ -524,8 +524,8 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
     Write-Host "$('═' * 70)`n"
 
     $expectedMs = $null
-    $script:_preLabel = $null
-    $script:_preIter = $null
+    $preLabel = $null
+    $preIter = 0
 
     # Fetch PR info first — we need merge_commit_sha for version detection
     $pr = Get-PrInfo $PrNum
@@ -556,13 +556,14 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         $releaseBranch = Find-ReleaseBranchForCommit $pr.MergeCommitSha $Repo $detectedMajor
         if ($releaseBranch) {
             $expectedMs = $releaseBranch.Milestone
+            $ReleaseTag = $versionInfo.Tag
             Write-Host "  Found in release branch: $($releaseBranch.Branch) → $expectedMs"
         } else {
             # Step 2: Fall back to Versions.props at the merge commit
             if ($versionInfo) {
                 $ReleaseTag = $versionInfo.Tag
-                $script:_preLabel = $versionInfo.PreLabel
-                $script:_preIter = $versionInfo.PreIter
+                $preLabel = $versionInfo.PreLabel
+                $preIter = if ($versionInfo.PreIter) { $versionInfo.PreIter } else { 0 }
                 $preDisplay = if ($versionInfo.PreLabel) { " ($($versionInfo.PreLabel)$($versionInfo.PreIter))" } else { "" }
                 Write-Host "  Version from Versions.props at merge commit: $ReleaseTag$preDisplay"
             }
@@ -582,8 +583,6 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
             Write-Host "  Found in: $prevDisplay..$ReleaseTag"
         }
 
-        $preLabel = if ($script:_preLabel) { $script:_preLabel } else { $null }
-        $preIter = if ($script:_preIter) { $script:_preIter } else { 0 }
         $expectedMs = ConvertTo-Milestone $ReleaseTag $preLabel $preIter
     }
     if (-not $expectedMs) { throw "Cannot determine milestone for PR #$PrNum" }

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -317,9 +317,65 @@ function Find-TagContainingPr([int]$PrNum, [string]$Repo, [int]$Major) {
     return $null
 }
 
-#endregion
+function ConvertBranchToMilestone([string]$BranchName) {
+    <# Converts a release branch name to a milestone name:
+       release/10.0.1xx        → ".NET 10.0 GA"
+       release/10.0.1xx-sr5    → ".NET 10 SR5"
+       release/11.0.1xx-preview3 → ".NET 11.0-preview3"
+       release/11.0.1xx-rc1    → ".NET 11.0-rc1" #>
+    if ($BranchName -match '^release/(\d+)\.0\.\d+xx$') {
+        return ".NET $([int]$Matches[1]).0 GA"
+    }
+    if ($BranchName -match '^release/(\d+)\.0\.\d+xx-sr(\d+)$') {
+        return ".NET $([int]$Matches[1]) SR$([int]$Matches[2])"
+    }
+    if ($BranchName -match '^release/(\d+)\.0\.\d+xx-(preview|rc)(\d+)$') {
+        return ".NET $([int]$Matches[1]).0-$($Matches[2])$([int]$Matches[3])"
+    }
+    return $null
+}
 
-#region ── GitHub helpers ─────────────────────────────────────────────────
+function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Major) {
+    <# Finds the earliest release branch containing a commit.
+       Checks GA branch first, then SR/preview/RC branches in order.
+       Returns @{ Branch; Milestone } or $null. #>
+
+    # Fetch all release branches for this major version
+    $remoteBranches = git -C $Repo --no-pager ls-remote --heads origin "refs/heads/release/$Major.0.*" 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not $remoteBranches) { return $null }
+
+    $branches = ($remoteBranches -split "`n") | ForEach-Object {
+        if ($_ -match 'refs/heads/(.+)$') { $Matches[1] }
+    } | Where-Object { $_ }
+
+    # Sort: GA first, then by type and number
+    # GA: release/10.0.1xx (no suffix)
+    # SR: release/10.0.1xx-sr1, sr2, ...
+    # Preview: release/11.0.1xx-preview1, preview2, ...
+    # RC: release/11.0.1xx-rc1, rc2, ...
+    $sorted = $branches | Sort-Object {
+        if ($_ -match '-sr(\d+)$')      { return 1000 + [int]$Matches[1] }
+        if ($_ -match '-preview(\d+)$') { return 100  + [int]$Matches[1] }
+        if ($_ -match '-rc(\d+)$')      { return 2000 + [int]$Matches[1] }
+        return 0  # GA (no suffix) comes first
+    }
+
+    # Fetch branch tips and check ancestry
+    foreach ($branch in $sorted) {
+        # Make sure we have the branch ref locally
+        $null = git -C $Repo fetch origin $branch --quiet 2>&1
+        $isAncestor = git -C $Repo merge-base --is-ancestor $CommitSha "origin/$branch" 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $milestone = ConvertBranchToMilestone $branch
+            if ($milestone) {
+                return @{ Branch = $branch; Milestone = $milestone }
+            }
+        }
+    }
+    return $null
+}
+
+#endregion
 
 function Invoke-GhApi([string]$Endpoint) {
     $result = gh api $Endpoint 2>&1
@@ -489,32 +545,44 @@ function Invoke-AnalyzeSinglePr([int]$PrNum, [string]$ReleaseTag, [string]$Repo)
         }
         Write-Host "  Using explicit tag: $ReleaseTag"
     } elseif ($pr.MergeCommitSha) {
-        # No tag — read Versions.props at the merge commit to determine
-        # the version the branch was building when this PR merged.
+        # Step 1: Check release branches first — find the earliest release containing this commit.
+        # This is the most accurate signal for which release the PR actually ships in.
         $versionInfo = Get-VersionFromGitRef $pr.MergeCommitSha $Repo
-        if ($versionInfo) {
-            $ReleaseTag = $versionInfo.Tag
-            $script:_preLabel = $versionInfo.PreLabel
-            $script:_preIter = $versionInfo.PreIter
-            $preDisplay = if ($versionInfo.PreLabel) { " ($($versionInfo.PreLabel)$($versionInfo.PreIter))" } else { "" }
-            Write-Host "  Version from Versions.props at merge commit: $ReleaseTag$preDisplay"
+        $detectedMajor = if ($versionInfo -and $versionInfo.Tag -match '^(\d+)\.') { [int]$Matches[1] } else { Get-CurrentMajorVersion $Repo }
+
+        $releaseBranch = Find-ReleaseBranchForCommit $pr.MergeCommitSha $Repo $detectedMajor
+        if ($releaseBranch) {
+            $expectedMs = $releaseBranch.Milestone
+            Write-Host "  Found in release branch: $($releaseBranch.Branch) → $expectedMs"
+        } else {
+            # Step 2: Fall back to Versions.props at the merge commit
+            if ($versionInfo) {
+                $ReleaseTag = $versionInfo.Tag
+                $script:_preLabel = $versionInfo.PreLabel
+                $script:_preIter = $versionInfo.PreIter
+                $preDisplay = if ($versionInfo.PreLabel) { " ($($versionInfo.PreLabel)$($versionInfo.PreIter))" } else { "" }
+                Write-Host "  Version from Versions.props at merge commit: $ReleaseTag$preDisplay"
+            }
         }
     }
 
-    # Fallback: try to find in existing tag ranges
-    if (-not $ReleaseTag) {
-        Write-Host "Auto-detecting release tag for PR #$PrNum..."
-        $fallbackMajor = Get-CurrentMajorVersion $Repo
-        $found = Find-TagContainingPr $PrNum $Repo $fallbackMajor
-        if (-not $found) { throw "PR #$PrNum not found in any release tag range for .NET $fallbackMajor" }
-        $ReleaseTag = $found.Tag
-        $prevDisplay = if ($found.PreviousTag) { $found.PreviousTag } else { "(root)" }
-        Write-Host "  Found in: $prevDisplay..$ReleaseTag"
-    }
+    # Determine expected milestone if not already set by release branch detection
+    if (-not $expectedMs) {
+        # Fallback: try to find in existing tag ranges
+        if (-not $ReleaseTag) {
+            Write-Host "Auto-detecting release tag for PR #$PrNum..."
+            $fallbackMajor = Get-CurrentMajorVersion $Repo
+            $found = Find-TagContainingPr $PrNum $Repo $fallbackMajor
+            if (-not $found) { throw "PR #$PrNum not found in any release tag range for .NET $fallbackMajor" }
+            $ReleaseTag = $found.Tag
+            $prevDisplay = if ($found.PreviousTag) { $found.PreviousTag } else { "(root)" }
+            Write-Host "  Found in: $prevDisplay..$ReleaseTag"
+        }
 
-    $preLabel = if ($script:_preLabel) { $script:_preLabel } else { $null }
-    $preIter = if ($script:_preIter) { $script:_preIter } else { 0 }
-    $expectedMs = ConvertTo-Milestone $ReleaseTag $preLabel $preIter
+        $preLabel = if ($script:_preLabel) { $script:_preLabel } else { $null }
+        $preIter = if ($script:_preIter) { $script:_preIter } else { 0 }
+        $expectedMs = ConvertTo-Milestone $ReleaseTag $preLabel $preIter
+    }
     if (-not $expectedMs) { throw "Cannot determine milestone for tag $ReleaseTag" }
 
     # Derive MajorVersion from the tag

--- a/.github/scripts/Fix-MilestoneDrift.ps1
+++ b/.github/scripts/Fix-MilestoneDrift.ps1
@@ -348,18 +348,15 @@ function Find-ReleaseBranchForCommit([string]$CommitSha, [string]$Repo, [int]$Ma
         if ($_ -match 'refs/heads/(.+)$') { $Matches[1] }
     } | Where-Object { $_ }
 
-    # Sort: GA first, then SRs, then previews, then RCs.
-    # If a commit is reachable from both GA and a preview, GA wins.
-    # Previews come before RCs because RCs are cut later in the cycle.
-    # GA: release/10.0.1xx (no suffix)
-    # SR: release/10.0.1xx-sr1, sr2, ...
-    # Preview: release/11.0.1xx-preview1, preview2, ...
-    # RC: release/11.0.1xx-rc1, rc2, ...
+    # Sort by chronological release order within a major version:
+    # preview1, preview2, ..., rc1, rc2, GA, sr1, sr2, ...
+    # A commit in both preview7 and GA should be milestoned preview7
+    # (that's where it first shipped).
     $sorted = $branches | Sort-Object {
-        if ($_ -match '-sr(\d+)$')      { return 100  + [int]$Matches[1] }
-        if ($_ -match '-preview(\d+)$') { return 200  + [int]$Matches[1] }
-        if ($_ -match '-rc(\d+)$')      { return 1000 + [int]$Matches[1] }
-        return 0  # GA (no suffix) comes first
+        if ($_ -match '-preview(\d+)$') { return 100  + [int]$Matches[1] }
+        if ($_ -match '-rc(\d+)$')      { return 200  + [int]$Matches[1] }
+        if ($_ -match '-sr(\d+)$')      { return 1000 + [int]$Matches[1] }
+        return 500  # GA (no suffix) — after previews/RCs, before SRs
     }
 
     # Fetch branch tips and check ancestry

--- a/.github/workflows/fix-milestone-drift.yml
+++ b/.github/workflows/fix-milestone-drift.yml
@@ -29,7 +29,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   manage-milestones:


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

Follow-up to #34686. Adds preview/RC milestone support and release branch detection to the milestone drift fixer.

## Problem

PRs merged to \`net11.0\` were not being milestoned because \`Versions.props\` on that branch always has \`PreReleaseVersionIteration=1\` regardless of which preview the PR actually ships in. The iteration is only bumped on release branches.

## Solution

### Release Branch Detection (Primary)

New detection step checks release branches first using \`merge-base --is-ancestor\`. For each PR, it finds the **earliest** release branch containing the merge commit:

| Release Branch | Milestone |
|---|---|
| \`release/10.0.1xx\` | \`.NET 10.0 GA\` |
| \`release/10.0.1xx-sr5\` | \`.NET 10 SR5\` |
| \`release/11.0.1xx-preview1\` | \`.NET 11.0-preview1\` |
| \`release/11.0.1xx-preview3\` | \`.NET 11.0-preview3\` |
| \`release/12.0.1xx-rc1\` | \`.NET 12.0-rc1\` |

### Detection Order

1. **Explicit \`-Tag\`** — if provided
2. **Release branches** — \`merge-base --is-ancestor\` against \`release/{Major}.0.1xx-*\` branches, earliest match wins
3. **Versions.props** at merge commit — fallback for PRs not yet on any release branch
4. **Tag range search** — last resort

### Preview/RC Milestone Mapping

\`ConvertTo-Milestone\` now accepts optional pre-release label and iteration:

| Input | Milestone |
|---|---|
| \`11.0.0 + preview + 3\` | \`.NET 11.0-preview3\` |
| \`12.0.0 + rc + 1\` | \`.NET 12.0-rc1\` |
| \`10.0.60\` (stable) | \`.NET 10 SR6\` (unchanged) |

## Validated Results

| PR | Base | Current Milestone | Script Result | Method |
|---|---|---|---|---|
| #33524 | net11.0 | .NET 11.0-preview1 | .NET 11.0-preview1 ✅ | Release branch |
| #33233 | net11.0 | .NET 11.0-preview1 | .NET 11.0-preview1 ✅ | Release branch |
| #30132 | net11.0 | .NET 11.0-preview3 | .NET 11.0-preview3 ✅ | Release branch |
| #33834 | net11.0 | .NET 11.0-preview3 | .NET 11.0-preview3 ✅ | Release branch |
| #34214 | net11.0 | .NET 11.0-preview2 | .NET 11.0-preview3 ✅ | Release branch (drift caught!) |
| #34945 | net11.0 | .NET 11.0-preview4 | preview1 (fallback) | Versions.props (no p4 branch yet) |
| #34620 | main | .NET 10 SR6 | .NET 10 SR6 ✅ | Release branch |
| #34047 | main | .NET 10 SR4.1 | .NET 10 SR5 ✅ | Release branch (drift caught!) |

PR #34214 is a real drift example: milestoned preview2 by a human, but actually on the preview3 release branch.

## Test Suite

88 Pester tests (11 new):
- 6 for \`ConvertTo-Milestone\` preview/RC mapping
- 5 for \`ConvertBranchToMilestone\` (GA, SR, preview, RC, non-release)
