### PR TITLE
[iOS] Fix ContentPage with ToolbarItem Clicked event leaks when presented as modal page

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
@@ -87,6 +87,12 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var modal = CurrentPlatformModalPage;
 			_platformModalPages.Remove(modal);
+			// iOS maps page ToolbarItems to native UIBarButtonItem instances.
+			// In Modal + NavigationPage scenarios, those wrappers can outlive the managed page
+			// briefly during dismiss and keep toolbar callbacks rooted, which delays collection
+			// of the popped modal page. Clearing ToolbarItems before DismissViewControllerAsync
+			// breaks that retention chain early so pop can complete without leaking page references.
+			ClearToolbarItemsForModalPop(modal);
 
 			var controller = (modal.Handler as IPlatformViewHandler)?.ViewController;
 
@@ -101,6 +107,38 @@ namespace Microsoft.Maui.Controls.Platform
 			// this will usually happen as a result of swapping out the content on the window
 			// which is what was acting as the PresentingViewController
 			return modal;
+		}
+
+		static void ClearToolbarItemsForModalPop(Page modal)
+		{
+			if (modal is null)
+			{
+				return;
+			}
+
+			ClearToolbarItems(modal);
+
+			if (modal is NavigationPage navigationPage)
+			{
+				var current = navigationPage.CurrentPage;
+				if (current is not null && current != modal)
+				{
+					ClearToolbarItems(current);
+				}
+			}
+		}
+
+		static void ClearToolbarItems(Page page)
+		{
+			if (page.ToolbarItems.Count == 0)
+			{
+				return;
+			}
+
+			for (var i = page.ToolbarItems.Count - 1; i >= 0; i--)
+			{
+				page.ToolbarItems.RemoveAt(i);
+			}
 		}
 
 		Task PushModalPlatformAsync(Page modal, bool animated)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
@@ -105,17 +105,6 @@ namespace Microsoft.Maui.Controls.Platform
 			return modal;
 		}
 
-		static void DisconnectHandlersForModalPop(Page modal)
-		{
-			if (modal is null)
-			{
-				return;
-			}
-
-			// Disconnect the popped page's handler to break native wrapper retention chains
-			modal.Handler?.DisconnectHandler();
-		}
-
 		Task PushModalPlatformAsync(Page modal, bool animated)
 		{
 			EndEditing();

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
@@ -87,12 +87,6 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			var modal = CurrentPlatformModalPage;
 			_platformModalPages.Remove(modal);
-			// iOS maps page ToolbarItems to native UIBarButtonItem instances.
-			// In Modal + NavigationPage scenarios, those wrappers can outlive the managed page
-			// briefly during dismiss and keep toolbar callbacks rooted, which delays collection
-			// of the popped modal page. Clearing ToolbarItems before DismissViewControllerAsync
-			// breaks that retention chain early so pop can complete without leaking page references.
-			ClearToolbarItemsForModalPop(modal);
 
 			var controller = (modal.Handler as IPlatformViewHandler)?.ViewController;
 
@@ -100,6 +94,7 @@ namespace Microsoft.Maui.Controls.Platform
 				modalWrapper.PresentingViewController is not null)
 			{
 				await modalWrapper.PresentingViewController.DismissViewControllerAsync(animated);
+				DisconnectHandlersForModalPop(modal);
 				return modal;
 			}
 
@@ -109,36 +104,15 @@ namespace Microsoft.Maui.Controls.Platform
 			return modal;
 		}
 
-		static void ClearToolbarItemsForModalPop(Page modal)
+		static void DisconnectHandlersForModalPop(Page modal)
 		{
 			if (modal is null)
 			{
 				return;
 			}
 
-			ClearToolbarItems(modal);
-
-			if (modal is NavigationPage navigationPage)
-			{
-				var current = navigationPage.CurrentPage;
-				if (current is not null && current != modal)
-				{
-					ClearToolbarItems(current);
-				}
-			}
-		}
-
-		static void ClearToolbarItems(Page page)
-		{
-			if (page.ToolbarItems.Count == 0)
-			{
-				return;
-			}
-
-			for (var i = page.ToolbarItems.Count - 1; i >= 0; i--)
-			{
-				page.ToolbarItems.RemoveAt(i);
-			}
+			// Disconnect the popped page's handler to break native wrapper retention chains
+			modal.Handler?.DisconnectHandler();
 		}
 
 		Task PushModalPlatformAsync(Page modal, bool animated)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Maui.Controls.Platform
 			// if the presenting VC is null that means the modal window was already dismissed
 			// this will usually happen as a result of swapping out the content on the window
 			// which is what was acting as the PresentingViewController
