### PR TITLE
 [Android] Fix CarouselView Issue29216 test regression on candidate branch

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (args.IsAnimated)
 			{
-				if (_gotoPosition == -1)
+				if (_gotoPosition == -1 && _initialized)
 					_gotoPosition = args.Index;
 				ScrollHelper.AnimateScrollToPosition(position, args.ScrollToPosition);
 			}


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### Root Cause
During CarouselView startup, `UpdateFromPosition` triggers an initial animated scroll to center the first item. In this flow, `_gotoPosition` is set, but `CarouselViewScrolled` exits early (`!_initialized`), so `UpdatePosition` never clears it. This leaves `_gotoPosition` stuck at `0`, blocking subsequent programmatic scrolls.

When `Position = 1` is later set (Issue29216), the guard condition (`_gotoPosition == -1`) fails, preventing the scroll.
 
### Description of Change
Updated the animated scroll path to assign `_gotoPosition` only after initialization.
This aligns it with the non-animated fix - [34996](https://github.com/dotnet/maui/pull/34996), preserves startup centering behavior, and ensures `_gotoPosition` is set only when it can be properly cleared.

### Issues Fixed
Fixes regression introduced by #34570 : 
`Issue29216CarouselViewScrollingIssue  on Candidate branch`.
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac