### PR TITLE
[Enhancement]Add accessibility label support for toolbar back button

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1797,7 +1797,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					NavigationItem.Title = title;
 				}
 
-				if (!string.IsNullOrEmpty(backButtonTitle) || !string.IsNullOrEmpty(backButtonAccessibilityLabel))
+				if (backButtonTitle is not null || !string.IsNullOrEmpty(backButtonAccessibilityLabel))
 				{
 					// adding a custom event handler to UIBarButtonItem for navigating back seems to be ignored.
 					var barButtonItem = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				UpdateUseLargeTitles();
 			}
-			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName || e.PropertyName == NavigationPage.TitleProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName || e.PropertyName == NavigationPage.TitleProperty.PropertyName || e.PropertyName == NavigationPage.BackButtonAccessibilityLabelProperty.PropertyName)
 			{
 				var pack = (ParentingViewController)TopViewController;
 				pack?.UpdateTitleArea(pack.Child);
@@ -1637,7 +1637,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName ||
 					 e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 					UpdateTitleArea(Child);
-				else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName)
+				else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName || e.PropertyName == NavigationPage.BackButtonAccessibilityLabelProperty.PropertyName)
 					UpdateBackButtonTitle(Child);
 				else if (e.PropertyName == NavigationPage.IconColorProperty.PropertyName)
 					UpdateIconColor();
@@ -1801,10 +1801,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					// adding a custom event handler to UIBarButtonItem for navigating back seems to be ignored.
 					var barButtonItem = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
-					if (!string.IsNullOrEmpty(backButtonTitle))
-					{
-						barButtonItem.Title = backButtonTitle;
-					}
+					barButtonItem.Title = backButtonTitle ?? title;
 					if (!string.IsNullOrEmpty(backButtonAccessibilityLabel))
 					{
 						barButtonItem.AccessibilityLabel = backButtonAccessibilityLabel;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1797,15 +1797,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					NavigationItem.Title = title;
 				}
 
-				if (backButtonTitle is not null || backButtonAccessibilityLabel is not null)
+				if (!string.IsNullOrEmpty(backButtonTitle) || !string.IsNullOrEmpty(backButtonAccessibilityLabel))
 				{
 					// adding a custom event handler to UIBarButtonItem for navigating back seems to be ignored.
 					var barButtonItem = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
-					if (backButtonTitle is not null)
+					if (!string.IsNullOrEmpty(backButtonTitle))
 					{
 						barButtonItem.Title = backButtonTitle;
 					}
-					if (backButtonAccessibilityLabel is not null)
+					if (!string.IsNullOrEmpty(backButtonAccessibilityLabel))
 					{
 						barButtonItem.AccessibilityLabel = backButtonAccessibilityLabel;
 					}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1801,9 +1801,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					// adding a custom event handler to UIBarButtonItem for navigating back seems to be ignored.
 					var barButtonItem = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
-					// When no custom title is provided, fall back to the page title so iOS
-					// shows the same text it would have shown with the default back button.
-					barButtonItem.Title = backButtonTitle ?? title;
+					if (backButtonTitle is not null)
+					{
+						barButtonItem.Title = backButtonTitle;
+					}
 					if (backButtonAccessibilityLabel is not null)
 					{
 						barButtonItem.AccessibilityLabel = backButtonAccessibilityLabel;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1788,18 +1788,32 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			public bool NeedsTitleViewContainer(Page page) => NavigationPage.GetTitleIconImageSource(page) != null || NavigationPage.GetTitleView(page) != null;
 
-			internal void UpdateBackButtonTitle(Page page) => UpdateBackButtonTitle(page.Title, NavigationPage.GetBackButtonTitle(page));
+			internal void UpdateBackButtonTitle(Page page) => UpdateBackButtonTitle(page.Title, NavigationPage.GetBackButtonTitle(page), NavigationPage.GetBackButtonAccessibilityLabel(page));
 
-			internal void UpdateBackButtonTitle(string title, string backButtonTitle)
+			internal void UpdateBackButtonTitle(string title, string backButtonTitle, string backButtonAccessibilityLabel = null)
 			{
 				if (!string.IsNullOrWhiteSpace(title))
+				{
 					NavigationItem.Title = title;
+				}
 
-				if (backButtonTitle != null)
+				if (backButtonTitle is not null || backButtonAccessibilityLabel is not null)
+				{
 					// adding a custom event handler to UIBarButtonItem for navigating back seems to be ignored.
-					NavigationItem.BackBarButtonItem = new UIBarButtonItem { Title = backButtonTitle, Style = UIBarButtonItemStyle.Plain };
+					var barButtonItem = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
+					// When no custom title is provided, fall back to the page title so iOS
+					// shows the same text it would have shown with the default back button.
+					barButtonItem.Title = backButtonTitle ?? title;
+					if (backButtonAccessibilityLabel is not null)
+					{
+						barButtonItem.AccessibilityLabel = backButtonAccessibilityLabel;
+					}
+					NavigationItem.BackBarButtonItem = barButtonItem;
+				}
 				else
+				{
 					NavigationItem.BackBarButtonItem = null;
+				}
 			}
 
 			internal void UpdateTitleArea(Page page)
@@ -1819,11 +1833,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				if (!(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsMacCatalystVersionAtLeast(11)) && !isBackButtonTextSet)
 					backButtonText = "";
 
+				string backButtonAccessibilityLabel = NavigationPage.GetBackButtonAccessibilityLabel(page);
+
 				_navigation.TryGetTarget(out NavigationRenderer n);
 
 				// First page and we have a flyout detail to contend with
 				UpdateLeftBarButtonItem();
-				UpdateBackButtonTitle(page.Title ?? n?.NavPage.Title, backButtonText);
+				UpdateBackButtonTitle(page.Title ?? n?.NavPage.Title, backButtonText, backButtonAccessibilityLabel);
 
 				//var hadTitleView = NavigationItem.TitleView != null;
 				ClearTitleViewContainer();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -562,12 +562,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var accessibilityLabel = backButtonHandler.GetPropertyIfSet<string>(
 				BackButtonBehavior.AccessibilityLabelProperty, null);
 
-			if (!string.IsNullOrEmpty(accessibilityLabel))
-			{
-				toolbar.NavigationContentDescription = accessibilityLabel;
-				return;
-			}
-
 			var automationId = image?.AutomationId ?? text;
 
 			//if AutomationId was specified the user wants to use UITests and interact with FlyoutIcon
@@ -582,6 +576,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_navigate_up_description);
 				else
 					toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_open_drawer_description);
