### PR TITLE
Add category-filter and prNumber parameters to UI/device test pipelines

### DIFF
--- a/eng/helix_xharness.proj
+++ b/eng/helix_xharness.proj
@@ -32,6 +32,17 @@
         <ControlsTestCategoriesToSkipForRestOfTests>CollectionView;Shell;HybridWebView</ControlsTestCategoriesToSkipForRestOfTests>
     </PropertyGroup>
 
+    <!--
+        DeviceTestCategoryFilter: When set (semicolon-separated category names),
+        all work items are filtered to only run the specified categories.
+        Passed from ci-device-tests.yml via extraHelixArguments.
+        This overrides the default iOS category splitting behavior.
+    -->
+    <PropertyGroup Condition="'$(DeviceTestCategoryFilter)' != ''">
+        <!-- When filtering, disable iOS category splitting — run everything in one filtered work item -->
+        <ControlsTestCategoriesToSkipForRestOfTests></ControlsTestCategoriesToSkipForRestOfTests>
+    </PropertyGroup>
+
     <!-- AI test categories to skip on CI (Apple Intelligence models are not available on Helix machines) -->
     <PropertyGroup Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'maccatalyst'">
         <AITestCategoriesToSkipOnCI>AppleIntelligenceChatClient</AITestCategoriesToSkipOnCI>
@@ -252,6 +263,26 @@
 
         <Message Text="Created @(XHarnessAppBundleToTest->Count()) iOS work items" Importance="high" Condition="'$(TargetOS)' == 'ios'" />
         <Message Text="Created @(HelixWorkItem->Count()) Windows work items" Importance="high" Condition="'$(TargetOS)' == 'windows'" />
+
+        <!--
+            DeviceTestCategoryFilter override:
+            When set, replace CustomCommands on ALL Apple work items to only run
+            the specified categories. This lets ci-device-tests.yml pass targeted
+            category filters via extraHelixArguments.
+            Format: semicolon-separated category names, e.g. "Button;Label;Shell"
+        -->
+        <ItemGroup Condition="'$(DeviceTestCategoryFilter)' != '' and ('$(TargetOS)' == 'ios' or '$(TargetOS)' == 'maccatalyst')">
+            <XHarnessAppBundleToTest>
+                <CustomCommands>xharness apple test --target "$target" --app "$app" --output-directory "$output_directory" --timeout "$timeout" --launch-timeout "$launch_timeout" --set-env="TestFilter=Category=$(DeviceTestCategoryFilter)"</CustomCommands>
+            </XHarnessAppBundleToTest>
+        </ItemGroup>
+        <ItemGroup Condition="'$(DeviceTestCategoryFilter)' != '' and '$(TargetOS)' == 'android'">
+            <XHarnessApkToTest>
+                <AndroidInstrumentationArguments>TestFilter=Category=$(DeviceTestCategoryFilter)</AndroidInstrumentationArguments>
+            </XHarnessApkToTest>
+        </ItemGroup>
+
+        <Message Text="DeviceTestCategoryFilter applied: $(DeviceTestCategoryFilter)" Importance="high" Condition="'$(DeviceTestCategoryFilter)' != ''" />
     </Target>
 
 

--- a/eng/pipelines/arcade/stage-device-tests.yml
+++ b/eng/pipelines/arcade/stage-device-tests.yml
@@ -182,9 +182,9 @@ stages:
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
             ${{ if eq(parameters.runAsPublic, true) }}:
-              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=False
+              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=False ${{ parameters.extraHelixArguments }}
             ${{ else }}:
-              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=True
+              HelixProjectArguments: /p:TargetOS=ios /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsIOS_ /p:HelixInternal=True ${{ parameters.extraHelixArguments }}
             HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
@@ -236,9 +236,9 @@ stages:
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
             ${{ if eq(parameters.runAsPublic, true) }}:
-              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=False
+              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=False ${{ parameters.extraHelixArguments }}
             ${{ else }}:
-              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=True
+              HelixProjectArguments: /p:TargetOS=maccatalyst /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsMacCatalyst_ /p:HelixInternal=True ${{ parameters.extraHelixArguments }}
             HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
@@ -288,9 +288,9 @@ stages:
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
             ${{ if eq(parameters.runAsPublic, true) }}:
-              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=False
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=False ${{ parameters.extraHelixArguments }}
             ${{ else }}:
-              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=True
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsAndroid_ /p:HelixInternal=True ${{ parameters.extraHelixArguments }}
             HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
@@ -395,9 +395,9 @@ stages:
           parameters:
             HelixProjectPath: ${{ parameters.helixProject }}
             ${{ if eq(parameters.runAsPublic, true) }}:
-              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=False
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=False ${{ parameters.extraHelixArguments }}
             ${{ else }}:
