### PR TITLE
[iOS] Fix StaticResource Hot Reload crash on iOS

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -285,11 +285,10 @@ namespace Microsoft.Maui.Controls.Xaml
 				{
 					if (Context.ExceptionHandler != null)
 					{
-						// Defense-in-depth: StaticResourceExtension.ProvideValue already handles
-						// the Hot Reload case (returns null when ExceptionHandler2 is set), so
-						// this catch is not normally reached. But if a future change breaks that
-						// invariant, report the error and skip the property rather than crashing
-						// via iOS UIKit lifecycle callbacks (#35018).
+						// During Hot Reload (handler present), report the exception and skip the
+						// property rather than re-throwing.
+						// Re-throwing here propagates through iOS UIKit lifecycle callbacks during
+						// Shell item setup, corrupting Shell state and crashing the app (#35018).
 						Context.ExceptionHandler(e);
 						value = null;
 						return;

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -285,10 +285,12 @@ namespace Microsoft.Maui.Controls.Xaml
 				{
 					if (Context.ExceptionHandler != null)
 					{
-						// During Hot Reload (handler present), skip the property rather than
-						// re-throwing. ProvideValue already reported the error to ExceptionHandler2.
-						// Re-throwing here propagates through iOS UIKit lifecycle callbacks during
-						// Shell item setup, corrupting Shell state and crashing the app (#35018).
+						// Defense-in-depth: StaticResourceExtension.ProvideValue already handles
+						// the Hot Reload case (returns null when ExceptionHandler2 is set), so
+						// this catch is not normally reached. But if a future change breaks that
+						// invariant, report the error and skip the property rather than crashing
+						// via iOS UIKit lifecycle callbacks (#35018).
+						Context.ExceptionHandler(e);
 						value = null;
 						return;
 					}

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -281,12 +281,17 @@ namespace Microsoft.Maui.Controls.Xaml
 			}
 			catch (Exception e)
 			{
-				// StaticResourceExtension must always rethrow even when a handler is present —
-				// unlike other markup extensions, swallowing this exception would silently apply
-				// an invalid value to the property. Notify the handler first to log the error.
 				if (markupExtension is StaticResourceExtension)
 				{
-					Context.ExceptionHandler?.Invoke(e);
+					if (Context.ExceptionHandler != null)
+					{
+						// During Hot Reload (handler present), skip the property rather than
+						// re-throwing. ProvideValue already reported the error to ExceptionHandler2.
+						// Re-throwing here propagates through iOS UIKit lifecycle callbacks during
+						// Shell item setup, corrupting Shell state and crashing the app (#35018).
+						value = null;
+						return;
+					}
 					throw;
 				}
 

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Maui.Controls.Xaml
 					// Return null so the page loads with degraded styling instead of crashing.
 					// On iOS, throwing here propagates through UIKit lifecycle callbacks during
 					// Shell item setup, corrupting Shell state (#35018).
-					// Note: null clears reference-type properties (Style, ImageSource) and is
-					// silently ignored for value-type properties (FontSize, Thickness), which
-					// retain their previous value.
+					// Note: null clears reference-type properties (Style, ImageSource). For
+					// non-nullable value-type properties (FontSize, Thickness), the assignment
+					// is skipped and an additional diagnostic may be reported.
 					return null;
 				}
 				throw ex;

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -36,8 +36,12 @@ namespace Microsoft.Maui.Controls.Xaml
 					var rootObjectProvider = (IRootObjectProvider)serviceProvider.GetService(typeof(IRootObjectProvider));
 					var root = rootObjectProvider.RootObject;
 					ehandler.Invoke((ex, XamlFilePathAttribute.GetFilePathForObject(root)));
+					// During Hot Reload the IDE sets ExceptionHandler2 to collect errors.
+					// Return null so the page loads with degraded styling instead of crashing.
+					// On iOS, throwing here propagates through UIKit lifecycle callbacks during
+					// Shell item setup, corrupting Shell state (#35018).
+					return null;
 				}
-				// Throw an exception when the key is not found
 				throw ex;
 			}
 

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Maui.Controls.Xaml
 					// Return null so the page loads with degraded styling instead of crashing.
 					// On iOS, throwing here propagates through UIKit lifecycle callbacks during
 					// Shell item setup, corrupting Shell state (#35018).
+					// Note: null clears reference-type properties (Style, ImageSource) and is
+					// silently ignored for value-type properties (FontSize, Thickness), which
+					// retain their previous value.
 					return null;
 				}
 				throw ex;

--- a/src/Controls/tests/Xaml.UnitTests/HotReloadStaticResourceException.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/HotReloadStaticResourceException.xaml.cs
@@ -48,13 +48,13 @@ public partial class HotReloadStaticResourceException : ContentPage
 					Assert.Equal(13, xpe.XmlInfo.LinePosition);
 				}
 			};