+			}
+
+			// Custom accessibility label takes final priority over all other descriptions
+			if (!string.IsNullOrEmpty(accessibilityLabel))
+			{
+				toolbar.NavigationContentDescription = accessibilityLabel;
 			}
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -558,6 +558,16 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var backButtonHandler = Shell.GetEffectiveBackButtonBehavior(Page);
 			var image = GetFlyoutIcon(backButtonHandler, Page);
 			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
+
+			var accessibilityLabel = backButtonHandler.GetPropertyIfSet<string>(
+				BackButtonBehavior.AccessibilityLabelProperty, null);
+
+			if (!string.IsNullOrEmpty(accessibilityLabel))
+			{
+				toolbar.NavigationContentDescription = accessibilityLabel;
+				return;
+			}
+
 			var automationId = image?.AutomationId ?? text;
 
 			//if AutomationId was specified the user wants to use UITests and interact with FlyoutIcon

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -599,22 +599,22 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				if (NavigationItem.LeftBarButtonItem != null)
 				{
-					var customA11yLabel = behavior.GetPropertyIfSet<string?>(BackButtonBehavior.AccessibilityLabelProperty, null);
-					bool hasCustomLabel = !string.IsNullOrEmpty(customA11yLabel);
+					var customAccessibilityLabel = behavior.GetPropertyIfSet<string?>(BackButtonBehavior.AccessibilityLabelProperty, null);
+					bool hasCustomLabel = !string.IsNullOrEmpty(customAccessibilityLabel);
 
 					if (String.IsNullOrWhiteSpace(image?.AutomationId))
 					{
 						if (IsRootPage || !backButtonVisible)
 						{
 							NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
-							NavigationItem.LeftBarButtonItem.AccessibilityLabel = hasCustomLabel ? customA11yLabel : "Menu";
+							NavigationItem.LeftBarButtonItem.AccessibilityLabel = hasCustomLabel ? customAccessibilityLabel : "Menu";
 						}
 						else
 						{
 							NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "Back";
 							if (hasCustomLabel)
 							{
-								NavigationItem.LeftBarButtonItem.AccessibilityLabel = customA11yLabel;
+								NavigationItem.LeftBarButtonItem.AccessibilityLabel = customAccessibilityLabel;
 							}
 						}
 					}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -625,6 +625,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					else
 					{
 						NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = image.AutomationId;
+						if (hasCustomLabel)
+						{
+							NavigationItem.LeftBarButtonItem.AccessibilityLabel = customAccessibilityLabel;
+						}
 					}
 
 					if (image != null)
@@ -676,6 +680,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 								if (text is not null)
 								{
 									barButtonItem.Title = text;
+								}
+								else if (barButtonItem.Title is null)
+								{
+									// Preserve default back button title when only accessibility label is set
+									barButtonItem.Title = previousNavItem.Title;
 								}
 								if (!string.IsNullOrEmpty(accessibilityLabel))
 								{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -599,15 +599,24 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				if (NavigationItem.LeftBarButtonItem != null)
 				{
+					var customA11yLabel = behavior.GetPropertyIfSet<string?>(BackButtonBehavior.AccessibilityLabelProperty, null);
+					bool hasCustomLabel = !string.IsNullOrEmpty(customA11yLabel);
+
 					if (String.IsNullOrWhiteSpace(image?.AutomationId))
 					{
 						if (IsRootPage || !backButtonVisible)
 						{
 							NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
-							NavigationItem.LeftBarButtonItem.AccessibilityLabel = "Menu";
+							NavigationItem.LeftBarButtonItem.AccessibilityLabel = hasCustomLabel ? customA11yLabel : "Menu";
 						}
 						else
+						{
 							NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "Back";
+							if (hasCustomLabel)
+							{
+								NavigationItem.LeftBarButtonItem.AccessibilityLabel = customA11yLabel;
+							}
+						}
 					}
 					else
 					{
@@ -618,7 +627,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					{
 #pragma warning disable CS0618 // Type or member is obsolete
 						NavigationItem.LeftBarButtonItem.SetAccessibilityHint(image);
-						NavigationItem.LeftBarButtonItem.SetAccessibilityLabel(image);
+						if (!hasCustomLabel)
+						{
+							NavigationItem.LeftBarButtonItem.SetAccessibilityLabel(image);
+						}
 #pragma warning restore CS0618 // Type or member is obsolete
 					}
 				}
@@ -637,6 +649,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			var behavior = BackButtonBehavior;
 			var text = behavior.GetPropertyIfSet<string?>(BackButtonBehavior.TextOverrideProperty, null);
+			var accessibilityLabel = behavior.GetPropertyIfSet<string?>(BackButtonBehavior.AccessibilityLabelProperty, null);
 
 			var navController = ViewController?.NavigationController;
 
@@ -653,10 +666,17 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 						var previousNavItem = viewControllers[count - 2].NavigationItem;
 						if (previousNavItem != null)
 						{
-							if (text is not null)
+							if (text is not null || !string.IsNullOrEmpty(accessibilityLabel))
 							{
 								var barButtonItem = (previousNavItem.BackBarButtonItem ??= new UIBarButtonItem());
-								barButtonItem.Title = text;
+								if (text is not null)
+								{
+									barButtonItem.Title = text;
+								}
+								if (!string.IsNullOrEmpty(accessibilityLabel))
+								{
+									barButtonItem.AccessibilityLabel = accessibilityLabel;
+								}
 							}
 							else if (previousNavItem.BackBarButtonItem != null)
 							{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -616,6 +616,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 							{
 								NavigationItem.LeftBarButtonItem.AccessibilityLabel = customAccessibilityLabel;
 							}
+							else
+							{
+								NavigationItem.LeftBarButtonItem.AccessibilityLabel = null;
+							}
 						}
 					}
 					else
@@ -677,9 +681,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 								{
 									barButtonItem.AccessibilityLabel = accessibilityLabel;
 								}
+								else
+								{
+									barButtonItem.AccessibilityLabel = null;
+								}
 							}
 							else if (previousNavItem.BackBarButtonItem != null)
 							{
+								previousNavItem.BackBarButtonItem.AccessibilityLabel = null;
 								previousNavItem.BackBarButtonItem = null;
 							}
 						}

--- a/src/Controls/src/Core/NavigationPage/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPage.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Maui.Controls
 		/// <summary>Bindable property for attached property <c>BackButtonTitle</c>.</summary>
 		public static readonly BindableProperty BackButtonTitleProperty = BindableProperty.CreateAttached("BackButtonTitle", typeof(string), typeof(Page), null);
 
+		/// <summary>Bindable property for attached property <c>BackButtonAccessibilityLabel</c>.</summary>
+		public static readonly BindableProperty BackButtonAccessibilityLabelProperty = BindableProperty.CreateAttached("BackButtonAccessibilityLabel", typeof(string), typeof(Page), null);
+
 		/// <summary>Bindable property for attached property <c>HasNavigationBar</c>.</summary>
 		public static readonly BindableProperty HasNavigationBarProperty =
 			BindableProperty.CreateAttached("HasNavigationBar", typeof(bool), typeof(Page), true);
@@ -174,6 +177,14 @@ namespace Microsoft.Maui.Controls
 		public static string GetBackButtonTitle(BindableObject page)
 		{
 			return (string)page.GetValue(BackButtonTitleProperty);
+		}
+
+		/// <summary>Gets the accessibility label for the back button of the specified <paramref name="page"/>.</summary>
+		/// <param name="page">The <see cref="Microsoft.Maui.Controls.Page"/> whose back-button's accessibility label is being requested.</param>
+		/// <returns>The accessibility label read by screen readers for the back button, or <see langword="null"/> if not set.</returns>
+		public static string GetBackButtonAccessibilityLabel(BindableObject page)
+		{
+			return (string)page.GetValue(BackButtonAccessibilityLabelProperty);
 		}
 
 		/// <summary>Returns a value that indicates whether <paramref name="page"/> has a back button.</summary>
@@ -353,6 +364,14 @@ namespace Microsoft.Maui.Controls
 		public static void SetBackButtonTitle(BindableObject page, string value)
 		{
 			page.SetValue(BackButtonTitleProperty, value);
+		}
+
+		/// <summary>Sets the accessibility label for the back button of <paramref name="page"/>, allowing the text read by screen readers to differ from the visible back button title.</summary>
+		/// <param name="page">The page parameter.</param>
+		/// <param name="value">The accessibility label value to set.</param>
+		public static void SetBackButtonAccessibilityLabel(BindableObject page, string value)
+		{
+			page.SetValue(BackButtonAccessibilityLabelProperty, value);
 		}
 
 		/// <summary>Adds or removes a back button to <paramref name="page"/>, with optional animation.</summary>

--- a/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPage/NavigationPageToolbar.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Maui.Controls
 				e.IsOneOf(
 					PlatformConfiguration.WindowsSpecific.Page.ToolbarDynamicOverflowEnabledProperty,
 					PlatformConfiguration.WindowsSpecific.Page.ToolbarPlacementProperty) ||
-				e.Is(FlyoutPage.FlyoutLayoutBehaviorProperty))
+				e.Is(FlyoutPage.FlyoutLayoutBehaviorProperty) ||
+				e.Is(NavigationPage.BackButtonAccessibilityLabelProperty))
 			{
 				ApplyChanges(_currentNavigationPage);
 			}