+			DisposeHelpers.DisposeModalAndChildHandlers(modal);
 			return modal;
 		}
 

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using Microsoft.Maui.Platform;
@@ -94,7 +95,7 @@ namespace Microsoft.Maui.Controls.Platform
 				modalWrapper.PresentingViewController is not null)
 			{
 				await modalWrapper.PresentingViewController.DismissViewControllerAsync(animated);
-				DisconnectHandlersForModalPop(modal);
+				DisposeHelpers.DisposeModalAndChildHandlers(modal);
 				return modal;
 			}
 

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34892.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34892.cs
@@ -1,0 +1,168 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 34892, "ContentPage with ToolbarItem Clicked event leaks when presented as modal page", PlatformAffected.iOS)]
+public class Issue34892 : Shell
+{
+	public Issue34892()
+	{
+		Items.Add(new ShellContent
+		{
+			ContentTemplate = new DataTemplate(() => new Issue34892MainPage())
+		});
+	}
+}
+
+public class Issue34892MainPage : ContentPage
+{
+	readonly List<WeakReference> _pageRefs = new List<WeakReference>();
+	readonly Label _statusLabel;
+
+	public Issue34892MainPage()
+	{
+		Title = "ToolbarItem Leak Repro";
+
+		var pushLeakPageModalButton = new Button
+		{
+			Text = "Push LeakPage (Modal)",
+			AutomationId = "PushLeakPageModalButton"
+		};
+		pushLeakPageModalButton.Clicked += OnPushLeakPageModal;
+
+		var forceGcButton = new Button
+		{
+			Text = "Force GC & Check",
+			AutomationId = "ForceGCButton"
+		};
+		forceGcButton.Clicked += OnForceGC;
+
+		_statusLabel = new Label
+		{
+			AutomationId = "StatusLabel",
+			FontSize = 14,
+			TextColor = Colors.Red
+		};
+
+		Content = new VerticalStackLayout
+		{
+			Padding = new Thickness(30),
+			Spacing = 20,
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				pushLeakPageModalButton,
+				forceGcButton,
+				_statusLabel
+			}
+		};
+	}
+
+	async void OnPushLeakPage(object sender, EventArgs e)
+	{
+		var page = new Issue34892LeakPage();
+		_pageRefs.Add(new WeakReference(page));
+		await Navigation.PushAsync(page);
+	}
+
+	async void OnPushLeakPageModal(object sender, EventArgs e)
+	{
+		var page = new Issue34892LeakPage();
+		_pageRefs.Add(new WeakReference(page));
+		await Navigation.PushModalAsync(new NavigationPage(page));
+	}
+
+	async void OnForceGC(object sender, EventArgs e)
+	{
+		for (var i = 0; i < 10; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			await Task.Delay(100);
+		}
+
+		var alive = 0;
+		var collected = 0;
+
+		foreach (var wr in _pageRefs)
+		{
+			if (wr.IsAlive)
+			{
+				alive++;
+			}
+			else
+			{
+				collected++;
+			}
+		}
+
+		var message = $"Still alive: {alive}";
+		_statusLabel.Text = message;
+	}
+}
+
+public class Issue34892LeakPage : ContentPage
+{
+	static int _instanceCount;
+	readonly int _id;
+
+	public Issue34892LeakPage()
+	{
+		Title = "Leak Page";
+		_id = ++_instanceCount;
+
+		var toolbarItem = new ToolbarItem
+		{
+			Text = "Action"
+		};
+		toolbarItem.Clicked += OnToolbarItemClicked;
+		ToolbarItems.Add(toolbarItem);
+
+		var closeButton = new Button
+		{
+			Text = "Close",
+			AutomationId = "LeakPageCloseButton"
+		};
+		closeButton.Clicked += OnCloseClicked;
+
+		Content = new VerticalStackLayout
+		{
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			Spacing = 20,
+			Children =
+			{
+				new Label
+				{
+					Text = "This page has a ToolbarItem with a Clicked event.",
+					HorizontalOptions = LayoutOptions.Center
+				},
+				new Label
+				{
+					Text = "Dismiss this page and check if it gets collected.",
+					HorizontalOptions = LayoutOptions.Center
+				},
+				closeButton
+			}
+		};
+	}
+
+	void OnToolbarItemClicked(object sender, EventArgs e)
+	{
+	}
+
+	async void OnCloseClicked(object sender, EventArgs e)
+	{
+		if (Navigation.ModalStack.Count > 0)
+		{
+			await Navigation.PopModalAsync();
+		}
+		else
+		{
+			await Navigation.PopAsync();
+		}
+	}
+
+	~Issue34892LeakPage()
+	{
+	}
+}

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue34892.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue34892.cs
@@ -56,13 +56,6 @@ public class Issue34892MainPage : ContentPage
 		};
 	}
 