-              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=True
+              HelixProjectArguments: /p:TargetOS=android /p:TestRunNameSuffix=_$(_BuildConfig)_CoreCLR /p:TestRunNamePrefix=DeviceTestsAndroid_CoreCLR_ /p:HelixInternal=True ${{ parameters.extraHelixArguments }}
             HelixAccessToken: ${{ parameters.HelixAccessToken }}
             HelixConfiguration: $(_BuildConfig)
             IncludeDotNetCli: true
@@ -625,9 +625,9 @@ stages:
             parameters:
               HelixProjectPath: ${{ parameters.helixProject }}
               ${{ if eq(parameters.runAsPublic, true) }}:
-                HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_ /p:HelixInternal=False
+                HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_ /p:HelixInternal=False ${{ parameters.extraHelixArguments }}
               ${{ else }}:
-                HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_ /p:HelixInternal=True
+                HelixProjectArguments: /p:TargetOS=windows /p:TestRunNameSuffix=_$(_BuildConfig) /p:TestRunNamePrefix=DeviceTestsWindows_ /p:HelixInternal=True ${{ parameters.extraHelixArguments }}
               HelixAccessToken: ${{ parameters.HelixAccessToken }}
               HelixConfiguration: $(_BuildConfig)
               IncludeDotNetCli: true

--- a/eng/pipelines/ci-device-tests.yml
+++ b/eng/pipelines/ci-device-tests.yml
@@ -55,6 +55,16 @@ variables:
 
 parameters:
 
+- name: deviceTestCategories
+  displayName: 'Device Test Categories to run (semicolon-separated, e.g. Button;Label;Shell). Empty = all categories.'
+  type: string
+  default: ''
+
+- name: prNumber
+  displayName: 'PR number to test (checks out the PR branch). Leave empty for current branch.'
+  type: string
+  default: ''
+
 # Internal pools (dnceng)
 - name: windowsPoolInternal
   type: object
@@ -129,7 +139,19 @@ stages:
         runAsPublic: true
       runWindowsTests: true
       TargetFrameworkVersion: ${{ targetFrameworkVersion.tfm }}
+      # When deviceTestCategories is specified, pass it to helix_xharness.proj
+      # which will apply it as a TestFilter on all work items.
+      ${{ if ne(parameters.deviceTestCategories, '') }}:
+        extraHelixArguments: '/p:DeviceTestCategoryFilter=${{ parameters.deviceTestCategories }}'
       prepareSteps:
+      - ${{ if ne(parameters.prNumber, '') }}:
+        - script: |
+            echo "Checking out PR #${{ parameters.prNumber }}..."
+            git fetch origin pull/${{ parameters.prNumber }}/head:pr-${{ parameters.prNumber }}
+            git checkout pr-${{ parameters.prNumber }}
+            echo "Checked out PR #${{ parameters.prNumber }}"
+            git log --oneline -1
+          displayName: 'Checkout PR #${{ parameters.prNumber }}'
       - template: /eng/pipelines/common/provision.yml@self
         parameters:
           checkoutDirectory: '$(System.DefaultWorkingDirectory)'

--- a/eng/pipelines/ci-uitests.yml
+++ b/eng/pipelines/ci-uitests.yml
@@ -64,6 +64,16 @@ parameters:
     type: boolean
     default: false
 
+  - name: uiTestCategories
+    displayName: 'UI Test Categories to run (comma-separated, e.g. Button,Label,Shell). Empty = all categories.'
+    type: string
+    default: ''
+
+  - name: prNumber
+    displayName: 'PR number to test (checks out the PR branch). Leave empty for current branch.'
+    type: string
+    default: ''
+
   # Internal pools (dnceng)
   - name: androidPoolInternal
     type: object
@@ -150,6 +160,13 @@ stages:
 
   - template: common/ui-tests.yml
     parameters:
+      # When uiTestCategories is specified, run only those categories (single matrix entry).
+      # When empty (default), the full categoryGroupsToTest list from ui-tests.yml is used.
+      ${{ if ne(parameters.uiTestCategories, '') }}:
+        categoryGroupsToTest:
+          - '${{ parameters.uiTestCategories }}'
+      # When prNumber is specified, checkout that PR branch before building.
+      prNumber: ${{ parameters.prNumber }}
       # Select pools based on pipeline - internal vs public
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         androidPool: ${{ parameters.androidPoolInternal }}

--- a/eng/pipelines/common/ui-tests.yml
+++ b/eng/pipelines/common/ui-tests.yml
@@ -12,6 +12,7 @@ parameters:
   defaultiOSVersion: '26.0'
   timeoutInMinutes: 180
   skipProvisioning: true
+  prNumber: '' # When set, checks out the PR branch before building
   BuildNativeAOT: false # Parameter to control whether NativeAOT artifacts should be built
   RunNativeAOT: false # Parameter to control whether NativeAOT UI tests should run
   categoryGroupsToTest:
