### PR TITLE
[Android] Fix VerifyFlowDirectionRTLCanReorderItemsTrueWithCanMixGroups test failure regression

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/ReorderableItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/ReorderableItemsViewAdapter.cs
@@ -37,9 +37,23 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var toItemsSource = itemsSource.GetGroupItemsViewSource(toGroupIndex);
 				var toItemIndex = toIndex - (toItemsSource?.HasHeader == true ? 1 : 0);
 
-				if (toGroupIndex > fromGroupIndex)
+				if (toGroupIndex != fromGroupIndex)
 				{
-					toItemIndex = toItemIndex + 1;
+					// When targeting the group header of a non-empty group, block the move.
+					// This prevents an item from being prematurely inserted at the start of the
+					// group as the drag passes over its header. Dropping onto an empty group's
+					// header is still allowed to support the empty-group drag scenario.
+					if (toItemsSource?.HasHeader == true && toIndex == 0 && toList?.Count > 0)
+					{
+						return false;
+					}
+
+					// When moving forward into a different group, adjust the target index
+					// to insert after the resolved position rather than before it.
+					if (toGroupIndex > fromGroupIndex)
+					{
+						toItemIndex = toItemIndex + 1;
+					}
 				}
 
 				if (toGroupIndex != fromGroupIndex && !itemsView.CanMixGroups)


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Description

Fixes a regression introduced by PR #31867, where all grouped CollectionView drag-and-drop reorder tests fail on Android — most visibly `VerifyFlowDirectionRTLCanReorderItemsTrueWithCanMixGroups`.

### Root cause

PR #31867 changed SimpleItemTouchHelperCallback.OnMove from checking the target view type to checking the source view type, so that items can be dropped onto empty group headers. The side effect: OnItemMove can now be called with a non-empty group's GroupHeader as toPosition.

When dragging an item forward past the next group's header (e.g., "Banana" toward "Potato"), OnItemMove fires with the GroupHeader as target and prematurely inserts the item mid-gesture, before the drop is intentional.

LTR tests pass accidentally — the premature insertion moves the item downward, so the newY > initialY assertion coincidentally passes.
RTL test fails — the mid-gesture NotifyItemMoved causes a layout pass that makes ItemTouchHelper's internal gesture offset stale in RTL coordinate space, aborting the drag and leaving newY == initialY.


### Description of Change
Added a guard in `ReorderableItemsViewAdapter.OnItemMove:` when the drag targets a non-empty group's header (toIndex == 0, HasHeader == true, Count > 0), return false immediately — no data mutation, drag continues cleanly. Empty group headers are still allowed as drop targets, preserving the original PR #31867 intent.


### Issues Fixed

- Regression introduced by PR #31867
- **Resolved test case:** VerifyFlowDirectionRTLCanReorderItemsTrueWithCanMixGroups

### Output
| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/e61cb83d-d631-4a75-9715-85366cad9593"> | <img src="https://github.com/user-attachments/assets/9f10fd8b-f173-426d-ae54-79daa82beb56">|