### PR TITLE
[Windows] Fix for CS1061 build error caused by missing HasMenuBarContent property in MauiToolbar

### DIFF
--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -191,6 +191,8 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		internal bool HasMenuBarContent => _menuBar is not null && _menuBar.Items.Count > 0;
+
 		internal void SetMenuBar(MenuBar? menuBar)
 		{
 			_menuBar = menuBar;


### PR DESCRIPTION
<!-- Please let the below note in for people that find this PR -->
> [!NOTE]
> Are you waiting for the changes in this PR to be merged?
> It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. Thank you!

<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Issues Details

PR #30382 introduced a call to Toolbar?.HasMenuBarContent was introduced inside RootNavigationView.IsHeaderContentEmpty(), but the HasMenuBarContentproperty was not defined in MauiToolbar, which caused a CS1061 build error on Windows.

**Error Details:**  error CS1061: 'MauiToolbar' does not contain a definition for 'HasMenuBarContent' and no accessible extension method 'HasMenuBarContent' accepting a first argument of type 'MauiToolbar' could be found (are you missing a using directive or an assembly reference?)

### Description of Change

Implemented the missing internal bool HasMenuBarContent property in MauiToolbar.xaml.cs. This property returns true when the toolbar has a non-null MenuBar containing at least one item, ensuring consistency with the existing visibility logic used in SetMenuBar().

### Fixes

Fixes build error introduced by PR #30382 on Windows