@@ -248,10 +249,16 @@ namespace Microsoft.Maui.Controls
 			else
 				BarHeight = null;
 
-			if (previousPage != null)
+			if (previousPage is not null)
+			{
 				BackButtonTitle = NavigationPage.GetBackButtonTitle(previousPage);
+				BackButtonAccessibilityLabel = NavigationPage.GetBackButtonAccessibilityLabel(previousPage);
+			}
 			else
+			{
 				BackButtonTitle = null;
+				BackButtonAccessibilityLabel = null;
+			}
 
 			TitleIcon = NavigationPage.GetTitleIconImageSource(currentPage);
 

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -122,10 +122,16 @@ namespace Microsoft.Maui.Controls.Platform
 				if (nativeToolbar.NavigationIcon is DrawerArrowDrawable iconDrawable)
 					iconDrawable.Progress = 1;
 
+				var backButtonAccessibilityLabel = toolbar.BackButtonAccessibilityLabel;
 				var backButtonTitle = toolbar.BackButtonTitle;
 				ImageSource image = toolbar.TitleIcon;
 
-				if (!string.IsNullOrEmpty(backButtonTitle))
+				if (!string.IsNullOrEmpty(backButtonAccessibilityLabel))
+				{
+					// Accessibility label takes priority — TalkBack reads this instead of the title.
+					nativeToolbar.NavigationContentDescription = backButtonAccessibilityLabel;
+				}
+				else if (!string.IsNullOrEmpty(backButtonTitle))
 				{
 					nativeToolbar.NavigationContentDescription = backButtonTitle;
 				}

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -39,15 +39,28 @@ namespace Microsoft.Maui.Controls.Platform
 			UpdateBackButtonVisibility(platformToolbar, toolbar);
 
 			// Set Narrator text for the back button when a custom label is provided.