-			
-			// Now expect the exception to be thrown (after handler is invoked)
-			var exception = Assert.Throws<XamlParseException>(() => new HotReloadStaticResourceException(inflator));
-			
-			// Verify handler was invoked and exception details are correct
+
+			// With the fix for #35018, missing resources during Hot Reload (handler set)
+			// no longer throw — the error is reported to the handler and the property is
+			// skipped, allowing the page to load with degraded styling.
+			var page = new HotReloadStaticResourceException(inflator);
+			Assert.NotNull(page);
 			Assert.True(handled, "Exception handler was not invoked");
-			Assert.Contains("StaticResource not found for key MissingResource", exception.Message, System.StringComparison.Ordinal);
 		}
 #else
 		[Fact(Skip = "This test runs only in debug")]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35018.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35018.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui35018">
+    <VerticalStackLayout>
+        <Label 
+            x:Name="headlineLabel"
+            Text="Hello World"
+            Style="{StaticResource Headline}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35018.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35018.xaml.cs
@@ -1,0 +1,99 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.UnitTests;
+using Xunit;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests;
+
+public partial class Maui35018 : ContentPage
+{
+	public Maui35018()
+	{
+		InitializeComponent();
+	}
+
+	[Collection("Xaml Inflation")]
+	public class Tests : BaseTestFixture
+	{
+		protected internal override void Setup()
+		{
+			base.Setup();
+			var app = new MockApplication();
+			app.Resources.Add("Headline", new Style(typeof(Label))
+			{
+				Setters = { new Setter { Property = Label.FontSizeProperty, Value = 32.0 } }
+			});
+			Application.SetCurrentApplication(app);
+			DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+
+		protected internal override void TearDown()
+		{
+			AppInfo.SetCurrent(null);
+			Controls.Internals.ResourceLoader.ResourceProvider2 = null;
+			Controls.Internals.ResourceLoader.ExceptionHandler2 = null;
+			base.TearDown();
+		}
+
+#if DEBUG
+		[Theory]
+		[InlineData(XamlInflator.Runtime)]
+		[InlineData(XamlInflator.SourceGen)]
+		internal void InitialLoadWithResourceSucceeds(XamlInflator inflator)
+		{
+			// "Headline" exists in Application.Resources — page loads fine
+			var page = new Maui35018(inflator);
+			Assert.NotNull(page);
+			Assert.Equal(32.0, page.headlineLabel.FontSize);
+		}
+
+		[Theory]
+		[InlineData(XamlInflator.Runtime)]
+		[InlineData(XamlInflator.SourceGen)]
+		internal void HotReloadAfterResourceRenameShouldNotCrash(XamlInflator inflator)
+		{
+			// Issue #35018: During Hot Reload the user renames a resource key in Styles.xaml
+			// ("Headline" → "Headline2"). The page still references {StaticResource Headline},
+			// which no longer exists. PR #33859 changed StaticResourceExtension to always throw
+			// even when ExceptionHandler2 is set. On iOS this propagates through UIKit lifecycle
+			// callbacks during Shell item setup, corrupting Shell state and crashing the app.
+			//
+			// Expected: When ExceptionHandler2 is set (Hot Reload context), a missing
+			// StaticResource should be reported to the handler but the page should still load
+			// gracefully (with degraded styling), not throw and crash the app.
+
+			// Step 1: Initial load succeeds
+			var page = new Maui35018(inflator);
+			Assert.NotNull(page);
+
+			// Step 2: Simulate Hot Reload resource rename ("Headline" → "Headline2")
+			Application.Current.Resources.Remove("Headline");
+			Application.Current.Resources.Add("Headline2", new Style(typeof(Label))
+			{
+				Setters = { new Setter { Property = Label.FontSizeProperty, Value = 32.0 } }
+			});
+
+			// Step 3: ExceptionHandler2 is set (IDE Hot Reload context)
+			bool handlerInvoked = false;
+			Controls.Internals.ResourceLoader.ExceptionHandler2 = (ex) =>
+			{
+				handlerInvoked = true;
+			};
+
+			// Step 4: Rebuild the page — should load without throwing.
+			// REGRESSION: Currently throws XamlParseException despite handler being set,
+			// which on iOS crashes the app via UIKit callback propagation.
+			var reloadedPage = new Maui35018(inflator);
+			Assert.NotNull(reloadedPage);
+			Assert.True(handlerInvoked, "ExceptionHandler2 should be invoked for the missing resource");
+		}
+#else
+		[Fact(Skip = "Hot Reload tests run only in DEBUG")]
+		public void InitialLoadWithResourceSucceeds() { }
+
+		[Fact(Skip = "Hot Reload tests run only in DEBUG")]
+		public void HotReloadAfterResourceRenameShouldNotCrash() { }
+#endif
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui35018.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui35018.xaml.cs
@@ -37,6 +37,8 @@ public partial class Maui35018 : ContentPage
 		}
 
 #if DEBUG
+		// XamlC is excluded: it generates IL at compile time and doesn't participate in
+		// runtime Hot Reload re-inflation, so it cannot exercise this scenario.
 		[Theory]
 		[InlineData(XamlInflator.Runtime)]
 		[InlineData(XamlInflator.SourceGen)]
@@ -63,9 +65,10 @@ public partial class Maui35018 : ContentPage
 			// StaticResource should be reported to the handler but the page should still load
 			// gracefully (with degraded styling), not throw and crash the app.
 
-			// Step 1: Initial load succeeds
+			// Step 1: Initial load succeeds with the style applied
 			var page = new Maui35018(inflator);
 			Assert.NotNull(page);
+			Assert.Equal(32.0, page.headlineLabel.FontSize);
 
 			// Step 2: Simulate Hot Reload resource rename ("Headline" → "Headline2")
 			Application.Current.Resources.Remove("Headline");
@@ -78,15 +81,19 @@ public partial class Maui35018 : ContentPage
 			bool handlerInvoked = false;
 			Controls.Internals.ResourceLoader.ExceptionHandler2 = (ex) =>
 			{
+				var (exception, _) = ex;
+				Assert.Contains("StaticResource not found for key Headline", exception.Message, System.StringComparison.Ordinal);
 				handlerInvoked = true;
 			};
 
 			// Step 4: Rebuild the page — should load without throwing.
-			// REGRESSION: Currently throws XamlParseException despite handler being set,
-			// which on iOS crashes the app via UIKit callback propagation.
+			// The missing Style means the label reverts to default font size.
 			var reloadedPage = new Maui35018(inflator);
 			Assert.NotNull(reloadedPage);
 			Assert.True(handlerInvoked, "ExceptionHandler2 should be invoked for the missing resource");
+
+			// Verify degraded styling: the 32pt style is gone, label has default font size
+			Assert.NotEqual(32.0, reloadedPage.headlineLabel.FontSize);
 		}
 #else
 		[Fact(Skip = "Hot Reload tests run only in DEBUG")]


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Description

Fixes #35018 — The MAUI app quits with no errors after editing a ResourceDictionary XAML file on iOS Simulator during Hot Reload.

### Root Cause

PR #33859 (commit 6874c805d8) changed `StaticResourceExtension.ProvideValue` to always throw `XamlParseException` for missing resources, even when `ExceptionHandler2` is set (Hot Reload / IDE context). This change was correct for app launch consistency (#23903), but on iOS it exposes a platform-specific weakness:

During Hot Reload, the Shell rebuilds via `InitializeComponent()`, which on iOS synchronously triggers:

```
Shell.InitializeComponent() → adds ShellItems
  → iOS ShellItemRenderer.CreateTabRenderers()
    → UpdateTabBarHidden()
      → UIKit sets TabBarHidden
        → UIKit calls ViewDidLoad() synchronously
          → ShellSectionRootRenderer.LoadRenderers()
            → GetOrCreateContent() → MainPage constructor
              → StaticResourceExtension.ProvideValue()
                → XamlParseException
```

The exception propagates through UIKit lifecycle callbacks, corrupting Shell state and crashing the app. Android/Windows are unaffected because they create page content lazily.

### Fix

Two changes that restore graceful degradation during Hot Reload:

1. **`StaticResourceExtension.ProvideValue`**: When `ExceptionHandler2` is set (Hot Reload), report the error to the handler and return `null` instead of throwing. Without a handler (normal launch), still throws.

2. **`ApplyPropertiesVisitor`**: When `ExceptionHandler` is set and `StaticResourceExtension` throws, skip the property assignment (set `value = null`, return) instead of re-throwing. The page loads with degraded styling.

The error is still reported to the IDE via `ExceptionHandler2`, so the Error List shows the missing resource diagnostic.

### Comparison with #33859

| Scenario | Before #33859 | After #33859 | This PR |
|----------|--------------|-------------|---------|
| Missing resource, no handler (normal launch) | Throw | Throw | Throw ✅ |
| Missing resource, handler set (Hot Reload) | Report + return null | Report + throw 💥 | Report + return null ✅ |

### Test

Added `Maui35018.xaml` + `Maui35018.xaml.cs` — reproduces the Hot Reload resource rename scenario:
- `InitialLoadWithResourceSucceeds` — page loads when "Headline" exists
- `HotReloadAfterResourceRenameShouldNotCrash` — after removing "Headline" (simulating rename), page loads with handler invoked, no crash

Updated `HotReloadStaticResourceException.xaml.cs` to match new behavior (page loads instead of throwing when handler is set).