@@ -63,6 +64,14 @@ stages:
           REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
           APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
         steps:
+          - ${{ if ne(parameters.prNumber, '') }}:
+            - script: |
+                echo "Checking out PR #${{ parameters.prNumber }}..."
+                git fetch origin pull/${{ parameters.prNumber }}/head:pr-${{ parameters.prNumber }}
+                git checkout pr-${{ parameters.prNumber }}
+                echo "Checked out PR #${{ parameters.prNumber }}"
+                git log --oneline -1
+              displayName: 'Checkout PR #${{ parameters.prNumber }}'
           - template: ui-tests-build-sample.yml
             parameters:
                 runtimeVariant: "Mono"
@@ -79,6 +88,14 @@ stages:
           REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
           APPIUM_HOME: $(System.DefaultWorkingDirectory)/.appium/
         steps:
+          - ${{ if ne(parameters.prNumber, '') }}:
+            - script: |
+                echo "Checking out PR #${{ parameters.prNumber }}..."
+                git fetch origin pull/${{ parameters.prNumber }}/head:pr-${{ parameters.prNumber }}
+                git checkout pr-${{ parameters.prNumber }}
+                echo "Checked out PR #${{ parameters.prNumber }}"
+                git log --oneline -1
+              displayName: 'Checkout PR #${{ parameters.prNumber }}'
           - template: ui-tests-build-sample.yml
             parameters:
                 runtimeVariant: "CoreCLR"


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

## Summary

This PR exposes new pipeline parameters that let `maui-pr-uitests` and `maui-pr-devicetests` be triggered manually for a targeted subset of test categories on any PR branch. The goal is to enable fast, focused regression checks against an in-flight PR without needing to run the full UI/device test matrix or merge the PR first.

## Why

The intended workflow pairs this PR with the companion PR (#34856), which detects which UI/device test categories a given PR is likely to affect and surfaces those category names in the AI Summary comment posted on the PR. A reviewer (or automation) can then copy those category values directly into the parameters added here and queue a targeted run of `maui-pr-uitests` / `maui-pr-devicetests` against the PR branch — getting fast signal on the relevant subset of tests without paying the cost of the full matrix.

## What changed

- **`eng/pipelines/ci-uitests.yml`** — Adds two pipeline parameters:
  - `uiTestCategories` (string, comma-separated, e.g. `Button,Label,Shell`). When set, overrides `categoryGroupsToTest` with a single matrix entry that runs only those categories. When empty (default), the full matrix runs as before.
  - `prNumber` (string). When set, the build checks out `refs/pull/<N>/head` before building, so any PR can be tested without merging.
- **`eng/pipelines/ci-device-tests.yml`** — Adds two pipeline parameters:
  - `deviceTestCategories` (string, semicolon-separated, e.g. `Button;Label;Shell`). Forwarded to `helix_xharness.proj` as `/p:DeviceTestCategoryFilter=...` via `extraHelixArguments`.
  - `prNumber` (string, same behavior as `ci-uitests.yml`).
- **`eng/pipelines/common/ui-tests.yml`** — Adds the `prNumber` parameter and a PR-checkout step before the Mono and CoreCLR build legs.
- **`eng/pipelines/arcade/stage-device-tests.yml`** — Wires the existing `extraHelixArguments` parameter through to all `HelixProjectArguments` invocations (iOS, MacCatalyst, Android, Android CoreCLR, Windows). The parameter was previously declared but never actually plumbed.
- **`eng/helix_xharness.proj`** — Adds the `DeviceTestCategoryFilter` MSBuild property. When set:
  - Disables iOS category splitting (so all categories run in a single filtered work item, not split per-heavy-category).
  - Applies the filter via `--set-env=TestFilter=Category=...` on Apple work items and `--arg TestFilter=...` on Android.

## New parameter quick-reference

| Pipeline | Parameter | Format | Example |
| --- | --- | --- | --- |
| maui-pr-uitests | `uiTestCategories` | comma-separated | `Button,Label,Shell` |
| maui-pr-devicetests | `deviceTestCategories` | semicolon-separated | `Button;Label;Shell` |
| both | `prNumber` | integer | `34699` |

## Companion PR

This PR is the pipeline-side half of a two-PR change. The companion is dotnet/maui#34856, which detects the affected UI/device test categories for a given PR and prints them in the AI Summary comment. The values printed by `Detect-UITestCategories.ps1` plug directly into the `uiTestCategories` / `deviceTestCategories` / `prNumber` parameters added here.

## Inspiration / prior art

Inspired by dotnet/maui#33176 ("Add PR category detection for UI tests"). We deliberately kept scope smaller here — that PR also explored skipping the provisioning/build legs entirely when no matching categories exist for a PR. That optimization is a reasonable follow-up once the manual-trigger workflow proves itself, but it is intentionally out of scope for this PR.