-			// We only set AutomationProperties.Name when there's an explicit label —
-			// otherwise, leave it untouched so WinUI's default "Back" announcement is preserved.
+			// We save the default value before first override and restore it when the label is cleared,
+			// so WinUI's default "Back" announcement is preserved.
 			if (platformToolbar.NavigationViewBackButton is not null)
 			{
+				var backButton = platformToolbar.NavigationViewBackButton;
 				var accessibilityLabel = toolbar.BackButtonAccessibilityLabel;
+
 				if (!string.IsNullOrEmpty(accessibilityLabel))
 				{
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
-						platformToolbar.NavigationViewBackButton, accessibilityLabel);
+					// Save the default value before first override
+					if (backButton.Tag is not string)
+					{
+						backButton.Tag = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(backButton);
+					}
+
+					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(backButton, accessibilityLabel);
+				}
+				else if (backButton.Tag is string savedDefault)
+				{
+					// Restore the original default ("Back") when the custom label is cleared
+					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(backButton, savedDefault);
+					backButton.Tag = null;
 				}
 			}
 

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -38,6 +38,19 @@ namespace Microsoft.Maui.Controls.Platform
 
 			UpdateBackButtonVisibility(platformToolbar, toolbar);
 
+			// Set Narrator text for the back button when a custom label is provided.
+			// We only set AutomationProperties.Name when there's an explicit label —
+			// otherwise, leave it untouched so WinUI's default "Back" announcement is preserved.
+			if (platformToolbar.NavigationViewBackButton is not null)
+			{
+				var accessibilityLabel = toolbar.BackButtonAccessibilityLabel;
+				if (!string.IsNullOrEmpty(accessibilityLabel))
+				{
+					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+						platformToolbar.NavigationViewBackButton, accessibilityLabel);
+				}
+			}
+
 			toolbar.Handler?.UpdateValue(nameof(Toolbar.BarBackground));
 		}
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -92,6 +92,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -92,3 +92,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -94,4 +94,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonAccessibilityLabel(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonAccessibilityLabel(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -83,12 +83,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionBadge(Microsoft.Maui.Controls.ShellSection shellSection, int index) -> void
-~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
-~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
-~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
-~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -83,3 +83,12 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
 ~virtual Microsoft.Maui.Controls.Platform.Compatibility.ShellItemRenderer.UpdateShellSectionBadge(Microsoft.Maui.Controls.ShellSection shellSection, int index) -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -90,4 +90,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -88,3 +88,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -79,3 +79,12 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -88,6 +88,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -79,12 +79,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
-~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
-~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
-~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -90,4 +90,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -88,3 +88,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -79,3 +79,12 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
+~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
+~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -88,6 +88,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -79,12 +79,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextColorProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.ToolbarItem.BadgeTextProperty -> Microsoft.Maui.Controls.BindableProperty
-~Microsoft.Maui.Controls.Editor.ReturnCommand.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.Editor.ReturnCommand.set -> void
-~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.get -> object
-~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
-~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -80,6 +80,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -82,4 +82,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonAccessibilityLabel(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonAccessibilityLabel(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -77,3 +77,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -80,3 +80,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -78,4 +78,8 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonAccessibilityLabel(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonAccessibilityLabel(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -76,6 +76,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -76,3 +76,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -73,3 +73,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -76,6 +76,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -78,4 +78,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -76,3 +76,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -73,3 +73,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -67,3 +67,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -67,6 +67,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
 ~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
-Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
+~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -64,3 +64,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~Microsoft.Maui.Controls.Editor.ReturnCommandParameter.set -> void
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.Editor.ReturnCommandProperty -> Microsoft.Maui.Controls.BindableProperty
+~static Microsoft.Maui.Controls.NavigationPage.GetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page) -> string
+~static Microsoft.Maui.Controls.NavigationPage.SetBackButtonAccessibilityLabel(Microsoft.Maui.Controls.BindableObject page, string value) -> void
+~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -69,4 +69,6 @@ virtual Microsoft.Maui.Controls.LongPressingEventArgs.GetPosition(Microsoft.Maui
 ~static readonly Microsoft.Maui.Controls.NavigationPage.BackButtonAccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.get -> string
 ~Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabel.set -> void
-~static Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.BackButtonBehavior.AccessibilityLabelProperty -> Microsoft.Maui.Controls.BindableProperty
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.get -> string
+~Microsoft.Maui.Controls.Toolbar.BackButtonAccessibilityLabel.set -> void

--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -35,6 +35,10 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TextOverrideProperty =
 			BindableProperty.Create(nameof(TextOverride), typeof(string), typeof(BackButtonBehavior), null, BindingMode.OneTime);
 
+		/// <summary>Bindable property for <see cref="AccessibilityLabel"/>.</summary>
+		public static readonly BindableProperty AccessibilityLabelProperty =
+			BindableProperty.Create(nameof(AccessibilityLabel), typeof(string), typeof(BackButtonBehavior), null, BindingMode.OneWay);
+
 		/// <summary>
 		/// Gets or sets the command to execute when the back button is pressed. This is a bindable property.
 		/// </summary>
@@ -96,6 +100,16 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (string)GetValue(TextOverrideProperty); }
 			set { SetValue(TextOverrideProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the accessibility label announced by the screen reader for the back button,
+		/// independent of the visible text (<see cref="TextOverride"/>). This is a bindable property.
+		/// </summary>
+		public string AccessibilityLabel
+		{
+			get { return (string)GetValue(AccessibilityLabelProperty); }
+			set { SetValue(AccessibilityLabelProperty, value); }
 		}
 
 		bool IsEnabledCore

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Maui.Controls
 #endif
 			BackButtonVisible = backButtonVisible && stack.Count > 1;
 			BackButtonEnabled = _backButtonBehavior?.IsEnabled ?? true;
+			BackButtonAccessibilityLabel = _backButtonBehavior?.AccessibilityLabel;
 			ToolbarItems = _toolbarTracker.ToolbarItems;
 
 			UpdateTitle();

--- a/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Android.cs
@@ -161,6 +161,9 @@ namespace Microsoft.Maui.Controls
 		public static void MapBackButtonTitle(ToolbarHandler arg1, Toolbar arg2) =>
 			MapBackButtonTitle((IToolbarHandler)arg1, arg2);
 
+		public static void MapBackButtonAccessibilityLabel(ToolbarHandler arg1, Toolbar arg2) =>
+			MapBackButtonAccessibilityLabel((IToolbarHandler)arg1, arg2);
+
 		public static void MapToolbarItems(ToolbarHandler arg1, Toolbar arg2) =>
 			MapToolbarItems((IToolbarHandler)arg1, arg2);
 
@@ -196,6 +199,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public static void MapBackButtonTitle(IToolbarHandler arg1, Toolbar arg2)
+		{
+			arg1.PlatformView.UpdateBackButton(arg2);
+		}
+
+		public static void MapBackButtonAccessibilityLabel(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBackButton(arg2);
 		}

--- a/src/Controls/src/Core/Toolbar/Toolbar.Mapper.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Mapper.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Controls
 			ToolbarHandler.Mapper.ReplaceMapping<Toolbar, IToolbarHandler>(nameof(Toolbar.IconColor), MapIconColor);
 			ToolbarHandler.Mapper.ReplaceMapping<Toolbar, IToolbarHandler>(nameof(Toolbar.ToolbarItems), MapToolbarItems);
 			ToolbarHandler.Mapper.ReplaceMapping<Toolbar, IToolbarHandler>(nameof(Toolbar.BackButtonTitle), MapBackButtonTitle);
+			ToolbarHandler.Mapper.ReplaceMapping<Toolbar, IToolbarHandler>(nameof(Toolbar.BackButtonAccessibilityLabel), MapBackButtonAccessibilityLabel);
 			ToolbarHandler.Mapper.ReplaceMapping<Toolbar, IToolbarHandler>(nameof(Toolbar.BarBackground), MapBarBackground);
 			ToolbarHandler.Mapper.ReplaceMapping<Toolbar, IToolbarHandler>(nameof(Toolbar.BarTextColor), MapBarTextColor);
 #endif

--- a/src/Controls/src/Core/Toolbar/Toolbar.Tizen.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Tizen.cs
@@ -41,6 +41,13 @@ namespace Microsoft.Maui.Controls
 		public static void MapIsVisible(ToolbarHandler handler, Toolbar toolbar) =>
 			MapIsVisible((IToolbarHandler)handler, toolbar);
 
+		public static void MapBackButtonAccessibilityLabel(ToolbarHandler handler, Toolbar toolbar) =>
+			MapBackButtonAccessibilityLabel((IToolbarHandler)handler, toolbar);
+
+		public static void MapBackButtonAccessibilityLabel(IToolbarHandler handler, Toolbar toolbar)
+		{
+			// Tizen back button accessibility — not yet implemented
+		}
 
 		public static void MapBarTextColor(IToolbarHandler handler, Toolbar toolbar)
 		{

--- a/src/Controls/src/Core/Toolbar/Toolbar.Windows.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.Windows.cs
@@ -314,6 +314,14 @@ namespace Microsoft.Maui.Controls
 		public static void MapToolbarDynamicOverflowEnabled(ToolbarHandler arg1, Toolbar arg2) =>
 			MapToolbarDynamicOverflowEnabled((IToolbarHandler)arg1, arg2);
 
+		public static void MapBackButtonAccessibilityLabel(ToolbarHandler arg1, Toolbar arg2) =>
+			MapBackButtonAccessibilityLabel((IToolbarHandler)arg1, arg2);
+
+		public static void MapBackButtonAccessibilityLabel(IToolbarHandler arg1, Toolbar arg2)
+		{
+			arg1.PlatformView.UpdateBackButton(arg2);
+		}
+
 		public static void MapToolbarPlacement(IToolbarHandler arg1, Toolbar arg2)
 		{
 		}

--- a/src/Controls/src/Core/Toolbar/Toolbar.cs
+++ b/src/Controls/src/Core/Toolbar/Toolbar.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls
 		Brush _barBackground;
 		ImageSource _titleIcon;
 		string _backButtonTitle;
+		string _backButtonAccessibilityLabel;
 		double? _barHeight;
 		IEnumerable<ToolbarItem> _toolbarItems;
 		bool _dynamicOverflowEnabled;
@@ -35,6 +36,7 @@ namespace Microsoft.Maui.Controls
 		public IEnumerable<ToolbarItem> ToolbarItems { get => _toolbarItems; set => SetProperty(ref _toolbarItems, value); }
 		public double? BarHeight { get => _barHeight; set => SetProperty(ref _barHeight, value); }
 		public string BackButtonTitle { get => _backButtonTitle; set => SetProperty(ref _backButtonTitle, value); }
+		public string BackButtonAccessibilityLabel { get => _backButtonAccessibilityLabel; set => SetProperty(ref _backButtonAccessibilityLabel, value); }
 		public ImageSource TitleIcon { get => _titleIcon; set => SetProperty(ref _titleIcon, value); }
 		public Brush BarBackground { get => _barBackground; set => SetProperty(ref _barBackground, value); }
 		public virtual Color BarTextColor { get => _barTextColor; set => SetProperty(ref _barTextColor, value); }

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -303,5 +303,57 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(toolbar.IsVisible);
 		}
+		[Fact]
+		public void BackButtonBehaviorAccessibilityLabelSet()
+		{
+			var backButtonBehavior = new BackButtonBehavior()
+			{
+				AccessibilityLabel = "Navigate Back"
+			};
+
+			Assert.Equal("Navigate Back", backButtonBehavior.AccessibilityLabel);
+		}
+
+		[Fact]
+		public void BackButtonBehaviorAccessibilityLabelDefaultIsNull()
+		{
+			var backButtonBehavior = new BackButtonBehavior();
+			Assert.Null(backButtonBehavior.AccessibilityLabel);
+		}
+
+		[Fact]
+		public async Task BackButtonBehaviorAccessibilityLabelPropagesToToolbar()
+		{
+			var page = new ContentPage();
+			TestShell testShell = new TestShell(new ContentPage());
+			await testShell.Navigation.PushAsync(page);
+
+			var backButtonBehavior = new BackButtonBehavior()
+			{
+				AccessibilityLabel = "Return to Home"
+			};
+
+			Shell.SetBackButtonBehavior(page, backButtonBehavior);
+			Assert.Equal("Return to Home", testShell.Toolbar.BackButtonAccessibilityLabel);
+		}
+
+		[Fact]
+		public async Task BackButtonBehaviorAccessibilityLabelUpdatesOnPropertyChanged()
+		{
+			var page = new ContentPage();
+			TestShell testShell = new TestShell(new ContentPage());
+			var backButtonBehavior = new BackButtonBehavior()
+			{
+				AccessibilityLabel = "Initial"
+			};
+
+			Shell.SetBackButtonBehavior(page, backButtonBehavior);
+			await testShell.Navigation.PushAsync(page);
+
+			Assert.Equal("Initial", testShell.Toolbar.BackButtonAccessibilityLabel);
+
+			backButtonBehavior.AccessibilityLabel = "Updated";
+			Assert.Equal("Updated", testShell.Toolbar.BackButtonAccessibilityLabel);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public async Task BackButtonBehaviorAccessibilityLabelPropagesToToolbar()
+		public async Task BackButtonBehaviorAccessibilityLabelPropagatesToToolbar()
 		{
 			var page = new ContentPage();
 			TestShell testShell = new TestShell(new ContentPage());

--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		public async Task NavigationPageBackButtonAccessibilityLabelPropagesToToolbar()
+		public async Task NavigationPageBackButtonAccessibilityLabelPropagatesToToolbar()
 		{
 			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;

--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -295,5 +295,35 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.NotEqual(modalPageToolBar, rootPageToolbar);
 
 		}
+		[Fact]
+		public void NavigationPageSetBackButtonAccessibilityLabel()
+		{
+			var page = new ContentPage();
+			NavigationPage.SetBackButtonAccessibilityLabel(page, "Go Back");
+			Assert.Equal("Go Back", NavigationPage.GetBackButtonAccessibilityLabel(page));
+		}
+
+		[Fact]
+		public void NavigationPageBackButtonAccessibilityLabelDefaultIsNull()
+		{
+			var page = new ContentPage();
+			Assert.Null(NavigationPage.GetBackButtonAccessibilityLabel(page));
+		}
+
+		[Fact]
+		public async Task NavigationPageBackButtonAccessibilityLabelPropagesToToolbar()
+		{
+			var window = new TestWindow();
+			IToolbarElement toolbarElement = window;
+			var navPage = new NavigationPage(new ContentPage());
+			window.Page = navPage;
+
+			var page = new ContentPage();
+			NavigationPage.SetBackButtonAccessibilityLabel(page, "Return");
+			await navPage.PushAsync(page);
+
+			var toolbar = (Toolbar)toolbarElement.Toolbar;
+			Assert.Equal("Return", toolbar.BackButtonAccessibilityLabel);
+		}
 	}
 }


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

### Issue Details
There is currently no way to set a custom accessibility label for the toolbar back button independently of the visible text. Screen readers (VoiceOver, TalkBack, Narrator) read the back button’s title, but developers often need a more descriptive label without changing the UI.
This PR addresses that gap for both NavigationPage and Shell across Android, iOS, macCatalyst, and Windows.

### Description of Changes
Introduced new BackButtonAccessibilityLabel APIs for both NavigationPage and Shell, allowing developers to customize screen reader announcements independently of the visible back button text.

**NavigationPage**
- Added attached property BackButtonAccessibilityLabelProperty with SetBackButtonAccessibilityLabel and GetBackButtonAccessibilityLabel methods 
- The label is set on the parent page and applied to the child page’s back button, following the existing SetBackButtonTitle pattern 

**Shell**
- Added AccessibilityLabel bindable property to BackButtonBehavior 
- Can be used alongside existing properties like TextOverride and IconOverride 

### Platform Implementations

**Android**

- Applied via ContentDescription on the toolbar navigation icon 
- Implemented through ToolbarExtensions (NavigationPage) and ShellToolbarTracker (Shell) 

**iOS / macCatalyst**

- Set via AccessibilityLabel on BackBarButtonItem (NavigationPage) and on LeftBarButtonItem / BackBarButtonItem (Shell) 
- Property change handlers added for runtime updates 

**Windows**

- Applied via AutomationProperties.Name on the back button 
- Uses a save/restore pattern with the Tag property to preserve and restore the default WinUI "Back" announcement

**Additional Notes**

- Added 7 unit tests: 
NavigationPage: set, clear, default 
Shell: set, clear, default, dynamic update 

- Updated Public API across all 7 TFM files

### Issues Fixed
Fixes #17984

### Screenshots

Mac:
| Shell | NavigationPage |
|----------|----------|
| <img width="800" height="750"  src="https://github.com/user-attachments/assets/7bf7bd5c-f9d7-4d3b-9d1d-a008b0330675"> | <img width="800" height="750"  src="https://github.com/user-attachments/assets/f650c04e-7a94-4dac-8b28-023a47de3ae6"> |

iOS:
| Shell | NavigationPage |
|----------|----------|
| <img width="2000" height="750"  src="https://github.com/user-attachments/assets/0e6373ce-df92-4b23-9340-29ccdfd55d28"> | <img width="2000" height="750"  src="https://github.com/user-attachments/assets/aa740634-dedb-4d09-81c8-167e311f2290"> |

Android:

https://github.com/user-attachments/assets/72fc16a6-c62d-400d-82e6-c0f8bb8b9ff4