-	async void OnPushLeakPage(object sender, EventArgs e)
-	{
-		var page = new Issue34892LeakPage();
-		_pageRefs.Add(new WeakReference(page));
-		await Navigation.PushAsync(page);
-	}
-
 	async void OnPushLeakPageModal(object sender, EventArgs e)
 	{
 		var page = new Issue34892LeakPage();
@@ -72,31 +65,14 @@ public class Issue34892MainPage : ContentPage
 
 	async void OnForceGC(object sender, EventArgs e)
 	{
-		for (var i = 0; i < 10; i++)
+		try
 		{
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
-			await Task.Delay(100);
+			await GarbageCollectionHelper.WaitForGC(2000, _pageRefs.ToArray());
 		}
+		catch { }
 
-		var alive = 0;
-		var collected = 0;
-
-		foreach (var wr in _pageRefs)
-		{
-			if (wr.IsAlive)
-			{
-				alive++;
-			}
-			else
-			{
-				collected++;
-			}
-		}
-
-		var message = $"Still alive: {alive}";
-		_statusLabel.Text = message;
+		var alive = _pageRefs.Count(wr => wr.IsAlive);
+		_statusLabel.Text = $"Still alive: {alive}";
 	}
 }
 
@@ -162,7 +138,4 @@ public class Issue34892LeakPage : ContentPage
 		}
 	}
 
-	~Issue34892LeakPage()
-	{
-	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34892.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34892.cs
@@ -23,7 +23,8 @@ public class Issue34892 : _IssuesUITest
 		App.WaitForElement("ForceGCButton");
 		App.Tap("ForceGCButton");
 		App.WaitForElement("StatusLabel");
-		Assert.That(App.WaitForElement("StatusLabel"), Is.EqualTo("Still alive: 0"));
+		Thread.Sleep(1000); // Allow some time for the GC to finalize objects
+		Assert.That(App.WaitForElement("StatusLabel").GetText(), Is.EqualTo("Still alive: 0"));
 
 		App.WaitForElement("PushLeakPageModalButton");
 		App.Tap("PushLeakPageModalButton");
@@ -32,6 +33,7 @@ public class Issue34892 : _IssuesUITest
 		App.WaitForElement("ForceGCButton");
 		App.Tap("ForceGCButton");
 		App.WaitForElement("StatusLabel");
-		Assert.That(App.WaitForElement("StatusLabel"), Is.EqualTo("Still alive: 0"));
+		Thread.Sleep(1000); // Allow some time for the GC to finalize objects
+		Assert.That(App.WaitForElement("StatusLabel").GetText(), Is.EqualTo("Still alive: 0"));
 	}
 }

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34892.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue34892.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue34892 : _IssuesUITest
+{
+	public Issue34892(TestDevice device) : base(device)
+	{
+	}
+
+	public override string Issue => "ContentPage with ToolbarItem Clicked event leaks when presented as modal page";
+
+	[Test]
+	[Category(UITestCategories.ToolbarItem)]
+	public void ToolbarItemClickedHandlerDoesNotLeakModalPage()
+	{
+		App.WaitForElement("PushLeakPageModalButton");
+		App.Tap("PushLeakPageModalButton");
+		App.WaitForElement("LeakPageCloseButton");
+		App.Tap("LeakPageCloseButton");
+		App.WaitForElement("ForceGCButton");
+		App.Tap("ForceGCButton");
+		App.WaitForElement("StatusLabel");
+		Assert.That(App.WaitForElement("StatusLabel"), Is.EqualTo("Still alive: 0"));
+
+		App.WaitForElement("PushLeakPageModalButton");
+		App.Tap("PushLeakPageModalButton");
+		App.WaitForElement("LeakPageCloseButton");
+		App.Tap("LeakPageCloseButton");
+		App.WaitForElement("ForceGCButton");
+		App.Tap("ForceGCButton");
+		App.WaitForElement("StatusLabel");
+		Assert.That(App.WaitForElement("StatusLabel"), Is.EqualTo("Still alive: 0"));
+	}
+}


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

<!-- Please keep the note below for people who find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment whether this change resolves your issue. Thank you!<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->
### Issue Details
When a page with a ToolbarItem + Clicked handler was pushed as a modal wrapped in NavigationPage, then popped via PopModalAsync(), the page was not garbage collected.

### Root Cause
iOS maps ToolbarItems → native UIBarButtonItem wrappers at push time. Those wrappers subscribe to Clicked/PropertyChanged on the ToolbarItem. On modal pop, iOS defers the native dismiss animation, so the UIBarButtonItem objects briefly outlive the managed page. That keeps the ToolbarItem event handler references rooted, preventing the page from being collected.

### Description of Change

<!-- Enter description of the fix in this section -->
Added handler disposal in both dismissal branches:
* After successful dismiss via presenting controller
* In the fallback branch when presenting controller is already null

Note : The user mentioned that this issue was reproduced on Android, but it is not reproducible in the latest source. It seems to be resolved on the Android platform. So fix added only for iOS.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #34892 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->

**Tested the behavior in the following platforms.**
- [x] Android
- [x] Windows
- [x] iOS
- [x] Mac


| Before  | After  |
|---------|--------|
| **iOS**<br> <video src="https://github.com/user-attachments/assets/cf55be12-7d26-455e-8c38-d7dd54828225" width="300" height="600"> | **iOS**<br> <video src="https://github.com/user-attachments/assets/8fffffb3-8f21-45fb-a53f-80dfaba1aa5e" width="300" height="600"> |
