### PR TITLE
 [Android] Fix VerifyHybridWebViewWithShadow UI test regression on candidate branch

### DIFF
--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -34,16 +34,16 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnSizeChanged(width, height, oldWidth, oldHeight);
 
-			// Update clip bounds to match the actual size once layout is complete.
 			if (width > 0 && height > 0)
 			{
-				_clipRect.Set(0, 0, width, height);
-				ClipBounds = _clipRect;
+				// Remove clip bounds once layout is complete and the view has its
+				// correct size. Setting null instead of exact bounds allows visual
+				// effects like shadows to render outside the view area.
+				ClipBounds = null;
 			}
 			else
 			{
-				// Reset to empty rect when the view becomes zero-sized or hidden,
-				// to avoid stale non-zero clip bounds.
+				// Re-apply empty clip bounds when the view becomes zero-sized or hidden.
 				_clipRect.Set(0, 0, 0, 0);
 				ClipBounds = _clipRect;
 			}

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -27,16 +27,16 @@ namespace Microsoft.Maui.Platform
 		{
 			base.OnSizeChanged(width, height, oldWidth, oldHeight);
 
-			// Update clip bounds to match the actual size once layout is complete.
 			if (width > 0 && height > 0)
 			{
-				_clipRect.Set(0, 0, width, height);
-				ClipBounds = _clipRect;
+				// Remove clip bounds once layout is complete and the view has its
+				// correct size. Setting null instead of exact bounds allows visual
+				// effects like shadows to render outside the view area.
+				ClipBounds = null;
 			}
 			else
 			{
-				// Reset to empty rect when the view becomes zero-sized or hidden,
-				// to avoid stale non-zero clip bounds.
+				// Re-apply empty clip bounds when the view becomes zero-sized or hidden.
 				_clipRect.Set(0, 0, 0, 0);
 				ClipBounds = _clipRect;
 			}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
Applying `ClipBounds = Rect(0, 0, width, height)` constrained the WebView strictly to its layout bounds, preventing shadows (rendered by the parent `WrapperView`) from drawing outside the view. This clipped the shadow and caused UI test failures due to visual mismatch with baseline snapshots.
 
### Description of Change
Updated logic to set `ClipBounds = null` once the view has a valid size, restoring default Android behavior where layout bounds (not `ClipBounds`) control rendering.

- Constructor still applies an empty clip to prevent pre-layout full-screen flash
- Zero-size scenarios reapply the empty clip to maintain correctness
- Aligns with existing handling in `LayoutViewGroup` [Ref](https://github.com/praveenkumarkarunanithi/maui/blob/main/src/Core/src/Platform/Android/LayoutViewGroup.cs#L161) when clipping is disabled

 
### Issues Fixed
Fixes regression introduced by #33207 : 
`VerifyHybridWebViewWithShadow` on Candidate branch.
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac