### PR TITLE
Add .cab and ReconnectModal.razor.js to signing config

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,7 +29,7 @@
     <FileSignInfo Include="ReconnectModal.razor.js" CertificateName="Microsoft400" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="MSI workload cab signing">
     <!-- Sign cab files embedded inside MSI workload packs -->
     <FileExtensionSignInfo Include=".cab" CertificateName="Microsoft400" />
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -23,7 +23,9 @@
     <FileSignInfo Include="OpenSans-Semibold.ttf" CertificateName="3PartyScriptsSHA2" />
     <FileSignInfo Include="FluentSystemIcons-Regular.ttf" CertificateName="3PartyScriptsSHA2" />
     <FileSignInfo Include="SegoeUI-Semibold.ttf" CertificateName="3PartyScriptsSHA2" />
+  </ItemGroup>
 
+  <ItemGroup Label="Microsoft files">
     <FileSignInfo Include="ReconnectModal.razor.js" CertificateName="Microsoft400" />
   </ItemGroup>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -23,6 +23,13 @@
     <FileSignInfo Include="OpenSans-Semibold.ttf" CertificateName="3PartyScriptsSHA2" />
     <FileSignInfo Include="FluentSystemIcons-Regular.ttf" CertificateName="3PartyScriptsSHA2" />
     <FileSignInfo Include="SegoeUI-Semibold.ttf" CertificateName="3PartyScriptsSHA2" />
+
+    <FileSignInfo Include="ReconnectModal.razor.js" CertificateName="Microsoft400" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Sign cab files embedded inside MSI workload packs -->
+    <FileExtensionSignInfo Include=".cab" CertificateName="Microsoft400" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,4 +39,4 @@
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)\**\*.zip" Condition="'$(PostBuildSign)' == 'true'" />
   </ItemGroup>
-</Project>   
+</Project>


### PR DESCRIPTION
The Visual Studio signing scan flags unsigned files inside MAUI workload pack MSIs. This PR adds signing configuration for two categories of unsigned files:

### 1. Unsigned `.cab` files (75 files across 75 payloads)

Every MAUI workload pack MSI contains an embedded `cab1.cab.cab` cabinet archive that is currently unsigned. This affects 69 `maui*` payloads and 6 `aspnetcorewebviewmaui*` payloads across net9.0/net10.0 × arm64/x64/x86.

**Fix:** Add `FileExtensionSignInfo` for `.cab` with `Microsoft400` (which Arcade auto-converts to `MicrosoftDotNet500` since `UseDotNetCertificate` is `true`).

**Affected payloads (cab):**
- `mauicontrols{10020100200,90120901200}{arm64,x64,x86}`
- `mauicontrolsbuildtasks{10020100200,90120901200}{arm64,x64,x86}`
- `mauicontrolscompatibility90120901200{arm64,x64,x86}`
- `mauicontrolscore{10020100200,90120901200}{arm64,x64,x86}`
- `mauicontrolsxaml{10020100200,90120901200}{arm64,x64,x86}`
- `mauicore{10020100200,90120901200}{arm64,x64,x86}`
- `mauiessentials{10020100200,90120901200}{arm64,x64,x86}`
- `mauigraphics{10020100200,90120901200}{arm64,x64,x86}`
- `mauigraphicswindows{10020100200,90120901200}{arm64,x64,x86}`
- `mauiresizetizer{10020100200,90120901200}{arm64,x64,x86}`
- `mauisdknet{10,9}{10020100200,90120901200}{arm64,x64,x86}`
- `mauitemplatesnet{10,9}{10020100200,90120901200}{arm64,x64,x86}`
- `aspnetcorewebviewmaui{10020100200,90120901200}{arm64,x64,x86}`

### 2. Unsigned `ReconnectModal.razor.js` (3 files)

The Blazor reconnect modal script from `Microsoft.AspNetCore.Components.Web` is packed into `mauitemplatesnet10` workload MSIs without a signature.

**Fix:** Add `FileSignInfo` for `ReconnectModal.razor.js` with `Microsoft400`.

**Affected payloads (js):**
- `mauitemplatesnet1010020100200{arm64,x64,x86}`